### PR TITLE
Link reflex manager to workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Multimodal Emotion Tracking & Feedback
 
 Built with 🤖 OpenAI ChatGPT (4o, 4.1, o3, Codex)
 No traditional coding background—AI-first from day one.
-Now featuring workflow-driven reflex experiments for continuous optimization.
+Now featuring workflow-driven reflex experiments—workflows can directly trigger, optimize, and evaluate reflexes as part of their execution. Reflex trials and optimizations are fully logged and explainable.
 
 multimodal_tracker.py
 Fuses face detection, recognition, and facial emotion analysis with voice sentiment from the microphone.
@@ -483,6 +483,7 @@ Workflow steps may trigger reflex trials using `action: run:reflex` with a `rule
 
 ```bash
 python workflow_controller.py --run-workflow demo_reflex
+python reflex_dashboard.py --history wtest
 ```
 
 ### Workflow Library & Auto-Healing

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -47,11 +47,8 @@ def run_cli(args: argparse.Namespace) -> None:
             print(json.dumps(l))
 
     if args.history:
-        data = load_experiments()
-        info = data.get(args.history)
-        if info:
-            for entry in info.get("history", [])[-10:]:
-                print(json.dumps(entry))
+        for entry in mgr.get_history(args.history)[-10:]:
+            print(json.dumps(entry))
 
 
 def run_dashboard() -> None:
@@ -69,7 +66,9 @@ def run_dashboard() -> None:
 
     st.set_page_config(page_title="Reflex Dashboard")
     st.title("Reflex Experiments")
-    data = load_experiments()
+    mgr = rm.ReflexManager()
+    mgr.load_experiments()
+    data = mgr.experiments
     for name, info in data.items():
         st.subheader(name)
         st.write(info.get("status", "running"))
@@ -78,7 +77,7 @@ def run_dashboard() -> None:
             rate = stats.get("success", 0) / max(1, stats.get("trials", 1))
             cols[idx].metric(r, f"{rate:.2f}", f"{stats.get('trials',0)} trials")
         with st.expander("History"):
-            for entry in info.get("history", [])[-10:]:
+            for entry in mgr.get_history(name)[-10:]:
                 st.json(entry)
 
     st.header("Recent Learning Events")

--- a/workflow_controller.py
+++ b/workflow_controller.py
@@ -130,9 +130,7 @@ def load_workflow_file(path: str) -> None:
             def _reflex_action(step=step, rule=rule):
                 import reflex_manager as rm
 
-                mgr = rm.get_default_manager()
-                if not mgr:
-                    raise RuntimeError("no reflex manager")
+                mgr = rm.default_manager()
                 success = mgr.execute_rule(rule)
                 r = next((rr for rr in mgr.rules if rr.name == rule), None)
                 step["reflex_status"] = r.status if r else None
@@ -238,13 +236,11 @@ def run_workflow(
                 rule = step.get("params", {}).get("rule", step.get("rule", step.get("name")))
                 step["reflex_rule"] = rule
 
-                def _reflex_action(step=step, rule=rule):
+                def _reflex_action(step=step, rule=rule, agent=agent, persona=persona):
                     import reflex_manager as rm
 
-                    mgr = rm.get_default_manager()
-                    if not mgr:
-                        raise RuntimeError("no reflex manager")
-                    success = mgr.execute_rule(rule)
+                    mgr = rm.default_manager()
+                    success = mgr.execute_rule(rule, agent=agent, persona=persona)
                     r = next((rr for rr in mgr.rules if rr.name == rule), None)
                     step["reflex_status"] = r.status if r else None
                     return success


### PR DESCRIPTION
## Summary
- support lazy default manager creation
- log trial history and expose `get_history`
- propagate agent/persona when workflow steps run reflexes
- show reflex history via CLI and Streamlit dashboard
- document the new reflex experiment integration
- test CLI `--history` output for standalone and workflow reflexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6839f68ada6c8320b9ca93b91a44afab