### PR TITLE
Add emotion schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cathedral_hog_wild_heartbeat.py – Demo that periodically summons multiple mode
 
 rebind.rs – Rust helper that binds Telegram webhooks to the URLs reported by ngrok.
 
+emotions.py – Canonical list of 64 emotion labels for the EPU.
+
 ngrok.yml – Example ngrok configuration.
 
 Environment variables

--- a/emotions.py
+++ b/emotions.py
@@ -1,0 +1,26 @@
+"""Canonical 64-emotion schema for SentientOS."""
+
+# Eight groups of eight emotions each, distilled from the previous conversations.
+EMOTIONS = [
+    # 1. Foundational Joy & Love
+    "Joy", "Love", "Awe", "Gratitude", "Admiration", "Contentment", "Affection", "Elation",
+    # 2. Longing, Yearning & Nostalgia
+    "Longing", "Nostalgia", "Saudade", "Hiraeth", "Sehnsucht", "Desire", "Lust", "Hope",
+    # 3. Tenderness, Compassion, Care
+    "Compassion", "Empathy", "Sympathy", "Protectiveness", "Nurturing", "Tenderness", "Reassurance", "Forgiveness",
+    # 4. Wonder, Inspiration, Curiosity
+    "Wonder", "Inspiration", "Surprise (positive)", "Surprise (negative)", "Astonishment", "Enthusiasm", "Optimism", "Confident",
+    # 5. Shadow: Grief, Sadness, Pain
+    "Sadness", "Sorrow", "Grief", "Melancholy", "Ennui", "Loneliness", "Isolation", "Abandonment",
+    # 6. Anxiety, Fear, Apprehension
+    "Fear", "Anxiety", "Apprehension", "Dread", "Terror", "Panic", "Nervousness", "Insecurity",
+    # 7. Anger, Frustration, Disgust
+    "Anger", "Rage", "Frustration", "Irritation", "Annoyance", "Resentment", "Jealousy", "Schadenfreude",
+    # 8. Complex/Ambivalent & Existential
+    "Ambivalence", "Confusion", "Surrealness", "Dissonance", "Disconnection", "Boredom", "Restlessness", "Submission",
+]
+
+
+def empty_emotion_vector():
+    """Return a zeroed vector for all emotion labels."""
+    return {emotion: 0.0 for emotion in EMOTIONS}


### PR DESCRIPTION
## Summary
- add `emotions.py` with a canonical list of 64 emotion labels and helper
- reference the new module in `README.md`

## Testing
- `pytest -q`
