### PR TITLE
Enable workflow-driven reflex experimentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Multimodal Emotion Tracking & Feedback
 
 Built with 🤖 OpenAI ChatGPT (4o, 4.1, o3, Codex)
 No traditional coding background—AI-first from day one.
+Now featuring workflow-driven reflex experiments for continuous optimization.
 
 multimodal_tracker.py
 Fuses face detection, recognition, and facial emotion analysis with voice sentiment from the microphone.
@@ -478,6 +479,11 @@ steps:
 Use `--load` to read scripts, `--list-workflows` to see them, `--run-workflow <name>` to execute, and `--edit-workflow <name>` to open the file in `$EDITOR`.
 
 Workflows integrate with policy and reflection just like individual controller actions.
+Workflow steps may trigger reflex trials using `action: run:reflex` with a `rule` parameter. Each run records a trial in the reflex manager and updates the step's `reflex_status` field.
+
+```bash
+python workflow_controller.py --run-workflow demo_reflex
+```
 
 ### Workflow Library & Auto-Healing
 
@@ -578,6 +584,7 @@ python reflex_dashboard.py --log 5
 The dashboard lists active experiments with success rates and provides buttons
 to promote, reject, or revert a rule. Every action records an audit trail so
 changes can be rolled back at any time.
+Workflow-triggered trials appear here automatically when a step uses `run:reflex`.
 
 CLI examples:
 
@@ -586,4 +593,5 @@ python reflex_dashboard.py --list-experiments
 python reflex_dashboard.py --promote my_rule
 python reflex_dashboard.py --demote my_rule
 python reflex_dashboard.py --revert
+python reflex_dashboard.py --history my_rule
 ```

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -46,6 +46,13 @@ def run_cli(args: argparse.Namespace) -> None:
         for l in logs:
             print(json.dumps(l))
 
+    if args.history:
+        data = load_experiments()
+        info = data.get(args.history)
+        if info:
+            for entry in info.get("history", [])[-10:]:
+                print(json.dumps(entry))
+
 
 def run_dashboard() -> None:
     if st is None:
@@ -55,6 +62,7 @@ def run_dashboard() -> None:
         ap.add_argument("--promote")
         ap.add_argument("--demote")
         ap.add_argument("--revert", action="store_true")
+        ap.add_argument("--history")
         args = ap.parse_args()
         run_cli(args)
         return
@@ -69,6 +77,9 @@ def run_dashboard() -> None:
         for idx, (r, stats) in enumerate(info.get("rules", {}).items()):
             rate = stats.get("success", 0) / max(1, stats.get("trials", 1))
             cols[idx].metric(r, f"{rate:.2f}", f"{stats.get('trials',0)} trials")
+        with st.expander("History"):
+            for entry in info.get("history", [])[-10:]:
+                st.json(entry)
 
     st.header("Recent Learning Events")
     logs = rs.recent_reflex_learn(20)


### PR DESCRIPTION
## Summary
- support global reflex manager and `execute_rule`
- integrate reflex trials triggered by workflow steps using `run:reflex`
- surface experiment history in `reflex_dashboard` CLI and UI
- document new reflex workflow usage and dashboard options
- test workflow-triggered reflex optimization loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6839f016ac988320b5f5322fd99927bd