### PR TITLE
Add plugin framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,37 @@ pytest
 Policy, Gesture & Persona Engine
 --------------------------------
 `policy_engine.py` loads YAML or JSON policies at runtime to drive gestures and persona swaps. Policies define conditions on emotion vectors or tags and map them to actions. Use `python policy_engine.py policy show` to inspect active rules. Policies can be diffed, applied, or rolled back without restarting, and every action is audited.
+
+Extensible Gesture & Persona Plug-ins
+------------------------------------
+Drop Python plug-ins in ``gp_plugins/`` to add new gestures or persona modules.
+Each plug-in defines a ``register`` function that registers a ``BasePlugin``
+subclass. Example plug-in:
+
+```python
+from plugin_framework import BasePlugin
+
+class WaveHandPlugin(BasePlugin):
+    plugin_type = "gesture"
+    schema = {"speed": "float"}
+
+    def execute(self, event):
+        return {"gesture": "wave", "speed": event.get("speed", 1)}
+
+    def simulate(self, event):
+        return {"gesture": "wave", "speed": event.get("speed", 1), "explanation": "Simulated"}
+
+def register(reg):
+    reg("wave_hand", WaveHandPlugin())
+```
+
+List or test plug-ins:
+
+```bash
+python plugins_cli.py list
+python plugins_cli.py test wave_hand
+```
+In headless mode plug-ins simulate actions but still log to the trust engine.
 No secrets are present in this repo.
 Copy .env.example to .env and fill in your credentials before running.
 

--- a/gp_plugins/wave_hand.py
+++ b/gp_plugins/wave_hand.py
@@ -1,0 +1,26 @@
+"""Simple wave hand gesture plug-in."""
+
+from plugin_framework import BasePlugin
+
+class WaveHandPlugin(BasePlugin):
+    plugin_type = "gesture"
+    schema = {"speed": "float"}
+
+    def execute(self, event):
+        speed = event.get("speed", 1.0)
+        return {
+            "gesture": "wave",
+            "speed": speed,
+            "explanation": f"Waving hand at speed {speed}"
+        }
+
+    def simulate(self, event):
+        speed = event.get("speed", 1.0)
+        return {
+            "gesture": "wave",
+            "speed": speed,
+            "explanation": f"Simulated wave at speed {speed}"
+        }
+
+def register(reg):
+    reg("wave_hand", WaveHandPlugin())

--- a/plugin_framework.py
+++ b/plugin_framework.py
@@ -1,0 +1,106 @@
+"""Plug-in framework for gestures, personas, and actions."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from utils import is_headless
+import trust_engine as te
+
+
+class BasePlugin:
+    """Base class for gesture/persona/action plug-ins."""
+
+    plugin_type: str = "plugin"
+    schema: Dict[str, Any] = {}
+
+    def execute(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Run the plug-in for real hardware."""
+        raise NotImplementedError
+
+    def simulate(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Simulate execution in headless mode."""
+        return {"simulated": True}
+
+    def run(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute or simulate depending on headless mode."""
+        if is_headless():
+            result = self.simulate(event)
+            result.setdefault("simulated", True)
+        else:
+            result = self.execute(event)
+        return result
+
+
+PLUGINS: dict[str, BasePlugin] = {}
+PLUGINS_INFO: dict[str, str] = {}
+_LOADED_FILES: list[Path] = []
+
+
+def register_plugin(name: str, plugin: BasePlugin) -> None:
+    """Register a plug-in instance."""
+    PLUGINS[name] = plugin
+
+
+def load_plugins() -> None:
+    """Load plug-ins from disk."""
+    global PLUGINS, PLUGINS_INFO, _LOADED_FILES
+    PLUGINS = {}
+    PLUGINS_INFO = {}
+    plugins_dir = Path(os.getenv("GP_PLUGINS_DIR", "gp_plugins"))
+    if not plugins_dir.exists():
+        return
+    _LOADED_FILES = list(plugins_dir.glob("*.py"))
+    for fp in _LOADED_FILES:
+        spec: dict[str, Any] = {}
+        try:
+            code = fp.read_text(encoding="utf-8")
+            exec(compile(code, str(fp), "exec"), spec)
+        except Exception:
+            continue
+        reg = spec.get("register")
+        if callable(reg):
+            try:
+                reg(register_plugin)
+            except Exception:
+                pass
+        PLUGINS_INFO[fp.stem] = (spec.get("__doc__") or "").strip()
+
+
+def list_plugins() -> dict[str, str]:
+    """Return available plug-ins and their descriptions."""
+    return dict(PLUGINS_INFO)
+
+
+def plugin_doc(name: str) -> Dict[str, Any]:
+    plug = PLUGINS.get(name)
+    if not plug:
+        raise ValueError("Unknown plugin")
+    return {
+        "id": name,
+        "type": plug.plugin_type,
+        "schema": plug.schema,
+        "doc": PLUGINS_INFO.get(name, ""),
+    }
+
+
+def run_plugin(name: str, event: Dict[str, Any] | None = None, *, cause: str = "test", user: str = "plugin") -> Dict[str, Any]:
+    """Execute a plug-in and log via the trust engine."""
+    plug = PLUGINS.get(name)
+    if not plug:
+        raise ValueError("Unknown plugin")
+    evt = event or {}
+    result = plug.run(evt)
+    explanation = result.get("explanation", f"{name} executed")
+    te.log_event(plug.plugin_type, cause, explanation, name, {"event": evt, "result": result, "headless": is_headless()})
+    return result
+
+
+def test_plugin(name: str) -> Dict[str, Any]:
+    """Run a plug-in with empty event for testing."""
+    return run_plugin(name, {"test": True}, cause="plugin_test")
+
+
+load_plugins()

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,0 +1,35 @@
+"""CLI for managing gesture/persona plug-ins."""
+
+import argparse
+import json
+import plugin_framework as pf
+
+
+def main() -> None:
+    pf.load_plugins()
+    ap = argparse.ArgumentParser(prog="plugins")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sub.add_parser("list")
+    t = sub.add_parser("test")
+    t.add_argument("plugin_id")
+    d = sub.add_parser("doc")
+    d.add_argument("plugin_id")
+
+    args = ap.parse_args()
+
+    if args.cmd == "list":
+        for name, desc in pf.list_plugins().items():
+            print(f"{name}: {desc}")
+    elif args.cmd == "test":
+        out = pf.test_plugin(args.plugin_id)
+        print(json.dumps(out, indent=2))
+    elif args.cmd == "doc":
+        info = pf.plugin_doc(args.plugin_id)
+        print(json.dumps(info, indent=2))
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_plugin_framework.py
+++ b/tests/test_plugin_framework.py
@@ -1,0 +1,33 @@
+import importlib
+
+
+def setup_env(tmp_path, monkeypatch, headless=True):
+    monkeypatch.setenv("TRUST_DIR", str(tmp_path / "trust"))
+    monkeypatch.setenv("GP_PLUGINS_DIR", "gp_plugins")
+    if headless:
+        monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
+    else:
+        monkeypatch.delenv("SENTIENTOS_HEADLESS", raising=False)
+    import trust_engine as te
+    import plugin_framework as pf
+    importlib.reload(te)
+    importlib.reload(pf)
+    pf.load_plugins()
+    return pf, te
+
+
+def test_wave_hand_headless(tmp_path, monkeypatch):
+    pf, te = setup_env(tmp_path, monkeypatch, headless=True)
+    assert "wave_hand" in pf.list_plugins()
+    res = pf.run_plugin("wave_hand", {"speed": 2}, cause="unit")
+    assert res.get("simulated")
+    events = te.list_events(limit=1)
+    assert events and events[0]["cause"] == "unit" and events[0]["data"]["headless"]
+
+
+def test_wave_hand_real(tmp_path, monkeypatch):
+    pf, te = setup_env(tmp_path, monkeypatch, headless=False)
+    res = pf.run_plugin("wave_hand", {"speed": 1}, cause="real")
+    assert not res.get("simulated")
+    events = te.list_events(limit=1)
+    assert events and not events[0]["data"]["headless"]


### PR DESCRIPTION
## Summary
- enable gesture/persona plug‑ins with `plugin_framework`
- provide simple CLI for plug‑ins
- sample `wave_hand` gesture plug‑in
- document gesture/persona plug‑ins in README
- test plug‑in loading and trust logging

## Testing
- `pytest -q`