### PR TITLE
Add runtime final approver overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,14 +255,24 @@ Final Approval Chain
 --------------------
 Set ``REQUIRED_FINAL_APPROVER`` to a comma separated list (e.g.
 ``REQUIRED_FINAL_APPROVER=4o,alice``) to require approval from each approver in
-sequence. The chain can also be loaded from ``FINAL_APPROVER_FILE``. At runtime a
-CLI can override the chain with ``--final-approvers"`` or ``--final-approver-file``.
+sequence. The chain can also be loaded from ``FINAL_APPROVER_FILE``.
 Every approver decision is appended to ``logs/final_approval.jsonl`` and changes
 are only applied once **all** approvers consent.
 
+Runtime Overrides
+-----------------
+All CLI utilities accept ``--final-approvers`` and ``--final-approver-file`` to
+override the approval chain without touching config files. ``--final-approvers``
+accepts a comma **or** space separated list. ``--final-approver-file`` may
+contain a JSON array or one approver per line.
+
+The active approver list is resolved in the following order (highest priority
+first): CLI override > file override > ``REQUIRED_FINAL_APPROVER`` environment
+variable.
+
 ```bash
-python memory_cli.py --final-approvers 4o,alice approve_patch <id>
-python suggestion_cli.py --final-approver-file approvers.json accept <id>
+python memory_cli.py --final-approvers "4o alice" approve_patch <id>
+python suggestion_cli.py --final-approver-file approvers.txt accept <id>
 ```
 
 Policy, Gesture & Persona Engine

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import json
+import re
 from pathlib import Path
 import memory_manager as mm
 from api import actuator
@@ -90,11 +91,11 @@ def main():
     parser.add_argument(
         "--final-approvers",
         default=os.getenv("REQUIRED_FINAL_APPROVER", "4o"),
-        help="Comma separated list or config file of required approvers",
+        help="Comma or space separated list or config file of required approvers",
     )
     parser.add_argument(
         "--final-approver-file",
-        help="JSON file listing approvers to require at runtime",
+        help="File with approver names (JSON list or newline separated) to require at runtime",
     )
     sub = parser.add_subparsers(dest="cmd")
 
@@ -182,18 +183,16 @@ def main():
     args = parser.parse_args()
     if args.final_approver_file:
         fp = Path(args.final_approver_file)
-        if fp.exists():
-            final_approval.override_approvers(json.loads(fp.read_text()))
-        else:
-            final_approval.override_approvers([])
+        chain = final_approval.load_file_approvers(fp) if fp.exists() else []
+        final_approval.override_approvers(chain, source="file")
     elif args.final_approvers:
         fp = Path(args.final_approvers)
         if fp.exists():
-            final_approval.override_approvers(json.loads(fp.read_text()))
+            chain = final_approval.load_file_approvers(fp)
         else:
-            final_approval.override_approvers(
-                [a.strip() for a in args.final_approvers.split(",") if a.strip()]
-            )
+            parts = re.split(r"[,\s]+", args.final_approvers)
+            chain = [a.strip() for a in parts if a.strip()]
+        final_approval.override_approvers(chain, source="cli")
     if args.cmd == "purge":
         mm.purge_memory(max_age_days=args.age, max_files=args.max)
     elif args.cmd == "summarize":


### PR DESCRIPTION
## Summary
- allow CLI override via new runtime options
- log approver source (env/file/cli) in `final_approval`
- document runtime override behavior
- test CLI/file overrides and priority order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b21930b708320bb565e4f0516497c