### PR TITLE
Add suggestion chain and provenance features

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,3 +649,21 @@ python suggestion_cli.py accept <id>
 ```
 
 Audit logs note who approved or dismissed each request so the collaborative decision trail is preserved.
+
+### Suggestion Chain
+
+Every suggestion forms part of a traceable chain. When a suggestion is implemented or dismissed and further issues arise, a follow-up suggestion is automatically created linking back to the previous one. View the full chain:
+
+```bash
+python suggestion_cli.py chain <id>
+```
+
+Rationales evolve as agents vote and comment. Each refinement appends a summary and is marked `Refined`.
+
+Show the entire provenance log for a suggestion including creation, votes, rationale updates, and the final decision:
+
+```bash
+python suggestion_cli.py provenance <id>
+```
+
+Dashboard and CLI views allow you to trace exactly how a policy changed over time.

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import json
 import review_requests as rr
 
 
@@ -28,6 +29,12 @@ def main() -> None:
     a.add_argument("--agent")
     a.add_argument("--persona")
 
+    ch = sub.add_parser("chain")
+    ch.add_argument("id")
+
+    pr = sub.add_parser("provenance")
+    pr.add_argument("id")
+
     sub.add_parser("accept").add_argument("id")
     sub.add_parser("dismiss").add_argument("id")
 
@@ -51,6 +58,12 @@ def main() -> None:
         rr.implement_request(args.id)
     elif args.cmd == "dismiss":
         rr.dismiss_request(args.id)
+    elif args.cmd == "chain":
+        for item in rr.get_chain(args.id):
+            print(f"{item['id']} {item.get('status')} {item.get('suggestion')}")
+    elif args.cmd == "provenance":
+        for entry in rr.get_provenance(args.id):
+            print(json.dumps(entry))
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- support linking suggestions into chains with new `previous` field
- refine rationales automatically on comments/votes
- log provenance and expose via CLI
- new CLI commands `chain` and `provenance`
- document suggestion chain usage
- tests for chain creation, refinement, and provenance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a3d9e961c832082434179c1c2643f