### PR TITLE
Add plugin self-healing and proposal system

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ Launch the minimal dashboard to view and control plug-ins:
 ```bash
 python plugin_dashboard.py  # http://localhost:5001
 ```
+
+### Self-healing and model proposals
+
+Plug-ins report health status automatically. When a plug-in throws an
+exception it is logged, auto-reloaded, and disabled if the problem persists.
+Suggested actions appear in the dashboard health panel along with a live log
+stream. The model can also propose new plug-ins or updates via
+`propose_plugin(name, url)`. Proposals are listed on the dashboard and must be
+approved or denied by the user before installation. Every healing and
+installation step is trust-logged.
 Log Tailing and Tests
 Tail logs:
 

--- a/plugin_dashboard.py
+++ b/plugin_dashboard.py
@@ -8,6 +8,10 @@ app = Flask(__name__)
 def index():
     return """<html><body><h3>Plugin Dashboard</h3>
 <table id='tbl'></table>
+<h4>Health</h4>
+<pre id='health'></pre>
+<h4>Proposals</h4>
+<table id='props'></table>
 <pre id='logs' style='height:200px;overflow:auto'></pre>
 <script>
 async function load(){
@@ -19,6 +23,17 @@ async function load(){
     html+=`<tr><td>${p.id}</td><td>${p.enabled?'enabled':'disabled'}</td><td>${b}<button onclick="testPlugin('${p.id}')">Test</button></td></tr>`;
   }
   document.getElementById('tbl').innerHTML=html;
+  const h=await fetch('/api/health');
+  const hd=await h.json();
+  document.getElementById('health').textContent=JSON.stringify(hd,null,2);
+  const pr=await fetch('/api/proposals');
+  const pd=await pr.json();
+  let ph='<tr><th>Name</th><th>Status</th><th>Action</th></tr>';
+  for(const p of pd){
+    const a=p.status==='pending'?`<button onclick="approve('${p.name}')">Approve</button><button onclick="deny('${p.name}')">Deny</button>`:'';
+    ph+=`<tr><td>${p.name}</td><td>${p.status}</td><td>${a}</td></tr>`;
+  }
+  document.getElementById('props').innerHTML=ph;
 }
 async function toggle(id,en){
   await fetch('/api/'+(en?'disable':'enable'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({plugin:id})});
@@ -27,6 +42,16 @@ async function toggle(id,en){
 }
 async function testPlugin(id){
   await fetch('/api/test',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({plugin:id})});
+  await loadLogs();
+}
+async function approve(name){
+  await fetch('/api/approve',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})});
+  await load();
+  await loadLogs();
+}
+async function deny(name){
+  await fetch('/api/deny',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})});
+  await load();
   await loadLogs();
 }
 async function loadLogs(){
@@ -65,6 +90,31 @@ def test_api():
 @app.route('/api/logs', methods=['GET', 'POST'])
 def logs_api():
     return jsonify(te.list_events(limit=20))
+
+
+@app.route('/api/health', methods=['GET', 'POST'])
+def health_api():
+    return jsonify(pf.list_health())
+
+
+@app.route('/api/proposals', methods=['GET', 'POST'])
+def proposals_api():
+    props = pf.list_proposals()
+    return jsonify([{"name": k, "status": v.get("status"), "url": v.get("url")} for k, v in props.items()])
+
+
+@app.route('/api/approve', methods=['POST'])
+def approve_api():
+    name = (request.get_json() or {}).get('name')
+    pf.approve_proposal(name, user='dashboard')
+    return jsonify({'status': 'ok'})
+
+
+@app.route('/api/deny', methods=['POST'])
+def deny_api():
+    name = (request.get_json() or {}).get('name')
+    pf.deny_proposal(name, user='dashboard')
+    return jsonify({'status': 'ok'})
 
 if __name__=='__main__':
     app.run(port=5001)

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -5,9 +5,11 @@ import json
 import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-def setup(tmp_path, monkeypatch):
+def setup(tmp_path, monkeypatch, plugin_dir=None):
     monkeypatch.setenv("TRUST_DIR", str(tmp_path/"trust"))
-    monkeypatch.setenv("GP_PLUGINS_DIR", "gp_plugins")
+    if plugin_dir is None:
+        plugin_dir = "gp_plugins"
+    monkeypatch.setenv("GP_PLUGINS_DIR", str(plugin_dir))
     monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
     import plugin_framework as pf
     import plugin_dashboard as pd
@@ -39,3 +41,25 @@ def test_dashboard_toggle(tmp_path, monkeypatch):
     body = body if isinstance(body, str) else body.decode()
     logs = json.loads(body)
     assert logs
+
+
+def test_dashboard_health_and_proposals(tmp_path, monkeypatch):
+    plugins = tmp_path / 'gp_plugins'
+    plugins.mkdir()
+    failing = plugins / 'bad.py'
+    failing.write_text("""from plugin_framework import BasePlugin\nclass B(BasePlugin):\n    def execute(self,e): raise RuntimeError('x')\n    def simulate(self,e): raise RuntimeError('x')\n\ndef register(r): r('bad', B())\n""", encoding='utf-8')
+    pd = setup(tmp_path, monkeypatch, plugins)
+    client = pd.app.test_client()
+    client.post('/api/plugins')
+    client.post('/api/test', json={'plugin':'bad'})
+    res = client.post('/api/health')
+    data = json.loads(res.data if isinstance(res.data, str) else res.data.decode())
+    assert 'bad' in data
+    pd_cli = pd.app.test_client()
+    sample = tmp_path / 'samp.py'
+    sample.write_text("""from plugin_framework import BasePlugin\nclass S(BasePlugin):\n    def execute(self,e): return {'ok':True}\n    def simulate(self,e): return {'ok':True}\n\ndef register(r): r('samp', S())\n""", encoding='utf-8')
+    pf = importlib.import_module('plugin_framework')
+    pf.propose_plugin('samp', str(sample), user='model')
+    res = pd_cli.post('/api/proposals')
+    props = json.loads(res.data if isinstance(res.data, str) else res.data.decode())
+    assert any(p['name']=='samp' for p in props)


### PR DESCRIPTION
## Summary
- add plugin self-healing logic and proposal/approval API
- expose plugin health and proposals in dashboard
- document flows for new features in README
- test plugin recovery, proposals, and dashboard endpoints

## Testing
- `pytest -q`