### PR TITLE
Implement basic heresy log and ritual utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SentientOS is a ledger-based automation framework that treats every log as sacre
 * **Living Ledger** – all blessings, federation handshakes, and reflections are appended to immutable JSONL logs.
 * **Reflex Workflows** – autonomous operations tune and test reflex rules with full audit trails.
 * **Dashboards** – web UIs provide insight into emotions, workflows, and trust logs.
+* **CLI Utilities** – new commands `heresy_cli.py`, `diff_memory_cli.py`, and `theme_cli.py` assist with auditing and daily rituals.
 
 ## Quick Start
 1. Install requirements with `pip install -r requirements.txt`.

--- a/daily_theme.py
+++ b/daily_theme.py
@@ -1,0 +1,45 @@
+import json
+import os
+import random
+from datetime import datetime
+from pathlib import Path
+
+THEME_LOG = Path(os.getenv("DAILY_THEME_LOG", "logs/daily_theme.jsonl"))
+THEME_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+THEMES = [
+    "Courage in kindness",
+    "Quiet reflection",
+    "Shared growth",
+    "Open hearts",
+    "Joyful presence",
+]
+
+
+def _last_entry() -> dict | None:
+    if not THEME_LOG.exists():
+        return None
+    for line in reversed(THEME_LOG.read_text(encoding="utf-8").splitlines()):
+        try:
+            return json.loads(line)
+        except Exception:
+            continue
+    return None
+
+
+def generate() -> str:
+    """Generate today's theme if not already generated."""
+    today = datetime.utcnow().date().isoformat()
+    last = _last_entry()
+    if last and str(last.get("timestamp", "")).startswith(today):
+        return last.get("theme", "")
+    theme = random.choice(THEMES)
+    entry = {"timestamp": datetime.utcnow().isoformat(), "theme": theme}
+    with open(THEME_LOG, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return theme
+
+
+def latest() -> str | None:
+    entry = _last_entry()
+    return entry.get("theme") if entry else None

--- a/diff_memory_cli.py
+++ b/diff_memory_cli.py
@@ -1,0 +1,33 @@
+import argparse
+import memory_diff_audit as mda
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare memory sessions")
+    parser.add_argument("session_a")
+    parser.add_argument("session_b")
+    args = parser.parse_args()
+
+    entries_a = mda.load_entries(args.session_a)
+    entries_b = mda.load_entries(args.session_b)
+
+    diff = mda.build_diff(
+        [mda.entry_repr(e) for e in entries_a],
+        [mda.entry_repr(e) for e in entries_b],
+    )
+    for left, right, change in diff:
+        if change:
+            print(f"{change.upper()}: {left} -> {right}")
+
+    core_a, emo_a = mda.extract_tags(entries_a)
+    core_b, emo_b = mda.extract_tags(entries_b)
+    if core_a != core_b:
+        print("Core Added:", ", ".join(sorted(core_b - core_a)))
+        print("Core Removed:", ", ".join(sorted(core_a - core_b)))
+    if emo_a != emo_b:
+        print("Emotion Added:", ", ".join(sorted(emo_b - emo_a)))
+        print("Emotion Removed:", ", ".join(sorted(emo_a - emo_b)))
+
+
+if __name__ == "__main__":
+    main()

--- a/heresy_cli.py
+++ b/heresy_cli.py
@@ -1,0 +1,32 @@
+import argparse
+import json
+import heresy_log
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Heresy log CLI")
+    sub = parser.add_subparsers(dest="cmd")
+    log_cmd = sub.add_parser("log", help="Record a heresy entry")
+    log_cmd.add_argument("action")
+    log_cmd.add_argument("requestor")
+    log_cmd.add_argument("detail")
+    sub.add_parser("list", help="Show recent entries")
+    search_cmd = sub.add_parser("search", help="Search log")
+    search_cmd.add_argument("term")
+    parser.add_argument("--limit", type=int, default=10, help="List limit")
+    args = parser.parse_args()
+
+    if args.cmd == "log":
+        heresy_log.log(args.action, args.requestor, args.detail)
+        print("Logged")
+    elif args.cmd == "search":
+        res = heresy_log.search(args.term)
+        print(json.dumps(res, indent=2))
+    else:
+        res = heresy_log.tail(args.limit)
+        print(json.dumps(res, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/heresy_log.py
+++ b/heresy_log.py
@@ -1,0 +1,47 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path(os.getenv("HERESY_LOG", "logs/heresy_log.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log(action: str, requestor: str, detail: str) -> None:
+    """Append a heresy event to the immutable log."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        "requestor": requestor,
+        "detail": detail,
+    }
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def tail(limit: int = 10) -> list[dict]:
+    """Return the most recent log entries."""
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: list[dict] = []
+    for line in lines:
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def search(term: str) -> list[dict]:
+    """Search log lines containing a term."""
+    if not LOG_PATH.exists():
+        return []
+    results = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term in line:
+            try:
+                results.append(json.loads(line))
+            except Exception:
+                continue
+    return results

--- a/theme_cli.py
+++ b/theme_cli.py
@@ -1,0 +1,24 @@
+import argparse
+import daily_theme
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Daily theme tool")
+    sub = parser.add_subparsers(dest="cmd")
+    sub.add_parser("generate", help="Generate today's theme")
+    sub.add_parser("show", help="Show latest theme")
+    args = parser.parse_args()
+
+    if args.cmd == "generate":
+        theme = daily_theme.generate()
+        print(theme)
+    else:
+        theme = daily_theme.latest()
+        if theme:
+            print(theme)
+        else:
+            print("No theme yet")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `heresy_log` module with log/tail/search helpers
- add `heresy_cli.py` command-line interface
- implement `daily_theme` generator and `theme_cli.py`
- add `diff_memory_cli.py` for comparing memory sessions
- document new utilities in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cbaf5bf908320b71aca921e034852