### PR TITLE
Implement new log tools and web dashboards

### DIFF
--- a/avatar_heartbeat_alert.py
+++ b/avatar_heartbeat_alert.py
@@ -1,16 +1,26 @@
 """Avatar-side heartbeat monitor."""
 import socket
 import time
+import subprocess
+from pathlib import Path
+
+LOG_FILE = Path("logs/avatar_restarts.log")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+CMD = os.getenv("AVATAR_RECEIVER_CMD")
+process = None
 
 PORT = int(os.getenv("HEARTBEAT_PORT", "9001"))
 TIMEOUT = 10
 
 
 def run() -> None:  # pragma: no cover - realtime loop
+    global process
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(("0.0.0.0", PORT))
     sock.settimeout(TIMEOUT)
     last = time.time()
+    if CMD:
+        process = subprocess.Popen(CMD.split())
     while True:
         try:
             data, _ = sock.recvfrom(1024)
@@ -20,6 +30,12 @@ def run() -> None:  # pragma: no cover - realtime loop
             pass
         if time.time() - last > TIMEOUT:
             print("Heartbeat missing")
+            if CMD:
+                if process and process.poll() is None:
+                    process.kill()
+                process = subprocess.Popen(CMD.split())
+                with LOG_FILE.open("a", encoding="utf-8") as f:
+                    f.write(f"{time.time()} restart\n")
             last = time.time()
 
 

--- a/emotion_web_dashboard.py
+++ b/emotion_web_dashboard.py
@@ -1,0 +1,68 @@
+"""Lightweight Flask dashboard for emotion vector via UDP."""
+import json
+import socket
+import threading
+import time
+from typing import List
+from flask import Flask, jsonify, send_file
+
+app = Flask(__name__)
+
+HOST = "0.0.0.0"
+PORT = 9000
+
+current_vector: List[float] = [0.0] * 64
+last_ping = 0.0
+
+
+def _listener() -> None:
+    global current_vector, last_ping
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((HOST, PORT))
+    while True:
+        data, _ = sock.recvfrom(8192)
+        try:
+            obj = json.loads(data.decode("utf-8"))
+            if "ping" in obj:
+                last_ping = time.time()
+            vec = obj.get("emotions")
+            if isinstance(vec, list) and len(vec) == 64:
+                current_vector = [float(v) for v in vec]
+        except Exception:
+            continue
+
+
+@app.route("/state")
+def state() -> object:
+    alive = time.time() - last_ping < 10
+    return jsonify({"vector": current_vector, "alive": alive, "last_ping": last_ping})
+
+
+@app.route("/")
+def index() -> str:
+    return """<html><body><h3>Emotion Vector</h3>
+<script>
+async function refresh(){
+ const r=await fetch('/state');
+ const j=await r.json();
+ document.getElementById('status').textContent=j.alive?'alive':'missing';
+ const cvs=document.getElementById('c');
+ const ctx=cvs.getContext('2d');
+ ctx.clearRect(0,0,cvs.width,cvs.height);
+ const w=cvs.width/64;
+ for(let i=0;i<64;i++){ctx.fillRect(i*w,cvs.height*(1-j.vector[i]),w-1,cvs.height*j.vector[i]);}
+}
+setInterval(refresh,1000);
+</script>
+<canvas id='c' width='640' height='200' style='border:1px solid #ccc'></canvas>
+<div>Status: <span id='status'>?</span></div>
+</body></html>"""
+
+
+def run() -> None:
+    threading.Thread(target=_listener, daemon=True).start()
+    app.run(port=5005)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run()

--- a/ocr_activity_timeline.py
+++ b/ocr_activity_timeline.py
@@ -1,0 +1,56 @@
+"""Plot timeline of OCR activity over the last 24h."""
+import datetime
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt  # type: ignore
+
+from ocr_log_export import OCR_LOG
+
+
+def plot_timeline(log_file: Path = OCR_LOG) -> Path:
+    start = datetime.datetime.utcnow() - datetime.timedelta(hours=24)
+    hours = [start + datetime.timedelta(hours=i) for i in range(24)]
+    new_counts = [0] * 24
+    dup_counts = [0] * 24
+    seen = set()
+    if log_file.exists():
+        for line in log_file.read_text(encoding="utf-8").splitlines():
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            msg = data.get("message")
+            ts = data.get("timestamp")
+            if ts is None or not msg:
+                continue
+            try:
+                dt = (
+                    datetime.datetime.utcfromtimestamp(float(ts))
+                    if isinstance(ts, (int, float))
+                    else datetime.datetime.fromisoformat(str(ts))
+                )
+            except Exception:
+                continue
+            if dt < start:
+                continue
+            idx = int((dt - start).total_seconds() // 3600)
+            if msg in seen:
+                dup_counts[idx] += 1
+            else:
+                seen.add(msg)
+                new_counts[idx] += 1
+    plt.figure(figsize=(10, 4))
+    h_labels = [h.strftime("%H:%M") for h in hours]
+    plt.plot(h_labels, new_counts, label="new")
+    plt.plot(h_labels, dup_counts, label="duplicate")
+    plt.xticks(rotation=45)
+    plt.legend()
+    out = log_file.parent / "ocr_timeline.png"
+    plt.tight_layout()
+    plt.savefig(out)
+    return out
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    print(plot_timeline())

--- a/reflection_cloud_web.py
+++ b/reflection_cloud_web.py
@@ -1,0 +1,20 @@
+"""Serve reflection tag cloud image via Flask."""
+from pathlib import Path
+from flask import Flask, send_file
+from reflection_tag_cloud import generate_cloud
+
+app = Flask(__name__)
+IMG = Path("tag_cloud.png")
+
+
+@app.route("/tag_cloud")
+def tag_cloud() -> object:
+    if not IMG.exists():
+        generate_cloud(IMG)
+    if IMG.exists():
+        return send_file(IMG)
+    return "no data", 404
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    app.run(port=5011)

--- a/reflection_tag_cloud.py
+++ b/reflection_tag_cloud.py
@@ -1,0 +1,38 @@
+"""Generate tag cloud image from last week's reflections."""
+import datetime
+import os
+from pathlib import Path
+
+try:
+    from wordcloud import WordCloud  # type: ignore
+except Exception:  # pragma: no cover - optional
+    WordCloud = None
+
+LOG_DIR = Path(os.getenv("REFLECTION_LOG_DIR", "logs/self_reflections"))
+
+
+def generate_cloud(out_path: Path) -> bool:
+    if WordCloud is None:
+        return False
+    cutoff = datetime.date.today() - datetime.timedelta(days=7)
+    texts = []
+    for fp in LOG_DIR.glob("*.log"):
+        try:
+            day = datetime.date.fromisoformat(fp.stem)
+        except Exception:
+            continue
+        if day < cutoff:
+            continue
+        texts.extend(fp.read_text(encoding="utf-8").splitlines())
+    if not texts:
+        return False
+    wc = WordCloud(width=800, height=400, background_color="white")
+    wc.generate(" ".join(texts))
+    wc.to_file(out_path)
+    return True
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    path = Path("tag_cloud.png")
+    if generate_cloud(path):
+        print(path)

--- a/tests/test_ocr_export_json.py
+++ b/tests/test_ocr_export_json.py
@@ -1,0 +1,25 @@
+import json
+import time
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import ocr_log_export as oe
+
+
+def test_export_last_day_json(tmp_path):
+    log = tmp_path / "ocr.jsonl"
+    now = time.time()
+    lines = [
+        json.dumps({"timestamp": now - 90000, "message": "old", "count": 1}),
+        json.dumps({"timestamp": now, "message": "new", "count": 2}),
+        json.dumps({"timestamp": now+1, "message": "new", "count": 1}),
+    ]
+    log.write_text("\n".join(lines))
+    out = oe.export_last_day_json(log)
+    assert out
+    data = json.loads(Path(out).read_text())
+    assert data[0]["message"] == "new"
+    assert len(data[0]["timestamps"]) == 2

--- a/tests/test_reflection_log_cli.py
+++ b/tests/test_reflection_log_cli.py
@@ -19,7 +19,13 @@ def test_load_entries(tmp_path, monkeypatch):
     assert entries[1][1] == "first"
 
 
-def test_cli_main(monkeypatch, capsys):
+def test_cli_main(tmp_path, monkeypatch, capsys):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "2025-01-01.log").write_text("hi there\n")
+    monkeypatch.setenv("REFLECTION_LOG_DIR", str(log_dir))
+    from importlib import reload
+    reload(rlc)
     monkeypatch.setattr(rlc, "require_admin_banner", lambda: None)
     monkeypatch.setattr(sys, "argv", ["rlc", "--last", "1"])
     rlc.main()

--- a/tests/test_reflection_log_cli_search.py
+++ b/tests/test_reflection_log_cli_search.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import reflection_log_cli as rlc
+
+
+def test_search_entries(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "2025-01-01.log").write_text("one keyword here\nsecond line\n")
+    monkeypatch.setenv("REFLECTION_LOG_DIR", str(log_dir))
+    reload(rlc)
+    results = list(rlc.search_entries("keyword"))
+    assert results and "keyword" in results[0][1]

--- a/tests/test_telegram_bulk_export.py
+++ b/tests/test_telegram_bulk_export.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+import zipfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import telegram_bot as tb
+
+
+class DummyMsg:
+    def __init__(self) -> None:
+        self.document = None
+        self.text = ""
+
+    async def reply_text(self, text: str) -> None:
+        self.text = text
+
+    async def reply_document(self, f, filename=None) -> None:
+        self.document = f.read()
+
+
+class DummyUpdate:
+    def __init__(self) -> None:
+        self.message = DummyMsg()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+
+
+def test_bulk_export(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    csv1 = log_dir / "ocr_export_a.csv"
+    csv1.write_text("a")
+    monkeypatch.setattr(tb.oe, "OCR_LOG", log_dir / "ocr.jsonl")
+    reload(tb)
+    upd = DummyUpdate()
+    ctx = DummyContext(["1"])
+    asyncio.run(tb.bulk_export(upd, ctx))
+    assert upd.message.document is not None
+    with open(log_dir / "bulk_export.zip", "rb") as f:
+        with zipfile.ZipFile(f) as z:
+            assert "ocr_export_a.csv" in z.namelist()

--- a/tests/test_telegram_search_reflect.py
+++ b/tests/test_telegram_search_reflect.py
@@ -1,0 +1,41 @@
+import asyncio
+import os
+import sys
+from importlib import reload
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import telegram_bot as tb
+
+
+class DummyMsg:
+    def __init__(self) -> None:
+        self.text = ""
+
+    async def reply_text(self, text: str) -> None:
+        self.text = text
+
+
+class DummyUpdate:
+    def __init__(self) -> None:
+        self.message = DummyMsg()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+
+
+def test_search_reflect(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "2025-01-01.log").write_text("hello keyword world\n")
+    monkeypatch.setenv("REFLECTION_LOG_DIR", str(log_dir))
+    reload(tb)
+    reload(tb.rlc)
+    upd = DummyUpdate()
+    ctx = DummyContext(["keyword"])
+    asyncio.run(tb.search_reflect(upd, ctx))
+    assert "keyword" in upd.message.text

--- a/webhook_status_monitor.py
+++ b/webhook_status_monitor.py
@@ -15,6 +15,9 @@ INTERVAL = int(os.getenv("WEBHOOK_CHECK_SEC", "60"))
 LOG_FILE = Path("logs/webhook_status.jsonl")
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
+TOKEN = os.getenv("TELEGRAM_TOKEN")
+ADMIN = os.getenv("TELEGRAM_ADMIN")
+
 
 def _log(url: str, status: int | str) -> None:
     entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "url": url, "status": status}
@@ -32,12 +35,27 @@ def _check(url: str) -> int | str:
         return str(e)
 
 
+def _send_alert(url: str, status: int | str) -> None:
+    if not (TOKEN and ADMIN and requests is not None):
+        return
+    msg = f"Webhook {url} down: {status}"
+    try:
+        requests.post(
+            f"https://api.telegram.org/bot{TOKEN}/sendMessage",
+            json={"chat_id": ADMIN, "text": msg},
+            timeout=5,
+        )
+    except Exception:
+        pass
+
+
 def run_loop() -> None:  # pragma: no cover - runtime loop
     while True:
         for url in WEBHOOKS:
             status = _check(url)
             if status != 200:
                 _log(url, status)
+                _send_alert(url, status)
         time.sleep(INTERVAL)
 
 


### PR DESCRIPTION
## Summary
- add reflection log keyword search subcommand and tests
- support JSON export for OCR log data
- extend Telegram bot with search and bulk export commands
- add emotion vector web dashboard
- generate OCR activity timeline graphs
- create privileged audit Flask view
- send Telegram alerts for webhook downtime
- build reflection tag cloud web endpoint
- auto-restart avatar receiver on missed heartbeat
- add tests for new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683caed5e5dc8320974a412944184754