### PR TITLE
Implement live replay and story export features

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ Additional options:
   --image-cmd CMD   use CMD to generate images (e.g. "gen.sh {prompt} {out}")
   --image-api URL   POST prompt to URL for scene images
   --export-demo ZIP  package media and metadata into demo ZIP
+  --export-md PATH   export storyboard as Markdown
+  --export-html PATH export storyboard as HTML
+  --export-web PATH  export single-file web story
+  --publish          copy exported web story to ./public
   --live            capture events in real time
   --analytics       export emotion/persona analytics CSV
   --image-prompt-field FIELD  use FIELD from memory for scene image prompts
@@ -337,6 +341,18 @@ python replay.py --import-demo demo.zip
 
 During playback an emotion meter overlay shows the dominant mood for each chapter.
 In headless mode an ASCII indicator is printed.
+
+Live story mode streams new events in real time:
+
+```bash
+python replay.py --storyboard sb.json --live --avatar-callback ./avatar.sh
+```
+
+After generating a storyboard you can export and share it:
+
+```bash
+python storymaker.py ... --storyboard sb.json --export-web story.html --publish
+```
 
 The emotion and sync JSON files can be used by visualization dashboards to show
 mood or persona changes over time.

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -94,3 +94,13 @@ def test_highlight_only(tmp_path, capsys, monkeypatch):
     out = capsys.readouterr().out
     assert "Chapter 1" not in out and "Chapter 2" in out
 
+
+def test_live_playback(tmp_path, monkeypatch):
+    sb = tmp_path / "sb.json"
+    sb.write_text(json.dumps({"chapters": []}))
+    calls = []
+    monkeypatch.setattr(replay, "playback", lambda p, **k: calls.append(json.loads(Path(p).read_text())["chapters"]))
+    sb.write_text(json.dumps({"chapters": [{"chapter": 1, "title": "A", "t_start": 0, "t_end": 0.1}]}))
+    replay.live_playback(str(sb), headless=True, poll=0, max_chapters=1)
+    assert calls and calls[0][0]["title"] == "A"
+

--- a/tests/test_storymaker.py
+++ b/tests/test_storymaker.py
@@ -209,3 +209,19 @@ def test_auto_storyboard(tmp_path):
     data = json.loads(out.read_text())
     assert data["chapters"][0]["title"]
 
+
+def test_story_exports(tmp_path):
+    sb = tmp_path / "sb.json"
+    sb.write_text(json.dumps({"chapters": [{"chapter": 1, "title": "A", "text": "hi"}]}))
+    md = tmp_path / "out.md"
+    html = tmp_path / "out.html"
+    web = tmp_path / "web.html"
+    storymaker.export_markdown(str(sb), str(md))
+    storymaker.export_html(str(sb), str(html))
+    storymaker.export_web(str(sb), str(web))
+    pub_dir = tmp_path / "pub"
+    storymaker.publish_story(str(web), str(pub_dir))
+    assert md.exists() and html.exists() and web.exists()
+    assert "<html>" in html.read_text()
+    assert (pub_dir / "web.html").exists()
+


### PR DESCRIPTION
## Summary
- add real-time playback via `live_playback` and CLI `--live`
- add Markdown/HTML/web export helpers in `storymaker`
- support publishing exported web stories
- update README with new options and examples
- add tests for live playback and export functions

## Testing
- `pytest -q`