### PR TITLE
Add runtime plugin control with dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ bash
 Copy
 Edit
 python api/actuator.py plugins --reload
+
+Gesture/persona plug-ins can be enabled or disabled at runtime. Use the CLI or web dashboard:
+
+```bash
+python plugins_cli.py status
+python plugins_cli.py disable wave_hand
+python plugins_cli.py enable wave_hand
+```
+
+Launch the minimal dashboard to view and control plug-ins:
+
+```bash
+python plugin_dashboard.py  # http://localhost:5001
+```
 Log Tailing and Tests
 Tail logs:
 
@@ -205,6 +219,10 @@ List or test plug-ins:
 ```bash
 python plugins_cli.py list
 python plugins_cli.py test wave_hand
+python plugins_cli.py status       # show enabled/disabled state
+python plugins_cli.py disable wave_hand
+python plugins_cli.py enable wave_hand
+python plugins_cli.py reload       # live reload
 ```
 In headless mode plug-ins simulate actions but still log to the trust engine.
 No secrets are present in this repo.

--- a/plugin_dashboard.py
+++ b/plugin_dashboard.py
@@ -1,0 +1,70 @@
+from flask import Flask, jsonify, request
+import plugin_framework as pf
+import trust_engine as te
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return """<html><body><h3>Plugin Dashboard</h3>
+<table id='tbl'></table>
+<pre id='logs' style='height:200px;overflow:auto'></pre>
+<script>
+async function load(){
+  const r=await fetch('/api/plugins');
+  const data=await r.json();
+  let html='<tr><th>Plugin</th><th>Status</th><th>Actions</th></tr>';
+  for(const p of data){
+    const b=p.enabled?`<button onclick="toggle('${p.id}',true)">Disable</button>`:`<button onclick="toggle('${p.id}',false)">Enable</button>`;
+    html+=`<tr><td>${p.id}</td><td>${p.enabled?'enabled':'disabled'}</td><td>${b}<button onclick="testPlugin('${p.id}')">Test</button></td></tr>`;
+  }
+  document.getElementById('tbl').innerHTML=html;
+}
+async function toggle(id,en){
+  await fetch('/api/'+(en?'disable':'enable'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({plugin:id})});
+  await load();
+  await loadLogs();
+}
+async function testPlugin(id){
+  await fetch('/api/test',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({plugin:id})});
+  await loadLogs();
+}
+async function loadLogs(){
+  const r=await fetch('/api/logs');
+  const data=await r.json();
+  document.getElementById('logs').textContent=JSON.stringify(data,null,2);
+}
+setInterval(loadLogs,2000);
+load();loadLogs();
+</script></body></html>"""
+
+@app.route('/api/plugins', methods=['GET', 'POST'])
+def plugins_api():
+    info=pf.list_plugins()
+    status=pf.plugin_status()
+    return jsonify([{"id":n,"doc":info[n],"enabled":status.get(n,True)} for n in info])
+
+@app.route('/api/enable', methods=['POST'])
+def enable_api():
+    name=(request.get_json() or {}).get('plugin')
+    pf.enable_plugin(name, user='dashboard')
+    return jsonify({'status':'enabled'})
+
+@app.route('/api/disable', methods=['POST'])
+def disable_api():
+    name=(request.get_json() or {}).get('plugin')
+    pf.disable_plugin(name, user='dashboard')
+    return jsonify({'status':'disabled'})
+
+@app.route('/api/test', methods=['POST'])
+def test_api():
+    name=(request.get_json() or {}).get('plugin')
+    res=pf.test_plugin(name)
+    return jsonify(res)
+
+@app.route('/api/logs', methods=['GET', 'POST'])
+def logs_api():
+    return jsonify(te.list_events(limit=20))
+
+if __name__=='__main__':
+    app.run(port=5001)

--- a/plugin_framework.py
+++ b/plugin_framework.py
@@ -36,6 +36,7 @@ class BasePlugin:
 
 PLUGINS: dict[str, BasePlugin] = {}
 PLUGINS_INFO: dict[str, str] = {}
+PLUGIN_STATE: dict[str, bool] = {}
 _LOADED_FILES: list[Path] = []
 
 
@@ -46,7 +47,7 @@ def register_plugin(name: str, plugin: BasePlugin) -> None:
 
 def load_plugins() -> None:
     """Load plug-ins from disk."""
-    global PLUGINS, PLUGINS_INFO, _LOADED_FILES
+    global PLUGINS, PLUGINS_INFO, PLUGIN_STATE, _LOADED_FILES
     PLUGINS = {}
     PLUGINS_INFO = {}
     plugins_dir = Path(os.getenv("GP_PLUGINS_DIR", "gp_plugins"))
@@ -67,11 +68,50 @@ def load_plugins() -> None:
             except Exception:
                 pass
         PLUGINS_INFO[fp.stem] = (spec.get("__doc__") or "").strip()
+        # Preserve enabled/disabled state across reloads
+        PLUGIN_STATE.setdefault(fp.stem, True)
+
+    # Remove state entries for missing plugins
+    for name in list(PLUGIN_STATE.keys()):
+        if name not in PLUGINS_INFO:
+            PLUGIN_STATE.pop(name, None)
 
 
 def list_plugins() -> dict[str, str]:
     """Return available plug-ins and their descriptions."""
     return dict(PLUGINS_INFO)
+
+
+def available_plugins(plugin_type: str | None = None) -> list[str]:
+    """Return names of enabled plug-ins, optionally filtered by type."""
+    names = [n for n, enabled in plugin_status().items() if enabled]
+    if plugin_type:
+        names = [n for n in names if PLUGINS[n].plugin_type == plugin_type]
+    return names
+
+
+def plugin_status() -> Dict[str, bool]:
+    """Return enabled/disabled status for each loaded plugin."""
+    return {name: PLUGIN_STATE.get(name, True) for name in PLUGINS_INFO}
+
+
+def enable_plugin(name: str, *, user: str = "system", reason: str = "enable") -> None:
+    if name not in PLUGINS_INFO:
+        raise ValueError("Unknown plugin")
+    PLUGIN_STATE[name] = True
+    te.log_event("plugin_enable", reason, f"Enabled {name}", user)
+
+
+def disable_plugin(name: str, *, user: str = "system", reason: str = "disable") -> None:
+    if name not in PLUGINS_INFO:
+        raise ValueError("Unknown plugin")
+    PLUGIN_STATE[name] = False
+    te.log_event("plugin_disable", reason, f"Disabled {name}", user)
+
+
+def reload_plugins(*, user: str = "system", reason: str = "reload") -> None:
+    load_plugins()
+    te.log_event("plugin_reload", reason, "Plugins reloaded", user, {"plugins": list(PLUGINS_INFO)})
 
 
 def plugin_doc(name: str) -> Dict[str, Any]:
@@ -91,6 +131,8 @@ def run_plugin(name: str, event: Dict[str, Any] | None = None, *, cause: str = "
     plug = PLUGINS.get(name)
     if not plug:
         raise ValueError("Unknown plugin")
+    if not PLUGIN_STATE.get(name, True):
+        raise ValueError("Plugin disabled")
     evt = event or {}
     result = plug.run(evt)
     explanation = result.get("explanation", f"{name} executed")
@@ -101,6 +143,11 @@ def run_plugin(name: str, event: Dict[str, Any] | None = None, *, cause: str = "
 def test_plugin(name: str) -> Dict[str, Any]:
     """Run a plug-in with empty event for testing."""
     return run_plugin(name, {"test": True}, cause="plugin_test")
+
+
+def model_trigger(name: str, event: Dict[str, Any] | None = None, *, reason: str = "model_request", user: str = "model") -> Dict[str, Any]:
+    """Trigger a plug-in from a model with trust logging."""
+    return run_plugin(name, event or {}, cause=reason, user=user)
 
 
 load_plugins()

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -11,22 +11,41 @@ def main() -> None:
     sub = ap.add_subparsers(dest="cmd")
 
     sub.add_parser("list")
+    sub.add_parser("status")
+    sub.add_parser("reload")
     t = sub.add_parser("test")
     t.add_argument("plugin_id")
     d = sub.add_parser("doc")
     d.add_argument("plugin_id")
+    en = sub.add_parser("enable")
+    en.add_argument("plugin_id")
+    di = sub.add_parser("disable")
+    di.add_argument("plugin_id")
 
     args = ap.parse_args()
 
     if args.cmd == "list":
         for name, desc in pf.list_plugins().items():
             print(f"{name}: {desc}")
+    elif args.cmd == "status":
+        for name, enabled in pf.plugin_status().items():
+            status = "enabled" if enabled else "disabled"
+            print(f"{name}: {status}")
+    elif args.cmd == "reload":
+        pf.reload_plugins(user="cli")
+        print("Reloaded")
     elif args.cmd == "test":
         out = pf.test_plugin(args.plugin_id)
         print(json.dumps(out, indent=2))
     elif args.cmd == "doc":
         info = pf.plugin_doc(args.plugin_id)
         print(json.dumps(info, indent=2))
+    elif args.cmd == "enable":
+        pf.enable_plugin(args.plugin_id, user="cli")
+        print(f"Enabled {args.plugin_id}")
+    elif args.cmd == "disable":
+        pf.disable_plugin(args.plugin_id, user="cli")
+        print(f"Disabled {args.plugin_id}")
     else:
         ap.print_help()
 

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import importlib
+import json
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRUST_DIR", str(tmp_path/"trust"))
+    monkeypatch.setenv("GP_PLUGINS_DIR", "gp_plugins")
+    monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
+    import plugin_framework as pf
+    import plugin_dashboard as pd
+    importlib.reload(pf)
+    importlib.reload(pd)
+    return pd
+
+def test_dashboard_toggle(tmp_path, monkeypatch):
+    pd = setup(tmp_path, monkeypatch)
+    client = pd.app.test_client()
+    res = client.post('/api/plugins')
+    body = res.data if isinstance(res.data, str) else res.data.decode()
+    data = json.loads(body)
+    assert any(p['id']=='wave_hand' for p in data)
+    client.post('/api/disable', json={'plugin':'wave_hand'})
+    body = client.post('/api/plugins').data
+    body = body if isinstance(body, str) else body.decode()
+    data = json.loads(body)
+    status = {p['id']:p['enabled'] for p in data}
+    assert not status['wave_hand']
+    client.post('/api/enable', json={'plugin':'wave_hand'})
+    body = client.post('/api/plugins').data
+    body = body if isinstance(body, str) else body.decode()
+    data = json.loads(body)
+    status = {p['id']:p['enabled'] for p in data}
+    assert status['wave_hand']
+    client.post('/api/test', json={'plugin':'wave_hand'})
+    body = client.post('/api/logs').data
+    body = body if isinstance(body, str) else body.decode()
+    logs = json.loads(body)
+    assert logs


### PR DESCRIPTION
## Summary
- add ability to enable/disable and reload plugins at runtime
- expose plugin status and model-trigger helper APIs
- create simple Flask dashboard for plugin control
- extend plugins CLI with new commands
- document runtime management and dashboard usage
- test plugin state changes and dashboard API

## Testing
- `pytest -q`