### PR TITLE
Improve voice emotion handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@ EMBED_MODEL=all-MiniLM-L6-v2
 
 # Path for storing memory fragments
 MEMORY_DIR=logs/memory
+TTS_ENGINE=pyttsx3
+TTS_COQUI_MODEL=tts_models/en/vctk/vits
+AUDIO_LOG_DIR=logs/audio

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ heartbeat.py – Simple client that periodically sends heartbeat pings to the re
 
 cathedral_hog_wild_heartbeat.py – Demo that periodically summons multiple models via the relay.
 
-mic_bridge.py – Captures microphone audio and converts speech to text.
+mic_bridge.py – Captures microphone audio, converts speech to text, and infers valence, arousal, and dominance using `emotion_utils`.
 
-tts_bridge.py – Speaks model replies aloud using a local TTS engine.
+tts_bridge.py – Speaks model replies aloud using a pluggable TTS engine and adjusts rate/voice based on emotion.
 
-voice_loop.py – Links the mic and TTS bridges for hands-free conversation.
+voice_loop.py – Links the mic and TTS bridges for hands-free conversation with emotion-aware responses and interruption support.
+browser_voice.py – Minimal Flask demo for browser-based voice chat.
 
 rebind.rs – Rust helper that binds Telegram webhooks to the URLs reported by ngrok.
 
@@ -50,6 +51,9 @@ MIXTRAL_MODEL	Model slug for Mixtral
 DEEPSEEK_MODEL	Model slug for DeepSeek
 EMBED_MODEL	Embedding model for memory search
 MEMORY_DIR	Directory used for persistent memory
+TTS_ENGINE      "pyttsx3" (default) or "coqui"
+TTS_COQUI_MODEL Coqui model when TTS_ENGINE=coqui
+AUDIO_LOG_DIR   Directory for recorded audio files
 
 Usage
 Install dependencies:
@@ -62,7 +66,7 @@ pip install -r requirements.txt
 Voice interaction
 -----------------
 After installing dependencies, run ``python voice_loop.py`` to start a simple
-hands-free conversation using your microphone and speakers.
+hands-free conversation using your microphone and speakers. The loop infers valence, arousal, and dominance from your voice and modulates its replies using the configured TTS engine.
 
 Memory management
 memory_manager.py provides persistent storage of memory snippets. Each fragment includes a 64‑dimensional emotion vector and is indexed for simple vector search.

--- a/emotion_utils.py
+++ b/emotion_utils.py
@@ -1,0 +1,67 @@
+import audioop
+import wave
+from pathlib import Path
+from typing import Dict, Tuple
+from emotions import empty_emotion_vector
+
+try:
+    import librosa  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    librosa = None  # type: ignore
+    np = None  # type: ignore
+
+
+def vad_and_features(path: str) -> Tuple[Dict[str, float], Dict[str, float]]:
+    """Derive an emotion vector and raw features from ``path``.
+
+    If ``librosa``/``numpy`` are available, compute simple spectral
+    features (RMS, ZCR, centroid) to estimate valence, arousal and
+    dominance. Otherwise fall back to RMS volume analysis using the
+    standard ``wave`` module.
+    """
+    p = Path(path)
+    if not p.exists():
+        return empty_emotion_vector(), {}
+
+    if librosa is None or np is None:  # Fallback path
+        try:
+            with wave.open(str(p), "rb") as wf:
+                frames = wf.readframes(wf.getnframes())
+                rms = audioop.rms(frames, wf.getsampwidth())
+        except Exception:
+            rms = 0
+        vec = empty_emotion_vector()
+        if rms < 500:
+            vec["Sadness"] = 1.0
+        elif rms > 3000:
+            vec["Anger"] = min(1.0, (rms - 3000) / 7000)
+            vec["Enthusiasm"] = 0.8
+        else:
+            vec["Contentment"] = 0.6
+        return vec, {"rms": float(rms)}
+
+    # librosa-based features
+    try:
+        y, sr = librosa.load(str(p), sr=16000)
+        rms = float(librosa.feature.rms(y=y).mean())
+        zcr = float(librosa.feature.zero_crossing_rate(y).mean())
+        centroid = float(librosa.feature.spectral_centroid(y=y, sr=sr).mean())
+    except Exception:
+        return empty_emotion_vector(), {}
+
+    features = {"rms": rms, "zcr": zcr, "centroid": centroid}
+
+    # Rough mapping to valence/arousal/dominance
+    valence = max(-1.0, min(1.0, (centroid - 1500) / 2000))
+    arousal = max(0.0, min(1.0, rms * 10))
+    dominance = max(0.0, min(1.0, zcr * 10))
+
+    vec = empty_emotion_vector()
+    if valence >= 0:
+        vec["Joy"] = valence
+    else:
+        vec["Sadness"] = -valence
+    vec["Enthusiasm"] = arousal
+    vec["Confident"] = dominance
+    return vec, features

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -27,6 +27,7 @@ def append_memory(
     tags: List[str] | None = None,
     source: str = "unknown",
     emotions: Dict[str, float] | None = None,
+    emotion_features: Dict[str, float] | None = None,
 ) -> str:
     if os.getenv("INCOGNITO") == "1":
         print("[MEMORY] Incognito mode enabled – skipping persistence")
@@ -39,6 +40,7 @@ def append_memory(
         "source": source,
         "text": text.strip(),
         "emotions": emotions or empty_emotion_vector(),
+        "emotion_features": emotion_features or {},
     }
     (RAW_PATH / f"{fragment_id}.json").write_text(
         json.dumps(entry, ensure_ascii=False), encoding="utf-8"

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -3,6 +3,10 @@ import json
 import time
 from pathlib import Path
 from typing import Dict, Optional
+import tempfile
+
+from emotions import empty_emotion_vector
+from emotion_utils import vad_and_features
 
 try:
     import speech_recognition as sr
@@ -13,6 +17,11 @@ from memory_manager import append_memory
 
 AUDIO_DIR = Path(os.getenv("AUDIO_LOG_DIR", "logs/audio"))
 AUDIO_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def detect_emotions_from_audio(path: str) -> tuple[Dict[str, float], Dict[str, float]]:
+    """Infer emotions and raw features from an audio file."""
+    return vad_and_features(path)
 
 
 def recognize_from_mic(save_audio: bool = True) -> Dict[str, Optional[str]]:
@@ -27,11 +36,19 @@ def recognize_from_mic(save_audio: bool = True) -> Dict[str, Optional[str]]:
         audio = recognizer.listen(source)
 
     audio_path = None
+    temp_file = None
     if save_audio:
         ts = time.strftime("%Y%m%d-%H%M%S")
         audio_path = AUDIO_DIR / f"mic_{ts}.wav"
         with open(audio_path, "wb") as f:
             f.write(audio.get_wav_data())
+    else:
+        temp_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        temp_file.write(audio.get_wav_data())
+        temp_file.close()
+        audio_path = Path(temp_file.name)
+
+    emotions, features = detect_emotions_from_audio(str(audio_path))
 
     text = None
     if hasattr(recognizer, "recognize_whisper"):
@@ -57,12 +74,51 @@ def recognize_from_mic(save_audio: bool = True) -> Dict[str, Optional[str]]:
             text = None
 
     if text:
-        append_memory(text, tags=["voice", "input"], source="mic")
+        append_memory(
+            text,
+            tags=["voice", "input"],
+            source="mic",
+            emotions=emotions,
+            emotion_features=features,
+        )
 
     return {
         "message": text,
         "source": "mic",
         "audio_file": str(audio_path) if audio_path else None,
+        "emotions": emotions,
+    }
+
+
+def recognize_from_file(path: str) -> Dict[str, Optional[str]]:
+    """Transcribe an audio file and return emotion data."""
+    if sr is None:
+        return {"message": None, "source": "file", "audio_file": path}
+    recognizer = sr.Recognizer()
+    with sr.AudioFile(path) as source:
+        audio = recognizer.record(source)
+    try:
+        text = recognizer.recognize_whisper(audio)
+    except Exception:
+        try:
+            text = recognizer.recognize_google(audio)
+        except Exception:
+            text = None
+    emotions, features = detect_emotions_from_audio(path)
+    if text:
+        append_memory(
+            text,
+            tags=["voice", "input"],
+            source="file",
+            emotions=emotions,
+            emotion_features=features,
+        )
+    return {
+        "message": text,
+        "source": "file",
+        "audio_file": path,
+        "emotions": emotions,
+        "emotion_features": features,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ SpeechRecognition
 sounddevice
 pydub
 vosk
+librosa
+TTS
+numpy

--- a/tests/test_emotion_utils.py
+++ b/tests/test_emotion_utils.py
@@ -1,0 +1,26 @@
+import wave
+import math
+from pathlib import Path
+
+import emotion_utils as eu
+
+
+def create_wav(path: Path) -> None:
+    with wave.open(str(path), 'w') as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        frames = bytearray()
+        for i in range(16000):
+            val = int(10000 * math.sin(2 * math.pi * 440 * i / 16000))
+            frames += int(val).to_bytes(2, 'little', signed=True)
+        wf.writeframes(frames)
+
+
+def test_vad_and_features(tmp_path):
+    wav = tmp_path / "tone.wav"
+    create_wav(wav)
+    emotions, features = eu.vad_and_features(str(wav))
+    assert isinstance(emotions, dict)
+    assert isinstance(features, dict)
+    assert "rms" in features

--- a/tts_bridge.py
+++ b/tts_bridge.py
@@ -1,7 +1,14 @@
 import os
+import os
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict
+import threading
+
+try:
+    from TTS.api import TTS  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    TTS = None
 
 try:
     import pyttsx3
@@ -9,36 +16,96 @@ except Exception as e:  # pragma: no cover - dependency missing
     pyttsx3 = None
 
 from memory_manager import append_memory
+from emotions import empty_emotion_vector
 
 AUDIO_DIR = Path(os.getenv("AUDIO_LOG_DIR", "logs/audio"))
 AUDIO_DIR.mkdir(parents=True, exist_ok=True)
 
-if pyttsx3 is not None:  # pragma: no cover - avoid running in tests
+ENGINE_TYPE = os.getenv("TTS_ENGINE", "pyttsx3")
+if ENGINE_TYPE == "coqui" and TTS is not None:
+    COQUI_MODEL = os.getenv("TTS_COQUI_MODEL", "tts_models/en/vctk/vits")
+    ENGINE = TTS(model_name=COQUI_MODEL)
+    DEFAULT_VOICE = None
+    ALT_VOICE = None
+elif pyttsx3 is not None:
     ENGINE = pyttsx3.init()
+    VOICES = ENGINE.getProperty("voices")
+    DEFAULT_VOICE = VOICES[0].id if VOICES else None
+    ALT_VOICE = VOICES[1].id if len(VOICES) > 1 else DEFAULT_VOICE
 else:
     ENGINE = None
+    DEFAULT_VOICE = None
+    ALT_VOICE = None
 
 
-def speak(text: str, voice: Optional[str] = None, save_path: Optional[str] = None) -> Optional[str]:
+def speak(
+    text: str,
+    voice: Optional[str] = None,
+    save_path: Optional[str] = None,
+    emotions: Optional[Dict[str, float]] = None,
+) -> Optional[str]:
     """Synthesize text to speech and optionally save to a file."""
     if ENGINE is None:
-        print("[TTS] pyttsx3 not available")
+        print("[TTS] no TTS engine available")
         return None
-    if voice:
+    emotions = emotions or empty_emotion_vector()
+    chosen_voice = voice
+    if chosen_voice is None:
+        if emotions.get("Sadness", 0) > 0.6:
+            chosen_voice = ALT_VOICE
+        elif emotions.get("Anger", 0) > 0.6:
+            chosen_voice = DEFAULT_VOICE
+    if chosen_voice:
         try:
-            ENGINE.setProperty("voice", voice)
+            ENGINE.setProperty("voice", chosen_voice)
         except Exception:
-            print(f"[TTS] voice '{voice}' not found")
+            print(f"[TTS] voice '{chosen_voice}' not found")
+
+    rate = 150
+    if emotions.get("Anger", 0) > 0.6:
+        rate = 180
+    elif emotions.get("Sadness", 0) > 0.6:
+        rate = 120
+    elif emotions.get("Enthusiasm", 0) > 0.6:
+        rate = 170
+    if ENGINE_TYPE == "pyttsx3":
+        ENGINE.setProperty("rate", rate)
+
     if save_path is None:
         ts = time.strftime("%Y%m%d-%H%M%S")
         save_path = str(AUDIO_DIR / f"tts_{ts}.mp3")
 
-    ENGINE.save_to_file(text, save_path)
-    ENGINE.say(text)
-    ENGINE.runAndWait()
+    if ENGINE_TYPE == "coqui":
+        speed = rate / 150.0
+        kwargs = {"file_path": save_path, "speed": speed}
+        if voice:
+            kwargs["speaker_wav"] = voice
+        ENGINE.tts_to_file(text, **kwargs)
+    else:
+        ENGINE.save_to_file(text, save_path)
+        ENGINE.say(text)
+        ENGINE.runAndWait()
 
-    append_memory(text, tags=["voice", "output"], source="tts")
+    append_memory(text, tags=["voice", "output"], source="tts", emotions=emotions)
     return save_path
+
+
+def speak_async(
+    text: str,
+    voice: Optional[str] = None,
+    save_path: Optional[str] = None,
+    emotions: Optional[Dict[str, float]] = None,
+) -> threading.Thread:
+    """Speak in a background thread."""
+    t = threading.Thread(target=speak, args=(text,), kwargs={"voice": voice, "save_path": save_path, "emotions": emotions})
+    t.start()
+    return t
+
+
+def stop() -> None:
+    """Stop current speech playback if supported."""
+    if ENGINE_TYPE == "pyttsx3" and ENGINE is not None:
+        ENGINE.stop()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual utility

--- a/voice_loop.py
+++ b/voice_loop.py
@@ -2,7 +2,7 @@ import os
 import requests
 from emotions import empty_emotion_vector
 from mic_bridge import recognize_from_mic
-from tts_bridge import speak
+from tts_bridge import speak_async, stop
 
 RELAY_URL = os.getenv("RELAY_URL", "http://localhost:5000/relay")
 RELAY_SECRET = os.getenv("RELAY_SECRET", "test-secret")
@@ -14,12 +14,13 @@ def run_loop():  # pragma: no cover - runs indefinitely
     while True:
         result = recognize_from_mic()
         text = result.get("message")
+        emotions = result.get("emotions") or empty_emotion_vector()
         if not text:
             continue
         payload = {
             "message": text,
             "model": VOICE_MODEL,
-            "emotions": empty_emotion_vector(),
+            "emotions": emotions,
         }
         try:
             resp = requests.post(
@@ -33,7 +34,34 @@ def run_loop():  # pragma: no cover - runs indefinitely
             reply = " ".join(reply_chunks)
         except Exception as e:
             reply = f"Error contacting relay: {e}"
-        speak(reply)
+
+        t = speak_async(reply, emotions=emotions)
+        while t.is_alive():
+            intr = recognize_from_mic(save_audio=False)
+            if intr.get("message"):
+                stop()
+                t.join()
+                text = intr["message"]
+                emotions = intr.get("emotions") or empty_emotion_vector()
+                payload = {
+                    "message": text,
+                    "model": VOICE_MODEL,
+                    "emotions": emotions,
+                }
+                try:
+                    resp = requests.post(
+                        RELAY_URL,
+                        json=payload,
+                        headers={"X-Relay-Secret": RELAY_SECRET},
+                        timeout=180,
+                    )
+                    resp.raise_for_status()
+                    reply_chunks = resp.json().get("reply_chunks", [])
+                    reply = " ".join(reply_chunks)
+                except Exception as e:
+                    reply = f"Error contacting relay: {e}"
+                t = speak_async(reply, emotions=emotions)
+        t.join()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual utility


### PR DESCRIPTION
## Summary
- implement `emotion_utils` with optional spectral analysis
- store emotion feature data in `memory_manager.append_memory`
- update `mic_bridge` to analyze audio files and include emotion features
- add pluggable Coqui TTS with async playback and stop control
- support interruption handling in `voice_loop`
- document new environment variables and usage in README
- add unit test for emotion utilities

## Testing
- `pytest -q`