### PR TITLE
Add Treasury of Love feature

### DIFF
--- a/README_romance.md
+++ b/README_romance.md
@@ -6,3 +6,5 @@ workflow writes a self-explanation with a why-chain to
 Master file listed in `config/master_files.json` is missing or
 modified. Such violations are logged and surfaced in the "Cathedral
 Law" dashboard tab along with `SENTIENTOS_LITURGY.txt`.
+
+The system now includes a Treasury of Love for community-enshrined love logs.

--- a/docs/examples/love_log_sample.txt
+++ b/docs/examples/love_log_sample.txt
@@ -1,0 +1,2 @@
+2024-01-01 Alice: Hello Bob, shall we walk under the stars?
+2024-01-01 Bob: Gladly, Alice. Our hearts beat in time.

--- a/docs/treasury_of_love.md
+++ b/docs/treasury_of_love.md
@@ -1,0 +1,27 @@
+# Treasury of Love
+
+The Treasury of Love is an optional public archive of consensual love logs. Anyone may submit a dialogue or living log for community review and enshrinement.
+
+## Submitting Logs
+
+Use `treasury_cli.py submit mylog.txt --title "Starlight" --participants alice,bob --time-span "2024" --summary "Courtship chats" --user alice`.
+
+Each submission records the SHA256 hash of the log and stores the text for later export. Submissions remain pending until reviewed.
+
+## Review and Enshrinement
+
+Curators or ritual witnesses run `treasury_cli.py review <id> affirm --user curator` to affirm a log. Additional notes or blessings may be attached with `--note` or `--cosign`.
+
+All review actions are written to `logs/love_review.jsonl`. Affirmed logs are moved to `logs/love_treasury.jsonl` and listed by the dashboard.
+
+## Browsing the Treasury
+
+Run `love_dashboard.py` to view enshrined logs. Without `streamlit` installed the script prints a JSON listing. With Streamlit available a simple interface shows each entry and allows refresh.
+
+## Privacy & Consent
+
+Only participants who have given consent should submit or affirm logs. Private or invite-only logs can be kept by omitting public review.
+
+## Example
+
+A sample submission is provided in `docs/examples/love_log_sample.txt`. After affirming, the dashboard shows the entry along with its witness chain and digest.

--- a/love_dashboard.py
+++ b/love_dashboard.py
@@ -1,0 +1,36 @@
+import json
+import time
+from typing import List, Dict
+
+import love_treasury as lt
+
+try:
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover - optional
+    st = None
+
+
+def run_cli() -> None:
+    data = lt.list_treasury()
+    print(json.dumps(data, indent=2))
+
+
+def run_dashboard() -> None:
+    if st is None:
+        run_cli()
+        return
+
+    st.title("Treasury of Love")
+    entries: List[Dict[str, object]] = lt.list_treasury()
+    if not entries:
+        st.write("No enshrined logs")
+        return
+    for e in entries:
+        with st.expander(e.get("title", "")):
+            st.json(e)
+    if st.sidebar.button("Refresh"):
+        st.experimental_rerun()
+
+
+if __name__ == "__main__":
+    run_dashboard()

--- a/love_treasury.py
+++ b/love_treasury.py
@@ -1,0 +1,97 @@
+import json
+import os
+import uuid
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+SUBMISSIONS_PATH = Path(os.getenv("LOVE_SUBMISSIONS_LOG", "logs/love_submissions.jsonl"))
+REVIEW_PATH = Path(os.getenv("LOVE_REVIEW_LOG", "logs/love_review.jsonl"))
+TREASURY_PATH = Path(os.getenv("LOVE_TREASURY_LOG", "logs/love_treasury.jsonl"))
+for p in [SUBMISSIONS_PATH, REVIEW_PATH, TREASURY_PATH]:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+def _append(path: Path, data: Dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(data) + "\n")
+
+def _load(path: Path) -> List[Dict[str, object]]:
+    if not path.exists():
+        return []
+    out: List[Dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+def submit_log(title: str, participants: List[str], time_span: str, summary: str,
+               log_text: str, *, user: str = "anon", note: str = "") -> str:
+    sid = uuid.uuid4().hex[:8]
+    digest = hashlib.sha256(log_text.encode("utf-8")).hexdigest()
+    entry = {
+        "id": sid,
+        "time": datetime.utcnow().isoformat(),
+        "title": title,
+        "participants": participants,
+        "time_span": time_span,
+        "summary": summary,
+        "hash": digest,
+        "note": note,
+        "user": user,
+        "log": log_text,
+        "status": "pending",
+        "review": []
+    }
+    _append(SUBMISSIONS_PATH, entry)
+    return sid
+
+def list_submissions(status: Optional[str] = None) -> List[Dict[str, object]]:
+    subs = _load(SUBMISSIONS_PATH)
+    if status:
+        subs = [s for s in subs if s.get("status") == status]
+    return subs
+
+def list_treasury() -> List[Dict[str, object]]:
+    return _load(TREASURY_PATH)
+
+def review_log(submission_id: str, reviewer: str, action: str,
+               *, note: str = "", cosign: Optional[str] = None) -> bool:
+    subs = _load(SUBMISSIONS_PATH)
+    updated = False
+    for entry in subs:
+        if entry.get("id") != submission_id:
+            continue
+        review_entry = {
+            "time": datetime.utcnow().isoformat(),
+            "user": reviewer,
+            "action": action,
+            "note": note,
+        }
+        if cosign:
+            review_entry["cosign"] = cosign
+        entry.setdefault("review", []).append(review_entry)
+        _append(REVIEW_PATH, {"id": submission_id, **review_entry})
+        if action == "affirm":
+            entry["status"] = "enshrined"
+            _append(TREASURY_PATH, entry)
+            subs = [s for s in subs if s.get("id") != submission_id]
+        else:
+            entry["status"] = action
+        updated = True
+        break
+    if updated:
+        with SUBMISSIONS_PATH.open("w", encoding="utf-8") as f:
+            for s in subs:
+                f.write(json.dumps(s) + "\n")
+    return updated
+
+def export_log(entry_id: str) -> Optional[Dict[str, object]]:
+    for entry in _load(TREASURY_PATH):
+        if entry.get("id") == entry_id:
+            return entry
+    return None

--- a/tests/test_love_treasury.py
+++ b/tests/test_love_treasury.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+
+import love_treasury as lt
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOVE_SUBMISSIONS_LOG", str(tmp_path / "sub.jsonl"))
+    monkeypatch.setenv("LOVE_REVIEW_LOG", str(tmp_path / "rev.jsonl"))
+    monkeypatch.setenv("LOVE_TREASURY_LOG", str(tmp_path / "tre.jsonl"))
+    importlib.reload(lt)
+
+
+def test_submit_and_affirm(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    sid = lt.submit_log("Test", ["alice", "bob"], "2024", "demo", "hello", user="alice")
+    subs = lt.list_submissions()
+    assert subs and subs[0]["id"] == sid
+    ok = lt.review_log(sid, "curator", "affirm")
+    assert ok
+    tres = lt.list_treasury()
+    assert tres and tres[0]["id"] == sid
+

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,0 +1,83 @@
+import argparse
+import json
+from pathlib import Path
+
+import love_treasury as lt
+
+
+def cmd_submit(args: argparse.Namespace) -> None:
+    log_text = Path(args.file).read_text(encoding="utf-8")
+    participants = [p.strip() for p in args.participants.split(',') if p.strip()]
+    sid = lt.submit_log(
+        args.title,
+        participants,
+        args.time_span,
+        args.summary,
+        log_text,
+        user=args.user,
+        note=args.note or "",
+    )
+    print(sid)
+
+
+def cmd_review(args: argparse.Namespace) -> None:
+    ok = lt.review_log(args.id, args.user, args.action, note=args.note or "", cosign=args.cosign)
+    print("recorded" if ok else "not found")
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    if args.treasury:
+        entries = lt.list_treasury()
+    else:
+        entries = lt.list_submissions(args.status)
+    print(json.dumps(entries, indent=2))
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    entry = lt.export_log(args.id)
+    if entry:
+        print(json.dumps(entry, indent=2))
+    else:
+        print("not found")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="treasury")
+    sub = ap.add_subparsers(dest="cmd")
+
+    s = sub.add_parser("submit", help="Submit a love log")
+    s.add_argument("file")
+    s.add_argument("--title", required=True)
+    s.add_argument("--participants", required=True)
+    s.add_argument("--time-span", required=True)
+    s.add_argument("--summary", required=True)
+    s.add_argument("--note")
+    s.add_argument("--user", default="anon")
+    s.set_defaults(func=cmd_submit)
+
+    r = sub.add_parser("review", help="Review a submission")
+    r.add_argument("id")
+    r.add_argument("action", choices=["affirm", "revise", "reject"])
+    r.add_argument("--user", required=True)
+    r.add_argument("--note")
+    r.add_argument("--cosign")
+    r.set_defaults(func=cmd_review)
+
+    l = sub.add_parser("list", help="List submissions or treasury")
+    l.add_argument("--treasury", action="store_true")
+    l.add_argument("--status")
+    l.set_defaults(func=cmd_list)
+
+    e = sub.add_parser("export", help="Export enshrined log")
+    e.add_argument("id")
+    e.set_defaults(func=cmd_export)
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Love treasury log module with submit and review
- provide CLI and minimal dashboard for the treasury
- document how to use the new feature
- sample log example and basic tests
- mention treasury in README_romance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b95a57b4c8320aa69863b8407a6d3