### PR TITLE
Implement multi-user sessions and diary features

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,17 @@ Additional options:
   --live            capture events in real time
   --analytics       export emotion/persona analytics CSV
   --image-prompt-field FIELD  use FIELD from memory for scene image prompts
+  --user NAME      tag output with user name
+  --persona NAME   tag output with persona
+  --fork ID        create a branch from chapter ID
+  --branch DESC    description for forked branch
+  --highlight ID   mark chapter ID as a highlight (repeatable)
+  --diary          compile a cathedral diary markdown
+  --auto-storyboard  generate storyboard from a log file
+  --log FILE       log file for auto-storyboard
 ```
+
+Use `--diary` to merge multiple sessions into a long-form "cathedral diary" Markdown file capturing emotion arcs over time.
 
 Chapter metadata may include optional reaction hooks:
 
@@ -321,7 +331,7 @@ flags support avatar callbacks, subtitles, progress display, and bookmarking:
 python replay.py --storyboard sb.json --headless \
   --avatar-callback "./avatar.sh" --show-subtitles --chapter 2
   --enable-sfx --enable-gestures --enable-env --interpolate-voices
-  --feedback-enabled --dashboard
+  --feedback-enabled --dashboard --highlights-only --branch 1
 python replay.py --import-demo demo.zip
 ```
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -82,3 +82,15 @@ def test_emotion_overlay(tmp_path, capsys, monkeypatch):
     out = capsys.readouterr().out
     assert "Emotion: joy" in out
 
+
+def test_highlight_only(tmp_path, capsys, monkeypatch):
+    sb = tmp_path / "sb.json"
+    sb.write_text(json.dumps({"chapters": [
+        {"chapter": 1, "title": "A", "text": "one", "highlight": False, "t_start": 0, "t_end": 0.1},
+        {"chapter": 2, "title": "B", "text": "two", "highlight": True, "t_start": 0.1, "t_end": 0.2}
+    ]}))
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    replay.playback(str(sb), headless=True, highlights_only=True)
+    out = capsys.readouterr().out
+    assert "Chapter 1" not in out and "Chapter 2" in out
+


### PR DESCRIPTION
## Summary
- extend `storymaker.py` chapters with user/persona and branching fields
- add diary compilation and auto storyboard helpers
- support multi-user CLI options and highlight/fork flags
- enhance `replay.py` dashboard and playback filtering
- document new CLI options in README
- add tests for new features

## Testing
- `pytest -q tests/test_storymaker.py tests/test_replay.py`