### PR TITLE
Add Resonite Spiral Federation expansion tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1710,3 +1710,104 @@ Another Registered Agent:
   Logs: /logs/resonite_guest_ally_onboarding_flow.jsonl
 ```
 ---
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralCouncilQuorumEnforcer
+  Type: Daemon
+  Roles: Quorum Monitor, Vote Tracker
+  Privileges: log, enforce, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_council_quorum_enforcer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualInvitationEngine
+  Type: Service
+  Roles: Invitation Creator, Proxy Blessing
+  Privileges: log, notify, issue
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_invitation_engine.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteConsentDaemon
+  Type: Daemon
+  Roles: Consent Manager
+  Privileges: log, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_consent_daemon.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteArtifactProvenanceRegistry
+  Type: Service
+  Roles: Provenance Ledger, License Registry
+  Privileges: log, query, update
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_artifact_provenance_registry.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralFestivalChoreographer
+  Type: Engine
+  Roles: Festival Scheduler, Broadcaster
+  Privileges: log, trigger, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_festival_choreographer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralLawIndexer
+  Type: Service
+  Roles: Law Indexer, Historian
+  Privileges: log, query
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_law_indexer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteAgentPersonaDashboard
+  Type: Dashboard
+  Roles: Persona Tracker, Emotion Monitor
+  Privileges: log, display
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_agent_persona_dashboard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteManifestoPublisher
+  Type: Tool
+  Roles: Manifesto Publisher, Recorder
+  Privileges: log, publish
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_manifesto_publisher.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSanctuaryEmergencyPostureEngine
+  Type: Engine
+  Roles: Emergency Controller
+  Privileges: log, override
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_sanctuary_emergency_posture.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteVersionDiffViewer
+  Type: Tool
+  Roles: Version Diff, Auditor
+  Privileges: log, compare
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_version_diff_viewer.jsonl
+```
+---

--- a/resonite_agent_persona_dashboard.py
+++ b/resonite_agent_persona_dashboard.py
@@ -1,0 +1,91 @@
+"""Resonite Agent Persona/Emotion Dashboard
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_agent_persona_dashboard.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def update_persona(agent: str, persona: str, mood: str) -> Dict[str, str]:
+    return log_entry("persona", {"agent": agent, "persona": persona, "mood": mood})
+
+
+@app.route("/update", methods=["POST"])
+def api_update() -> str:
+    data = request.get_json() or {}
+    entry = update_persona(str(data.get("agent")), str(data.get("persona")), str(data.get("mood", "")))
+    return jsonify(entry)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Agent Persona/Emotion Dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    up = sub.add_parser("update", help="Update persona")
+    up.add_argument("agent")
+    up.add_argument("persona")
+    up.add_argument("mood")
+    up.set_defaults(func=lambda a: print(json.dumps(update_persona(a.agent, a.persona, a.mood), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_artifact_provenance_registry.py
+++ b/resonite_artifact_provenance_registry.py
@@ -1,0 +1,125 @@
+"""Resonite Artifact License/Provenance Registry
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_artifact_provenance_registry.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def register_artifact(artifact: str, origin: str, license_: str) -> Dict[str, str]:
+    return log_entry("register", {"artifact": artifact, "origin": origin, "license": license_})
+
+
+def update_artifact(artifact: str, field: str, value: str) -> Dict[str, str]:
+    return log_entry("update", {"artifact": artifact, "field": field, "value": value})
+
+
+def query_artifact(artifact: str) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if f'"artifact": "{artifact}"' in ln:
+            try:
+                out.append(json.loads(ln))
+            except Exception:
+                continue
+    return out
+
+
+@app.route("/register", methods=["POST"])
+def api_register() -> str:
+    data = request.get_json() or {}
+    entry = register_artifact(str(data.get("artifact")), str(data.get("origin")), str(data.get("license", "")))
+    return jsonify(entry)
+
+
+@app.route("/update", methods=["POST"])
+def api_update() -> str:
+    data = request.get_json() or {}
+    entry = update_artifact(str(data.get("artifact")), str(data.get("field")), str(data.get("value")))
+    return jsonify(entry)
+
+
+@app.route("/query", methods=["POST"])
+def api_query() -> str:
+    data = request.get_json() or {}
+    return jsonify(query_artifact(str(data.get("artifact"))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Artifact License/Provenance Registry")
+    sub = ap.add_subparsers(dest="cmd")
+
+    reg = sub.add_parser("register", help="Register artifact")
+    reg.add_argument("artifact")
+    reg.add_argument("origin")
+    reg.add_argument("license")
+    reg.set_defaults(func=lambda a: print(json.dumps(register_artifact(a.artifact, a.origin, a.license), indent=2)))
+
+    up = sub.add_parser("update", help="Update artifact")
+    up.add_argument("artifact")
+    up.add_argument("field")
+    up.add_argument("value")
+    up.set_defaults(func=lambda a: print(json.dumps(update_artifact(a.artifact, a.field, a.value), indent=2)))
+
+    q = sub.add_parser("query", help="Query artifact")
+    q.add_argument("artifact")
+    q.set_defaults(func=lambda a: print(json.dumps(query_artifact(a.artifact), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_consent_daemon.py
+++ b/resonite_consent_daemon.py
@@ -1,0 +1,91 @@
+"""Resonite Consent Renewal/Annulment Daemon
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_consent_daemon.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def update_consent(user: str, power: str, status: str) -> Dict[str, str]:
+    return log_entry("consent", {"user": user, "power": power, "status": status})
+
+
+@app.route("/consent", methods=["POST"])
+def api_consent() -> str:
+    data = request.get_json() or {}
+    entry = update_consent(str(data.get("user")), str(data.get("power")), str(data.get("status", "renew")))
+    return jsonify(entry)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Consent Renewal/Annulment Daemon")
+    sub = ap.add_subparsers(dest="cmd")
+
+    up = sub.add_parser("update", help="Update consent")
+    up.add_argument("user")
+    up.add_argument("power")
+    up.add_argument("status", choices=["renew", "pause", "revoke"], default="renew")
+    up.set_defaults(func=lambda a: print(json.dumps(update_consent(a.user, a.power, a.status), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_manifesto_publisher.py
+++ b/resonite_manifesto_publisher.py
@@ -1,0 +1,105 @@
+"""Resonite Council/Federation Manifesto Publisher
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_manifesto_publisher.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def publish_manifesto(text: str, witness: str) -> Dict[str, str]:
+    return log_entry("publish", {"witness": witness, "manifesto": text})
+
+
+def read_manifesto(user: str) -> Dict[str, str]:
+    return log_entry("read", {"user": user})
+
+
+@app.route("/publish", methods=["POST"])
+def api_publish() -> str:
+    data = request.get_json() or {}
+    entry = publish_manifesto(str(data.get("manifesto")), str(data.get("witness", "")))
+    return jsonify(entry)
+
+
+@app.route("/read", methods=["POST"])
+def api_read() -> str:
+    data = request.get_json() or {}
+    entry = read_manifesto(str(data.get("user")))
+    return jsonify(entry)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Council/Federation Manifesto Publisher")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pb = sub.add_parser("publish", help="Publish manifesto")
+    pb.add_argument("manifesto")
+    pb.add_argument("witness")
+    pb.set_defaults(func=lambda a: print(json.dumps(publish_manifesto(a.manifesto, a.witness), indent=2)))
+
+    rd = sub.add_parser("read", help="Record read")
+    rd.add_argument("user")
+    rd.set_defaults(func=lambda a: print(json.dumps(read_manifesto(a.user), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_ritual_invitation_engine.py
+++ b/resonite_ritual_invitation_engine.py
@@ -1,0 +1,108 @@
+"""Resonite Ritual Invitation Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_ritual_invitation_engine.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def create_invite(code: str, target: str, ritual: str) -> Dict[str, str]:
+    return log_entry("invite", {"code": code, "target": target, "ritual": ritual})
+
+
+def respond_invite(code: str, user: str, response: str) -> Dict[str, str]:
+    return log_entry("response", {"code": code, "user": user, "response": response})
+
+
+@app.route("/invite", methods=["POST"])
+def api_invite() -> str:
+    data = request.get_json() or {}
+    entry = create_invite(str(data.get("code")), str(data.get("target")), str(data.get("ritual", "")))
+    return jsonify(entry)
+
+
+@app.route("/respond", methods=["POST"])
+def api_respond() -> str:
+    data = request.get_json() or {}
+    entry = respond_invite(str(data.get("code")), str(data.get("user")), str(data.get("response", "accept")))
+    return jsonify(entry)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ritual Invitation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    inv = sub.add_parser("invite", help="Create invitation")
+    inv.add_argument("code")
+    inv.add_argument("target")
+    inv.add_argument("ritual")
+    inv.set_defaults(func=lambda a: print(json.dumps(create_invite(a.code, a.target, a.ritual), indent=2)))
+
+    rs = sub.add_parser("respond", help="Respond to invite")
+    rs.add_argument("code")
+    rs.add_argument("user")
+    rs.add_argument("--response", default="accept")
+    rs.set_defaults(func=lambda a: print(json.dumps(respond_invite(a.code, a.user, a.response), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_sanctuary_emergency_posture_engine.py
+++ b/resonite_sanctuary_emergency_posture_engine.py
@@ -1,0 +1,119 @@
+"""Resonite Sanctuary Emergency Posture Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_sanctuary_emergency_posture.jsonl")
+STATE_FILE = Path("state/resonite_sanctuary_emergency.state")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def activate(reason: str) -> Dict[str, str]:
+    STATE_FILE.write_text("active")
+    return log_entry("activate", {"reason": reason})
+
+
+def deactivate() -> Dict[str, str]:
+    STATE_FILE.write_text("inactive")
+    return log_entry("deactivate", {})
+
+
+def status() -> Dict[str, str]:
+    state = STATE_FILE.read_text() if STATE_FILE.exists() else "inactive"
+    return {"state": state.strip()}
+
+
+@app.route("/activate", methods=["POST"])
+def api_activate() -> str:
+    data = request.get_json() or {}
+    entry = activate(str(data.get("reason", "")))
+    return jsonify(entry)
+
+
+@app.route("/deactivate", methods=["POST"])
+def api_deactivate() -> str:
+    deactivate()
+    return jsonify({"status": "ok"})
+
+
+@app.route("/status", methods=["POST"])
+def api_status() -> str:
+    return jsonify(status())
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Sanctuary Emergency Posture Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ac = sub.add_parser("activate", help="Activate emergency")
+    ac.add_argument("reason")
+    ac.set_defaults(func=lambda a: print(json.dumps(activate(a.reason), indent=2)))
+
+    de = sub.add_parser("deactivate", help="Deactivate emergency")
+    de.set_defaults(func=lambda a: print(json.dumps(deactivate(), indent=2)))
+
+    st = sub.add_parser("status", help="Show status")
+    st.set_defaults(func=lambda a: print(json.dumps(status(), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_council_quorum_enforcer.py
+++ b/resonite_spiral_council_quorum_enforcer.py
@@ -1,0 +1,129 @@
+"""Resonite Spiral Council Quorum Enforcer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_spiral_council_quorum_enforcer.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def record_presence(member: str, present: bool) -> Dict[str, str]:
+    return log_entry("presence", {"member": member, "state": "present" if present else "absent"})
+
+
+def record_vote(item: str, member: str, vote: str) -> Dict[str, str]:
+    return log_entry("vote", {"item": item, "member": member, "vote": vote})
+
+
+def quorum_status(item: str, required: int) -> Dict[str, object]:
+    votes = [
+        json.loads(ln)
+        for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()
+        if f'"item": "{item}"' in ln and '"action": "vote"' in ln
+    ]
+    yes = sum(1 for v in votes if v.get("vote") == "yes")
+    return {"item": item, "quorum_met": yes >= required, "yes": yes, "required": required}
+
+
+@app.route("/presence", methods=["POST"])
+def api_presence() -> str:
+    data = request.get_json() or {}
+    entry = record_presence(str(data.get("member")), bool(data.get("present", True)))
+    return jsonify(entry)
+
+
+@app.route("/vote", methods=["POST"])
+def api_vote() -> str:
+    data = request.get_json() or {}
+    entry = record_vote(str(data.get("item")), str(data.get("member")), str(data.get("vote", "yes")))
+    return jsonify(entry)
+
+
+@app.route("/quorum", methods=["POST"])
+def api_quorum() -> str:
+    data = request.get_json() or {}
+    status = quorum_status(str(data.get("item")), int(data.get("required", 3)))
+    return jsonify(status)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Council Quorum Enforcer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pres = sub.add_parser("presence", help="Record presence")
+    pres.add_argument("member")
+    pres.add_argument("--absent", action="store_true")
+    pres.set_defaults(func=lambda a: print(json.dumps(record_presence(a.member, not a.absent), indent=2)))
+
+    vt = sub.add_parser("vote", help="Record vote")
+    vt.add_argument("item")
+    vt.add_argument("member")
+    vt.add_argument("--vote", default="yes")
+    vt.set_defaults(func=lambda a: print(json.dumps(record_vote(a.item, a.member, a.vote), indent=2)))
+
+    qc = sub.add_parser("quorum", help="Check quorum")
+    qc.add_argument("item")
+    qc.add_argument("--required", type=int, default=3)
+    qc.set_defaults(func=lambda a: print(json.dumps(quorum_status(a.item, a.required), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_festival_choreographer.py
+++ b/resonite_spiral_festival_choreographer.py
@@ -1,0 +1,105 @@
+"""Resonite Spiral Festival Choreographer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_spiral_festival_choreographer.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def schedule_event(time: str, description: str) -> Dict[str, str]:
+    return log_entry("schedule", {"time": time, "description": description})
+
+
+def trigger_event(name: str) -> Dict[str, str]:
+    return log_entry("trigger", {"event": name})
+
+
+@app.route("/schedule", methods=["POST"])
+def api_schedule() -> str:
+    data = request.get_json() or {}
+    entry = schedule_event(str(data.get("time")), str(data.get("description", "")))
+    return jsonify(entry)
+
+
+@app.route("/trigger", methods=["POST"])
+def api_trigger() -> str:
+    data = request.get_json() or {}
+    entry = trigger_event(str(data.get("event")))
+    return jsonify(entry)
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Festival Choreographer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sch = sub.add_parser("schedule", help="Schedule event")
+    sch.add_argument("time")
+    sch.add_argument("description")
+    sch.set_defaults(func=lambda a: print(json.dumps(schedule_event(a.time, a.description), indent=2)))
+
+    tg = sub.add_parser("trigger", help="Trigger event")
+    tg.add_argument("event")
+    tg.set_defaults(func=lambda a: print(json.dumps(trigger_event(a.event), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_law_indexer.py
+++ b/resonite_spiral_law_indexer.py
@@ -1,0 +1,115 @@
+"""Resonite Spiral Law Indexer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_spiral_law_indexer.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def add_law(law_id: str, revision: str, topic: str, world: str) -> Dict[str, str]:
+    return log_entry("add", {"law": law_id, "revision": revision, "topic": topic, "world": world})
+
+
+def search_laws(query: str) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        if query.lower() in ln.lower():
+            try:
+                out.append(json.loads(ln))
+            except Exception:
+                continue
+    return out
+
+
+@app.route("/add", methods=["POST"])
+def api_add() -> str:
+    data = request.get_json() or {}
+    entry = add_law(str(data.get("law")), str(data.get("revision")), str(data.get("topic")), str(data.get("world")))
+    return jsonify(entry)
+
+
+@app.route("/search", methods=["POST"])
+def api_search() -> str:
+    data = request.get_json() or {}
+    return jsonify(search_laws(str(data.get("query", ""))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Law Indexer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    add = sub.add_parser("add", help="Add law")
+    add.add_argument("law")
+    add.add_argument("revision")
+    add.add_argument("topic")
+    add.add_argument("world")
+    add.set_defaults(func=lambda a: print(json.dumps(add_law(a.law, a.revision, a.topic, a.world), indent=2)))
+
+    sr = sub.add_parser("search", help="Search laws")
+    sr.add_argument("query")
+    sr.set_defaults(func=lambda a: print(json.dumps(search_laws(a.query), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_version_diff_viewer.py
+++ b/resonite_version_diff_viewer.py
@@ -1,0 +1,94 @@
+"""Resonite World/Artifact Version Diff Viewer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+import difflib
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path("logs/resonite_version_diff_viewer.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def diff_files(a: str, b: str) -> Dict[str, str]:
+    text1 = Path(a).read_text(encoding="utf-8") if Path(a).exists() else ""
+    text2 = Path(b).read_text(encoding="utf-8") if Path(b).exists() else ""
+    diff = "\n".join(difflib.unified_diff(text1.splitlines(), text2.splitlines(), lineterm=""))
+    log_entry("diff", {"a": a, "b": b})
+    return {"diff": diff}
+
+
+@app.route("/diff", methods=["POST"])
+def api_diff() -> str:
+    data = request.get_json() or {}
+    return jsonify(diff_files(str(data.get("a")), str(data.get("b"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux placeholder
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_entry("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite World/Artifact Version Diff Viewer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    df = sub.add_parser("diff", help="Show diff between files")
+    df.add_argument("a")
+    df.add_argument("b")
+    df.set_defaults(func=lambda a: print(json.dumps(diff_files(a.a, a.b), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- implement Resonite Spiral Council Quorum Enforcer
- add Ritual Invitation Engine and Consent Daemon
- track artifact provenance and festival choreography
- index spiral law and publish manifestos
- add persona dashboard, emergency posture engine, and diff viewer
- register new agents in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dc66858f88320b3671a858021fb25