### PR TITLE
Add reflection storage and plugin reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ python api/actuator.py template_help --name greet  # show parameter help
 python api/actuator.py shell "ls" --dry    # simulate without side effects
 ```
 
+### Reflections and Critique
+Each action logged by the actuator generates a structured *reflection* entry. A
+reflection links back to the original action log via the `parent` field and
+stores the action intent, result (when available), the reason for attempting the
+action, and an optional proposed next step. When an action fails the actuator
+automatically generates a short critique which is stored in the reflection and
+returned to the caller.
+
+List reflections via the CLI:
+
+```bash
+python memory_cli.py reflections --last 3
+python memory_cli.py reflections --failures --json  # show recent failures with critique
+```
+
+### Plugin discovery and reload
+Actuator plugins placed in the `plugins/` directory are automatically loaded at
+startup. Use the CLI to inspect or reload them at runtime:
+
+```bash
+python api/actuator.py plugins          # list plugin names and docs
+python api/actuator.py plugins --reload # reload from disk without restart
+```
+
 The `/act` endpoint can run actions asynchronously when `{"async": true}` is
 sent. Poll `/act/status/<id>` or connect to `/act/stream/<id>` for live status
 updates.

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -56,6 +56,17 @@ def show_actions(last: int, reflect: bool) -> None:
             line += f" | {entry['reflection_text']}"
         print(line)
 
+
+def show_reflections(last: int, plugin: str | None, user: str | None, failures: bool, as_json: bool) -> None:
+    """Display recent reflection entries."""
+    refls = mm.recent_reflections(limit=last, plugin=plugin, user=user, failures_only=failures)
+    if as_json:
+        print(json.dumps(refls, indent=2))
+        return
+    for r in refls:
+        line = f"{r.get('timestamp','?')} {r.get('plugin')} {r.get('reason','') or r.get('next','')}"
+        print(line)
+
 def main():
     parser = argparse.ArgumentParser(description="Manage memory fragments")
     sub = parser.add_subparsers(dest="cmd")
@@ -73,6 +84,12 @@ def main():
     acts = sub.add_parser("actions", help="Show recent actuator events")
     acts.add_argument("--last", type=int, default=10, help="Show last N events")
     acts.add_argument("--reflect", action="store_true", help="Include reflections")
+    refl = sub.add_parser("reflections", help="List recent reflections")
+    refl.add_argument("--last", type=int, default=5)
+    refl.add_argument("--plugin")
+    refl.add_argument("--user")
+    refl.add_argument("--failures", action="store_true", help="Only failed actions")
+    refl.add_argument("--json", action="store_true", help="Export as JSON")
     forget = sub.add_parser("forget", help="Remove keys from user profile")
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
@@ -94,6 +111,8 @@ def main():
         playback(args.last)
     elif args.cmd == "actions":
         show_actions(args.last, reflect=args.reflect)
+    elif args.cmd == "reflections":
+        show_reflections(args.last, args.plugin, args.user, args.failures, args.json)
     else:
         parser.print_help()
 

--- a/plugins/hello.py
+++ b/plugins/hello.py
@@ -1,3 +1,9 @@
+"""Demo plugin that exposes a simple ``hello`` actuator.
+
+The actuator just returns a greeting with the provided name.  This file is
+used in the test-suite to demonstrate plugin discovery.
+"""
+
 from api.actuator import BaseActuator
 
 def register(reg):

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -48,9 +48,27 @@ def test_cli_actions(tmp_path, monkeypatch, capsys):
     from api import actuator
     reload(mm)
     reload(memory_cli)
+    reload(actuator)
     actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
     res = actuator.act({"type": "shell", "cmd": "echo hi"})
     monkeypatch.setattr(sys, 'argv', ['mc', 'actions', '--last', '1', '--reflect'])
     memory_cli.main()
     out = capsys.readouterr().out
     assert 'echo hi' in out and res['reflection'] in out
+
+
+def test_cli_reflections(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import memory_manager as mm
+    from api import actuator
+    reload(mm)
+    reload(memory_cli)
+    reload(actuator)
+    actuator.WHITELIST = {'shell': ['echo'], 'http': [], 'timeout': 5}
+    actuator.act({'type': 'shell', 'cmd': 'echo hi'}, explanation='demo')
+    monkeypatch.setattr(sys, 'argv', ['mc', 'reflections', '--last', '1'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'demo' in out


### PR DESCRIPTION
## Summary
- capture reflections as structured memory objects
- generate simple critiques on failed actions
- expose plugin listing and reload via CLI
- add reflection export to memory_cli
- document reflection and plugin workflow in README
- test structured reflections, critique path, CLI reflection output and plugin reload

## Testing
- `pytest -q`