### PR TITLE
Implement avatar ritual modules

### DIFF
--- a/avatar_chronicle_generator.py
+++ b/avatar_chronicle_generator.py
@@ -1,0 +1,62 @@
+"""Ritual Avatar Chronicle Generator
+
+Compile a markdown chronicle of avatar creation, blessings, and retirements.
+
+Example:
+    python avatar_chronicle_generator.py --out chronicle.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+LOGS = [
+    Path("logs/avatar_memory_link.jsonl"),
+    Path("logs/avatar_council_log.jsonl"),
+    Path("logs/avatar_retirement.jsonl"),
+]
+
+
+def _load(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def generate_markdown() -> str:
+    entries = []
+    for path in LOGS:
+        entries.extend(_load(path))
+    entries.sort(key=lambda e: e.get("timestamp", ""))
+    lines = ["# Avatar Chronicle"]
+    for e in entries:
+        ts = e.get("timestamp")
+        avatar = e.get("avatar", "")
+        event = e.get("event", e.get("vote", ""))
+        mood = e.get("mood", "")
+        lines.append(f"- {ts} **{avatar}** {event} {mood}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate avatar chronicle")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+    md = generate_markdown()
+    if args.out:
+        Path(args.out).write_text(md, encoding="utf-8")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_council_blessing.py
+++ b/avatar_council_blessing.py
@@ -1,0 +1,102 @@
+"""Avatar Council Blessing
+
+Council members vote on major avatars. Votes are logged and a final blessing
+is recorded once quorum is reached.
+
+Example:
+    python avatar_council_blessing.py vote avatar1 alice
+    python avatar_council_blessing.py status avatar1 --quorum 2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_COUNCIL_LOG", "logs/avatar_council_log.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_vote(avatar: str, member: str, up: bool = True, commentary: str = "") -> Dict[str, str]:
+    """Record a council vote for an avatar."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "member": member,
+        "vote": "up" if up else "down",
+        "commentary": commentary,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def votes_for(avatar: str) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if f'"avatar": "{avatar}"' not in line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def check_quorum(avatar: str, quorum: int = 3) -> bool:
+    vs = votes_for(avatar)
+    up = sum(1 for v in vs if v.get("vote") == "up")
+    if up >= quorum:
+        blessing = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "avatar": avatar,
+            "event": "crowned",
+            "blessing": "Council quorum achieved",
+        }
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(blessing) + "\n")
+        return True
+    return False
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar council blessing")
+    sub = ap.add_subparsers(dest="cmd")
+
+    vt = sub.add_parser("vote", help="Cast a vote")
+    vt.add_argument("avatar")
+    vt.add_argument("member")
+    vt.add_argument("--down", action="store_true")
+    vt.add_argument("--commentary", default="")
+    vt.set_defaults(
+        func=lambda a: print(
+            json.dumps(
+                log_vote(a.avatar, a.member, up=not a.down, commentary=a.commentary),
+                indent=2,
+            )
+        )
+    )
+
+    st = sub.add_parser("status", help="Check vote status")
+    st.add_argument("avatar")
+    st.add_argument("--quorum", type=int, default=3)
+    st.set_defaults(
+        func=lambda a: print(
+            json.dumps({"quorum_met": check_quorum(a.avatar, a.quorum)}, indent=2)
+        )
+    )
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_federation_blessing.py
+++ b/avatar_federation_blessing.py
@@ -1,0 +1,49 @@
+"""Avatar Federation Blessing Ritual
+
+Import an avatar from another node and record a local blessing.
+Presence pulse is captured to color the ritual log.
+
+Example:
+    python avatar_federation_blessing.py import avatar.tar.gz ./avatars alice
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import avatar_federation as af
+from presence_pulse_api import pulse
+
+LOG_PATH = Path(os.getenv("AVATAR_FED_BLESSING_LOG", "logs/avatar_federation_blessing.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def import_with_blessing(tar: Path, dest: Path, officiant: str) -> dict:
+    dest_path = af.import_avatar(tar, dest, reason="federation")
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": dest_path.name,
+        "officiant": officiant,
+        "pulse": pulse(),
+        "blessing": f"Avatar from {tar} accepted and crowned",
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar federation blessing")
+    ap.add_argument("tar")
+    ap.add_argument("dest")
+    ap.add_argument("--officiant", default="")
+    args = ap.parse_args()
+    entry = import_with_blessing(Path(args.tar), Path(args.dest), args.officiant)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_memory_linker.py
+++ b/avatar_memory_linker.py
@@ -1,0 +1,100 @@
+"""Avatar Memory Linker CLI
+
+Links avatar events (generation, invocation, federation) to moods and memory fragments.
+Each link is recorded in a ritual ledger for later query.
+
+Example:
+    python avatar_memory_linker.py link avatar1 blend created --mood joy --memory 123
+    python avatar_memory_linker.py list --term forgiveness
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_MEMORY_LINK_LOG", "logs/avatar_memory_link.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_link(
+    avatar: str,
+    event: str,
+    mood: str = "",
+    memory: str = "",
+    blessing: str = "",
+    confession: str = "",
+) -> Dict[str, str]:
+    """Record a link between an avatar event and memory fragments."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "event": event,
+        "mood": mood,
+        "memory": memory,
+        "blessing": blessing,
+        "confession": confession,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_links(term: str = "") -> List[Dict[str, str]]:
+    """Return logged links optionally filtered by a search term."""
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term and term not in line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar memory linker")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lk = sub.add_parser("link", help="Link an avatar event to memory")
+    lk.add_argument("avatar")
+    lk.add_argument("event")
+    lk.add_argument("--mood", default="")
+    lk.add_argument("--memory", default="")
+    lk.add_argument("--blessing", default="")
+    lk.add_argument("--confession", default="")
+    lk.set_defaults(
+        func=lambda a: print(
+            json.dumps(
+                log_link(
+                    a.avatar,
+                    a.event,
+                    mood=a.mood,
+                    memory=a.memory,
+                    blessing=a.blessing,
+                    confession=a.confession,
+                ),
+                indent=2,
+            )
+        )
+    )
+
+    ls = sub.add_parser("list", help="List links")
+    ls.add_argument("--term", default="")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_links(a.term), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_mood_evolution.py
+++ b/avatar_mood_evolution.py
@@ -1,0 +1,43 @@
+"""Avatar Mood Evolution Visualizer
+
+Graph the mood tags of an avatar across its history.
+Currently prints a simple time ordered list. TODO: real graphs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+LOG_PATH = Path(os.getenv("AVATAR_MEMORY_LINK_LOG", "logs/avatar_memory_link.jsonl"))
+
+
+def mood_history(avatar: str) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if f'"avatar": "{avatar}"' not in line:
+            continue
+        try:
+            entry = json.loads(line)
+        except Exception:
+            continue
+        out.append(entry)
+    out.sort(key=lambda e: e.get("timestamp", ""))
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar mood evolution")
+    ap.add_argument("avatar")
+    args = ap.parse_args()
+    for e in mood_history(args.avatar):
+        print(e.get("timestamp"), e.get("mood"))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_mood_recap.py
+++ b/avatar_mood_recap.py
@@ -1,0 +1,70 @@
+"""Ritual Avatar Mood Recap
+
+Summarize moods and blessing lines of avatar events over a period.
+Outputs markdown by default.
+
+Example:
+    python avatar_mood_recap.py --days 1 --out recap.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_MEMORY_LINK_LOG", "logs/avatar_memory_link.jsonl"))
+
+
+def load_entries(days: int = 1) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    start = datetime.utcnow() - timedelta(days=days)
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            entry = json.loads(line)
+        except Exception:
+            continue
+        ts = entry.get("timestamp")
+        try:
+            dt = datetime.fromisoformat(str(ts))
+        except Exception:
+            continue
+        if dt >= start:
+            out.append(entry)
+    return out
+
+
+def recap_markdown(days: int = 1) -> str:
+    entries = load_entries(days)
+    lines = ["# Avatar Mood Recap"]
+    current = {}
+    for e in entries:
+        avatar = e.get("avatar")
+        mood = e.get("mood")
+        if not avatar:
+            continue
+        current.setdefault(avatar, []).append(mood)
+    for avatar, moods in current.items():
+        lines.append(f"\n## {avatar}\n")
+        lines.append(", ".join([m for m in moods if m]))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar mood recap")
+    ap.add_argument("--days", type=int, default=1)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+    md = recap_markdown(args.days)
+    if args.out:
+        Path(args.out).write_text(md, encoding="utf-8")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_presence_pulse_animation.py
+++ b/avatar_presence_pulse_animation.py
@@ -1,0 +1,43 @@
+"""Avatar Presence Pulse Animation
+
+Animates avatar presence intensity in sync with the presence pulse API.
+Currently outputs an ASCII bar to represent animation.
+TODO: real GUI or dashboard integration.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from presence_pulse_api import pulse
+
+LOG_PATH = Path("logs/avatar_animation.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def animate_once(avatar: str) -> dict:
+    p = pulse()
+    bar = "#" * int(p * 10)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "pulse": p,
+        "animation": bar,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar presence pulse animation")
+    ap.add_argument("avatar")
+    args = ap.parse_args()
+    entry = animate_once(args.avatar)
+    print(entry["animation"])
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_retirement.py
+++ b/avatar_retirement.py
@@ -1,0 +1,51 @@
+"""Avatar Retirement & Archive Ritual
+
+Retire an avatar with reflection and preserve it in an archive.
+The act is logged in a ritual ledger.
+
+Example:
+    python avatar_retirement.py retire avatar1.blend retired/ --mood nostalgia --reason "story closed"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+LOG_PATH = Path(os.getenv("AVATAR_RETIRE_LOG", "logs/avatar_retirement.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def retire_avatar(path: Path, archive: Path, mood: str = "", reason: str = "") -> dict:
+    archive.mkdir(parents=True, exist_ok=True)
+    dest = archive / path.name
+    if path.exists():
+        shutil.copy2(path, dest)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": path.name,
+        "mood": mood,
+        "reason": reason,
+        "archive": str(dest),
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Retire avatar")
+    ap.add_argument("avatar")
+    ap.add_argument("archive")
+    ap.add_argument("--mood", default="")
+    ap.add_argument("--reason", default="")
+    args = ap.parse_args()
+    entry = retire_avatar(Path(args.avatar), Path(args.archive), args.mood, args.reason)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_teaching_logger.py
+++ b/avatar_teaching_logger.py
@@ -1,0 +1,80 @@
+"""Avatar Teaching Session Logger
+
+Log ritual teaching sessions involving avatars.
+
+Example:
+    python avatar_teaching_logger.py log alice bob avatar1 "crown ritual" --mood joy
+    python avatar_teaching_logger.py list
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_TEACH_LOG", "logs/avatar_teaching.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_session(teacher: str, learner: str, avatar: str, ritual: str, mood: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "teacher": teacher,
+        "learner": learner,
+        "avatar": avatar,
+        "ritual": ritual,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_sessions(term: str = "") -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term and term not in line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar teaching logger")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Record a teaching session")
+    lg.add_argument("teacher")
+    lg.add_argument("learner")
+    lg.add_argument("avatar")
+    lg.add_argument("ritual")
+    lg.add_argument("--mood", default="")
+    lg.set_defaults(
+        func=lambda a: print(
+            json.dumps(
+                log_session(a.teacher, a.learner, a.avatar, a.ritual, a.mood), indent=2
+            )
+        )
+    )
+
+    ls = sub.add_parser("list", help="List sessions")
+    ls.add_argument("--term", default="")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_sessions(a.term), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_avatar_rituals.py
+++ b/tests/test_avatar_rituals.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_avatar_memory_linker(tmp_path, monkeypatch):
+    log = tmp_path / "link.jsonl"
+    monkeypatch.setenv("AVATAR_MEMORY_LINK_LOG", str(log))
+    import avatar_memory_linker as aml
+    importlib.reload(aml)
+    aml.log_link("ava", "created", mood="joy", memory="m1")
+    assert log.exists()
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+
+
+def test_avatar_council_blessing(tmp_path, monkeypatch):
+    log = tmp_path / "council.jsonl"
+    monkeypatch.setenv("AVATAR_COUNCIL_LOG", str(log))
+    import avatar_council_blessing as acb
+    importlib.reload(acb)
+    acb.log_vote("ava", "alice")
+    assert acb.check_quorum("ava", quorum=1)
+    lines = log.read_text().splitlines()
+    assert len(lines) >= 2
+
+
+def test_avatar_retirement(tmp_path, monkeypatch):
+    log = tmp_path / "retire.jsonl"
+    arch = tmp_path / "arch"
+    src = tmp_path / "a.blend"
+    src.write_text("data")
+    monkeypatch.setenv("AVATAR_RETIRE_LOG", str(log))
+    import avatar_retirement as ar
+    importlib.reload(ar)
+    ar.retire_avatar(src, arch, mood="peace", reason="end")
+    assert (arch / "a.blend").exists()
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1


### PR DESCRIPTION
## Summary
- add memory linker for avatars
- log avatar council votes and quorum blessing
- recap avatar moods via CLI
- add federation blessing recording
- support avatar retirement archiving
- log avatar teaching sessions
- generate avatar chronicles
- animate avatars with presence pulse
- visualize avatar mood evolution
- cover new features with pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cd16edb0483209d56b69e2a96968c