### PR TITLE
Enhance rituals and doctrine watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Every reflex promotion or demotion is logged with user, timestamp, and context f
 
 Run `python installer/setup_installer.py` for a one-click setup. The installer installs all dependencies, seeds example files, and walks you through providing API keys and checking your microphone. No user data ever leaves your machine. When complete, a small onboarding dashboard lists active models and your handle.
 
+The cathedral will not run until you affirm the liturgy. On first launch `user_profile.update_profile()` invokes a short ritual requiring your signature. This moment is logged as a ceremonial welcome before any other feature is unlocked.
+
 ## Living Ledger
 
 The living ledger is the cathedral's memory. Every support blessing and every federation handshake is appended here so no presence fades.
@@ -401,6 +403,7 @@ python ritual.py logs --last 5
 Reports are appended to ``logs/doctrine_status.jsonl`` and public events to
 ``logs/public_rituals.jsonl`` for transparency. View the log with
 ``python public_feed_dashboard.py`` or ``doctrine_cli.py feed``.
+Pass ``--watch`` to ``doctrine.py`` to run a guardian daemon that alerts if any master file is mutated or permissions change.
 
 Policy, Gesture & Persona Engine
 --------------------------------

--- a/docs/master_file_doctrine.md
+++ b/docs/master_file_doctrine.md
@@ -25,5 +25,4 @@ Example acceptance entry:
 
 If any master file is altered or missing the system enters **Ritual Refusal
 Mode**. All modules calling `doctrine.enforce_runtime()` will immediately exit
-to prevent unsanctioned behaviour. A filesystem watchdog can be enabled to alert
-on mutation attempts in real time.
+to prevent unsanctioned behaviour. Pass `--watch` to `doctrine.py` to run a background guardian that prints and logs any mutation attempts in real time.

--- a/tests/test_doctrine_runtime.py
+++ b/tests/test_doctrine_runtime.py
@@ -62,3 +62,12 @@ def test_enforce_runtime_raises(tmp_path, monkeypatch):
     f.write_text("bad")
     with pytest.raises(SystemExit):
         doctrine.enforce_runtime()
+
+
+def test_watch_flag_invokes_daemon(tmp_path, monkeypatch, capsys):
+    doctrine = setup_env(tmp_path, monkeypatch)
+    called = {}
+    monkeypatch.setattr(doctrine, "watch_daemon", lambda: called.setdefault("w", True))
+    monkeypatch.setattr(sys, "argv", ["doc", "--watch", "report"])
+    doctrine.main()
+    assert called.get("w")

--- a/tests/test_ritual_cli.py
+++ b/tests/test_ritual_cli.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import json
+import threading
+import importlib
+from pathlib import Path
+
+import ritual
+import doctrine
+import ledger
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOCTRINE_CONSENT_LOG", str(tmp_path / "consent.jsonl"))
+    monkeypatch.setenv("DOCTRINE_STATUS_LOG", str(tmp_path / "status.jsonl"))
+    monkeypatch.setenv("DOCTRINE_AMEND_LOG", str(tmp_path / "amend.jsonl"))
+    monkeypatch.setenv("PUBLIC_RITUAL_LOG", str(tmp_path / "public.jsonl"))
+    monkeypatch.setenv("DOCTRINE_SIGNATURE_LOG", str(tmp_path / "sig.jsonl"))
+
+    def log_support(name, message, amount=""):
+        entry = {
+            "timestamp": "now",
+            "supporter": name,
+            "message": message,
+            "amount": amount,
+            "ritual": "Sanctuary blessing acknowledged and remembered.",
+        }
+        p = tmp_path / "support_log.jsonl"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    monkeypatch.setattr(ledger, "log_support", log_support)
+    importlib.reload(doctrine)
+    importlib.reload(ritual)
+    return tmp_path
+
+
+def test_concurrent_affirm_bless(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+
+    def affirm():
+        doctrine.affirm("alice")
+
+    def bless():
+        ledger.log_support("alice", "hi")
+
+    threads = [threading.Thread(target=affirm) for _ in range(3)]
+    threads += [threading.Thread(target=bless) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    cons = Path(os.environ["DOCTRINE_CONSENT_LOG"]).read_text().splitlines()
+    sup = (tmp_path / "support_log.jsonl").read_text().splitlines()
+    assert len(cons) == 3
+    assert len(sup) == 3
+
+
+def test_cli_edge_cases(tmp_path, monkeypatch, capsys):
+    setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["ritual", "affirm", "--signature", "☯️", "--user", "bob"])
+    ritual.main()
+    long_msg = "x" * 512
+    monkeypatch.setattr(sys, "argv", ["ritual", "bless", "--name", "bob", "--message", long_msg, "--amount", "1"])
+    ritual.main()
+    monkeypatch.setattr(sys, "argv", ["ritual", "recap", "--highlight", "--last", "5"])
+    ritual.main()
+    out = capsys.readouterr().out
+    assert "Affirmations:" in out and "Blessings:" in out

--- a/user_profile.py
+++ b/user_profile.py
@@ -32,7 +32,9 @@ def update_profile(**updates) -> dict:
     profile = load_profile()
     if not profile_exists:
         ritual.require_liturgy_acceptance()
-        rl.log_event("profile_created", getpass.getuser())
+        user = getpass.getuser()
+        rl.log_event("ceremonial_welcome", user)
+        rl.log_event("profile_created", user)
     profile.update({k: v for k, v in updates.items() if v is not None})
     save_profile(profile)
     return profile


### PR DESCRIPTION
## Summary
- add ceremonial welcome on first-time profile creation
- implement `recap` subcommand in `ritual.py`
- implement `--watch` guardian daemon for doctrine
- document new features in README and Master Doctrine
- test ritual CLI edge cases and concurrent usage
- test doctrine watch CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683bbce3c26c8320b769144718c6ba8c