### PR TITLE
Implement OCR HTML report and telegram export features

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -56,6 +56,11 @@ def require_admin_banner() -> None:
     user = getpass.getuser()
     tool = Path(sys.argv[0]).stem
     print_privilege_banner(tool)
+    try:
+        import privilege_lint as pl_lint
+        pl_lint.audit_use("cli", tool)
+    except Exception:
+        pass
     if is_admin():
         pl.log_privilege(user, platform.system(), tool, "success")
         print(ADMIN_BANNER)

--- a/avatar_heartbeat_alert.py
+++ b/avatar_heartbeat_alert.py
@@ -1,0 +1,27 @@
+"""Avatar-side heartbeat monitor."""
+import socket
+import time
+
+PORT = int(os.getenv("HEARTBEAT_PORT", "9001"))
+TIMEOUT = 10
+
+
+def run() -> None:  # pragma: no cover - realtime loop
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("0.0.0.0", PORT))
+    sock.settimeout(TIMEOUT)
+    last = time.time()
+    while True:
+        try:
+            data, _ = sock.recvfrom(1024)
+            if b"ping" in data:
+                last = time.time()
+        except socket.timeout:
+            pass
+        if time.time() - last > TIMEOUT:
+            print("Heartbeat missing")
+            last = time.time()
+
+
+if __name__ == "__main__":
+    run()

--- a/emotion_vector_visualizer.py
+++ b/emotion_vector_visualizer.py
@@ -1,0 +1,56 @@
+"""Simple Tkinter app to visualize emotion vectors from UDP."""
+import json
+import os
+import socket
+import threading
+import tkinter as tk
+
+HOST = os.getenv("EMO_VIS_HOST", "0.0.0.0")
+PORT = int(os.getenv("EMO_VIS_PORT", "9000"))
+
+
+class Visualizer:
+    def __init__(self) -> None:
+        self.vec = [0.0] * 64
+        self.root = tk.Tk()
+        self.root.title("Emotion Vector")
+        self.bars = []
+        for i in range(64):
+            var = tk.DoubleVar(value=0)
+            bar = tk.Scale(
+                self.root,
+                variable=var,
+                from_=0,
+                to=1,
+                resolution=0.01,
+                orient="vertical",
+                showvalue=False,
+                length=100,
+            )
+            bar.grid(row=0, column=i)
+            self.bars.append((var, bar))
+        threading.Thread(target=self.listen, daemon=True).start()
+        self.update_gui()
+        self.root.mainloop()
+
+    def listen(self) -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind((HOST, PORT))
+        while True:
+            data, _ = sock.recvfrom(8192)
+            try:
+                obj = json.loads(data.decode("utf-8"))
+                vec = obj.get("emotions")
+                if isinstance(vec, list) and len(vec) == 64:
+                    self.vec = [float(v) for v in vec]
+            except Exception:
+                continue
+
+    def update_gui(self) -> None:
+        for (var, _), val in zip(self.bars, self.vec):
+            var.set(val)
+        self.root.after(500, self.update_gui)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    Visualizer()

--- a/ocr_duplicate_heatmap.py
+++ b/ocr_duplicate_heatmap.py
@@ -1,0 +1,45 @@
+"""Generate heatmap image from OCR log data with bbox positions."""
+import json
+import os
+from pathlib import Path
+
+try:
+    from PIL import Image  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - optional
+    Image = None
+    np = None
+
+LOG = Path(os.getenv("OCR_RELAY_LOG", "logs/ocr_relay.jsonl"))
+
+
+def generate_heatmap(out_path: Path, width: int = 1280, height: int = 720) -> bool:
+    if Image is None or np is None:
+        return False
+    heat = np.zeros((height, width), dtype=float)
+    if not LOG.exists():
+        return False
+    for line in LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            data = json.loads(line)
+        except Exception:
+            continue
+        bbox = data.get("bbox")
+        if not bbox or len(bbox) != 4:
+            continue
+        x1, y1, x2, y2 = [int(v) for v in bbox]
+        x1 = max(0, min(width - 1, x1))
+        x2 = max(0, min(width - 1, x2))
+        y1 = max(0, min(height - 1, y1))
+        y2 = max(0, min(height - 1, y2))
+        heat[y1:y2, x1:x2] += data.get("count", 1)
+    if not heat.any():
+        return False
+    heat_img = (heat / heat.max() * 255).astype("uint8")
+    img = Image.fromarray(heat_img, mode="L")
+    img.save(out_path)
+    return True
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    generate_heatmap(Path("ocr_heatmap.png"))

--- a/ocr_log_html_report.py
+++ b/ocr_log_html_report.py
@@ -1,0 +1,72 @@
+import datetime
+import json
+import os
+from pathlib import Path
+
+OCR_LOG = Path(os.getenv("OCR_RELAY_LOG", "logs/ocr_relay.jsonl"))
+
+
+def generate_html_report(log_file: Path = OCR_LOG) -> str:
+    """Return path to generated HTML report from deduplicated OCR log."""
+    stats: dict[str, dict[str, object]] = {}
+    if log_file.exists():
+        for line in log_file.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            msg = data.get("message")
+            ts = data.get("timestamp")
+            if not msg or ts is None:
+                continue
+            try:
+                dt = (
+                    datetime.datetime.utcfromtimestamp(float(ts))
+                    if isinstance(ts, (int, float))
+                    else datetime.datetime.fromisoformat(str(ts))
+                )
+            except Exception:
+                dt = datetime.datetime.utcnow()
+            entry = stats.setdefault(
+                msg, {"count": 0, "first": dt, "last": dt}
+            )
+            entry["count"] = int(entry.get("count", 0)) + int(data.get("count", 1))
+            if dt < entry["first"]:
+                entry["first"] = dt
+            if dt > entry["last"]:
+                entry["last"] = dt
+    if not stats:
+        return ""
+
+    rows = [
+        (m, v["count"], v["first"].isoformat(), v["last"].isoformat())
+        for m, v in stats.items()
+    ]
+    rows.sort(key=lambda r: r[1], reverse=True)
+
+    html = [
+        "<html><head><meta charset='utf-8'><title>OCR Report</title>",
+        "<style>table{border-collapse:collapse}th,td{border:1px solid #ccc;padding:4px}</style>",
+        "<script>function sort(n){var t=document.getElementById('tbl');var r=Array.from(t.rows).slice(1);r.sort(function(a,b){return a.cells[n].innerText.localeCompare(b.cells[n].innerText)});r.forEach(function(e){t.appendChild(e)});}</script>",
+        "</head><body><table id='tbl'><thead><tr>",
+        "<th onclick='sort(0)'>Message</th>",
+        "<th onclick='sort(1)'>Count</th>",
+        "<th onclick='sort(2)'>First Seen</th>",
+        "<th onclick='sort(3)'>Last Seen</th>",
+        "</tr></thead><tbody>",
+    ]
+    for m, c, f, l in rows:
+        html.append(
+            f"<tr><td>{m}</td><td>{c}</td><td>{f}</td><td>{l}</td></tr>"
+        )
+    html.append("</tbody></table></body></html>")
+    out_name = datetime.datetime.utcnow().strftime("ocr_report_%Y%m%d_%H%M%S.html")
+    out_path = log_file.parent / out_name
+    out_path.write_text("\n".join(html), encoding="utf-8")
+    return str(out_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    print(generate_html_report())

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -1,4 +1,7 @@
 import sys
+import json
+import datetime
+import os
 from pathlib import Path
 
 DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
@@ -13,6 +16,20 @@ ENTRY_PATTERNS = [
 ]
 
 DOCSTRING_SEARCH_LINES = 60
+
+AUDIT_FILE = Path(os.getenv("PRIVILEGED_AUDIT_FILE", "logs/privileged_audit.jsonl"))
+AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def audit_use(tool: str, command: str) -> None:
+    """Append a privileged command usage entry."""
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "tool": tool,
+        "command": command,
+    }
+    with AUDIT_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
 
 
 def _has_header(path: Path) -> bool:

--- a/tests/test_ocr_html_report.py
+++ b/tests/test_ocr_html_report.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import ocr_log_html_report as rep
+
+
+def test_generate_html_report(tmp_path):
+    log = tmp_path / "ocr.jsonl"
+    data = [
+        {"timestamp": 1, "message": "hi", "count": 2},
+        {"timestamp": 2, "message": "hi", "count": 1},
+        {"timestamp": 3, "message": "bye", "count": 1},
+    ]
+    log.write_text("\n".join(json.dumps(d) for d in data))
+    out = rep.generate_html_report(log)
+    assert out
+    html = Path(out).read_text()
+    assert "<table" in html and "hi" in html and "bye" in html

--- a/tests/test_privilege_audit.py
+++ b/tests/test_privilege_audit.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+
+
+def test_audit_use(tmp_path, monkeypatch):
+    log = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("PRIVILEGED_AUDIT_FILE", str(log))
+    reload(pl)
+    pl.audit_use("cli", "tool")
+    data = log.read_text().strip()
+    assert "tool" in data

--- a/tests/test_reflection_log_cli_export.py
+++ b/tests/test_reflection_log_cli_export.py
@@ -1,0 +1,22 @@
+import sys
+import os
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import reflection_log_cli as rlc
+
+
+def test_export_day(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    day_file = log_dir / "2025-01-01.log"
+    day_file.write_text("one\ntwo\n")
+    monkeypatch.setenv("REFLECTION_LOG_DIR", str(log_dir))
+    reload(rlc)
+    out = tmp_path / "out.txt"
+    ok = rlc.export_day("2025-01-01", out, markdown=True)
+    assert ok
+    text = out.read_text()
+    assert "- one" in text and "- two" in text

--- a/tests/test_telegram_digest.py
+++ b/tests/test_telegram_digest.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import telegram_bot as tb
+
+
+class DummyMsg:
+    def __init__(self) -> None:
+        self.text = ""
+
+    async def reply_text(self, text: str) -> None:
+        self.text = text
+
+
+class DummyUpdate:
+    def __init__(self) -> None:
+        self.message = DummyMsg()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+
+
+def test_digest(tmp_path, monkeypatch):
+    digest = tmp_path / "digest.txt"
+    digest.write_text("hello")
+
+    def fake_generate():
+        return str(digest)
+
+    monkeypatch.setattr(tb.rd, "generate_digest", fake_generate)
+    reload(tb)
+    upd = DummyUpdate()
+    ctx = DummyContext()
+    asyncio.run(tb.digest(upd, ctx))
+    assert "hello" in upd.message.text

--- a/tests/test_telegram_export_ocr.py
+++ b/tests/test_telegram_export_ocr.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import telegram_bot as tb
+
+
+class DummyMsg:
+    def __init__(self) -> None:
+        self.document = None
+        self.text = ""
+
+    async def reply_text(self, text: str) -> None:
+        self.text = text
+
+    async def reply_document(self, f, filename=None) -> None:
+        self.document = f.read()
+
+
+class DummyUpdate:
+    def __init__(self) -> None:
+        self.message = DummyMsg()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+
+
+def test_export_ocr(tmp_path, monkeypatch):
+    log = tmp_path / "ocr.jsonl"
+    log.write_text("{}\n")
+    monkeypatch.setenv("OCR_RELAY_LOG", str(log))
+    reload(tb)
+
+    def fake_export(path=log):
+        out = tmp_path / "out.csv"
+        out.write_text("ok")
+        return str(out)
+
+    monkeypatch.setattr(tb.oe, "export_last_day_csv", fake_export)
+    upd = DummyUpdate()
+    ctx = DummyContext()
+    asyncio.run(tb.export_ocr(upd, ctx))
+    assert upd.message.document == b"ok"

--- a/webhook_status_monitor.py
+++ b/webhook_status_monitor.py
@@ -1,0 +1,45 @@
+"""Periodic checker for Telegram webhook URLs."""
+import datetime
+import json
+import os
+import time
+from pathlib import Path
+
+try:
+    import requests
+except Exception:  # pragma: no cover - optional
+    requests = None
+
+WEBHOOKS = [u.strip() for u in os.getenv("TELEGRAM_WEBHOOKS", "").split(",") if u.strip()]
+INTERVAL = int(os.getenv("WEBHOOK_CHECK_SEC", "60"))
+LOG_FILE = Path("logs/webhook_status.jsonl")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _log(url: str, status: int | str) -> None:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "url": url, "status": status}
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _check(url: str) -> int | str:
+    if requests is None:
+        return 200
+    try:
+        r = requests.get(url, timeout=5)
+        return r.status_code
+    except Exception as e:  # pragma: no cover - network errors
+        return str(e)
+
+
+def run_loop() -> None:  # pragma: no cover - runtime loop
+    while True:
+        for url in WEBHOOKS:
+            status = _check(url)
+            if status != 200:
+                _log(url, status)
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    run_loop()


### PR DESCRIPTION
## Summary
- generate sortable HTML reports from OCR logs
- allow exporting self reflection logs via CLI
- add /export_ocr and /digest commands to Telegram bot
- log privileged command usage
- provide webhook monitor and heartbeat utilities
- add emotion vector and OCR heatmap tools
- create reflection digest generator
- tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683caccfb9dc8320a6f112d95eb04abc