### PR TITLE
Add NeosVR ritual utility modules

### DIFF
--- a/neos_avatar_emotion_animation_sync.py
+++ b/neos_avatar_emotion_animation_sync.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_ANIMATION_LOG", "logs/neos_avatar_animation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_animation(emotion: str, memory: str, animation: str) -> Dict[str, str]:
+    """Record an avatar animation event."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "emotion": emotion,
+        "memory": memory,
+        "animation": animation,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+ANIMATION_MAP = {
+    "joy": "smile",
+    "sadness": "frown",
+    "anger": "glare",
+    "surprise": "wide_eyes",
+}
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Emotion-Animation Sync")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pulse = sub.add_parser("pulse", help="Send test emotion pulse")
+    pulse.add_argument("emotion")
+    pulse.add_argument("memory")
+    pulse.set_defaults(func=lambda a: print(json.dumps(
+        log_animation(a.emotion, a.memory, ANIMATION_MAP.get(a.emotion, "neutral")),
+        indent=2)))
+
+    hist = sub.add_parser("history", help="Show animation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_relic_generator.py
+++ b/neos_avatar_relic_generator.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_RELIC_LOG", "logs/neos_avatar_relics.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_relic(avatar: str, relic_type: str) -> Dict[str, str]:
+    """Create an avatar relic entry."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "type": relic_type,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Relic Generator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cr = sub.add_parser("create", help="Create relic")
+    cr.add_argument("avatar")
+    cr.add_argument("type")
+    cr.set_defaults(func=lambda a: print(json.dumps(create_relic(a.avatar, a.type), indent=2)))
+
+    hist = sub.add_parser("history", help="Show relic history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_ritual_feedback.py
+++ b/neos_avatar_ritual_feedback.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_RITUAL_FEEDBACK_LOG", "logs/neos_avatar_ritual_feedback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_feedback(avatar: str, feedback: str, adaptation: str = "") -> Dict[str, str]:
+    """Record ritual feedback from VR."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "feedback": feedback,
+        "adaptation": adaptation,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Ritual Feedback Loop")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Record feedback")
+    lg.add_argument("avatar")
+    lg.add_argument("feedback")
+    lg.add_argument("--adaptation", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_feedback(a.avatar, a.feedback, a.adaptation), indent=2)))
+
+    hist = sub.add_parser("history", help="Show feedback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_sanctuary_customizer.py
+++ b/neos_avatar_sanctuary_customizer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_SANCTUARY_CUSTOM_LOG", "logs/neos_sanctuary_custom.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_change(room: str, setting: str, value: str) -> Dict[str, str]:
+    """Record a sanctuary customization change."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "room": room,
+        "setting": setting,
+        "value": value,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Sanctuary Customizer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ch = sub.add_parser("change", help="Record customization change")
+    ch.add_argument("room")
+    ch.add_argument("setting")
+    ch.add_argument("value")
+    ch.set_defaults(func=lambda a: print(json.dumps(log_change(a.room, a.setting, a.value), indent=2)))
+
+    hist = sub.add_parser("history", help="Show change history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_festival_visualizer.py
+++ b/neos_council_festival_visualizer.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_COUNCIL_VIS_LOG", "logs/neos_council_visualizer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str, mood: str = "") -> Dict[str, str]:
+    """Record a council or festival event."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Council & Festival Visualizer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Record event")
+    lg.add_argument("event")
+    lg.add_argument("--mood", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_event(a.event, a.mood), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_succession_ceremony.py
+++ b/neos_council_succession_ceremony.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_COUNCIL_SUCCESSION_LOG", "logs/neos_council_succession.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_action(action: str, councilor: str) -> Dict[str, str]:
+    """Record an onboarding or succession action."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        "councilor": councilor,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Council Succession Ceremony")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ob = sub.add_parser("onboard", help="Onboard councilor")
+    ob.add_argument("name")
+    ob.set_defaults(func=lambda a: print(json.dumps(record_action("onboard", a.name), indent=2)))
+
+    bless = sub.add_parser("bless", help="Bless councilor")
+    bless.add_argument("name")
+    bless.set_defaults(func=lambda a: print(json.dumps(record_action("bless", a.name), indent=2)))
+
+    hist = sub.add_parser("history", help="Show ceremony history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_festival_federation_hub.py
+++ b/neos_festival_federation_hub.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_HUB_LOG", "logs/neos_festival_federation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_handshake(peer: str, artifact: str = "") -> Dict[str, str]:
+    """Record a festival federation handshake."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "peer": peer,
+        "artifact": artifact,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Festival Federation Hub")
+    sub = ap.add_subparsers(dest="cmd")
+
+    hs = sub.add_parser("handshake", help="Record federation handshake")
+    hs.add_argument("peer")
+    hs.add_argument("--artifact", default="")
+    hs.set_defaults(func=lambda a: print(json.dumps(log_handshake(a.peer, a.artifact), indent=2)))
+
+    hist = sub.add_parser("history", help="Show handshake history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_presence_pulse_beacon.py
+++ b/neos_presence_pulse_beacon.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_PULSE_LOG", "logs/neos_presence_pulse.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def send_pulse(pulse_type: str, mood: str = "") -> Dict[str, str]:
+    """Record a presence pulse event."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": pulse_type,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Presence Pulse Beacon")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pulse = sub.add_parser("pulse", help="Send presence pulse")
+    pulse.add_argument("type")
+    pulse.add_argument("--mood", default="")
+    pulse.set_defaults(func=lambda a: print(json.dumps(send_pulse(a.type, a.mood), indent=2)))
+
+    hist = sub.add_parser("history", help="Show pulse history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_ritual_witness_module.py
+++ b/neos_ritual_witness_module.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_WITNESS_LOG", "logs/neos_ritual_witnesses.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def add_witness(event: str, witness: str) -> Dict[str, str]:
+    """Record a witness to a ritual event."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "witness": witness,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_witnesses(event: str = "") -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            e = json.loads(ln)
+        except Exception:
+            continue
+        if event and e.get("event") != event:
+            continue
+        out.append(e)
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Ritual Witness Module")
+    sub = ap.add_subparsers(dest="cmd")
+
+    addp = sub.add_parser("add", help="Add witness")
+    addp.add_argument("event")
+    addp.add_argument("witness")
+    addp.set_defaults(func=lambda a: print(json.dumps(add_witness(a.event, a.witness), indent=2)))
+
+    lst = sub.add_parser("list", help="List witnesses")
+    lst.add_argument("--event", default="")
+    lst.set_defaults(func=lambda a: print(json.dumps(list_witnesses(a.event), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_sanctuary_room_generator.py
+++ b/neos_sanctuary_room_generator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_ROOM_LOG", "logs/neos_sanctuary_rooms.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def create_room(name: str, memory: str) -> Dict[str, str]:
+    """Create a sanctuary room entry."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "room": name,
+        "memory": memory,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def place_artifact(room: str, artifact: str) -> Dict[str, str]:
+    """Log an artifact placement."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "room": room,
+        "artifact": artifact,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Sanctuary Room Generator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    new = sub.add_parser("new", help="Create new room")
+    new.add_argument("name")
+    new.add_argument("memory")
+    new.set_defaults(func=lambda a: print(json.dumps(create_room(a.name, a.memory), indent=2)))
+
+    art = sub.add_parser("artifact", help="Place artifact in room")
+    art.add_argument("room")
+    art.add_argument("artifact")
+    art.set_defaults(func=lambda a: print(json.dumps(place_artifact(a.room, a.artifact), indent=2)))
+
+    hist = sub.add_parser("history", help="Show room history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a set of NeosVR utilities for emotion sync, sanctuary rooms, ritual feedback, council visualizations, presence pulses, relic generation, witness logging, council succession, sanctuary customization and festival federation
- each tool logs to its own JSONL ledger and exposes a CLI

## Testing
- `python privilege_lint.py` *(fails: missing privilege headers in existing CLI files)*

------
https://chatgpt.com/codex/tasks/task_b_683cea310cec8320aa4478886a8d8151