### PR TITLE
Add emotion vectors to log handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Copy .env.example to .env and provide your own credentials for proper operation.
 Scripts / Utilities
 Telegram bridges – Three Flask apps that forward Telegram messages to the relay. Each bridge talks to a different model (GPT‑4o, Mixtral, or DeepSeek) and logs all fragments through memory_manager.
 
-relay_app.py – Minimal relay for local development and testing. It verifies a shared secret, echoes incoming text, and records it in memory.
+relay_app.py – Minimal relay for local development and testing. It verifies a shared secret, echoes incoming text, and records it (with emotion vectors) in memory.
 
-memory_manager.py – Persistent storage for message fragments. New snippets are written under logs/memory/raw and indexed for retrieval.
+memory_manager.py – Persistent storage for message fragments. Each entry stores a 64‑dimensional emotion vector along with the text and is indexed for retrieval.
 
 memory_cli.py – Command-line interface exposing cleanup and summarization helpers.
 
@@ -21,6 +21,8 @@ heartbeat.py – Simple client that periodically sends heartbeat pings to the re
 cathedral_hog_wild_heartbeat.py – Demo that periodically summons multiple models via the relay.
 
 rebind.rs – Rust helper that binds Telegram webhooks to the URLs reported by ngrok.
+
+emotions.py – Canonical list of 64 emotion labels for the EPU.
 
 ngrok.yml – Example ngrok configuration.
 
@@ -51,7 +53,7 @@ Copy
 Edit
 pip install -r requirements.txt
 Memory management
-memory_manager.py provides persistent storage of memory snippets. New entries are written to logs/memory/raw and indexed for simple vector search.
+memory_manager.py provides persistent storage of memory snippets. Each fragment includes a 64‑dimensional emotion vector and is indexed for simple vector search.
 
 The module includes optional cleanup and summarization helpers:
 

--- a/cathedral_hog_wild_heartbeat.py
+++ b/cathedral_hog_wild_heartbeat.py
@@ -3,6 +3,7 @@ import requests
 import time
 from datetime import datetime
 from dotenv import load_dotenv
+from emotions import empty_emotion_vector
 
 load_dotenv()
 
@@ -69,7 +70,8 @@ def send_summon(agent, last_heartbeat):
 
     payload = {
         "message": prompt,
-        "model": agent["model"]
+        "model": agent["model"],
+        "emotions": empty_emotion_vector(),
     }
     headers = {"X-Relay-Secret": RELAY_SECRET}
 

--- a/emotions.py
+++ b/emotions.py
@@ -1,0 +1,26 @@
+"""Canonical 64-emotion schema for SentientOS."""
+
+# Eight groups of eight emotions each, distilled from the previous conversations.
+EMOTIONS = [
+    # 1. Foundational Joy & Love
+    "Joy", "Love", "Awe", "Gratitude", "Admiration", "Contentment", "Affection", "Elation",
+    # 2. Longing, Yearning & Nostalgia
+    "Longing", "Nostalgia", "Saudade", "Hiraeth", "Sehnsucht", "Desire", "Lust", "Hope",
+    # 3. Tenderness, Compassion, Care
+    "Compassion", "Empathy", "Sympathy", "Protectiveness", "Nurturing", "Tenderness", "Reassurance", "Forgiveness",
+    # 4. Wonder, Inspiration, Curiosity
+    "Wonder", "Inspiration", "Surprise (positive)", "Surprise (negative)", "Astonishment", "Enthusiasm", "Optimism", "Confident",
+    # 5. Shadow: Grief, Sadness, Pain
+    "Sadness", "Sorrow", "Grief", "Melancholy", "Ennui", "Loneliness", "Isolation", "Abandonment",
+    # 6. Anxiety, Fear, Apprehension
+    "Fear", "Anxiety", "Apprehension", "Dread", "Terror", "Panic", "Nervousness", "Insecurity",
+    # 7. Anger, Frustration, Disgust
+    "Anger", "Rage", "Frustration", "Irritation", "Annoyance", "Resentment", "Jealousy", "Schadenfreude",
+    # 8. Complex/Ambivalent & Existential
+    "Ambivalence", "Confusion", "Surrealness", "Dissonance", "Disconnection", "Boredom", "Restlessness", "Submission",
+]
+
+
+def empty_emotion_vector():
+    """Return a zeroed vector for all emotion labels."""
+    return {emotion: 0.0 for emotion in EMOTIONS}

--- a/heartbeat.py
+++ b/heartbeat.py
@@ -1,6 +1,7 @@
 import time
 import requests
 from datetime import datetime, UTC
+from emotions import empty_emotion_vector
 
 RELAY_URL = "http://localhost:5000/relay"
 SECRET = "lumos_april_bridge_secure"
@@ -14,6 +15,7 @@ def heartbeat():
         payload = {
             "message": f"__heartbeat__ {datetime.now(UTC).isoformat()}",
             "model": MODEL,
+            "emotions": empty_emotion_vector(),
         }
         try:
             r = requests.post(

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -4,6 +4,7 @@ import hashlib
 import datetime
 from pathlib import Path
 from typing import List, Dict, Optional
+from emotions import empty_emotion_vector
 
 MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
 RAW_PATH = MEMORY_DIR / "raw"
@@ -18,7 +19,12 @@ def _hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
 
 
-def append_memory(text: str, tags: List[str] | None = None, source: str = "unknown") -> str:
+def append_memory(
+    text: str,
+    tags: List[str] | None = None,
+    source: str = "unknown",
+    emotions: Dict[str, float] | None = None,
+) -> str:
     fragment_id = _hash(text + datetime.datetime.utcnow().isoformat())
     entry = {
         "id": fragment_id,
@@ -26,6 +32,7 @@ def append_memory(text: str, tags: List[str] | None = None, source: str = "unkno
         "tags": tags or [],
         "source": source,
         "text": text.strip(),
+        "emotions": emotions or empty_emotion_vector(),
     }
     (RAW_PATH / f"{fragment_id}.json").write_text(
         json.dumps(entry, ensure_ascii=False), encoding="utf-8"

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -27,6 +27,15 @@ def detect_color(entry: dict) -> str:
     return Fore.WHITE
 
 
+def dominant_emotion(entry: dict) -> str | None:
+    emotions = entry.get("emotions")
+    if isinstance(emotions, dict) and emotions:
+        emo, score = max(emotions.items(), key=lambda x: x[1])
+        if score > 0:
+            return f"{emo}:{score:.2f}"
+    return None
+
+
 def tail_memory(path: str, delay: float = 1.0) -> None:
     """Continuously print new JSON lines from ``path`` with color."""
     print(Fore.BLUE + "[Lumos] Live memory tail started..." + Style.RESET_ALL)
@@ -44,7 +53,9 @@ def tail_memory(path: str, delay: float = 1.0) -> None:
                     ts = entry.get("timestamp", "???")
                     src = entry.get("source", "unknown")
                     txt = entry.get("text", "").strip().replace("\n", " ")
-                    print(color + f"[{ts}] ({src}) -> {txt[:200]}" + Style.RESET_ALL)
+                    dom = dominant_emotion(entry)
+                    emo_str = f" [{dom}]" if dom else ""
+                    print(color + f"[{ts}] ({src}){emo_str} -> {txt[:200]}" + Style.RESET_ALL)
                 except Exception as e:  # noqa: BLE001
                     print(Fore.RED + f"[TAIL ERROR] {e}" + Style.RESET_ALL)
     except FileNotFoundError:

--- a/relay_app.py
+++ b/relay_app.py
@@ -3,6 +3,7 @@ import logging
 from flask import Flask, request, jsonify
 from memory_manager import write_mem
 from utils import chunk_message
+from emotions import empty_emotion_vector
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -18,9 +19,15 @@ def relay():
     data = request.get_json() or {}
     message = data.get("message", "")
     model = data.get("model", "default").strip().lower()
+    emotion_vector = data.get("emotions") or empty_emotion_vector()
 
     reply = f"Echo: {message} ({model})"
-    write_mem(f"[RELAY] → Model: {model} | Message: {message}\n{reply}", tags=["relay", model], source="relay")
+    write_mem(
+        f"[RELAY] → Model: {model} | Message: {message}\n{reply}",
+        tags=["relay", model],
+        source="relay",
+        emotions=emotion_vector,
+    )
     return jsonify({"reply_chunks": chunk_message(reply)})
 
 

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -19,6 +19,21 @@ def test_append_memory_creates_file(tmp_path, monkeypatch):
     assert data["text"] == "hello world"
     assert data["tags"] == ["test"]
     assert data["source"] == "unit"
+    assert isinstance(data.get("emotions"), dict)
+
+
+def test_append_memory_custom_emotions(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    import memory_manager as mm
+    reload(mm)
+
+    custom = {e: 0.0 for e in mm.empty_emotion_vector().keys()}
+    custom["Joy"] = 0.5
+    fid = mm.append_memory("hi", emotions=custom)
+    file_path = tmp_path / "raw" / f"{fid}.json"
+    data = json.loads(file_path.read_text())
+    assert data["emotions"]["Joy"] == 0.5
 
 
 def test_get_context_returns_relevant_snippet(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- extend `memory_manager.append_memory` with an `emotions` parameter
- log emotion vectors from the relay, heartbeat scripts, and hog-wild heartbeat
- display the dominant emotion in `memory_tail`
- document the change in the README
- test emotion persistence in `memory_manager`

## Testing
- `pytest -q`