### PR TITLE
Finalize patch management logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ python memory_cli.py approve_patch <id>
 python memory_cli.py reject_patch <id>
 python memory_cli.py rollback_patch <id>
 These commands can be invoked manually or scheduled via cron/Task Scheduler.
+### Patch management
+Patches are stored in `patches.json` inside `MEMORY_DIR`. Use the CLI to manage them and review events:
+```bash
+python memory_cli.py patches             # list patch proposals
+python memory_cli.py apply_patch "fix bug"  # record a manual patch note
+python memory_cli.py approve_patch <id>     # mark patch approved
+python memory_cli.py reject_patch <id>      # mark patch rejected
+python memory_cli.py rollback_patch <id>    # mark patch rolled back
+python memory_cli.py events --last 5        # view patch events
+```
+
 
 Actuator CLI
 ```bash

--- a/self_patcher.py
+++ b/self_patcher.py
@@ -51,6 +51,7 @@ def rollback_patch(pid: str) -> bool:
             p["rolled_back"] = True
             _save(patches)
             mm.append_memory(f"Patch {pid} rolled back", tags=["self_patch"], source="rollback")
+            notify("patch_rolled_back", {"id": pid})
             return True
     return False
 

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -137,3 +137,43 @@ def test_cli_reject_patch(tmp_path, monkeypatch, capsys):
     assert any(x['id'] == p['id'] and x.get('rejected') for x in patches)
     events = notification.list_events(2)
     assert any(e['event'] == 'patch_rejected' for e in events)
+
+
+def test_cli_approve_patch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import self_patcher
+    import notification
+    reload(notification)
+    reload(self_patcher)
+    reload(memory_cli)
+    p = self_patcher.apply_patch('note', auto=False)
+    monkeypatch.setattr(sys, 'argv', ['mc', 'approve_patch', p['id']])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'Approved' in out
+    patches = self_patcher.list_patches()
+    assert any(x['id'] == p['id'] and x.get('approved') for x in patches)
+    events = notification.list_events(2)
+    assert any(e['event'] == 'patch_approved' for e in events)
+
+
+def test_cli_rollback_patch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('MEMORY_DIR', str(tmp_path))
+    from importlib import reload
+    import memory_cli
+    import self_patcher
+    import notification
+    reload(notification)
+    reload(self_patcher)
+    reload(memory_cli)
+    p = self_patcher.apply_patch('note', auto=False)
+    monkeypatch.setattr(sys, 'argv', ['mc', 'rollback_patch', p['id']])
+    memory_cli.main()
+    out = capsys.readouterr().out
+    assert 'Rolled back' in out
+    patches = self_patcher.list_patches()
+    assert any(x['id'] == p['id'] and x.get('rolled_back') for x in patches)
+    events = notification.list_events(2)
+    assert any(e['event'] == 'patch_rolled_back' for e in events)

--- a/tests/test_self_patcher.py
+++ b/tests/test_self_patcher.py
@@ -3,11 +3,14 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import self_patcher
+import notification
 
 
 def test_apply_and_rollback(tmp_path, monkeypatch):
     monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
     from importlib import reload
+    import notification
+    reload(notification)
     reload(self_patcher)
     p = self_patcher.apply_patch("note", auto=False)
     patches = self_patcher.list_patches()
@@ -23,6 +26,9 @@ def test_apply_and_rollback(tmp_path, monkeypatch):
     patches = self_patcher.list_patches()
     assert any(x["id"] == p["id"] and x.get("approved") for x in patches)
 
+    events = notification.list_events(3)
+    assert any(e["event"] == "patch_rolled_back" for e in events)
+    assert any(e["event"] == "patch_approved" for e in events)
 
 def test_reject_patch(tmp_path, monkeypatch):
     monkeypatch.setenv("MEMORY_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary
- log rollback events in `self_patcher`
- expand README patch management section
- add CLI tests for patch approval and rollback
- record events for approval and rollback in unit tests

## Testing
- `pytest -q`