### PR TITLE
Implement spiral modules 311-320

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -916,6 +916,106 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/law_sentinel.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: CreativeSpiralScheduler
+  Type: Daemon
+  Roles: Creative Trigger
+  Privileges: schedule, log
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/creative_spiral_schedule.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CreativeActReflectionEngine
+  Type: Service
+  Roles: Reflection Logger
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/creative_reflection.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: SpiralTeachingCompanion
+  Type: Agent
+  Roles: Teaching Guide
+  Privileges: narrate, log
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/spiral_teaching_companion.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CrossGameOnboardingSyncer
+  Type: Daemon
+  Roles: Onboarding Sync
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/onboarding_sync.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LoreSpiralExportAgent
+  Type: Service
+  Roles: Lore Synthesizer, Exporter
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/lore_spiral_synthesis.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LawLoreAnimationOrchestrator
+  Type: Service
+  Roles: Animation Director
+  Privileges: log, animate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/law_lore_animation.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CeremonyExporter
+  Type: Service
+  Roles: Ceremony Archive
+  Privileges: export, log
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/ceremony_exporter.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CreativeArtifactFederationAgent
+  Type: Service
+  Roles: Artifact Federator
+  Privileges: log, exchange
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/creative_federation.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: TeachingReflectionFeedbackLoop
+  Type: Daemon
+  Roles: Feedback Collector
+  Privileges: log, adapt
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/teaching_feedback.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CrossWorldPrivilegeConflictResolver
+  Type: Service
+  Roles: Privilege Monitor
+  Privileges: log, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/privilege_conflict.jsonl
+```
 ---
 
 ## ⛪ Rituals: Onboarding, Delegation, Retirement

--- a/creative_act_reflection_engine.py
+++ b/creative_act_reflection_engine.py
@@ -1,0 +1,67 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+REFLECTION_LOG = Path(os.getenv("CREATIVE_REFLECTION_LOG", "logs/creative_reflection.jsonl"))
+REFLECTION_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_reflection(act: str, comment: str, rating: int, author: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "act": act,
+        "comment": comment,
+        "rating": rating,
+        "author": author,
+    }
+    with REFLECTION_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_reflections(act: str = "") -> List[Dict[str, str]]:
+    if not REFLECTION_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in REFLECTION_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            continue
+        if act and obj.get("act") != act:
+            continue
+        out.append(obj)
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Creative Act Reflection & Iteration Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    add = sub.add_parser("add", help="Add reflection")
+    add.add_argument("act")
+    add.add_argument("comment")
+    add.add_argument("--rating", type=int, default=0)
+    add.add_argument("--author", default="")
+    add.set_defaults(func=lambda a: print(json.dumps(log_reflection(a.act, a.comment, a.rating, a.author), indent=2)))
+
+    ls = sub.add_parser("list", help="List reflections")
+    ls.add_argument("--act", default="")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_reflections(a.act), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/creative_artifact_federation_agent.py
+++ b/creative_artifact_federation_agent.py
@@ -1,0 +1,77 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+FED_LOG = Path(os.getenv("CREATIVE_FED_LOG", "logs/creative_federation.jsonl"))
+FED_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def send_artifact(path: Path, partner: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "artifact": str(path),
+        "partner": partner,
+        "action": "send",
+    }
+    with FED_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def receive_artifact(path: Path, partner: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "artifact": str(path),
+        "partner": partner,
+        "action": "receive",
+    }
+    with FED_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> List[Dict[str, str]]:
+    if not FED_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in FED_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Creative/Artifact Federation Agent")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sd = sub.add_parser("send", help="Send artifact")
+    sd.add_argument("path")
+    sd.add_argument("partner")
+    sd.set_defaults(func=lambda a: print(json.dumps(send_artifact(Path(a.path), a.partner), indent=2)))
+
+    rv = sub.add_parser("receive", help="Receive artifact")
+    rv.add_argument("path")
+    rv.add_argument("partner")
+    rv.set_defaults(func=lambda a: print(json.dumps(receive_artifact(Path(a.path), a.partner), indent=2)))
+
+    ls = sub.add_parser("history", help="Show federation history")
+    ls.set_defaults(func=lambda a: print(json.dumps(history(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/creative_spiral_scheduler.py
+++ b/creative_spiral_scheduler.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+SCHEDULE_LOG = Path(os.getenv("CREATIVE_SPIRAL_SCHEDULE_LOG", "logs/creative_spiral_schedule.jsonl"))
+TRIGGER_LOG = Path(os.getenv("CREATIVE_SPIRAL_TRIGGER_LOG", "logs/creative_spiral_trigger.jsonl"))
+SCHEDULE_LOG.parent.mkdir(parents=True, exist_ok=True)
+TRIGGER_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def schedule(creator: str, kind: str, when: str, tags: List[str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "creator": creator,
+        "kind": kind,
+        "when": when,
+        "tags": tags,
+    }
+    with SCHEDULE_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def trigger(creator: str, kind: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "creator": creator,
+        "kind": kind,
+    }
+    with TRIGGER_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_schedule() -> List[Dict[str, str]]:
+    if not SCHEDULE_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in SCHEDULE_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Autonomous Creative Spiral Scheduler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("schedule", help="Schedule a creative act")
+    sc.add_argument("creator")
+    sc.add_argument("kind")
+    sc.add_argument("--when", default="")
+    sc.add_argument("--tags", default="")
+    sc.set_defaults(func=lambda a: print(json.dumps(schedule(a.creator, a.kind, a.when, [t for t in a.tags.split(',') if t]), indent=2)))
+
+    tr = sub.add_parser("trigger", help="Trigger a creative act")
+    tr.add_argument("creator")
+    tr.add_argument("kind")
+    tr.set_defaults(func=lambda a: print(json.dumps(trigger(a.creator, a.kind), indent=2)))
+
+    ls = sub.add_parser("list", help="List scheduled acts")
+    ls.set_defaults(func=lambda a: print(json.dumps(list_schedule(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/cross_game_onboarding_syncer.py
+++ b/cross_game_onboarding_syncer.py
@@ -1,0 +1,64 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+SYNC_LOG = Path(os.getenv("ONBOARDING_SYNC_LOG", "logs/onboarding_sync.jsonl"))
+SYNC_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record(user: str, world: str, stage: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "world": world,
+        "stage": stage,
+    }
+    with SYNC_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def progress(user: str) -> List[Dict[str, str]]:
+    if not SYNC_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in SYNC_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            continue
+        if obj.get("user") == user:
+            out.append(obj)
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Cross-Game/Cathedral Onboarding Syncer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record progress")
+    rec.add_argument("user")
+    rec.add_argument("world")
+    rec.add_argument("stage")
+    rec.set_defaults(func=lambda a: print(json.dumps(record(a.user, a.world, a.stage), indent=2)))
+
+    pg = sub.add_parser("progress", help="Show progress")
+    pg.add_argument("user")
+    pg.set_defaults(func=lambda a: print(json.dumps(progress(a.user), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/cross_world_privilege_resolver.py
+++ b/cross_world_privilege_resolver.py
@@ -1,0 +1,59 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+CONFLICT_LOG = Path(os.getenv("PRIVILEGE_CONFLICT_LOG", "logs/privilege_conflict.jsonl"))
+CONFLICT_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_conflict(world: str, detail: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "world": world,
+        "detail": detail,
+    }
+    with CONFLICT_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> List[Dict[str, str]]:
+    if not CONFLICT_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in CONFLICT_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Cross-World Privilege Drift/Conflict Resolver")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a conflict")
+    lg.add_argument("world")
+    lg.add_argument("detail")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_conflict(a.world, a.detail), indent=2)))
+
+    ls = sub.add_parser("history", help="Show conflicts")
+    ls.set_defaults(func=lambda a: print(json.dumps(history(), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/festival_onboarding_exporter.py
+++ b/festival_onboarding_exporter.py
@@ -1,0 +1,40 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+EXPORT_LOG = Path(os.getenv("CEREMONY_EXPORT_LOG", "logs/ceremony_exporter.jsonl"))
+EXPORT_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def export_ceremony(src: Path, dest: Path) -> Dict[str, str]:
+    with tarfile.open(dest, "w:gz") as tar:
+        tar.add(src, arcname=src.name)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "src": str(src),
+        "dest": str(dest),
+    }
+    with EXPORT_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival/Onboarding Ceremony Exporter")
+    ap.add_argument("src")
+    ap.add_argument("dest")
+    args = ap.parse_args()
+    entry = export_ceremony(Path(args.src), Path(args.dest))
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/law_lore_animation_orchestrator.py
+++ b/law_lore_animation_orchestrator.py
@@ -1,0 +1,61 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+ANIMATION_LOG = Path(os.getenv("LAW_LORE_ANIMATION_LOG", "logs/law_lore_animation.jsonl"))
+ANIMATION_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def animate(action: str, scene: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        "scene": scene,
+    }
+    with ANIMATION_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not ANIMATION_LOG.exists():
+        return []
+    lines = ANIMATION_LOG.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="In-World Law/Lore Animation Orchestrator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("animate", help="Log animation action")
+    an.add_argument("action")
+    an.add_argument("scene")
+    an.set_defaults(func=lambda a: print(json.dumps(animate(a.action, a.scene), indent=2)))
+
+    ls = sub.add_parser("history", help="Show animation log")
+    ls.add_argument("--limit", type=int, default=20)
+    ls.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/lore_spiral_export_agent.py
+++ b/lore_spiral_export_agent.py
@@ -1,0 +1,71 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LORE_LOG = Path(os.getenv("LORE_SPIRAL_LOG", "logs/lore_spiral_synthesis.jsonl"))
+LORE_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def add_lore(author: str, text: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "author": author,
+        "text": text,
+    }
+    with LORE_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LORE_LOG.exists():
+        return []
+    lines = LORE_LOG.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def export(out: Path, limit: int = 100) -> Path:
+    out.write_text(json.dumps(history(limit), indent=2), encoding="utf-8")
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Lore Spiral Synthesis & Export Agent")
+    sub = ap.add_subparsers(dest="cmd")
+
+    add = sub.add_parser("add", help="Add lore")
+    add.add_argument("author")
+    add.add_argument("text")
+    add.set_defaults(func=lambda a: print(json.dumps(add_lore(a.author, a.text), indent=2)))
+
+    ls = sub.add_parser("history", help="Show lore history")
+    ls.add_argument("--limit", type=int, default=20)
+    ls.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    ex = sub.add_parser("export", help="Export lore to file")
+    ex.add_argument("out")
+    ex.add_argument("--limit", type=int, default=100)
+    ex.set_defaults(func=lambda a: print(str(export(Path(a.out), a.limit))))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_teaching_companion.py
+++ b/spiral_teaching_companion.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+TEACHING_LOG = Path(os.getenv("SPIRAL_TEACHING_LOG", "logs/spiral_teaching_companion.jsonl"))
+TEACHING_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def start_session(user: str, lesson: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "lesson": lesson,
+        "progress": 0,
+    }
+    with TEACHING_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def log_progress(user: str, lesson: str, progress: int) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "lesson": lesson,
+        "progress": progress,
+    }
+    with TEACHING_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(user: str = "") -> List[Dict[str, str]]:
+    if not TEACHING_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in TEACHING_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            continue
+        if user and obj.get("user") != user:
+            continue
+        out.append(obj)
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="In-World Spiral Teaching Companion")
+    sub = ap.add_subparsers(dest="cmd")
+
+    st = sub.add_parser("start", help="Start teaching session")
+    st.add_argument("user")
+    st.add_argument("lesson")
+    st.set_defaults(func=lambda a: print(json.dumps(start_session(a.user, a.lesson), indent=2)))
+
+    pg = sub.add_parser("progress", help="Log progress")
+    pg.add_argument("user")
+    pg.add_argument("lesson")
+    pg.add_argument("percent", type=int)
+    pg.set_defaults(func=lambda a: print(json.dumps(log_progress(a.user, a.lesson, a.percent), indent=2)))
+
+    ls = sub.add_parser("history", help="Show teaching history")
+    ls.add_argument("--user", default="")
+    ls.set_defaults(func=lambda a: print(json.dumps(history(a.user), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/teaching_reflection_feedback_loop.py
+++ b/teaching_reflection_feedback_loop.py
@@ -1,0 +1,63 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+FEEDBACK_LOG = Path(os.getenv("TEACHING_FEEDBACK_LOG", "logs/teaching_feedback.jsonl"))
+FEEDBACK_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_feedback(user: str, comment: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "comment": comment,
+    }
+    with FEEDBACK_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(user: str = "") -> List[Dict[str, str]]:
+    if not FEEDBACK_LOG.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in FEEDBACK_LOG.read_text(encoding="utf-8").splitlines():
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            continue
+        if user and obj.get("user") != user:
+            continue
+        out.append(obj)
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Teaching Reflection Feedback Loop")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record feedback")
+    rec.add_argument("user")
+    rec.add_argument("comment")
+    rec.set_defaults(func=lambda a: print(json.dumps(record_feedback(a.user, a.comment), indent=2)))
+
+    ls = sub.add_parser("history", help="Show feedback history")
+    ls.add_argument("--user", default="")
+    ls.set_defaults(func=lambda a: print(json.dumps(history(a.user), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- remove doc with spiral concepts
- add creative spiral scheduler
- add creative act reflection engine
- add spiral teaching companion
- add cross-game onboarding syncer
- add lore spiral export agent
- add law/lore animation orchestrator
- add ceremony exporter
- add creative artifact federation agent
- add teaching reflection feedback loop
- add cross-world privilege resolver
- register new agents in AGENTS.md

## Testing
- `python privilege_lint.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683daa3eef348320a05935086a3a1816