### PR TITLE
Add self-tuning feedback and reflex governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ When any face exceeds a threshold, the associated feedback action is executed (p
 
 Register new actions or embodiment targets via FeedbackManager.
 
+### Reflex Learning & User Feedback
+
+Feedback rules can now self-tune when `FeedbackManager.learning` is enabled.
+Every action receives a short user rating (yes/no or comment). Responses are
+written to `logs/reflex_user_feedback.jsonl` and aggregated per rule.
+After five ratings, thresholds and cooldowns automatically adjust based on
+success rate. Each tuning event is logged to `logs/reflex_tuning.jsonl` with the
+before/after values and rationale.
+
+Example feedback log entry:
+
+```json
+{"time": 1720000000.0, "action_id": "abcd1234", "rule": "calming_routine", "rating": 1}
+```
+
+Example tuning log entry:
+
+```json
+{"time": 1720000050.0, "rule": "calming_routine", "before": {"threshold": 0.6}, "after": {"threshold": 0.55}, "rationale": "success rate 0.80 - lowering threshold"}
+```
+See `docs/sample_user_feedback.jsonl` for a sample feedback log.
+See `config/multimodal_reflex_examples.json` for templates that trigger when
+multiple signals agree (emotion, EEG, and haptics).
+
 Reflex Manager
 reflex_manager.py:
 Runs reflex routines from timers, file changes, or on-demand triggers using the actuator.
@@ -68,6 +92,9 @@ Runs reflex routines from timers, file changes, or on-demand triggers using the 
 Panic flag halts all actions.
 
 Rules support interval, file_change, or on_demand triggers.
+Conditional triggers can also poll arbitrary signals via a check function. See
+`config/multimodal_reflex_examples.json` for reference definitions combining
+emotion, EEG, and haptics.
 
 Default rules are loaded from `config/reflex_rules.json` and include:
 * `bridge_stability_monitor` - watches `logs/bridge_watchdog.jsonl` and escalates if restarts exceed three in 10 minutes.

--- a/config/multimodal_reflex_examples.json
+++ b/config/multimodal_reflex_examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "stress_warning",
+    "trigger": "conditional",
+    "check_func": "reflex_examples:stress_warning_check",
+    "interval": 2,
+    "actions": [{"type": "notify", "channel": "stress"}]
+  },
+  {
+    "name": "fatigue_alert",
+    "trigger": "conditional",
+    "check_func": "reflex_examples:fatigue_alert_check",
+    "interval": 2,
+    "actions": [{"type": "notify", "channel": "fatigue"}]
+  },
+  {
+    "name": "focus_prompt",
+    "trigger": "conditional",
+    "check_func": "reflex_examples:focus_prompt_check",
+    "interval": 2,
+    "actions": [{"type": "notify", "channel": "focus"}]
+  }
+]

--- a/docs/sample_user_feedback.jsonl
+++ b/docs/sample_user_feedback.jsonl
@@ -1,0 +1,2 @@
+{"time": 1720000000.0, "action_id": "abcd1234", "rule": "calming_routine", "rating": 1, "comment": "felt better"}
+{"time": 1720000010.0, "action_id": "def0567", "rule": "calming_routine", "rating": 0, "comment": "no effect"}

--- a/feedback.py
+++ b/feedback.py
@@ -5,6 +5,8 @@ import importlib
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
+import json
+import uuid
 
 try:
     from playsound import playsound  # type: ignore
@@ -30,6 +32,7 @@ class FeedbackRule:
     cooldown: float = 1.0
     duration: float = 0.0
     custom_check: Optional[Callable[[float, Dict[str, float], Dict[str, Any]], bool]] = None
+    name: str = ""
 
 
 @dataclass
@@ -42,6 +45,11 @@ class FeedbackManager:
     active_since: Dict[Tuple[int, str, str], float] = field(default_factory=dict)
     history: List[Dict[str, Any]] = field(default_factory=list)
     log_path: Path = Path(os.getenv("FEEDBACK_LOG", "logs/feedback_actions.jsonl"))
+    user_log_path: Path = Path(os.getenv("FEEDBACK_USER_LOG", "logs/reflex_user_feedback.jsonl"))
+    tuning_log_path: Path = Path(os.getenv("REFLEX_TUNING_LOG", "logs/reflex_tuning.jsonl"))
+    learning: bool = False
+    rule_stats: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    tuning_history: List[Dict[str, Any]] = field(default_factory=list)
 
     def add_rule(self, rule: FeedbackRule) -> None:
         self.rules.append(rule)
@@ -81,7 +89,9 @@ class FeedbackManager:
                 action = self.actions.get(rule.action)
                 if action:
                     action(rule, user_id, value)
+                action_id = uuid.uuid4().hex
                 entry = {
+                    "id": action_id,
                     "time": ts,
                     "user": user_id,
                     "emotion": rule.emotion,
@@ -92,12 +102,77 @@ class FeedbackManager:
                 self.log_path.parent.mkdir(parents=True, exist_ok=True)
                 with open(self.log_path, "a", encoding="utf-8") as f:
                     f.write(json.dumps(entry) + "\n")
+                self.request_feedback(rule, action_id)
                 self.active_since.pop(key, None)
             else:
                 self.active_since.pop(key, None)
 
     def get_history(self, limit: int = 20) -> List[Dict[str, Any]]:
         return self.history[-limit:]
+
+    # ------------------------------------------------------------------
+    def log_user_feedback(self, action_id: str, rule: FeedbackRule, rating: int, comment: str = "") -> None:
+        entry = {
+            "time": time.time(),
+            "action_id": action_id,
+            "rule": rule.name or rule.action,
+            "rating": rating,
+            "comment": comment,
+        }
+        self.user_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.user_log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        stats = self.rule_stats.setdefault(rule.name or rule.action, {"hits": 0, "positive": 0})
+        stats["hits"] += 1
+        if rating > 0:
+            stats["positive"] += 1
+        if self.learning:
+            self._maybe_tune(rule, stats)
+
+    def request_feedback(self, rule: FeedbackRule, action_id: str) -> None:
+        if os.getenv("FEEDBACK_NO_PROMPT"):
+            return
+        try:
+            resp = input(f"Did action '{rule.action}' help? (y/n or comment) ").strip()
+        except Exception:
+            return
+        if not resp:
+            return
+        rating = 1 if resp.lower().startswith("y") else 0
+        comment = "" if resp.lower() in {"y", "n"} else resp
+        self.log_user_feedback(action_id, rule, rating, comment)
+
+    def _maybe_tune(self, rule: FeedbackRule, stats: Dict[str, int]) -> None:
+        if stats["hits"] < 5:
+            return
+        rate = stats["positive"] / max(1, stats["hits"])
+        before = {"threshold": rule.threshold, "cooldown": rule.cooldown}
+        rationale = ""
+        tuned = False
+        if rate > 0.7 and rule.threshold > 0.1:
+            rule.threshold = max(0.0, rule.threshold - 0.05)
+            rationale = f"success rate {rate:.2f} - lowering threshold"
+            tuned = True
+        elif rate < 0.3 and rule.threshold < 1.0:
+            rule.threshold = min(1.0, rule.threshold + 0.05)
+            rule.cooldown += 1
+            rationale = f"low success {rate:.2f} - raising threshold"
+            tuned = True
+        if tuned:
+            after = {"threshold": rule.threshold, "cooldown": rule.cooldown}
+            log = {
+                "time": time.time(),
+                "rule": rule.name or rule.action,
+                "before": before,
+                "after": after,
+                "rationale": rationale,
+            }
+            self.tuning_history.append(log)
+            self.tuning_log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.tuning_log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(log) + "\n")
+        stats["hits"] = 0
+        stats["positive"] = 0
 
 
 # ----- Built-in actions -----

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -44,6 +44,17 @@ def run_cli(args: argparse.Namespace) -> None:
             policy=args.policy,
             reviewer=args.reviewer,
         )
+    if args.freeze:
+        mgr.freeze_rule(args.freeze)
+    if args.unfreeze:
+        mgr.unfreeze_rule(args.unfreeze)
+    if args.edit:
+        name, key, value = args.edit
+        try:
+            val = json.loads(value)
+        except Exception:
+            val = value
+        mgr.edit_rule(name, **{key: val})
     if args.revert:
         mgr.revert_last()
     if args.revert_rule:
@@ -89,6 +100,17 @@ def run_cli(args: argparse.Namespace) -> None:
             entries = [e for e in entries if e.get("action") == args.filter_action]
         for entry in entries:
             print(json.dumps(entry))
+    if args.list_feedback:
+        path = Path(os.getenv("FEEDBACK_USER_LOG", "logs/reflex_user_feedback.jsonl"))
+        if path.exists():
+            for line in path.read_text().splitlines():
+                print(line)
+    if args.feedback_log:
+        path = Path(os.getenv("FEEDBACK_USER_LOG", "logs/reflex_user_feedback.jsonl"))
+        if path.exists():
+            lines = path.read_text().splitlines()[-args.feedback_log:]
+            for ln in lines:
+                print(ln)
 
 
 def run_dashboard() -> None:
@@ -100,10 +122,15 @@ def run_dashboard() -> None:
         ap.add_argument("--demote")
         ap.add_argument("--revert", action="store_true")
         ap.add_argument("--revert-rule")
+        ap.add_argument("--freeze")
+        ap.add_argument("--unfreeze")
+        ap.add_argument("--edit", nargs=3, metavar=("RULE", "KEY", "VALUE"))
         ap.add_argument("--history")
         ap.add_argument("--annotate", nargs=2, metavar=("RULE", "COMMENT"))
         ap.add_argument("--tag")
         ap.add_argument("--audit")
+        ap.add_argument("--list-feedback", action="store_true")
+        ap.add_argument("--feedback-log", type=int)
         ap.add_argument("--agent")
         ap.add_argument("--persona")
         ap.add_argument("--policy")

--- a/reflex_examples.py
+++ b/reflex_examples.py
@@ -1,0 +1,36 @@
+import json
+import os
+from pathlib import Path
+
+EMOTION_LOG = Path(os.getenv("EMOTION_LOG", "logs/emotions.jsonl"))
+EEG_LOG = Path(os.getenv("EEG_FEATURE_LOG", "logs/eeg_features.jsonl"))
+HAPTIC_LOG = Path(os.getenv("HAPTIC_LOG", "logs/haptics_events.jsonl"))
+
+
+def _last_value(path: Path, field: str) -> float:
+    if not path.exists():
+        return 0.0
+    try:
+        line = path.read_text(encoding="utf-8").splitlines()[-1]
+        data = json.loads(line)
+        return float(data.get(field, 0.0))
+    except Exception:
+        return 0.0
+
+
+def stress_warning_check() -> bool:
+    fear = _last_value(EMOTION_LOG, "Fear")
+    beta = _last_value(EEG_LOG, "focus")
+    agitation = _last_value(HAPTIC_LOG, "value")
+    return fear > 0.7 and (beta > 0.5 or agitation > 0.5)
+
+
+def fatigue_alert_check() -> bool:
+    drowsy = _last_value(EEG_LOG, "drowsiness")
+    agitation = _last_value(HAPTIC_LOG, "value")
+    return drowsy > 0.6 and agitation < 0.3
+
+
+def focus_prompt_check() -> bool:
+    focus = _last_value(EEG_LOG, "focus")
+    return focus < 0.3

--- a/tests/test_feedback_learning.py
+++ b/tests/test_feedback_learning.py
@@ -1,0 +1,23 @@
+import json
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_learning_tuning(tmp_path, monkeypatch):
+    monkeypatch.setenv("FEEDBACK_USER_LOG", str(tmp_path / "u.jsonl"))
+    monkeypatch.setenv("REFLEX_TUNING_LOG", str(tmp_path / "t.jsonl"))
+    import importlib, feedback
+    importlib.reload(feedback)
+    from feedback import FeedbackManager, FeedbackRule
+
+    fm = FeedbackManager(learning=True)
+    fm.register_action("noop", lambda r, u, v: None)
+    rule = FeedbackRule(emotion="Fear", threshold=0.6, action="noop", name="calm")
+    fm.add_rule(rule)
+    for i in range(5):
+        fm.log_user_feedback(str(i), rule, 1 if i < 4 else 0)
+    assert rule.threshold < 0.6
+    logs = (tmp_path / "t.jsonl").read_text().splitlines()
+    assert logs and json.loads(logs[0])["rule"] == "calm"
+

--- a/tests/test_reflex_freeze.py
+++ b/tests/test_reflex_freeze.py
@@ -1,0 +1,23 @@
+import importlib
+
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import reflex_manager as rm
+
+
+def test_freeze_unfreeze(tmp_path):
+    manager = rm.ReflexManager()
+    rule = rm.ReflexRule(rm.OnDemandTrigger(), [], name="f")
+    manager.add_rule(rule)
+    manager.freeze_rule("f")
+    manager.promote_rule("f")
+    assert rule.status != "preferred"
+    manager.unfreeze_rule("f")
+    import final_approval
+    importlib.reload(final_approval)
+    rm.final_approval.request_approval = lambda *a, **k: True
+    manager.promote_rule("f")
+    assert rule.status == "preferred"
+
+


### PR DESCRIPTION
## Summary
- implement learning mode for `FeedbackManager`
- log user ratings and tuning changes
- add conditional reflex triggers and freeze/edit helpers
- expose new CLI options for reflex dashboard
- document reflex learning and provide examples
- add tests for tuning and rule freezing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b6698279c832091aef6e470824bee