### PR TITLE
Implement live story capture and feedback features

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ reject_patch → patch_rejected
 
 rollback_patch → patch_rolled_back
 
+During replay you can provide user feedback or patch suggestions:
+
+```bash
+python replay.py --storyboard sb.json --feedback-enabled
+```
+Feedback lines are logged to `storyboard.feedback.jsonl` and may be applied as patches later.
+
 Actuator, Reflections, and Plugins
 Actuator CLI (api/actuator.py):
 
@@ -290,6 +297,9 @@ Additional options:
   --image-cmd CMD   use CMD to generate images (e.g. "gen.sh {prompt} {out}")
   --image-api URL   POST prompt to URL for scene images
   --export-demo ZIP  package media and metadata into demo ZIP
+  --live            capture events in real time
+  --analytics       export emotion/persona analytics CSV
+  --image-prompt-field FIELD  use FIELD from memory for scene image prompts
 ```
 
 Chapter metadata may include optional reaction hooks:
@@ -311,6 +321,7 @@ flags support avatar callbacks, subtitles, progress display, and bookmarking:
 python replay.py --storyboard sb.json --headless \
   --avatar-callback "./avatar.sh" --show-subtitles --chapter 2
   --enable-sfx --enable-gestures --enable-env --interpolate-voices
+  --feedback-enabled --dashboard
 python replay.py --import-demo demo.zip
 ```
 

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,0 +1,54 @@
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import storymaker
+import replay
+import tts_bridge
+
+
+def test_live_capture(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "memory.jsonl").write_text(json.dumps({"timestamp":"2024-01-01T10:00:00","text":"start"})+"\n")
+    monkeypatch.setattr(tts_bridge, "speak", lambda *a, **k: str(tmp_path/"a.mp3"))
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    out = tmp_path / "live.json"
+    storymaker.run_live(str(out), log_dir, dry_run=True, limit=1, poll=0)
+    data = json.loads(out.read_text())
+    assert data["chapters"]
+
+
+def test_dashboard_display(tmp_path):
+    sb = tmp_path / "sb.json"
+    sb.write_text(json.dumps({"chapters":[{"chapter":1,"title":"A"}]}))
+    app = replay.run_dashboard(str(sb))
+    client = app.test_client()
+    res = client.post("/chapters")
+    data = res.data if isinstance(res.data, str) else res.data.decode()
+    assert "A" in data
+
+
+def test_feedback_workflow(tmp_path, monkeypatch):
+    sb = tmp_path / "sb.json"
+    sb.write_text(json.dumps({"chapters":[{"chapter":1,"title":"A","t_start":0,"t_end":0.1}]}))
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    monkeypatch.setattr("builtins.input", lambda prompt='': "ok")
+    replay.playback(str(sb), headless=True, feedback_enabled=True)
+    fb = sb.with_suffix(".feedback.jsonl")
+    assert fb.exists() and "ok" in fb.read_text()
+
+
+def test_analytics_export(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "memory.jsonl").write_text(json.dumps({"timestamp":"2024-01-01T09:00:00","text":"a"})+"\n")
+    (log_dir / "emotions.jsonl").write_text(json.dumps({"timestamp":"2024-01-01T09:10:00","emotions":{"Joy":1.0}})+"\n")
+    csv_path = tmp_path / "out.csv"
+    storymaker.export_analytics("2024-01-01 00:00","2024-01-01 23:59", log_dir, str(csv_path))
+    data = csv_path.read_text()
+    assert "chapter" in data and "joy" in data


### PR DESCRIPTION
## Summary
- add live capture mode and analytics export to **storymaker.py**
- implement simple dashboard, feedback logging, and CLI updates for **replay.py**
- document new options in README
- test live capture, dashboard display, feedback workflow, and analytics export

## Testing
- `pytest -q`
