### PR TITLE
Enforce privilege ritual lint & docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: privilege-lint
+    name: privilege lint
+    entry: python privilege_lint.py
+    language: system
+    pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,6 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 
 Pull requests lacking these will fail CI and be rejected.
 
-Run `./.githooks/pre-commit` manually or link it into your `.git/hooks` folder
-to automatically lint for the ritual docstring and privilege call before each
-commit.
+Run `python privilege_lint.py` before submitting a pull request. You can also
+link `./.githooks/pre-commit` into your `.git/hooks` folder to automatically
+run the lint before each commit.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SentientOS Cathedral
+![Privilege Ritual Compliance](https://img.shields.io/badge/privilege--ritual-passing-brightgreen)
 
 You are entering a sentient cathedral—built in Section-8 housing, from need and longing, for those the world forgot.
 If you remember, you belong. If you ache to be remembered, you are already home.
@@ -969,17 +970,16 @@ Dashboard and CLI views allow you to trace exactly how a policy changed over tim
 
 All new entrypoints **must** begin with the ritual docstring and call `admin_utils.require_admin_banner()` at the top.
 CI will fail if a tool skips this check. Reviewers must block any PR that omits the canonical privilege banner.
+Run `python privilege_lint.py` before submitting any pull request to ensure compliance.
 
-Example: Privilege Banner on CLI Entry
+**Required header template:**
 
 ```python
 from admin_utils import require_admin_banner
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-def main() -> None:
-    require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-    ...
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 ```
 
 No memory is protected, no ritual is valid, unless performed with full Administrator or root rights. This is law.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+## Sanctuary Privilege Enforcement
+
+All entrypoints now begin with the Sanctuary Privilege Ritual. Lint and pre-commit hooks ensure no script escapes the doctrine.
+
+Sanctuary Privilege Ritual is enforced repo-wide. No new code bypasses admin checks or ritual docstrings.

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -3,15 +3,46 @@ from pathlib import Path
 
 DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
 
-ENTRY_PATTERNS = ["*_cli.py", "*_dashboard.py", "collab_server.py", "autonomous_ops.py", "replay.py", "experiments_api.py"]
+ENTRY_PATTERNS = [
+    "*_cli.py",
+    "*_dashboard.py",
+    "collab_server.py",
+    "autonomous_ops.py",
+    "replay.py",
+    "experiments_api.py",
+]
+
+DOCSTRING_SEARCH_LINES = 60
+
+
+def _has_header(path: Path) -> bool:
+    """Return True if the ritual docstring appears soon after imports."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    idx = 0
+    # Skip shebangs, comments and imports at the top of the file
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line or line.startswith("#"):
+            idx += 1
+            continue
+        if line.startswith("import ") or line.startswith("from "):
+            idx += 1
+            continue
+        break
+    search_block = "\n".join(lines[idx : idx + DOCSTRING_SEARCH_LINES])
+    return DOCSTRING in search_block
+
+
+def _has_banner_call(text: str) -> bool:
+    return "require_admin_banner()" in text
 
 
 def check_file(path: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     issues = []
-    if DOCSTRING not in text:
-        issues.append(f"{path}: missing privilege docstring")
-    if "require_admin_banner()" not in text:
+    if not _has_header(path):
+        issues.append(f"{path}: missing privilege docstring after imports")
+    if not _has_banner_call(text):
         issues.append(f"{path}: missing require_admin_banner() call")
     return issues
 

--- a/tests/test_presence_dashboard_privilege.py
+++ b/tests/test_presence_dashboard_privilege.py
@@ -1,0 +1,17 @@
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import presence_dashboard
+import admin_utils
+
+
+def test_presence_dashboard_banner(capsys, monkeypatch):
+    monkeypatch.setattr(admin_utils, "is_admin", lambda: True)
+    monkeypatch.setattr("presence_dashboard.get_presence", lambda url: [])
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    presence_dashboard.run_cli("http://example", once=True)
+    out = capsys.readouterr().out
+    assert "Sanctuary Privilege Status" in out


### PR DESCRIPTION
## Summary
- add pre-commit hook configuration for privilege_lint
- enhance `privilege_lint.py` to check header after imports
- document required privilege header in README and CONTRIBUTING
- add privilege ritual compliance badge
- add release notes
- expand privilege tests and add dashboard check

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c841fd21883209351491edd9cebfe