### PR TITLE
Add avatar festival and blessing engines

### DIFF
--- a/avatar_blessing_propagation_web.py
+++ b/avatar_blessing_propagation_web.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Avatar Blessing Propagation Web."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_BLESSING_PROPAGATION_LOG", "logs/avatar_blessing_propagation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_propagation(source: str, target: str, blessing: str, note: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "target": target,
+        "blessing": blessing,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_propagation() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def generate_graph() -> str:
+    lines = ["digraph blessings {"]
+    for e in list_propagation():
+        src = e["source"]
+        dst = e["target"]
+        lbl = e["blessing"]
+        lines.append(f'    "{src}" -> "{dst}" [label="{lbl}"];')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Blessing Propagation Web")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a propagation event")
+    lg.add_argument("source")
+    lg.add_argument("target")
+    lg.add_argument("blessing")
+    lg.add_argument("--note", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_propagation(a.source, a.target, a.blessing, a.note), indent=2)))
+
+    ls = sub.add_parser("list", help="List propagation events")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_propagation(), indent=2)))
+
+    gr = sub.add_parser("graph", help="Generate graphviz DOT of propagation")
+    gr.set_defaults(func=lambda a: print(generate_graph()))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_blessing_proposal_engine.py
+++ b/avatar_blessing_proposal_engine.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Avatar Autonomous Blessing Proposal Engine."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+PROPOSAL_LOG = Path(os.getenv("AVATAR_BLESSING_PROPOSAL_LOG", "logs/avatar_blessing_proposals.jsonl"))
+APPROVAL_LOG = Path(os.getenv("AVATAR_BLESSING_APPROVAL_LOG", "logs/avatar_blessing_approved.jsonl"))
+for p in (PROPOSAL_LOG, APPROVAL_LOG):
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def propose(avatar: str, mood: str, reason: str, line: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "mood": mood,
+        "reason": reason,
+        "line": line,
+        "status": "pending",
+    }
+    with PROPOSAL_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_proposals() -> List[Dict[str, str]]:
+    if not PROPOSAL_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in PROPOSAL_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def approve(index: int) -> Dict[str, str]:
+    proposals = list_proposals()
+    if index < 0 or index >= len(proposals):
+        raise IndexError("invalid proposal index")
+    entry = proposals[index]
+    entry["status"] = "approved"
+    with APPROVAL_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Blessing Proposal Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pr = sub.add_parser("propose", help="Propose a new blessing")
+    pr.add_argument("avatar")
+    pr.add_argument("mood")
+    pr.add_argument("reason")
+    pr.add_argument("line")
+    pr.set_defaults(func=lambda a: print(json.dumps(propose(a.avatar, a.mood, a.reason, a.line), indent=2)))
+
+    ls = sub.add_parser("list", help="List blessing proposals")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_proposals(), indent=2)))
+
+    apv = sub.add_parser("approve", help="Approve a proposal by index")
+    apv.add_argument("index", type=int)
+    apv.set_defaults(func=lambda a: print(json.dumps(approve(a.index), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_conflict_drama_engine.py
+++ b/avatar_conflict_drama_engine.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Ritual Avatar Conflict Drama Engine."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_CONFLICT_DRAMA_LOG", "logs/avatar_conflict_drama.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_conflict(parties: List[str], issue: str, resolution: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "parties": parties,
+        "issue": issue,
+        "resolution": resolution,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_conflicts() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def narrate(entry: Dict[str, str]) -> str:
+    parties = " vs ".join(entry.get("parties", []))
+    return (
+        f"### Conflict: {parties}\n"
+        f"**Issue:** {entry['issue']}\n\n"
+        f"**Resolution:** {entry['resolution']}\n"
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Conflict Drama Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a conflict")
+    lg.add_argument("parties")
+    lg.add_argument("issue")
+    lg.add_argument("resolution")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_conflict([p.strip() for p in a.parties.split(',') if p.strip()], a.issue, a.resolution), indent=2)))
+
+    ls = sub.add_parser("list", help="List conflicts")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_conflicts(), indent=2)))
+
+    pl = sub.add_parser("play", help="Narrate latest conflict")
+    pl.set_defaults(func=lambda a: print(narrate(list_conflicts()[-1])) if list_conflicts() else print("No conflicts logged"))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_delegation.py
+++ b/avatar_delegation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Avatars with Council/Oracle Delegation."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_DELEGATION_LOG", "logs/avatar_delegation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def delegate(avatar: str, role: str, duration: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "role": role,
+        "duration": duration,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_delegations() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Council/Oracle Delegation")
+    sub = ap.add_subparsers(dest="cmd")
+
+    dl = sub.add_parser("delegate", help="Delegate a role to an avatar")
+    dl.add_argument("avatar")
+    dl.add_argument("role")
+    dl.add_argument("duration")
+    dl.set_defaults(func=lambda a: print(json.dumps(delegate(a.avatar, a.role, a.duration), indent=2)))
+
+    ls = sub.add_parser("list", help="List delegations")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_delegations(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_emotion_adaptive_animation.py
+++ b/avatar_emotion_adaptive_animation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Avatar Emotion-Adaptive Animation Engine."""
+
+import argparse
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+LOG_PATH = Path(os.getenv("AVATAR_ANIMATION_LOG", "logs/avatar_animation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_change(avatar: str, mood: str, reaction: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "mood": mood,
+        "reaction": reaction,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def run_daemon(avatar: str, mood: str, interval: float) -> None:
+    while True:
+        record_change(avatar, mood, "adaptive update")
+        time.sleep(interval)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Emotion-Adaptive Animation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rc = sub.add_parser("record", help="Record an animation change")
+    rc.add_argument("avatar")
+    rc.add_argument("mood")
+    rc.add_argument("reaction")
+    rc.set_defaults(func=lambda a: print(json.dumps(record_change(a.avatar, a.mood, a.reaction), indent=2)))
+
+    dn = sub.add_parser("daemon", help="Run adaptive daemon")
+    dn.add_argument("avatar")
+    dn.add_argument("mood")
+    dn.add_argument("--interval", type=float, default=60.0)
+    dn.set_defaults(func=lambda a: run_daemon(a.avatar, a.mood, a.interval))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_federation_festival_coordinator.py
+++ b/avatar_federation_festival_coordinator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Avatar Federation Festival Coordinator."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_FEDERATION_FESTIVAL_LOG", "logs/avatar_federation_festival.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def schedule_festival(name: str, avatars: List[str], note: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "avatars": avatars,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_festivals() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def generate_lorebook(entry: Dict[str, str], html: bool = False) -> str:
+    avatars = ", ".join(entry.get("avatars", []))
+    md = (
+        f"# Federation Festival {entry['name']}\n"
+        f"**Participants:** {avatars}\n\n"
+        f"**Note:** {entry['note']}\n"
+    )
+    if not html:
+        return md
+    return md.replace("\n", "<br>\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Federation Festival Coordinator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("schedule", help="Schedule a federation festival")
+    sc.add_argument("name")
+    sc.add_argument("avatars")
+    sc.add_argument("--note", default="")
+    sc.set_defaults(func=lambda a: print(json.dumps(schedule_festival(a.name, [v.strip() for v in a.avatars.split(',') if v.strip()], a.note), indent=2)))
+
+    ls = sub.add_parser("list", help="List festivals")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_festivals(), indent=2)))
+
+    lb = sub.add_parser("lorebook", help="Generate lorebook for latest festival")
+    lb.add_argument("--html", action="store_true")
+    lb.set_defaults(func=lambda a: print(generate_lorebook(list_festivals()[-1], html=a.html)) if list_festivals() else print("No festivals logged"))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_festival_memory_capsule.py
+++ b/avatar_festival_memory_capsule.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Ritual Avatar Festival Memory Capsule."""
+
+import argparse
+import json
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_FESTIVAL_CAPSULE_LOG", "logs/avatar_festival_capsules.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_capsule(name: str, files: List[Path], out: Path) -> Path:
+    with tarfile.open(out, "w:gz") as tar:
+        for fp in files:
+            tar.add(fp, arcname=fp.name)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "capsule": str(out),
+        "files": [str(f) for f in files],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return out
+
+
+def list_capsules() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Festival Memory Capsule")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cr = sub.add_parser("create", help="Create a memory capsule")
+    cr.add_argument("name")
+    cr.add_argument("out")
+    cr.add_argument("files", nargs="+")
+    cr.set_defaults(func=lambda a: print(create_capsule(a.name, [Path(f) for f in a.files], Path(a.out))))
+
+    ls = sub.add_parser("list", help="List capsules")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_capsules(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_mass_invocation.py
+++ b/avatar_mass_invocation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Cathedral Festival Mass Avatar Invocation."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_MASS_INVOCATION_LOG", "logs/avatar_mass_invocation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_invocation(name: str, avatars: List[str], mood: str, line: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "festival": name,
+        "avatars": avatars,
+        "mood": mood,
+        "line": line,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_invocations() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def generate_gallery(entry: Dict[str, str], html: bool = False) -> str:
+    avatars = ", ".join(entry.get("avatars", []))
+    md = (
+        f"# {entry['festival']} Mass Invocation\n"
+        f"**Mood:** {entry['mood']}\n\n"
+        f"**Ritual Line:** {entry['line']}\n\n"
+        f"**Avatars:** {avatars}\n"
+    )
+    if not html:
+        return md
+    return md.replace("\n", "<br>\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Festival Mass Avatar Invocation")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cr = sub.add_parser("create", help="Create invocation entry")
+    cr.add_argument("festival")
+    cr.add_argument("avatars")
+    cr.add_argument("--mood", default="")
+    cr.add_argument("--line", default="")
+    cr.set_defaults(func=lambda a: print(json.dumps(create_invocation(a.festival, [v.strip() for v in a.avatars.split(',') if v.strip()], a.mood, a.line), indent=2)))
+
+    pg = sub.add_parser("program", help="Generate program for latest invocation")
+    pg.add_argument("--html", action="store_true")
+    pg.set_defaults(func=lambda a: print(generate_gallery(list_invocations()[-1], html=a.html)) if list_invocations() else print("No invocations logged"))
+
+    ls = sub.add_parser("list", help="List invocations")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_invocations(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_sanctuary_scene_generator.py
+++ b/avatar_sanctuary_scene_generator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Avatar Sanctuary/Chamber Scene Generator."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_SCENE_LOG", "logs/avatar_sanctuary_scenes.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_scene(avatar: str, mood: str, blessing: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "mood": mood,
+        "blessing": blessing,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_scenes() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def render_scene(entry: Dict[str, str], html: bool = False) -> str:
+    md = (
+        f"## Avatar {entry['avatar']} Chamber\n"
+        f"Mood: {entry['mood']}\n\n"
+        f"Blessing: {entry['blessing']}\n"
+    )
+    if not html:
+        return md
+    return md.replace("\n", "<br>\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Sanctuary Scene Generator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cr = sub.add_parser("create", help="Create a scene")
+    cr.add_argument("avatar")
+    cr.add_argument("mood")
+    cr.add_argument("blessing")
+    cr.set_defaults(func=lambda a: print(json.dumps(create_scene(a.avatar, a.mood, a.blessing), indent=2)))
+
+    ls = sub.add_parser("list", help="List scenes")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_scenes(), indent=2)))
+
+    rd = sub.add_parser("render", help="Render latest scene")
+    rd.add_argument("--html", action="store_true")
+    rd.set_defaults(func=lambda a: print(render_scene(list_scenes()[-1], html=a.html)) if list_scenes() else print("No scenes logged"))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_teaching_session_generator.py
+++ b/avatar_teaching_session_generator.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Avatar-Driven Teaching Session Generator."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_TEACHING_SESSION_LOG", "logs/avatar_teaching_sessions.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def plan_session(avatar: str, ritual: str, lesson: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "ritual": ritual,
+        "lesson": lesson,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_sessions() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def latest_lesson() -> str:
+    sessions = list_sessions()
+    if not sessions:
+        return "No sessions logged"
+    s = sessions[-1]
+    return f"Avatar {s['avatar']} teaches {s['ritual']}: {s['lesson']}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Teaching Session Generator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pl = sub.add_parser("plan", help="Plan a teaching session")
+    pl.add_argument("avatar")
+    pl.add_argument("ritual")
+    pl.add_argument("lesson")
+    pl.set_defaults(func=lambda a: print(json.dumps(plan_session(a.avatar, a.ritual, a.lesson), indent=2)))
+
+    ls = sub.add_parser("list", help="List sessions")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_sessions(), indent=2)))
+
+    tm = sub.add_parser("teachme", help="Show latest lesson")
+    tm.set_defaults(func=lambda a: print(latest_lesson()))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -5,5 +5,15 @@
 - `presence_ledger.py` – immutable memory of blessings and federation events.
 - `emotion_dashboard.py` – real-time emotion tracking interface.
 - `reflection_stream.py` – logging for autonomous reflections and diagnostics.
+- `avatar_blessing_proposal_engine.py` – avatars propose their own blessings.
+- `avatar_mass_invocation.py` – coordinate festival mass avatar invocations.
+- `avatar_teaching_session_generator.py` – plan teaching sessions for rituals.
+- `avatar_conflict_drama_engine.py` – narrate avatar conflicts and resolutions.
+- `avatar_blessing_propagation_web.py` – visualize blessing propagation.
+- `avatar_delegation.py` – delegate council or oracle roles to avatars.
+- `avatar_emotion_adaptive_animation.py` – adapt animations to avatar moods.
+- `avatar_festival_memory_capsule.py` – archive festival artifacts and logs.
+- `avatar_sanctuary_scene_generator.py` – create virtual chambers for avatars.
+- `avatar_federation_festival_coordinator.py` – manage cross-cathedral festivals.
 
 See other files in this repository and `docs/README_FULL.md` for a detailed tour.


### PR DESCRIPTION
## Summary
- implement autonomous blessing proposal engine
- orchestrate mass avatar invocations
- add teaching session generator
- dramatize avatar conflicts
- track blessing propagation events
- log council/oracle delegation
- adapt avatar animations to mood
- create festival memory capsules
- generate avatar chambers
- coordinate federation festivals
- document new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cd9dec2488320aea4302ab4d88fdd