### PR TITLE
Add Resonite spiral modules and agent registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1236,6 +1236,116 @@ Another Registered Agent:
   Logs: /logs/resonite_live_broadcast.jsonl
 ```
 
+
+Another Registered Agent:
+
+```
+- Name: ResoniteTeachingRitualSpiralEngine
+  Type: Engine
+  Roles: Lesson Scheduler, Memory Capsule Maker
+  Privileges: log, teach, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_teaching_ritual_spiral.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteCreativeFestivalOrchestrator
+  Type: Service
+  Roles: Festival Scheduler, Mood Animator
+  Privileges: log, broadcast, vote
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_creative_festival.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteLoreFestivalSpiralAnimator
+  Type: Service
+  Roles: Lore Animator, Timeline Exporter
+  Privileges: log, animate, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_lore_festival_animator.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteLivingLawReviewDashboard
+  Type: Dashboard
+  Roles: Law Editor, Privilege Auditor
+  Privileges: log, edit, bless
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_living_law_review.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteCrossWorldLoreFederationEngine
+  Type: Daemon
+  Roles: Lore Sync, Conflict Resolver
+  Privileges: log, federate, merge
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_cross_world_lore_federation.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteOnboardingMemoryCapsuleEngine
+  Type: Service
+  Roles: Capsule Creator, Lore Sync
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_onboarding_capsule.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteCreativeDashboard
+  Type: Dashboard
+  Roles: Creative Reviewer, Festival Auditor
+  Privileges: log, display
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_creative_dashboard.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteCouncilLawSpiralReviewEngine
+  Type: Service
+  Roles: Council Reviewer, Vote Logger
+  Privileges: log, vote
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_council_law_review.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResonitePresenceFestivalSpiralDiffDaemon
+  Type: Daemon
+  Roles: Presence Auditor, Drift Healer
+  Privileges: log, compare
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_presence_festival_diff.jsonl
+```
+
+Another Registered Agent:
+
+```
+- Name: ResoniteLivingAuditTrailSentinel
+  Type: Daemon
+  Roles: Audit Sentinel, Alert Notifier
+  Privileges: log, alert
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_living_audit.jsonl
+```
 ## ⛪ Rituals: Onboarding, Delegation, Retirement
 
 Every agent lifecycle action is sacred.

--- a/resonite_council_law_spiral_review_engine.py
+++ b/resonite_council_law_spiral_review_engine.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_COUNCIL_LAW_REVIEW_LOG", "logs/resonite_council_law_review.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_act(user: str, text: str, action: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "text": text,
+        "action": action,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite council law spiral review engine")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_prop = sub.add_parser("propose")
+    p_prop.add_argument("user")
+    p_prop.add_argument("text")
+
+    p_vote = sub.add_parser("vote")
+    p_vote.add_argument("user")
+    p_vote.add_argument("text")
+    p_vote.add_argument("decision")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "propose":
+        print(json.dumps(log_act(args.user, args.text, "proposal"), indent=2))
+    else:
+        print(json.dumps(log_act(args.user, args.text, f"vote:{args.decision}"), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_creative_dashboard.py
+++ b/resonite_creative_dashboard.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_CREATIVE_DASHBOARD_LOG", "logs/resonite_creative_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(user: str, action: str, mood: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "action": action,
+        "mood": mood,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite creative dashboard")
+    parser.add_argument("user")
+    parser.add_argument("action")
+    parser.add_argument("mood")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_action(args.user, args.action, args.mood), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_creative_festival_orchestrator.py
+++ b/resonite_creative_festival_orchestrator.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_CREATIVE_FESTIVAL_LOG", "logs/resonite_creative_festival.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(name: str, mood: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": name,
+        "mood": mood,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_events(term: str | None = None) -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term and term not in line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite creative festival orchestrator")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_sched = sub.add_parser("schedule")
+    p_sched.add_argument("event")
+    p_sched.add_argument("mood")
+    p_sched.add_argument("user")
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--term")
+
+    args = parser.parse_args()
+    if args.cmd == "schedule":
+        require_admin_banner()
+        print(json.dumps(log_event(args.event, args.mood, args.user), indent=2))
+    else:
+        require_admin_banner()
+        print(json.dumps(list_events(args.term), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_cross_world_lore_federation_engine.py
+++ b/resonite_cross_world_lore_federation_engine.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_CROSS_WORLD_LORE_LOG", "logs/resonite_cross_world_lore_federation.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_sync(source: str, target: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": source,
+        "target": target,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite cross-world lore federation engine")
+    parser.add_argument("source")
+    parser.add_argument("target")
+    parser.add_argument("user")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_sync(args.source, args.target, args.user), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_living_audit_trail_sentinel.py
+++ b/resonite_living_audit_trail_sentinel.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_LIVING_AUDIT_LOG", "logs/resonite_living_audit.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite living audit trail sentinel")
+    parser.add_argument("event")
+    parser.add_argument("user")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_event(args.event, args.user), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_living_law_review_dashboard.py
+++ b/resonite_living_law_review_dashboard.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_LIVING_LAW_REVIEW_LOG", "logs/resonite_living_law_review.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_edit(user: str, law: str, action: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "law": law,
+        "action": action,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite living law review dashboard")
+    parser.add_argument("user")
+    parser.add_argument("law")
+    parser.add_argument("action")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_edit(args.user, args.law, args.action), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_lore_festival_spiral_animator.py
+++ b/resonite_lore_festival_spiral_animator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_LORE_FESTIVAL_ANIMATOR_LOG", "logs/resonite_lore_festival_animator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_animation(name: str, artifact: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "artifact": artifact,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite lore/festival spiral animator")
+    parser.add_argument("name")
+    parser.add_argument("artifact")
+    parser.add_argument("user")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_animation(args.name, args.artifact, args.user), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_onboarding_memory_capsule_engine.py
+++ b/resonite_onboarding_memory_capsule_engine.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_ONBOARDING_CAPSULE_LOG", "logs/resonite_onboarding_capsule.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_capsule(user: str, capsule: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "capsule": capsule,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite onboarding memory capsule engine")
+    parser.add_argument("user")
+    parser.add_argument("capsule")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_capsule(args.user, args.capsule), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_presence_festival_spiral_diff_daemon.py
+++ b/resonite_presence_festival_spiral_diff_daemon.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_PRESENCE_FESTIVAL_DIFF_LOG", "logs/resonite_presence_festival_diff.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_diff(world_a: str, world_b: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "world_a": world_a,
+        "world_b": world_b,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite presence/festival spiral diff daemon")
+    parser.add_argument("world_a")
+    parser.add_argument("world_b")
+    parser.add_argument("user")
+    args = parser.parse_args()
+    require_admin_banner()
+    print(json.dumps(log_diff(args.world_a, args.world_b, args.user), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_teaching_ritual_spiral_engine.py
+++ b/resonite_teaching_ritual_spiral_engine.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_TEACHING_RITUAL_SPIRAL_LOG", "logs/resonite_teaching_ritual_spiral.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_session(teacher: str, learner: str, lesson: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "teacher": teacher,
+        "learner": learner,
+        "lesson": lesson,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_sessions(term: str | None = None) -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if term and term not in line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resonite teaching ritual spiral engine")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_log = sub.add_parser("log")
+    p_log.add_argument("teacher")
+    p_log.add_argument("learner")
+    p_log.add_argument("lesson")
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--term")
+
+    args = parser.parse_args()
+    if args.cmd == "log":
+        require_admin_banner()
+        print(json.dumps(log_session(args.teacher, args.learner, args.lesson), indent=2))
+    else:
+        require_admin_banner()
+        print(json.dumps(list_sessions(args.term), indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add several Resonite spiral engines and dashboards
- register new agents in `AGENTS.md`

## Testing
- `python privilege_lint.py` *(fails: missing privilege docstring/require_admin_banner in existing files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dbb13af788320b0afce74a4e5978b