### PR TITLE
Implement autonomous operations framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,3 +757,7 @@ python suggestion_cli.py provenance <id>
 ```
 
 Dashboard and CLI views allow you to trace exactly how a policy changed over time.
+
+## Autonomous Operations
+
+`autonomous_ops.py` introduces a lightweight loop for self-initiated experiments and reflex tuning. It watches sensor logs, proposes experiments with `experiment_tracker.auto_propose_experiment`, and dispatches actions via `api.actuator.auto_call`. See `docs/autonomous_ops.md` for details.

--- a/autonomous_ops.py
+++ b/autonomous_ops.py
@@ -1,0 +1,103 @@
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import experiment_tracker as et
+import reflex_manager as rm
+from api import actuator
+
+DATA_STREAMS = [
+    Path('logs/emotion.jsonl'),
+    Path('logs/eeg.jsonl'),
+    Path('logs/haptics.jsonl'),
+    Path('logs/bio.jsonl'),
+    Path('logs/system.log'),
+]
+
+STATE_FILE = Path('logs/autonomous_state.json')
+
+
+def _load_state() -> Dict[str, Any]:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_state(state: Dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state))
+
+
+state = _load_state()
+
+
+def scan_streams() -> List[Dict[str, Any]]:
+    """Return new signal events since last scan."""
+    events: List[Dict[str, Any]] = []
+    for fp in DATA_STREAMS:
+        if not fp.exists():
+            continue
+        last_pos = state.get(fp.name, 0)
+        try:
+            with fp.open('r', encoding='utf-8') as f:
+                f.seek(last_pos)
+                for line in f:
+                    try:
+                        events.append(json.loads(line))
+                    except Exception:
+                        continue
+                state[fp.name] = f.tell()
+        except Exception:
+            continue
+    _save_state(state)
+    return events
+
+
+def analyze_events(events: List[Dict[str, Any]]) -> None:
+    for ev in events:
+        stress = ev.get('stress', 0)
+        beta = ev.get('beta', 0)
+        if stress > 0.8 and beta > 0.8:
+            exp_id = et.auto_propose_experiment(
+                description='stress beta mitigation',
+                conditions='stress>0.8 & beta>0.8',
+                expected='reduced stress',
+                signals=ev,
+            )
+            rule = rm.ReflexRule(
+                rm.OnDemandTrigger(),
+                [{'type': 'workflow', 'name': 'calm_down'}],
+                name=f'autocalm_{exp_id}',
+            )
+            manager = rm.get_default_manager() or rm.ReflexManager()
+            rm.set_default_manager(manager)
+            manager.auto_generate_rule(rule.trigger, rule.actions, rule.name, signals=ev)
+            actuator.auto_call({'type': 'workflow', 'name': 'calm_down'}, explanation='auto stress mitigation', trace=exp_id)
+
+
+def run_loop(interval: float = 60.0) -> None:
+    manager = rm.get_default_manager() or rm.ReflexManager()
+    rm.set_default_manager(manager)
+    manager.start()
+    try:
+        while True:
+            events = scan_streams()
+            if events:
+                analyze_events(events)
+            manager.auto_prune()
+            time.sleep(interval)
+    finally:
+        manager.stop()
+
+
+if __name__ == '__main__':
+    import argparse
+
+    p = argparse.ArgumentParser(description='Autonomous operations loop')
+    p.add_argument('--interval', type=float, default=60.0)
+    args = p.parse_args()
+    run_loop(args.interval)

--- a/docs/autonomous_ops.md
+++ b/docs/autonomous_ops.md
@@ -1,0 +1,13 @@
+# Autonomous Operations
+
+`autonomous_ops.py` provides a minimal self-monitoring loop. It scans emotion, EEG, haptic and bio logs for anomalies and automatically creates experiments and reflex rules when stress spikes are detected.
+
+Generated rules are logged to `logs/reflections/reflex_audit.jsonl` and all actions dispatched autonomously are written to `logs/autonomous_calls.jsonl` via `api.actuator.auto_call`.
+
+Run the loop with:
+
+```bash
+python autonomous_ops.py --interval 30
+```
+
+The loop continuously prunes ineffective rules and stores offsets in `logs/autonomous_state.json` so it only processes new events. The included example detects simultaneous high stress and beta EEG and starts a `calm_down` workflow.

--- a/experiment_tracker.py
+++ b/experiment_tracker.py
@@ -34,6 +34,30 @@ def _audit(action: str, exp_id: str, **meta: Any) -> None:
         f.write(json.dumps(entry) + "\n")
 
 
+def auto_propose_experiment(
+    description: str,
+    conditions: str,
+    expected: str,
+    *,
+    signals: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Programmatically create and immediately activate an experiment."""
+    exp_id = propose_experiment(
+        description,
+        conditions,
+        expected,
+        proposer="auto",
+    )
+    update_status(exp_id, "active")
+    _audit("auto_propose", exp_id, signals=signals)
+    return exp_id
+
+
+def log_trigger(exp_id: str, signals: Optional[Dict[str, Any]] = None) -> None:
+    """Record that an experiment was triggered by autonomous logic."""
+    _audit("trigger", exp_id, signals=signals)
+
+
 def propose_experiment(
     description: str,
     conditions: str,


### PR DESCRIPTION
## Summary
- support autonomous experiment submission and triggers
- add auto rule generation and pruning helpers
- log autonomous actuator calls via `auto_call`
- implement `autonomous_ops.py` example loop
- document autonomous operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b6def740883208284c10a5fe9bede