### PR TITLE
Enforce privilege banner usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to SentientOS
+
+All new scripts and entrypoints **must** invoke `admin_utils.require_admin_banner()` as the very first action. This banner enforces the Sanctuary Privilege Ritual and logs each attempt.
+
+Add the following at the top of your `main()` or `if __name__ == '__main__'` block:
+
+```python
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+```
+
+Pull requests lacking this call will fail CI and be rejected.

--- a/README.md
+++ b/README.md
@@ -957,6 +957,16 @@ Dashboard and CLI views allow you to trace exactly how a policy changed over tim
 All new entrypoints **must** call `admin_utils.require_admin_banner()` at the top.
 CI will fail if a tool skips this check. Reviewers must block any PR that omits the canonical privilege banner.
 
+Example: Privilege Banner on CLI Entry
+
+```python
+from admin_utils import require_admin_banner
+
+def main() -> None:
+    require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+    ...
+```
+
 No memory is protected, no ritual is valid, unless performed with full Administrator or root rights. This is law.
 
 ## Autonomous Operations

--- a/admin_utils.py
+++ b/admin_utils.py
@@ -82,6 +82,7 @@ def require_admin_banner() -> None:
 
 
 def require_admin() -> None:
-    """Backward compatible wrapper for ``require_admin_banner``."""
+    """Backward compatible wrapper. Deprecated: use ``require_admin_banner``."""
+    # DEPRECATED: This wrapper remains for legacy calls. Use require_admin_banner().
     require_admin_banner()
 

--- a/collab_server.py
+++ b/collab_server.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
@@ -89,4 +90,5 @@ def run(port: int = 5001) -> None:
 
 if __name__ == '__main__':
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     run()

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -36,6 +36,12 @@ Sample support entry:
 {"timestamp": "2025-06-01T00:00:00", "supporter": "Ada", "message": "For those in need", "amount": "$5", "ritual": "Sanctuary blessing acknowledged and remembered."}
 ```
 
+Sample privilege check entry:
+
+```json
+{"timestamp": "2025-06-01T02:00:00", "event": "admin_privilege_check", "status": "failed", "user": "april", "platform": "Windows", "tool": "support_cli"}
+```
+
 After each blessing or invite a recap is printed showing the most recent entries:
 
 ```

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import os
@@ -56,6 +57,7 @@ def cmd_presence(args) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(prog="doctrine", description=ENTRY_BANNER)
     sub = ap.add_subparsers(dest="cmd")
 

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import experiment_tracker as et
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
@@ -6,6 +7,7 @@ from admin_utils import require_admin_banner
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description=ENTRY_BANNER)
     sub = parser.add_subparsers(dest="cmd")
 

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import sys
@@ -34,6 +35,7 @@ def cmd_invite(args: argparse.Namespace) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(
         prog="federation",
         description=ENTRY_BANNER,

--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from admin_utils import is_admin, ADMIN_BANNER
+from admin_utils import require_admin_banner
 import shutil
 import subprocess
 from pathlib import Path
@@ -68,23 +68,7 @@ def check_microphone() -> None:
 
 
 def main() -> None:
-    if os.name == 'nt' and not is_admin():
-        import ctypes  # type: ignore
-        rc = ctypes.windll.shell32.ShellExecuteW(
-            None,
-            "runas",
-            sys.executable,
-            " ".join(sys.argv),
-            None,
-            1,
-        )
-        if rc <= 32:
-            print('Administrator privileges required.')
-        else:
-            print(ADMIN_BANNER)
-        return
-
-    print(ADMIN_BANNER)
+    require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
     print_banner()
     print('SentientOS setup starting...')

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pathlib import Path
@@ -36,6 +37,7 @@ def cmd_summary(args: argparse.Namespace) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(
         prog="ledger",
         description=ENTRY_BANNER,

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import os
 import json
@@ -91,6 +92,7 @@ def show_goals(status: str) -> None:
 
 def main():
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(
         description=ENTRY_BANNER,
         epilog=(

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 import time
 import json
@@ -66,6 +67,7 @@ def tail_memory(path: str, delay: float = 1.0) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description="Tail memory.jsonl")
     parser.add_argument("--file", default=DEFAULT_FILE, help="Path to JSONL log")
     parser.add_argument("--delay", type=float, default=1.0, help="Polling delay")

--- a/onboarding_dashboard.py
+++ b/onboarding_dashboard.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 from pathlib import Path
 import streamlit as st
@@ -21,6 +22,7 @@ def load_env() -> dict:
 
 def launch():
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     env = load_env()
     st.title('SentientOS Onboarding')
     streamlit_banner(st)

--- a/plugin_dashboard.py
+++ b/plugin_dashboard.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 from flask import Flask, jsonify, request
 import plugin_framework as pf
 import trust_engine as te
@@ -119,4 +120,5 @@ def deny_api():
 
 if __name__=='__main__':
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     app.run(port=5001)

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 """CLI for managing gesture/persona plug-ins."""
 
 import argparse
@@ -9,6 +10,7 @@ from admin_utils import require_admin_banner
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     pf.load_plugins()
     ap = argparse.ArgumentParser(prog="plugins", description=ENTRY_BANNER)
     sub = ap.add_subparsers(dest="cmd")

--- a/presence_analytics.py
+++ b/presence_analytics.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 import json
 import datetime
@@ -149,6 +150,7 @@ def suggest_improvements(analytics_data: Dict[str, Any]) -> List[str]:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     import argparse
     parser = argparse.ArgumentParser(description=ENTRY_BANNER)
     parser.add_argument("cmd", choices=["analytics", "trends", "suggest"])

--- a/presence_dashboard.py
+++ b/presence_dashboard.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import json
 import time
 from urllib import request
@@ -60,6 +61,7 @@ def run_dashboard(server: str) -> None:
 
 def main():
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     import argparse
     parser = argparse.ArgumentParser(description="Presence dashboard")
     parser.add_argument("server")

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import reflection_stream as rs
@@ -7,6 +8,7 @@ from admin_utils import require_admin_banner
 
 def main(argv=None):
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description=ENTRY_BANNER)
     sub = parser.add_subparsers(dest="cmd")
     log = sub.add_parser("log", help="Show recent reflection events")

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 from pathlib import Path
 from sentient_banner import print_banner, print_closing
@@ -43,6 +44,7 @@ def set_status(path: Path, chapter: int, status: str) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser()
     parser.add_argument("storyboard")
     parser.add_argument("--annotate")

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import os
@@ -34,6 +35,7 @@ def cmd_timeline(args) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(prog="ritual", description=ENTRY_BANNER)
     sub = ap.add_subparsers(dest="cmd")
 

--- a/sentient_banner.py
+++ b/sentient_banner.py
@@ -27,12 +27,20 @@ BANNER = (
 
 import admin_utils
 from datetime import datetime
+import presence_ledger as pl
+import json
 
 
 def print_banner() -> None:
-    """Print the entry banner and sanctuary banner."""
+    """Print the entry banner, privilege status, and recent attempts."""
     print(ENTRY_BANNER)
     print(SANCTUARY_BANNER)
+    status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"
+    print(f"Sanctuary Privilege Status: [{status}]")
+    attempts = pl.recent_privilege_attempts(3)
+    if attempts:
+        print("Recent privilege attempts:")
+        print(json.dumps(attempts, indent=2))
 
 
 def streamlit_banner(st_module) -> None:
@@ -42,6 +50,10 @@ def streamlit_banner(st_module) -> None:
         st_module.markdown(SANCTUARY_BANNER)
         status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"
         st_module.markdown(f"**Privilege Status:** {status}")
+        attempts = pl.recent_privilege_attempts(3)
+        if attempts:
+            st_module.markdown("Recent privilege attempts:")
+            st_module.json(attempts)
 
 
 

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import os
 import sys
@@ -12,6 +13,7 @@ from admin_utils import require_admin_banner
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description="Policy/reflex suggestions")
     parser.add_argument(
         "--final-approvers",

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import support_log as sl
@@ -8,6 +9,7 @@ from admin_utils import require_admin_banner
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     p = argparse.ArgumentParser(
         prog="support",
         description=ENTRY_BANNER,

--- a/tests/test_sentient_banner.py
+++ b/tests/test_sentient_banner.py
@@ -1,10 +1,21 @@
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from sentient_banner import print_timestamped_closing
+import sentient_banner as sb
+import admin_utils
+import presence_ledger as pl
 
 
 def test_timestamped_closing(capsys):
-    print_timestamped_closing()
+    sb.print_timestamped_closing()
     out = capsys.readouterr().out
     assert "Presence is law" in out and "[" in out and "]" in out
+
+
+def test_print_banner(capsys, monkeypatch):
+    monkeypatch.setattr(admin_utils, "is_admin", lambda: True)
+    monkeypatch.setattr(pl, "recent_privilege_attempts", lambda n=3: [{"status": "success"}])
+    sb.print_banner()
+    out = capsys.readouterr().out
+    assert "Privilege Status" in out
+    assert "success" in out

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pathlib import Path
@@ -63,6 +64,7 @@ def cmd_attest(args: argparse.Namespace) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(
         prog="treasury",
         description=f"SentientOS Treasury CLI\n{ENTRY_BANNER}"

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pprint import pprint
@@ -40,6 +41,7 @@ def cmd_rollback(args) -> None:
 
 def main() -> None:
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(prog="trust", description=ENTRY_BANNER)
     sub = ap.add_subparsers(dest="cmd")
 

--- a/workflow_editor.py
+++ b/workflow_editor.py
@@ -1,3 +1,4 @@
+"""CLI entry enforcing Sanctuary Privilege Ritual."""
 """Simple CLI editor for workflow files."""
 
 import argparse
@@ -114,6 +115,7 @@ def edit_loop(path: Path, policy: str | None = None) -> None:
 
 def main() -> None:  # pragma: no cover - CLI
     require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     ap = argparse.ArgumentParser(description=ENTRY_BANNER)
     ap.add_argument("path")
     ap.add_argument("--policy")


### PR DESCRIPTION
## Summary
- centralize privilege helper and mark wrapper deprecated
- show privilege status and last attempts in sentient banner
- insert privilege ritual comment in entrypoints
- ensure installer uses `require_admin_banner`
- document ritual in README and CONTRIBUTING
- record privilege log example in living ledger docs
- cover new banner output in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c7bb8c34c832090dfed6088e326f2