### PR TITLE
Add autonomous micro-agent loop and critique escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ memory_tail.py – Colorized log viewer for logs/memory.jsonl.
 
 heartbeat.py – Simple client that periodically sends heartbeat pings to the relay.
 
+autonomous_reflector.py – Background micro-agent that cycles through plan–act–reflect loops. It executes open goals via the actuator, stores critiques, and escalates repeated failures.
+
 cathedral_hog_wild_heartbeat.py – Demo that periodically summons multiple models via the relay.
 
 mic_bridge.py – Captures microphone audio, converts speech to text, and infers emotions using a configurable detector (heuristic or neural). Supports fusion with vision input (image file) for multimodal emotion vectors.
@@ -119,6 +121,7 @@ python memory_cli.py playback --last 5    # show recent fragments with emotion l
 python memory_cli.py timeline             # view the emotion timeline/mood trend
 python memory_cli.py actions --last 5     # show recent actuator events
 python memory_cli.py actions --last 5 --reflect  # include reflections
+python memory_cli.py goals --status open  # list open goals
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI

--- a/autonomous_reflector.py
+++ b/autonomous_reflector.py
@@ -1,0 +1,50 @@
+import time
+from api import actuator
+import memory_manager as mm
+
+INTERVAL = 60
+
+
+def _plan() -> dict | None:
+    goals = mm.get_goals(open_only=False)
+    for g in goals:
+        if g.get("status") not in {"completed", "stuck"}:
+            return g
+    return None
+
+
+def _act(goal: dict) -> dict:
+    step = goal.get("critique_step", 0)
+    intent = goal.get("intent", {})
+    return actuator.act(intent, explanation=goal.get("text", ""), critique_step=step)
+
+
+def _reflect(goal: dict, result: dict) -> None:
+    goal["last_result"] = result
+    if result.get("status") == "finished":
+        goal["status"] = "completed"
+    else:
+        goal["status"] = "failed"
+        goal["failure_count"] = goal.get("failure_count", 0) + 1
+        goal["critique_step"] = result.get("critique_step", goal.get("critique_step", 0))
+        goal["critique"] = result.get("critique")
+        if goal["failure_count"] >= 3:
+            goal["status"] = "stuck"
+    mm.save_goal(goal)
+
+
+def run_loop(interval: float = INTERVAL, iterations: int | None = None) -> None:
+    actuator.reload_plugins()
+    count = 0
+    while iterations is None or count < iterations:
+        goal = _plan()
+        if goal:
+            res = _act(goal)
+            _reflect(goal, res)
+        if iterations is not None:
+            count += 1
+        time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    run_loop()

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -67,6 +67,19 @@ def show_reflections(last: int, plugin: str | None, user: str | None, failures: 
         line = f"{r.get('timestamp','?')} {r.get('plugin')} {r.get('reason','') or r.get('next','')}"
         print(line)
 
+
+def show_goals(status: str) -> None:
+    goals = mm.get_goals(open_only=False)
+    for g in goals:
+        if status != "all" and g.get("status") != status:
+            continue
+        line = f"{g.get('status')} {g.get('text','')}"
+        if g.get('failure_count'):
+            line += f" ({g['failure_count']})"
+        if g.get('critique'):
+            line += f" | {g['critique']}"
+        print(line)
+
 def main():
     parser = argparse.ArgumentParser(description="Manage memory fragments")
     sub = parser.add_subparsers(dest="cmd")
@@ -90,6 +103,14 @@ def main():
     refl.add_argument("--user")
     refl.add_argument("--failures", action="store_true", help="Only failed actions")
     refl.add_argument("--json", action="store_true", help="Export as JSON")
+
+    goals = sub.add_parser("goals", help="List goals")
+    goals.add_argument(
+        "--status",
+        default="open",
+        choices=["open", "failed", "completed", "stuck", "all"],
+        help="Filter by status",
+    )
     forget = sub.add_parser("forget", help="Remove keys from user profile")
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
@@ -113,6 +134,8 @@ def main():
         show_actions(args.last, reflect=args.reflect)
     elif args.cmd == "reflections":
         show_reflections(args.last, args.plugin, args.user, args.failures, args.json)
+    elif args.cmd == "goals":
+        show_goals(args.status)
     else:
         parser.print_help()
 

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -72,3 +72,16 @@ def test_cli_reflections(tmp_path, monkeypatch, capsys):
     memory_cli.main()
     out = capsys.readouterr().out
     assert 'demo' in out
+
+def test_cli_goals(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import memory_manager as mm
+    reload(mm)
+    reload(memory_cli)
+    mm.add_goal('demo', intent={'type': 'hello', 'name': 'Ada'})
+    monkeypatch.setattr(sys, 'argv', ['mc', 'goals', '--status', 'open'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'demo' in out

--- a/tests/test_micro_agent.py
+++ b/tests/test_micro_agent.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import autonomous_reflector as ar
+import memory_manager as mm
+from api import actuator
+from importlib import reload
+
+
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    monkeypatch.setenv("ACT_PLUGINS_DIR", "plugins")
+    reload(mm)
+    reload(actuator)
+    reload(ar)
+
+
+def test_micro_agent_completes_goal(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    mm.add_goal("say hi", intent={"type": "hello", "name": "Ada"})
+    ar.run_loop(interval=0.01, iterations=1)
+    goals = mm.get_goals(open_only=False)
+    assert goals and goals[0]["status"] == "completed"
+    refl = mm.recent_reflections(limit=1)
+    assert refl
+
+
+def test_micro_agent_escalation(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    actuator.WHITELIST = {"shell": ["echo"], "http": [], "timeout": 5}
+    mm.add_goal("fail", intent={"type": "shell", "cmd": "rm"})
+    ar.run_loop(interval=0.01, iterations=3)
+    goal = mm.get_goals(open_only=False)[0]
+    assert goal["status"] == "stuck"
+    assert goal.get("failure_count", 0) >= 3


### PR DESCRIPTION
## Summary
- create `autonomous_reflector.py` implementing a micro-agent plan-act-reflect loop
- add goal management helpers to `memory_manager.py`
- extend `api/actuator.py` with critique step escalation
- expose goals via `memory_cli.py`
- document new tool and CLI
- test micro-agent loop and goals CLI

## Testing
- `pytest -q`