### PR TITLE
Add new interactive modules

### DIFF
--- a/backchannel.py
+++ b/backchannel.py
@@ -1,0 +1,56 @@
+import os
+import json
+import time
+import random
+import datetime
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    from tts_bridge import speak_async
+except Exception:  # pragma: no cover - optional
+    speak_async = None
+
+from mic_bridge import recognize_from_mic
+
+PHRASES: List[str] = ["mm-hmm", "right...", "go on..."]
+GAP_SECONDS = float(os.getenv("BACKCHANNEL_GAP", "6"))
+LOG_FILE = Path("logs/backchannel_audit.jsonl")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _log(trigger: str, phrase: str, extra: Dict[str, str] | None = None) -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "trigger": trigger,
+        "phrase": phrase,
+    }
+    if extra:
+        entry.update(extra)
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def run_loop() -> None:  # pragma: no cover - real-time loop
+    last_speech = time.time()
+    print(f"[BACKCHANNEL] Running with gap {GAP_SECONDS}s")
+    while True:
+        result = recognize_from_mic(save_audio=False)
+        text = result.get("message")
+        emotions = result.get("emotions") or {}
+        if text:
+            last_speech = time.time()
+            continue
+        if time.time() - last_speech > GAP_SECONDS:
+            phrase = random.choice(PHRASES)
+            _log("gap", phrase, {"emotions": emotions})
+            if speak_async is not None:
+                t = speak_async(phrase)
+                t.join()
+            else:
+                print(phrase)
+            last_speech = time.time()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    run_loop()

--- a/bridge_watchdog.py
+++ b/bridge_watchdog.py
@@ -1,0 +1,76 @@
+import json
+import os
+import subprocess
+import time
+import datetime
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    import requests
+except Exception:  # pragma: no cover - optional
+    requests = None
+
+WATCH_URLS: List[str] = [u.strip() for u in os.getenv("BRIDGE_URLS", "http://localhost:5000/relay").split(",") if u.strip()]
+CHECK_INTERVAL = float(os.getenv("BRIDGE_CHECK_SEC", "5"))
+RESTART_CMD = os.getenv("BRIDGE_RESTART_CMD", "")
+LOG_FILE = Path("logs/bridge_watchdog.jsonl")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+_state: Dict[str, bool] = {}
+
+
+def _log(event: str, target: str, detail: str = "") -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "event": event,
+        "target": target,
+        "detail": detail,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _check(url: str) -> bool:
+    if requests is None:
+        return True
+    try:
+        resp = requests.get(url, timeout=2)
+        return resp.status_code == 200
+    except Exception as e:  # pragma: no cover - network errors
+        _log("error", url, str(e))
+        return False
+
+
+def _restart() -> bool:
+    if not RESTART_CMD:
+        return False
+    try:
+        subprocess.run(RESTART_CMD.split(), check=True)
+        _log("restart", RESTART_CMD)
+        return True
+    except Exception as e:  # pragma: no cover - restart issues
+        _log("restart_failed", RESTART_CMD, str(e))
+        return False
+
+
+def run_loop() -> None:  # pragma: no cover - real-time loop
+    print(f"[WATCHDOG] Monitoring {', '.join(WATCH_URLS)}")
+    while True:
+        for url in WATCH_URLS:
+            ok = _check(url)
+            prev = _state.get(url, True)
+            _state[url] = ok
+            if ok:
+                if not prev:
+                    _log("recovered", url)
+                continue
+            _log("down", url)
+            if _restart():
+                _state[url] = True
+        time.sleep(CHECK_INTERVAL)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run_loop()

--- a/memory_map.py
+++ b/memory_map.py
@@ -1,0 +1,58 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    import pandas as pd  # type: ignore
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover - optional
+    pd = None
+    st = None
+
+import memory_manager as mm
+
+MEMORY_DIR = mm.RAW_PATH
+
+
+def load_entries(limit: int = 200) -> List[Dict[str, Any]]:
+    files = sorted(MEMORY_DIR.glob("*.json"))[-limit:]
+    out: List[Dict[str, Any]] = []
+    for fp in files:
+        try:
+            data = json.loads(fp.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        emo = data.get("emotions", {})
+        data = {
+            "timestamp": data.get("timestamp"),
+            "text": data.get("text", "")[:200],
+            "persona": data.get("source", "unknown"),
+            **{k: float(v) for k, v in emo.items()},
+        }
+        out.append(data)
+    return out
+
+
+def run_dashboard() -> None:
+    if st is None or pd is None:
+        for e in load_entries():
+            print(json.dumps(e))
+        return
+
+    st.set_page_config(page_title="Memory Map", layout="wide")
+    st.title("Memory Timeline")
+    limit = st.sidebar.number_input("History", 50, 1000, 200)
+    data = load_entries(limit=int(limit))
+    if not data:
+        st.write("No memory entries found")
+        return
+    df = pd.DataFrame(data)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    emo_cols = [c for c in df.columns if c not in {"timestamp", "text", "persona"}]
+    st.line_chart(df.set_index("timestamp")[emo_cols])
+    st.dataframe(df.tail(20))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI fallback
+    run_dashboard()

--- a/persona_designer.py
+++ b/persona_designer.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover - optional
+    st = None
+
+PERSONA_DIR = Path("personas")
+PERSONA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def save_persona(name: str, data: Dict[str, Any]) -> Path:
+    path = PERSONA_DIR / f"{name}.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def run_app() -> None:
+    if st is None:
+        print("streamlit not available")
+        return
+    st.set_page_config(page_title="Persona Designer", layout="centered")
+    st.title("Persona Designer")
+    name = st.text_input("Persona name")
+    traits = st.text_area("Traits", "Friendly and helpful")
+    voice = st.text_input("Voice file/path")
+    seed = st.text_area("Seed memory")
+    if st.button("Save") and name:
+        data = {"traits": traits, "voice": voice, "seed": seed}
+        path = save_persona(name, data)
+        st.success(f"Saved to {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    run_app()

--- a/presence.py
+++ b/presence.py
@@ -1,0 +1,47 @@
+import os
+import json
+import time
+import datetime
+from pathlib import Path
+from typing import List
+
+try:
+    from mic_bridge import recognize_from_mic
+except Exception:  # pragma: no cover - defensive
+    recognize_from_mic = None
+
+WAKE_WORDS: List[str] = [w.strip() for w in os.getenv("WAKE_WORDS", "Lumos").split(",") if w.strip()]
+LOG_FILE = Path("logs/presence_events.jsonl")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _log(word: str, text: str) -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "word": word,
+        "heard": text,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def run_loop() -> None:  # pragma: no cover - realtime usage
+    if recognize_from_mic is None:
+        print("[PRESENCE] mic capture unavailable")
+        return
+    print(f"[PRESENCE] Listening for wake words: {', '.join(WAKE_WORDS)}")
+    while True:
+        result = recognize_from_mic(save_audio=False)
+        text = (result.get("message") or "").lower()
+        if not text:
+            continue
+        for w in WAKE_WORDS:
+            if w.lower() in text:
+                _log(w, text)
+                print(f"[PRESENCE] Detected {w}")
+                break
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run_loop()


### PR DESCRIPTION
## Summary
- implement a backchannel loop to speak filler phrases
- add a simple wake word detector for presence events
- visualize memory history via Streamlit in `memory_map.py`
- provide a basic GUI to create persona configs
- monitor relay health with a bridge watchdog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b5be36d548320807177a7db198a31