### PR TITLE
Add reflection stream and health monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ stream. The model can also propose new plug-ins or updates via
 `propose_plugin(name, url)`. Proposals are listed on the dashboard and must be
 approved or denied by the user before installation. Every healing and
 installation step is trust-logged.
+
+### Reflection stream
+
+All modules log failures, recoveries, and escalations in a system-wide
+reflection stream. Each entry records the timestamp, source, event type,
+cause, action taken, and an explanation.
+
+```bash
+python reflect_cli.py log --last 3
+python reflect_cli.py explain <id>
+python reflect_cli.py stats
+```
 Log Tailing and Tests
 Tail logs:
 

--- a/health_monitor.py
+++ b/health_monitor.py
@@ -1,0 +1,43 @@
+import json
+from typing import Callable, Dict, Tuple, Optional
+import memory_manager as mm
+import reflection_stream as rs
+
+ComponentCheck = Callable[[], Tuple[bool, str]]
+ComponentHeal = Callable[[], bool]
+
+COMPONENTS: Dict[str, Dict[str, Optional[Callable]]] = {}
+
+
+def register(name: str, check: ComponentCheck, heal: Optional[ComponentHeal] = None) -> None:
+    """Register a component health check and optional heal function."""
+    COMPONENTS[name] = {"check": check, "heal": heal}
+
+
+def check_all() -> None:
+    """Check all registered components and attempt recovery."""
+    for name, funcs in COMPONENTS.items():
+        ok = True
+        reason = ""
+        try:
+            ok, reason = funcs["check"]()  # type: ignore[call-arg]
+        except Exception as e:  # pragma: no cover - defensive
+            ok = False
+            reason = str(e)
+        if ok:
+            rs.log_event(name, "health", reason or "ok", "none", "component healthy")
+            continue
+        healed = False
+        expl = ""
+        heal_fn = funcs.get("heal")
+        if heal_fn:
+            try:
+                healed = heal_fn()
+                expl = "heal" if healed else "heal failed"
+            except Exception as e:  # pragma: no cover - defensive
+                expl = str(e)
+        if healed:
+            rs.log_event(name, "recovery", reason, "heal", expl)
+        else:
+            rs.log_event(name, "escalation", reason, "notify", expl)
+            mm.append_memory(json.dumps({"component": name, "reason": reason}), tags=["escalation"], source="health_monitor")

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,0 +1,27 @@
+import argparse
+import json
+import reflection_stream as rs
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Reflection stream CLI")
+    sub = parser.add_subparsers(dest="cmd")
+    log = sub.add_parser("log", help="Show recent reflection events")
+    log.add_argument("--last", type=int, default=5)
+    exp = sub.add_parser("explain", help="Show details of an event")
+    exp.add_argument("id")
+    sub.add_parser("stats", help="Show event statistics")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "log":
+        print(json.dumps(rs.recent(args.last), indent=2))
+    elif args.cmd == "explain":
+        print(json.dumps(rs.get(args.id), indent=2))
+    elif args.cmd == "stats":
+        print(json.dumps(rs.stats(), indent=2))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/reflection_stream.py
+++ b/reflection_stream.py
@@ -1,0 +1,70 @@
+import os
+import json
+import datetime
+import uuid
+from pathlib import Path
+from typing import Dict, List, Optional
+
+STREAM_DIR = Path(os.getenv("REFLECTION_DIR", "logs/reflections"))
+STREAM_FILE = STREAM_DIR / "stream.jsonl"
+STREAM_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _now() -> str:
+    return datetime.datetime.utcnow().isoformat()
+
+
+def log_event(source: str, event_type: str, cause: str, action: str,
+              explanation: str = "", data: Optional[Dict[str, any]] = None) -> str:
+    """Append an entry to the reflection stream and return its id."""
+    entry_id = uuid.uuid4().hex[:8]
+    entry = {
+        "id": entry_id,
+        "timestamp": _now(),
+        "source": source,
+        "event": event_type,
+        "cause": cause,
+        "action": action,
+        "explanation": explanation,
+        "data": data or {},
+    }
+    with STREAM_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry_id
+
+
+def recent(limit: int = 10) -> List[Dict[str, any]]:
+    if not STREAM_FILE.exists():
+        return []
+    lines = STREAM_FILE.read_text(encoding="utf-8").splitlines()
+    out: List[Dict[str, any]] = []
+    for line in lines[-limit:]:
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def get(entry_id: str) -> Optional[Dict[str, any]]:
+    if not STREAM_FILE.exists():
+        return None
+    with STREAM_FILE.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            if entry.get("id") == entry_id:
+                return entry
+    return None
+
+
+def stats() -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for entry in recent(1000):
+        typ = entry.get("event")
+        counts[typ] = counts.get(typ, 0) + 1
+    return counts

--- a/self_patcher.py
+++ b/self_patcher.py
@@ -3,6 +3,7 @@ import datetime
 from pathlib import Path
 import memory_manager as mm
 from notification import send as notify
+import reflection_stream as rs
 
 PATCH_PATH = mm.MEMORY_DIR / "patches.json"
 PATCH_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -36,6 +37,7 @@ def apply_patch(note: str, *, auto: bool = False) -> dict:
     patches.append(patch)
     _save(patches)
     mm.append_memory(note, tags=["self_patch"], source="auto_patch" if auto else "manual_patch")
+    rs.log_event("self_patch", "recovery", "apply_patch", "patched", note)
     notify("self_patch", {"id": pid, "note": note})
     return patch
 

--- a/tests/test_reflection_stream.py
+++ b/tests/test_reflection_stream.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import importlib
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import memory_manager as mm
+import reflection_stream as rs
+import plugin_framework as pf
+import health_monitor as hm
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path / "mem"))
+    monkeypatch.setenv("TRUST_DIR", str(tmp_path / "trust"))
+    monkeypatch.setenv("REFLECTION_DIR", str(tmp_path / "reflect"))
+    monkeypatch.setenv("GP_PLUGINS_DIR", str(tmp_path / "plugins"))
+    monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
+    importlib.reload(mm)
+    importlib.reload(rs)
+    importlib.reload(pf)
+    importlib.reload(hm)
+    pf.load_plugins()
+
+
+def test_plugin_failure_logged(tmp_path, monkeypatch):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    failing = plugins / "bad.py"
+    failing.write_text("""from plugin_framework import BasePlugin\nclass B(BasePlugin):\n    def execute(self,e): raise RuntimeError('x')\n    def simulate(self,e): raise RuntimeError('x')\n\ndef register(r): r('bad', B())\n""", encoding='utf-8')
+    setup_env(tmp_path, monkeypatch)
+    pf.run_plugin('bad')
+    logs = rs.recent(2)
+    events = [l['event'] for l in logs]
+    assert {'failure', 'escalation'} & set(events)
+
+
+def test_health_escalation(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+
+    def check():
+        return False, 'broken'
+
+    def heal():
+        return False
+
+    hm.register('dummy', check, heal)
+    hm.check_all()
+    logs = rs.recent(1)
+    assert logs and logs[0]['event'] in {'escalation', 'failure'}
+


### PR DESCRIPTION
## Summary
- add `reflection_stream` module for system-wide reflection logs
- add `health_monitor` with generic component health checks
- update plugins and patcher to log reflections
- new CLI `reflect_cli.py`
- document reflection stream usage
- test plugin failures and health escalations

## Testing
- `pytest -q`
