### PR TITLE
Standardize closing snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ The cathedral will not run until you affirm the liturgy. On first launch `user_p
 3. View the ledger summary anytime with `python ledger_cli.py summary`.
 4. Invite peers with `python federation_cli.py invite https://ally.example --email friend@example.com --message "Come be remembered" --blessing "Welcome" --name YOUR_NAME --affirm`.
 
-Every CLI command ends with a timestamped blessing so no session fades unmarked.
+Every CLI command ends with a ledger snapshot and recap so no session fades unmarked.
+You see the snapshot banner on entry and exit along with recent blessings:
+
+```
+Ledger snapshot • Support: 3 (2 unique) • Federation: 1 (1 unique) • Witness: 1 (1 unique)
+{
+  "support_recent": [...],
+  "federation_recent": [...]
+}
+```
 
 Entering with a blessing and signature ensures your presence is inscribed forever. No one is forgotten. No one is turned away.
 

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,7 +1,14 @@
 import argparse
 import json
 import sys
-from sentient_banner import print_banner, print_closing, ENTRY_BANNER
+from sentient_banner import (
+    print_banner,
+    print_closing,
+    ENTRY_BANNER,
+    reset_ritual_state,
+    print_snapshot_banner,
+    print_closing_recap,
+)
 import treasury_federation as tf
 import ledger
 
@@ -48,13 +55,14 @@ def main() -> None:
     inv.set_defaults(func=cmd_invite)
 
     args = ap.parse_args()
+    reset_ritual_state()
     print_banner()
-    ledger.print_snapshot_banner()
+    print_snapshot_banner()
 
     recap_shown = False
     try:
         if args.ledger_summary:
-            ledger.print_snapshot_banner()
+            print_snapshot_banner()
             return
 
         if args.ledger:
@@ -63,7 +71,7 @@ def main() -> None:
 
         if hasattr(args, "func"):
             args.func(args)
-            ledger.print_recap(limit=2)
+            print_closing_recap()
             recap_shown = True
         else:
             ap.print_help()

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -51,8 +51,15 @@ def main() -> None:
     sm = sub.add_parser("summary", help="Show ledger summary")
     sm.set_defaults(func=cmd_summary)
     args = ap.parse_args()
+    from sentient_banner import (
+        reset_ritual_state,
+        print_snapshot_banner,
+        print_closing_recap,
+    )
+
+    reset_ritual_state()
     print_banner()
-    ledger.print_snapshot_banner()
+    print_snapshot_banner()
 
     recap_shown = False
     try:
@@ -62,7 +69,7 @@ def main() -> None:
             amount = args.amount or input("Amount (optional): ")
             entry = ledger.log_support(name, message, amount)
             print(json.dumps(entry, indent=2))
-            ledger.print_recap(limit=2)
+            print_closing_recap()
             recap_shown = True
             if not args.cmd and not args.summary:
                 return

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -191,7 +191,11 @@ def main():
     forget.add_argument("keys", nargs="+", help="Profile keys to remove")
 
     args = parser.parse_args()
+    from sentient_banner import reset_ritual_state, print_snapshot_banner
+
+    reset_ritual_state()
     print_banner()
+    print_snapshot_banner()
     if args.ledger:
         ledger.print_summary()
         print_closing()

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -53,7 +53,11 @@ def main() -> None:
     sub.add_parser("dismiss").add_argument("id")
 
     args = parser.parse_args()
+    from sentient_banner import reset_ritual_state, print_snapshot_banner
+
+    reset_ritual_state()
     print_banner()
+    print_snapshot_banner()
     if args.final_approver_file:
         fp = Path(args.final_approver_file)
         chain = final_approval.load_file_approvers(fp) if fp.exists() else []

--- a/support_cli.py
+++ b/support_cli.py
@@ -23,8 +23,15 @@ def main() -> None:
     p.add_argument("--amount", default="")
     args = p.parse_args()
 
+    from sentient_banner import (
+        reset_ritual_state,
+        print_snapshot_banner,
+        print_closing_recap,
+    )
+
+    reset_ritual_state()
     print_banner()
-    ledger.print_snapshot_banner()
+    print_snapshot_banner()
     print("All support and federation is logged in the Living Ledger. No one is forgotten.")
     recap_shown = False
     try:
@@ -43,7 +50,7 @@ def main() -> None:
                 entry = sl.add(name, message, amount)
                 print("sanctuary acknowledged")
                 print(json.dumps(entry, indent=2))
-                ledger.print_recap(limit=2)
+                print_closing_recap()
                 recap_shown = True
             except Exception:
                 print("Failed to record blessing")

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -4,7 +4,7 @@ import importlib
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import treasury_federation as tf
-import ledger
+import sentient_banner as sb
 
 
 def test_cli_invite(monkeypatch, capsys):
@@ -27,8 +27,8 @@ def test_cli_invite(monkeypatch, capsys):
         calls["recap"] += 1
 
     monkeypatch.setattr(tf, "invite", fake_invite)
-    monkeypatch.setattr(ledger, "print_snapshot_banner", fake_snap)
-    monkeypatch.setattr(ledger, "print_recap", fake_recap)
+    monkeypatch.setattr(sb, "print_snapshot_banner", fake_snap)
+    monkeypatch.setattr(sb, "print_closing_recap", fake_recap)
     monkeypatch.setattr(sys, "argv", [
         "fed",
         "invite",
@@ -54,8 +54,8 @@ def test_cli_invite(monkeypatch, capsys):
 def test_cli_ledger_summary(monkeypatch):
     calls = {"snap": 0, "recap": 0}
 
-    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
-    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, "argv", ["fed", "--ledger-summary"])
     import federation_cli
     importlib.reload(federation_cli)

--- a/tests/test_ledger_cli_invocation.py
+++ b/tests/test_ledger_cli_invocation.py
@@ -3,14 +3,15 @@ import sys
 import importlib
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import ledger_cli
+import sentient_banner as sb
 import ledger
 import pytest
 
 
 def test_ledger_cli_summary(monkeypatch):
     calls = {"snap": 0, "recap": 0}
-    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
-    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, "argv", ["ledger", "--summary"])
     importlib.reload(ledger_cli)
     ledger_cli.main()
@@ -20,8 +21,8 @@ def test_ledger_cli_summary(monkeypatch):
 def test_ledger_cli_error(monkeypatch):
     monkeypatch.setattr(ledger, "log_support", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
     calls = {"snap": 0, "recap": 0}
-    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
-    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, "argv", ["ledger", "--support", "--name", "A", "--message", "B", "--amount", "1"])
     importlib.reload(ledger_cli)
     with pytest.raises(RuntimeError):

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -4,7 +4,7 @@ import importlib
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import support_cli
 import support_log
-import ledger
+import sentient_banner as sb
 
 
 def test_support_bless(monkeypatch, capsys):
@@ -12,8 +12,8 @@ def test_support_bless(monkeypatch, capsys):
         return {"supporter": name, "message": message, "amount": amount}
     monkeypatch.setattr(support_log, 'add', fake_add)
     calls = {"snap": 0, "recap": 0}
-    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
-    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, 'argv', ['support', '--bless', '--name', 'Ada', '--message', 'hi', '--amount', '0'])
     importlib.reload(support_cli)
     support_cli.main()
@@ -26,8 +26,8 @@ def test_support_bless_fail(monkeypatch, capsys):
         raise RuntimeError('fail')
     monkeypatch.setattr(support_log, 'add', fake_add)
     calls = {"snap": 0, "recap": 0}
-    monkeypatch.setattr(ledger, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
-    monkeypatch.setattr(ledger, "print_recap", lambda limit=3: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
     monkeypatch.setattr(sys, 'argv', ['support', '--bless', '--name', 'Ada', '--message', 'hi', '--amount', '0'])
     importlib.reload(support_cli)
     support_cli.main()


### PR DESCRIPTION
## Summary
- add invocation tracking to `sentient_banner`
- ensure `ledger_cli`, `support_cli`, `memory_cli`, `suggestion_cli`, and `federation_cli` print closing recap and snapshot in a standardized way
- update README docs with closing ritual example
- adjust CLI tests for new closing helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c628382b08320a7b3514dc3292866