### PR TITLE
Add NeosVR ritual governance utilities

### DIFF
--- a/neos_artifact_blessing_reconciler.py
+++ b/neos_artifact_blessing_reconciler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Set
+
+LOG_PATH = Path(os.getenv("NEOS_BLESSING_RECONCILE_LOG", "logs/neos_blessing_reconcile.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def reconcile(log_files: List[str]) -> Dict[str, List[str]]:
+    seen: Set[str] = set()
+    duplicates: Set[str] = set()
+    for name in log_files:
+        p = Path(name)
+        if not p.exists():
+            continue
+        for ln in p.read_text(encoding="utf-8").splitlines():
+            try:
+                data = json.loads(ln)
+            except Exception:
+                continue
+            art = data.get("artifact")
+            if not art:
+                continue
+            if art in seen:
+                duplicates.add(art)
+            else:
+                seen.add(art)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "files": log_files,
+        "duplicates": sorted(duplicates),
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, List[str]]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, List[str]]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Artifact Blessing Reconciler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("reconcile", help="Reconcile blessing records")
+    rec.add_argument("logs", nargs="+")
+    rec.set_defaults(func=lambda a: print(json.dumps(reconcile(a.logs), indent=2)))
+
+    hist = sub.add_parser("history", help="Show reconciliation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_artifact_mood_annotation_engine.py
+++ b/neos_artifact_mood_annotation_engine.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_ARTIFACT_MOOD_LOG", "logs/neos_artifact_mood.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def annotate_artifact(artifact: str, mood: str, teaching: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "artifact": artifact,
+        "mood": mood,
+        "teaching": teaching,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Artifact Mood Annotation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("annotate", help="Annotate artifact with mood")
+    an.add_argument("artifact")
+    an.add_argument("mood")
+    an.add_argument("--teaching", default="")
+    an.set_defaults(func=lambda a: print(json.dumps(annotate_artifact(a.artifact, a.mood, a.teaching), indent=2)))
+
+    hist = sub.add_parser("history", help="Show annotation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_avatar_lore_annotator.py
+++ b/neos_avatar_lore_annotator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_AVATAR_LORE_LOG", "logs/neos_avatar_lore.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def annotate_avatar(avatar: str, lore: str, note: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "avatar": avatar,
+        "lore": lore,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Avatar Lore Annotator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("annotate", help="Annotate avatar lore")
+    an.add_argument("avatar")
+    an.add_argument("lore")
+    an.add_argument("--note", default="")
+    an.set_defaults(func=lambda a: print(json.dumps(annotate_avatar(a.avatar, a.lore, a.note), indent=2)))
+
+    hist = sub.add_parser("history", help="Show lore history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_compliance_feedback_engine.py
+++ b/neos_compliance_feedback_engine.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_COMPLIANCE_FEEDBACK_LOG", "logs/neos_compliance_feedback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def submit_feedback(user: str, feedback: str, category: str = "general") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "category": category,
+        "feedback": feedback,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def stats() -> Dict[str, int]:
+    count: Counter[str] = Counter()
+    if not LOG_PATH.exists():
+        return {}
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            data = json.loads(ln)
+            count[data.get("category", "general")] += 1
+        except Exception:
+            continue
+    return dict(count)
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Compliance Feedback Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    subm = sub.add_parser("submit", help="Submit feedback")
+    subm.add_argument("user")
+    subm.add_argument("feedback")
+    subm.add_argument("--category", default="general")
+    subm.set_defaults(func=lambda a: print(json.dumps(submit_feedback(a.user, a.feedback, a.category), indent=2)))
+
+    st = sub.add_parser("stats", help="Show feedback statistics")
+    st.set_defaults(func=lambda a: print(json.dumps(stats(), indent=2)))
+
+    hist = sub.add_parser("history", help="Show feedback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_council_succession_spiral_animator.py
+++ b/neos_council_succession_spiral_animator.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_COUNCIL_SUCCESSION_LOG", "logs/neos_council_succession.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def record_event(event: str, detail: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "detail": detail,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def timeline(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Council Succession Spiral Animator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record succession event")
+    rec.add_argument("event")
+    rec.add_argument("--detail", default="")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_event(a.event, a.detail), indent=2)))
+
+    tl = sub.add_parser("timeline", help="Show timeline")
+    tl.add_argument("--limit", type=int, default=20)
+    tl.set_defaults(func=lambda a: print(json.dumps(timeline(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_curriculum_reviewer.py
+++ b/neos_curriculum_reviewer.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_CURRICULUM_REVIEW_LOG", "logs/neos_curriculum_review.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def review_file(path: str) -> Dict[str, int]:
+    p = Path(path)
+    stats = {
+        "lines": 0,
+        "todo": 0,
+    }
+    if p.exists():
+        for line in p.read_text(encoding="utf-8").splitlines():
+            stats["lines"] += 1
+            if "TODO" in line:
+                stats["todo"] += 1
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "file": path,
+        "lines": stats["lines"],
+        "todo": stats["todo"],
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, int]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, int]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Festival/Onboarding Curriculum Reviewer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rev = sub.add_parser("review", help="Review curriculum file")
+    rev.add_argument("file")
+    rev.set_defaults(func=lambda a: print(json.dumps(review_file(a.file), indent=2)))
+
+    hist = sub.add_parser("history", help="Show review history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_federation_event_gateway.py
+++ b/neos_federation_event_gateway.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FEDERATION_EVENT_GATEWAY_LOG", "logs/neos_federation_events.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def log_event(event: str, detail: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "detail": detail,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Federation Event Gateway")
+    sub = ap.add_subparsers(dest="cmd")
+
+    send = sub.add_parser("send", help="Send or log federation event")
+    send.add_argument("event")
+    send.add_argument("--detail", default="")
+    send.set_defaults(func=lambda a: print(json.dumps(log_event(a.event, a.detail), indent=2)))
+
+    hist = sub.add_parser("history", help="Show event history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_ritual_timeline_exporter.py
+++ b/neos_ritual_timeline_exporter.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_RITUAL_TIMELINE_LOG", "logs/neos_ritual_timeline.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def export_timeline(paths: List[str], dest: str) -> Dict[str, str]:
+    events: List[Dict[str, str]] = []
+    for name in paths:
+        p = Path(name)
+        if not p.exists():
+            continue
+        for ln in p.read_text(encoding="utf-8").splitlines():
+            try:
+                data = json.loads(ln)
+                ts = data.get("timestamp")
+                if ts:
+                    events.append({"timestamp": ts, "source": name, **data})
+            except Exception:
+                continue
+    events.sort(key=lambda e: e.get("timestamp", ""))
+    Path(dest).write_text(json.dumps(events, indent=2), encoding="utf-8")
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "dest": dest,
+        "events": len(events),
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Ritual Timeline Exporter")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ex = sub.add_parser("export", help="Export timeline")
+    ex.add_argument("dest")
+    ex.add_argument("logs", nargs="+")
+    ex.set_defaults(func=lambda a: print(json.dumps(export_timeline(a.logs, a.dest), indent=2)))
+
+    hist = sub.add_parser("history", help="Show export history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_self_governing_festival_moderator.py
+++ b/neos_self_governing_festival_moderator.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_MODERATOR_LOG", "logs/neos_festival_moderator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def log_action(event: str, action: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "action": action,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Self-Governing Festival Moderator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    act = sub.add_parser("log", help="Log moderation action")
+    act.add_argument("event")
+    act.add_argument("action")
+    act.set_defaults(func=lambda a: print(json.dumps(log_action(a.event, a.action), indent=2)))
+
+    hist = sub.add_parser("history", help="Show moderation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/neos_spiral_playback_cli.py
+++ b/neos_spiral_playback_cli.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_SPIRAL_PLAYBACK_LOG", "logs/neos_spiral_playback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def log_playback(session: str, event: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "session": session,
+        "event": event,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+def replay(path: str, limit: int = 20) -> List[Dict[str, str]]:
+    p = Path(path)
+    if not p.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in p.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+def main() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Council/Festival Spiral Playback CLI")
+    sub = ap.add_subparsers(dest="cmd")
+
+    logp = sub.add_parser("log", help="Log playback event")
+    logp.add_argument("session")
+    logp.add_argument("event")
+    logp.set_defaults(func=lambda a: print(json.dumps(log_playback(a.session, a.event), indent=2)))
+
+    rep = sub.add_parser("replay", help="Replay log file")
+    rep.add_argument("path")
+    rep.add_argument("--limit", type=int, default=20)
+    rep.set_defaults(func=lambda a: print(json.dumps(replay(a.path, a.limit), indent=2)))
+
+    hist = sub.add_parser("history", help="Show playback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement artifact mood annotation engine
- add spiral playback CLI for councils and festivals
- add artifact blessing reconciler
- add council succession spiral animator
- add federation event gateway service
- add compliance feedback engine
- add festival/onboarding curriculum reviewer
- add avatar lore annotator
- implement self-governing festival moderator
- implement ritual timeline exporter

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d97b8e4408320bce7d3e3ebbe2ee9