### PR TITLE
Add avatar ritual record and dream modules

### DIFF
--- a/avatar_blessing_ceremony_api.py
+++ b/avatar_blessing_ceremony_api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Avatar Blessing Ceremony API."""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("AVATAR_BLESSING_CEREMONY_LOG", "logs/avatar_blessing_ceremony.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_blessing(avatar: str, blessing: str, celebrant: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "blessing": blessing,
+        "celebrant": celebrant,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_blessings() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+@app.post("/blessings")
+def api_log_blessing():
+    data = request.json or {}
+    avatar = data.get("avatar", "")
+    blessing = data.get("blessing", "")
+    celebrant = data.get("celebrant", "")
+    entry = log_blessing(avatar, blessing, celebrant)
+    return jsonify(entry)
+
+
+@app.get("/blessings")
+def api_list_blessings():
+    return jsonify(list_blessings())
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5000")))

--- a/avatar_heirloom_transmission.py
+++ b/avatar_heirloom_transmission.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Avatar Heirloom Transmission Ritual."""
+
+import argparse
+import json
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_HEIRLOOM_LOG", "logs/avatar_heirloom_transmissions.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def transmit_heirlooms(source: str, target: str, files: List[Path]) -> Dict[str, str]:
+    archive = Path(f"{source}_to_{target}_{int(datetime.utcnow().timestamp())}.tar.gz")
+    with tarfile.open(archive, "w:gz") as tar:
+        for fp in files:
+            tar.add(fp, arcname=fp.name)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "target": target,
+        "archive": str(archive),
+        "files": [str(f) for f in files],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_transmissions() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Heirloom Transmission")
+    sub = ap.add_subparsers(dest="cmd")
+
+    tr = sub.add_parser("transmit", help="Transmit heirlooms")
+    tr.add_argument("source")
+    tr.add_argument("target")
+    tr.add_argument("files", nargs="+")
+    tr.set_defaults(func=lambda a: print(json.dumps(transmit_heirlooms(a.source, a.target, [Path(f) for f in a.files]), indent=2)))
+
+    ls = sub.add_parser("list", help="List transmissions")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_transmissions(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_herald_bard_system.py
+++ b/avatar_herald_bard_system.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Autonomous Avatar Herald/Bard System.
+
+Logs ritual announcements, omens, and celebration poems.
+"""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_HERALD_LOG", "logs/avatar_herald_events.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event_type: str, content: str, mood: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": event_type,
+        "content": content,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_events() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Herald/Bard System")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a herald event")
+    lg.add_argument("type")
+    lg.add_argument("content")
+    lg.add_argument("--mood", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_event(a.type, a.content, a.mood), indent=2)))
+
+    ls = sub.add_parser("list", help="List events")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_events(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_memory_dream_sequencer.py
+++ b/avatar_memory_dream_sequencer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Avatar Memory Dream Sequencer.
+
+Generates and logs dream sequences based on memory lineage and mood.
+"""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_DREAM_SEQUENCE_LOG", "logs/avatar_dream_sequences.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_dream(seed: str, memories: List[str], mood: str, narrative: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "seed": seed,
+        "memories": memories,
+        "mood": mood,
+        "narrative": narrative,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_dreams() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Memory Dream Sequencer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a dream sequence")
+    lg.add_argument("seed")
+    lg.add_argument("--memories", default="")
+    lg.add_argument("--mood", default="")
+    lg.add_argument("--narrative", default="")
+    lg.set_defaults(
+        func=lambda a: print(
+            json.dumps(
+                log_dream(
+                    a.seed,
+                    [m.strip() for m in a.memories.split(",") if m.strip()],
+                    a.mood,
+                    a.narrative,
+                ),
+                indent=2,
+            )
+        )
+    )
+
+    ls = sub.add_parser("list", help="List dream sequences")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_dreams(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_performance_scoreboard.py
+++ b/avatar_performance_scoreboard.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Ritual Avatar Performance Scoreboard."""
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_PERFORMANCE_LOG", "logs/avatar_performance.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_metric(avatar: str, metric: str, value: int) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "metric": metric,
+        "value": value,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def aggregate_scores() -> Dict[str, Dict[str, int]]:
+    scores: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    if not LOG_PATH.exists():
+        return {}
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            e = json.loads(line)
+        except Exception:
+            continue
+        scores[e["avatar"]][e["metric"]] += int(e.get("value", 0))
+    return scores
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Performance Scoreboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a performance metric")
+    lg.add_argument("avatar")
+    lg.add_argument("metric")
+    lg.add_argument("value", type=int)
+    lg.set_defaults(func=lambda a: print(json.dumps(log_metric(a.avatar, a.metric, a.value), indent=2)))
+
+    ag = sub.add_parser("aggregate", help="Show aggregated scores")
+    ag.set_defaults(func=lambda a: print(json.dumps(aggregate_scores(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_ritual_witnesses.py
+++ b/avatar_ritual_witnesses.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Avatars as Ritual Witnesses."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_WITNESS_LOG", "logs/avatar_witnesses.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_witness(event: str, avatar: str, note: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "avatar": avatar,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_witnesses(event: str | None = None) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            e = json.loads(line)
+            if event is None or e.get("event") == event:
+                out.append(e)
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Ritual Witnesses")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a witness")
+    lg.add_argument("event")
+    lg.add_argument("avatar")
+    lg.add_argument("--note", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_witness(a.event, a.avatar, a.note), indent=2)))
+
+    ls = sub.add_parser("list", help="List witnesses")
+    ls.add_argument("--event", default=None)
+    ls.set_defaults(func=lambda a: print(json.dumps(list_witnesses(event=a.event), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_sanctuary_artifacts_generator.py
+++ b/avatar_sanctuary_artifacts_generator.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Avatar Sanctuary Artifacts Generator."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_ARTIFACT_LOG", "logs/avatar_sanctuary_artifacts.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_artifact(creator: str, kind: str, description: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "creator": creator,
+        "kind": kind,
+        "description": description,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_artifacts() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Sanctuary Artifacts Generator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cr = sub.add_parser("create", help="Create an artifact")
+    cr.add_argument("creator")
+    cr.add_argument("kind")
+    cr.add_argument("description")
+    cr.set_defaults(func=lambda a: print(json.dumps(create_artifact(a.creator, a.kind, a.description), indent=2)))
+
+    ls = sub.add_parser("list", help="List artifacts")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_artifacts(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_succession_visualizer.py
+++ b/avatar_succession_visualizer.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Avatar Succession Ceremony Visualizer.
+
+Creates a Graphviz representation of avatar lineage and blessings.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+LINEAGE_LOG = Path(os.getenv("AVATAR_LINEAGE_LOG", "logs/avatar_lineage.jsonl"))
+
+
+def load_entries(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def generate_graph() -> str:
+    lines = ["digraph succession {"]
+    for e in load_entries(LINEAGE_LOG):
+        child = e.get("avatar")
+        for parent in e.get("parents", []):
+            lines.append(f'    "{parent}" -> "{child}";')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Succession Visualizer")
+    ap.add_argument("--graph", action="store_true", help="Output Graphviz DOT")
+    args = ap.parse_args()
+    if args.graph:
+        print(generate_graph())
+    else:
+        print(json.dumps(load_entries(LINEAGE_LOG), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -15,5 +15,15 @@
 - `avatar_festival_memory_capsule.py` – archive festival artifacts and logs.
 - `avatar_sanctuary_scene_generator.py` – create virtual chambers for avatars.
 - `avatar_federation_festival_coordinator.py` – manage cross-cathedral festivals.
+- `avatar_memory_dream_sequencer.py` – generate and log dream sequences.
+- `ritual_avatar_hall_of_records.py` – archive and search ritual records.
+- `avatar_succession_visualizer.py` – visualize avatar succession lineages.
+- `avatar_herald_bard_system.py` – compose ritual announcements and poems.
+- `ritual_avatar_chronicle_video.py` – compile logs into video chronicles.
+- `avatar_blessing_ceremony_api.py` – API for blessing ceremonies.
+- `avatar_ritual_witnesses.py` – log avatars as ceremony witnesses.
+- `avatar_heirloom_transmission.py` – transmit heirloom memories across cathedrals.
+- `avatar_performance_scoreboard.py` – review avatar performance metrics.
+- `avatar_sanctuary_artifacts_generator.py` – craft and log sanctuary artifacts.
 
 See other files in this repository and `docs/README_FULL.md` for a detailed tour.

--- a/ritual_avatar_chronicle_video.py
+++ b/ritual_avatar_chronicle_video.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Ritual Avatar Chronicle-to-Video Compiler.
+
+Creates placeholder video compilations from ritual logs.
+"""
+
+import argparse
+import json
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_CHRONICLE_VIDEO_LOG", "logs/avatar_chronicle_video.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def compile_chronicle(name: str, logs: List[Path], out: Path) -> Path:
+    with tarfile.open(out, "w:gz") as tar:
+        for fp in logs:
+            tar.add(fp, arcname=fp.name)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "archive": str(out),
+        "logs": [str(p) for p in logs],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return out
+
+
+def list_compilations() -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Chronicle to Video")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cp = sub.add_parser("compile", help="Compile ritual logs")
+    cp.add_argument("name")
+    cp.add_argument("out")
+    cp.add_argument("logs", nargs="+")
+    cp.set_defaults(func=lambda a: print(compile_chronicle(a.name, [Path(p) for p in a.logs], Path(a.out))))
+
+    ls = sub.add_parser("list", help="List compilations")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_compilations(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/ritual_avatar_hall_of_records.py
+++ b/ritual_avatar_hall_of_records.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Ritual Avatar Hall of Records.
+
+Archives and searches important avatar ritual events.
+"""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("AVATAR_HALL_RECORDS_LOG", "logs/avatar_hall_of_records.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_record(record_type: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": record_type,
+        "data": data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_records(record_type: str | None = None) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            entry = json.loads(line)
+            if record_type is None or entry.get("type") == record_type:
+                out.append(entry)
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Avatar Hall of Records")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a record")
+    lg.add_argument("type")
+    lg.add_argument("data", nargs="*", help="key=value pairs")
+    lg.set_defaults(
+        func=lambda a: print(
+            json.dumps(
+                log_record(
+                    a.type,
+                    {k: v for k, v in (d.split("=", 1) for d in a.data)},
+                ),
+                indent=2,
+            )
+        )
+    )
+
+    ls = sub.add_parser("list", help="List records")
+    ls.add_argument("--type", default=None)
+    ls.set_defaults(
+        func=lambda a: print(json.dumps(list_records(record_type=a.type), indent=2))
+    )
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement avatar memory dream sequencer
- add ritual avatar hall of records logger
- create avatar succession visualizer
- add autonomous herald/bard event logger
- compile ritual chronicles into videos
- provide simple API for blessing ceremonies
- log avatars as ceremony witnesses
- transmit avatar heirlooms
- track avatar performance metrics
- generate sanctuary artifacts
- document new modules

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cdb8dfccc8320b799905580bd5d21