### PR TITLE
Implement basic system control layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,3 +396,18 @@ All components are modular, swappable, and extensible.
 Presence, feedback, memory, reflection, analytics, and automation—no arbitrary limits.
 The cathedral is ready.
 
+
+### System Control Layer
+
+`input_controller.py` and `ui_controller.py` provide modular abstractions for controlling the keyboard and GUI. Backends such as `pyautogui`, `keyboard`, `pywinauto`, or `uiautomation` can be selected at runtime. Every action is written to `logs/memory/events.jsonl` with persona and backend information.
+
+Example:
+
+```bash
+python input_controller.py --type "Hello world" --persona Alice
+python ui_controller.py --click "OK" --persona Bob
+```
+
+Use `--panic` with either CLI to instantly halt further actions. The panic state is recorded to the event log and can be cleared with `input_controller.reset_panic()` or `ui_controller.reset_panic()`.
+
+To add a new backend, implement the backend class with `type_text` or `click_button` and register it in the `BACKENDS` dictionary. Presence or collaboration systems can attach `@mentions` via the `mentions` parameter when invoking controller methods.

--- a/input_controller.py
+++ b/input_controller.py
@@ -1,0 +1,134 @@
+import os
+import json
+import datetime
+from pathlib import Path
+from typing import Callable, Dict, Any, Optional
+
+try:
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pyautogui = None
+
+try:
+    import keyboard  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    keyboard = None
+
+# Unified event log shared with notification module
+MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
+EVENT_PATH = MEMORY_DIR / "events.jsonl"
+EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+PANIC = False
+
+
+def _now() -> str:
+    return datetime.datetime.utcnow().isoformat()
+
+
+def _log(event: str, persona: Optional[str], backend: str, details: Dict[str, Any]) -> None:
+    entry = {
+        "timestamp": _now(),
+        "event": event,
+        "persona": persona or "default",
+        "backend": backend,
+        "details": details,
+    }
+    with open(EVENT_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+class BaseInputBackend:
+    def type_text(self, text: str, target_window: Optional[str] = None) -> None:
+        raise NotImplementedError
+
+
+class DummyBackend(BaseInputBackend):
+    def type_text(self, text: str, target_window: Optional[str] = None) -> None:
+        print(f"[DUMMY] type '{text}' -> {target_window}")
+
+
+class PyAutoGUIBackend(BaseInputBackend):
+    def type_text(self, text: str, target_window: Optional[str] = None) -> None:
+        if pyautogui is None:
+            raise RuntimeError("pyautogui not available")
+        pyautogui.write(text)
+
+
+class KeyboardBackend(BaseInputBackend):
+    def type_text(self, text: str, target_window: Optional[str] = None) -> None:
+        if keyboard is None:
+            raise RuntimeError("keyboard not available")
+        keyboard.write(text)
+
+
+BACKENDS: Dict[str, BaseInputBackend] = {
+    "dummy": DummyBackend(),
+}
+if pyautogui:
+    BACKENDS["pyautogui"] = PyAutoGUIBackend()
+if keyboard:
+    BACKENDS["keyboard"] = KeyboardBackend()
+
+
+class InputController:
+    def __init__(self, backend: str = "dummy", permission_callback: Optional[Callable[..., bool]] = None):
+        self.backend = BACKENDS.get(backend, BACKENDS["dummy"])
+        self.backend_name = backend
+        self.permission_callback = permission_callback
+
+    def type_text(
+        self,
+        text: str,
+        target_window: Optional[str] = None,
+        persona: Optional[str] = None,
+        log: bool = True,
+        mentions: Optional[list[str]] = None,
+    ) -> None:
+        if PANIC:
+            raise RuntimeError("Panic mode active")
+        if self.permission_callback and not self.permission_callback(action="type_text", text=text, target_window=target_window):
+            raise PermissionError("Permission denied")
+        self.backend.type_text(text, target_window)
+        if log:
+            _log(
+                "input.type_text",
+                persona,
+                self.backend_name,
+                {"text": text, "target_window": target_window, "mentions": mentions or []},
+            )
+
+
+def trigger_panic() -> None:
+    global PANIC
+    PANIC = True
+    _log("panic", None, "system", {"state": "on"})
+
+
+def reset_panic() -> None:
+    global PANIC
+    PANIC = False
+    _log("panic", None, "system", {"state": "off"})
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Input controller CLI")
+    parser.add_argument("--type")
+    parser.add_argument("--persona")
+    parser.add_argument("--backend", default="dummy")
+    parser.add_argument("--panic", action="store_true", help="Trigger panic mode")
+    args = parser.parse_args()
+
+    if args.panic:
+        trigger_panic()
+        print("Panic triggered")
+        return
+
+    ic = InputController(backend=args.backend)
+    ic.type_text(args.type, persona=args.persona)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_system_control.py
+++ b/tests/test_system_control.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import input_controller as ic
+import ui_controller as uc
+
+
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    reload(ic)
+    reload(uc)
+
+
+def test_input_logging(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    controller = ic.InputController()
+    controller.type_text("hi", persona="Alice")
+    log = (tmp_path / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    assert any("input.type_text" in l and "Alice" in l for l in log)
+
+
+def test_ui_logging(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    uctrl = uc.UIController()
+    uctrl.click_button("OK", persona="Bob")
+    lines = (tmp_path / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    assert any("ui.click_button" in l and "Bob" in l for l in lines)
+
+
+def test_panic(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    ic.trigger_panic()
+    with pytest.raises(RuntimeError):
+        controller = ic.InputController()
+        controller.type_text("fail")
+    ic.reset_panic()

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -1,0 +1,141 @@
+import os
+import json
+import datetime
+from pathlib import Path
+from typing import Callable, Dict, Any, Optional
+
+try:
+    from pywinauto.application import Application  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Application = None
+
+try:
+    import uiautomation as auto  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    auto = None
+
+MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
+EVENT_PATH = MEMORY_DIR / "events.jsonl"
+EVENT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+PANIC = False
+
+
+def _now() -> str:
+    return datetime.datetime.utcnow().isoformat()
+
+
+def _log(event: str, persona: Optional[str], backend: str, details: Dict[str, Any]) -> None:
+    entry = {
+        "timestamp": _now(),
+        "event": event,
+        "persona": persona or "default",
+        "backend": backend,
+        "details": details,
+    }
+    with open(EVENT_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+class BaseUIBackend:
+    def click_button(self, label: str, window: Optional[str] = None) -> None:
+        raise NotImplementedError
+
+
+class DummyUIBackend(BaseUIBackend):
+    def click_button(self, label: str, window: Optional[str] = None) -> None:
+        print(f"[DUMMY] click '{label}' -> {window}")
+
+
+class PyWinAutoBackend(BaseUIBackend):
+    def click_button(self, label: str, window: Optional[str] = None) -> None:
+        if Application is None:
+            raise RuntimeError("pywinauto not available")
+        if window:
+            app = Application().connect(title=window)
+            dlg = app.window(title=window)
+            dlg[label].click()
+        else:
+            raise RuntimeError("window required for pywinauto backend")
+
+
+class UIAutomationBackend(BaseUIBackend):
+    def click_button(self, label: str, window: Optional[str] = None) -> None:
+        if auto is None:
+            raise RuntimeError("uiautomation not available")
+        ctrl = auto.WindowControl(searchDepth=1, Name=window) if window else auto.ControlFromCursor()
+        btn = ctrl.ButtonControl(Name=label)
+        btn.Click()
+
+
+BACKENDS: Dict[str, BaseUIBackend] = {
+    "dummy": DummyUIBackend(),
+}
+if Application:
+    BACKENDS["pywinauto"] = PyWinAutoBackend()
+if auto:
+    BACKENDS["uiautomation"] = UIAutomationBackend()
+
+
+class UIController:
+    def __init__(self, backend: str = "dummy", permission_callback: Optional[Callable[..., bool]] = None):
+        self.backend = BACKENDS.get(backend, BACKENDS["dummy"])
+        self.backend_name = backend
+        self.permission_callback = permission_callback
+
+    def click_button(
+        self,
+        label: str,
+        window: Optional[str] = None,
+        persona: Optional[str] = None,
+        log: bool = True,
+        mentions: Optional[list[str]] = None,
+    ) -> None:
+        if PANIC:
+            raise RuntimeError("Panic mode active")
+        if self.permission_callback and not self.permission_callback(action="click_button", label=label, window=window):
+            raise PermissionError("Permission denied")
+        self.backend.click_button(label, window)
+        if log:
+            _log(
+                "ui.click_button",
+                persona,
+                self.backend_name,
+                {"label": label, "window": window, "mentions": mentions or []},
+            )
+
+
+def trigger_panic() -> None:
+    global PANIC
+    PANIC = True
+    _log("panic", None, "system", {"state": "on"})
+
+
+def reset_panic() -> None:
+    global PANIC
+    PANIC = False
+    _log("panic", None, "system", {"state": "off"})
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="UI controller CLI")
+    parser.add_argument("--click")
+    parser.add_argument("--window")
+    parser.add_argument("--persona")
+    parser.add_argument("--backend", default="dummy")
+    parser.add_argument("--panic", action="store_true")
+    args = parser.parse_args()
+
+    if args.panic:
+        trigger_panic()
+        print("Panic triggered")
+        return
+
+    uc = UIController(backend=args.backend)
+    uc.click_button(args.click, window=args.window, persona=args.persona)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `input_controller.py` with pluggable backends and panic switch
- add `ui_controller.py` for GUI interactions
- log all control actions to unified event log
- provide CLI usage and panic mechanism docs in README
- add tests for controllers

## Testing
- `pytest -q tests/test_system_control.py`
- `pytest -q`