### PR TITLE
Add avatar hooks and scene image options

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,12 +287,16 @@ Additional options:
   --emotion-data PATH  save emotion/persona info as JSON
   --sync-metadata PATH  save chapter timing info for AV sync
   --scene-images    generate experimental scene illustrations
+  --image-cmd CMD   use CMD to generate images (e.g. "gen.sh {prompt} {out}")
+  --image-api URL   POST prompt to URL for scene images
 ```
 
-Use `replay.py` to play back a storyboard with audio and optional images:
+Use `replay.py` to play back a storyboard with audio and optional images. New
+flags support avatar callbacks, subtitles, progress display, and bookmarking:
 
 ```bash
-python replay.py --storyboard sb.json --headless
+python replay.py --storyboard sb.json --headless \
+  --avatar-callback "./avatar.sh" --show-subtitles --chapter 2
 ```
 
 The emotion and sync JSON files can be used by visualization dashboards to show

--- a/replay.py
+++ b/replay.py
@@ -1,22 +1,70 @@
 import argparse
 import json
 import time
+import subprocess
 from pathlib import Path
 
 
-def playback(storyboard: str, headless: bool = False, gui: bool = False, audio_only: bool = False) -> None:
+def _fmt_time(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m:02}:{s:02}"
+
+
+def _trigger_avatar(emotion: str, persona: str, ts: float, cmd: str | None) -> None:
+    if cmd:
+        full = f"{cmd} --emotion={emotion} --persona={persona} --time={ts}"
+        try:
+            subprocess.run(full, shell=True, check=False)
+        except Exception:
+            print(f"[Avatar] {full}")
+    else:
+        print(f"[Avatar] set_avatar(preset='{emotion}', persona='{persona}')")
+
+
+def playback(
+    storyboard: str,
+    headless: bool = False,
+    gui: bool = False,
+    audio_only: bool = False,
+    avatar_callback: str | None = None,
+    show_subtitles: bool = False,
+    start_chapter: int = 1,
+) -> None:
     data = json.loads(Path(storyboard).read_text())
-    for ch in data.get('chapters', []):
-        print(f"Chapter {ch.get('chapter')}: {ch.get('title','')}")
-        if not audio_only:
-            txt = ch.get('text', '')
-            if txt:
-                print(txt)
-        if not headless and ch.get('audio'):
+    chapters = data.get("chapters", [])
+    total = len(chapters)
+    for ch in chapters[start_chapter - 1 :]:
+        num = ch.get("chapter") or chapters.index(ch) + 1
+        title = ch.get("title", "")
+        emotion = ch.get("mood") or ch.get("emotion", "neutral")
+        persona = ch.get("voice") or ch.get("persona", "")
+        ts = ch.get("t_start", 0)
+        _trigger_avatar(emotion, persona, ts, avatar_callback)
+        print(f"Chapter {num}/{total}: {title}")
+        duration = max(0.1, ch.get("t_end", 0) - ch.get("t_start", 0))
+        if show_subtitles:
+            line = ch.get("text", "")
+            if headless:
+                print(line)
+        if not headless and ch.get("audio"):
             print(f"[PLAY] {ch['audio']}")
-        if not headless and gui and ch.get('image'):
+        if not headless and gui and ch.get("image"):
             print(f"[IMAGE] {ch['image']}")
-        time.sleep(0.1)
+        start = time.time()
+        while True:
+            elapsed = time.time() - start
+            pct = min(elapsed / duration, 1.0)
+            bar = "#" * int(pct * 20)
+            if headless:
+                print(
+                    f"Chapter {num}/{total} [{bar:<20}] {int(pct*100)}% ({_fmt_time(elapsed)}/{_fmt_time(duration)})",
+                    end="\r",
+                )
+            if pct >= 1.0:
+                break
+            time.sleep(0.1)
+        if headless:
+            print()
 
 
 def main(argv=None):
@@ -25,8 +73,19 @@ def main(argv=None):
     parser.add_argument('--headless', action='store_true')
     parser.add_argument('--gui', action='store_true')
     parser.add_argument('--audio-only', action='store_true')
+    parser.add_argument('--avatar-callback')
+    parser.add_argument('--show-subtitles', action='store_true')
+    parser.add_argument('--chapter', type=int, default=1)
     args = parser.parse_args(argv)
-    playback(args.storyboard, headless=args.headless, gui=args.gui, audio_only=args.audio_only)
+    playback(
+        args.storyboard,
+        headless=args.headless,
+        gui=args.gui,
+        audio_only=args.audio_only,
+        avatar_callback=args.avatar_callback,
+        show_subtitles=args.show_subtitles,
+        start_chapter=args.chapter,
+    )
 
 
 if __name__ == '__main__':

--- a/tests/test_storymaker.py
+++ b/tests/test_storymaker.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import subprocess
 import datetime as dt
 from pathlib import Path
 
@@ -111,6 +112,18 @@ def test_scene_image_generation(tmp_path, monkeypatch):
     storymaker.run_pipeline(
         "2024-01-01 00:00", "2024-01-01 23:59", str(tmp_path / "demo.mp4"), log_dir,
         dry_run=True, chapters=True, scene_images=True
+    )
+    assert (tmp_path / "chapter_1.png").exists()
+
+
+def test_image_cmd_option(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "memory.jsonl").write_text(json.dumps({"timestamp": "2024-01-01T08:00:00", "text": "start"}) + "\n")
+    monkeypatch.setattr(tts_bridge, "speak", lambda *a, **k: str(tmp_path / "a.mp3"))
+    storymaker.run_pipeline(
+        "2024-01-01 00:00", "2024-01-01 23:59", str(tmp_path / "demo.mp4"), log_dir,
+        dry_run=True, chapters=True, scene_images=True, image_cmd="touch {out}"
     )
     assert (tmp_path / "chapter_1.png").exists()
 


### PR DESCRIPTION
## Summary
- support avatar callback, subtitles, bookmarks, and progress in replay
- allow scene images via `--image-cmd`/`--image-api` in storymaker
- document new options for storymaker and replay
- test replay avatar callback, subtitle output, progress bar, and image display
- test storymaker image command option

## Testing
- `pytest -q`