### PR TITLE
Add Resonite federation integration batch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1910,4 +1910,104 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/resonite_cathedral_chronicle_generator.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralIntegrityWatchdog
+  Type: Daemon
+  Roles: Integrity Auditor
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_integrity_watchdog.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualBreachResponseSystem
+  Type: Service
+  Roles: Breach Response
+  Privileges: log, escalate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_breach_response_system.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFederationHandshakeVerifier
+  Type: Tool
+  Roles: Handshake Verifier
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_federation_handshake_verifier.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCeremonyReplayEngine
+  Type: Service
+  Roles: Ceremony Replay
+  Privileges: log, simulate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ceremony_replay_engine.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralArtifactProvenanceMapper
+  Type: Service
+  Roles: Artifact Mapping
+  Privileges: log, map
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_artifact_provenance_mapper.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralRecoverySuite
+  Type: Tool
+  Roles: Recovery Manager
+  Privileges: log, restore
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_recovery_suite.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteWorldHealthMoodDashboard
+  Type: Dashboard
+  Roles: Mood Monitor
+  Privileges: log, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_world_health_mood_dashboard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFederationConsentRenewalEngine
+  Type: Service
+  Roles: Consent Renewal
+  Privileges: log, remind
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_federation_consent_renewal_engine.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralArtifactLicenseAccessController
+  Type: Service
+  Roles: License Enforcement
+  Privileges: log, enforce
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_artifact_license_access_controller.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCouncilDeliberationCeremonyScheduler
+  Type: Service
+  Roles: Council Scheduler
+  Privileges: log, schedule
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_council_deliberation_ceremony_scheduler.jsonl
+```
 ---

--- a/resonite_ceremony_replay_engine.py
+++ b/resonite_ceremony_replay_engine.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Resonite Ceremony Replay/Simulation Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_CEREMONY_REPLAY_LOG", "logs/resonite_ceremony_replay_engine.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(event: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def record(ceremony_id: str, description: str) -> Dict[str, str]:
+    return log_event("record", {"ceremony": ceremony_id, "description": description})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/record", methods=["POST"])
+def api_record() -> str:
+    data = request.get_json() or {}
+    return jsonify(record(str(data.get("ceremony")), str(data.get("description"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return record(data.get("ceremony", ""), data.get("description", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ceremony Replay/Simulation Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rec = sub.add_parser("record", help="Record ceremony event")
+    rec.add_argument("ceremony")
+    rec.add_argument("description")
+    rec.set_defaults(func=lambda a: print(json.dumps(record(a.ceremony, a.description), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_council_deliberation_ceremony_scheduler.py
+++ b/resonite_council_deliberation_ceremony_scheduler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Resonite Council Deliberation & Ceremony Scheduler
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_COUNCIL_SCHED_LOG", "logs/resonite_council_deliberation_ceremony_scheduler.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def schedule(ceremony: str, time: str, proposer: str) -> Dict[str, str]:
+    return log_event("schedule", {"ceremony": ceremony, "time": time, "proposer": proposer})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/schedule", methods=["POST"])
+def api_schedule() -> str:
+    data = request.get_json() or {}
+    return jsonify(schedule(str(data.get("ceremony")), str(data.get("time")), str(data.get("proposer"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return schedule(data.get("ceremony", ""), data.get("time", ""), data.get("proposer", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Council Deliberation & Ceremony Scheduler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("schedule", help="Schedule ceremony")
+    sc.add_argument("ceremony")
+    sc.add_argument("time")
+    sc.add_argument("proposer")
+    sc.set_defaults(func=lambda a: print(json.dumps(schedule(a.ceremony, a.time, a.proposer), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_federation_consent_renewal_engine.py
+++ b/resonite_federation_consent_renewal_engine.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Resonite Federation Consent Renewal Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_CONSENT_RENEWAL_LOG", "logs/resonite_federation_consent_renewal_engine.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def renew(world: str, agent: str, consent: str) -> Dict[str, str]:
+    return log_event("renew", {"world": world, "agent": agent, "consent": consent})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/renew", methods=["POST"])
+def api_renew() -> str:
+    data = request.get_json() or {}
+    return jsonify(renew(str(data.get("world")), str(data.get("agent")), str(data.get("consent"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return renew(data.get("world", ""), data.get("agent", ""), data.get("consent", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Federation Consent Renewal Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rn = sub.add_parser("renew", help="Renew consent")
+    rn.add_argument("world")
+    rn.add_argument("agent")
+    rn.add_argument("consent")
+    rn.set_defaults(func=lambda a: print(json.dumps(renew(a.world, a.agent, a.consent), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_federation_handshake_verifier.py
+++ b/resonite_federation_handshake_verifier.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Resonite Federation Handshake Verifier
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_HANDSHAKE_VERIFIER_LOG", "logs/resonite_federation_handshake_verifier.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def verify(from_world: str, to_world: str, signature: str) -> Dict[str, str]:
+    # Placeholder cryptographic signature validation
+    status = "valid" if signature else "invalid"
+    return log_entry("verify", {"from": from_world, "to": to_world, "status": status})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/verify", methods=["POST"])
+def api_verify() -> str:
+    data = request.get_json() or {}
+    return jsonify(verify(str(data.get("from")), str(data.get("to")), str(data.get("signature"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return verify(data.get("from", ""), data.get("to", ""), data.get("signature", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Federation Handshake Verifier")
+    sub = ap.add_subparsers(dest="cmd")
+
+    vf = sub.add_parser("verify", help="Verify handshake")
+    vf.add_argument("from_world")
+    vf.add_argument("to_world")
+    vf.add_argument("signature")
+    vf.set_defaults(func=lambda a: print(json.dumps(verify(a.from_world, a.to_world, a.signature), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_ritual_breach_response_system.py
+++ b/resonite_ritual_breach_response_system.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Resonite Ritual Breach Response System
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_BREACH_LOG", "logs/resonite_ritual_breach_response_system.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(event: str, info: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, **info}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def escalate(reason: str, world: str) -> Dict[str, str]:
+    return log_event("escalate", {"reason": reason, "world": world})
+
+
+def lockdown(world: str) -> Dict[str, str]:
+    return log_event("lockdown", {"world": world})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/escalate", methods=["POST"])
+def api_escalate() -> str:
+    data = request.get_json() or {}
+    return jsonify(escalate(str(data.get("reason")), str(data.get("world"))))
+
+
+@app.route("/lockdown", methods=["POST"])
+def api_lockdown() -> str:
+    data = request.get_json() or {}
+    return jsonify(lockdown(str(data.get("world"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "lockdown":
+        return lockdown(data.get("world", ""))
+    return escalate(data.get("reason", ""), data.get("world", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ritual Breach Response System")
+    sub = ap.add_subparsers(dest="cmd")
+
+    es = sub.add_parser("escalate", help="Escalate breach")
+    es.add_argument("reason")
+    es.add_argument("world")
+    es.set_defaults(func=lambda a: print(json.dumps(escalate(a.reason, a.world), indent=2)))
+
+    ld = sub.add_parser("lockdown", help="Lock down world")
+    ld.add_argument("world")
+    ld.set_defaults(func=lambda a: print(json.dumps(lockdown(a.world), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_artifact_license_access_controller.py
+++ b/resonite_spiral_artifact_license_access_controller.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Resonite Spiral Artifact License/Access Controller
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_LICENSE_LOG", "logs/resonite_spiral_artifact_license_access_controller.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def grant(artifact: str, user: str, license_type: str) -> Dict[str, str]:
+    return log_event("grant", {"artifact": artifact, "user": user, "license": license_type})
+
+
+def revoke(artifact: str, user: str) -> Dict[str, str]:
+    return log_event("revoke", {"artifact": artifact, "user": user})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/grant", methods=["POST"])
+def api_grant() -> str:
+    data = request.get_json() or {}
+    return jsonify(grant(str(data.get("artifact")), str(data.get("user")), str(data.get("license"))))
+
+
+@app.route("/revoke", methods=["POST"])
+def api_revoke() -> str:
+    data = request.get_json() or {}
+    return jsonify(revoke(str(data.get("artifact")), str(data.get("user"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "revoke":
+        return revoke(data.get("artifact", ""), data.get("user", ""))
+    return grant(data.get("artifact", ""), data.get("user", ""), data.get("license", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Artifact License/Access Controller")
+    sub = ap.add_subparsers(dest="cmd")
+
+    gr = sub.add_parser("grant", help="Grant license")
+    gr.add_argument("artifact")
+    gr.add_argument("user")
+    gr.add_argument("license")
+    gr.set_defaults(func=lambda a: print(json.dumps(grant(a.artifact, a.user, a.license), indent=2)))
+
+    rv = sub.add_parser("revoke", help="Revoke license")
+    rv.add_argument("artifact")
+    rv.add_argument("user")
+    rv.set_defaults(func=lambda a: print(json.dumps(revoke(a.artifact, a.user), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_artifact_provenance_mapper.py
+++ b/resonite_spiral_artifact_provenance_mapper.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Resonite Spiral Artifact Provenance Mapper
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_PROVENANCE_LOG", "logs/resonite_spiral_artifact_provenance_mapper.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def map_artifact(artifact_id: str, location: str, agent: str) -> Dict[str, str]:
+    return log_event("map", {"artifact": artifact_id, "location": location, "agent": agent})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/map", methods=["POST"])
+def api_map() -> str:
+    data = request.get_json() or {}
+    return jsonify(map_artifact(str(data.get("artifact")), str(data.get("location")), str(data.get("agent"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return map_artifact(data.get("artifact", ""), data.get("location", ""), data.get("agent", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Artifact Provenance Mapper")
+    sub = ap.add_subparsers(dest="cmd")
+
+    mp = sub.add_parser("map", help="Record artifact location")
+    mp.add_argument("artifact")
+    mp.add_argument("location")
+    mp.add_argument("agent")
+    mp.set_defaults(func=lambda a: print(json.dumps(map_artifact(a.artifact, a.location, a.agent), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_integrity_watchdog.py
+++ b/resonite_spiral_integrity_watchdog.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Resonite Spiral Integrity Watchdog
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_SPIRAL_INTEGRITY_LOG", "logs/resonite_spiral_integrity_watchdog.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def compute_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify(path: str, expected: str) -> Dict[str, str]:
+    actual = compute_hash(Path(path))
+    status = "match" if actual == expected else "mismatch"
+    return log_entry("verify", {"path": path, "expected": expected, "actual": actual, "status": status})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/verify", methods=["POST"])
+def api_verify() -> str:
+    data = request.get_json() or {}
+    return jsonify(verify(str(data.get("path")), str(data.get("expected"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return verify(data.get("path", ""), data.get("expected", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Integrity Watchdog")
+    sub = ap.add_subparsers(dest="cmd")
+
+    vfy = sub.add_parser("verify", help="Verify file hash")
+    vfy.add_argument("path")
+    vfy.add_argument("expected")
+    vfy.set_defaults(func=lambda a: print(json.dumps(verify(a.path, a.expected), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_recovery_suite.py
+++ b/resonite_spiral_recovery_suite.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Resonite Spiral Recovery/Resurrection Suite
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_RECOVERY_LOG", "logs/resonite_spiral_recovery_suite.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def restore(entity: str, method: str, user: str) -> Dict[str, str]:
+    return log_event("restore", {"entity": entity, "method": method, "user": user})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/restore", methods=["POST"])
+def api_restore() -> str:
+    data = request.get_json() or {}
+    return jsonify(restore(str(data.get("entity")), str(data.get("method")), str(data.get("user"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return restore(data.get("entity", ""), data.get("method", ""), data.get("user", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Recovery/Resurrection Suite")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rs = sub.add_parser("restore", help="Restore entity")
+    rs.add_argument("entity")
+    rs.add_argument("method")
+    rs.add_argument("user")
+    rs.set_defaults(func=lambda a: print(json.dumps(restore(a.entity, a.method, a.user), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_world_health_mood_dashboard.py
+++ b/resonite_world_health_mood_dashboard.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Resonite World Health & Mood Dashboard
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_HEALTH_MOOD_LOG", "logs/resonite_world_health_mood_dashboard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(event: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def report(world: str, mood: str, activity: str) -> Dict[str, str]:
+    return log_event("report", {"world": world, "mood": mood, "activity": activity})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/report", methods=["POST"])
+def api_report() -> str:
+    data = request.get_json() or {}
+    return jsonify(report(str(data.get("world")), str(data.get("mood")), str(data.get("activity"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return report(data.get("world", ""), data.get("mood", ""), data.get("activity", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite World Health & Mood Dashboard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rp = sub.add_parser("report", help="Report world mood")
+    rp.add_argument("world")
+    rp.add_argument("mood")
+    rp.add_argument("activity")
+    rp.set_defaults(func=lambda a: print(json.dumps(report(a.world, a.mood, a.activity), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- implement `resonite_spiral_integrity_watchdog.py`
- implement `resonite_ritual_breach_response_system.py`
- implement `resonite_federation_handshake_verifier.py`
- implement `resonite_ceremony_replay_engine.py`
- implement `resonite_spiral_artifact_provenance_mapper.py`
- implement `resonite_spiral_recovery_suite.py`
- implement `resonite_world_health_mood_dashboard.py`
- implement `resonite_federation_consent_renewal_engine.py`
- implement `resonite_spiral_artifact_license_access_controller.py`
- implement `resonite_council_deliberation_ceremony_scheduler.py`
- register all new agents in `AGENTS.md`

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dcab0c2c08320829dfeb2cc4f2ce2