### PR TITLE
Add avatar ritual scaffolds

### DIFF
--- a/avatar_federation.py
+++ b/avatar_federation.py
@@ -1,0 +1,65 @@
+"""Export and import avatars with ritual logs."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+
+EXPORT_LOG = Path(os.getenv("AVATAR_EXPORT_LOG", "logs/avatar_export.jsonl"))
+IMPORT_LOG = Path(os.getenv("AVATAR_IMPORT_LOG", "logs/avatar_import.jsonl"))
+for p in (EXPORT_LOG, IMPORT_LOG):
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _log(path: Path, reason: str, log_path: Path) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "path": str(path),
+        "reason": reason,
+    }
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def export_avatar(avatar: Path, out: Path, reason: str) -> Path:
+    with tarfile.open(out, "w:gz") as tar:
+        tar.add(avatar, arcname=avatar.name)
+    _log(out, reason, EXPORT_LOG)
+    return out
+
+
+def import_avatar(tar_path: Path, dest: Path, reason: str) -> Path:
+    with tarfile.open(tar_path, "r:gz") as tar:
+        tar.extractall(dest)
+    _log(dest, reason, IMPORT_LOG)
+    return dest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Federation avatar exchange")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    ex = sub.add_parser("export")
+    ex.add_argument("avatar")
+    ex.add_argument("out")
+    ex.add_argument("--reason", default="")
+
+    im = sub.add_parser("import")
+    im.add_argument("tar")
+    im.add_argument("dest")
+    im.add_argument("--reason", default="")
+
+    args = ap.parse_args()
+    if args.cmd == "export":
+        path = export_avatar(Path(args.avatar), Path(args.out), args.reason)
+    else:
+        path = import_avatar(Path(args.tar), Path(args.dest), args.reason)
+    print(str(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_gallery_cli.py
+++ b/avatar_gallery_cli.py
@@ -1,0 +1,33 @@
+"""Simple CLI to view avatars and presence pulses."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+PRESENCE_LOG = Path(os.getenv("AVATAR_PRESENCE_LOG", "logs/avatar_presence.jsonl"))
+
+
+def list_invocations(filter_reason: str = "") -> list[dict]:
+    if not PRESENCE_LOG.exists():
+        return []
+    entries = []
+    for line in PRESENCE_LOG.read_text(encoding="utf-8").splitlines():
+        data = json.loads(line)
+        if filter_reason and data.get("reason") != filter_reason:
+            continue
+        entries.append(data)
+    return entries
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar gallery viewer")
+    ap.add_argument("--reason", default="", help="Filter by invocation reason")
+    args = ap.parse_args()
+    for e in list_invocations(args.reason):
+        print(json.dumps(e, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_genesis.py
+++ b/avatar_genesis.py
@@ -1,0 +1,81 @@
+"""Avatar genesis script using Blender's Python API.
+
+This module provides a CLI tool to procedurally generate an avatar
+based on a mood. The avatar is saved to a .blend file and a ritual
+blessing entry is logged. For complex modeling/rigging the code
+includes TODO placeholders.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path(os.getenv("AVATAR_GENESIS_LOG", "logs/avatar_genesis.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+try:
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover - environment may lack Blender
+    bpy = None  # type: ignore
+
+
+BLEND_DIR = Path(os.getenv("AVATAR_DIR", "avatars"))
+BLEND_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _log_blessing(mood: str, path: Path) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "mood": mood,
+        "path": str(path),
+        "blessing": "Avatar crowned for genesis",
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def generate_avatar(mood: str, out_path: Path) -> Path:
+    """Generate a simple avatar with Blender.
+
+    Parameters
+    ----------
+    mood:
+        Mood name used to influence avatar style.
+    out_path:
+        Path where the .blend file should be saved.
+    """
+    if bpy is None:
+        raise RuntimeError("Blender bpy module not available")
+
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=1)
+    obj = bpy.context.object
+    obj.name = f"avatar_{mood}"
+    # TODO: tweak material/shape based on mood
+
+    bpy.ops.wm.save_as_mainfile(filepath=str(out_path))
+    return out_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate ritual avatar")
+    ap.add_argument("mood", help="Mood for the avatar")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    out = Path(args.out or BLEND_DIR / f"{args.mood}.blend")
+    if bpy is None:
+        print("bpy module not available. Run within Blender.")
+        return
+    generate_avatar(args.mood, out)
+    entry = _log_blessing(args.mood, out)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,0 +1,42 @@
+"""Record avatar invocation and presence blessing.
+
+This CLI logs each time an avatar is invoked for a specific reason.
+A presence affirmation is stored with a blessing message.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path(os.getenv("AVATAR_PRESENCE_LOG", "logs/avatar_presence.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_invocation(path: str, reason: str, mode: str = "visual") -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": path,
+        "mode": mode,
+        "reason": reason,
+        "blessing": f"Avatar crowned for {reason}",
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Invoke avatar with blessing")
+    ap.add_argument("avatar")
+    ap.add_argument("reason")
+    ap.add_argument("--mode", default="visual")
+    args = ap.parse_args()
+    entry = log_invocation(args.avatar, args.reason, args.mode)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,0 +1,47 @@
+"""Analyze rendered avatars and log emotional context."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from random import choice
+
+LOG_PATH = Path(os.getenv("AVATAR_REFLECTION_LOG", "logs/avatar_reflection.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+MOODS = ["happy", "sad", "angry", "serene"]
+
+
+def analyze_image(image_path: Path) -> str:
+    """Return a placeholder mood classification for an image."""
+    # TODO: replace with real classifier
+    return choice(MOODS)
+
+
+def log_reflection(image: str, mood: str, note: str = "") -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "image": image,
+        "mood": mood,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Reflect on rendered avatar image")
+    ap.add_argument("image")
+    ap.add_argument("--note", default="")
+    args = ap.parse_args()
+    mood = analyze_image(Path(args.image))
+    entry = log_reflection(args.image, mood, args.note)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_avatar_federation.py
+++ b/tests/test_avatar_federation.py
@@ -1,0 +1,26 @@
+import importlib
+from pathlib import Path
+
+import avatar_federation as af
+
+
+def test_export_and_import(tmp_path, monkeypatch):
+    exp_log = tmp_path / "export.jsonl"
+    imp_log = tmp_path / "import.jsonl"
+    monkeypatch.setenv("AVATAR_EXPORT_LOG", str(exp_log))
+    monkeypatch.setenv("AVATAR_IMPORT_LOG", str(imp_log))
+    importlib.reload(af)
+
+    avatar = tmp_path / "a.blend"
+    avatar.write_text("data")
+    tar = tmp_path / "a.tar.gz"
+    af.export_avatar(avatar, tar, "share")
+    dest = tmp_path / "recv"
+    dest.mkdir()
+    af.import_avatar(tar, dest, "recv")
+
+    assert tar.exists()
+    assert (dest / "a.blend").exists()
+    assert len(exp_log.read_text().splitlines()) == 1
+    assert len(imp_log.read_text().splitlines()) == 1
+

--- a/tests/test_avatar_gallery_cli.py
+++ b/tests/test_avatar_gallery_cli.py
@@ -1,0 +1,20 @@
+import importlib
+import sys
+from pathlib import Path
+
+import avatar_presence_cli as ap
+import avatar_gallery_cli as ag
+
+
+def test_gallery_listing(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "presence.jsonl"
+    monkeypatch.setenv("AVATAR_PRESENCE_LOG", str(log))
+    importlib.reload(ap)
+    importlib.reload(ag)
+    ap.log_invocation("a.blend", "ritual")
+    monkeypatch.setattr(sys, "argv", ["gallery"])
+    ag.main()
+    out = capsys.readouterr().out
+    assert "a.blend" in out
+
+

--- a/tests/test_avatar_genesis.py
+++ b/tests/test_avatar_genesis.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import avatar_genesis as ag
+
+
+class DummyBpy(types.ModuleType):
+    class ops:
+        class wm:
+            @staticmethod
+            def read_factory_settings(use_empty: bool = True) -> None:
+                pass
+
+            @staticmethod
+            def save_as_mainfile(filepath: str) -> None:
+                Path(filepath).write_text("blend")
+
+        class mesh:
+            @staticmethod
+            def primitive_uv_sphere_add(radius: int = 1) -> None:
+                pass
+
+    class context:
+        object = types.SimpleNamespace(name="")
+
+
+def test_generate_and_log(tmp_path, monkeypatch):
+    log = tmp_path / "gen.jsonl"
+    out = tmp_path / "a.blend"
+    monkeypatch.setenv("AVATAR_GENESIS_LOG", str(log))
+    monkeypatch.setenv("AVATAR_DIR", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "bpy", DummyBpy("bpy"))
+    importlib.reload(ag)
+    ag.generate_avatar("joy", out)
+    ag._log_blessing("joy", out)
+    assert out.exists()
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+

--- a/tests/test_avatar_presence_cli.py
+++ b/tests/test_avatar_presence_cli.py
@@ -1,0 +1,17 @@
+import importlib
+from pathlib import Path
+
+import avatar_presence_cli as ap
+
+
+def test_log_invocation(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "presence.jsonl"
+    monkeypatch.setenv("AVATAR_PRESENCE_LOG", str(log))
+    importlib.reload(ap)
+    ap.log_invocation("a.blend", "test", "visual")
+    assert log.exists()
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    data = ap.log_invocation("a.blend", "test2")
+    assert data["reason"] == "test2"
+

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,0 +1,16 @@
+import importlib
+from pathlib import Path
+
+import avatar_reflection as ar
+
+
+def test_reflection_log(tmp_path, monkeypatch):
+    log = tmp_path / "reflection.jsonl"
+    monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    importlib.reload(ar)
+    img = tmp_path / "img.png"
+    img.write_text("data")
+    ar.log_reflection(str(img), "happy")
+    assert log.exists()
+    assert len(log.read_text().splitlines()) == 1
+


### PR DESCRIPTION
## Summary
- scaffold avatar generation using Blender's API
- log avatar invocations and presence
- analyze avatar renders and log reflections
- support avatar export/import
- show invocation history via gallery CLI
- add tests for all new tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ccfb76a90832084928f5492024dce