### PR TITLE
Add memory CLI tool and expand docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Sample environment configuration for SentientOS
+
+# Directory for storing memory fragments
+MEMORY_DIR=logs/memory
+
+# Secret token used by the relay and heartbeat scripts
+RELAY_SECRET=your_relay_secret
+
+# URL for the relay service
+RELAY_URL=http://localhost:5000/relay

--- a/README.md
+++ b/README.md
@@ -1,7 +1,46 @@
-# SentientOS
+# SentientOS Scripts
+
+This repository contains utilities and small services used to run the SentientOS agents. The code was originally stored in a single file but has been split for clarity.
+
+## Utilities
+- `relay_app.py` – simple relay used for tests and local development.
+- `memory_manager.py` – persistent store for message fragments.
+- `memory_tail.py` – colorized log tailing helper.
+- `heartbeat.py` – periodic heartbeat client.
+- `cathedral_hog_wild_heartbeat.py` – multi-agent heartbeat example.
+- `rebind.rs` – Rust utility for rebinding Telegram webhooks via ngrok.
+
+## Configuration
+- `ngrok.yml` – example ngrok configuration.
+- `.env.example` – list of required environment variables.
+
+## Memory management
+
+`memory_manager.py` provides persistent storage of memory snippets. New entries are written to `logs/memory/raw` and indexed for simple vector search.
+
+The module includes optional cleanup and summarization helpers:
+
+- `purge_memory(max_age_days=None, max_files=None)` removes old fragments by age or keeps the newest `max_files` records.
+- `summarize_memory()` concatenates raw fragments into daily summary files under `logs/memory/distilled`.
+
+`memory_cli.py` exposes these functions for command-line use:
+
+```bash
+python memory_cli.py purge --age 30       # delete fragments older than 30 days
+python memory_cli.py purge --max 1000     # keep only the most recent 1000 entries
+python memory_cli.py summarize            # build/update daily summaries
+```
+
+These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Install dependencies using:
 
 ```bash
 pip install -r requirements.txt
+```
+
+Run tests with:
+
+```bash
+pytest
 ```

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,0 +1,26 @@
+import argparse
+import memory_manager as mm
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage SentientOS memory")
+    sub = parser.add_subparsers(dest="command")
+
+    purge = sub.add_parser("purge", help="Delete old memory fragments")
+    purge.add_argument("--age", type=int, dest="age", help="Remove fragments older than AGE days")
+    purge.add_argument("--max", type=int, dest="max_files", help="Keep only the newest MAX fragments")
+
+    sub.add_parser("summarize", help="Concatenate daily summaries")
+
+    args = parser.parse_args()
+
+    if args.command == "purge":
+        mm.purge_memory(max_age_days=args.age, max_files=args.max_files)
+    elif args.command == "summarize":
+        mm.summarize_memory()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide command-line tool `memory_cli.py`
- document utilities and memory maintenance steps
- add example `.env` configuration file

## Testing
- `pytest -q`
- `python -m py_compile *.py`
