### PR TITLE
Add multi-goal planner with escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ memory_tail.py – Colorized log viewer for logs/memory.jsonl.
 
 heartbeat.py – Simple client that periodically sends heartbeat pings to the relay.
 
-autonomous_reflector.py – Background micro-agent that cycles through plan–act–reflect loops. It executes open goals via the actuator, stores critiques, and escalates repeated failures.
+autonomous_reflector.py – Background micro-agent that cycles through plan–act–reflect loops. It now manages multiple goals in parallel with prioritization and scheduling. Reflections generate self-improvement notes and failed goals trigger escalation plugins.
 
 cathedral_hog_wild_heartbeat.py – Demo that periodically summons multiple models via the relay.
 
@@ -122,6 +122,10 @@ python memory_cli.py timeline             # view the emotion timeline/mood trend
 python memory_cli.py actions --last 5     # show recent actuator events
 python memory_cli.py actions --last 5 --reflect  # include reflections
 python memory_cli.py goals --status open  # list open goals
+python memory_cli.py add_goal "check disk" --intent '{"type":"shell","cmd":"df"}'
+python memory_cli.py complete_goal <id>
+python memory_cli.py delete_goal <id>
+python memory_cli.py run --cycles 3  # run agent cycles
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI
@@ -166,6 +170,8 @@ python api/actuator.py plugins --reload # reload from disk without restart
 The `/act` endpoint can run actions asynchronously when `{"async": true}` is
 sent. Poll `/act/status/<id>` or connect to `/act/stream/<id>` for live status
 updates.
+Additional endpoints support goal management and manual agent runs:
+`/goals/add`, `/goals/list`, `/goals/complete`, `/goals/delete`, and `/agent/run`.
 
 Log tailing
 Use memory_tail.py to stream new entries from logs/memory.jsonl:

--- a/autonomous_reflector.py
+++ b/autonomous_reflector.py
@@ -6,17 +6,23 @@ INTERVAL = 60
 
 
 def _plan() -> dict | None:
-    goals = mm.get_goals(open_only=False)
-    for g in goals:
-        if g.get("status") not in {"completed", "stuck"}:
-            return g
-    return None
+    """Select the next goal to work on."""
+    return mm.next_goal()
 
 
 def _act(goal: dict) -> dict:
     step = goal.get("critique_step", 0)
     intent = goal.get("intent", {})
     return actuator.act(intent, explanation=goal.get("text", ""), critique_step=step)
+
+
+def _self_patch(goal: dict, result: dict) -> None:
+    """Log a brief self-improvement note based on the outcome."""
+    if result.get("status") == "finished":
+        note = f"Goal {goal['id']} succeeded"
+    else:
+        note = f"Goal {goal['id']} failed {goal.get('failure_count',0)} times"
+    mm.append_memory(note, tags=["self_patch"], source="agent")
 
 
 def _reflect(goal: dict, result: dict) -> None:
@@ -30,10 +36,13 @@ def _reflect(goal: dict, result: dict) -> None:
         goal["critique"] = result.get("critique")
         if goal["failure_count"] >= 3:
             goal["status"] = "stuck"
+            actuator.act({"type": "escalate", "goal": goal["id"], "text": goal.get("text", "")})
     mm.save_goal(goal)
+    _self_patch(goal, result)
 
 
 def run_loop(interval: float = INTERVAL, iterations: int | None = None) -> None:
+    """Run the autonomous cycle for ``iterations`` steps."""
     actuator.reload_plugins()
     count = 0
     while iterations is None or count < iterations:
@@ -46,5 +55,20 @@ def run_loop(interval: float = INTERVAL, iterations: int | None = None) -> None:
         time.sleep(interval)
 
 
+def run_once() -> None:
+    """Execute a single planning cycle."""
+    run_loop(iterations=1)
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI
-    run_loop()
+    import argparse
+
+    p = argparse.ArgumentParser(description="Run autonomous agent")
+    p.add_argument("--once", action="store_true", help="Run a single cycle")
+    p.add_argument("--cycles", type=int, help="Number of cycles to run")
+    args = p.parse_args()
+
+    if args.once:
+        run_once()
+    else:
+        run_loop(iterations=args.cycles)

--- a/plugins/escalate.py
+++ b/plugins/escalate.py
@@ -1,0 +1,11 @@
+"""Plugin that logs escalation events."""
+from api.actuator import BaseActuator
+import memory_manager as mm
+
+def register(reg):
+    class EscalateActuator(BaseActuator):
+        def execute(self, intent):
+            text = f"Escalation for {intent.get('goal')}: {intent.get('text','')}"
+            mm.append_memory(text, tags=["escalation"], source="escalate")
+            return {"escalated": intent.get('goal')}
+    reg('escalate', EscalateActuator())

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -85,3 +85,17 @@ def test_cli_goals(tmp_path, monkeypatch, capsys):
     memory_cli.main()
     out = capsys.readouterr().out
     assert 'demo' in out
+
+
+def test_cli_add_goal(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import memory_manager as mm
+    reload(mm)
+    reload(memory_cli)
+    monkeypatch.setattr(sys, 'argv', ['mc', 'add_goal', 'demo', '--intent', '{"type":"hello","name":"Ada"}'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    goals = mm.get_goals(open_only=False)
+    assert goals and goals[0]['text'] == 'demo'

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -59,3 +59,18 @@ def test_act_async_status(tmp_path, monkeypatch):
             break
         time.sleep(0.1)
     assert status.get("status") == "finished"
+
+
+def test_goal_api(tmp_path, monkeypatch):
+    client = setup_app(tmp_path, monkeypatch)
+    resp = client.post(
+        "/goals/add",
+        json={"text": "demo", "intent": {"type": "hello", "name": "Ada"}},
+        headers={"X-Relay-Secret": "secret123"},
+    )
+    goal = resp.get_json()
+    assert goal.get("text") == "demo"
+    gid = goal["id"]
+    client.post("/agent/run", json={"cycles": 1}, headers={"X-Relay-Secret": "secret123"})
+    resp = client.post("/goals/complete", json={"id": gid}, headers={"X-Relay-Secret": "secret123"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- support multiple prioritized goals with scheduling
- log self-patches for improvement
- escalate stuck goals via new plugin
- expose goal management routes in relay app
- extend CLI for goal management and running the agent
- update tests for new features

## Testing
- `pytest -q`