### PR TITLE
Implement NeosVR integration utilities

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -26,5 +26,15 @@
 - `avatar_performance_scoreboard.py` – review avatar performance metrics.
 - `avatar_sanctuary_artifacts_generator.py` – craft and log sanctuary artifacts.
 - `avatar_artifact_gallery.py` – curate and search all avatar artifacts.
+- `neos_bridge.py` – bridge messages to a NeosVR LogiX folder.
+- `neos_avatar_emotion_pipeline.py` – map emotion vectors to avatar blendshapes.
+- `neos_avatar_crowning_cli.py` – crown a new VR avatar and log the ritual.
+- `neos_sanctuary_scene_pipeline.py` – generate sanctuary scene configs for Neos.
+- `neos_council_onboarding.py` – run council onboarding ceremonies in VR.
+- `neos_memory_playback.py` – replay memory fragments via the bridge.
+- `neos_federation_sync.py` – broadcast cross-world presence pulses.
+- `neos_avatar_teaching_mode.py` – lead onboarding sessions as an avatar.
+- `neos_artifact_logger.py` – bless and archive sanctuary artifacts for VR.
+- `neos_presence_dashboard.py` – visualize presence pulse events in real time.
 
 See other files in this repository and `docs/README_FULL.md` for a detailed tour.

--- a/neos_artifact_logger.py
+++ b/neos_artifact_logger.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import presence_ledger as pl
+
+LOG_PATH = Path(os.getenv("NEOS_ARTIFACT_LOG", "logs/neos_artifacts.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_artifact(name: str, description: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "description": description,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log(name, "artifact", description)
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Sanctuary Artifact Logger")
+    ap.add_argument("name")
+    ap.add_argument("description")
+    args = ap.parse_args()
+    entry = log_artifact(args.name, args.description)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_crowning_cli.py
+++ b/neos_avatar_crowning_cli.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import presence_ledger as pl
+import memory_manager as mm
+import neos_bridge as nb
+
+LOG_PATH = Path(os.getenv("NEOS_CROWN_LOG", "logs/neos_avatar_crowning.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+AGENTS_PATH = Path("AGENTS.md")
+
+
+def crown_avatar(name: str) -> dict:
+    banner = AGENTS_PATH.read_text(encoding="utf-8")
+    nb.send_message("crowning", f"{name} crowned")
+    pl.log(name, "crowned", "NeosVR avatar")
+    mm.append_memory(f"{name} crowned as VR avatar", tags=["vr", "crown"], source="neos")
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": name,
+        "banner_excerpt": banner.splitlines()[:5],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Crowning Ceremony")
+    ap.add_argument("avatar")
+    args = ap.parse_args()
+    entry = crown_avatar(args.avatar)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_emotion_pipeline.py
+++ b/neos_avatar_emotion_pipeline.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BRIDGE_DIR = Path(os.getenv("NEOS_BRIDGE_DIR", "C:/SentientOS/neos"))
+BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+LOG_PATH = Path(os.getenv("NEOS_EMOTION_LOG", "logs/neos_avatar_emotion.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def map_emotions(vector: Dict[str, float], memory_fragment: str) -> Dict[str, Any]:
+    """Map emotion vector to avatar blendshape placeholder."""
+    mapping = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "memory": memory_fragment,
+        "vector": vector,
+        "blendshape": max(vector, key=vector.get) if vector else "neutral",
+    }
+    file_path = BRIDGE_DIR / f"emotion_{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.json"
+    file_path.write_text(json.dumps(mapping, ensure_ascii=False, indent=2), encoding="utf-8")
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(mapping) + "\n")
+    return mapping
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Emotion Pipeline")
+    ap.add_argument("vector", help="Path to JSON emotion vector")
+    ap.add_argument("memory", help="Memory fragment text")
+    args = ap.parse_args()
+    vec = {}
+    try:
+        vec = json.loads(Path(args.vector).read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    mapping = map_emotions(vec, args.memory)
+    print(json.dumps(mapping, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_teaching_mode.py
+++ b/neos_avatar_teaching_mode.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import neos_bridge as nb
+import presence_ledger as pl
+
+LOG_PATH = Path(os.getenv("NEOS_TEACH_LOG", "logs/neos_avatar_teaching.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def teach(avatar: str, lesson: str) -> dict:
+    nb.send_message("teaching", f"{avatar}: {lesson}")
+    entry = {"timestamp": datetime.utcnow().isoformat(), "avatar": avatar, "lesson": lesson}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log(avatar, "teaching", lesson)
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Teaching Mode")
+    ap.add_argument("avatar")
+    ap.add_argument("lesson")
+    args = ap.parse_args()
+    entry = teach(args.avatar, args.lesson)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_bridge.py
+++ b/neos_bridge.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+BRIDGE_DIR = Path(os.getenv("NEOS_BRIDGE_DIR", "C:/SentientOS/neos"))
+BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+LOG_PATH = Path(os.getenv("NEOS_BRIDGE_LOG", "logs/neos_bridge.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def send_message(category: str, text: str) -> Dict[str, str]:
+    """Write ``text`` to the bridge folder and log the event."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "category": category,
+        "text": text,
+    }
+    file_path = BRIDGE_DIR / f"{category}_{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.txt"
+    file_path.write_text(text, encoding="utf-8")
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    """Return recent bridge events."""
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Bridge Connector")
+    sub = ap.add_subparsers(dest="cmd")
+
+    snd = sub.add_parser("send", help="Send a message")
+    snd.add_argument("category")
+    snd.add_argument("text")
+    snd.set_defaults(func=lambda a: print(json.dumps(send_message(a.category, a.text), indent=2)))
+
+    tst = sub.add_parser("test", help="Send a test presence message")
+    tst.set_defaults(func=lambda a: print(json.dumps(send_message("test", "presence ping"), indent=2)))
+
+    hist = sub.add_parser("history", help="Show bridge history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_onboarding.py
+++ b/neos_council_onboarding.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import presence_ledger as pl
+import neos_bridge as nb
+
+LOG_PATH = Path(os.getenv("NEOS_COUNCIL_LOG", "logs/neos_council.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def onboard(keeper: str) -> dict:
+    nb.send_message("onboard", f"{keeper} joins the council")
+    pl.log(keeper, "onboarded", "council ritual")
+    entry = {"timestamp": datetime.utcnow().isoformat(), "keeper": keeper, "event": "onboard"}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Council/Onboarding Engine")
+    ap.add_argument("keeper")
+    args = ap.parse_args()
+    entry = onboard(args.keeper)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_federation_sync.py
+++ b/neos_federation_sync.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import neos_bridge as nb
+import presence_ledger as pl
+
+LOG_PATH = Path(os.getenv("NEOS_FEDERATION_LOG", "logs/neos_federation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def broadcast(event: str, note: str) -> dict:
+    nb.send_message("federation", f"{event}: {note}")
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("federation", event, note)
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Cross-World Federation Sync")
+    ap.add_argument("event")
+    ap.add_argument("note")
+    args = ap.parse_args()
+    entry = broadcast(args.event, args.note)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_memory_playback.py
+++ b/neos_memory_playback.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import memory_manager as mm
+import neos_bridge as nb
+
+LOG_PATH = Path(os.getenv("NEOS_PLAYBACK_LOG", "logs/neos_memory_playback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def playback(fragment: str) -> dict:
+    nb.send_message("playback", fragment)
+    entry = {"timestamp": datetime.utcnow().isoformat(), "fragment": fragment}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    mm.append_memory(f"Playback: {fragment}", tags=["vr", "playback"], source="neos")
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Ritual Memory Playback")
+    ap.add_argument("fragment", help="Text to replay in VR")
+    args = ap.parse_args()
+    entry = playback(args.fragment)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_presence_dashboard.py
+++ b/neos_presence_dashboard.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import presence_ledger as pl
+
+LOG_PATH = Path(os.getenv("NEOS_PRESENCE_LOG", "logs/neos_presence_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_event(event: str, note: str = "") -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Presence Pulse Dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record presence event")
+    rec.add_argument("event")
+    rec.add_argument("--note", default="")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_event(a.event, a.note), indent=2)))
+
+    led = sub.add_parser("ledger", help="Show recent privilege attempts")
+    led.add_argument("--limit", type=int, default=5)
+    led.set_defaults(func=lambda a: print(json.dumps(pl.recent_privilege_attempts(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_sanctuary_scene_pipeline.py
+++ b/neos_sanctuary_scene_pipeline.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+BRIDGE_DIR = Path(os.getenv("NEOS_BRIDGE_DIR", "C:/SentientOS/neos"))
+BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+LOG_PATH = Path(os.getenv("NEOS_SCENE_LOG", "logs/neos_scene_pipeline.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def generate_scene(mood: str, blessing: str) -> Dict[str, Any]:
+    scene = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "mood": mood,
+        "blessing": blessing,
+        "rooms": [{"name": "sanctuary", "lighting": mood}],
+    }
+    file_path = BRIDGE_DIR / f"scene_{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.json"
+    file_path.write_text(json.dumps(scene, ensure_ascii=False, indent=2), encoding="utf-8")
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(scene) + "\n")
+    return scene
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Sanctuary Scene Pipeline")
+    ap.add_argument("mood")
+    ap.add_argument("blessing")
+    args = ap.parse_args()
+    scene = generate_scene(args.mood, args.blessing)
+    print(json.dumps(scene, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add NeosVR bridge connector and related pipelines
- log avatar emotions and crowning events
- build basic council/onboarding and federation sync tools
- create teaching mode, memory playback, and artifact logger
- expose presence dashboard for VR
- document new modules in MODULES.md

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ce8a3ab2883208b2d1ffbd4add48d