### PR TITLE
Integrate undoable system control actions and policy checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,3 +411,7 @@ python ui_controller.py --click "OK" --persona Bob
 Use `--panic` with either CLI to instantly halt further actions. The panic state is recorded to the event log and can be cleared with `input_controller.reset_panic()` or `ui_controller.reset_panic()`.
 
 To add a new backend, implement the backend class with `type_text` or `click_button` and register it in the `BACKENDS` dictionary. Presence or collaboration systems can attach `@mentions` via the `mentions` parameter when invoking controller methods.
+
+Each controller action records an `undo_id` and stores an in-memory lambda so that the last step can be reverted. Use `python input_controller.py --undo-last --persona Alice` (or the UI equivalent) to roll back the most recent action for a persona.
+
+When a `policy_engine.PolicyEngine` instance is supplied to a controller, every action is checked against the active policy file. Policies can deny actions based on persona, tags, or time of day. Denied actions are logged with `status="failed"` and are surfaced by the reflection manager which proposes an `undo` step.

--- a/input_controller.py
+++ b/input_controller.py
@@ -1,8 +1,12 @@
 import os
 import json
 import datetime
+import uuid
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, Optional, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints
+    from policy_engine import PolicyEngine
 
 try:
     import pyautogui  # type: ignore
@@ -26,16 +30,34 @@ def _now() -> str:
     return datetime.datetime.utcnow().isoformat()
 
 
-def _log(event: str, persona: Optional[str], backend: str, details: Dict[str, Any]) -> None:
+def _log(
+    event: str,
+    persona: Optional[str],
+    backend: str,
+    details: Dict[str, Any],
+    *,
+    status: str = "ok",
+    error: Optional[str] = None,
+    undo_id: Optional[str] = None,
+    event_id: Optional[str] = None,
+) -> str:
+    event_id = event_id or uuid.uuid4().hex[:8]
     entry = {
+        "id": event_id,
         "timestamp": _now(),
         "event": event,
         "persona": persona or "default",
         "backend": backend,
         "details": details,
+        "status": status,
     }
+    if error:
+        entry["error"] = error
+    if undo_id:
+        entry["undo_id"] = undo_id
     with open(EVENT_PATH, "a", encoding="utf-8") as f:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return event_id
 
 
 class BaseInputBackend:
@@ -72,10 +94,17 @@ if keyboard:
 
 
 class InputController:
-    def __init__(self, backend: str = "dummy", permission_callback: Optional[Callable[..., bool]] = None):
+    def __init__(
+        self,
+        backend: str = "dummy",
+        permission_callback: Optional[Callable[..., bool]] = None,
+        policy_engine: Optional["PolicyEngine"] = None,
+    ) -> None:
         self.backend = BACKENDS.get(backend, BACKENDS["dummy"])
         self.backend_name = backend
         self.permission_callback = permission_callback
+        self.policy_engine = policy_engine
+        self._history: List[tuple[str, Optional[str], Callable[[], None]]] = []
 
     def type_text(
         self,
@@ -89,14 +118,50 @@ class InputController:
             raise RuntimeError("Panic mode active")
         if self.permission_callback and not self.permission_callback(action="type_text", text=text, target_window=target_window):
             raise PermissionError("Permission denied")
+        if self.policy_engine:
+            actions = self.policy_engine.evaluate({"event": "input.type_text", "persona": persona})
+            if any(a.get("type") == "deny" for a in actions):
+                _log(
+                    "input.type_text",
+                    persona,
+                    self.backend_name,
+                    {"text": text, "target_window": target_window, "mentions": mentions or []},
+                    status="failed",
+                    error="policy_denied",
+                )
+                raise PermissionError("Policy denied")
         self.backend.type_text(text, target_window)
+        undo_id = uuid.uuid4().hex[:8]
+        self._history.append((undo_id, persona, lambda: self.backend.type_text("\b" * len(text), target_window)))
         if log:
             _log(
                 "input.type_text",
                 persona,
                 self.backend_name,
                 {"text": text, "target_window": target_window, "mentions": mentions or []},
+                undo_id=undo_id,
             )
+
+    def undo_last(self, persona: Optional[str] = None) -> bool:
+        for i in range(len(self._history) - 1, -1, -1):
+            uid, p, fn = self._history[i]
+            if persona is None or p == persona:
+                try:
+                    fn()
+                    _log("input.undo", p, self.backend_name, {"target": uid})
+                    self._history.pop(i)
+                    return True
+                except Exception as e:  # pragma: no cover - defensive
+                    _log(
+                        "input.undo",
+                        p,
+                        self.backend_name,
+                        {"target": uid},
+                        status="failed",
+                        error=str(e),
+                    )
+                    return False
+        return False
 
 
 def trigger_panic() -> None:
@@ -119,6 +184,7 @@ def main() -> None:
     parser.add_argument("--persona")
     parser.add_argument("--backend", default="dummy")
     parser.add_argument("--panic", action="store_true", help="Trigger panic mode")
+    parser.add_argument("--undo-last", action="store_true", help="Undo last action")
     args = parser.parse_args()
 
     if args.panic:
@@ -127,6 +193,12 @@ def main() -> None:
         return
 
     ic = InputController(backend=args.backend)
+    if args.undo_last:
+        if ic.undo_last(persona=args.persona):
+            print("Undone")
+        else:
+            print("Nothing to undo")
+        return
     ic.type_text(args.type, persona=args.persona)
 
 

--- a/policy_engine.py
+++ b/policy_engine.py
@@ -80,6 +80,12 @@ class PolicyEngine:
         for k, v in emotions.items():
             if event.get("emotions", {}).get(k, 0) < float(v):
                 return False
+        ev_name = cond.get("event")
+        if ev_name and ev_name != event.get("event"):
+            return False
+        persona = cond.get("persona")
+        if persona and persona != event.get("persona"):
+            return False
         tags = cond.get("tags")
         if tags:
             ev_tags = event.get("tags", [])

--- a/tests/test_self_reflection.py
+++ b/tests/test_self_reflection.py
@@ -8,6 +8,7 @@ import self_patcher
 from api import actuator
 import self_reflection
 from importlib import reload
+import pytest
 
 
 def setup_env(tmp_path, monkeypatch):
@@ -38,3 +39,22 @@ def test_reflection_on_failure(tmp_path, monkeypatch):
     notes = mm.recent_patches(limit=1)
     assert refls and refls[0]["reason"].startswith("Failure:")
     assert notes
+
+
+def test_reflection_on_system_control(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    pol = tmp_path / "pol.yml"
+    pol.write_text('{"policies":[{"conditions":{"event":"input.type_text"},"actions":[{"type":"deny"}]}]}')
+    import importlib
+    import policy_engine as pe
+    import input_controller as ic
+    importlib.reload(pe)
+    importlib.reload(ic)
+    engine = pe.PolicyEngine(str(pol))
+    ctrl = ic.InputController(policy_engine=engine)
+    with pytest.raises(PermissionError):
+        ctrl.type_text("hi")
+    mgr = self_reflection.SelfHealingManager()
+    mgr.run_cycle()
+    refls = mm.recent_reflections(limit=1, plugin="self_heal")
+    assert refls and refls[0]["next"] == "undo"


### PR DESCRIPTION
## Summary
- add undo handling and policy checks to InputController and UIController
- extend PolicyEngine matching for events/personas
- surface system control failures in self_reflection
- document undo and policy integration
- test undo, policy denial, and reflection behavior

## Testing
- `pytest -q`