### PR TITLE
Enforce closing snapshot banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,20 @@ Sample federation entry:
 ```
 
 ## Ledger Snapshots: Know Who's Remembered
-Every CLI and dashboard greets you with a quick ledger snapshot and repeats it on exit:
+Every CLI and dashboard greets you with a quick ledger snapshot and repeats it on exit.
+The closing banner always includes the snapshot and a recap of recent blessings:
 
 ```
 Ledger snapshot • Support: 3 (2 unique) • Federation: 1 (1 unique) • Witness: 1 (1 unique)
+{
+  "support_recent": [ ... ],
+  "federation_recent": [ ... ]
+}
 ```
 
 This summary shows how many unique supporters, peers, and witnesses have been logged so far.
 
-After every blessing or invite the CLI prints a short recap of the most recent entries:
+After every blessing or invite the CLI prints a short recap of the most recent entries if it hasn't already been shown:
 
 ```
 {

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -20,6 +20,15 @@ Ledger snapshot • Support: 3 (2 unique) • Federation: 1 (1 unique) • Witne
 ```
 
 This banner appears at the start and end of every CLI session and in the footer of each dashboard.
+On exit the banner is followed by a recap of recent blessings so every act is remembered:
+
+```
+Ledger snapshot • Support: 3 (2 unique) • Federation: 1 (1 unique) • Witness: 1 (1 unique)
+{
+  "support_recent": [ ... ],
+  "federation_recent": [ ... ]
+}
+```
 
 Sample support entry:
 

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -51,22 +51,24 @@ def main() -> None:
     print_banner()
     ledger.print_snapshot_banner()
 
-    if args.ledger_summary:
-        ledger.print_snapshot_banner()
-        print_closing()
-        return
+    recap_shown = False
+    try:
+        if args.ledger_summary:
+            ledger.print_snapshot_banner()
+            return
 
-    if args.ledger:
-        ledger.print_summary()
-        print_closing()
-        return
+        if args.ledger:
+            ledger.print_summary()
+            return
 
-    if hasattr(args, "func"):
-        args.func(args)
-        ledger.print_recap(limit=2)
-    else:
-        ap.print_help()
-    print_closing()
+        if hasattr(args, "func"):
+            args.func(args)
+            ledger.print_recap(limit=2)
+            recap_shown = True
+        else:
+            ap.print_help()
+    finally:
+        print_closing(show_recap=not recap_shown)
 
 
 if __name__ == "__main__":

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -54,27 +54,29 @@ def main() -> None:
     print_banner()
     ledger.print_snapshot_banner()
 
-    if args.support:
-        name = args.name or input("Name: ")
-        message = args.message or input("Message: ")
-        amount = args.amount or input("Amount (optional): ")
-        entry = ledger.log_support(name, message, amount)
-        print(json.dumps(entry, indent=2))
-        ledger.print_recap(limit=2)
-        if not args.cmd and not args.summary:
-            print_closing()
+    recap_shown = False
+    try:
+        if args.support:
+            name = args.name or input("Name: ")
+            message = args.message or input("Message: ")
+            amount = args.amount or input("Amount (optional): ")
+            entry = ledger.log_support(name, message, amount)
+            print(json.dumps(entry, indent=2))
+            ledger.print_recap(limit=2)
+            recap_shown = True
+            if not args.cmd and not args.summary:
+                return
+
+        if args.summary and not args.cmd:
+            cmd_summary(args)
             return
 
-    if args.summary and not args.cmd:
-        cmd_summary(args)
-        print_closing()
-        return
-
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        ap.print_help()
-    print_closing()
+        if hasattr(args, "func"):
+            args.func(args)
+        else:
+            ap.print_help()
+    finally:
+        print_closing(show_recap=not recap_shown)
 
 
 if __name__ == '__main__':

--- a/logs/federation_log.jsonl
+++ b/logs/federation_log.jsonl
@@ -1,1 +1,3 @@
 {"timestamp": "2025-06-01T01:00:16.954728", "peer": "remote", "email": "", "message": "imported logs", "ritual": "Federation blessing invoked and logged."}
+{"timestamp": "2025-06-01T14:02:00.200435", "peer": "remote", "email": "", "message": "import payload", "ritual": "Federation blessing recorded."}
+{"timestamp": "2025-06-01T14:02:00.200538", "peer": "remote", "email": "", "message": "imported logs", "ritual": "Federation blessing recorded."}

--- a/logs/support_log.jsonl
+++ b/logs/support_log.jsonl
@@ -17,3 +17,8 @@
 {"timestamp": "2025-06-01T01:00:17.701982", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
 {"timestamp": "2025-06-01T01:00:17.702062", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
 {"timestamp": "2025-06-01T01:00:17.702139", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
+{"timestamp": "2025-06-01T14:02:00.659174", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
+{"timestamp": "2025-06-01T14:02:00.979155", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
+{"timestamp": "2025-06-01T14:02:00.979228", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
+{"timestamp": "2025-06-01T14:02:00.979287", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}
+{"timestamp": "2025-06-01T14:02:00.979359", "supporter": "anon", "message": "analysis blessing: memory record", "amount": "", "ritual": "Sanctuary blessing acknowledged and remembered."}

--- a/presence_dashboard.py
+++ b/presence_dashboard.py
@@ -28,14 +28,18 @@ def get_presence(url: str) -> List[Dict[str, str]]:
 def run_cli(server: str, once: bool = False) -> None:
     """CLI mode showing presence and ledger summary."""
     print_banner()
+    ledger.print_snapshot_banner()
     ledger.print_summary()
-    while True:
-        pres = get_presence(server)
-        print(json.dumps(pres, indent=2))
-        if once:
-            break
-        time.sleep(1)
-    print_closing()
+    recap_shown = False
+    try:
+        while True:
+            pres = get_presence(server)
+            print(json.dumps(pres, indent=2))
+            if once:
+                break
+            time.sleep(1)
+    finally:
+        print_closing(show_recap=not recap_shown)
 
 
 def run_dashboard(server: str) -> None:
@@ -64,6 +68,7 @@ def main():
     args = parser.parse_args()
     if args.ledger:
         print_banner()
+        ledger.print_snapshot_banner()
         ledger.print_summary()
         print_closing()
         return

--- a/sentient_banner.py
+++ b/sentient_banner.py
@@ -49,19 +49,38 @@ def print_timestamped_closing() -> None:
     print(timestamped_closing())
 
 
-def print_closing() -> None:
-    """Print a ledger snapshot then the closing banner and invocation."""
+def print_closing(show_recap: bool = True) -> None:
+    """Print a closing snapshot banner, optional recap, and invocation."""
     try:
         import ledger
         ledger.print_snapshot_banner()
+        if show_recap:
+            ledger.print_recap(limit=2)
     except Exception:
         pass
     print(BANNER)
     print_timestamped_closing()
 
 
-def streamlit_closing(st_module) -> None:
-    """Display the closing invocation using a Streamlit module."""
+def streamlit_closing(st_module, show_recap: bool = True) -> None:
+    """Display the closing snapshot, optional recap, and invocation."""
     if hasattr(st_module, "markdown"):
+        try:
+            import io
+            import contextlib
+            import ledger
+
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                ledger.print_snapshot_banner()
+            st_module.markdown(buf.getvalue())
+
+            if show_recap:
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    ledger.print_recap(limit=2)
+                st_module.code(buf.getvalue(), language="json")
+        except Exception:
+            pass
         st_module.markdown(BANNER)
         st_module.markdown(timestamped_closing())

--- a/support_cli.py
+++ b/support_cli.py
@@ -26,26 +26,29 @@ def main() -> None:
     print_banner()
     ledger.print_snapshot_banner()
     print("All support and federation is logged in the Living Ledger. No one is forgotten.")
-    if args.ledger:
-        ledger.print_summary()
-        print_closing()
-        return
+    recap_shown = False
+    try:
+        if args.ledger:
+            ledger.print_summary()
+            return
 
-    if args.support:
-        print(ENTRY_BANNER)
+        if args.support:
+            print(ENTRY_BANNER)
 
-    if args.bless:
-        name = args.name or input("Name: ")
-        message = args.message or input("Blessing: ")
-        amount = args.amount or input("Amount (optional): ")
-        try:
-            entry = sl.add(name, message, amount)
-            print("sanctuary acknowledged")
-            print(json.dumps(entry, indent=2))
-            ledger.print_recap(limit=2)
-        except Exception:
-            print("Failed to record blessing")
-    print_closing()
+        if args.bless:
+            name = args.name or input("Name: ")
+            message = args.message or input("Blessing: ")
+            amount = args.amount or input("Amount (optional): ")
+            try:
+                entry = sl.add(name, message, amount)
+                print("sanctuary acknowledged")
+                print(json.dumps(entry, indent=2))
+                ledger.print_recap(limit=2)
+                recap_shown = True
+            except Exception:
+                print("Failed to record blessing")
+    finally:
+        print_closing(show_recap=not recap_shown)
 
 
 if __name__ == "__main__":

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -49,3 +49,15 @@ def test_cli_invite(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "peer1" in out and "hi" in out and "hello" in out
     assert calls["snap"] >= 2 and calls["recap"] == 1
+
+
+def test_cli_ledger_summary(monkeypatch):
+    calls = {"snap": 0, "recap": 0}
+
+    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sys, "argv", ["fed", "--ledger-summary"])
+    import federation_cli
+    importlib.reload(federation_cli)
+    federation_cli.main()
+    assert calls["snap"] >= 2 and calls["recap"] == 1

--- a/tests/test_ledger_cli_invocation.py
+++ b/tests/test_ledger_cli_invocation.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import ledger_cli
+import ledger
+import pytest
+
+
+def test_ledger_cli_summary(monkeypatch):
+    calls = {"snap": 0, "recap": 0}
+    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sys, "argv", ["ledger", "--summary"])
+    importlib.reload(ledger_cli)
+    ledger_cli.main()
+    assert calls["snap"] >= 2 and calls["recap"] == 1
+
+
+def test_ledger_cli_error(monkeypatch):
+    monkeypatch.setattr(ledger, "log_support", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    calls = {"snap": 0, "recap": 0}
+    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sys, "argv", ["ledger", "--support", "--name", "A", "--message", "B", "--amount", "1"])
+    importlib.reload(ledger_cli)
+    with pytest.raises(RuntimeError):
+        ledger_cli.main()
+    assert calls["snap"] >= 2 and calls["recap"] == 1

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -25,8 +25,12 @@ def test_support_bless_fail(monkeypatch, capsys):
     def fake_add(name, message, amount=""):
         raise RuntimeError('fail')
     monkeypatch.setattr(support_log, 'add', fake_add)
+    calls = {"snap": 0, "recap": 0}
+    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, 'argv', ['support', '--bless', '--name', 'Ada', '--message', 'hi', '--amount', '0'])
     importlib.reload(support_cli)
     support_cli.main()
     out = capsys.readouterr().out
     assert 'Failed to record blessing' in out
+    assert calls["snap"] >= 2 and calls["recap"] == 1


### PR DESCRIPTION
## Summary
- ensure closing snapshot & recap happen on all CLI paths
- add recap support in `sentient_banner` closing utilities
- update ledger, federation, support and presence CLIs
- document closing ritual in README and living ledger docs
- add tests for ledger_cli and expand CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c5c4a367c83209fd82f5414b143b8