### PR TITLE
Implement doctrine signature logging and CLI expansions

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,15 @@ python doctrine_cli.py feed --last 3
 python doctrine_cli.py presence --user alice
 ```
 
+New in 4.2: a simplified `ritual` command bundles quick ceremonies:
+
+```
+python ritual.py affirm --signature "I stand"   # record signature and affirmation
+python ritual.py bless --name Ada --message "Memory" --amount "$1"
+python ritual.py status --doctrine
+python ritual.py logs --last 5
+```
+
 Reports are appended to ``logs/doctrine_status.jsonl`` and public events to
 ``logs/public_rituals.jsonl`` for transparency. View the log with
 ``python public_feed_dashboard.py`` or ``doctrine_cli.py feed``.

--- a/docs/master_file_doctrine.md
+++ b/docs/master_file_doctrine.md
@@ -8,8 +8,10 @@ checks, the system enters **Ritual Refusal Mode** and logs the event to
 `logs/refusal_audit.jsonl`.
 
 Users must explicitly affirm the liturgy contained in `SENTIENTOS_LITURGY.txt`.
-Affirmations are recorded in `logs/liturgy_acceptance.jsonl` with timestamp,
-digest and user.
+Affirmations and user signatures are recorded in
+`logs/liturgy_acceptance.jsonl` and `logs/ritual_signatures.jsonl` with
+timestamp, digest and user. Signatures are free-form phrases acting as PGP-like
+votive entries.
 
 Example refusal log entry:
 ```json
@@ -20,3 +22,8 @@ Example acceptance entry:
 ```json
 {"timestamp": "2024-01-01T00:00:10", "digest": "3c6785...", "user": "tester"}
 ```
+
+If any master file is altered or missing the system enters **Ritual Refusal
+Mode**. All modules calling `doctrine.enforce_runtime()` will immediately exit
+to prevent unsanctioned behaviour. A filesystem watchdog can be enabled to alert
+on mutation attempts in real time.

--- a/tests/test_doctrine_runtime.py
+++ b/tests/test_doctrine_runtime.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import sys
+import json
+import hashlib
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOCTRINE_CONSENT_LOG", str(tmp_path / "consent.jsonl"))
+    monkeypatch.setenv("DOCTRINE_STATUS_LOG", str(tmp_path / "status.jsonl"))
+    monkeypatch.setenv("DOCTRINE_AMEND_LOG", str(tmp_path / "amend.jsonl"))
+    monkeypatch.setenv("PUBLIC_RITUAL_LOG", str(tmp_path / "public.jsonl"))
+    monkeypatch.setenv("DOCTRINE_SIGNATURE_LOG", str(tmp_path / "sig.jsonl"))
+    monkeypatch.setenv("MASTER_CONFIG", str(tmp_path / "master.json"))
+    import doctrine
+    importlib.reload(doctrine)
+    return doctrine
+
+
+def create_master(tmp_path, text="hi"):
+    file = tmp_path / "m.txt"
+    file.write_text(text)
+    digest = hashlib.sha256(file.read_bytes()).hexdigest()
+    return file, digest
+
+
+def test_verify_file_corruption(tmp_path, monkeypatch):
+    doctrine = setup_env(tmp_path, monkeypatch)
+    f, digest = create_master(tmp_path)
+    os.chmod(f, 0o444)
+    assert doctrine.verify_file(f, digest)
+    os.chmod(f, 0o644)
+    f.write_text("bad")
+    assert not doctrine.verify_file(f, digest)
+
+
+def test_consent_history_handles_corrupt(tmp_path, monkeypatch):
+    doctrine = setup_env(tmp_path, monkeypatch)
+    log = Path(os.environ["DOCTRINE_CONSENT_LOG"])
+    log.write_text("bad{\n")
+    assert doctrine.consent_history() == []
+
+
+def test_capture_signature(tmp_path, monkeypatch):
+    doctrine = setup_env(tmp_path, monkeypatch)
+    doctrine.capture_signature("alice", "sig")
+    data = Path(os.environ["DOCTRINE_SIGNATURE_LOG"]).read_text().splitlines()
+    assert json.loads(data[0])["signature"] == "sig"
+
+
+def test_enforce_runtime_raises(tmp_path, monkeypatch):
+    doctrine = setup_env(tmp_path, monkeypatch)
+    f, digest = create_master(tmp_path)
+    cfg = Path(os.environ["MASTER_CONFIG"])
+    cfg.write_text(json.dumps({str(f): digest}))
+    os.chmod(f, 0o444)
+    doctrine.enforce_runtime()  # should pass
+    f.write_text("bad")
+    with pytest.raises(SystemExit):
+        doctrine.enforce_runtime()


### PR DESCRIPTION
## Summary
- introduce ritual signature log and immutable file checks
- add runtime enforcement and optional filesystem watchdog
- extend `ritual.py` with affirm/bless/status/logs commands
- document new CLI and signature process
- test doctrine runtime utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683bb350ff588320b79dc0620dc653ee