### PR TITLE
Enable advanced feedback and reflex automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Emotional Feedback & Dashboard
 Emotional feedback:
 The Streamlit dashboard (emotion_dashboard.py) displays live, per-person emotion data and can trigger feedback rules defined in feedback.py.
 
-Create a JSON file (e.g. feedback_rules.json):
+Example feedback rules (`config/feedback_rules.json`):
 
-json
-Copy
-Edit
+```json
 [
-  {"emotion": "Anger", "threshold": 0.7, "action": "print"}
+  {"emotion": "Confident", "threshold": 0.85, "action": "positive_cue", "duration": 30},
+  {"emotion": "Fear", "threshold": 0.6, "action": "calming_routine", "check_func": "feedback_rules:stress_confirmed"}
 ]
+```
 Run the dashboard:
 
 bash
@@ -68,6 +68,10 @@ Runs reflex routines from timers, file changes, or on-demand triggers using the 
 Panic flag halts all actions.
 
 Rules support interval, file_change, or on_demand triggers.
+
+Default rules are loaded from `config/reflex_rules.json` and include:
+* `bridge_stability_monitor` - watches `logs/bridge_watchdog.jsonl` and escalates if restarts exceed three in 10 minutes.
+* `daily_digest` - every 24 hours summarizes logs and notifies the dashboard.
 
 Example:
 
@@ -629,6 +633,8 @@ python reflex_dashboard.py --log 5
 The dashboard lists active experiments with success rates and provides buttons
 to promote, reject, or revert a rule. Every action records an audit trail so
 changes can be rolled back at any time.
+`emotion_dashboard.py` also displays rule status and lets administrators promote,
+demote or comment on any rule while viewing live feedback triggers.
 Workflow-triggered trials appear here automatically when a step uses `run:reflex`.
 
 CLI examples:

--- a/config/feedback_rules.json
+++ b/config/feedback_rules.json
@@ -1,0 +1,16 @@
+[
+  {
+    "emotion": "Confident",
+    "threshold": 0.85,
+    "action": "positive_cue",
+    "duration": 30,
+    "cooldown": 10
+  },
+  {
+    "emotion": "Fear",
+    "threshold": 0.6,
+    "action": "calming_routine",
+    "check_func": "feedback_rules:stress_confirmed",
+    "cooldown": 10
+  }
+]

--- a/config/reflex_rules.json
+++ b/config/reflex_rules.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "bridge_stability_monitor",
+    "trigger": "file_change",
+    "path": "logs/bridge_watchdog.jsonl",
+    "actions": [
+      {"type": "pycall", "func": "reflex_rules:bridge_restart_check"}
+    ]
+  },
+  {
+    "name": "daily_digest",
+    "trigger": "interval",
+    "seconds": 86400,
+    "preferred": true,
+    "actions": [
+      {"type": "pycall", "func": "reflex_rules:daily_digest_action"}
+    ]
+  }
+]

--- a/feedback_rules.py
+++ b/feedback_rules.py
@@ -1,0 +1,10 @@
+"""Custom feedback rule helpers."""
+from __future__ import annotations
+from typing import Dict, Any
+
+
+def stress_confirmed(value: float, emotions: Dict[str, float], ctx: Dict[str, Any]) -> bool:
+    """Return True if EEG or biosignal data also indicates stress."""
+    eeg_beta = ctx.get("eeg", {}).get("beta", 0.0)
+    heart = ctx.get("biosignals", {}).get("heart_rate", 0.0)
+    return eeg_beta > ctx.get("beta_threshold", 0.6) or heart > ctx.get("hr_threshold", 100)

--- a/plugins/pycall.py
+++ b/plugins/pycall.py
@@ -1,0 +1,19 @@
+"""Execute a local Python function via the actuator framework."""
+from importlib import import_module
+from api.actuator import BaseActuator
+
+
+def register(reg):
+    class PyCallActuator(BaseActuator):
+        def execute(self, intent):
+            target = intent.get("func")
+            if not target or ":" not in target:
+                raise ValueError("func must be module:function")
+            mod_name, func_name = target.split(":", 1)
+            mod = import_module(mod_name)
+            func = getattr(mod, func_name)
+            args = intent.get("args", [])
+            kwargs = intent.get("kwargs", {})
+            return {"result": func(*args, **kwargs)}
+
+    reg("pycall", PyCallActuator())

--- a/reflex_rules.py
+++ b/reflex_rules.py
@@ -1,0 +1,44 @@
+"""Custom reflex actions for bridge monitoring and daily digest."""
+from __future__ import annotations
+import json
+import datetime
+from pathlib import Path
+from api import actuator
+import notification
+import daily_digest
+
+
+def bridge_restart_check() -> None:
+    """Check recent restart events and escalate if too frequent."""
+    log = Path("logs/bridge_watchdog.jsonl")
+    now = datetime.datetime.utcnow()
+    cutoff = now - datetime.timedelta(minutes=10)
+    count = 0
+    if log.exists():
+        for line in log.read_text(encoding="utf-8").splitlines():
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            if data.get("event") != "restart":
+                continue
+            try:
+                ts = datetime.datetime.fromisoformat(data.get("timestamp", ""))
+            except Exception:
+                continue
+            if ts >= cutoff:
+                count += 1
+    metrics = {"timestamp": now.isoformat(), "recent_restarts": count}
+    metric_path = Path("logs/bridge_metrics.json")
+    metric_path.parent.mkdir(parents=True, exist_ok=True)
+    metric_path.write_text(json.dumps(metrics))
+    notification.send("bridge.restart", metrics)
+    if count > 3:
+        actuator.dispatch({"type": "escalate", "goal": "bridge", "text": "failover"})
+        notification.send("bridge.failover", metrics)
+
+
+def daily_digest_action() -> None:
+    """Generate a daily log digest and notify listeners."""
+    summary = daily_digest.run_digest()
+    notification.send("daily.digest", summary)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,4 +1,5 @@
 import json
+import time
 from feedback import FeedbackManager, FeedbackRule
 
 
@@ -22,3 +23,31 @@ def test_load_rules(tmp_path):
     fm.register_action('rec', lambda r, u, v: None)
     fm.load_rules(str(cfg))
     assert fm.rules and fm.rules[0].emotion == 'Anger'
+
+
+def test_rule_duration(monkeypatch):
+    fm = FeedbackManager()
+    out = {}
+    fm.register_action('rec', lambda r, u, v: out.setdefault('hits', 0) or out.update({'hits': out.get('hits',0)+1}))
+    fm.add_rule(FeedbackRule(emotion='Focus', threshold=0.5, action='rec', duration=0.1))
+    fm.process(1, {'Focus': 0.6})
+    assert out.get('hits') is None
+    time.sleep(0.11)
+    fm.process(1, {'Focus': 0.6})
+    assert out.get('hits') == 1
+
+
+def test_load_rules_with_check(tmp_path, monkeypatch):
+    mod = tmp_path / 'mod.py'
+    mod.write_text('def check(v,e,c):\n    return c.get("flag")')
+    cfg = tmp_path / 'rules.json'
+    cfg.write_text(json.dumps([{'emotion': 'Joy', 'threshold': 0.5, 'action': 'rec', 'check_func': 'mod:check'}]))
+    import sys
+    sys.path.insert(0, str(tmp_path))
+    fm = FeedbackManager()
+    trig = {}
+    fm.register_action('rec', lambda r,u,v: trig.setdefault('hit', True))
+    fm.load_rules(str(cfg))
+    fm.process(1, {'Joy':0.6}, {'flag': True})
+    assert trig.get('hit')
+    sys.path.remove(str(tmp_path))


### PR DESCRIPTION
## Summary
- add pycall actuator plugin
- implement bridge and digest reflex routines
- support duration and custom checks in feedback rules
- create example feedback and reflex rule configs
- enhance emotion dashboard with reflex controls and logging
- document new capabilities
- test new feedback manager features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b636d2f5c83208b8fde056d1a1884