### PR TITLE
Add ledger recaps and snapshots on CLI entry and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,31 @@ Ledger snapshot • Support: 3 (2 unique) • Federation: 1 (1 unique) • Witne
 
 This summary shows how many unique supporters, peers, and witnesses have been logged so far.
 
+After every blessing or invite the CLI prints a short recap of the most recent entries:
+
+```
+{
+  "support_recent": [
+    {
+      "timestamp": "2025-06-01T00:00:00",
+      "supporter": "Ada",
+      "message": "For those in need",
+      "amount": "$5",
+      "ritual": "Sanctuary blessing acknowledged and remembered."
+    }
+  ],
+  "federation_recent": [
+    {
+      "timestamp": "2025-06-01T01:00:00",
+      "peer": "https://ally.example",
+      "email": "friend@example.com",
+      "message": "sync completed",
+      "ritual": "Federation blessing recorded."
+    }
+  ]
+}
+```
+
 Browse or export the ledgers at any time:
 
 ```bash

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -27,6 +27,19 @@ Sample support entry:
 {"timestamp": "2025-06-01T00:00:00", "supporter": "Ada", "message": "For those in need", "amount": "$5", "ritual": "Sanctuary blessing acknowledged and remembered."}
 ```
 
+After each blessing or invite a recap is printed showing the most recent entries:
+
+```
+{
+  "support_recent": [
+    {"timestamp": "2025-06-01T00:00:00", "supporter": "Ada", "message": "For those in need", "amount": "$5", "ritual": "Sanctuary blessing acknowledged and remembered."}
+  ],
+  "federation_recent": [
+    {"timestamp": "2025-06-01T01:00:00", "peer": "https://ally.example", "email": "friend@example.com", "message": "sync completed", "ritual": "Federation blessing recorded."}
+  ]
+}
+```
+
 To review your presence during onboarding run:
 
 ```bash

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -62,10 +62,12 @@ def main() -> None:
         print(json.dumps(entry, indent=2))
         ledger.print_recap(limit=2)
         if not args.cmd and not args.summary:
+            print_closing()
             return
 
     if args.summary and not args.cmd:
         cmd_summary(args)
+        print_closing()
         return
 
     if hasattr(args, "func"):

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -48,4 +48,4 @@ def test_cli_invite(monkeypatch, capsys):
     federation_cli.main()
     out = capsys.readouterr().out
     assert "peer1" in out and "hi" in out and "hello" in out
-    assert calls["snap"] >= 1 and calls["recap"] == 1
+    assert calls["snap"] >= 2 and calls["recap"] == 1

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -19,7 +19,7 @@ def test_support_bless(monkeypatch, capsys):
     support_cli.main()
     out = capsys.readouterr().out
     assert 'sanctuary acknowledged' in out
-    assert calls["snap"] >= 1 and calls["recap"] == 1
+    assert calls["snap"] >= 2 and calls["recap"] == 1
 
 def test_support_bless_fail(monkeypatch, capsys):
     def fake_add(name, message, amount=""):


### PR DESCRIPTION
## Summary
- show recap snippet in README and docs
- always close `ledger_cli` with snapshot banner
- update tests for new snapshot expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c5b1714648320b092f9827766b487