### PR TITLE
Integrate EEG and biosignal stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,20 @@ export SENTIENTOS_HEADLESS=1
 pytest
 ```
 
+EEG, Haptics & Biosignals
+-------------------------
+``eeg_bridge.py`` streams raw EEG samples and band power analysis to
+``logs/eeg_events.jsonl``. ``eeg_features.py`` derives cognitive states such as
+focus or drowsiness and logs to ``logs/eeg_features.jsonl``. ``haptics_bridge.py``
+and ``bio_bridge.py`` log tactile feedback and biosensor metrics to
+``logs/haptics_events.jsonl`` and ``logs/bio_events.jsonl`` respectively. These
+modalities are fused by the :class:`epu.EmotionProcessingUnit` and visualised in
+``memory_map.py`` when the relevant logs exist.
+
+Synthetic streams for CI are available via ``eeg_emulator.py``. Hardware
+dependencies (``mne``, ``brainflow``, ``pyserial``) are optional and skipped in
+headless mode.
+
 Final Approval Chain
 --------------------
 Set ``REQUIRED_FINAL_APPROVER`` to a comma separated list (e.g.

--- a/bio_bridge.py
+++ b/bio_bridge.py
@@ -1,0 +1,44 @@
+"""Biosignal integration bridge.
+
+Collects physiological metrics from wearables or IoT sensors (heart rate,
+skin conductance, temperature) and logs them to ``logs/bio_events.jsonl``.
+The implementation uses random data in headless mode or when dependencies are
+missing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Dict
+
+from utils import is_headless
+
+LOG_FILE = Path(os.getenv("BIO_LOG", "logs/bio_events.jsonl"))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def read_biosignals() -> Dict[str, float]:
+    """Return the latest biosignal measurements."""
+    # Real implementations would pull from BLE/USB APIs
+    heart_rate = random.randint(60, 90)
+    gsr = random.random()
+    temp = 36.0 + random.random()
+    entry = {
+        "timestamp": time.time(),
+        "heart_rate": heart_rate,
+        "gsr": gsr,
+        "temperature": temp,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    for _ in range(5):
+        print(read_biosignals())
+        time.sleep(0.5)

--- a/eeg_bridge.py
+++ b/eeg_bridge.py
@@ -1,0 +1,104 @@
+"""EEG bridge for real or emulated headsets.
+
+This module streams raw EEG samples from supported headsets or a synthetic
+source. Each sample is timestamped and logged to ``logs/eeg_events.jsonl``.
+Band power estimates (alpha, beta, theta, gamma) are also logged.
+
+The bridge falls back to a simple random data generator if ``mne`` or
+``brainflow`` are unavailable or if ``SENTIENTOS_HEADLESS`` is enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from utils import is_headless
+
+try:  # optional dependencies
+    import mne  # type: ignore
+    from brainflow.board_shim import BoardShim  # type: ignore
+except Exception:  # pragma: no cover - optional
+    mne = None
+    BoardShim = None
+
+LOG_FILE = Path(os.getenv("EEG_LOG", "logs/eeg_events.jsonl"))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+class EEGBridge:
+    """Stream EEG samples from a headset or synthetic source."""
+
+    def __init__(self, board_id: Optional[int] = None) -> None:
+        self.board_id = board_id
+        self.headless = is_headless() or BoardShim is None
+        if not self.headless and board_id is not None:
+            try:
+                BoardShim.enable_dev_board_logger()
+                self.board = BoardShim(board_id, {})
+                self.board.prepare_session()
+            except Exception:  # pragma: no cover - hardware failure
+                self.board = None
+                self.headless = True
+        else:
+            self.board = None
+
+    def _sample(self) -> List[float]:
+        if self.board is not None:
+            try:
+                data = self.board.get_current_board_data(1)
+                return data.tolist()
+            except Exception:  # pragma: no cover - hardware failure
+                pass
+        # fallback synthetic sample
+        return [random.random() for _ in range(8)]
+
+    def _band_power(self, data: List[float]) -> Dict[str, float]:
+        if mne is None:
+            return {
+                "alpha": random.random(),
+                "beta": random.random(),
+                "theta": random.random(),
+                "gamma": random.random(),
+            }
+        try:
+            psd = mne.time_frequency.psd_array_welch([data], sfreq=250, n_fft=256)
+            freqs = psd[1]
+            power = psd[0][0]
+            return {
+                "alpha": float(power[(freqs >= 8) & (freqs <= 12)].mean()),
+                "beta": float(power[(freqs >= 12) & (freqs <= 30)].mean()),
+                "theta": float(power[(freqs >= 4) & (freqs <= 8)].mean()),
+                "gamma": float(power[(freqs >= 30) & (freqs <= 50)].mean()),
+            }
+        except Exception:  # pragma: no cover - calculation failure
+            return {
+                "alpha": random.random(),
+                "beta": random.random(),
+                "theta": random.random(),
+                "gamma": random.random(),
+            }
+
+    def read_sample(self) -> Dict[str, object]:
+        """Return a sample with timestamp and band power."""
+        raw = self._sample()
+        bands = self._band_power(raw)
+        entry = {"timestamp": time.time(), "raw": raw, "band_power": bands}
+        with LOG_FILE.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    def stream(self, duration: float = 5.0, interval: float = 0.5) -> None:
+        """Stream samples for ``duration`` seconds."""
+        end = time.time() + duration
+        while time.time() < end:
+            self.read_sample()
+            time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    EEGBridge().stream()

--- a/eeg_emulator.py
+++ b/eeg_emulator.py
@@ -1,0 +1,28 @@
+"""Synthetic EEG stream for testing pipelines.
+
+This module emits random EEG events matching the schema produced by
+:mod:`eeg_bridge` and :mod:`eeg_features`. It is useful for CI where no hardware
+is present.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterator
+
+from eeg_bridge import EEGBridge
+from eeg_features import analyze_sample
+
+
+def run(duration: float = 2.0, interval: float = 0.5) -> None:
+    """Stream synthetic EEG events for ``duration`` seconds."""
+    bridge = EEGBridge()
+    end = time.time() + duration
+    while time.time() < end:
+        sample = bridge.read_sample()
+        analyze_sample(sample)
+        time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run()

--- a/eeg_features.py
+++ b/eeg_features.py
@@ -1,0 +1,48 @@
+"""EEG feature extraction helpers.
+
+This module reads raw EEG samples from :mod:`eeg_bridge` and estimates simple
+cognitive states such as focus or drowsiness. Detected states are timestamped and
+logged to ``logs/eeg_features.jsonl``.
+
+The implementation here uses placeholder heuristics so that unit tests can run
+without hardware or heavy dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Dict
+
+LOG_FILE = Path(os.getenv("EEG_FEATURE_LOG", "logs/eeg_features.jsonl"))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def analyze_sample(sample: Dict[str, object]) -> Dict[str, object]:
+    """Return cognitive state estimates for a raw EEG sample."""
+    bands = sample.get("band_power", {}) if isinstance(sample, dict) else {}
+    focus = float(bands.get("beta", random.random()))
+    drowsy = float(bands.get("theta", random.random()))
+    entry = {
+        "timestamp": sample.get("timestamp", time.time()),
+        "focus": focus,
+        "drowsiness": drowsy,
+        "blink": random.random() > 0.9,
+        "jaw_clench": random.random() > 0.95,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    from eeg_bridge import EEGBridge
+
+    bridge = EEGBridge()
+    for _ in range(5):
+        s = bridge.read_sample()
+        print(analyze_sample(s))
+        time.sleep(0.5)

--- a/epu.py
+++ b/epu.py
@@ -24,7 +24,15 @@ MOOD_LOG.parent.mkdir(parents=True, exist_ok=True)
 
 class EmotionProcessingUnit:
     def __init__(self, weights: Optional[Dict[str, float]] = None, decay: float = 0.8, window: int = 5) -> None:
-        self.weights = weights or {"audio": 1.0, "text": 1.0, "vision": 1.0, "review": 1.0}
+        self.weights = weights or {
+            "audio": 1.0,
+            "text": 1.0,
+            "vision": 1.0,
+            "review": 1.0,
+            "eeg": 1.0,
+            "haptics": 1.0,
+            "bio": 1.0,
+        }
         self.decay = decay
         self.history: Deque[Dict[str, float]] = deque(maxlen=window)
         self.current = empty_emotion_vector()
@@ -34,11 +42,23 @@ class EmotionProcessingUnit:
         with open(MOOD_LOG, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
 
-    def update(self, audio: Optional[Dict[str, float]] = None, text: Optional[Dict[str, float]] = None, vision: Optional[Dict[str, float]] = None, review: Optional[Dict[str, float]] = None) -> Dict[str, float]:
+    def update(
+        self,
+        audio: Optional[Dict[str, float]] = None,
+        text: Optional[Dict[str, float]] = None,
+        vision: Optional[Dict[str, float]] = None,
+        review: Optional[Dict[str, float]] = None,
+        eeg: Optional[Dict[str, float]] = None,
+        haptics: Optional[Dict[str, float]] = None,
+        bio: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, float]:
         fused = fuse(audio or {}, text or {}, vision_vec=vision or {}, weights=self.weights)
-        if review:
-            for k, v in review.items():
-                fused[k] = (fused.get(k, 0.0) * (1 - self.weights.get("review", 1.0)) + v * self.weights.get("review", 1.0))
+        for name, vec in {"review": review, "eeg": eeg, "haptics": haptics, "bio": bio}.items():
+            if not vec:
+                continue
+            w = self.weights.get(name, 1.0)
+            for k, v in vec.items():
+                fused[k] = fused.get(k, 0.0) * (1 - w) + v * w
         for k in self.current:
             self.current[k] = self.current[k] * self.decay + fused.get(k, 0.0) * (1 - self.decay)
         self.history.append(dict(self.current))

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ pandas
 streamlit
 Flask-SocketIO
 python-socketio
+mne
+brainflow
+pyserial

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -1,0 +1,56 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from importlib import reload
+from pathlib import Path
+
+import epu
+
+
+def test_eeg_emulator(tmp_path, monkeypatch):
+    eeg_log = tmp_path / "eeg.jsonl"
+    feat_log = tmp_path / "feat.jsonl"
+    monkeypatch.setenv("EEG_LOG", str(eeg_log))
+    monkeypatch.setenv("EEG_FEATURE_LOG", str(feat_log))
+    import eeg_emulator
+    reload(eeg_emulator)
+    eeg_emulator.run(duration=0.1, interval=0.05)
+    assert eeg_log.exists() and feat_log.exists()
+    assert eeg_log.read_text().strip() != ""
+    assert feat_log.read_text().strip() != ""
+
+
+def test_haptics_and_bio(tmp_path, monkeypatch):
+    h_log = tmp_path / "h.jsonl"
+    b_log = tmp_path / "b.jsonl"
+    monkeypatch.setenv("HAPTIC_LOG", str(h_log))
+    monkeypatch.setenv("BIO_LOG", str(b_log))
+    import haptics_bridge
+    import bio_bridge
+    reload(haptics_bridge)
+    reload(bio_bridge)
+    haptics_bridge.HapticsBridge().read_event()
+    bio_bridge.read_biosignals()
+    assert h_log.exists() and b_log.exists()
+
+
+def test_epu_modalities():
+    e = epu.EmotionProcessingUnit()
+    out = e.update(eeg={"Joy": 1.0}, haptics={"Anger": 0.5}, bio={"Joy": 0.2})
+    assert isinstance(out, dict)
+
+
+def test_relay_extra_endpoints(tmp_path, monkeypatch):
+    from tests.test_relay import setup_app
+    mood_log = tmp_path / "m.jsonl"
+    mood_log.write_text(json.dumps({"timestamp": 0, "mood": {"Joy": 1}}) + "\n")
+    monkeypatch.setenv("EPU_MOOD_LOG", str(mood_log))
+    monkeypatch.setenv("RELAY_SECRET", "secret123")
+    import epu
+    epu.MOOD_LOG = mood_log
+    client = setup_app(tmp_path, monkeypatch)
+    resp = client.post("/mood")
+    assert resp.status_code == 200
+    assert resp.get_json().get("Joy") == 1
+

--- a/tts_bridge.py
+++ b/tts_bridge.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 from typing import Optional, Dict
 import threading
+import random
 
 try:
     from TTS.api import TTS  # Coqui TTS, optional dependency
@@ -169,6 +170,17 @@ def speak_async(
     t = threading.Thread(target=speak, args=(text,), kwargs={"voice": voice, "save_path": save_path, "emotions": emotions})
     t.start()
     return t
+
+
+PARALINGUISTIC = ["mm-hmm", "uh-huh", "*sigh*", "*breath*"]
+
+
+def backchannel(emotions: Optional[Dict[str, float]] = None) -> Optional[threading.Thread]:
+    """Inject a short non-verbal utterance asynchronously."""
+    if HEADLESS or ENGINE is None:
+        return None
+    cue = random.choice(PARALINGUISTIC)
+    return speak_async(cue, emotions=emotions)
 
 def stop() -> None:
     """Stop current speech playback if supported."""


### PR DESCRIPTION
## Summary
- add EEG bridge, feature extractor and emulator modules
- implement haptic and bio bridges
- extend EmotionProcessingUnit with EEG/haptic/bio modalities
- expose mood and sensor endpoints in relay_app
- add backchannel support in tts_bridge and update voice_loop
- visualize new streams in memory_map
- document new integrations and update requirements
- provide tests covering new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b5e2f90bc8320ac6f6a4f11622455