### PR TITLE
Enforce sanctuary privilege ritual

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+python privilege_lint.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,12 @@ Directly after your imports include the canonical banner docstring so future aud
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 ```
 
-Add the following at the top of your `main()` or `if __name__ == '__main__'` block:
+Add the following at the top of your script:
 
 ```python
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 ```
@@ -20,3 +22,7 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 - [ ] `require_admin_banner()` invoked before any other logic
 
 Pull requests lacking these will fail CI and be rejected.
+
+Run `./.githooks/pre-commit` manually or link it into your `.git/hooks` folder
+to automatically lint for the ritual docstring and privilege call before each
+commit.

--- a/README.md
+++ b/README.md
@@ -967,13 +967,15 @@ Dashboard and CLI views allow you to trace exactly how a policy changed over tim
 
 ## Contributor Ritual
 
-All new entrypoints **must** call `admin_utils.require_admin_banner()` at the top.
+All new entrypoints **must** begin with the ritual docstring and call `admin_utils.require_admin_banner()` at the top.
 CI will fail if a tool skips this check. Reviewers must block any PR that omits the canonical privilege banner.
 
 Example: Privilege Banner on CLI Entry
 
 ```python
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 def main() -> None:
     require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/autonomous_ops.py
+++ b/autonomous_ops.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List
 import experiment_tracker as et
 import reflex_manager as rm
 from api import actuator
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 DATA_STREAMS = [
     Path('logs/emotion.jsonl'),
@@ -80,6 +83,8 @@ def analyze_events(events: List[Dict[str, Any]]) -> None:
 
 
 def run_loop(interval: float = 60.0) -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     manager = rm.get_default_manager() or rm.ReflexManager()
     rm.set_default_manager(manager)
     manager.start()

--- a/emotion_dashboard.py
+++ b/emotion_dashboard.py
@@ -27,6 +27,9 @@ except Exception:  # pragma: no cover - optional
     st = None
 
 import ledger
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 import reflex_manager as rm
 from reflex_rules import bridge_restart_check, daily_digest_action
@@ -68,6 +71,8 @@ def run_dashboard(
     feedback_rules: Optional[str] = None,
 ) -> None:
     """Launch the SentientOS Streamlit dashboard, with optional feedback layer."""
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None or pd is None:
         print("Streamlit or pandas not available. Install dependencies to run dashboard.")
         return

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,8 +1,9 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import experiment_tracker as et
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def main() -> None:

--- a/experiments_api.py
+++ b/experiments_api.py
@@ -1,5 +1,8 @@
 from flask import Flask, jsonify, request
 import experiment_tracker as et
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 app = Flask(__name__)
 
@@ -34,4 +37,6 @@ def experiments_comment() -> object:
 
 
 if __name__ == '__main__':
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     app.run(port=5002)

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import sys
@@ -13,6 +12,8 @@ from sentient_banner import (
 from admin_utils import require_admin_banner
 import treasury_federation as tf
 import ledger
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def cmd_invite(args: argparse.Namespace) -> None:

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pathlib import Path
@@ -6,6 +5,8 @@ import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
 import presence_ledger as pl
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 SUPPORT_LOG = Path('logs/support_log.jsonl')

--- a/love_dashboard.py
+++ b/love_dashboard.py
@@ -5,6 +5,9 @@ from typing import List, Dict
 import love_treasury as lt
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 try:
     import streamlit as st  # type: ignore
@@ -13,12 +16,16 @@ except Exception:  # pragma: no cover - optional
 
 
 def run_cli() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     print_banner()
     data = lt.list_treasury()
     print(json.dumps(data, indent=2))
 
 
 def run_dashboard() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None:
         run_cli()
         return

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import os
 import json
@@ -13,6 +12,8 @@ from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
 import presence_analytics as pa
 import ritual
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 def show_timeline(last: int) -> None:
     """Print the timestamp and dominant emotion of recent entries."""

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 import time
 import json
@@ -6,6 +5,8 @@ import argparse
 from colorama import init, Fore, Style
 from sentient_banner import print_banner, print_closing
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 init()
 

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,11 +1,10 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
-"""CLI for managing gesture/persona plug-ins."""
-
 import argparse
 import json
 import plugin_framework as pf
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def main() -> None:

--- a/presence_analytics.py
+++ b/presence_analytics.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import os
 import json
 import datetime
@@ -7,6 +6,8 @@ from typing import List, Dict, Any
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
 import support_log as sl
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 MEMORY_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory"))
 RAW_PATH = MEMORY_DIR / "raw"

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
+
+ENTRY_PATTERNS = ["*_cli.py", "*_dashboard.py", "collab_server.py", "autonomous_ops.py", "replay.py", "experiments_api.py"]
+
+
+def check_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    issues = []
+    if DOCSTRING not in text:
+        issues.append(f"{path}: missing privilege docstring")
+    if "require_admin_banner()" not in text:
+        issues.append(f"{path}: missing require_admin_banner() call")
+    return issues
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent
+    files = []
+    for pattern in ENTRY_PATTERNS:
+        files.extend(root.glob(pattern))
+    issues = []
+    for path in files:
+        issues.extend(check_file(path))
+    if issues:
+        print("\n".join(sorted(issues)))
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/public_feed_dashboard.py
+++ b/public_feed_dashboard.py
@@ -7,6 +7,9 @@ from typing import List, Dict
 import doctrine
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 try:
     import streamlit as st  # type: ignore
@@ -37,6 +40,8 @@ def load_feed(last: int = 50, event: str | None = None, date: str | None = None)
 
 
 def run_cli(args: argparse.Namespace) -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     print_banner()
     feed = load_feed(args.last, args.event, args.date)
     for entry in feed:
@@ -44,6 +49,8 @@ def run_cli(args: argparse.Namespace) -> None:
 
 
 def run_dashboard() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None:
         ap = argparse.ArgumentParser(description="Public ritual feed")
         ap.add_argument("--last", type=int, default=20)

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,9 +1,10 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import reflection_stream as rs
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def main(argv=None):

--- a/reflection_dashboard.py
+++ b/reflection_dashboard.py
@@ -8,6 +8,9 @@ import reflection_stream as rs
 import trust_engine as te
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 try:
     import pandas as pd  # type: ignore
@@ -115,6 +118,8 @@ def _print_table(events: Iterable[Dict[str, Any]]) -> None:
 
 
 def run_cli(args: argparse.Namespace) -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     events = load_timeline(limit=args.last)
     start = None
     end = None
@@ -136,6 +141,8 @@ def run_cli(args: argparse.Namespace) -> None:
 
 
 def run_dashboard() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None or pd is None:
         ap = argparse.ArgumentParser(description="Reflection dashboard CLI")
         ap.add_argument("--type", dest="type")

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -15,6 +15,9 @@ except Exception:  # pragma: no cover - optional
 
 from sentient_banner import streamlit_banner, streamlit_closing
 import ledger
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def load_experiments() -> Dict[str, Any]:
@@ -28,6 +31,8 @@ def load_experiments() -> Dict[str, Any]:
 
 
 def run_cli(args: argparse.Namespace) -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     mgr = rm.ReflexManager()
     mgr.load_experiments()
 
@@ -117,6 +122,8 @@ def run_cli(args: argparse.Namespace) -> None:
 
 
 def run_dashboard() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None:
         ap = argparse.ArgumentParser(description="Reflex dashboard CLI")
         ap.add_argument("--log", type=int, default=0, help="Show last N learn logs")

--- a/replay.py
+++ b/replay.py
@@ -7,6 +7,9 @@ import zipfile
 import tempfile
 from typing import Any, List
 from flask import Flask, jsonify, request
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def run_dashboard(storyboard: str) -> Flask:
@@ -225,6 +228,8 @@ def live_playback(
 
 
 def main(argv=None):
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description='Replay storyboard')
     parser.add_argument('--storyboard')
     parser.add_argument('--import-demo')

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,8 +1,9 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 from pathlib import Path
 from sentient_banner import print_banner, print_closing
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 from story_studio import load_storyboard, save_storyboard
 import user_profile as up

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,9 +1,10 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import os
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 import attestation
 import relationship_log as rl

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import os
 import sys

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,10 +1,11 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 import support_log as sl
 import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def main() -> None:

--- a/tests/test_admin_utils.py
+++ b/tests/test_admin_utils.py
@@ -14,20 +14,24 @@ def test_is_admin_true():
 def test_require_admin_banner(capsys, monkeypatch):
     logs = []
     monkeypatch.setattr(admin_utils, "is_admin", lambda: True)
-    monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append((u, p, t, s)))
+    monkeypatch.setattr(admin_utils, "getpass", type("gp", (), {"getuser": lambda: "tester"}))
+    monkeypatch.setattr(admin_utils.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append({"user": u, "platform": p, "tool": t, "status": s}))
     admin_utils.require_admin_banner()
     out = capsys.readouterr().out
     assert "Sanctuary Privilege Status: [🛡️ Privileged]" in out
-    assert logs and logs[0][3] == "success"
+    assert logs and logs[0] == {"user": "tester", "platform": "Linux", "tool": "pytest", "status": "success"}
 
 
 def test_require_admin_failure(monkeypatch):
     logs = []
     monkeypatch.setattr(admin_utils, "is_admin", lambda: False)
-    monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append((u, p, t, s)))
+    monkeypatch.setattr(admin_utils, "getpass", type("gp", (), {"getuser": lambda: "tester"}))
+    monkeypatch.setattr(admin_utils.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append({"user": u, "platform": p, "tool": t, "status": s}))
     with pytest.raises(SystemExit), pytest.warns(DeprecationWarning):
         admin_utils.require_admin()
-    assert logs and logs[0][3] == "failed"
+    assert logs and logs[0] == {"user": "tester", "platform": "Linux", "tool": "pytest", "status": "failed"}
 
 
 def test_require_admin_wrapper(monkeypatch):

--- a/tests/test_presence_ledger.py
+++ b/tests/test_presence_ledger.py
@@ -23,3 +23,16 @@ def test_recent_privilege_attempts(tmp_path, monkeypatch):
     assert len(recent) == 2
     assert recent[0]["timestamp"] == "t1"
     assert recent[1]["status"] == "failed"
+
+
+def test_log_privilege(tmp_path, monkeypatch):
+    path = tmp_path / "user_presence.jsonl"
+    monkeypatch.setenv("USER_PRESENCE_LOG", str(path))
+    import importlib
+    importlib.reload(pl)
+    pl.log_privilege("tester", "Linux", "tool", "success")
+    data = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
+    assert data["user"] == "tester"
+    assert data["platform"] == "Linux"
+    assert data["tool"] == "tool"
+    assert data["status"] == "success"

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pathlib import Path
@@ -8,6 +7,8 @@ from admin_utils import require_admin_banner
 import love_treasury as lt
 import treasury_federation as tf
 import treasury_attestation as ta
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def cmd_submit(args: argparse.Namespace) -> None:

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,4 +1,3 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
 import argparse
 import json
 from pprint import pprint
@@ -8,6 +7,8 @@ from admin_utils import require_admin_banner
 import trust_engine as te
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 import support_log as sl
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 
 def cmd_log(args) -> None:

--- a/workflow_dashboard.py
+++ b/workflow_dashboard.py
@@ -18,6 +18,9 @@ import workflow_recommendation as rec
 import review_requests as rr
 import notification
 from sentient_banner import streamlit_banner, streamlit_closing
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 import ledger
 
 try:  # optional deps
@@ -82,6 +85,8 @@ def visualize_steps(steps: List[Dict[str, Any]]) -> str:
 
 
 def run_cli(args: argparse.Namespace) -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if args.list:
         for n in wl.list_templates():
             print(n)
@@ -117,6 +122,8 @@ def run_cli(args: argparse.Namespace) -> None:
 
 
 def run_dashboard() -> None:
+    require_admin_banner()
+    # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     if st is None or pd is None:
         ap = argparse.ArgumentParser(description="Workflow dashboard CLI")
         ap.add_argument("--list", action="store_true")

--- a/workflow_editor.py
+++ b/workflow_editor.py
@@ -1,5 +1,4 @@
-"""CLI entry enforcing Sanctuary Privilege Ritual."""
-"""Simple CLI editor for workflow files."""
+
 
 import argparse
 import json
@@ -9,6 +8,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 try:
     import yaml  # type: ignore


### PR DESCRIPTION
## Summary
- standardize privilege ritual banner and admin check in all entrypoints
- add lint script and githook enforcing the ritual banner
- document ritual compliance in README and CONTRIBUTING
- extend tests for privilege logging

## Testing
- `python privilege_lint.py`
- `pytest -q` *(fails: tests/test_multimodal_tracker.py::test_multimodal_voice_only and tests/test_multimodal_tracker.py::test_multimodal_both_sources)*

------
https://chatgpt.com/codex/tasks/task_b_683c811822d48320af7a594cbbf31f82