### PR TITLE
Add utility modules for actuator, facial emotion, digest and EPU

### DIFF
--- a/actuator.py
+++ b/actuator.py
@@ -1,0 +1,86 @@
+"""Simple actuator REST API.
+
+This module exposes minimal endpoints for executing commands via the
+existing ``api.actuator`` helpers. It is intended as a lightweight
+bridge that other services can call.
+
+Endpoints
+---------
+/act : queue or execute an action. Supports ``shell``, ``http`` and
+    ``file`` intents. POST JSON payloads with optional ``async`` flag.
+/act_status : query the status of an async action.
+/act_stream : server-sent events stream of action status updates.
+
+Every execution is logged to ``logs/actuator_audit.jsonl`` with the
+requesting user, full intent, and resulting status. The underlying
+``api.actuator`` module enforces whitelists for shell/HTTP/file access
+via ``config/act_whitelist.yml``.
+
+Integration Notes: mount these endpoints under an existing Flask app or run this module directly. Dashboard clients may poll ``/act_status`` or stream ``/act_stream`` for progress updates.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+from flask import Flask, Response, jsonify, request
+
+from api import actuator as core_actuator
+
+AUDIT_LOG = Path(os.getenv("ACTUATOR_AUDIT_LOG", "logs/actuator_audit.jsonl"))
+AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def _log(entry: Dict[str, Any]) -> None:
+    entry["timestamp"] = time.time()
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+@app.route("/act", methods=["POST"])
+def act_endpoint() -> Response:
+    payload = request.get_json() or {}
+    user = request.headers.get("X-User", "anonymous")
+    explanation = payload.pop("why", None)
+    if payload.pop("async", False):
+        action_id = core_actuator.start_async(payload, explanation=explanation, user=user)
+        _log({"user": user, "intent": payload, "status": "queued", "id": action_id})
+        return jsonify({"status": "queued", "id": action_id})
+
+    result = core_actuator.act(payload, explanation=explanation, user=user)
+    _log({"user": user, "intent": payload, "result": result})
+    return jsonify(result)
+
+
+@app.route("/act_status", methods=["POST"])
+def act_status_endpoint() -> Response:
+    aid = (request.get_json() or {}).get("id", "")
+    return jsonify(core_actuator.get_status(aid))
+
+
+@app.route("/act_stream", methods=["POST"])
+def act_stream_endpoint() -> Response:
+    aid = (request.get_json() or {}).get("id", "")
+
+    def gen():
+        last = None
+        while True:
+            status = core_actuator.get_status(aid)
+            if status != last:
+                yield f"data: {json.dumps(status)}\n\n"
+                last = status
+            if status.get("status") in {"finished", "failed", "unknown"}:
+                break
+            time.sleep(0.5)
+
+    return Response(gen(), mimetype="text/event-stream")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    app.run(debug=True)

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1,0 +1,86 @@
+"""Daily digest utility.
+
+This script summarizes recent log activity and emotion changes. It is
+expected to be scheduled (e.g. via cron) every 24 hours. Older log
+fragments can optionally be pruned to keep disk usage reasonable.
+
+Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards can read ``logs/daily_digest.jsonl`` for a summary feed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+DIGEST_LOG = Path(os.getenv("DAILY_DIGEST_LOG", "logs/daily_digest.jsonl"))
+DIGEST_LOG.parent.mkdir(parents=True, exist_ok=True)
+RETENTION_DAYS = int(os.getenv("DIGEST_KEEP_DAYS", "7"))
+
+
+def _parse_ts(ts: str) -> _dt.datetime:
+    try:
+        return _dt.datetime.fromisoformat(ts)
+    except Exception:
+        return _dt.datetime.utcnow()
+
+
+def _summarize_file(path: Path, since: _dt.datetime) -> int:
+    count = 0
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    data = json.loads(line)
+                    ts = _parse_ts(str(data.get("timestamp")))
+                    if ts >= since:
+                        count += 1
+                except Exception:
+                    continue
+    except FileNotFoundError:
+        return 0
+    return count
+
+
+def run_digest(period_hours: int = 24) -> Dict[str, int]:
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(hours=period_hours)
+    logs_dir = Path("logs")
+    summary: Dict[str, int] = {}
+    for fp in logs_dir.rglob("*.jsonl"):
+        if fp.name == DIGEST_LOG.name:
+            continue
+        summary[str(fp)] = _summarize_file(fp, cutoff)
+    entry = {"timestamp": _dt.datetime.utcnow().isoformat(), "summary": summary}
+    with open(DIGEST_LOG, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    _prune_old(logs_dir)
+    return summary
+
+
+def _prune_old(root: Path) -> None:
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=RETENTION_DAYS)
+    for fp in root.rglob("*.jsonl"):
+        try:
+            lines = [
+                l
+                for l in fp.read_text(encoding="utf-8").splitlines()
+                if l.strip()
+            ]
+        except Exception:
+            continue
+        keep: List[str] = []
+        for line in lines:
+            try:
+                data = json.loads(line)
+                ts = _parse_ts(str(data.get("timestamp")))
+                if ts >= cutoff:
+                    keep.append(line)
+            except Exception:
+                keep.append(line)
+        fp.write_text("\n".join(keep) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run_digest()

--- a/epu.py
+++ b/epu.py
@@ -1,0 +1,52 @@
+"""Emotion Processing Unit (EPU).
+
+Fuses audio, text, vision and reviewer emotion vectors with configurable
+weights. Maintains a rolling mood vector smoothed over time using a
+simple decay/moving average.
+
+Integration Notes: create a single ``EmotionProcessingUnit`` and feed updates from audio/text/vision review pipelines. The resulting mood vector can be streamed to dashboards via ``MOOD_LOG``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Optional
+
+from emotion_utils import empty_emotion_vector, fuse
+
+MOOD_LOG = Path(os.getenv("EPU_MOOD_LOG", "logs/epu_mood.jsonl"))
+MOOD_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+class EmotionProcessingUnit:
+    def __init__(self, weights: Optional[Dict[str, float]] = None, decay: float = 0.8, window: int = 5) -> None:
+        self.weights = weights or {"audio": 1.0, "text": 1.0, "vision": 1.0, "review": 1.0}
+        self.decay = decay
+        self.history: Deque[Dict[str, float]] = deque(maxlen=window)
+        self.current = empty_emotion_vector()
+
+    def _log(self, vec: Dict[str, float]) -> None:
+        entry = {"timestamp": time.time(), "mood": vec}
+        with open(MOOD_LOG, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def update(self, audio: Optional[Dict[str, float]] = None, text: Optional[Dict[str, float]] = None, vision: Optional[Dict[str, float]] = None, review: Optional[Dict[str, float]] = None) -> Dict[str, float]:
+        fused = fuse(audio or {}, text or {}, vision_vec=vision or {}, weights=self.weights)
+        if review:
+            for k, v in review.items():
+                fused[k] = (fused.get(k, 0.0) * (1 - self.weights.get("review", 1.0)) + v * self.weights.get("review", 1.0))
+        for k in self.current:
+            self.current[k] = self.current[k] * self.decay + fused.get(k, 0.0) * (1 - self.decay)
+        self.history.append(dict(self.current))
+        self._log(self.current)
+        return dict(self.current)
+
+    def mood(self) -> Dict[str, float]:
+        return dict(self.current)
+
+    def history_list(self) -> Dict[str, float]:  # alias for compatibility
+        return self.mood()

--- a/face_emotion.py
+++ b/face_emotion.py
@@ -1,0 +1,72 @@
+"""Face emotion detection helper.
+
+This module uses the ``fer`` library to analyze emotions from webcam
+frames or still images. Detected vectors match the format used by
+``emotion_utils`` and can be fed directly into ``multimodal_tracker``
+or other dashboards.
+
+All results are logged to ``logs/face_emotion.jsonl``.
+
+Integration Notes: call ``FaceEmotionDetector.webcam_loop`` with a ``MultiModalEmotionTracker`` instance to automatically update the fusion vector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    from fer import FER  # type: ignore
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    FER = None
+    cv2 = None
+
+LOG_PATH = Path(os.getenv("FACE_EMOTION_LOG", "logs/face_emotion.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+class FaceEmotionDetector:
+    """Detect emotions from webcam or image input."""
+
+    def __init__(self, detector: Optional[FER] = None) -> None:
+        self.detector = detector or (FER(mtcnn=False) if FER else None)
+
+    def _log(self, emotions: Dict[str, float]) -> None:
+        entry = {"timestamp": time.time(), "emotions": emotions}
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def detect_image(self, path: str) -> Dict[str, float]:
+        if not self.detector or not cv2:
+            return {}
+        img = cv2.imread(path)
+        if img is None:
+            return {}
+        res = self.detector.detect_emotions(img)
+        emotions = res[0]["emotions"] if res else {}
+        self._log(emotions)
+        return {k: float(v) for k, v in emotions.items()}
+
+    def webcam_loop(self, tracker: Optional["multimodal_tracker.MultiModalEmotionTracker"] = None, person_id: int = 0, max_frames: Optional[int] = None) -> None:
+        if not self.detector or not cv2:
+            print("[FACE_EMOTION] camera or FER not available")
+            return
+        cap = cv2.VideoCapture(0)
+        frames = 0
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+            res = self.detector.detect_emotions(frame)
+            emotions = res[0]["emotions"] if res else {}
+            self._log(emotions)
+            if tracker:
+                tracker.memory.add(person_id, "vision", emotions, time.time())
+            frames += 1
+            if max_frames is not None and frames >= max_frames:
+                break
+        cap.release()


### PR DESCRIPTION
## Summary
- add REST actuator server with /act, /act_status and /act_stream endpoints
- implement FER-based face emotion detector that can feed the multimodal tracker
- provide a daily digest script for summarizing and pruning logs
- create Emotion Processing Unit for rolling mood vectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b50c9c0dc8320a770b4491a27cc39