### PR TITLE
Implement reflex experiment tracking with CLI controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,3 +566,12 @@ python reflex_dashboard.py --log 5
 The dashboard lists active experiments with success rates and provides buttons
 to promote, reject, or revert a rule. Every action records an audit trail so
 changes can be rolled back at any time.
+
+CLI examples:
+
+```bash
+python reflex_dashboard.py --list-experiments
+python reflex_dashboard.py --promote my_rule
+python reflex_dashboard.py --demote my_rule
+python reflex_dashboard.py --revert
+```

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -23,12 +23,23 @@ def load_experiments() -> Dict[str, Any]:
 
 
 def run_cli(args: argparse.Namespace) -> None:
-    data = load_experiments()
-    for name, info in data.items():
-        print(name, info.get("status", "running"))
-        for r, stats in info.get("rules", {}).items():
-            rate = stats.get("success", 0) / max(1, stats.get("trials", 1))
-            print(f"  {r}: {stats.get('trials',0)} trials, {rate:.2f} success")
+    mgr = rm.ReflexManager()
+    mgr.load_experiments()
+
+    if args.promote:
+        mgr.promote_rule(args.promote, by="cli")
+    if args.demote:
+        mgr.demote_rule(args.demote, by="cli")
+    if args.revert:
+        mgr.revert_last()
+
+    if args.list_experiments:
+        data = load_experiments()
+        for name, info in data.items():
+            print(name, info.get("status", "running"))
+            for r, stats in info.get("rules", {}).items():
+                rate = stats.get("success", 0) / max(1, stats.get("trials", 1))
+                print(f"  {r}: {stats.get('trials',0)} trials, {rate:.2f} success")
 
     if args.log:
         logs = rs.recent_reflex_learn(args.log)
@@ -40,6 +51,10 @@ def run_dashboard() -> None:
     if st is None:
         ap = argparse.ArgumentParser(description="Reflex dashboard CLI")
         ap.add_argument("--log", type=int, default=0, help="Show last N learn logs")
+        ap.add_argument("--list-experiments", action="store_true")
+        ap.add_argument("--promote")
+        ap.add_argument("--demote")
+        ap.add_argument("--revert", action="store_true")
         args = ap.parse_args()
         run_cli(args)
         return


### PR DESCRIPTION
## Summary
- add manual promotion/demotion CLI to reflex dashboard
- track reflex trials with success/failure counts
- auto promote/demote rules based on trial results
- document new dashboard CLI usage
- test auto promotion/demotion and CLI commands

## Testing
- `pytest -q`