### PR TITLE
Add memory CLI utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+logs/
+.env
+.env.*
+*.log

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ Install dependencies using:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Memory management
+
+`memory_manager.py` stores chat fragments in `logs/memory/raw` and builds a vector index for quick lookup.
+
+Use `memory_cli.py` to maintain the store:
+
+```bash
+python memory_cli.py purge --age 30   # remove fragments older than 30 days
+python memory_cli.py purge --max 1000 # keep only the most recent 1000 entries
+python memory_cli.py summarize        # create/update daily summaries
+```
+
+Fragments are summarized per day in `logs/memory/distilled`.

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,0 +1,26 @@
+import argparse
+from memory_manager import purge_memory, summarize_memory
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage SentientOS memory")
+    subparsers = parser.add_subparsers(dest="command")
+
+    purge = subparsers.add_parser("purge", help="Delete old memory fragments")
+    purge.add_argument("--age", type=int, help="Remove fragments older than AGE days", dest="age")
+    purge.add_argument("--max", type=int, help="Keep only the newest MAX fragments", dest="max_files")
+
+    subparsers.add_parser("summarize", help="Concatenate daily summaries")
+
+    args = parser.parse_args()
+
+    if args.command == "purge":
+        purge_memory(max_age_days=args.age, max_files=args.max_files)
+    elif args.command == "summarize":
+        summarize_memory()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small command-line helper `memory_cli.py`
- document memory management tasks in the README
- add `.gitignore` for caches and logs

## Testing
- `pytest -q`
- `python -m py_compile *.py`
