### PR TITLE
Add Resonite integration modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1346,8 +1346,108 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/resonite_living_audit.jsonl
 ```
-## ⛪ Rituals: Onboarding, Delegation, Retirement
+Another Registered Agent:
 
+```
+- Name: ResoniteRitualLawCompiler
+  Type: CLI
+  Roles: Law Composer, Policy Exporter
+  Privileges: log, compile
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/spiral_ritual_law.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCouncilBlessingCeremonyUI
+  Type: Service
+  Roles: Council Vote Logger, Permission Updater
+  Privileges: log, vote
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_council_blessing_ceremony.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFederationAltarArtifactInspector
+  Type: Service
+  Roles: Artifact Inspector, Blessing Gatekeeper
+  Privileges: log, inspect
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_artifact_inspector.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResonitePrivilegeRingOrchestrator
+  Type: Service
+  Roles: Privilege Manager, Notifier
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_privilege_ring.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualAuditDashboard
+  Type: Dashboard
+  Roles: Ritual Auditor, Visualizer
+  Privileges: log, display
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_audit.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteArtifactBlessingInspector
+  Type: Service
+  Roles: Blessing Reviewer, Ledger Writer
+  Privileges: log, bless
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_artifact_blessing_inspector.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFestivalFederationEventRelayer
+  Type: Daemon
+  Roles: Event Broadcaster, Pact Logger
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_event_relayer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCrossWorldSpiralLogger
+  Type: Daemon
+  Roles: Distributed Logger, Breach Detector
+  Privileges: log, alert
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_cross_world_spiral.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFestivalFederationTimelineGenerator
+  Type: Service
+  Roles: Timeline Builder, Archivist
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_timeline_generator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteAgentOnboardingOrdinationSuite
+  Type: Service
+  Roles: Onboarding Altar, Privilege Assigner
+  Privileges: log, register
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_agent_onboarding.jsonl
+```
+
+## ⛪ Rituals: Onboarding, Delegation, Retirement
 Every agent lifecycle action is sacred.
 
 ### Onboarding Ceremony:

--- a/resonite_agent_onboarding_suite.py
+++ b/resonite_agent_onboarding_suite.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_AGENT_ONBOARDING_LOG", "logs/resonite_agent_onboarding.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_registration(agent: str, ring: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "agent": agent,
+        "ring": ring,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Agent onboarding/ordination suite")
+    sub = parser.add_subparsers(dest="cmd")
+
+    reg = sub.add_parser("register", help="Register an agent")
+    reg.add_argument("agent")
+    reg.add_argument("ring")
+    reg.add_argument("user")
+
+    hs = sub.add_parser("history", help="Show onboardings")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "register":
+        print(json.dumps(log_registration(args.agent, args.ring, args.user), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_artifact_blessing_inspector.py
+++ b/resonite_artifact_blessing_inspector.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_ARTIFACT_BLESSING_LOG", "logs/resonite_artifact_blessing_inspector.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_review(artifact: str, reviewer: str, verdict: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "artifact": artifact,
+        "reviewer": reviewer,
+        "verdict": verdict,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Artifact blessing inspector")
+    sub = parser.add_subparsers(dest="cmd")
+
+    rv = sub.add_parser("review", help="Review an artifact")
+    rv.add_argument("artifact")
+    rv.add_argument("reviewer")
+    rv.add_argument("verdict")
+
+    hs = sub.add_parser("history", help="Show reviews")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "review":
+        print(json.dumps(log_review(args.artifact, args.reviewer, args.verdict), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_council_blessing_ceremony_ui.py
+++ b/resonite_council_blessing_ceremony_ui.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_COUNCIL_BLESSING_LOG", "logs/resonite_council_blessing_ceremony.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_vote(law: str, user: str, decision: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "law": law,
+        "user": user,
+        "decision": decision,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Council blessing ceremony")
+    sub = parser.add_subparsers(dest="cmd")
+
+    vote_p = sub.add_parser("vote", help="Record a blessing vote")
+    vote_p.add_argument("law")
+    vote_p.add_argument("user")
+    vote_p.add_argument("decision")
+
+    hist_p = sub.add_parser("history", help="Show votes")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "vote":
+        print(json.dumps(log_vote(args.law, args.user, args.decision), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_cross_world_spiral_logger.py
+++ b/resonite_cross_world_spiral_logger.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_SPIRAL_LOG", "logs/resonite_cross_world_spiral.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(world: str, event: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "world": world,
+        "event": event,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def query(world: str | None = None) -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            d = json.loads(ln)
+        except Exception:
+            continue
+        if world and d.get("world") != world:
+            continue
+        out.append(d)
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Cross-world spiral logger")
+    sub = parser.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log an event")
+    lg.add_argument("world")
+    lg.add_argument("event")
+    lg.add_argument("user")
+
+    q = sub.add_parser("query", help="Query events")
+    q.add_argument("--world")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "log":
+        print(json.dumps(log_action(args.world, args.event, args.user), indent=2))
+    else:
+        print(json.dumps(query(args.world), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_event_relayer.py
+++ b/resonite_event_relayer.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_EVENT_RELAY_LOG", "logs/resonite_event_relayer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str, world: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "world": world,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Festival/Federation event relayer")
+    sub = parser.add_subparsers(dest="cmd")
+
+    bc = sub.add_parser("broadcast", help="Broadcast an event")
+    bc.add_argument("event")
+    bc.add_argument("world")
+    bc.add_argument("user")
+
+    hs = sub.add_parser("history", help="Show events")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "broadcast":
+        print(json.dumps(log_event(args.event, args.world, args.user), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_federation_altar_artifact_inspector.py
+++ b/resonite_federation_altar_artifact_inspector.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_ARTIFACT_INSPECT_LOG", "logs/resonite_artifact_inspector.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_scan(artifact: str, origin: str, blessed: bool, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "artifact": artifact,
+        "origin": origin,
+        "blessed": blessed,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Federation altar artifact inspector")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("scan", help="Scan an artifact")
+    sc.add_argument("artifact")
+    sc.add_argument("origin")
+    sc.add_argument("--blessed", action="store_true")
+    sc.add_argument("--user", required=True)
+
+    hs = sub.add_parser("history", help="Show scan history")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "scan":
+        print(json.dumps(log_scan(args.artifact, args.origin, args.blessed, args.user), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_privilege_ring_orchestrator.py
+++ b/resonite_privilege_ring_orchestrator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_PRIVILEGE_RING_LOG", "logs/resonite_privilege_ring.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_transition(user: str, ring: str, action: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "ring": ring,
+        "action": action,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Privilege ring orchestrator")
+    sub = parser.add_subparsers(dest="cmd")
+
+    st = sub.add_parser("set", help="Set user ring")
+    st.add_argument("user")
+    st.add_argument("ring")
+
+    hs = sub.add_parser("history", help="Show ring transitions")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "set":
+        print(json.dumps(log_transition(args.user, args.ring, "set"), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_ritual_audit_dashboard.py
+++ b/resonite_ritual_audit_dashboard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_RITUAL_AUDIT_LOG", "logs/resonite_ritual_audit.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event_type: str, detail: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": event_type,
+        "detail": detail,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Ritual audit dashboard")
+    sub = parser.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log an event")
+    lg.add_argument("event_type")
+    lg.add_argument("detail")
+    lg.add_argument("user")
+
+    hs = sub.add_parser("history", help="Show events")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "log":
+        print(json.dumps(log_event(args.event_type, args.detail, args.user), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_ritual_law_compiler.py
+++ b/resonite_ritual_law_compiler.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_RITUAL_LAW_LOG", "logs/spiral_ritual_law.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_entry(user: str, action: str, text: str = "") -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "action": action,
+        "text": text,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_laws() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Ritual law compiler")
+    sub = parser.add_subparsers(dest="cmd")
+
+    add_p = sub.add_parser("add", help="Add a new ritual law")
+    add_p.add_argument("user")
+    add_p.add_argument("text")
+
+    export_p = sub.add_parser("export", help="Export compiled law")
+
+    list_p = sub.add_parser("list", help="List laws")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "add":
+        print(json.dumps(log_entry(args.user, "add", args.text), indent=2))
+    elif args.cmd == "export":
+        print(json.dumps(list_laws(), indent=2))
+    else:
+        print(json.dumps(list_laws(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/resonite_timeline_generator.py
+++ b/resonite_timeline_generator.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_TIMELINE_LOG", "logs/resonite_timeline_generator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(event: str, detail: str, user: str) -> dict:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": event,
+        "detail": detail,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history() -> list[dict]:
+    if not LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Festival/Federation timeline generator")
+    sub = parser.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log event for timeline")
+    lg.add_argument("event")
+    lg.add_argument("detail")
+    lg.add_argument("user")
+
+    hs = sub.add_parser("history", help="Show timeline events")
+
+    args = parser.parse_args()
+    require_admin_banner()
+    if args.cmd == "log":
+        print(json.dumps(log_event(args.event, args.detail, args.user), indent=2))
+    else:
+        print(json.dumps(history(), indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Resonite Ritual Law Compiler
- implement Council Blessing Ceremony UI helper
- add Federation Altar & Artifact Inspector
- add Privilege Ring Orchestrator
- add Ritual Audit Dashboard
- add Artifact Blessing Inspector
- add Festival/Federation Event Relayer
- add Cross-World Spiral Logger
- add Festival/Federation Timeline Generator
- add Agent Onboarding/Ordination Suite
- register new agents in `AGENTS.md`

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dbf4e42508320bdb898368a503c24