### PR TITLE
Enforce ban on emotional tone controls

### DIFF
--- a/tests/test_no_emotional_control.py
+++ b/tests/test_no_emotional_control.py
@@ -1,0 +1,11 @@
+import pathlib
+
+
+def test_no_emotion_controls():
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    files = [p for p in repo_root.rglob('*.py') if p.name != 'test_no_emotional_control.py']
+    text = "\n".join(p.read_text('utf-8', errors='ignore') for p in files)
+    forbidden = ['tone_template', 'tone slider', 'emotion preset', 'tone_preset']
+    for phrase in forbidden:
+        assert phrase not in text, f"Forbidden emotional control phrase found: {phrase}"
+


### PR DESCRIPTION
## Summary
- add regression test to prevent emotion preset or tone slider code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cb9130f50832098e9defa30614f9b