### PR TITLE
Add festival and healing modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1017,6 +1017,106 @@ Another Registered Agent:
   Logs: /logs/privilege_conflict.jsonl
 ```
 ---
+Another Registered Agent:
+
+```
+- Name: ArtifactLoreSelfHealingEngine
+  Type: Service
+  Roles: Artifact Healer
+  Privileges: log, repair, propose
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/artifact_heal.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: FestivalFederationRitualAIOrchestrator
+  Type: Service
+  Roles: Festival Planner
+  Privileges: log, schedule
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/festival_orchestrator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LivingSpiralLoreTeachingDashboard
+  Type: Dashboard
+  Roles: Lore Viewer, Editor
+  Privileges: query, log, edit
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/spiral_dashboard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AutonomousSelfPatchingAgent
+  Type: Daemon
+  Roles: Self-Healer
+  Privileges: propose, apply, log
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/self_patch_agent.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AvatarArtifactFestivalAIAnimator
+  Type: Service
+  Roles: Festival Animator
+  Privileges: animate, log
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/festival_animator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: FestivalFederationPresenceDiffEngine
+  Type: Service
+  Roles: Presence Diff
+  Privileges: log, compare
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/presence_diff.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: TeachingLoreCurationEngine
+  Type: Service
+  Roles: Lore Curator
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/teaching_curation.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: RitualTimelineVisualizerExporter
+  Type: Service
+  Roles: Timeline Exporter
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/ritual_timeline.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: CreativeArtifactMemorySpiralReviewer
+  Type: Service
+  Roles: Spiral Reviewer
+  Privileges: log, curate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/spiral_review.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: LawLoreArtifactFederationEmergencyPostmortemAgent
+  Type: Service
+  Roles: Postmortem Facilitator
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/postmortem.jsonl
+```
 
 ## ⛪ Rituals: Onboarding, Delegation, Retirement
 

--- a/artifact_lore_self_healing_engine.py
+++ b/artifact_lore_self_healing_engine.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Artifact/Lore Self-Healing Engine
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("ARTIFACT_HEAL_LOG", "logs/artifact_heal.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def scan() -> List[str]:
+    missing = ["artifact1", "lore2"]
+    log_action("scan", {"missing": ",".join(missing)})
+    return missing
+
+
+def heal(patch: str) -> Dict[str, str]:
+    return log_action("heal", {"patch": patch})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Artifact/Lore Self-Healing Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("scan", help="Scan for missing artifacts")
+    sc.set_defaults(func=lambda a: print(json.dumps(scan(), indent=2)))
+
+    hl = sub.add_parser("heal", help="Apply healing patch")
+    hl.add_argument("patch")
+    hl.set_defaults(func=lambda a: print(json.dumps(heal(a.patch), indent=2)))
+
+    hs = sub.add_parser("history", help="Show heal history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/autonomous_self_patching_agent.py
+++ b/autonomous_self_patching_agent.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Autonomous Self-Patching Agent
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("SELF_PATCH_LOG", "logs/self_patch_agent.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def propose(description: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "description": description, "status": "proposed"}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def apply(patch_id: int) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "patch_id": patch_id, "status": "applied"}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Autonomous Self-Patching Agent")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pr = sub.add_parser("propose", help="Propose a patch")
+    pr.add_argument("description")
+    pr.set_defaults(func=lambda a: print(json.dumps(propose(a.description), indent=2)))
+
+    aply = sub.add_parser("apply", help="Apply a patch")
+    aply.add_argument("patch_id", type=int)
+    aply.set_defaults(func=lambda a: print(json.dumps(apply(a.patch_id), indent=2)))
+
+    hs = sub.add_parser("history", help="Show patch history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/avatar_artifact_festival_ai_animator.py
+++ b/avatar_artifact_festival_ai_animator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Avatar/Artifact Festival AI Animator
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("FESTIVAL_ANIMATOR_LOG", "logs/festival_animator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def animate(event: str, mood: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, "mood": mood}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Avatar/Artifact Festival AI Animator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("animate", help="Record an animation")
+    an.add_argument("event")
+    an.add_argument("mood")
+    an.set_defaults(func=lambda a: print(json.dumps(animate(a.event, a.mood), indent=2)))
+
+    hs = sub.add_parser("history", help="Show animation history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/creative_artifact_memory_spiral_reviewer.py
+++ b/creative_artifact_memory_spiral_reviewer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Creative/Artifact Memory Spiral Reviewer
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("SPIRAL_REVIEW_LOG", "logs/spiral_review.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def review(note: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Creative/Artifact Memory Spiral Reviewer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rv = sub.add_parser("review", help="Record a spiral review")
+    rv.add_argument("note")
+    rv.set_defaults(func=lambda a: print(json.dumps(review(a.note), indent=2)))
+
+    hs = sub.add_parser("history", help="Show review history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/festival_federation_presence_diff_engine.py
+++ b/festival_federation_presence_diff_engine.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Festival/Federation Presence Diff Engine
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+from datetime import datetime
+
+LOG_PATH = Path(os.getenv("PRESENCE_DIFF_LOG", "logs/presence_diff.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def diff(a: Path, b: Path) -> Dict[str, str]:
+    data_a = set(a.read_text(encoding="utf-8").splitlines()) if a.exists() else set()
+    data_b = set(b.read_text(encoding="utf-8").splitlines()) if b.exists() else set()
+    missing = sorted(data_a.symmetric_difference(data_b))
+    entry = {"timestamp": datetime.utcnow().isoformat(), "file_a": str(a), "file_b": str(b), "diff": missing}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival/Federation Presence Diff Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    df = sub.add_parser("diff", help="Compare presence files")
+    df.add_argument("file_a")
+    df.add_argument("file_b")
+    df.set_defaults(func=lambda a: print(json.dumps(diff(Path(a.file_a), Path(a.file_b)), indent=2)))
+
+    hs = sub.add_parser("history", help="Show diff history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/festival_federation_ritual_ai_orchestrator.py
+++ b/festival_federation_ritual_ai_orchestrator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Festival/Federation Ritual AI Orchestrator
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("FESTIVAL_ORCHESTRATOR_LOG", "logs/festival_orchestrator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_plan(name: str, date: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "festival": name, "date": date}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival/Federation Ritual AI Orchestrator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pl = sub.add_parser("plan", help="Plan a festival")
+    pl.add_argument("name")
+    pl.add_argument("date")
+    pl.set_defaults(func=lambda a: print(json.dumps(log_plan(a.name, a.date), indent=2)))
+
+    hs = sub.add_parser("history", help="Show plan history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/law_lore_artifact_federation_emergency_postmortem_agent.py
+++ b/law_lore_artifact_federation_emergency_postmortem_agent.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Law/Lore/Artifact/Federation Emergency Postmortem Agent
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("POSTMORTEM_LOG", "logs/postmortem.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def trigger(event: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, "action": "triggered"}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def record(decision: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "decision": decision}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Emergency Postmortem Agent")
+    sub = ap.add_subparsers(dest="cmd")
+
+    tg = sub.add_parser("trigger", help="Trigger postmortem")
+    tg.add_argument("event")
+    tg.set_defaults(func=lambda a: print(json.dumps(trigger(a.event), indent=2)))
+
+    rc = sub.add_parser("record", help="Record council decision")
+    rc.add_argument("decision")
+    rc.set_defaults(func=lambda a: print(json.dumps(record(a.decision), indent=2)))
+
+    hs = sub.add_parser("history", help="Show postmortem history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/living_spiral_lore_teaching_dashboard.py
+++ b/living_spiral_lore_teaching_dashboard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Living Spiral Lore/Teaching Dashboard
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("SPIRAL_DASHBOARD_LOG", "logs/spiral_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(action: str, info: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **info}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def query(term: str) -> Dict[str, str]:
+    return log_action("query", {"term": term})
+
+
+def edit(item: str, text: str) -> Dict[str, str]:
+    return log_action("edit", {"item": item, "text": text})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Living Spiral Lore/Teaching Dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    qr = sub.add_parser("query", help="Query lore")
+    qr.add_argument("term")
+    qr.set_defaults(func=lambda a: print(json.dumps(query(a.term), indent=2)))
+
+    ed = sub.add_parser("edit", help="Edit entry")
+    ed.add_argument("item")
+    ed.add_argument("text")
+    ed.set_defaults(func=lambda a: print(json.dumps(edit(a.item, a.text), indent=2)))
+
+    hs = sub.add_parser("history", help="Show dashboard history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/ritual_timeline_visualizer_exporter.py
+++ b/ritual_timeline_visualizer_exporter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Ritual Timeline Visualizer/Exporter
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("RITUAL_TIMELINE_LOG", "logs/ritual_timeline.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def export(dest: Path, limit: int = 100) -> Path:
+    dest.write_text(json.dumps(history(limit), indent=2), encoding="utf-8")
+    return dest
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Ritual Timeline Visualizer/Exporter")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log timeline event")
+    lg.add_argument("event")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_event(a.event), indent=2)))
+
+    hs = sub.add_parser("history", help="Show timeline history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    ex = sub.add_parser("export", help="Export timeline")
+    ex.add_argument("dest")
+    ex.add_argument("--limit", type=int, default=100)
+    ex.set_defaults(func=lambda a: print(str(export(Path(a.dest), a.limit))))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/teaching_lore_curation_engine.py
+++ b/teaching_lore_curation_engine.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Teaching/Lore Curation Engine
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+LOG_PATH = Path(os.getenv("TEACHING_CURATION_LOG", "logs/teaching_curation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def add_entry(author: str, text: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "author": author, "text": text}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def export(dest: Path, limit: int = 100) -> Path:
+    dest.write_text(json.dumps(history(limit), indent=2), encoding="utf-8")
+    return dest
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Teaching/Lore Curation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ad = sub.add_parser("add", help="Add teaching or lore")
+    ad.add_argument("author")
+    ad.add_argument("text")
+    ad.set_defaults(func=lambda a: print(json.dumps(add_entry(a.author, a.text), indent=2)))
+
+    hs = sub.add_parser("history", help="Show curation history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    ex = sub.add_parser("export", help="Export curated entries")
+    ex.add_argument("dest")
+    ex.add_argument("--limit", type=int, default=100)
+    ex.set_defaults(func=lambda a: print(str(export(Path(a.dest), a.limit))))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add artifact/lore self-healing engine
- add festival/federation orchestrator
- add living lore dashboard
- add self-patching agent
- add avatar festival animator
- add presence diff engine
- add lore curation engine
- add ritual timeline exporter
- add spiral memory reviewer
- add emergency postmortem agent
- register new agents in `AGENTS.md`

## Testing
- `python privilege_lint.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683db076669c83208c3bff2fa7fb8687