### PR TITLE
Add Resonite Council resilience modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2010,4 +2010,104 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/resonite_council_deliberation_ceremony_scheduler.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: ResoniteCouncilLawVaultEngine
+  Type: Service
+  Roles: Law Vault
+  Privileges: log, amend
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_council_law_vault_engine.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCouncilResilienceStressTestOrchestrator
+  Type: Daemon
+  Roles: Stress Tester
+  Privileges: log, simulate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_council_resilience_stress_test_orchestrator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteWorldProvenanceMapExplorer
+  Type: Service
+  Roles: Provenance Mapper
+  Privileges: log, map
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_world_provenance_map_explorer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralBellOfPause
+  Type: Daemon
+  Roles: Emergency Broadcaster
+  Privileges: log, pause
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_bell_of_pause.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralCouncilRolePrivilegeAuditor
+  Type: Service
+  Roles: Role Auditor
+  Privileges: log, edit
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_council_role_privilege_auditor.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralMemoryCapsuleRegistry
+  Type: Service
+  Roles: Capsule Registry
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_memory_capsule_registry.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFederationArtifactLicenseBroker
+  Type: Service
+  Roles: License Broker
+  Privileges: log, approve
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_federation_artifact_license_broker.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteWorldHealthMoodAnalytics
+  Type: Service
+  Roles: Health Monitor
+  Privileges: log, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_world_health_mood_analytics.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualTimelineComposer
+  Type: Service
+  Roles: Timeline Composer
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_timeline_composer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResonitePublicOutreachAnnouncer
+  Type: Service
+  Roles: Outreach Announcer
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_public_outreach_announcer.jsonl
+```
 ---

--- a/resonite_council_law_vault_engine.py
+++ b/resonite_council_law_vault_engine.py
@@ -1,0 +1,169 @@
+"""Resonite Council Law Vault & Amendment Engine
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_LAW_VAULT_LOG", "logs/resonite_council_law_vault_engine.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        **data,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def propose_law(title: str, text: str, author: str) -> Dict[str, str]:
+    law_id = str(uuid.uuid4())
+    return log_event("propose", {"id": law_id, "title": title, "text": text, "author": author})
+
+
+def amend_law(law_id: str, amendment: str, author: str) -> Dict[str, str]:
+    return log_event("amend", {"id": law_id, "amendment": amendment, "author": author})
+
+
+def freeze_law(law_id: str, author: str) -> Dict[str, str]:
+    return log_event("freeze", {"id": law_id, "author": author})
+
+
+def revoke_law(law_id: str, author: str) -> Dict[str, str]:
+    return log_event("revoke", {"id": law_id, "author": author})
+
+
+def seal(law_id: str, quorum: str, intention: str) -> Dict[str, str]:
+    return log_event("seal", {"id": law_id, "quorum": quorum, "intention": intention})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/propose", methods=["POST"])
+def api_propose() -> str:
+    data = request.get_json() or {}
+    return jsonify(propose_law(str(data.get("title")), str(data.get("text")), str(data.get("author"))))
+
+
+@app.route("/amend", methods=["POST"])
+def api_amend() -> str:
+    data = request.get_json() or {}
+    return jsonify(amend_law(str(data.get("id")), str(data.get("amendment")), str(data.get("author"))))
+
+
+@app.route("/freeze", methods=["POST"])
+def api_freeze() -> str:
+    data = request.get_json() or {}
+    return jsonify(freeze_law(str(data.get("id")), str(data.get("author"))))
+
+
+@app.route("/revoke", methods=["POST"])
+def api_revoke() -> str:
+    data = request.get_json() or {}
+    return jsonify(revoke_law(str(data.get("id")), str(data.get("author"))))
+
+
+@app.route("/seal", methods=["POST"])
+def api_seal() -> str:
+    data = request.get_json() or {}
+    return jsonify(seal(str(data.get("id")), str(data.get("quorum")), str(data.get("intention"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "propose":
+        return propose_law(data.get("title", ""), data.get("text", ""), data.get("author", ""))
+    if action == "amend":
+        return amend_law(data.get("id", ""), data.get("amendment", ""), data.get("author", ""))
+    if action == "freeze":
+        return freeze_law(data.get("id", ""), data.get("author", ""))
+    if action == "revoke":
+        return revoke_law(data.get("id", ""), data.get("author", ""))
+    if action == "seal":
+        return seal(data.get("id", ""), data.get("quorum", ""), data.get("intention", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Council Law Vault & Amendment Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pp = sub.add_parser("propose", help="Propose a new law")
+    pp.add_argument("title")
+    pp.add_argument("text")
+    pp.add_argument("author")
+    pp.set_defaults(func=lambda a: print(json.dumps(propose_law(a.title, a.text, a.author), indent=2)))
+
+    am = sub.add_parser("amend", help="Amend existing law")
+    am.add_argument("id")
+    am.add_argument("amendment")
+    am.add_argument("author")
+    am.set_defaults(func=lambda a: print(json.dumps(amend_law(a.id, a.amendment, a.author), indent=2)))
+
+    fr = sub.add_parser("freeze", help="Freeze a law")
+    fr.add_argument("id")
+    fr.add_argument("author")
+    fr.set_defaults(func=lambda a: print(json.dumps(freeze_law(a.id, a.author), indent=2)))
+
+    rv = sub.add_parser("revoke", help="Revoke a law")
+    rv.add_argument("id")
+    rv.add_argument("author")
+    rv.set_defaults(func=lambda a: print(json.dumps(revoke_law(a.id, a.author), indent=2)))
+
+    sl = sub.add_parser("seal", help="Seal amendment")
+    sl.add_argument("id")
+    sl.add_argument("quorum")
+    sl.add_argument("intention")
+    sl.set_defaults(func=lambda a: print(json.dumps(seal(a.id, a.quorum, a.intention), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_council_resilience_stress_test_orchestrator.py
+++ b/resonite_council_resilience_stress_test_orchestrator.py
@@ -1,0 +1,107 @@
+"""Resonite Council Resilience Stress-Test Orchestrator
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_STRESS_TEST_LOG", "logs/resonite_council_resilience_stress_test_orchestrator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def start_test(name: str, params: str) -> Dict[str, str]:
+    return log_event("start", {"test": name, "params": params})
+
+
+def report_result(name: str, result: str) -> Dict[str, str]:
+    return log_event("result", {"test": name, "result": result})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/start", methods=["POST"])
+def api_start() -> str:
+    data = request.get_json() or {}
+    return jsonify(start_test(str(data.get("name")), str(data.get("params"))))
+
+
+@app.route("/result", methods=["POST"])
+def api_result() -> str:
+    data = request.get_json() or {}
+    return jsonify(report_result(str(data.get("name")), str(data.get("result"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "start":
+        return start_test(data.get("name", ""), data.get("params", ""))
+    if action == "result":
+        return report_result(data.get("name", ""), data.get("result", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Council Resilience Stress-Test Orchestrator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    st = sub.add_parser("start", help="Start stress test")
+    st.add_argument("name")
+    st.add_argument("params")
+    st.set_defaults(func=lambda a: print(json.dumps(start_test(a.name, a.params), indent=2)))
+
+    rs = sub.add_parser("result", help="Record test result")
+    rs.add_argument("name")
+    rs.add_argument("result")
+    rs.set_defaults(func=lambda a: print(json.dumps(report_result(a.name, a.result), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_federation_artifact_license_broker.py
+++ b/resonite_federation_artifact_license_broker.py
@@ -1,0 +1,125 @@
+"""Resonite Federation/Artifact License Broker
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_LICENSE_BROKER_LOG", "logs/resonite_federation_artifact_license_broker.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def request_license(artifact: str, requester: str) -> Dict[str, str]:
+    req_id = str(uuid.uuid4())
+    return log_event("request", {"id": req_id, "artifact": artifact, "requester": requester})
+
+
+def approve_license(req_id: str, approver: str) -> Dict[str, str]:
+    return log_event("approve", {"id": req_id, "approver": approver})
+
+
+def view_license(artifact: str) -> Dict[str, str]:
+    return log_event("view", {"artifact": artifact})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/request", methods=["POST"])
+def api_request() -> str:
+    data = request.get_json() or {}
+    return jsonify(request_license(str(data.get("artifact")), str(data.get("requester"))))
+
+
+@app.route("/approve", methods=["POST"])
+def api_approve() -> str:
+    data = request.get_json() or {}
+    return jsonify(approve_license(str(data.get("id")), str(data.get("approver"))))
+
+
+@app.route("/view", methods=["POST"])
+def api_view() -> str:
+    data = request.get_json() or {}
+    return jsonify(view_license(str(data.get("artifact"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "request":
+        return request_license(data.get("artifact", ""), data.get("requester", ""))
+    if action == "approve":
+        return approve_license(data.get("id", ""), data.get("approver", ""))
+    if action == "view":
+        return view_license(data.get("artifact", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Federation/Artifact License Broker")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rq = sub.add_parser("request", help="Request license")
+    rq.add_argument("artifact")
+    rq.add_argument("requester")
+    rq.set_defaults(func=lambda a: print(json.dumps(request_license(a.artifact, a.requester), indent=2)))
+
+    apv = sub.add_parser("approve", help="Approve license")
+    apv.add_argument("id")
+    apv.add_argument("approver")
+    apv.set_defaults(func=lambda a: print(json.dumps(approve_license(a.id, a.approver), indent=2)))
+
+    vw = sub.add_parser("view", help="View license")
+    vw.add_argument("artifact")
+    vw.set_defaults(func=lambda a: print(json.dumps(view_license(a.artifact), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_public_outreach_announcer.py
+++ b/resonite_public_outreach_announcer.py
@@ -1,0 +1,107 @@
+"""Resonite Public Blessing/Outreach Announcer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_OUTREACH_LOG", "logs/resonite_public_outreach_announcer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def broadcast(message: str, author: str) -> Dict[str, str]:
+    return log_event("broadcast", {"message": message, "author": author})
+
+
+def feedback(user: str, text: str) -> Dict[str, str]:
+    return log_event("feedback", {"user": user, "text": text})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/broadcast", methods=["POST"])
+def api_broadcast() -> str:
+    data = request.get_json() or {}
+    return jsonify(broadcast(str(data.get("message")), str(data.get("author"))))
+
+
+@app.route("/feedback", methods=["POST"])
+def api_feedback() -> str:
+    data = request.get_json() or {}
+    return jsonify(feedback(str(data.get("user")), str(data.get("text"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "feedback":
+        return feedback(data.get("user", ""), data.get("text", ""))
+    if action == "broadcast":
+        return broadcast(data.get("message", ""), data.get("author", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Public Blessing/Outreach Announcer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    bc = sub.add_parser("broadcast", help="Broadcast message")
+    bc.add_argument("message")
+    bc.add_argument("author")
+    bc.set_defaults(func=lambda a: print(json.dumps(broadcast(a.message, a.author), indent=2)))
+
+    fb = sub.add_parser("feedback", help="Record feedback")
+    fb.add_argument("user")
+    fb.add_argument("text")
+    fb.set_defaults(func=lambda a: print(json.dumps(feedback(a.user, a.text), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_ritual_timeline_composer.py
+++ b/resonite_ritual_timeline_composer.py
@@ -1,0 +1,93 @@
+"""Resonite Onboarding/Festival Ritual Timeline Composer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_TIMELINE_COMPOSER_LOG", "logs/resonite_ritual_timeline_composer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def compose_timeline(name: str, events: List[str]) -> Dict[str, str]:
+    return log_event("compose", {"name": name, "events": events})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/compose", methods=["POST"])
+def api_compose() -> str:
+    data = request.get_json() or {}
+    events = data.get("events") or []
+    if not isinstance(events, list):
+        events = [str(events)]
+    return jsonify(compose_timeline(str(data.get("name")), [str(e) for e in events]))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    events = data.get("events") or []
+    if not isinstance(events, list):
+        events = [events]
+    return compose_timeline(data.get("name", ""), [str(e) for e in events])
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Onboarding/Festival Ritual Timeline Composer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cp = sub.add_parser("compose", help="Compose timeline")
+    cp.add_argument("name")
+    cp.add_argument("events", nargs="+")
+    cp.set_defaults(func=lambda a: print(json.dumps(compose_timeline(a.name, a.events), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_bell_of_pause.py
+++ b/resonite_spiral_bell_of_pause.py
@@ -1,0 +1,103 @@
+"""Resonite Spiral Bell of Pause Broadcast System
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_BELL_PAUSE_LOG", "logs/resonite_spiral_bell_of_pause.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def trigger_pause(reason: str, world: str) -> Dict[str, str]:
+    return log_event("pause", {"world": world, "reason": reason})
+
+
+def resolve_pause(world: str) -> Dict[str, str]:
+    return log_event("resolve", {"world": world})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/pause", methods=["POST"])
+def api_pause() -> str:
+    data = request.get_json() or {}
+    return jsonify(trigger_pause(str(data.get("reason")), str(data.get("world"))))
+
+
+@app.route("/resolve", methods=["POST"])
+def api_resolve() -> str:
+    data = request.get_json() or {}
+    return jsonify(resolve_pause(str(data.get("world"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "resolve":
+        return resolve_pause(data.get("world", ""))
+    return trigger_pause(data.get("reason", ""), data.get("world", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Bell of Pause Broadcast System")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pa = sub.add_parser("pause", help="Trigger pause")
+    pa.add_argument("reason")
+    pa.add_argument("world")
+    pa.set_defaults(func=lambda a: print(json.dumps(trigger_pause(a.reason, a.world), indent=2)))
+
+    rs = sub.add_parser("resolve", help="Resolve pause")
+    rs.add_argument("world")
+    rs.set_defaults(func=lambda a: print(json.dumps(resolve_pause(a.world), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_council_role_privilege_auditor.py
+++ b/resonite_spiral_council_role_privilege_auditor.py
@@ -1,0 +1,139 @@
+"""Resonite Spiral Council Role/Privilege Auditor
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_ROLE_AUDIT_LOG", "logs/resonite_spiral_council_role_privilege_auditor.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def view_role(agent: str) -> Dict[str, str]:
+    return log_event("view", {"agent": agent})
+
+
+def edit_role(agent: str, role: str) -> Dict[str, str]:
+    return log_event("edit", {"agent": agent, "role": role})
+
+
+def suspend_role(agent: str) -> Dict[str, str]:
+    return log_event("suspend", {"agent": agent})
+
+
+def transfer_role(agent: str, target: str) -> Dict[str, str]:
+    return log_event("transfer", {"agent": agent, "target": target})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/view", methods=["POST"])
+def api_view() -> str:
+    data = request.get_json() or {}
+    return jsonify(view_role(str(data.get("agent"))))
+
+
+@app.route("/edit", methods=["POST"])
+def api_edit() -> str:
+    data = request.get_json() or {}
+    return jsonify(edit_role(str(data.get("agent")), str(data.get("role"))))
+
+
+@app.route("/suspend", methods=["POST"])
+def api_suspend() -> str:
+    data = request.get_json() or {}
+    return jsonify(suspend_role(str(data.get("agent"))))
+
+
+@app.route("/transfer", methods=["POST"])
+def api_transfer() -> str:
+    data = request.get_json() or {}
+    return jsonify(transfer_role(str(data.get("agent")), str(data.get("target"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "view":
+        return view_role(data.get("agent", ""))
+    if action == "edit":
+        return edit_role(data.get("agent", ""), data.get("role", ""))
+    if action == "suspend":
+        return suspend_role(data.get("agent", ""))
+    if action == "transfer":
+        return transfer_role(data.get("agent", ""), data.get("target", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Council Role/Privilege Auditor")
+    sub = ap.add_subparsers(dest="cmd")
+
+    vw = sub.add_parser("view", help="View agent role")
+    vw.add_argument("agent")
+    vw.set_defaults(func=lambda a: print(json.dumps(view_role(a.agent), indent=2)))
+
+    ed = sub.add_parser("edit", help="Edit agent role")
+    ed.add_argument("agent")
+    ed.add_argument("role")
+    ed.set_defaults(func=lambda a: print(json.dumps(edit_role(a.agent, a.role), indent=2)))
+
+    sp = sub.add_parser("suspend", help="Suspend agent role")
+    sp.add_argument("agent")
+    sp.set_defaults(func=lambda a: print(json.dumps(suspend_role(a.agent), indent=2)))
+
+    tr = sub.add_parser("transfer", help="Transfer role")
+    tr.add_argument("agent")
+    tr.add_argument("target")
+    tr.set_defaults(func=lambda a: print(json.dumps(transfer_role(a.agent, a.target), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_memory_capsule_registry.py
+++ b/resonite_spiral_memory_capsule_registry.py
@@ -1,0 +1,112 @@
+"""Resonite Spiral Memory Capsule Registry
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_MEMORY_CAPSULE_LOG", "logs/resonite_spiral_memory_capsule_registry.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def register_capsule(path: str, world: str, custodian: str) -> Dict[str, str]:
+    h = hashlib.sha256(Path(path).read_bytes()).hexdigest() if Path(path).exists() else ""
+    return log_event("register", {"capsule": path, "hash": h, "world": world, "custodian": custodian})
+
+
+def verify_capsule(path: str, expected: str) -> Dict[str, str]:
+    h = hashlib.sha256(Path(path).read_bytes()).hexdigest() if Path(path).exists() else ""
+    status = "match" if h == expected else "mismatch"
+    return log_event("verify", {"capsule": path, "expected": expected, "actual": h, "status": status})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/register", methods=["POST"])
+def api_register() -> str:
+    data = request.get_json() or {}
+    return jsonify(register_capsule(str(data.get("path")), str(data.get("world")), str(data.get("custodian"))))
+
+
+@app.route("/verify", methods=["POST"])
+def api_verify() -> str:
+    data = request.get_json() or {}
+    return jsonify(verify_capsule(str(data.get("path")), str(data.get("expected"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "register":
+        return register_capsule(data.get("path", ""), data.get("world", ""), data.get("custodian", ""))
+    if action == "verify":
+        return verify_capsule(data.get("path", ""), data.get("expected", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Memory Capsule Registry")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rg = sub.add_parser("register", help="Register capsule")
+    rg.add_argument("path")
+    rg.add_argument("world")
+    rg.add_argument("custodian")
+    rg.set_defaults(func=lambda a: print(json.dumps(register_capsule(a.path, a.world, a.custodian), indent=2)))
+
+    vf = sub.add_parser("verify", help="Verify capsule")
+    vf.add_argument("path")
+    vf.add_argument("expected")
+    vf.set_defaults(func=lambda a: print(json.dumps(verify_capsule(a.path, a.expected), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_world_health_mood_analytics.py
+++ b/resonite_world_health_mood_analytics.py
@@ -1,0 +1,108 @@
+"""Resonite Ritual World Health & Mood Analytics
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_WORLD_HEALTH_LOG", "logs/resonite_world_health_mood_analytics.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def record_health(world: str, metric: str, value: str) -> Dict[str, str]:
+    return log_event("health", {"world": world, "metric": metric, "value": value})
+
+
+def record_mood(world: str, mood: str) -> Dict[str, str]:
+    return log_event("mood", {"world": world, "mood": mood})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/health", methods=["POST"])
+def api_health() -> str:
+    data = request.get_json() or {}
+    return jsonify(record_health(str(data.get("world")), str(data.get("metric")), str(data.get("value"))))
+
+
+@app.route("/mood", methods=["POST"])
+def api_mood() -> str:
+    data = request.get_json() or {}
+    return jsonify(record_mood(str(data.get("world")), str(data.get("mood"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "health":
+        return record_health(data.get("world", ""), data.get("metric", ""), data.get("value", ""))
+    if action == "mood":
+        return record_mood(data.get("world", ""), data.get("mood", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ritual World Health & Mood Analytics")
+    sub = ap.add_subparsers(dest="cmd")
+
+    hl = sub.add_parser("health", help="Record health metric")
+    hl.add_argument("world")
+    hl.add_argument("metric")
+    hl.add_argument("value")
+    hl.set_defaults(func=lambda a: print(json.dumps(record_health(a.world, a.metric, a.value), indent=2)))
+
+    md = sub.add_parser("mood", help="Record mood")
+    md.add_argument("world")
+    md.add_argument("mood")
+    md.set_defaults(func=lambda a: print(json.dumps(record_mood(a.world, a.mood), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_world_provenance_map_explorer.py
+++ b/resonite_world_provenance_map_explorer.py
@@ -1,0 +1,88 @@
+"""Resonite Ceremony/World Provenance Map Explorer
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_WORLD_PROVENANCE_LOG", "logs/resonite_world_provenance_map_explorer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def map_entity(entity: str, origin: str, blessing: str) -> Dict[str, str]:
+    return log_event("map", {"entity": entity, "origin": origin, "blessing": blessing})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/map", methods=["POST"])
+def api_map() -> str:
+    data = request.get_json() or {}
+    return jsonify(map_entity(str(data.get("entity")), str(data.get("origin")), str(data.get("blessing"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+# ProtoFlux hook
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return map_entity(data.get("entity", ""), data.get("origin", ""), data.get("blessing", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ceremony/World Provenance Map Explorer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    mp = sub.add_parser("map", help="Map entity provenance")
+    mp.add_argument("entity")
+    mp.add_argument("origin")
+    mp.add_argument("blessing")
+    mp.set_defaults(func=lambda a: print(json.dumps(map_entity(a.entity, a.origin, a.blessing), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- implement council law vault and amendment engine
- add resilience stress-test orchestrator
- add world provenance map explorer
- add bell of pause broadcast system
- add council role/privilege auditor
- add memory capsule registry
- add artifact license broker
- add world health & mood analytics
- add ritual timeline composer
- add public outreach announcer
- register new modules in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ddec6c10c8320a97f88483b510a8a