### PR TITLE
Add collaborative policy suggestion features

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,4 +638,14 @@ python workflow_review.vote_review demo alice
 python workflow_review.vote_review demo bob
 ```
 
+New `suggestion_cli.py` manages collaborative policy suggestions:
+
+```bash
+python suggestion_cli.py list
+python suggestion_cli.py vote <id> --user alice
+python suggestion_cli.py comment <id> "needs more context" --user bob
+python suggestion_cli.py explain <id>
+python suggestion_cli.py accept <id>
+```
+
 Audit logs note who approved or dismissed each request so the collaborative decision trail is preserved.

--- a/review_requests.py
+++ b/review_requests.py
@@ -1,12 +1,25 @@
 import os
 import json
 import uuid
+import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-import datetime
 
 REQUESTS_FILE = Path(os.getenv("REVIEW_REQUESTS_FILE", "logs/review_requests.jsonl"))
+AUDIT_FILE = Path(os.getenv("SUGGESTION_AUDIT_FILE", "logs/suggestion_audit.jsonl"))
 REQUESTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _audit(action: str, request_id: str, **meta: Any) -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "action": action,
+        "request": request_id,
+        **meta,
+    }
+    with AUDIT_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
 
 
 def log_request(
@@ -36,6 +49,40 @@ def log_request(
     return entry_id
 
 
+def log_policy_suggestion(
+    kind: str,
+    target: str,
+    suggestion: str,
+    rationale: str,
+    *,
+    agent: Optional[str] = None,
+    persona: Optional[str] = None,
+    policy: Optional[str] = None,
+    assign: Optional[str] = None,
+) -> str:
+    """Create a policy/reflex suggestion with rationale."""
+    entry_id = uuid.uuid4().hex[:8]
+    entry = {
+        "id": entry_id,
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "kind": kind,
+        "target": target,
+        "suggestion": suggestion,
+        "rationale": rationale,
+        "agent": agent,
+        "persona": persona,
+        "policy": policy,
+        "assigned": assign,
+        "status": "pending",
+        "votes": {},
+        "comments": [],
+    }
+    with REQUESTS_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    _audit("create", entry_id, by=agent or "system")
+    return entry_id
+
+
 def list_requests(status: Optional[str] = None) -> List[Dict[str, Any]]:
     if not REQUESTS_FILE.exists():
         return []
@@ -50,6 +97,69 @@ def list_requests(status: Optional[str] = None) -> List[Dict[str, Any]]:
             continue
         out.append(entry)
     return out
+
+
+def get_request(request_id: str) -> Optional[Dict[str, Any]]:
+    for entry in list_requests():
+        if entry.get("id") == request_id:
+            return entry
+    return None
+
+
+def _rewrite(entries: List[Dict[str, Any]]) -> None:
+    REQUESTS_FILE.write_text("\n".join(json.dumps(e, ensure_ascii=False) for e in entries) + "\n", encoding="utf-8")
+
+
+def comment_request(request_id: str, user: str, text: str) -> bool:
+    entries = list_requests()
+    changed = False
+    for e in entries:
+        if e.get("id") == request_id:
+            e.setdefault("comments", []).append({
+                "user": user,
+                "text": text,
+                "timestamp": datetime.datetime.utcnow().isoformat(),
+            })
+            changed = True
+            _audit("comment", request_id, by=user)
+    if changed:
+        _rewrite(entries)
+    return changed
+
+
+def vote_request(request_id: str, user: str, upvote: bool = True, threshold: int = 2) -> bool:
+    entries = list_requests()
+    changed = False
+    for e in entries:
+        if e.get("id") == request_id:
+            votes = e.setdefault("votes", {})
+            votes[user] = 1 if upvote else -1
+            pos = sum(1 for v in votes.values() if v > 0)
+            if pos >= threshold and e.get("status") == "pending":
+                e["status"] = "approved"
+                _audit("auto_approve", request_id)
+            changed = True
+            _audit("vote", request_id, by=user, value=1 if upvote else -1)
+    if changed:
+        _rewrite(entries)
+    return changed
+
+
+def assign_request(request_id: str, *, agent: Optional[str] = None, persona: Optional[str] = None) -> bool:
+    entries = list_requests()
+    changed = False
+    for e in entries:
+        if e.get("id") == request_id:
+            ass = e.setdefault("assigned", [])
+            if agent:
+                ass.append(f"agent:{agent}")
+            if persona:
+                ass.append(f"persona:{persona}")
+            changed = True
+            _audit("assign", request_id, agent=agent, persona=persona)
+    if changed:
+        _rewrite(entries)
+    return changed
 
 
 def update_request(request_id: str, status: str) -> bool:
@@ -71,3 +181,17 @@ def update_request(request_id: str, status: str) -> bool:
     if changed:
         REQUESTS_FILE.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
     return changed
+
+
+def implement_request(request_id: str) -> bool:
+    if update_request(request_id, "implemented"):
+        _audit("implement", request_id)
+        return True
+    return False
+
+
+def dismiss_request(request_id: str) -> bool:
+    if update_request(request_id, "dismissed"):
+        _audit("dismiss", request_id)
+        return True
+    return False

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,0 +1,59 @@
+import argparse
+import sys
+import review_requests as rr
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Policy/reflex suggestions")
+    sub = parser.add_subparsers(dest="cmd")
+
+    l = sub.add_parser("list")
+    l.add_argument("--status", default="pending")
+
+    ex = sub.add_parser("explain")
+    ex.add_argument("id")
+
+    c = sub.add_parser("comment")
+    c.add_argument("id")
+    c.add_argument("text")
+    c.add_argument("--user", required=True)
+
+    v = sub.add_parser("vote")
+    v.add_argument("id")
+    v.add_argument("--user", required=True)
+    v.add_argument("--down", action="store_true")
+
+    a = sub.add_parser("assign")
+    a.add_argument("id")
+    a.add_argument("--agent")
+    a.add_argument("--persona")
+
+    sub.add_parser("accept").add_argument("id")
+    sub.add_parser("dismiss").add_argument("id")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list":
+        for s in rr.list_requests(args.status):
+            if "suggestion" in s:
+                print(f"{s['id']} {s['suggestion']}")
+    elif args.cmd == "explain":
+        s = rr.get_request(args.id)
+        if s:
+            print(s.get("rationale", ""))
+    elif args.cmd == "comment":
+        rr.comment_request(args.id, args.user, args.text)
+    elif args.cmd == "vote":
+        rr.vote_request(args.id, args.user, upvote=not args.down)
+    elif args.cmd == "assign":
+        rr.assign_request(args.id, agent=args.agent, persona=args.persona)
+    elif args.cmd == "accept":
+        rr.implement_request(args.id)
+    elif args.cmd == "dismiss":
+        rr.dismiss_request(args.id)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_policy_suggestions.py
+++ b/tests/test_policy_suggestions.py
@@ -1,0 +1,48 @@
+import importlib
+import json
+
+import review_requests as rr
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("REVIEW_REQUESTS_FILE", str(tmp_path / "req.jsonl"))
+    monkeypatch.setenv("SUGGESTION_AUDIT_FILE", str(tmp_path / "audit.jsonl"))
+    importlib.reload(rr)
+
+
+def test_creation_and_explain(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    sid = rr.log_policy_suggestion(
+        "workflow",
+        "demo",
+        "increase timeout",
+        "3 failures in 5 runs",
+    )
+    item = rr.get_request(sid)
+    assert item and item["suggestion"].startswith("increase")
+    assert "rationale" in item
+
+
+def test_vote_promote(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    sid = rr.log_policy_suggestion("workflow", "demo", "do", "because")
+    rr.vote_request(sid, "alice", True)
+    info = rr.get_request(sid)
+    assert info["status"] == "pending"
+    rr.vote_request(sid, "bob", True)
+    info = rr.get_request(sid)
+    assert info["status"] == "approved"
+    log = (tmp_path / "audit.jsonl").read_text().splitlines()
+    assert any(json.loads(l).get("action") == "auto_approve" for l in log)
+
+
+def test_cli_explain(tmp_path, monkeypatch, capsys):
+    setup_env(tmp_path, monkeypatch)
+    sid = rr.log_policy_suggestion("workflow", "demo", "x", "why")
+    import suggestion_cli as sc
+    monkeypatch.setattr(
+        sc.sys, "argv", ["sc", "explain", sid], raising=False
+    )
+    sc.main()
+    out = capsys.readouterr().out
+    assert "why" in out

--- a/workflow_recommendation.py
+++ b/workflow_recommendation.py
@@ -53,6 +53,15 @@ def generate_review_requests(data: Dict[str, Any]) -> List[str]:
         if info.get("failures", 0) >= 3:
             reason = f"{info.get('failures')} failures"
             rr.log_request("workflow", wf, reason)
+            suggestion = f"Increase timeout for '{wf}'"
+            rationale = f"{info.get('failures')} failures out of {info.get('runs',1)} runs"
+            rr.log_policy_suggestion(
+                "workflow",
+                wf,
+                suggestion,
+                rationale,
+                policy="auto_timeout",
+            )
             flagged.append(wf)
     return flagged
 


### PR DESCRIPTION
## Summary
- implement policy suggestion logging with voting and audit
- add CLI `suggestion_cli.py` for collaborative review
- generate suggestions from workflow recommendations
- document new suggestion workflow in README
- test suggestion lifecycle and CLI explanation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683a22fd63c88320ae556acdc7884e55