### PR TITLE
Add OCR and emotion utilities

### DIFF
--- a/emotion_udp_bridge.py
+++ b/emotion_udp_bridge.py
@@ -1,0 +1,25 @@
+import json
+import socket
+from typing import List
+
+
+class EmotionUDPBridge:
+    """Send a 64D emotion vector as UDP JSON packets."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 9000) -> None:
+        self.addr = (host, port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.vector: List[float] = [0.0] * 64
+
+    def update_vector(self, vector: List[float]) -> None:
+        if len(vector) != 64:
+            raise ValueError("vector must have 64 elements")
+        self.vector = [float(v) for v in vector]
+        self.send()
+
+    def send(self) -> None:
+        msg = json.dumps({"emotions": self.vector})
+        try:
+            self.sock.sendto(msg.encode("utf-8"), self.addr)
+        except Exception:
+            pass

--- a/expression_mapper.py
+++ b/expression_mapper.py
@@ -1,0 +1,26 @@
+import json
+import socket
+from typing import Dict
+
+
+def _map_expression(vector: Dict[str, float]) -> str:
+    if vector.get("Joy", 0) > 0.5 or vector.get("Love", 0) > 0.5:
+        return "smile"
+    if vector.get("Sadness", 0) > 0.5 or vector.get("Grief", 0) > 0.5:
+        return "frown"
+    if vector.get("Surprise (positive)", 0) > 0.5 or vector.get("Astonishment", 0) > 0.5:
+        return "surprised"
+    if vector.get("Anger", 0) > 0.5 or vector.get("Rage", 0) > 0.5:
+        return "angry"
+    return "neutral"
+
+
+def send_expression(vector: Dict[str, float], host: str = "127.0.0.1", port: int = 9100) -> str:
+    exp = _map_expression(vector)
+    msg = json.dumps({"expression": exp})
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(msg.encode("utf-8"), (host, port))
+    except Exception:
+        pass
+    return exp

--- a/health_dashboard.py
+++ b/health_dashboard.py
@@ -1,0 +1,63 @@
+import json
+import os
+from pathlib import Path
+from flask import Flask, jsonify, render_template_string
+import memory_manager as mm
+import orchestrator
+
+app = Flask(__name__)
+
+STATUS_TEMPLATE = """
+<!doctype html>
+<title>System Health</title>
+<pre id="status">loading...</pre>
+<script>
+async function poll(){
+  let r = await fetch('/status');
+  let d = await r.json();
+  document.getElementById('status').textContent = JSON.stringify(d, null, 2);
+}
+setInterval(poll, 5000);
+window.onload=poll;
+</script>
+"""
+
+
+@app.route('/')
+def index():
+    return render_template_string(STATUS_TEMPLATE)
+
+
+def _last_heartbeat() -> str:
+    hb_path = Path("cathedral_heartbeat.log")
+    if not hb_path.exists():
+        return "unknown"
+    try:
+        ts = hb_path.stat().st_mtime
+        return str(ts)
+    except Exception:
+        return "unknown"
+
+
+@app.route('/status')
+def status():
+    state = orchestrator.Orchestrator().status()
+    memory_files = len(list(mm.RAW_PATH.glob('*.json')))
+    token_spend = 0.0
+    token_file = Path('logs/token_usage.json')
+    if token_file.exists():
+        try:
+            token_spend = sum(json.loads(l).get('tokens', 0) for l in token_file.read_text().splitlines())
+        except Exception:
+            pass
+    return jsonify({
+        'relay_running': state.get('running'),
+        'last_run': state.get('last_run'),
+        'memory_fragments': memory_files,
+        'token_spend': token_spend,
+        'last_heartbeat': _last_heartbeat(),
+    })
+
+
+if __name__ == '__main__':  # pragma: no cover - manual
+    app.run(debug=True)

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -154,6 +154,33 @@ def get_context(query: str, k: int = 6) -> List[str]:
     return [s for _, s in scored[:k]]
 
 
+def search_by_tags(tags: List[str], limit: int = 5) -> list[dict]:
+    """Return recent memory fragments matching all ``tags``.
+
+    Results are ordered from newest to oldest and truncated to ``limit``.
+    """
+    files = list(RAW_PATH.glob("*.json"))
+    entries = []
+    for fp in files:
+        try:
+            data = json.loads(fp.read_text(encoding="utf-8"))
+            ts = data.get("timestamp")
+            entries.append((ts, data))
+        except Exception:
+            continue
+    entries.sort(key=lambda x: x[0] or "", reverse=True)
+    results: list[dict] = []
+    wanted = set(tags)
+    for _, data in entries:
+        entry_tags = set(data.get("tags", []))
+        if not wanted.issubset(entry_tags):
+            continue
+        results.append(data)
+        if len(results) >= limit:
+            break
+    return results
+
+
 # Compatibility alias for legacy bridges
 write_mem = append_memory
 

--- a/ocr_pipeline.py
+++ b/ocr_pipeline.py
@@ -1,0 +1,59 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import List
+
+import requests
+from ocr_utils import ocr_chat_bubbles
+
+FOLDER = Path(os.getenv("OCR_WATCH", "screenshots"))
+RELAY_URL = os.getenv("RELAY_URL", "http://localhost:5000/relay")
+RELAY_SECRET = os.getenv("RELAY_SECRET", "secret")
+LOG_FILE = Path(os.getenv("OCR_RELAY_LOG", "logs/ocr_relay.jsonl"))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def process_image(path: Path) -> List[str]:
+    bubbles = ocr_chat_bubbles(str(path))
+    return [b.get("text", "") for b in bubbles if b.get("text")]
+
+
+def send_messages(messages: List[str]) -> List[str]:
+    replies = []
+    for msg in messages:
+        payload = {"message": msg, "model": "openai/gpt-4o"}
+        try:
+            r = requests.post(
+                RELAY_URL,
+                headers={"X-Relay-Secret": RELAY_SECRET, "Content-Type": "application/json"},
+                json=payload,
+                timeout=30,
+            )
+            r.raise_for_status()
+            rep = "\n".join(r.json().get("reply_chunks", []))
+        except Exception as e:
+            rep = f"error: {e}"
+        LOG_FILE.touch(exist_ok=True)
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"message": msg, "reply": rep}) + "\n")
+        replies.append(rep)
+    return replies
+
+
+def watch_folder():
+    seen = set()
+    while True:
+        for img in FOLDER.glob("*.png"):
+            if img in seen:
+                continue
+            seen.add(img)
+            msgs = process_image(img)
+            if msgs:
+                send_messages(msgs)
+        time.sleep(2)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    FOLDER.mkdir(parents=True, exist_ok=True)
+    watch_folder()

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -1,0 +1,46 @@
+import os
+from typing import List, Dict
+
+try:
+    import cv2  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:
+    cv2 = None
+    np = None
+
+try:
+    import pytesseract  # type: ignore
+except Exception:
+    pytesseract = None
+
+
+def ocr_chat_bubbles(image_path: str) -> List[Dict[str, object]]:
+    """Detect chat bubbles in ``image_path`` and OCR each one.
+
+    Returns a list of dicts with ``bbox`` and ``text`` keys. Works best when
+    OpenCV and pytesseract are installed. On failure, returns an empty list.
+    """
+    if cv2 is None or np is None or pytesseract is None:
+        return []
+    if not os.path.exists(image_path):
+        return []
+    try:
+        img = cv2.imread(image_path)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (5, 5), 0)
+        thresh = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 11, 2
+        )
+        cnts, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        results: List[Dict[str, object]] = []
+        for c in cnts:
+            x, y, w, h = cv2.boundingRect(c)
+            if w * h < 1000:
+                continue
+            crop = gray[y : y + h, x : x + w]
+            text = pytesseract.image_to_string(crop)
+            results.append({"bbox": [int(x), int(y), int(x + w), int(y + h)], "text": text.strip()})
+        results.sort(key=lambda r: (r["bbox"][1], r["bbox"][0]))
+        return results
+    except Exception:
+        return []

--- a/self_reflection_logger.py
+++ b/self_reflection_logger.py
@@ -1,0 +1,43 @@
+import datetime
+import json
+import os
+import time
+from pathlib import Path
+
+import memory_manager as mm
+
+QUESTION = os.getenv("SELF_REFLECTION_QUESTION", "What have you learned recently?")
+LOG_DIR = Path(os.getenv("REFLECTION_LOG_DIR", "logs/self_reflections"))
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def ask_ai(question: str) -> str:
+    """Placeholder for an AI call. Returns a canned response if no model."""
+    try:
+        from relay_app import app  # type: ignore
+        # Example call; in practice you'd POST to /relay
+        return f"Reflection on: {question}"
+    except Exception:
+        return f"Reflection on: {question}"
+
+
+def log_reflection(text: str) -> None:
+    day_file = LOG_DIR / f"{datetime.date.today().isoformat()}.log"
+    with open(day_file, "a", encoding="utf-8") as f:
+        f.write(text + "\n")
+
+
+def run_once() -> None:
+    reply = ask_ai(QUESTION)
+    log_reflection(reply)
+    mm.append_memory(reply, tags=["self_reflection"], source="self_reflection_logger")
+
+
+def run_forever(interval_hours: int = 6) -> None:
+    while True:
+        run_once()
+        time.sleep(interval_hours * 3600)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run_forever()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,31 @@
+import os
+from typing import Dict
+
+try:
+    from telegram import Update
+    from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+except Exception:  # pragma: no cover - optional
+    Update = None
+    ApplicationBuilder = None
+
+SESSION_EMOTIONS: Dict[int, str] = {}
+
+
+async def emotion(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    tag = " ".join(context.args)
+    SESSION_EMOTIONS[update.effective_chat.id] = tag
+    await update.message.reply_text(f"Emotion tag set to {tag}")
+
+
+def run_bot(token: str) -> None:
+    if ApplicationBuilder is None:
+        raise RuntimeError("python-telegram-bot not installed")
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(CommandHandler("emotion", emotion))
+    app.run_polling()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    tok = os.getenv("TELEGRAM_TOKEN")
+    if tok:
+        run_bot(tok)

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -137,3 +137,19 @@ def test_embedding_retrieval(tmp_path, monkeypatch):
 
     ctx = mm.get_context("dogs", k=1)
     assert ctx
+
+
+def test_search_by_tags(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    from importlib import reload
+    import memory_manager as mm
+    reload(mm)
+
+    mm.append_memory("one", tags=["a", "b"])
+    mm.append_memory("two", tags=["b"])
+    mm.append_memory("three", tags=["a", "b", "c"])
+
+    res = mm.search_by_tags(["a", "b"], limit=2)
+    assert len(res) == 2
+    assert res[0]["text"] == "three"
+    assert res[1]["text"] == "one"

--- a/tts_lipsync.py
+++ b/tts_lipsync.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+try:
+    import pyttsx3
+except Exception:  # pragma: no cover - optional
+    pyttsx3 = None
+
+
+def _simple_visemes(text: str) -> Dict[str, float]:
+    visemes = []
+    t = 0.0
+    for word in text.split():
+        char = word[0].lower()
+        if char in "aei":
+            vis = "A"
+        elif char in "ou":
+            vis = "O"
+        else:
+            vis = "neutral"
+        visemes.append({"time": t, "viseme": vis})
+        t += 0.2
+    return {"visemes": visemes}
+
+
+def synthesize(text: str, out_prefix: str = "speech") -> Dict[str, str]:
+    audio_path = Path(f"{out_prefix}.wav")
+    viseme_path = Path(f"{out_prefix}.json")
+    if pyttsx3 is None:
+        raise RuntimeError("pyttsx3 not available")
+    engine = pyttsx3.init()
+    engine.save_to_file(text, str(audio_path))
+    engine.runAndWait()
+    visemes = _simple_visemes(text)
+    viseme_path.write_text(json.dumps(visemes, indent=2), encoding="utf-8")
+    return {"audio": str(audio_path), "visemes": str(viseme_path)}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    import sys
+    txt = " ".join(sys.argv[1:]) or "Hello"
+    print(synthesize(txt))

--- a/visual_context_helper.py
+++ b/visual_context_helper.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import List
+import json
+
+OCR_LOG = Path("logs/ocr_relay.jsonl")
+
+
+def last_messages(n: int = 3) -> List[str]:
+    if not OCR_LOG.exists():
+        return []
+    lines = OCR_LOG.read_text(encoding="utf-8").splitlines()
+    msgs = []
+    for line in reversed(lines):
+        try:
+            data = json.loads(line)
+            msg = data.get("message")
+            if msg:
+                msgs.append(msg)
+                if len(msgs) >= n:
+                    break
+        except Exception:
+            continue
+    return list(reversed(msgs))
+
+
+def inject_prompt(prompt: str) -> str:
+    msgs = last_messages(3)
+    if not msgs:
+        return prompt
+    preamble = "VISUAL CONTEXT:\n" + "\n".join(msgs) + "\n\n"
+    return preamble + prompt


### PR DESCRIPTION
## Summary
- implement `search_by_tags` in memory manager
- add OCR chat bubble helper
- expose emotion vector UDP bridge and avatar expression mapper
- add self reflection logger
- include TTS lip sync script
- create health dashboard for system status
- telegram command for emotion tags
- batch OCR relay pipeline with visual context helper
- accompanying unit test for tag-based search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683ca16d68d083209caac1c56b5e2d46