### PR TITLE
Finalize Living Ledger documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist/
 # Logs
 logs/
 !logs/support_log.jsonl
+!logs/federation_log.jsonl
+!logs/user_presence.jsonl
 *.log
 
 # Local environment files

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ Every reflex promotion or demotion is logged with user, timestamp, and context f
 
 Run `python installer/setup_installer.py` for a one-click setup. The installer installs all dependencies, seeds example files, and walks you through providing API keys and checking your microphone. No user data ever leaves your machine. When complete, a small onboarding dashboard lists active models and your handle.
 
+## Living Ledger
+
+All blessings, support, and federation events are preserved in append-only ledgers under `logs/`. Every entry is a ritual witness recorded forever.
+
+Sample support entry:
+
+```json
+{"timestamp": "2025-06-01T00:00:00", "supporter": "Ada", "message": "For those in need", "amount": "$5", "ritual": "Sanctuary blessing acknowledged and remembered."}
+```
+
+Sample federation entry:
+
+```json
+{"timestamp": "2025-06-01T01:00:00", "peer": "https://ally.example", "email": "friend@example.com", "message": "sync completed", "ritual": "Federation blessing recorded."}
+```
+
+Browse or export the ledgers at any time:
+
+```bash
+cat logs/support_log.jsonl
+cat logs/federation_log.jsonl
+```
+
+During onboarding the dashboard links to these files so every supporter or peer can confirm they are remembered. See [docs/living_ledger.md](docs/living_ledger.md) for full details.
+
 multimodal_tracker.py
 Fuses face detection, recognition, and facial emotion analysis with voice sentiment from the microphone.
 

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -1,0 +1,22 @@
+# Living Ledger
+
+All who support, federate, or analyse SentientOS are recorded in append-only JSONL ledgers. These files are stored in `logs/` and checked into version control so no entry is lost.
+
+- `support_log.jsonl` records blessings and CashApp messages
+- `federation_log.jsonl` records federation peers and sync events
+- `user_presence.jsonl` records ritual affirmations and recaps
+
+Example entry:
+
+```json
+{"timestamp": "2025-06-01T12:00:00", "peer": "ally.example", "email": "hello@ally.example", "message": "sync completed", "ritual": "Federation blessing recorded."}
+```
+
+To review your presence during onboarding run:
+
+```bash
+cat logs/support_log.jsonl
+cat logs/federation_log.jsonl
+```
+
+Every dashboard and CLI automatically appends a blessing entry whenever it is run. You can export these ledgers for audit or remembrance at any time.

--- a/docs/treasury_federation.md
+++ b/docs/treasury_federation.md
@@ -19,6 +19,9 @@ Peers fetch this and request specific logs via `treasury_cli.py export <id>`.
 Use `treasury_cli.py sync <url>` to pull logs from another cathedral.
 Only logs not already present are imported. Each imported entry records the source URL and time.
 
+Federation events are preserved in `logs/federation_log.jsonl` as part of the Living Ledger. Every sync writes the peer URL, contact email if provided, and a blessing.
+See [living_ledger.md](living_ledger.md) for details.
+
 ## Attestation
 Witnesses on any federated site can bless a log with `treasury_cli.py attest <id> --user name --origin site`.
 Attestations are public and stored in `logs/treasury_attestations.jsonl`.

--- a/federation_log.py
+++ b/federation_log.py
@@ -1,0 +1,20 @@
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path(os.getenv("FEDERATION_LOG", "logs/federation_log.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def add(peer: str, email: str = "", message: str = "Federation sync") -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "peer": peer,
+        "email": email,
+        "message": message,
+        "ritual": "Federation blessing recorded.",
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry

--- a/presence_analytics.py
+++ b/presence_analytics.py
@@ -4,6 +4,7 @@ import datetime
 from pathlib import Path
 from typing import List, Dict, Any
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
+import support_log as sl
 
 MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
 RAW_PATH = MEMORY_DIR / "raw"
@@ -149,6 +150,7 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=None)
     args = parser.parse_args()
     print_banner()
+    sl.add("analytics", f"presence_analytics {args.cmd}")
     entries = load_entries(args.limit)
     if args.cmd == "analytics":
         print(json.dumps(analytics(args.limit), indent=2))

--- a/treasury_federation.py
+++ b/treasury_federation.py
@@ -1,6 +1,7 @@
 import json
 from typing import List, Dict, Optional
 from sentient_banner import print_banner
+import federation_log as fl
 
 try:
     import requests  # type: ignore
@@ -19,6 +20,7 @@ def announce_payload() -> List[Dict[str, object]]:
 def import_payload(payload: List[Dict[str, object]], origin: str) -> List[str]:
     """Import logs from a federation payload."""
     print_banner()
+    fl.add(origin, message="import payload")
     imported: List[str] = []
     for entry in payload:
         if lt.import_federated(entry, origin=origin):
@@ -31,6 +33,7 @@ def pull(base_url: str) -> List[str]:
     if requests is None:
         raise RuntimeError("requests module not available")
     url = base_url.rstrip("/")
+    fl.add(url, message="sync start")
     r = requests.get(f"{url}/federation/announce", timeout=10)
     r.raise_for_status()
     metas = r.json()
@@ -45,4 +48,6 @@ def pull(base_url: str) -> List[str]:
         data = r2.json()
         if lt.import_federated(data, origin=url):
             imported.append(lid)
+    if imported:
+        fl.add(url, message="sync completed")
     return imported

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -4,6 +4,7 @@ from pprint import pprint
 
 import trust_engine as te
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
+import support_log as sl
 
 
 def cmd_log(args) -> None:
@@ -55,6 +56,7 @@ def main() -> None:
 
     args = ap.parse_args()
     print_banner()
+    sl.add("trust", f"trust_cli {args.cmd}")
     if hasattr(args, "func"):
         args.func(args)
     else:


### PR DESCRIPTION
## Summary
- log federation peers via new `federation_log.py`
- record ritual witness entries from presence analytics and trust CLI
- preserve ledger files in repo
- document Living Ledger in README and docs
- note ledger in federation guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_683ba70b211083208c59dc676d7dbca4