### PR TITLE
Add notification history and orchestrator controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ python memory_cli.py add_goal "check disk" --intent '{"type":"shell","cmd":"df"}
 python memory_cli.py complete_goal <id>
 python memory_cli.py delete_goal <id>
 python memory_cli.py run --cycles 3  # run agent cycles
+python memory_cli.py events --last 5        # list notification events
+python memory_cli.py orchestrator start --cycles 10
+python memory_cli.py approve_patch <id>
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI
@@ -170,7 +173,8 @@ python api/actuator.py plugins --reload # reload from disk without restart
 The `/act` endpoint can run actions asynchronously when `{"async": true}` is
 sent. Poll `/act/status/<id>` or connect to `/act/stream/<id>` for live status
 updates.
-The orchestrator module can schedule agent cycles and ensures state persistence between runs. Use memory_cli schedule to invoke it. Notifications support email, webhook, or console output; subscribe via memory_cli subscribe.
+The orchestrator module can schedule agent cycles and ensures state persistence between runs. Use `memory_cli orchestrator start` to launch it or `schedule` for one-shot cycles. Notifications support email, webhook, or console output; manage subscriptions via `memory_cli subscribe` and `unsubscribe`.
+All notification events are logged to `events.jsonl` and can be viewed with `memory_cli events`.
 Additional endpoints support goal management and manual agent runs:
 `/goals/add`, `/goals/list`, `/goals/complete`, `/goals/delete`, and `/agent/run`.
 

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -361,6 +361,8 @@ def add_goal(
     goals = _load_goals()
     goals.append(goal)
     _save_goals(goals)
+    from notification import send as notify  # local import to avoid cycle
+    notify("goal_created", {"id": goal_id, "text": text})
     return goal
 
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -34,6 +34,34 @@ class Orchestrator:
         _save_state(self.state)
 
     def run_forever(self) -> None:
-        while True:
+        self.state["running"] = True
+        _save_state(self.state)
+        iterations = 0
+        cycles = self.state.get("cycles")
+        while self.state.get("running"):
             self.run_cycle()
+            iterations += 1
+            if cycles is not None and iterations >= cycles:
+                break
             time.sleep(self.interval)
+            self.state = _load_state()
+        self.state["running"] = False
+        _save_state(self.state)
+
+    # New public helpers
+    def start(self, cycles: int | None = None) -> None:
+        self.state["cycles"] = cycles
+        self.state["running"] = True
+        _save_state(self.state)
+        self.run_forever()
+
+    def stop(self) -> None:
+        self.state["running"] = False
+        _save_state(self.state)
+
+    def status(self) -> dict:
+        self.state = _load_state()
+        return {
+            "running": self.state.get("running", False),
+            "last_run": self.state.get("last_run"),
+        }

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -99,3 +99,21 @@ def test_cli_add_goal(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     goals = mm.get_goals(open_only=False)
     assert goals and goals[0]['text'] == 'demo'
+
+
+def test_cli_events_and_orchestrator(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import notification
+    reload(notification)
+    reload(memory_cli)
+    notification.send('goal_created', {'id': 'g'})
+    monkeypatch.setattr(sys, 'argv', ['mc', 'events', '--last', '1'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'goal_created' in out
+    monkeypatch.setattr(sys, 'argv', ['mc', 'orchestrator', 'status'])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'running' in out

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -28,3 +28,10 @@ def test_email_notification(tmp_path, monkeypatch):
     notification.add_subscription("self_patch", "email", "a@b.com")
     notification.send("self_patch", {"note": "hi"})
     assert calls.get("to") == "a@b.com"
+
+
+def test_event_history(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    notification.send("goal_created", {"id": "g1"})
+    events = notification.list_events(1)
+    assert events and events[0]["event"] == "goal_created"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import orchestrator
 import autonomous_reflector as ar
+import time
 
 
 def test_orchestrator_runs(tmp_path, monkeypatch):
@@ -16,3 +17,18 @@ def test_orchestrator_runs(tmp_path, monkeypatch):
     o.run_cycle()
     assert called
     assert orchestrator.STATE_PATH.exists()
+
+
+def test_orchestrator_start_stop(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    reload(orchestrator)
+    calls = []
+    monkeypatch.setattr(ar, "run_once", lambda: calls.append(True))
+    o = orchestrator.Orchestrator(interval=0.01)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    o.start(cycles=2)
+    assert len(calls) == 2
+    o.stop()
+    status = o.status()
+    assert status["running"] is False

--- a/tests/test_self_patcher.py
+++ b/tests/test_self_patcher.py
@@ -18,3 +18,7 @@ def test_apply_and_rollback(tmp_path, monkeypatch):
     for patch in patches:
         if patch["id"] == p["id"]:
             assert patch["rolled_back"]
+
+    assert self_patcher.approve_patch(p["id"])
+    patches = self_patcher.list_patches()
+    assert any(x["id"] == p["id"] and x.get("approved") for x in patches)


### PR DESCRIPTION
## Summary
- extend notification system with event logging and listing
- emit goal creation notifications
- enhance self patching with approval workflow and events
- control orchestrator via CLI with start/stop/status
- expose new CLI commands for events and patch management
- document orchestrator usage and event logs
- test new functionality

## Testing
- `pytest -q`