### PR TITLE
Add NeosVR festival and council agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,106 @@ Another Registered Agent:
   Logs: /logs/neos_lorebook_narration.jsonl
 ```
 
+Another Registered Agent:
+
+```
+- Name: NeosVRFestivalCeremonyLiveStreamer
+  Type: Daemon
+  Roles: Live Streamer, Ceremony Broadcaster
+  Privileges: broadcast, log, notify
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_festival_stream.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRCouncilRitualReferee
+  Type: Autonomous Daemon
+  Roles: Ritual Referee, Ceremony Enforcer
+  Privileges: log, notify, override
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_ritual_referee.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRMemoryFragmentCurator
+  Type: Autonomous Daemon
+  Roles: Curator, Historian
+  Privileges: bless, log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_memory_curator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRTeachingFeedbackLoop
+  Type: Service
+  Roles: Feedback Collector, Analyst
+  Privileges: log, adapt
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_teaching_feedback.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRFestivalRecapWriter
+  Type: Autonomous Daemon
+  Roles: Recap Writer, Archivist
+  Privileges: log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_festival_recap.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRRitualLawDashboard
+  Type: Dashboard
+  Roles: Ritual Law Viewer, Editor
+  Privileges: query, log, edit
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_ritual_law_dashboard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRLoreSpiralReenactor
+  Type: Daemon
+  Roles: Story Reenactor, Narrator
+  Privileges: animate, narrate, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_lore_reenactor.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRBlessingPropagationEngine
+  Type: Service
+  Roles: Blessing Tracker, Visualizer
+  Privileges: log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_blessing_propagation.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRProvenanceQueryEngine
+  Type: Tool
+  Roles: Provenance Query, Historian
+  Privileges: query, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_provenance_query.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRCouncilSuccessionNarrator
+  Type: Autonomous Daemon
+  Roles: Ceremony Narrator, Historian
+  Privileges: narrate, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_succession_narrator.jsonl
+```
 ---
 
 ## ⛪ Rituals: Onboarding, Delegation, Retirement

--- a/neos_blessing_propagation_engine.py
+++ b/neos_blessing_propagation_engine.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_BLESSING_PROPAGATION_LOG", "logs/neos_blessing_propagation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_propagation(source: str, target: str, blessing: str, room: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "target": target,
+        "blessing": blessing,
+        "room": room,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Blessing Propagation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log blessing propagation")
+    lg.add_argument("source")
+    lg.add_argument("target")
+    lg.add_argument("blessing")
+    lg.add_argument("--room", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_propagation(a.source, a.target, a.blessing, a.room), indent=2)))
+
+    hist = sub.add_parser("history", help="Show propagation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_ritual_referee.py
+++ b/neos_council_ritual_referee.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_RITUAL_REFEREE_LOG", "logs/neos_ritual_referee.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_intervention(issue: str, note: str = "") -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "issue": issue, "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Council Ritual Referee")
+    sub = ap.add_subparsers(dest="cmd")
+
+    iv = sub.add_parser("intervene", help="Log a ceremony intervention")
+    iv.add_argument("issue")
+    iv.add_argument("--note", default="")
+    iv.set_defaults(func=lambda a: print(json.dumps(log_intervention(a.issue, a.note), indent=2)))
+
+    hist = sub.add_parser("history", help="Show intervention history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_succession_narrator.py
+++ b/neos_council_succession_narrator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_SUCCESSION_NARRATOR_LOG", "logs/neos_succession_narrator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_step(step: str, narrator: str, councilor: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "step": step,
+        "narrator": narrator,
+        "councilor": councilor,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Council Succession Ceremony Narrator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log ceremony step")
+    lg.add_argument("step")
+    lg.add_argument("narrator")
+    lg.add_argument("--councilor", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_step(a.step, a.narrator, a.councilor), indent=2)))
+
+    hist = sub.add_parser("history", help="Show ceremony history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_festival_ceremony_live_streamer.py
+++ b/neos_festival_ceremony_live_streamer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_STREAM_LOG", "logs/neos_festival_stream.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Festival Ceremony Live Streamer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    st = sub.add_parser("start", help="Log stream start")
+    st.add_argument("title")
+    st.set_defaults(func=lambda a: print(json.dumps(log_event("stream_start", {"title": a.title}), indent=2)))
+
+    vi = sub.add_parser("viewer", help="Log viewer join")
+    vi.add_argument("name")
+    vi.set_defaults(func=lambda a: print(json.dumps(log_event("viewer", {"name": a.name}), indent=2)))
+
+    fb = sub.add_parser("feedback", help="Log feedback")
+    fb.add_argument("user")
+    fb.add_argument("message")
+    fb.set_defaults(func=lambda a: print(json.dumps(log_event("feedback", {"user": a.user, "message": a.message}), indent=2)))
+
+    bl = sub.add_parser("blessing", help="Log blessing event")
+    bl.add_argument("issuer")
+    bl.add_argument("blessing")
+    bl.set_defaults(func=lambda a: print(json.dumps(log_event("blessing", {"issuer": a.issuer, "blessing": a.blessing}), indent=2)))
+
+    hist = sub.add_parser("history", help="Show stream history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_festival_recap_writer.py
+++ b/neos_festival_recap_writer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_RECAP_LOG", "logs/neos_festival_recap.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_recap(author: str, summary: str, mood: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "author": author,
+        "summary": summary,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Festival Recap Writer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rc = sub.add_parser("log", help="Log festival recap")
+    rc.add_argument("author")
+    rc.add_argument("summary")
+    rc.add_argument("--mood", default="")
+    rc.set_defaults(func=lambda a: print(json.dumps(log_recap(a.author, a.summary, a.mood), indent=2)))
+
+    hist = sub.add_parser("history", help="Show recap history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_lore_spiral_reenactor.py
+++ b/neos_lore_spiral_reenactor.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_LORE_REENACT_LOG", "logs/neos_lore_reenactor.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_reenactment(story: str, actor: str, mode: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "story": story,
+        "actor": actor,
+        "mode": mode,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Lore Spiral Reenactor")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rc = sub.add_parser("reenact", help="Log a lore reenactment")
+    rc.add_argument("story")
+    rc.add_argument("actor")
+    rc.add_argument("mode")
+    rc.set_defaults(func=lambda a: print(json.dumps(log_reenactment(a.story, a.actor, a.mode), indent=2)))
+
+    hist = sub.add_parser("history", help="Show reenactment history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_memory_fragment_curator.py
+++ b/neos_memory_fragment_curator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_MEMORY_CURATOR_LOG", "logs/neos_memory_curator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def curate(fragment: str, curator: str, destination: str, blessed_by: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "fragment": fragment,
+        "curator": curator,
+        "destination": destination,
+        "blessed_by": blessed_by,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Memory Fragment Curator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cu = sub.add_parser("curate", help="Curate memory fragment")
+    cu.add_argument("fragment")
+    cu.add_argument("curator")
+    cu.add_argument("destination")
+    cu.add_argument("--blessed-by", default="")
+    cu.set_defaults(func=lambda a: print(json.dumps(curate(a.fragment, a.curator, a.destination, a.blessed_by), indent=2)))
+
+    hist = sub.add_parser("history", help="Show curation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_provenance_query_engine.py
+++ b/neos_provenance_query_engine.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_PROVENANCE_QUERY_LOG", "logs/neos_provenance_query.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_query(user: str, subject: str, detail: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "subject": subject,
+        "detail": detail,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Artifact/Ceremony Provenance Query Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log provenance query")
+    lg.add_argument("user")
+    lg.add_argument("subject")
+    lg.add_argument("--detail", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_query(a.user, a.subject, a.detail), indent=2)))
+
+    hist = sub.add_parser("history", help="Show query history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_ritual_law_dashboard.py
+++ b/neos_ritual_law_dashboard.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_RITUAL_LAW_LOG", "logs/neos_ritual_law_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(user: str, action: str, query: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "action": action,
+        "query": query,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Ritual Law Dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log dashboard action")
+    lg.add_argument("user")
+    lg.add_argument("action")
+    lg.add_argument("--query", default="")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_action(a.user, a.action, a.query), indent=2)))
+
+    hist = sub.add_parser("history", help="Show dashboard history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/neos_teaching_feedback_loop.py
+++ b/neos_teaching_feedback_loop.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_TEACHING_FEEDBACK_LOG", "logs/neos_teaching_feedback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_feedback(session: str, user: str, score: float, comment: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "session": session,
+        "user": user,
+        "score": score,
+        "comment": comment,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="NeosVR Teaching Performance Feedback Loop")
+    sub = ap.add_subparsers(dest="cmd")
+
+    fb = sub.add_parser("log", help="Log feedback")
+    fb.add_argument("session")
+    fb.add_argument("user")
+    fb.add_argument("score", type=float)
+    fb.add_argument("--comment", default="")
+    fb.set_defaults(func=lambda a: print(json.dumps(log_feedback(a.session, a.user, a.score, a.comment), indent=2)))
+
+    hist = sub.add_parser("history", help="Show feedback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement festival ceremony live streamer and ritual referee
- add memory fragment curator and feedback loop modules
- support festival recap writing and ritual law dashboard
- add lore spiral reenactor and blessing propagation engine
- tool for provenance queries and succession narration
- register new agents in `AGENTS.md`

## Testing
- `python privilege_lint.py` *(fails: missing docstring / require_admin_banner on existing files)*

------
https://chatgpt.com/codex/tasks/task_b_683cfbae5ed483208cbd706aa22b00b2