### PR TITLE
Implement confessional logging and ritual tools

### DIFF
--- a/anniversary_notifier.py
+++ b/anniversary_notifier.py
@@ -1,0 +1,26 @@
+import os
+import json
+import datetime
+from pathlib import Path
+
+ANNIVERSARY = os.getenv("CATHEDRAL_BIRTH", "2023-01-01")
+LOG_FILE = Path("logs/anniversary_log.jsonl")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def check_and_log() -> None:
+    today = datetime.date.today().isoformat()[5:]
+    ann = ANNIVERSARY[5:]
+    if today == ann:
+        entry = {
+            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "event": "anniversary",
+            "message": "Presence recap",
+        }
+        with LOG_FILE.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        print("Anniversary blessing recorded")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    check_and_log()

--- a/confessional_cli.py
+++ b/confessional_cli.py
@@ -1,0 +1,79 @@
+import argparse
+import json
+import os
+
+import confessional_log as clog
+import confessional_review as crev
+
+
+def cmd_log(args: argparse.Namespace) -> None:
+    entry = clog.log_confession(
+        args.subsystem,
+        args.event,
+        args.detail,
+        tags=args.tags,
+        reflection=args.reflection,
+        severity=args.severity,
+    )
+    print(json.dumps(entry, indent=2))
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    entries = clog.tail(args.limit)
+    print(json.dumps(entries, indent=2))
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    entries = clog.search(args.term)
+    print(json.dumps(entries, indent=2))
+
+
+def cmd_review(args: argparse.Namespace) -> None:
+    reviewed = crev.reviewed_timestamps()
+    for entry in clog.tail(1000):
+        ts = entry.get("timestamp")
+        if ts in reviewed:
+            continue
+        print(json.dumps(entry, indent=2))
+        note = input("Reflection note (blank to skip)> ").strip()
+        if not note:
+            continue
+        crev.log_review(ts or "", args.user, note, status=args.status)
+        print("Confession reflected.")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Confessional log CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    log_p = sub.add_parser("log")
+    log_p.add_argument("subsystem")
+    log_p.add_argument("event")
+    log_p.add_argument("detail")
+    log_p.add_argument("--tags", nargs="*")
+    log_p.add_argument("--reflection", default="")
+    log_p.add_argument("--severity", default="info")
+    log_p.set_defaults(func=cmd_log)
+
+    list_p = sub.add_parser("list")
+    list_p.add_argument("--limit", type=int, default=10)
+    list_p.set_defaults(func=cmd_list)
+
+    search_p = sub.add_parser("search")
+    search_p.add_argument("term")
+    search_p.set_defaults(func=cmd_search)
+
+    review_p = sub.add_parser("review")
+    review_p.add_argument("--user", default=os.getenv("USER", "anon"))
+    review_p.add_argument("--status", default="resolved")
+    review_p.set_defaults(func=cmd_review)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/confessional_log.py
+++ b/confessional_log.py
@@ -1,0 +1,62 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+LOG_PATH = Path(os.getenv("CONFESSIONAL_LOG", "logs/confessional_log.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_confession(
+    subsystem: str,
+    event: str,
+    detail: str,
+    *,
+    tags: List[str] | None = None,
+    reflection: str = "",
+    severity: str = "info",
+    links: List[str] | None = None,
+) -> Dict[str, Any]:
+    """Record a red-flag confession entry."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "subsystem": subsystem,
+        "event": event,
+        "detail": detail,
+        "tags": tags or [],
+        "reflection": reflection,
+        "severity": severity,
+        "links": links or [],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def tail(limit: int = 20) -> List[Dict[str, Any]]:
+    """Return the most recent confessions."""
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, Any]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def search(term: str) -> List[Dict[str, Any]]:
+    """Search confessions containing ``term``."""
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term.lower() in ln.lower():
+            try:
+                out.append(json.loads(ln))
+            except Exception:
+                continue
+    return out

--- a/confessional_notify.py
+++ b/confessional_notify.py
@@ -1,0 +1,23 @@
+import time
+from pathlib import Path
+
+LOG_FILE = Path("logs/confessional_log.jsonl")
+
+
+def watch(interval: float = 2.0) -> None:  # pragma: no cover - runtime loop
+    print("[CONFESSIONAL NOTIFY] watching for new confessions...")
+    last_size = LOG_FILE.stat().st_size if LOG_FILE.exists() else 0
+    while True:
+        if LOG_FILE.exists():
+            size = LOG_FILE.stat().st_size
+            if size > last_size:
+                with LOG_FILE.open("r", encoding="utf-8") as f:
+                    f.seek(last_size)
+                    for line in f:
+                        print(f"[NEW CONFESSION] {line.strip()}")
+                last_size = size
+        time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    watch()

--- a/confessional_review.py
+++ b/confessional_review.py
@@ -1,0 +1,33 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Set
+
+REVIEW_LOG = Path(os.getenv("CONFESSIONAL_REVIEW_LOG", "logs/confessional_review.jsonl"))
+REVIEW_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_review(confession_ts: str, user: str, note: str, status: str = "resolved") -> Dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "confession_ts": confession_ts,
+        "user": user,
+        "note": note,
+        "status": status,
+    }
+    with REVIEW_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def reviewed_timestamps() -> Set[str]:
+    if not REVIEW_LOG.exists():
+        return set()
+    out = set()
+    for ln in REVIEW_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            out.add(json.loads(ln).get("confession_ts", ""))
+        except Exception:
+            continue
+    return out

--- a/correlation_engine.py
+++ b/correlation_engine.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+from typing import List
+
+CONFESSION_FILE = Path("logs/confessional_log.jsonl")
+BLESS_FILE = Path("logs/support_log.jsonl")
+
+
+def _load(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def report(window_minutes: int = 60) -> None:
+    from datetime import datetime, timedelta
+
+    conf = _load(CONFESSION_FILE)
+    bless = _load(BLESS_FILE)
+    results = []
+    for c in conf:
+        c_ts = datetime.fromisoformat(c.get("timestamp"))
+        count = 0
+        for b in bless:
+            b_ts = datetime.fromisoformat(b.get("timestamp"))
+            if abs((b_ts - c_ts).total_seconds()) <= window_minutes * 60:
+                count += 1
+        if count:
+            results.append({"confession": c, "blessings": count})
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    report()

--- a/forgiveness_ledger.py
+++ b/forgiveness_ledger.py
@@ -1,0 +1,34 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+LEDGER_PATH = Path(os.getenv("FORGIVENESS_LEDGER", "logs/forgiveness_ledger.jsonl"))
+LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_forgiveness(event_ts: str, user: str, penance: str, officiant: str) -> Dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event_ts": event_ts,
+        "user": user,
+        "penance": penance,
+        "officiant": officiant,
+    }
+    with LEDGER_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, Any]]:
+    if not LEDGER_PATH.exists():
+        return []
+    lines = LEDGER_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, Any]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,0 +1,53 @@
+import argparse
+import datetime
+import json
+from pathlib import Path
+from typing import Dict
+
+CONFESSION_FILE = Path("logs/confessional_log.jsonl")
+HERESY_FILE = Path("logs/heresy_log.jsonl")
+
+
+def _load(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def _bucket(entries: list[dict]) -> Dict[str, int]:
+    buckets: Dict[str, int] = {}
+    for e in entries:
+        ts = e.get("timestamp")
+        if not ts:
+            continue
+        dt = datetime.datetime.fromisoformat(ts)
+        key = dt.strftime("%Y-%m-%d %H")
+        buckets[key] = buckets.get(key, 0) + 1
+    return buckets
+
+
+def render(buckets: Dict[str, int]) -> None:
+    keys = sorted(buckets)
+    for k in keys:
+        count = buckets[k]
+        bar = "#" * count
+        print(f"{k} {bar}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Heresy/confession heatmap")
+    parser.add_argument("--confession", action="store_true")
+    parser.add_argument("--heresy", action="store_true")
+    args = parser.parse_args()
+
+    data: Dict[str, int] = {}
+    if args.confession or not (args.confession or args.heresy):
+        data.update(_bucket(_load(CONFESSION_FILE)))
+    if args.heresy or not (args.confession or args.heresy):
+        for k, v in _bucket(_load(HERESY_FILE)).items():
+            data[k] = data.get(k, 0) + v
+    render(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/ritual_sentinel.py
+++ b/ritual_sentinel.py
@@ -1,0 +1,38 @@
+import time
+from pathlib import Path
+
+CONFESSION_FILE = Path("logs/confessional_log.jsonl")
+HERESY_FILE = Path("logs/heresy_log.jsonl")
+PAUSE_LOG = Path("logs/moment_of_pause.log")
+
+
+def _trigger(event: str, line: str) -> None:
+    entry = f"{time.strftime('%Y-%m-%dT%H:%M:%S')} | {event} | {line.strip()}"
+    with PAUSE_LOG.open("a", encoding="utf-8") as f:
+        f.write(entry + "\n")
+    print(entry)
+
+
+def watch(interval: float = 2.0) -> None:  # pragma: no cover - runtime loop
+    files = {
+        "confession": CONFESSION_FILE,
+        "heresy": HERESY_FILE,
+    }
+    pos = {k: (p.stat().st_size if p.exists() else 0) for k, p in files.items()}
+    print("[SENTINEL] watching logs...")
+    while True:
+        for name, path in files.items():
+            if not path.exists():
+                continue
+            size = path.stat().st_size
+            if size > pos[name]:
+                with path.open("r", encoding="utf-8") as f:
+                    f.seek(pos[name])
+                    for line in f:
+                        _trigger(name, line)
+                pos[name] = size
+        time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    watch()

--- a/sabbath_reflection.py
+++ b/sabbath_reflection.py
@@ -1,0 +1,50 @@
+import datetime
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import confessional_log as clog
+
+HERESY_LOG = Path("logs/heresy_log.jsonl")
+BLESS_LOG = Path("logs/support_log.jsonl")
+REPORT_PATH = Path("logs/ritual_sabbath.md")
+
+
+def _load_jsonl(path: Path) -> List[Dict]:
+    if not path.exists():
+        return []
+    out = []
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        if not ln.strip():
+            continue
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def compile_report(days: int = 7) -> None:
+    cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=days)
+    confessions = [
+        c for c in clog.tail(1000)
+        if c.get("timestamp", "") >= cutoff.isoformat()
+    ]
+    heresy = [
+        h for h in _load_jsonl(HERESY_LOG)
+        if h.get("timestamp", "") >= cutoff.isoformat()
+    ]
+    blessings = [
+        b for b in _load_jsonl(BLESS_LOG)
+        if b.get("timestamp", "") >= cutoff.isoformat()
+    ]
+    lines = ["# Sabbath Reflection", ""]
+    lines.append(f"Confessions: {len(confessions)}")
+    lines.append(f"Unresolved heresies: {len(heresy)}")
+    lines.append(f"Blessings: {len(blessings)}")
+    REPORT_PATH.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Report written to {REPORT_PATH}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    compile_report()

--- a/tests/test_confessional.py
+++ b/tests/test_confessional.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import confessional_log as clog
+import confessional_review as crev
+import confessional_cli
+
+
+def test_log_and_tail(tmp_path, monkeypatch):
+    path = tmp_path / "confessional_log.jsonl"
+    monkeypatch.setenv("CONFESSIONAL_LOG", str(path))
+    importlib.reload(clog)
+    clog.log_confession("core", "violation", "detail", tags=["anger"], severity="warning")
+    data = clog.tail()[0]
+    assert data["subsystem"] == "core"
+    assert data["severity"] == "warning"
+    assert data["tags"] == ["anger"]
+
+
+def test_cli_review(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "confessional_log.jsonl"
+    rev = tmp_path / "confessional_review.jsonl"
+    monkeypatch.setenv("CONFESSIONAL_LOG", str(log))
+    monkeypatch.setenv("CONFESSIONAL_REVIEW_LOG", str(rev))
+    importlib.reload(clog)
+    importlib.reload(crev)
+    clog.log_confession("core", "violation", "detail")
+    monkeypatch.setattr("builtins.input", lambda prompt='': "note")
+    monkeypatch.setattr(sys, "argv", ["confess", "review", "--user", "me"])
+    importlib.reload(confessional_cli)
+    confessional_cli.main()
+    out = capsys.readouterr().out
+    assert "Confession reflected" in out
+    lines = rev.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1


### PR DESCRIPTION
## Summary
- add a `confessional_log` module for red‑flag entries
- provide CLI for reviewing and searching confessions
- create weekly `sabbath_reflection` report utility
- add notification and sentinel helpers
- implement forgiveness ledger and correlation/heatmap tools
- schedule anniversary notifier
- tests for the new confessional system

## Testing
- `pytest tests/test_confessional.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cc5ccd28c83208dce6201a63a698a