### PR TITLE
Add music generation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,15 @@ python replay.py --storyboard sb.json --feedback-enabled
 ```
 Feedback lines are logged to `storyboard.feedback.jsonl` and may be applied as patches later.
 
+### Music Generation
+`music_cli.py` uses the Jukebox integration stub to turn prompts into short MP3 files.
+Each track is logged to `logs/music_log.jsonl` and a `music_generated` note is added to `logs/user_presence.jsonl`.
+
+```bash
+python music_cli.py generate "calm ocean at dusk" --emotion Joy=0.7 --user Ada
+```
+The resulting path and hash are printed and stored in the living ledger.
+
 Actuator, Reflections, and Plugins
 Actuator CLI (api/actuator.py):
 

--- a/ledger.py
+++ b/ledger.py
@@ -39,6 +39,26 @@ def log_federation(peer: str, email: str = "", message: str = "Federation sync")
     return _append(Path("logs/federation_log.jsonl"), entry)
 
 
+def log_music(
+    prompt: str,
+    emotion: Dict[str, float],
+    file_path: str,
+    result_hash: str,
+    user: str = "",
+) -> Dict[str, str]:
+    """Record a generated music track in the living ledger."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "prompt": prompt,
+        "emotion": emotion,
+        "file": file_path,
+        "hash": result_hash,
+        "user": user,
+        "ritual": "Music generation remembered.",
+    }
+    return _append(Path("logs/music_log.jsonl"), entry)
+
+
 def summarize_log(path: Path, limit: int = 3) -> Dict[str, List[Dict[str, str]]]:
     """Return count and last few entries for a ledger file."""
     if not path.exists():

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,0 +1,81 @@
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+import argparse
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import presence_ledger as pl
+import ledger
+from jukebox_integration import JukeboxIntegration
+from sentient_banner import (
+    print_banner,
+    print_closing,
+    print_snapshot_banner,
+    print_closing_recap,
+    reset_ritual_state,
+    ENTRY_BANNER,
+)
+
+
+def _parse_emotion(text: str) -> dict:
+    """Parse emotion string like 'Joy=0.8,Sadness=0.2'"""
+    emotions = {}
+    if not text:
+        return emotions
+    for part in text.split(','):
+        if '=' in part:
+            k, v = part.split('=', 1)
+            try:
+                emotions[k.strip()] = float(v)
+            except ValueError:
+                continue
+        else:
+            emotions[part.strip()] = 1.0
+    return emotions
+
+
+async def _generate(prompt: str, emotion: dict, user: str) -> dict:
+    juke = JukeboxIntegration()
+    path = await juke.generate_music(prompt, emotion)
+    h = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    entry = ledger.log_music(prompt, emotion, path, h, user)
+    pl.log(user or "anon", "music_generated", prompt)
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    parser = argparse.ArgumentParser(description=ENTRY_BANNER)
+    sub = parser.add_subparsers(dest="cmd")
+    gen = sub.add_parser("generate", help="Generate music from a prompt")
+    gen.add_argument("prompt")
+    gen.add_argument("--emotion", default="", help="Comma separated emotion=val pairs")
+    gen.add_argument("--user", default="anon")
+
+    args = parser.parse_args()
+
+    reset_ritual_state()
+    print_banner()
+    print_snapshot_banner()
+    recap_shown = False
+    try:
+        if args.cmd == "generate":
+            emo = _parse_emotion(args.emotion)
+            entry = asyncio.run(_generate(args.prompt, emo, args.user))
+            print(json.dumps(entry, indent=2))
+            print_closing_recap()
+            recap_shown = True
+        else:
+            parser.print_help()
+    finally:
+        print_closing(show_recap=not recap_shown)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import importlib
+import json
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import ledger
+import music_cli
+import jukebox_integration
+import presence_ledger as pl
+import sentient_banner as sb
+import admin_utils
+
+
+def test_log_music(monkeypatch, tmp_path):
+    entries = []
+
+    def fake_append(path: Path, entry: dict):
+        entries.append(entry)
+        return entry
+
+    monkeypatch.setattr(ledger, "_append", fake_append)
+    e = ledger.log_music("p", {"Joy": 1.0}, "f.mp3", "hash", "u")
+    assert e["prompt"] == "p"
+    assert entries[0]["file"] == "f.mp3"
+
+
+def test_music_cli_generate(monkeypatch, tmp_path, capsys):
+    song = tmp_path / "song.mp3"
+    song.write_bytes(b"data")
+
+    async def fake_gen(self, prompt, emotion):
+        return str(song)
+
+    monkeypatch.setattr(jukebox_integration.JukeboxIntegration, "generate_music", fake_gen)
+    monkeypatch.setattr(ledger, "log_music", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr(pl, "log", lambda *a, **k: None)
+    monkeypatch.setattr(admin_utils, "require_admin_banner", lambda: None)
+    calls = {"snap": 0, "recap": 0}
+    monkeypatch.setattr(sb, "print_snapshot_banner", lambda: calls.__setitem__("snap", calls["snap"] + 1))
+    monkeypatch.setattr(sb, "print_closing_recap", lambda: calls.__setitem__("recap", calls["recap"] + 1))
+    monkeypatch.setattr(sys, "argv", ["music_cli.py", "generate", "hi"])
+    importlib.reload(music_cli)
+    music_cli.main()
+    out = capsys.readouterr().out
+    assert "ok" in out
+    assert calls["snap"] >= 2 and calls["recap"] == 1


### PR DESCRIPTION
## Summary
- log generated tracks with `ledger.log_music`
- implement `music_cli.py` for simple Jukebox prompts
- document music CLI usage in README
- test logging and CLI behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c875c0fe88320b48bac24b47bad00