### PR TITLE
Enhance actuator with async queue and CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ python memory_cli.py purge --max 1000     # keep only the most recent 1000 fragm
 python memory_cli.py summarize            # build/update daily summaries
 python memory_cli.py playback --last 5    # show recent fragments with emotion labels and sources
 python memory_cli.py timeline             # view the emotion timeline/mood trend
+python memory_cli.py actions --last 5     # show recent actuator events
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI
@@ -128,7 +129,12 @@ python api/actuator.py email --to user@example.com --subject hi --body "hello"
 python api/actuator.py webhook --url http://hook --payload '{"ping":1}'
 python api/actuator.py template --name greet --params '{"name":"Ada"}'
 python api/actuator.py logs --last 5
+python api/actuator.py templates           # list template names
 ```
+
+The `/act` endpoint can run actions asynchronously when `{"async": true}` is
+sent. Poll `/act/status/<id>` or connect to `/act/stream/<id>` for live status
+updates.
 
 Log tailing
 Use memory_tail.py to stream new entries from logs/memory.jsonl:

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 from pathlib import Path
 import memory_manager as mm
+from api import actuator
 
 def show_timeline(last: int) -> None:
     """Print the timestamp and dominant emotion of recent entries."""
@@ -42,6 +43,16 @@ def playback(last: int) -> None:
         else:
             print(f"[{data.get('timestamp','?')}] {label}:{val:.2f} -> {txt}")
 
+
+def show_actions(last: int) -> None:
+    """Display recent actuator events with context."""
+    logs = actuator.recent_logs(last)
+    for entry in logs:
+        intent = entry.get("intent", {})
+        result = entry.get("result", entry.get("error"))
+        desc = json.dumps(intent)
+        print(f"{entry.get('timestamp','?')} {entry.get('status')} {desc} -> {result}")
+
 def main():
     parser = argparse.ArgumentParser(description="Manage memory fragments")
     sub = parser.add_subparsers(dest="cmd")
@@ -56,6 +67,8 @@ def main():
     plot.add_argument("--last", type=int, default=10, help="Show last N entries")
     pb = sub.add_parser("playback", help="Print recent fragments with emotions")
     pb.add_argument("--last", type=int, default=5, help="Show last N entries")
+    acts = sub.add_parser("actions", help="Show recent actuator events")
+    acts.add_argument("--last", type=int, default=10, help="Show last N events")
     forget = sub.add_parser("forget", help="Remove keys from user profile")
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
@@ -75,6 +88,8 @@ def main():
         show_timeline(args.last)
     elif args.cmd == "playback":
         playback(args.last)
+    elif args.cmd == "actions":
+        show_actions(args.last)
     else:
         parser.print_help()
 

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -143,3 +143,19 @@ def test_recent_logs_cli(tmp_path, monkeypatch, capsys):
     actuator.main()
     out = capsys.readouterr().out
     assert "hi" in out
+
+
+def test_template_prompting(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload as _reload
+    import memory_manager as mm
+    _reload(mm)
+    _reload(actuator)
+    actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
+    actuator.TEMPLATES = {"note": {"type": "shell", "cmd": "echo {text}"}}
+
+    monkeypatch.setattr(sys, "argv", ["ac", "template", "--name", "note"])
+    monkeypatch.setattr("builtins.input", lambda prompt: "test note")
+    actuator.main()
+    out = capsys.readouterr().out
+    assert "log_id" in out

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -38,3 +38,19 @@ def test_cli_playback(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert 'hello' in out
     assert 'Joy' in out
+
+
+def test_cli_actions(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import memory_manager as mm
+    from api import actuator
+    reload(mm)
+    reload(memory_cli)
+    actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
+    actuator.act({"type": "shell", "cmd": "echo hi"})
+    monkeypatch.setattr(sys, 'argv', ['mc', 'actions', '--last', '1'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'echo hi' in out


### PR DESCRIPTION
## Summary
- add async execution queue and status helpers in actuator
- expose queued actions via new `/act_status` and `/act_stream` endpoints
- support template listing and prompting via actuator CLI
- show recent actuator actions via `memory_cli actions`
- update tests for new features
- document new commands and endpoints

## Testing
- `pytest -q`