### PR TITLE
Implement chainable final approval with CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,16 +253,16 @@ pytest
 
 Final Approval Chain
 --------------------
-Set ``REQUIRED_FINAL_APPROVER=4o`` or a comma separated list such as
-``REQUIRED_FINAL_APPROVER=4o,alice`` to require approval from each approver in
-sequence. The approver list can also be loaded from a JSON file via
-``FINAL_APPROVER_FILE``. Approval decisions (including rationale) are logged to
-``logs/final_approval.jsonl`` and changes are only applied once **all**
-approvers consent.
+Set ``REQUIRED_FINAL_APPROVER`` to a comma separated list (e.g.
+``REQUIRED_FINAL_APPROVER=4o,alice``) to require approval from each approver in
+sequence. The chain can also be loaded from ``FINAL_APPROVER_FILE``. At runtime a
+CLI can override the chain with ``--final-approvers"`` or ``--final-approver-file``.
+Every approver decision is appended to ``logs/final_approval.jsonl`` and changes
+are only applied once **all** approvers consent.
 
 ```bash
 python memory_cli.py --final-approvers 4o,alice approve_patch <id>
-python suggestion_cli.py --final-approvers approvers.json accept <id>
+python suggestion_cli.py --final-approver-file approvers.json accept <id>
 ```
 
 Policy, Gesture & Persona Engine

--- a/final_approval.py
+++ b/final_approval.py
@@ -11,6 +11,7 @@ APPROVER_FILE = Path(os.getenv("FINAL_APPROVER_FILE", "config/final_approvers.js
 APPROVER_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 _LAST_APPROVER = ""
+_OVERRIDE: Optional[List[str]] = None
 
 
 def _env_decision(name: str) -> bool:
@@ -20,6 +21,8 @@ def _env_decision(name: str) -> bool:
 
 
 def load_approvers() -> List[str]:
+    if _OVERRIDE is not None:
+        return list(_OVERRIDE)
     env_val = os.getenv("REQUIRED_FINAL_APPROVER", "4o")
     approvers = [a.strip() for a in env_val.split(",") if a.strip()]
     if APPROVER_FILE.exists():
@@ -33,7 +36,16 @@ def load_approvers() -> List[str]:
 
 
 def set_approvers(approvers: List[str]) -> None:
+    """Persist approver chain and set as override."""
+    global _OVERRIDE
     APPROVER_FILE.write_text(json.dumps(approvers, ensure_ascii=False, indent=2), encoding="utf-8")
+    _OVERRIDE = list(approvers)
+
+
+def override_approvers(approvers: List[str]) -> None:
+    """Temporarily override approver chain without writing to disk."""
+    global _OVERRIDE
+    _OVERRIDE = list(approvers)
 
 
 def last_approver() -> str:

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -92,6 +92,10 @@ def main():
         default=os.getenv("REQUIRED_FINAL_APPROVER", "4o"),
         help="Comma separated list or config file of required approvers",
     )
+    parser.add_argument(
+        "--final-approver-file",
+        help="JSON file listing approvers to require at runtime",
+    )
     sub = parser.add_subparsers(dest="cmd")
 
     purge = sub.add_parser("purge", help="Delete old fragments")
@@ -176,13 +180,18 @@ def main():
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
     args = parser.parse_args()
-    if args.final_approvers:
+    if args.final_approver_file:
+        fp = Path(args.final_approver_file)
+        if fp.exists():
+            final_approval.override_approvers(json.loads(fp.read_text()))
+        else:
+            final_approval.override_approvers([])
+    elif args.final_approvers:
         fp = Path(args.final_approvers)
         if fp.exists():
-            final_approval.APPROVER_FILE = fp
-            final_approval.set_approvers(json.loads(fp.read_text()))
+            final_approval.override_approvers(json.loads(fp.read_text()))
         else:
-            final_approval.set_approvers(
+            final_approval.override_approvers(
                 [a.strip() for a in args.final_approvers.split(",") if a.strip()]
             )
     if args.cmd == "purge":

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 import reflex_manager as rm
 import reflection_stream as rs
+import final_approval
 
 try:
     import streamlit as st  # type: ignore
@@ -106,11 +107,27 @@ def run_dashboard() -> None:
         ap.add_argument("--persona")
         ap.add_argument("--policy")
         ap.add_argument("--reviewer")
+        ap.add_argument("--final-approvers", help="Comma separated approvers")
+        ap.add_argument("--final-approver-file", help="JSON file of approvers")
         ap.add_argument("--filter-agent")
         ap.add_argument("--filter-persona")
         ap.add_argument("--filter-policy")
         ap.add_argument("--filter-action")
         args = ap.parse_args()
+        if args.final_approver_file:
+            fp = Path(args.final_approver_file)
+            if fp.exists():
+                final_approval.override_approvers(json.loads(fp.read_text()))
+            else:
+                final_approval.override_approvers([])
+        elif args.final_approvers:
+            fp = Path(args.final_approvers)
+            if fp.exists():
+                final_approval.override_approvers(json.loads(fp.read_text()))
+            else:
+                final_approval.override_approvers(
+                    [a.strip() for a in args.final_approvers.split(",") if a.strip()]
+                )
         run_cli(args)
         return
 

--- a/reflex_manager.py
+++ b/reflex_manager.py
@@ -379,11 +379,13 @@ class ReflexManager:
         experiment: str | None = None,
         policy: Optional[str] = None,
         reviewer: Optional[str] = None,
+        approvers: Optional[List[str]] = None,
     ) -> None:
         rule = next((r for r in self.rules if r.name == name), None)
         if not rule:
             return
-        if not final_approval.request_approval(f"promote {name}"):
+        kwargs = {"approvers": approvers} if approvers is not None else {}
+        if not final_approval.request_approval(f"promote {name}", **kwargs):
             return
         prev = rule.status
         rule.status = "preferred"
@@ -414,11 +416,13 @@ class ReflexManager:
         experiment: str | None = None,
         policy: Optional[str] = None,
         reviewer: Optional[str] = None,
+        approvers: Optional[List[str]] = None,
     ) -> None:
         rule = next((r for r in self.rules if r.name == name), None)
         if not rule:
             return
-        if not final_approval.request_approval(f"demote {name}"):
+        kwargs = {"approvers": approvers} if approvers is not None else {}
+        if not final_approval.request_approval(f"demote {name}", **kwargs):
             return
         prev = rule.status
         rule.status = "inactive"

--- a/review_requests.py
+++ b/review_requests.py
@@ -220,10 +220,11 @@ def update_request(request_id: str, status: str) -> bool:
     return changed
 
 
-def implement_request(request_id: str) -> bool:
+def implement_request(request_id: str, approvers: Optional[list[str]] = None) -> bool:
     entry = get_request(request_id)
     desc = entry.get("suggestion") if entry else request_id
-    if not final_approval.request_approval(desc):
+    kwargs = {"approvers": approvers} if approvers is not None else {}
+    if not final_approval.request_approval(desc, **kwargs):
         _audit("blocked", request_id, approver=final_approval.last_approver())
         return False
     if update_request(request_id, "implemented"):

--- a/self_patcher.py
+++ b/self_patcher.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 from pathlib import Path
+from typing import Optional
 import memory_manager as mm
 from notification import send as notify
 import reflection_stream as rs
@@ -59,11 +60,12 @@ def rollback_patch(pid: str) -> bool:
     return False
 
 
-def approve_patch(pid: str) -> bool:
+def approve_patch(pid: str, approvers: Optional[list[str]] = None) -> bool:
     patches = _load()
     for p in patches:
         if p.get("id") == pid:
-            if not final_approval.request_approval(f"patch {pid}"):
+            kwargs = {"approvers": approvers} if approvers is not None else {}
+            if not final_approval.request_approval(f"patch {pid}", **kwargs):
                 return False
             p["approved"] = True
             p["rejected"] = False

--- a/tests/test_final_approval.py
+++ b/tests/test_final_approval.py
@@ -1,40 +1,90 @@
 import json
 import importlib
 from pathlib import Path
+import os
+import sys
+
+# ensure project root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import final_approval as fa
 
 
-def setup(tmp_path, approvers):
+def reload_with(tmp_path, monkeypatch, env=None, file_chain=None):
     log = tmp_path / "log.jsonl"
-    cfg = tmp_path / "approvers.json"
-    cfg.write_text(json.dumps(approvers))
-    return log, cfg
+    monkeypatch.setenv("FINAL_APPROVAL_LOG", str(log))
+    if env is not None:
+        monkeypatch.setenv("REQUIRED_FINAL_APPROVER", env)
+    else:
+        monkeypatch.delenv("REQUIRED_FINAL_APPROVER", raising=False)
+    if file_chain is not None:
+        cfg = tmp_path / "approvers.json"
+        cfg.write_text(json.dumps(file_chain))
+        monkeypatch.setenv("FINAL_APPROVER_FILE", str(cfg))
+    else:
+        monkeypatch.delenv("FINAL_APPROVER_FILE", raising=False)
+    importlib.reload(fa)
+    return log
+
+
+def test_single_approver_env(tmp_path, monkeypatch):
+    log = reload_with(tmp_path, monkeypatch, env="alice")
+    monkeypatch.setenv("ALICE_APPROVE", "true")
+    assert fa.request_approval("demo")
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert data["approver"] == "alice" and data["approved"]
 
 
 def test_multi_approver_chain(tmp_path, monkeypatch):
-    log, cfg = setup(tmp_path, ["4o", "alice"])
-    monkeypatch.setenv("FINAL_APPROVAL_LOG", str(log))
-    monkeypatch.setenv("FINAL_APPROVER_FILE", str(cfg))
+    log = reload_with(tmp_path, monkeypatch, file_chain=["4o", "alice"])
     monkeypatch.setenv("FOUR_O_APPROVE", "true")
     monkeypatch.setenv("ALICE_APPROVE", "true")
-    importlib.reload(fa)
     assert fa.request_approval("demo")
     lines = log.read_text().splitlines()
     assert len(lines) == 2
-    data = [json.loads(l) for l in lines]
-    assert all(d["approved"] for d in data)
+    assert all(json.loads(l)["approved"] for l in lines)
 
 
 def test_reject_in_chain(tmp_path, monkeypatch):
-    log, cfg = setup(tmp_path, ["4o", "alice"])
-    monkeypatch.setenv("FINAL_APPROVAL_LOG", str(log))
-    monkeypatch.setenv("FINAL_APPROVER_FILE", str(cfg))
+    log = reload_with(tmp_path, monkeypatch, file_chain=["4o", "alice"])
     monkeypatch.setenv("FOUR_O_APPROVE", "true")
     monkeypatch.setenv("ALICE_APPROVE", "false")
-    importlib.reload(fa)
     assert not fa.request_approval("demo")
     lines = log.read_text().splitlines()
     assert len(lines) == 2
     last = json.loads(lines[-1])
     assert not last["approved"] and last["approver"] == "alice"
+
+
+def test_override_chain(tmp_path, monkeypatch):
+    log = reload_with(tmp_path, monkeypatch, env="4o")
+    monkeypatch.setenv("FOUR_O_APPROVE", "false")
+    monkeypatch.setenv("ALICE_APPROVE", "true")
+    fa.override_approvers(["alice"])
+    assert fa.request_approval("demo")
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["approver"] == "alice"
+
+
+def test_cli_override(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    monkeypatch.setenv("FINAL_APPROVAL_LOG", str(tmp_path / "fa.jsonl"))
+    monkeypatch.setenv("REQUIRED_FINAL_APPROVER", "4o")
+    monkeypatch.setenv("FOUR_O_APPROVE", "false")
+    monkeypatch.setenv("ALICE_APPROVE", "true")
+    import importlib
+    import final_approval
+    importlib.reload(final_approval)
+    import memory_cli as mc
+    import self_patcher
+    p = self_patcher.apply_patch("note", auto=False)
+    import sys
+    monkeypatch.setattr(sys, "argv", ["mc", "--final-approvers", "alice", "approve_patch", p["id"]])
+    mc.main()
+    out = capsys.readouterr().out
+    assert "Approved" in out
+    log = Path(tmp_path / "fa.jsonl").read_text().splitlines()
+    assert json.loads(log[0])["approver"] == "alice"

--- a/workflow_review.py
+++ b/workflow_review.py
@@ -35,10 +35,11 @@ def load_review(name: str) -> Optional[Dict[str, str]]:
     return None
 
 
-def accept_review(name: str) -> bool:
+def accept_review(name: str, approvers: Optional[list[str]] = None) -> bool:
     info = load_review(name)
     desc = f"workflow {name}" if info else name
-    if not final_approval.request_approval(desc):
+    kwargs = {"approvers": approvers} if approvers is not None else {}
+    if not final_approval.request_approval(desc, **kwargs):
         _log_action(name, final_approval.last_approver(), "blocked")
         return False
     fp = REVIEW_DIR / f"{name}.json"


### PR DESCRIPTION
## Summary
- support approver overrides in `final_approval` and CLI tools
- allow policy engine, reflex manager and workflow review to pass approver lists
- document final-approver usage in README
- test approval chains and CLI override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b0d2344f08320b16b0a1b3157f735