### PR TITLE
Enforce privilege ritual banner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,11 @@
 # Contributing to SentientOS
 
 All new scripts and entrypoints **must** invoke `admin_utils.require_admin_banner()` as the very first action. This banner enforces the Sanctuary Privilege Ritual and logs each attempt.
+Directly after your imports include the canonical banner docstring so future audits can easily detect compliance:
+
+```python
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+```
 
 Add the following at the top of your `main()` or `if __name__ == '__main__'` block:
 
@@ -9,5 +14,9 @@ from admin_utils import require_admin_banner
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 ```
+## Reviewer Checklist
 
-Pull requests lacking this call will fail CI and be rejected.
+- [ ] Docstring `"Sanctuary Privilege Ritual: Do not remove. See doctrine for details."` present after imports
+- [ ] `require_admin_banner()` invoked before any other logic
+
+Pull requests lacking these will fail CI and be rejected.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Ritual refusal: You must run with administrator rights to access the cathedral's
 How to fix: Right-click the command and choose 'Run as administrator'.
 ```
 
+Successful elevation produces a similar banner with a success status and is logged in `logs/user_presence.jsonl`:
+
+```
+🛡️ Sanctuary Privilege Status: [🛡️ Privileged]
+Current user: YOUR_NAME
+Platform: Windows
+Sanctuary Privilege • SentientOS runs with full Administrator rights to safeguard memory and doctrine.
+```
+
+```json
+{"timestamp": "2025-06-01T02:00:00", "event": "admin_privilege_check", "status": "success", "user": "YOUR_NAME", "platform": "Windows", "tool": "support_cli"}
+```
+
 Every CLI and dashboard prints a `[🛡️ Privileged]` or `[⚠️ Not Privileged]` badge before any other output. Failed attempts are recorded in `logs/user_presence.jsonl` with the user, platform, tool, and status.
 
 Never run SentientOS in a shared or public environment. If you need to elevate:

--- a/admin_utils.py
+++ b/admin_utils.py
@@ -2,6 +2,7 @@ import os
 import sys
 import platform
 import getpass
+import warnings
 from pathlib import Path
 import presence_ledger as pl
 
@@ -83,6 +84,10 @@ def require_admin_banner() -> None:
 
 def require_admin() -> None:
     """Backward compatible wrapper. Deprecated: use ``require_admin_banner``."""
-    # DEPRECATED: This wrapper remains for legacy calls. Use require_admin_banner().
+    # DEPRECATED—see doctrine. Use require_admin_banner() for all new code.
+    warnings.warn(
+        "require_admin is deprecated, use require_admin_banner", DeprecationWarning,
+        stacklevel=2,
+    )
     require_admin_banner()
 

--- a/collab_server.py
+++ b/collab_server.py
@@ -1,9 +1,10 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
 from typing import Dict, Any
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 import notification
 

--- a/docs/living_ledger.md
+++ b/docs/living_ledger.md
@@ -42,6 +42,10 @@ Sample privilege check entry:
 {"timestamp": "2025-06-01T02:00:00", "event": "admin_privilege_check", "status": "failed", "user": "april", "platform": "Windows", "tool": "support_cli"}
 ```
 
+```json
+{"timestamp": "2025-06-01T02:00:05", "event": "admin_privilege_check", "status": "success", "user": "april", "platform": "Windows", "tool": "support_cli"}
+```
+
 After each blessing or invite a recap is printed showing the most recent entries:
 
 ```

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import os
@@ -9,6 +8,8 @@ import relationship_log as rl
 import presence_ledger as pl
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def cmd_show(args) -> None:

--- a/onboarding_dashboard.py
+++ b/onboarding_dashboard.py
@@ -1,10 +1,11 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 from pathlib import Path
 import streamlit as st
 from sentient_banner import streamlit_banner, streamlit_closing
 import ledger
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 ENV_FILE = Path(__file__).resolve().parent / '.env'
 

--- a/plugin_dashboard.py
+++ b/plugin_dashboard.py
@@ -1,8 +1,9 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 from flask import Flask, jsonify, request
 import plugin_framework as pf
 import trust_engine as te
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 app = Flask(__name__)
 

--- a/presence_dashboard.py
+++ b/presence_dashboard.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import json
 import time
 from urllib import request
@@ -11,6 +10,8 @@ from sentient_banner import (
 )
 from admin_utils import require_admin_banner
 import ledger
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 try:
     import streamlit as st  # type: ignore

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -10,6 +10,8 @@ import final_approval
 from sentient_banner import print_banner, print_closing
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 
 def main() -> None:
     require_admin_banner()

--- a/tests/test_admin_utils.py
+++ b/tests/test_admin_utils.py
@@ -25,12 +25,12 @@ def test_require_admin_failure(monkeypatch):
     logs = []
     monkeypatch.setattr(admin_utils, "is_admin", lambda: False)
     monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append((u, p, t, s)))
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit), pytest.warns(DeprecationWarning):
         admin_utils.require_admin()
     assert logs and logs[0][3] == "failed"
 
 
 def test_require_admin_wrapper(monkeypatch):
     monkeypatch.setattr(admin_utils, "require_admin_banner", lambda: (_ for _ in ()).throw(SystemExit))
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit), pytest.warns(DeprecationWarning):
         admin_utils.require_admin()


### PR DESCRIPTION
## Summary
- enforce the Sanctuary Privilege Ritual docstring after imports
- deprecate `require_admin` with warnings
- expand README and contributing docs with ritual instructions
- update dashboard and CLI entrypoints with canonical banner docstring
- log success and failure examples in living ledger docs
- test warning when deprecated helper is invoked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c7e46b2bc8320a6a5752138a6d331