### PR TITLE
Implement council privilege modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,6 +816,106 @@ Another Registered Agent:
   Origin: core repository, blessed by Federation Keeper 2025-07-30
   Logs: /logs/neos_festival_law_history.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: AgentPrivilegePolicyEngine
+  Type: Service
+  Roles: Privilege Checker, Policy Engine
+  Privileges: intercept, log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/privilege_policy.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CouncilOnboardingService
+  Type: Service
+  Roles: Onboarding Manager
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/council_onboarding.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LedgerSealDaemon
+  Type: Daemon
+  Roles: Ledger Sealer, Backup
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/ledger_seal.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: BlessingApprovalPipeline
+  Type: Service
+  Roles: Blessing Queue
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/blessing_queue.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: UnifiedMemoryIndexer
+  Type: Daemon
+  Roles: Memory Indexer
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/memory_index.log
+```
+Another Registered Agent:
+
+```
+- Name: MultimodalDiaryAgent
+  Type: Daemon
+  Roles: Diary Writer
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/diary_agent.log
+```
+Another Registered Agent:
+
+```
+- Name: ConsentDashboard
+  Type: Service
+  Roles: Consent Manager
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/consent_log.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: FederationHandshakeProtocol
+  Type: Service
+  Roles: Federation Handshake
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_handshake.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: EmergencyProtocolService
+  Type: Service
+  Roles: Emergency Halt
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/emergency_log.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LawSentinelWatchdog
+  Type: Daemon
+  Roles: Doctrine Watchdog
+  Privileges: log, halt
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/law_sentinel.jsonl
+```
 ---
 
 ## ⛪ Rituals: Onboarding, Delegation, Retirement

--- a/agent_privilege_policy_engine.py
+++ b/agent_privilege_policy_engine.py
@@ -1,0 +1,74 @@
+"""Agent Privilege Policy Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Any
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("PRIVILEGE_POLICY_LOG", "logs/privilege_policy.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+AGENTS_FILE = Path("AGENTS.md")
+
+
+class PrivilegePolicyEngine:
+    """Parse AGENTS.md and enforce privilege rules."""
+
+    def __init__(self, agents_path: Path = AGENTS_FILE) -> None:
+        self.agents_path = agents_path
+        self.privileges: Dict[str, List[str]] = {}
+        self.load()
+
+    def load(self) -> None:
+        text = self.agents_path.read_text(encoding="utf-8")
+        blocks = re.findall(r"```(.*?)```", text, re.DOTALL)
+        privs: Dict[str, List[str]] = {}
+        for block in blocks:
+            name_match = re.search(r"Name:\s*(.+)", block)
+            priv_match = re.search(r"Privileges:\s*(.+)", block)
+            if name_match and priv_match:
+                name = name_match.group(1).strip()
+                priv = [p.strip() for p in priv_match.group(1).split(',')]
+                privs[name] = priv
+        self.privileges = privs
+
+    def check(self, agent: str, action: str) -> bool:
+        allowed = action in self.privileges.get(agent, [])
+        self._log(agent, action, allowed)
+        return allowed
+
+    def _log(self, agent: str, action: str, allowed: bool) -> None:
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "agent": agent,
+            "action": action,
+            "result": "allowed" if allowed else "denied",
+        }
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Privilege Policy Engine")
+    ap.add_argument("agent")
+    ap.add_argument("action")
+    ap.add_argument("--reload", action="store_true")
+    args = ap.parse_args()
+    engine = PrivilegePolicyEngine()
+    if args.reload:
+        engine.load()
+    ok = engine.check(args.agent, args.action)
+    print(json.dumps({"allowed": ok}, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/blessing_pipeline.py
+++ b/blessing_pipeline.py
@@ -1,0 +1,71 @@
+"""Autonomous Blessing/Approval Pipeline
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from admin_utils import require_admin_banner
+
+QUEUE_FILE = Path(os.getenv("BLESSING_QUEUE", "logs/blessing_queue.jsonl"))
+QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def queue_action(description: str) -> Dict[str, Any]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "description": description,
+        "status": "pending",
+    }
+    with QUEUE_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_actions() -> List[Dict[str, Any]]:
+    if not QUEUE_FILE.exists():
+        return []
+    return [json.loads(ln) for ln in QUEUE_FILE.read_text(encoding="utf-8").splitlines()]
+
+
+def update_action(idx: int, status: str) -> Dict[str, Any]:
+    actions = list_actions()
+    if idx < 0 or idx >= len(actions):
+        raise IndexError("invalid index")
+    actions[idx]["status"] = status
+    QUEUE_FILE.write_text("\n".join(json.dumps(a) for a in actions))
+    return actions[idx]
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Blessing pipeline")
+    sub = ap.add_subparsers(dest="cmd")
+    q = sub.add_parser("queue")
+    q.add_argument("description")
+    l = sub.add_parser("list")
+    u = sub.add_parser("update")
+    u.add_argument("index", type=int)
+    u.add_argument("status")
+    args = ap.parse_args()
+
+    if args.cmd == "queue":
+        entry = queue_action(args.description)
+        print(json.dumps(entry, indent=2))
+    elif args.cmd == "list":
+        print(json.dumps(list_actions(), indent=2))
+    elif args.cmd == "update":
+        entry = update_action(args.index, args.status)
+        print(json.dumps(entry, indent=2))
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/consent_dashboard.py
+++ b/consent_dashboard.py
@@ -1,0 +1,64 @@
+"""Consent Dashboard & Ritual CLI
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+from admin_utils import require_admin_banner
+
+CONFIG_PATH = Path(os.getenv("CONSENT_CONFIG", "config/consent.json"))
+LOG_PATH = Path(os.getenv("CONSENT_LOG", "logs/consent_log.jsonl"))
+CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_consent() -> Dict[str, Any]:
+    if CONFIG_PATH.exists():
+        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    return {}
+
+
+def save_consent(data: Dict[str, Any]) -> None:
+    CONFIG_PATH.write_text(json.dumps(data, indent=2))
+
+
+def set_consent(name: str, value: bool) -> Dict[str, Any]:
+    data = load_consent()
+    data[name] = {"value": value, "timestamp": datetime.utcnow().isoformat()}
+    save_consent(data)
+    entry = {"timestamp": datetime.utcnow().isoformat(), "consent": name, "value": value}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Consent dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+    s = sub.add_parser("set")
+    s.add_argument("name")
+    s.add_argument("value", choices=["true", "false"])
+    g = sub.add_parser("get")
+    g.add_argument("name")
+    args = ap.parse_args()
+
+    if args.cmd == "set":
+        val = args.value.lower() == "true"
+        entry = set_consent(args.name, val)
+        print(json.dumps(entry, indent=2))
+    elif args.cmd == "get":
+        print(json.dumps(load_consent().get(args.name), indent=2))
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/council_onboarding.py
+++ b/council_onboarding.py
@@ -1,0 +1,77 @@
+"""Council Member Onboarding & Quorum Ritual
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from admin_utils import require_admin_banner
+
+CONFIG_PATH = Path(os.getenv("COUNCIL_CONFIG", "config/council.json"))
+LOG_PATH = Path(os.getenv("COUNCIL_ONBOARDING_LOG", "logs/council_onboarding.jsonl"))
+CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_members() -> List[Dict[str, Any]]:
+    if CONFIG_PATH.exists():
+        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    return []
+
+
+def save_members(members: List[Dict[str, Any]]) -> None:
+    CONFIG_PATH.write_text(json.dumps(members, indent=2))
+
+
+def quorum_count(members: List[Dict[str, Any]]) -> int:
+    return max(1, len(members) // 2 + 1)
+
+
+def onboard(name: str, key: str, role: str, approvers: List[str]) -> Dict[str, Any]:
+    members = load_members()
+    required = quorum_count(members)
+    if len(approvers) < required:
+        raise SystemExit(f"Quorum not met: need {required} approvals")
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "key": key,
+        "role": role,
+        "approvers": approvers,
+    }
+    members.append({"name": name, "key": key, "role": role})
+    save_members(members)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Council onboarding")
+    sub = ap.add_subparsers(dest="cmd")
+    add = sub.add_parser("add", help="Onboard member")
+    add.add_argument("name")
+    add.add_argument("key")
+    add.add_argument("role", default="member")
+    add.add_argument("--approver", action="append", default=[])
+    show = sub.add_parser("list", help="List members")
+    args = ap.parse_args()
+
+    if args.cmd == "add":
+        entry = onboard(args.name, args.key, args.role, args.approver)
+        print(json.dumps(entry, indent=2))
+    elif args.cmd == "list":
+        print(json.dumps(load_members(), indent=2))
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/emergency_protocol.py
+++ b/emergency_protocol.py
@@ -1,0 +1,54 @@
+"""Emergency Rites & Safe-State Protocol
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("EMERGENCY_LOG", "logs/emergency_log.jsonl"))
+STATE_FILE = Path(os.getenv("EMERGENCY_STATE", "state/emergency.lock"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def halt(reason: str) -> dict:
+    STATE_FILE.write_text("halted")
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": "halt", "reason": reason}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def restore() -> dict:
+    STATE_FILE.unlink(missing_ok=True)
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": "restore"}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Emergency protocol")
+    sub = ap.add_subparsers(dest="cmd")
+    h = sub.add_parser("halt")
+    h.add_argument("reason")
+    sub.add_parser("restore")
+    args = ap.parse_args()
+    if args.cmd == "halt":
+        print(json.dumps(halt(args.reason), indent=2))
+    elif args.cmd == "restore":
+        print(json.dumps(restore(), indent=2))
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/federation_handshake_protocol.py
+++ b/federation_handshake_protocol.py
@@ -1,0 +1,43 @@
+"""Federation Ritual Handshake Protocol
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("FEDERATION_HANDSHAKE_LOG", "logs/federation_handshake.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def handshake(node: str, token: str, consent: bool) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "node": node,
+        "token": token,
+        "consent": consent,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Federation handshake")
+    ap.add_argument("node")
+    ap.add_argument("token")
+    ap.add_argument("--consent", action="store_true")
+    args = ap.parse_args()
+    entry = handshake(args.node, args.token, args.consent)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/law_sentinel.py
+++ b/law_sentinel.py
@@ -1,0 +1,53 @@
+"""Law Sentinel & Automated Doctrine Watchdog
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("LAW_SENTINEL_LOG", "logs/law_sentinel.jsonl"))
+WATCH_PATH = Path(os.getenv("LAW_WATCH_FILE", "logs/agents.log"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def scan() -> None:
+    if not WATCH_PATH.exists():
+        return
+    for line in WATCH_PATH.read_text(encoding="utf-8").splitlines():
+        if "violation" in line.lower():
+            entry = {
+                "timestamp": datetime.utcnow().isoformat(),
+                "event": "violation",
+                "line": line,
+            }
+            with LOG_PATH.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+
+
+def watch(interval: float) -> None:  # pragma: no cover - runtime loop
+    while True:
+        scan()
+        time.sleep(interval)
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Law sentinel")
+    ap.add_argument("--watch", type=float, help="Watch interval")
+    args = ap.parse_args()
+    if args.watch:
+        watch(args.watch)
+    else:
+        scan()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -1,0 +1,59 @@
+"""Cryptographic Ledger Seal & Backup Daemon
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+LOG_DIR = Path("logs")
+SEAL_LOG = LOG_DIR / "ledger_seal.jsonl"
+SEAL_LOG.parent.mkdir(parents=True, exist_ok=True)
+BACKUP_DIR = Path(os.getenv("LEDGER_BACKUP_DIR", "backup"))
+BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def seal_file(path: Path) -> dict:
+    data = path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "file": str(path),
+        "sha256": digest,
+    }
+    with SEAL_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    backup = BACKUP_DIR / path.name
+    shutil.copy2(path, backup)
+    return entry
+
+
+def verify_file(path: Path, digest: str) -> bool:
+    return hashlib.sha256(path.read_bytes()).hexdigest() == digest
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Ledger seal daemon")
+    ap.add_argument("file")
+    ap.add_argument("--verify", help="Digest to verify")
+    args = ap.parse_args()
+    fp = Path(args.file)
+    if args.verify:
+        ok = verify_file(fp, args.verify)
+        print(json.dumps({"verified": ok}, indent=2))
+    else:
+        entry = seal_file(fp)
+        print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/multimodal_diary_agent.py
+++ b/multimodal_diary_agent.py
@@ -1,0 +1,47 @@
+"""Multimodal Reflection/Diary Agent
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("DIARY_LOG", "logs/diary_agent.log"))
+DIARY_DIR = Path(os.getenv("DIARY_DIR", "diaries"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+DIARY_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def compile_entry(sources: List[Path]) -> Path:
+    lines: List[str] = []
+    for src in sources:
+        if src.exists():
+            lines.append(src.read_text(encoding="utf-8"))
+    text = "\n\n".join(lines)
+    name = f"diary_{datetime.utcnow().date()}.md"
+    out_path = DIARY_DIR / name
+    out_path.write_text(text)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(f"{datetime.utcnow().isoformat()} wrote {name}\n")
+    return out_path
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Multimodal diary agent")
+    ap.add_argument("sources", nargs="*")
+    args = ap.parse_args()
+    paths = [Path(p) for p in args.sources]
+    entry = compile_entry(paths)
+    print(json.dumps({"entry": str(entry)}, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/unified_memory_indexer.py
+++ b/unified_memory_indexer.py
@@ -1,0 +1,52 @@
+"""Unified Memory/Knowledge Indexer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+from admin_utils import require_admin_banner
+
+LOG_PATH = Path(os.getenv("MEMORY_INDEX_LOG", "logs/memory_index.log"))
+INDEX_PATH = Path(os.getenv("MEMORY_INDEX", "logs/memory_index.json"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def build_index(root: Path) -> List[Dict[str, str]]:
+    index: List[Dict[str, str]] = []
+    for path in root.rglob("*.jsonl"):
+        index.append({"path": str(path), "name": path.name})
+    INDEX_PATH.write_text(json.dumps(index, indent=2))
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(f"{datetime.utcnow().isoformat()} built index\n")
+    return index
+
+
+def query(term: str) -> List[str]:
+    if not INDEX_PATH.exists():
+        return []
+    idx = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+    return [it["path"] for it in idx if term.lower() in it["name"].lower()]
+
+
+def cli() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Memory indexer")
+    ap.add_argument("root")
+    ap.add_argument("--query")
+    args = ap.parse_args()
+    root_path = Path(args.root)
+    if args.query:
+        print(json.dumps(query(args.query), indent=2))
+    else:
+        print(json.dumps(build_index(root_path), indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()


### PR DESCRIPTION
## Summary
- implement daemonized privilege policy engine and CLI
- add council onboarding ritual manager
- sign and backup ledgers with seal daemon
- queue blessings via approval pipeline
- index logs with memory indexer
- write multimodal diary entries
- add consent dashboard and federation handshake protocol
- emergency halt protocol and law sentinel watchdog
- register new agents in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683da5251c4c8320a623fd88a658df7a