### PR TITLE
Add actuator reflection, dry run, rate limit and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ python memory_cli.py summarize            # build/update daily summaries
 python memory_cli.py playback --last 5    # show recent fragments with emotion labels and sources
 python memory_cli.py timeline             # view the emotion timeline/mood trend
 python memory_cli.py actions --last 5     # show recent actuator events
+python memory_cli.py actions --last 5 --reflect  # include reflections
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI
@@ -130,6 +131,9 @@ python api/actuator.py webhook --url http://hook --payload '{"ping":1}'
 python api/actuator.py template --name greet --params '{"name":"Ada"}'
 python api/actuator.py logs --last 5
 python api/actuator.py templates           # list template names
+python api/actuator.py hello --name Bob    # example plugin actuator
+python api/actuator.py template_help --name greet  # show parameter help
+python api/actuator.py shell "ls" --dry    # simulate without side effects
 ```
 
 The `/act` endpoint can run actions asynchronously when `{"async": true}` is

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -44,14 +44,17 @@ def playback(last: int) -> None:
             print(f"[{data.get('timestamp','?')}] {label}:{val:.2f} -> {txt}")
 
 
-def show_actions(last: int) -> None:
+def show_actions(last: int, reflect: bool) -> None:
     """Display recent actuator events with context."""
-    logs = actuator.recent_logs(last)
+    logs = actuator.recent_logs(last, reflect=reflect)
     for entry in logs:
         intent = entry.get("intent", {})
         result = entry.get("result", entry.get("error"))
         desc = json.dumps(intent)
-        print(f"{entry.get('timestamp','?')} {entry.get('status')} {desc} -> {result}")
+        line = f"{entry.get('timestamp','?')} {entry.get('status')} {desc} -> {result}"
+        if reflect and entry.get("reflection_text"):
+            line += f" | {entry['reflection_text']}"
+        print(line)
 
 def main():
     parser = argparse.ArgumentParser(description="Manage memory fragments")
@@ -69,6 +72,7 @@ def main():
     pb.add_argument("--last", type=int, default=5, help="Show last N entries")
     acts = sub.add_parser("actions", help="Show recent actuator events")
     acts.add_argument("--last", type=int, default=10, help="Show last N events")
+    acts.add_argument("--reflect", action="store_true", help="Include reflections")
     forget = sub.add_parser("forget", help="Remove keys from user profile")
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
@@ -89,7 +93,7 @@ def main():
     elif args.cmd == "playback":
         playback(args.last)
     elif args.cmd == "actions":
-        show_actions(args.last)
+        show_actions(args.last, reflect=args.reflect)
     else:
         parser.print_help()
 

--- a/plugins/hello.py
+++ b/plugins/hello.py
@@ -1,0 +1,8 @@
+from api.actuator import BaseActuator
+
+def register(reg):
+    class HelloActuator(BaseActuator):
+        def execute(self, intent):
+            name = intent.get('name', 'world')
+            return {'hello': name}
+    reg('hello', HelloActuator())

--- a/prompt_assembler.py
+++ b/prompt_assembler.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import context_window as cw
+from api import actuator
 
 import memory_manager as mm
 import user_profile as up
@@ -15,6 +16,7 @@ def assemble_prompt(user_input: str, recent_messages: List[str] | None = None, k
     memories = mm.get_context(user_input, k=k)
     emotion_ctx = em.average_emotion()
     msgs, summary = cw.get_context()
+    reflections = [r.get("reflection_text", r.get("text")) for r in actuator.recent_logs(3, reflect=True)]
 
     sections = [f"SYSTEM:\n{SYSTEM_PROMPT}"]
     if profile:
@@ -29,6 +31,9 @@ def assemble_prompt(user_input: str, recent_messages: List[str] | None = None, k
     if recent_messages:
         ctx = "\n".join(recent_messages)
         sections.append(f"RECENT DIALOGUE:\n{ctx}")
+    if reflections:
+        rtxt = "\n".join(f"- {r}" for r in reflections if r)
+        sections.append(f"RECENT ACTION FEEDBACK:\n{rtxt}")
     if summary:
         sections.append(f"SUMMARY:\n{summary}")
     sections.append(f"USER:\n{user_input}")

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -49,8 +49,8 @@ def test_cli_actions(tmp_path, monkeypatch, capsys):
     reload(mm)
     reload(memory_cli)
     actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
-    actuator.act({"type": "shell", "cmd": "echo hi"})
-    monkeypatch.setattr(sys, 'argv', ['mc', 'actions', '--last', '1'])
+    res = actuator.act({"type": "shell", "cmd": "echo hi"})
+    monkeypatch.setattr(sys, 'argv', ['mc', 'actions', '--last', '1', '--reflect'])
     memory_cli.main()
     out = capsys.readouterr().out
-    assert 'echo hi' in out
+    assert 'echo hi' in out and res['reflection'] in out

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -22,3 +22,16 @@ def test_assemble_prompt_includes_profile_and_memory(tmp_path, monkeypatch):
     prompt = pa.assemble_prompt("cats", [])
     assert "Allen likes cats" in prompt
     assert "name: Allen" in prompt
+
+
+def test_prompt_includes_reflection(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    reload(up)
+    reload(mm)
+    reload(pa)
+    from api import actuator
+    actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
+    actuator.act({"type": "shell", "cmd": "echo hi"})
+    prompt = pa.assemble_prompt("hi", [])
+    assert "ACTION FEEDBACK" in prompt


### PR DESCRIPTION
## Summary
- add reflection logging and rate limiting to the actuator
- support dry-run, template help and template search in CLI
- expose action reflections through memory_cli and prompt assembler
- provide pluggable actuator registry with hello-world plugin
- add tests for reflections, rate limiting, dry runs, plugins and prompt context

## Testing
- `pytest -q`