### PR TITLE
Add actuator API and /act route

### DIFF
--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,0 +1,100 @@
+import subprocess
+from pathlib import Path
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback when requests isn't installed
+    requests = None
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback when PyYAML isn't installed
+    yaml = None
+import ast
+
+# Load whitelist
+WHITELIST_PATH = Path("config/act_whitelist.yml")
+def _load_yaml(text: str):
+    if yaml:
+        return yaml.safe_load(text)
+    data = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if ':' not in line:
+            continue
+        key, val = line.split(':', 1)
+        key = key.strip()
+        val = val.strip()
+        if val.startswith('[') and val.endswith(']'):
+            data[key] = ast.literal_eval(val)
+        else:
+            try:
+                data[key] = int(val)
+            except ValueError:
+                data[key] = val
+    return data
+
+if WHITELIST_PATH.exists():
+    WHITELIST = _load_yaml(WHITELIST_PATH.read_text()) or {}
+else:
+    WHITELIST = {"shell": [], "http": [], "timeout": 30}
+
+SANDBOX_DIR = Path("sandbox")
+SANDBOX_DIR.mkdir(exist_ok=True)
+
+def _allowed_shell(cmd: str) -> bool:
+    first = cmd.strip().split()[0] if cmd.strip() else ""
+    return first in WHITELIST.get("shell", [])
+
+def run_shell(cmd: str, cwd: str = ".") -> dict:
+    if not _allowed_shell(cmd):
+        raise PermissionError("Command not allowed")
+    res = subprocess.run(
+        cmd,
+        shell=True,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=WHITELIST.get("timeout", 30),
+    )
+    return {
+        "code": res.returncode,
+        "stdout": res.stdout,
+        "stderr": res.stderr,
+    }
+
+def http_fetch(url: str, method: str = "GET", **kwargs) -> dict:
+    allowed = any(url.startswith(p) for p in WHITELIST.get("http", []))
+    if not allowed:
+        raise PermissionError("URL not allowed")
+    timeout = WHITELIST.get("timeout", 30)
+    if requests:
+        resp = requests.request(method, url, timeout=timeout, **kwargs)
+        return {"status": resp.status_code, "text": resp.text}
+    import urllib.request
+    req = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        text = r.read().decode()
+        status = r.getcode()
+    return {"status": status, "text": text}
+
+def file_write(path: str, content: str) -> dict:
+    target = SANDBOX_DIR / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    return {"written": str(target)}
+
+def dispatch(intent: dict) -> dict:
+    itype = intent.get("type")
+    if itype == "shell":
+        return run_shell(intent.get("cmd", ""), cwd=intent.get("cwd", "."))
+    if itype == "http":
+        url = intent.get("url", "")
+        method = intent.get("method", "GET")
+        extras = {k: v for k, v in intent.items() if k not in {"type", "url", "method"}}
+        return http_fetch(url, method=method, **extras)
+    if itype == "file":
+        return file_write(intent.get("path", ""), intent.get("content", ""))
+    raise ValueError("Unsupported intent")

--- a/config/act_whitelist.yml
+++ b/config/act_whitelist.yml
@@ -1,0 +1,3 @@
+shell: ["ls", "df", "curl", "ping", "python"]
+http: ["http://", "https://"]
+timeout: 30

--- a/relay_app.py
+++ b/relay_app.py
@@ -1,9 +1,11 @@
 import os
+import json
 import logging
 from flask import Flask, request, jsonify
 from memory_manager import write_mem
 from utils import chunk_message
 from emotions import empty_emotion_vector
+from api import actuator
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -29,6 +31,50 @@ def relay():
         emotions=emotion_vector,
     )
     return jsonify({"reply_chunks": chunk_message(reply)})
+
+
+@app.route("/act", methods=["POST"])
+def act():
+    if request.headers.get("X-Relay-Secret") != RELAY_SECRET:
+        return "Forbidden", 403
+
+    intent = request.get_json() or {}
+    try:
+        result = actuator.dispatch(intent)
+    except Exception as e:
+        result = {"error": str(e)}
+
+    write_mem(
+        f"[ACT] Intent: {json.dumps(intent)}\nResult: {json.dumps(result)}",
+        tags=["act"],
+        source="relay",
+    )
+
+    try:
+        with app.test_request_context(
+            "/relay",
+            method="POST",
+            json={
+                "message": f"Why was action {intent} chosen?",
+                "model": intent.get("model", "default"),
+            },
+            headers={"X-Relay-Secret": RELAY_SECRET},
+        ):
+            exp_resp = relay()
+            explanation = exp_resp.get_json()["reply_chunks"][0]
+            write_mem(
+                f"[ACT EXPLAIN] {explanation}",
+                tags=["act", "explain"],
+                source="relay",
+            )
+    except Exception as e:  # pragma: no cover - best-effort
+        write_mem(
+            f"[ACT EXPLAIN ERROR] {e}",
+            tags=["act", "explain"],
+            source="relay",
+        )
+
+    return jsonify(result)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 requests
 pytest
 colorama
+PyYAML

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import relay_app
+from api import actuator
+
+
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    monkeypatch.setenv("RELAY_SECRET", "secret123")
+    reload(actuator)
+    reload(relay_app)
+    return relay_app.app.test_client()
+
+
+def test_run_shell_allowed(tmp_path, monkeypatch):
+    reload(actuator)
+    actuator.WHITELIST = {"shell": ["echo"], "http": ["http://"], "timeout": 5}
+    res = actuator.run_shell("echo hello", cwd=tmp_path)
+    assert res["code"] == 0
+    assert "hello" in res["stdout"]
+
+
+def test_run_shell_blocked():
+    reload(actuator)
+    actuator.WHITELIST = {"shell": ["echo"], "http": ["http://"], "timeout": 5}
+    import pytest
+    with pytest.raises(Exception):
+        actuator.run_shell("rm -rf /")
+
+
+def test_http_fetch(monkeypatch):
+    reload(actuator)
+    actuator.WHITELIST = {"shell": [], "http": ["http://"], "timeout": 5}
+
+    class FakeResp:
+        status_code = 200
+        text = "ok"
+
+    def fake_request(method, url, **kwargs):
+        fake_request.called = (method, url)
+        return FakeResp()
+
+    if actuator.requests is None:
+        from types import SimpleNamespace
+        actuator.requests = SimpleNamespace(request=fake_request)
+    else:
+        monkeypatch.setattr(actuator.requests, "request", fake_request)
+    res = actuator.http_fetch("http://example.com")
+    assert res == {"status": 200, "text": "ok"}
+    import pytest
+    with pytest.raises(Exception):
+        actuator.http_fetch("https://blocked.com")
+
+
+def test_act_route_respects_whitelist(tmp_path, monkeypatch):
+    client = setup(tmp_path, monkeypatch)
+    actuator.WHITELIST = {"shell": ["echo"], "http": ["http://"], "timeout": 5}
+
+    resp = client.post(
+        "/act",
+        json={"type": "shell", "cmd": "echo hi"},
+        headers={"X-Relay-Secret": "secret123"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "hi" in data.get("stdout", "")
+
+    resp = client.post(
+        "/act",
+        json={"type": "shell", "cmd": "rm -rf /"},
+        headers={"X-Relay-Secret": "secret123"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "error" in data


### PR DESCRIPTION
## Summary
- implement `api.actuator` with shell, HTTP, and file helpers
- add `/act` endpoint in `relay_app` that dispatches intents
- seed example whitelist in `config/act_whitelist.yml`
- include PyYAML in requirements
- test actuator helpers and `/act` route

## Testing
- `pytest -q`