### PR TITLE
Add reflex audit trail and review features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Multimodal Emotion Tracking & Feedback
 Built with 🤖 OpenAI ChatGPT (4o, 4.1, o3, Codex)
 No traditional coding background—AI-first from day one.
 Now featuring workflow-driven reflex experiments—workflows can directly trigger, optimize, and evaluate reflexes as part of their execution. Reflex trials and optimizations are fully logged and explainable.
+Every reflex promotion or demotion is logged with user, timestamp, and context for full transparency.
 
 multimodal_tracker.py
 Fuses face detection, recognition, and facial emotion analysis with voice sentiment from the microphone.
@@ -595,4 +596,10 @@ python reflex_dashboard.py --promote my_rule
 python reflex_dashboard.py --demote my_rule
 python reflex_dashboard.py --revert
 python reflex_dashboard.py --history my_rule
+python reflex_dashboard.py --annotate my_rule "needs review" --tag dangerous
+python reflex_dashboard.py --audit my_rule
 ```
+
+Every promotion or demotion is logged with the user, timestamp, and context so
+the entire reflex lifecycle is explainable. Use `--audit` to inspect these
+events and `--revert-rule` to roll back a specific change.

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -32,6 +32,12 @@ def run_cli(args: argparse.Namespace) -> None:
         mgr.demote_rule(args.demote, by="cli")
     if args.revert:
         mgr.revert_last()
+    if args.revert_rule:
+        mgr.revert_rule(args.revert_rule)
+    if args.annotate:
+        rule, comment = args.annotate
+        tags = [args.tag] if args.tag else None
+        mgr.annotate(rule, comment, tags=tags, by="cli")
 
     if args.list_experiments:
         data = load_experiments()
@@ -49,6 +55,9 @@ def run_cli(args: argparse.Namespace) -> None:
     if args.history:
         for entry in mgr.get_history(args.history)[-10:]:
             print(json.dumps(entry))
+    if args.audit:
+        for entry in mgr.get_audit(args.audit):
+            print(json.dumps(entry))
 
 
 def run_dashboard() -> None:
@@ -59,7 +68,11 @@ def run_dashboard() -> None:
         ap.add_argument("--promote")
         ap.add_argument("--demote")
         ap.add_argument("--revert", action="store_true")
+        ap.add_argument("--revert-rule")
         ap.add_argument("--history")
+        ap.add_argument("--annotate", nargs=2, metavar=("RULE", "COMMENT"))
+        ap.add_argument("--tag")
+        ap.add_argument("--audit")
         args = ap.parse_args()
         run_cli(args)
         return
@@ -84,6 +97,10 @@ def run_dashboard() -> None:
     logs = rs.recent_reflex_learn(20)
     for item in logs:
         st.json(item)
+
+    st.header("Audit Log")
+    for entry in mgr.get_audit()[-20:]:
+        st.json(entry)
 
 
 if __name__ == "__main__":

--- a/workflow_controller.py
+++ b/workflow_controller.py
@@ -236,13 +236,24 @@ def run_workflow(
                 rule = step.get("params", {}).get("rule", step.get("rule", step.get("name")))
                 step["reflex_rule"] = rule
 
-                def _reflex_action(step=step, rule=rule, agent=agent, persona=persona):
+                def _reflex_action(step=step, rule=rule, agent=agent, persona=persona, wf=name):
                     import reflex_manager as rm
 
                     mgr = rm.default_manager()
                     success = mgr.execute_rule(rule, agent=agent, persona=persona)
                     r = next((rr for rr in mgr.rules if rr.name == rule), None)
                     step["reflex_status"] = r.status if r else None
+                    _log(
+                        "workflow.reflex",
+                        {
+                            "workflow": wf,
+                            "rule": rule,
+                            "status": step.get("reflex_status"),
+                            "review": str(rm.ReflexManager.AUDIT_LOG),
+                        },
+                        agent=agent,
+                        persona=persona,
+                    )
                     return success
 
                 fn = _reflex_action


### PR DESCRIPTION
## Summary
- extend `reflex_manager.py` with audit logging, annotation, and revert support
- expose audit/annotation commands in `reflex_dashboard.py`
- log review links for workflow-triggered reflexes
- update documentation for collaborative reflex review
- test annotation, audit trails, and workflow review links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a0e7649708320bf44e23c39065588