### PR TITLE
Add memory log tailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ python memory_cli.py summarize            # build/update daily summaries
 
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
+
 This project contains various utilities for running local agents and logging their memory fragments.
 
 ## Memory management
@@ -53,6 +54,15 @@ python memory_cli.py summarize            # build/update daily summaries
 ```
 
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
+
+## Log tailing
+Use `memory_tail.py` to stream new entries from `logs/memory.jsonl`.
+
+```bash
+python memory_tail.py
+```
+Pass `--file` to tail a different log.
+
 
 Install dependencies using:
 

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -1,0 +1,63 @@
+import os
+import time
+import json
+import argparse
+from colorama import init, Fore, Style
+
+init()
+
+COLOR_MAP = {
+    "heartbeat": Fore.YELLOW,
+    "openai/gpt-4o": Fore.GREEN,
+    "mixtral": Fore.MAGENTA,
+    "deepseek-ai/deepseek-r1-distill-llama-70b-free": Fore.CYAN,
+}
+
+DEFAULT_FILE = os.getenv("MEMORY_FILE", os.path.join("logs", "memory.jsonl"))
+
+
+def detect_color(entry: dict) -> str:
+    source = (entry.get("source") or "").lower()
+    tags = [t.lower() for t in entry.get("tags", [])]
+    if source in COLOR_MAP:
+        return COLOR_MAP[source]
+    for t in tags:
+        if t in COLOR_MAP:
+            return COLOR_MAP[t]
+    return Fore.WHITE
+
+
+def tail_memory(path: str, delay: float = 1.0) -> None:
+    """Continuously print new JSON lines from ``path`` with color."""
+    print(Fore.BLUE + "[Lumos] Live memory tail started..." + Style.RESET_ALL)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            f.seek(0, os.SEEK_END)
+            while True:
+                line = f.readline()
+                if not line:
+                    time.sleep(delay)
+                    continue
+                try:
+                    entry = json.loads(line.strip())
+                    color = detect_color(entry)
+                    ts = entry.get("timestamp", "???")
+                    src = entry.get("source", "unknown")
+                    txt = entry.get("text", "").strip().replace("\n", " ")
+                    print(color + f"[{ts}] ({src}) -> {txt[:200]}" + Style.RESET_ALL)
+                except Exception as e:  # noqa: BLE001
+                    print(Fore.RED + f"[TAIL ERROR] {e}" + Style.RESET_ALL)
+    except FileNotFoundError:
+        print(Fore.RED + f"[ERROR] memory.jsonl not found: {path}" + Style.RESET_ALL)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Tail memory.jsonl")
+    parser.add_argument("--file", default=DEFAULT_FILE, help="Path to JSONL log")
+    parser.add_argument("--delay", type=float, default=1.0, help="Polling delay")
+    args = parser.parse_args()
+    tail_memory(args.file, delay=args.delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 python-dotenv
 requests
 pytest
+colorama


### PR DESCRIPTION
## Summary
- implement `memory_tail.py` to stream `logs/memory.jsonl`
- include `colorama` dependency
- document log tailer usage in README

## Testing
- `pytest -q`