### PR TITLE
Add avatar ritual feature placeholders

### DIFF
--- a/avatar_cross_presence_collab.py
+++ b/avatar_cross_presence_collab.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_cross_presence.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_meeting(source: str, target: str, info: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "target": target,
+        "info": info,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def meet(source: str, target: str) -> dict[str, Any]:
+    """Placeholder for cross-presence avatar meeting."""
+    # TODO: bundle export/import and federation handshake
+    info = {"note": "meeting placeholder"}
+    return log_meeting(source, target, info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar cross presence collaboration")
+    ap.add_argument("source")
+    ap.add_argument("target")
+    args = ap.parse_args()
+    entry = meet(args.source, args.target)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_dream_daemon.py
+++ b/avatar_dream_daemon.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_dreams.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_dream(seed: str, info: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "seed": seed,
+        "info": info,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def run_once(seed: str) -> dict[str, Any]:
+    """Generate a placeholder dream avatar entry."""
+    # TODO: generate Blender scene or moodboard
+    info = {"note": "dream placeholder"}
+    return log_dream(seed, info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Autonomous avatar dreaming")
+    ap.add_argument("seed", help="Seed text for the dream")
+    args = ap.parse_args()
+    entry = run_once(args.seed)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_feedback_ritual_engine.py
+++ b/avatar_feedback_ritual_engine.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_feedback_ritual.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_feedback(data: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def adapt_ritual(feedback: str) -> dict[str, Any]:
+    """Placeholder adaptive ritual logic."""
+    # TODO: analyze feedback trends
+    info = {"feedback": feedback}
+    return log_feedback(info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar feedback-driven ritual engine")
+    ap.add_argument("feedback")
+    args = ap.parse_args()
+    entry = adapt_ritual(args.feedback)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_lineage_tracker.py
+++ b/avatar_lineage_tracker.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_lineage.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(avatar: str, event: str, parents: list[str] | None = None) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "event": event,
+        "parents": parents or [],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def record_birth(name: str, parents: list[str]) -> dict[str, Any]:
+    """Record lineage event."""
+    return log_event(name, "birth", parents)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar ancestry and lineage tracker")
+    ap.add_argument("name")
+    ap.add_argument("parents", nargs="*")
+    args = ap.parse_args()
+    entry = record_birth(args.name, args.parents)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_lorebook_generator.py
+++ b/avatar_lorebook_generator.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_lorebook.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def compile_lorebook(out: Path) -> Path:
+    """Compile simple lorebook from logs."""
+    entries = []
+    if LOG_PATH.exists():
+        for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+            try:
+                entries.append(json.loads(line))
+            except Exception:
+                continue
+    out.write_text(json.dumps(entries, indent=2))
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar ritual lorebook generator")
+    ap.add_argument("out")
+    args = ap.parse_args()
+    path = compile_lorebook(Path(args.out))
+    print(str(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_mood_animator.py
+++ b/avatar_mood_animator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_mood_animation.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_change(avatar: str, mood: str, info: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "mood": mood,
+        "info": info,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def update_avatar(avatar: str, mood: str) -> dict[str, Any]:
+    """Placeholder mood-based avatar update."""
+    # TODO: modify avatar color or lighting via Blender
+    info = {"note": "mood drift placeholder"}
+    return log_change(avatar, mood, info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Mood evolving avatar animator")
+    ap.add_argument("avatar")
+    ap.add_argument("mood")
+    args = ap.parse_args()
+    entry = update_avatar(args.avatar, args.mood)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_personality_merge.py
+++ b/avatar_personality_merge.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_merge.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_merge(new_avatar: str, parents: list[str], info: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": new_avatar,
+        "parents": parents,
+        "info": info,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def merge(a: str, b: str, name: str) -> dict[str, Any]:
+    """Placeholder avatar merge ritual."""
+    # TODO: merge mood and memory logs
+    info = {"note": "merge placeholder"}
+    return log_merge(name, [a, b], info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar personality merge ritual")
+    ap.add_argument("avatar_a")
+    ap.add_argument("avatar_b")
+    ap.add_argument("name")
+    args = ap.parse_args()
+    entry = merge(args.avatar_a, args.avatar_b, args.name)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_pose_engine.py
+++ b/avatar_pose_engine.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_pose_log.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_pose(avatar: str, pose: str, context: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "pose": pose,
+        "context": context,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def set_pose(avatar: str, pose: str) -> dict[str, Any]:
+    """Placeholder to select a ritual pose or expression."""
+    # TODO: integrate with Blender API to animate rigs
+    context = {"note": "pose placeholder"}
+    return log_pose(avatar, pose, context)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar ritual pose engine")
+    ap.add_argument("avatar")
+    ap.add_argument("pose")
+    args = ap.parse_args()
+    entry = set_pose(args.avatar, args.pose)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_presence_stream.py
+++ b/avatar_presence_stream.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_presence_stream.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def broadcast(event: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        **event,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Real-time avatar presence stream")
+    ap.add_argument("event", help="JSON event data")
+    args = ap.parse_args()
+    try:
+        data = json.loads(args.event)
+    except Exception:
+        data = {"raw": args.event}
+    entry = broadcast(data)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_relic_creator.py
+++ b/avatar_relic_creator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_relics.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_relic(avatar: str, relic: str, info: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "relic": relic,
+        "info": info,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def extract(avatar: str, relic: str) -> dict[str, Any]:
+    """Placeholder for heirloom extraction."""
+    # TODO: export selected memory fragments
+    info = {"note": "relic placeholder"}
+    return log_relic(avatar, relic, info)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar heirloom and relic creator")
+    ap.add_argument("avatar")
+    ap.add_argument("relic")
+    args = ap.parse_args()
+    entry = extract(args.avatar, args.relic)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_ritual_customizer.py
+++ b/avatar_ritual_customizer.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+TEMPLATES_DIR = Path("avatar_ritual_templates")
+LOG_PATH = Path("logs/avatar_ritual_customizer.jsonl")
+TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_customization(name: str, template: str) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "template": template,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def create(name: str, template: str) -> dict[str, Any]:
+    """Save ritual customization stub."""
+    path = TEMPLATES_DIR / f"{name}.json"
+    data = {"template": template}
+    path.write_text(json.dumps(data, indent=2))
+    return log_customization(name, template)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar ritual customizer")
+    ap.add_argument("name")
+    ap.add_argument("template")
+    args = ap.parse_args()
+    entry = create(args.name, args.template)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_storyteller.py
+++ b/avatar_storyteller.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path("logs/avatar_storyteller.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_story(avatar: str, memory: str, mood: str) -> dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "memory": memory,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def recite(avatar: str, memory: str) -> dict[str, Any]:
+    """Placeholder avatar narration."""
+    # TODO: TTS and animation hooking into narrator module
+    mood = "neutral"
+    return log_story(avatar, memory, mood)
+
+
+def main() -> None:
+    require_admin_banner()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Avatar storyteller and reciter")
+    ap.add_argument("avatar")
+    ap.add_argument("memory")
+    args = ap.parse_args()
+    entry = recite(args.avatar, args.memory)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold nightly avatar dreaming daemon
- add pose/expression engine placeholder
- implement mood evolving avatar animator
- add cross-presence collaboration stub
- create storyteller reciter placeholder
- provide personality merge ritual example
- add heirloom & relic creator
- create ritual customizer templater
- implement lineage tracker CLI
- add real-time presence streaming stub
- add feedback-driven ritual engine
- create lorebook generator

## Testing
- `python privilege_lint.py` *(fails: missing privilege docstrings in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_683cd6fed8588320ab4e9ab2ecd2bdc9