### PR TITLE
Implement multi-agent policy attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,3 +603,21 @@ python reflex_dashboard.py --audit my_rule
 Every promotion or demotion is logged with the user, timestamp, and context so
 the entire reflex lifecycle is explainable. Use `--audit` to inspect these
 events and `--revert-rule` to roll back a specific change.
+
+### Multi-Agent and Policy Attribution
+
+System events, workflow steps, and reflex experiments now track exactly **who**
+performed every action and **why**. The audit trail records the agent or
+persona, any policy that triggered review, and the reviewer who approved or
+denied the change.
+
+```bash
+python reflex_dashboard.py --promote retry_step --agent bob --persona Lumos --policy escalation_rule
+python reflex_dashboard.py --audit retry_step --filter-agent bob
+python workflow_controller.py --run-workflow demo --agent helper_bot --persona Observer
+```
+
+Use `--filter-agent`, `--filter-persona`, `--filter-policy`, or `--filter-action`
+with `--audit` to quickly locate decisions. Dashboard views surface the same
+information so collaborative reviews show who is currently online and what
+policy actions occurred.

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -27,9 +27,21 @@ def run_cli(args: argparse.Namespace) -> None:
     mgr.load_experiments()
 
     if args.promote:
-        mgr.promote_rule(args.promote, by="cli")
+        mgr.promote_rule(
+            args.promote,
+            by=args.agent or "cli",
+            persona=args.persona,
+            policy=args.policy,
+            reviewer=args.reviewer,
+        )
     if args.demote:
-        mgr.demote_rule(args.demote, by="cli")
+        mgr.demote_rule(
+            args.demote,
+            by=args.agent or "cli",
+            persona=args.persona,
+            policy=args.policy,
+            reviewer=args.reviewer,
+        )
     if args.revert:
         mgr.revert_last()
     if args.revert_rule:
@@ -37,7 +49,15 @@ def run_cli(args: argparse.Namespace) -> None:
     if args.annotate:
         rule, comment = args.annotate
         tags = [args.tag] if args.tag else None
-        mgr.annotate(rule, comment, tags=tags, by="cli")
+        mgr.annotate(
+            rule,
+            comment,
+            tags=tags,
+            by=args.agent or "cli",
+            persona=args.persona,
+            policy=args.policy,
+            reviewer=args.reviewer,
+        )
 
     if args.list_experiments:
         data = load_experiments()
@@ -56,7 +76,16 @@ def run_cli(args: argparse.Namespace) -> None:
         for entry in mgr.get_history(args.history)[-10:]:
             print(json.dumps(entry))
     if args.audit:
-        for entry in mgr.get_audit(args.audit):
+        entries = mgr.get_audit(args.audit)
+        if args.filter_agent:
+            entries = [e for e in entries if e.get("by") == args.filter_agent]
+        if args.filter_persona:
+            entries = [e for e in entries if e.get("persona") == args.filter_persona]
+        if args.filter_policy:
+            entries = [e for e in entries if e.get("policy") == args.filter_policy]
+        if args.filter_action:
+            entries = [e for e in entries if e.get("action") == args.filter_action]
+        for entry in entries:
             print(json.dumps(entry))
 
 
@@ -73,6 +102,14 @@ def run_dashboard() -> None:
         ap.add_argument("--annotate", nargs=2, metavar=("RULE", "COMMENT"))
         ap.add_argument("--tag")
         ap.add_argument("--audit")
+        ap.add_argument("--agent")
+        ap.add_argument("--persona")
+        ap.add_argument("--policy")
+        ap.add_argument("--reviewer")
+        ap.add_argument("--filter-agent")
+        ap.add_argument("--filter-persona")
+        ap.add_argument("--filter-policy")
+        ap.add_argument("--filter-action")
         args = ap.parse_args()
         run_cli(args)
         return

--- a/tests/test_reflex_optimization.py
+++ b/tests/test_reflex_optimization.py
@@ -101,7 +101,7 @@ def test_cli_demote(tmp_path, monkeypatch, capsys):
     rd.st = None
     called = {}
 
-    def fake_demote(self, name, by="system", experiment=None):
+    def fake_demote(self, name, *, by="system", persona=None, experiment=None, policy=None, reviewer=None):
         called["name"] = name
 
     monkeypatch.setattr(rm.ReflexManager, "demote_rule", fake_demote)


### PR DESCRIPTION
## Summary
- extend reflex manager audit entries with persona, policy, and reviewer fields
- allow filtering audit logs in CLI by agent, persona, policy and action
- update workflow controller logging to capture policy events
- expand reflex dashboard CLI with attribution and filtering options
- document multi-agent and policy attribution usage
- tests for audit attribution and policy logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a12a254d4832093bd47f1f1cb3901