### PR TITLE
Enable reflex learning and multi-agent assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,3 +535,18 @@ can accept or dismiss the changes; every edit is logged to
 ```bash
 python workflow_editor.py workflows/demo.json
 ```
+
+### Reflex Learning & Multi-Agent Collaboration
+
+Reflex manager can now log improvement proposals and test alternative reflexes.
+Logs are stored in `logs/reflections/reflex_learn.jsonl` and visualized in the
+dashboard. Workflows accept `--agent` and `--persona` so runs can be attributed
+to specific bots or personas.
+
+```bash
+python workflow_controller.py --run-workflow demo --agent diagnostic_bot
+```
+
+Review proposals with `workflow_review.comment_review()` and vote on them from
+the CLI or dashboard. Use analytics to route a failing workflow from one persona
+to another.

--- a/tests/test_reflex_learning.py
+++ b/tests/test_reflex_learning.py
@@ -1,0 +1,36 @@
+import importlib
+import json
+
+import reflex_manager as rm
+import reflection_stream as rs
+import workflow_controller as wc
+
+
+def test_reflex_proposal_logging(tmp_path, monkeypatch):
+    monkeypatch.setenv("REFLECTION_DIR", str(tmp_path))
+    importlib.reload(rs)
+    importlib.reload(rm)
+    mgr = rm.ReflexManager()
+    mgr.propose_improvements({"usage": {"wf1": {"fail_rate": 0.6}}})
+    logs = rs.recent_reflex_learn(1)
+    assert logs and logs[0]["data"]["proposal"]["workflow"] == "wf1"
+
+
+def test_workflow_agent_logging(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    importlib.reload(wc)
+    wc.register_workflow("demo", [{"name": "s1", "action": lambda: None}])
+    assert wc.run_workflow("demo", agent="botA")
+    events = (tmp_path / "events.jsonl").read_text().splitlines()
+    assert any('"agent": "botA"' in ev for ev in events)
+
+
+def test_review_comment(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_REVIEW_DIR", str(tmp_path))
+    import workflow_review as wr
+    importlib.reload(wr)
+    wr.flag_for_review("demo", "a", "b")
+    wr.comment_review("demo", "alice", "looks good")
+    log = (tmp_path / "review_log.jsonl").read_text().splitlines()
+    assert log and json.loads(log[-1])["action"] == "comment"
+


### PR DESCRIPTION
## Summary
- log reflex learning events via new `reflex_learn` stream
- allow reflex manager to propose improvements and run A/B tests
- add agent/persona assignment to workflows and CLI
- record collaborative review comments and votes
- document reflex learning and multi-agent collaboration
- test reflex proposals, workflow assignments, and review comments

## Testing
- `pytest -q`