### PR TITLE
Add profile memory and prompt assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ purge_memory(max_age_days=None, max_files=None) removes old fragments by age or 
 
 summarize_memory() concatenates raw fragments into daily summary files under logs/memory/distilled.
 
+User profile and prompt assembly
+--------------------------------
+The ``user_profile`` module stores persistent key-value data about the user in
+``profile.json`` inside ``MEMORY_DIR``. ``prompt_assembler`` combines this
+profile information with relevant memory snippets (retrieved via
+``memory_manager.get_context``) to build a rich prompt for the models.
+
 Command-line usage via memory_cli.py:
 
 bash

--- a/prompt_assembler.py
+++ b/prompt_assembler.py
@@ -1,0 +1,24 @@
+from typing import List
+
+import memory_manager as mm
+import user_profile as up
+
+SYSTEM_PROMPT = "You are Lumos, an emotionally present AI assistant."
+
+
+def assemble_prompt(user_input: str, recent_messages: List[str] | None = None, k: int = 6) -> str:
+    """Build a prompt including profile and relevant memories."""
+    profile = up.format_profile()
+    memories = mm.get_context(user_input, k=k)
+
+    sections = [f"SYSTEM:\n{SYSTEM_PROMPT}"]
+    if profile:
+        sections.append(f"USER PROFILE:\n{profile}")
+    if memories:
+        mem_lines = "\n".join(f"- {m}" for m in memories)
+        sections.append(f"RELEVANT MEMORIES:\n{mem_lines}")
+    if recent_messages:
+        ctx = "\n".join(recent_messages)
+        sections.append(f"RECENT DIALOGUE:\n{ctx}")
+    sections.append(f"USER:\n{user_input}")
+    return "\n\n".join(sections)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import user_profile as up
+
+
+def test_profile_update_and_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    profile = up.update_profile(name="Allen", partner="April")
+    assert profile["name"] == "Allen"
+    loaded = up.load_profile()
+    assert loaded == profile
+

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import prompt_assembler as pa
+import user_profile as up
+import memory_manager as mm
+
+
+def test_assemble_prompt_includes_profile_and_memory(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    # reload modules with new env
+    from importlib import reload
+    reload(up)
+    reload(mm)
+    reload(pa)
+
+    up.update_profile(name="Allen")
+    mm.append_memory("Allen likes cats", tags=["test"], source="unit")
+
+    prompt = pa.assemble_prompt("cats", [])
+    assert "Allen likes cats" in prompt
+    assert "name: Allen" in prompt

--- a/user_profile.py
+++ b/user_profile.py
@@ -1,0 +1,37 @@
+import os
+import json
+from pathlib import Path
+
+MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
+PROFILE_PATH = MEMORY_DIR / "profile.json"
+
+
+def load_profile() -> dict:
+    """Load the user profile from disk."""
+    if PROFILE_PATH.exists():
+        try:
+            return json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def save_profile(profile: dict) -> None:
+    """Persist the profile to disk."""
+    PROFILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PROFILE_PATH.write_text(json.dumps(profile, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def update_profile(**updates) -> dict:
+    """Update profile values and save."""
+    profile = load_profile()
+    profile.update({k: v for k, v in updates.items() if v is not None})
+    save_profile(profile)
+    return profile
+
+
+def format_profile() -> str:
+    """Return profile as formatted lines for prompt injection."""
+    profile = load_profile()
+    lines = [f"- {k}: {v}" for k, v in profile.items()]
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- maintain user profile information for prompt injection
- build prompts from stored profile and context
- document profile/prompt features in README
- test new profile and prompt modules

## Testing
- `pytest -q`