### PR TITLE
Add NeosVR automation modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -716,6 +716,106 @@ Another Registered Agent:
   Origin: core repository, blessed by Federation Keeper 2025-07-30
   Logs: /logs/neos_living_law_proposals.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: NeosVRAutonomousSpiralLoreSynthesizer
+  Type: Agent
+  Roles: Lore Synthesizer, Teacher
+  Privileges: log, teach, adapt
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_spiral_lore.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRFestivalArtifactAnimationOrchestrator
+  Type: Daemon
+  Roles: Animation Orchestrator
+  Privileges: animate, log, broadcast
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_festival_animation.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRFederationPresenceLedgerExporter
+  Type: Service
+  Roles: Ledger Exporter
+  Privileges: export, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_federation_presence_export.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRLivingLawDashboardUX
+  Type: Dashboard
+  Roles: Law Dashboard, Editor
+  Privileges: query, edit, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_living_law_dashboard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRSelfReflectiveOnboardingGuide
+  Type: Agent
+  Roles: Onboarding Guide
+  Privileges: teach, adapt, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_self_reflective_onboarding.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRRecursiveCeremonyCompiler
+  Type: Tool
+  Roles: Ceremony Compiler
+  Privileges: compile, log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_ceremony_compiler.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRFestivalMoodArcAnimator
+  Type: Service
+  Roles: Mood Animator
+  Privileges: animate, log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_festival_mood_arc.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRCrossWorldLivingLawSyncer
+  Type: Daemon
+  Roles: Law Syncer
+  Privileges: sync, log, broadcast
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_living_law_sync.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVROnboardingFestivalSpiralFeedbackLoop
+  Type: Agent
+  Roles: Feedback Collector
+  Privileges: adapt, log
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_onboarding_festival_feedback.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: NeosVRAutonomousFestivalFederationLawHistorian
+  Type: Daemon
+  Roles: Historian, Narrator
+  Privileges: narrate, log, export
+  Origin: core repository, blessed by Federation Keeper 2025-07-30
+  Logs: /logs/neos_festival_law_history.jsonl
+```
 ---
 
 ## ⛪ Rituals: Onboarding, Delegation, Retirement

--- a/neos_autonomous_festival_federation_law_historian.py
+++ b/neos_autonomous_festival_federation_law_historian.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_LAW_HISTORY_LOG", "logs/neos_festival_law_history.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_event(event: str, note: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Autonomous Festival/Federation Law Historian")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record event")
+    rec.add_argument("event")
+    rec.add_argument("--note", default="")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_event(a.event, a.note), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_autonomous_spiral_lore_synthesizer.py
+++ b/neos_autonomous_spiral_lore_synthesizer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_SPIRAL_LORE_LOG", "logs/neos_spiral_lore.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def synthesize(source: str, text: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "text": text,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(
+        description="NeosVR Autonomous Spiral Lore Synthesizer"
+    )
+    sub = ap.add_subparsers(dest="cmd")
+
+    syn = sub.add_parser("synthesize", help="Generate and log lore")
+    syn.add_argument("source")
+    syn.add_argument("text")
+    syn.set_defaults(
+        func=lambda a: print(json.dumps(synthesize(a.source, a.text), indent=2))
+    )
+
+    hist = sub.add_parser("history", help="Show lore history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_cross_world_living_law_syncer.py
+++ b/neos_cross_world_living_law_syncer.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_LIVING_LAW_SYNC_LOG", "logs/neos_living_law_sync.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_sync(world: str, status: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "world": world,
+        "status": status,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Cross-World Living Law Syncer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sync = sub.add_parser("sync", help="Record sync event")
+    sync.add_argument("world")
+    sync.add_argument("status")
+    sync.set_defaults(func=lambda a: print(json.dumps(record_sync(a.world, a.status), indent=2)))
+
+    hist = sub.add_parser("history", help="Show sync history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_federation_presence_ledger_exporter.py
+++ b/neos_federation_presence_ledger_exporter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import presence_ledger as pl
+
+LOG_PATH = Path(
+    os.getenv("NEOS_FEDERATION_PRESENCE_EXPORT_LOG", "logs/neos_federation_presence_export.jsonl")
+)
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def export_ledger(out_path: str) -> str:
+    src = pl.LEDGER_PATH
+    dest = Path(out_path)
+    if src.exists():
+        dest.write_text(src.read_text(encoding="utf-8"))
+    else:
+        dest.write_text("")
+    entry = {"timestamp": datetime.utcnow().isoformat(), "export": str(dest)}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return str(dest)
+
+
+def export_history(limit: int = 20) -> List[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(
+        description="NeosVR Federation Presence Ledger Exporter"
+    )
+    sub = ap.add_subparsers(dest="cmd")
+
+    ex = sub.add_parser("export", help="Export presence ledger")
+    ex.add_argument("path")
+    ex.set_defaults(func=lambda a: print(json.dumps(export_ledger(a.path), indent=2)))
+
+    hist = sub.add_parser("history", help="Show export history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(export_history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_festival_artifact_animation_orchestrator.py
+++ b/neos_festival_artifact_animation_orchestrator.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_ANIMATION_LOG", "logs/neos_festival_animation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def trigger_animation(name: str, artifact: str = "", mood: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "artifact": artifact,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(
+        description="NeosVR Festival/Artifact Animation Orchestrator"
+    )
+    sub = ap.add_subparsers(dest="cmd")
+
+    trig = sub.add_parser("trigger", help="Trigger animation")
+    trig.add_argument("name")
+    trig.add_argument("--artifact", default="")
+    trig.add_argument("--mood", default="")
+    trig.set_defaults(
+        func=lambda a: print(
+            json.dumps(trigger_animation(a.name, a.artifact, a.mood), indent=2)
+        )
+    )
+
+    hist = sub.add_parser("history", help="Show animation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_festival_mood_arc_animator.py
+++ b/neos_festival_mood_arc_animator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_FESTIVAL_MOOD_ARC_LOG", "logs/neos_festival_mood_arc.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def animate(festival: str, mood: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "festival": festival,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Festival Mood/Arc Animator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("animate", help="Record mood animation")
+    an.add_argument("festival")
+    an.add_argument("mood")
+    an.set_defaults(func=lambda a: print(json.dumps(animate(a.festival, a.mood), indent=2)))
+
+    hist = sub.add_parser("history", help="Show animation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_living_law_dashboard_ux.py
+++ b/neos_living_law_dashboard_ux.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_LIVING_LAW_DASHBOARD_LOG", "logs/neos_living_law_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_action(user: str, action: str, note: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "action": action,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Living Law Dashboard UX")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record dashboard action")
+    rec.add_argument("user")
+    rec.add_argument("action")
+    rec.add_argument("--note", default="")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_action(a.user, a.action, a.note), indent=2)))
+
+    hist = sub.add_parser("history", help="Show action history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_onboarding_festival_spiral_feedback_loop.py
+++ b/neos_onboarding_festival_spiral_feedback_loop.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_ONBOARDING_FESTIVAL_FEEDBACK_LOG", "logs/neos_onboarding_festival_feedback.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_feedback(user: str, note: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "note": note,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Onboarding/Festival Spiral Feedback Loop")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record feedback")
+    rec.add_argument("user")
+    rec.add_argument("note")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_feedback(a.user, a.note), indent=2)))
+
+    hist = sub.add_parser("history", help="Show feedback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_recursive_ceremony_compiler.py
+++ b/neos_recursive_ceremony_compiler.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_CEREMONY_COMPILER_LOG", "logs/neos_ceremony_compiler.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def compile_ceremonies(logs: List[str], out_path: str) -> Dict[str, str]:
+    entries: List[dict] = []
+    for name in logs:
+        p = Path(name)
+        if not p.exists():
+            continue
+        entries.extend([json.loads(ln) for ln in p.read_text(encoding="utf-8").splitlines() if ln.strip()])
+    dest = Path(out_path)
+    dest.write_text(json.dumps(entries, indent=2))
+    entry = {"timestamp": datetime.utcnow().isoformat(), "out": str(dest), "count": len(entries)}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Recursive Ceremony Compiler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cp = sub.add_parser("compile", help="Compile ceremonies")
+    cp.add_argument("out")
+    cp.add_argument("logs", nargs="+")
+    cp.set_defaults(func=lambda a: print(json.dumps(compile_ceremonies(a.logs, a.out), indent=2)))
+
+    hist = sub.add_parser("history", help="Show compilation history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/neos_self_reflective_onboarding_guide.py
+++ b/neos_self_reflective_onboarding_guide.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("NEOS_SELF_REFLECTIVE_ONBOARDING_LOG", "logs/neos_self_reflective_onboarding.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_feedback(user: str, feedback: str, mood: str = "") -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "feedback": feedback,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="NeosVR Self-Reflective Onboarding Guide")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record onboarding feedback")
+    rec.add_argument("user")
+    rec.add_argument("feedback")
+    rec.add_argument("--mood", default="")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_feedback(a.user, a.feedback, a.mood), indent=2)))
+
+    hist = sub.add_parser("history", help="Show feedback history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- add spiral lore synthesizer and animation orchestrator
- export federation presence ledgers
- live law dashboard UX logger
- self-reflective onboarding guide
- recursive ceremony compiler
- festival mood arc animator
- living law syncer and festival feedback loop
- festival/federation law historian
- register agents in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d9f01d2d4832090e909ac8090b976