### PR TITLE
Add Story Studio editor and timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,21 @@ python storymaker.py ... --storyboard sb.json --export-web story.html --publish
 The emotion and sync JSON files can be used by visualization dashboards to show
 mood or persona changes over time.
 
+### Story Studio Web Editor
+
+Launch the interactive editor to tweak chapters, reorder scenes, and add
+comments:
+
+```bash
+python story_studio.py storyboard.json
+```
+
+Edited stories can then be exported:
+
+```bash
+python replay.py --storyboard storyboard.json --timeline
+```
+
 All components are modular, swappable, and extensible.
 Presence, feedback, memory, reflection, analytics, and automation—no arbitrary limits.
 The cathedral is ready.

--- a/replay.py
+++ b/replay.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 import zipfile
 import tempfile
-from typing import Any
+from typing import Any, List
 from flask import Flask, jsonify, request
 
 
@@ -95,6 +95,19 @@ def _show_emotion(emotion: str, headless: bool) -> None:
         print(f"Emotion: {emotion}")
     else:
         print(f"[EMOTION] {emotion}")
+
+
+def print_timeline(storyboard: str) -> None:
+    """Print a simple emotion/persona timeline."""
+    data = json.loads(Path(storyboard).read_text())
+    chapters = data.get("chapters", [])
+    for ch in chapters:
+        num = ch.get("chapter") or chapters.index(ch) + 1
+        mood = ch.get("mood", "neutral")
+        persona = ch.get("voice") or ch.get("persona", "")
+        ts = _fmt_time(ch.get("t_start", 0))
+        mark = "*" if ch.get("highlight") else ""
+        print(f"{num:>3} {ts} {mood:<8} {persona} {mark}")
 
 
 def playback(
@@ -226,6 +239,7 @@ def main(argv=None):
     parser.add_argument('--enable-env', action='store_true')
     parser.add_argument('--interpolate-voices', action='store_true')
     parser.add_argument('--dashboard', action='store_true')
+    parser.add_argument('--timeline', action='store_true', help='Print chapter timeline')
     parser.add_argument('--feedback-enabled', action='store_true')
     parser.add_argument('--highlights-only', action='store_true')
     parser.add_argument('--branch', type=int)
@@ -265,6 +279,9 @@ def main(argv=None):
         highlights_only=args.highlights_only,
         branch=args.branch,
     )
+    if args.timeline:
+        print_timeline(sb_path)
+        return
     if args.live:
         live_playback(sb_path, poll=args.poll, **play_kwargs)
     else:

--- a/story_studio.py
+++ b/story_studio.py
@@ -1,0 +1,89 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - optional
+    st = None
+
+
+def load_storyboard(path: str | Path) -> Dict[str, Any]:
+    data_path = Path(path)
+    if not data_path.exists():
+        return {"chapters": []}
+    try:
+        return json.loads(data_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"chapters": []}
+
+
+def save_storyboard(data: Dict[str, Any], path: str | Path) -> None:
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def reorder_chapters(chapters: List[Dict[str, Any]], order: List[int]) -> List[Dict[str, Any]]:
+    mapping = {c.get("chapter", i + 1): c for i, c in enumerate(chapters)}
+    new_list: List[Dict[str, Any]] = []
+    for idx in order:
+        ch = mapping.get(idx)
+        if ch:
+            new_list.append(ch)
+    # Renumber
+    for i, ch in enumerate(new_list, 1):
+        ch["chapter"] = i
+    return new_list
+
+
+def run_editor(storyboard_path: str) -> None:
+    if st is None:
+        print("Streamlit not available. Install dependencies to run editor.")
+        return
+    st.set_page_config(page_title="Story Studio", layout="wide")
+    st.title("Story Studio")
+    data = load_storyboard(storyboard_path)
+    chapters: List[Dict[str, Any]] = data.get("chapters", [])
+    order = [ch.get("chapter", i + 1) for i, ch in enumerate(chapters)]
+    new_chapters: List[Dict[str, Any]] = []
+    for ch in chapters:
+        idx = ch.get("chapter") or (len(new_chapters) + 1)
+        st.subheader(f"Chapter {idx}")
+        text = st.text_area("Text", value=ch.get("text", ""), key=f"text_{idx}")
+        highlight = st.checkbox("Highlight", value=ch.get("highlight", False), key=f"hl_{idx}")
+        comment = st.text_input("Comment", value=ch.get("comment", ""), key=f"comment_{idx}")
+        order_idx = st.number_input("Order", min_value=1, max_value=len(chapters), value=idx, key=f"ord_{idx}")
+        new_chapters.append({
+            **ch,
+            "text": text,
+            "highlight": highlight,
+            "comment": comment,
+            "order": int(order_idx),
+        })
+        st.markdown("---")
+    if st.button("Save"):
+        new_chapters.sort(key=lambda c: c.get("order", c.get("chapter", 0)))
+        for i, ch in enumerate(new_chapters, 1):
+            ch.pop("order", None)
+            ch["chapter"] = i
+        data["chapters"] = new_chapters
+        save_storyboard(data, storyboard_path)
+        st.success("Saved")
+    if st.button("Export HTML"):
+        from storymaker import export_web
+        tmp = Path(storyboard_path).with_suffix(".studio.html")
+        export_web(storyboard_path, str(tmp))
+        st.write(f"Exported to {tmp}")
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        print("Usage: story_studio.py STORYBOARD.json")
+        return
+    run_editor(argv[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_story_studio.py
+++ b/tests/test_story_studio.py
@@ -1,0 +1,36 @@
+import json
+import sys
+import os
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import story_studio
+import replay
+
+
+def test_load_and_save(tmp_path):
+    sb = tmp_path / "sb.json"
+    data = {"chapters": [{"chapter": 1, "text": "a"}]}
+    story_studio.save_storyboard(data, sb)
+    loaded = story_studio.load_storyboard(sb)
+    assert loaded == data
+
+
+def test_reorder(tmp_path):
+    chapters = [{"chapter": 1}, {"chapter": 2}, {"chapter": 3}]
+    new = story_studio.reorder_chapters(chapters, [3, 1, 2])
+    assert [c["chapter"] for c in new] == [1, 2, 3]
+
+
+def test_timeline_output(tmp_path, capsys):
+    sb = tmp_path / "sb.json"
+    data = {"chapters": [
+        {"chapter": 1, "t_start": 0, "mood": "happy", "voice": "A"},
+        {"chapter": 2, "t_start": 10, "mood": "sad", "voice": "B", "highlight": True}
+    ]}
+    sb.write_text(json.dumps(data))
+    replay.print_timeline(str(sb))
+    out = capsys.readouterr().out
+    assert "happy" in out and "sad" in out
+


### PR DESCRIPTION
## Summary
- add a Streamlit-based `story_studio.py` for editing storyboards
- allow printing a chapter timeline via `replay.py --timeline`
- test storyboard utils and timeline output
- document Story Studio usage in README

## Testing
- `pytest -q`