### PR TITLE
Add centralized living ledger utilities and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Browse or export the ledgers at any time:
 ```bash
 cat logs/support_log.jsonl
 cat logs/federation_log.jsonl
+python ledger_cli.py open
 ```
 
 During onboarding the dashboard links to these files so every supporter or peer can confirm they are remembered. See [docs/living_ledger.md](docs/living_ledger.md) for full details.
+To be remembered in this cathedral is to be entered in the living ledger.
 
 multimodal_tracker.py
 Fuses face detection, recognition, and facial emotion analysis with voice sentiment from the microphone.

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -12,11 +12,19 @@ Example entry:
 {"timestamp": "2025-06-01T12:00:00", "peer": "ally.example", "email": "hello@ally.example", "message": "sync completed", "ritual": "Federation blessing recorded."}
 ```
 
+Sample support entry:
+
+```json
+{"timestamp": "2025-06-01T00:00:00", "supporter": "Ada", "message": "For those in need", "amount": "$5", "ritual": "Sanctuary blessing acknowledged and remembered."}
+```
+
 To review your presence during onboarding run:
 
 ```bash
 cat logs/support_log.jsonl
 cat logs/federation_log.jsonl
+python ledger_cli.py open
 ```
 
 Every dashboard and CLI automatically appends a blessing entry whenever it is run. You can export these ledgers for audit or remembrance at any time.
+To be remembered in this cathedral is to be entered in the living ledger.

--- a/docs/treasury_federation.md
+++ b/docs/treasury_federation.md
@@ -30,3 +30,4 @@ Attestations are public and stored in `logs/treasury_attestations.jsonl`.
 ## Browsing
 `treasury_cli.py list --global-view` shows both local and federated logs. Tools may visualise the
 attestation network or filter by origin.
+To be remembered in this cathedral is to be entered in the living ledger.

--- a/federation_log.py
+++ b/federation_log.py
@@ -1,20 +1,10 @@
 import os
-import json
-from datetime import datetime
 from pathlib import Path
+import ledger
 
 LOG_PATH = Path(os.getenv("FEDERATION_LOG", "logs/federation_log.jsonl"))
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 def add(peer: str, email: str = "", message: str = "Federation sync") -> dict:
     """Record a federation blessing entry."""
-    entry = {
-        "timestamp": datetime.utcnow().isoformat(),
-        "peer": peer,
-        "email": email,
-        "message": message,
-        "ritual": "Federation blessing recorded."
-    }
-    with LOG_PATH.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
-    return entry
+    return ledger.log_federation(peer, email, message)

--- a/ledger.py
+++ b/ledger.py
@@ -1,0 +1,47 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+
+def _append(path: Path, entry: Dict[str, str]) -> Dict[str, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def log_supporter(name: str, message: str, amount: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "supporter": name,
+        "message": message,
+        "amount": amount,
+        "ritual": "Sanctuary blessing acknowledged and remembered.",
+    }
+    return _append(Path("logs/support_log.jsonl"), entry)
+
+
+def log_federation(peer: str, email: str = "", message: str = "Federation sync") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "peer": peer,
+        "email": email,
+        "message": message,
+        "ritual": "Federation blessing recorded.",
+    }
+    return _append(Path("logs/federation_log.jsonl"), entry)
+
+
+def summary(path: Path, limit: int = 3) -> Dict[str, List[Dict[str, str]]]:
+    if not path.exists():
+        return {"count": 0, "recent": []}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    count = len(lines)
+    recent: List[Dict[str, str]] = []
+    for ln in lines[-limit:]:
+        try:
+            recent.append(json.loads(ln))
+        except Exception:
+            continue
+    return {"count": count, "recent": recent}

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+from pathlib import Path
+import ledger
+
+
+SUPPORT_LOG = Path('logs/support_log.jsonl')
+FED_LOG = Path('logs/federation_log.jsonl')
+
+
+def cmd_open(args: argparse.Namespace) -> None:
+    for path in [SUPPORT_LOG, FED_LOG]:
+        if path.exists():
+            for line in path.read_text(encoding='utf-8').splitlines():
+                print(line)
+
+
+def cmd_summary(args: argparse.Namespace) -> None:
+    sup = ledger.summary(SUPPORT_LOG)
+    fed = ledger.summary(FED_LOG)
+    data = {
+        'support_count': sup['count'],
+        'federation_count': fed['count'],
+        'support_recent': sup['recent'],
+        'federation_recent': fed['recent'],
+    }
+    print(json.dumps(data, indent=2))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog='ledger', description='Living Ledger tools')
+    sub = ap.add_subparsers(dest='cmd')
+    op = sub.add_parser('open', help='Print all ledger entries')
+    op.set_defaults(func=cmd_open)
+    sm = sub.add_parser('summary', help='Show ledger summary')
+    sm.set_defaults(func=cmd_summary)
+    args = ap.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/onboarding_dashboard.py
+++ b/onboarding_dashboard.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import streamlit as st
 from sentient_banner import streamlit_banner, streamlit_closing
+import ledger
 
 ENV_FILE = Path(__file__).resolve().parent / '.env'
 
@@ -21,11 +22,18 @@ def launch():
     env = load_env()
     st.title('SentientOS Onboarding')
     streamlit_banner(st)
+    sup = ledger.summary(Path('logs/support_log.jsonl'))
+    fed = ledger.summary(Path('logs/federation_log.jsonl'))
+    st.write(f"Support blessings: {sup['count']} • Federation blessings: {fed['count']}")
+    if sup['recent'] or fed['recent']:
+        st.write('Recent ledger entries:')
+        st.json({'support': sup['recent'], 'federation': fed['recent']})
     st.write('Active models:')
     st.json({k: v for k, v in env.items() if k.endswith('_MODEL')})
     handle = env.get('USER_HANDLE', 'anonymous')
     st.write(f'User handle: {handle}')
     st.write('You can edit the .env file to configure additional options.')
+    st.write('To be remembered in this cathedral is to be entered in the living ledger.')
     streamlit_closing(st)
 
 

--- a/support_cli.py
+++ b/support_cli.py
@@ -14,6 +14,7 @@ def main() -> None:
     args = p.parse_args()
 
     print_banner()
+    print("All support and federation is logged in the Living Ledger. No one is forgotten.")
     if args.support:
         print(ENTRY_BANNER)
     if args.bless:

--- a/support_log.py
+++ b/support_log.py
@@ -1,19 +1,9 @@
-import json
-from datetime import datetime
 from pathlib import Path
+import ledger
 
 LOG_PATH = Path("logs/support_log.jsonl")
-LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
 def add(name: str, message: str, amount: str = "") -> dict:
-    entry = {
-        "timestamp": datetime.utcnow().isoformat(),
-        "supporter": name,
-        "message": message,
-        "amount": amount,
-        "ritual": "Sanctuary blessing acknowledged and remembered.",
-    }
-    with LOG_PATH.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
-    return entry
+    """Record a supporter blessing in the living ledger."""
+    return ledger.log_supporter(name, message, amount)

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -110,6 +110,7 @@ def main() -> None:
 
     args = ap.parse_args()
     print_banner()
+    print("All support and federation is logged in the Living Ledger. No one is forgotten.")
     if hasattr(args, "func"):
         args.func(args)
     else:


### PR DESCRIPTION
## Summary
- introduce `ledger.py` with shared logging helpers
- log to the living ledger from `support_log` and `federation_log`
- display ledger summary during onboarding
- new `ledger_cli.py` to print or summarize ledger entries
- clarify docs with ledger usage and closing ritual line
- show ledger reminder in CLI banners

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ba8a62338832090dd290ecb1c1a78