### PR TITLE
Add collaborative experiment governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,16 @@ Every promotion or demotion is logged with the user, timestamp, and context so
 the entire reflex lifecycle is explainable. Use `--audit` to inspect these
 events and `--revert-rule` to roll back a specific change.
 
+### Collaborative Experiment Governance
+
+Run `experiment_cli.py propose` to submit new reflex experiments complete with
+description, conditions, and expected outcome. Community members vote and
+comment via the CLI or the `/experiments` API. Votes are tallied in
+`logs/experiments.json` and every action is recorded to
+`logs/experiment_audit.jsonl`. Success rates are displayed with
+`experiment_cli.py list` so promising trials can be promoted to core reflexes or
+rolled back if they fail.
+
 ### Multi-Agent and Policy Attribution
 
 System events, workflow steps, and reflex experiments now track exactly **who**

--- a/docs/examples/experiment_audit_sample.jsonl
+++ b/docs/examples/experiment_audit_sample.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2024-01-01T00:00:00","action":"propose","experiment":"exp1","by":"alice"}
+{"timestamp":"2024-01-01T00:05:00","action":"vote","experiment":"exp1","by":"bob","value":1}

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,29 @@
+# Reflex Experiment Governance
+
+This module introduces collaborative experimentation for reflex rules.
+
+## Submitting Experiments
+
+Use `experiment_cli.py propose "desc" "conditions" "expected" --user alice` to
+create a new experiment. Each proposal receives a unique ID and is stored in
+`logs/experiments.json`. All actions are also recorded to
+`logs/experiment_audit.jsonl`.
+
+## Voting and Comments
+
+Participants may vote or comment on experiments using the CLI or the
+`/experiments` API. Once the configured threshold of positive votes is met the
+experiment status moves from `pending` to `active`.
+
+## Live Tracking
+
+Trigger counts and successes are recorded with `experiment_tracker.record_result`. The
+CLI `list` command shows success rates so the community can decide whether to
+promote a reflex to core status or adjust its parameters.
+
+## API Usage
+
+`experiments_api.py` exposes `/experiments` for listing and proposing experiments
+and `/experiments/vote` and `/experiments/comment` for community feedback.
+
+Permissions and authentication should be handled by the hosting application.

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,0 +1,57 @@
+import argparse
+import experiment_tracker as et
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reflex experiment CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p = sub.add_parser("propose")
+    p.add_argument("description")
+    p.add_argument("conditions")
+    p.add_argument("expected")
+    p.add_argument("--user")
+
+    l = sub.add_parser("list")
+    l.add_argument("--status")
+
+    v = sub.add_parser("vote")
+    v.add_argument("id")
+    v.add_argument("--user", required=True)
+    v.add_argument("--down", action="store_true")
+
+    c = sub.add_parser("comment")
+    c.add_argument("id")
+    c.add_argument("text")
+    c.add_argument("--user", required=True)
+
+    s = sub.add_parser("set-status")
+    s.add_argument("id")
+    s.add_argument("status")
+
+    args = parser.parse_args()
+
+    if args.cmd == "propose":
+        eid = et.propose_experiment(
+            args.description,
+            args.conditions,
+            args.expected,
+            proposer=args.user,
+        )
+        print(eid)
+    elif args.cmd == "list":
+        for info in et.list_experiments(args.status):
+            rate = info.get("success", 0) / max(1, info.get("triggers", 1))
+            print(info["id"], info.get("status"), f"{rate:.2f}", info.get("description"))
+    elif args.cmd == "vote":
+        et.vote_experiment(args.id, args.user, upvote=not args.down)
+    elif args.cmd == "comment":
+        et.comment_experiment(args.id, args.user, args.text)
+    elif args.cmd == "set-status":
+        et.update_status(args.id, args.status)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/experiment_tracker.py
+++ b/experiment_tracker.py
@@ -1,0 +1,134 @@
+import os
+import json
+import uuid
+import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DATA_FILE = Path(os.getenv("EXPERIMENTS_FILE", "logs/experiments.json"))
+AUDIT_FILE = Path(os.getenv("EXPERIMENT_AUDIT_FILE", "logs/experiment_audit.jsonl"))
+DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _now() -> str:
+    return datetime.datetime.utcnow().isoformat()
+
+
+def _load() -> List[Dict[str, Any]]:
+    if not DATA_FILE.exists():
+        return []
+    try:
+        return json.loads(DATA_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+def _save(data: List[Dict[str, Any]]) -> None:
+    DATA_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _audit(action: str, exp_id: str, **meta: Any) -> None:
+    entry = {"timestamp": _now(), "action": action, "experiment": exp_id, **meta}
+    with AUDIT_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def propose_experiment(
+    description: str,
+    conditions: str,
+    expected: str,
+    *,
+    proposer: Optional[str] = None,
+) -> str:
+    exp_id = uuid.uuid4().hex[:8]
+    data = _load()
+    info = {
+        "id": exp_id,
+        "description": description,
+        "conditions": conditions,
+        "expected": expected,
+        "status": "pending",
+        "votes": {},
+        "comments": [],
+        "triggers": 0,
+        "success": 0,
+    }
+    data.append(info)
+    _save(data)
+    _audit("propose", exp_id, by=proposer)
+    return exp_id
+
+
+def list_experiments(status: Optional[str] = None) -> List[Dict[str, Any]]:
+    data = _load()
+    if status:
+        data = [d for d in data if d.get("status") == status]
+    return data
+
+
+def get_experiment(exp_id: str) -> Optional[Dict[str, Any]]:
+    for e in _load():
+        if e.get("id") == exp_id:
+            return e
+    return None
+
+
+def vote_experiment(exp_id: str, user: str, upvote: bool = True, threshold: int = 2) -> bool:
+    data = _load()
+    changed = False
+    for e in data:
+        if e.get("id") == exp_id:
+            votes = e.setdefault("votes", {})
+            votes[user] = 1 if upvote else -1
+            pos = sum(1 for v in votes.values() if v > 0)
+            if pos >= threshold and e.get("status") == "pending":
+                e["status"] = "active"
+            changed = True
+            _audit("vote", exp_id, by=user, value=1 if upvote else -1)
+            break
+    if changed:
+        _save(data)
+    return changed
+
+
+def comment_experiment(exp_id: str, user: str, text: str) -> bool:
+    data = _load()
+    changed = False
+    for e in data:
+        if e.get("id") == exp_id:
+            e.setdefault("comments", []).append({
+                "user": user,
+                "text": text,
+                "timestamp": _now(),
+            })
+            changed = True
+            _audit("comment", exp_id, by=user)
+            break
+    if changed:
+        _save(data)
+    return changed
+
+
+def update_status(exp_id: str, status: str) -> bool:
+    data = _load()
+    for e in data:
+        if e.get("id") == exp_id:
+            e["status"] = status
+            _save(data)
+            _audit("status_change", exp_id, status=status)
+            return True
+    return False
+
+
+def record_result(exp_id: str, success: bool) -> bool:
+    data = _load()
+    for e in data:
+        if e.get("id") == exp_id:
+            e["triggers"] = e.get("triggers", 0) + 1
+            if success:
+                e["success"] = e.get("success", 0) + 1
+            _save(data)
+            _audit("result", exp_id, success=success)
+            return True
+    return False

--- a/experiments_api.py
+++ b/experiments_api.py
@@ -1,0 +1,37 @@
+from flask import Flask, jsonify, request
+import experiment_tracker as et
+
+app = Flask(__name__)
+
+
+@app.route('/experiments', methods=['GET', 'POST'])
+def experiments() -> object:
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        exp_id = et.propose_experiment(
+            data.get('description', ''),
+            data.get('conditions', ''),
+            data.get('expected', ''),
+            proposer=data.get('user')
+        )
+        return jsonify({'id': exp_id})
+    status = request.args.get('status')
+    return jsonify(et.list_experiments(status))
+
+
+@app.route('/experiments/vote', methods=['POST'])
+def experiments_vote() -> object:
+    data = request.get_json() or {}
+    et.vote_experiment(data.get('id', ''), data.get('user', ''), not data.get('down'))
+    return jsonify({'status': 'ok'})
+
+
+@app.route('/experiments/comment', methods=['POST'])
+def experiments_comment() -> object:
+    data = request.get_json() or {}
+    et.comment_experiment(data.get('id', ''), data.get('user', ''), data.get('text', ''))
+    return jsonify({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    app.run(port=5002)

--- a/tests/test_experiment_tracker.py
+++ b/tests/test_experiment_tracker.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import experiment_tracker as et
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("EXPERIMENTS_FILE", str(tmp_path / "exp.json"))
+    monkeypatch.setenv("EXPERIMENT_AUDIT_FILE", str(tmp_path / "audit.jsonl"))
+    importlib.reload(et)
+
+
+def test_propose_vote_comment(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    eid = et.propose_experiment("calming", "haptic agitation", "lower stress", proposer="alice")
+    assert et.get_experiment(eid)
+    et.vote_experiment(eid, "alice", True)
+    et.vote_experiment(eid, "bob", True)
+    info = et.get_experiment(eid)
+    assert info["status"] == "active"
+    et.comment_experiment(eid, "carol", "works")
+    info = et.get_experiment(eid)
+    assert info["comments"]
+    lines = (tmp_path / "audit.jsonl").read_text().splitlines()
+    assert any(json.loads(l)["action"] == "propose" for l in lines)


### PR DESCRIPTION
## Summary
- introduce `experiment_tracker.py` for experiment proposals, voting and results
- add `experiment_cli.py` for managing experiments from the command line
- expose new `/experiments` API in `experiments_api.py`
- document workflow in `docs/experiments.md` and sample audit log
- update README with collaborative experiment governance section
- add tests for new tracker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b6b99b91483209e9a694e74d5f7ca