### PR TITLE
Improve patch documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,11 @@ python memory_cli.py delete_goal <id>
 python memory_cli.py run --cycles 3  # run agent cycles
 python memory_cli.py events --last 5        # list notification events
 python memory_cli.py orchestrator start --cycles 10
+python memory_cli.py patches                 # list patch proposals
+python memory_cli.py apply_patch "fix bug"     # record a manual patch note
 python memory_cli.py approve_patch <id>
+python memory_cli.py reject_patch <id>
+python memory_cli.py rollback_patch <id>
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
 
 Actuator CLI

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -117,3 +117,23 @@ def test_cli_events_and_orchestrator(tmp_path, monkeypatch, capsys):
     memory_cli.main()
     out = capsys.readouterr().out
     assert 'running' in out
+
+
+def test_cli_reject_patch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import self_patcher
+    import notification
+    reload(notification)
+    reload(self_patcher)
+    reload(memory_cli)
+    p = self_patcher.apply_patch('note', auto=False)
+    monkeypatch.setattr(sys, 'argv', ['mc', 'reject_patch', p['id']])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'Rejected' in out
+    patches = self_patcher.list_patches()
+    assert any(x['id'] == p['id'] and x.get('rejected') for x in patches)
+    events = notification.list_events(2)
+    assert any(e['event'] == 'patch_rejected' for e in events)

--- a/tests/test_self_patcher.py
+++ b/tests/test_self_patcher.py
@@ -22,3 +22,17 @@ def test_apply_and_rollback(tmp_path, monkeypatch):
     assert self_patcher.approve_patch(p["id"])
     patches = self_patcher.list_patches()
     assert any(x["id"] == p["id"] and x.get("approved") for x in patches)
+
+
+def test_reject_patch(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    import notification
+    reload(notification)
+    reload(self_patcher)
+    p = self_patcher.apply_patch("note", auto=False)
+    assert self_patcher.reject_patch(p["id"])
+    patches = self_patcher.list_patches()
+    assert any(x["id"] == p["id"] and x.get("rejected") for x in patches)
+    events = notification.list_events(2)
+    assert any(e["event"] == "patch_rejected" for e in events)


### PR DESCRIPTION
## Summary
- document patch listing, applying, approval, rejection, and rollback commands in the README
- add unit test for `reject_patch`
- cover `reject_patch` via CLI in memory_cli tests

## Testing
- `pytest -q`