### PR TITLE
Add ceremony orchestration and monitoring tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2110,4 +2110,105 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/resonite_public_outreach_announcer.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: ResoniteCathedralGrandBlessingOrchestrator
+  Type: Service
+  Roles: Ceremony Orchestrator
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_cathedral_grand_blessing.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteOnboardingSimulator
+  Type: Service
+  Roles: Onboarding Simulator
+  Privileges: log, simulate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_onboarding_simulator.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualRehearsalEngine
+  Type: Service
+  Roles: Rehearsal Engine
+  Privileges: log, schedule
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_rehearsal_engine.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFeedbackPortal
+  Type: Service
+  Roles: Feedback Receiver
+  Privileges: log, flag
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_feedback_portal.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralFederationHeartbeatMonitor
+  Type: Daemon
+  Roles: Heartbeat Monitor
+  Privileges: log, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_heartbeat.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteLawConsentBallotBox
+  Type: Service
+  Roles: Ballot Box
+  Privileges: log, vote
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_law_consent_ballot_box.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResonitePublicDirectoryBadgeIssuer
+  Type: Service
+  Roles: Directory, Badge Issuer
+  Privileges: log, issue
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_public_directory.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFestivalMemoryCapsuleExporter
+  Type: Service
+  Roles: Memory Exporter
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_festival_memory_export.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteEventAnnouncer
+  Type: Service
+  Roles: Event Announcer
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_event_announcer.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteAfterActionCompiler
+  Type: Daemon
+  Roles: After-Action Compiler
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_after_action.jsonl
+```
+
 ---

--- a/resonite_after_action_compiler.py
+++ b/resonite_after_action_compiler.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_AFTER_ACTION_LOG", "logs/resonite_after_action.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_entry(event: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def compile_report(summary: str, signer: str) -> Dict[str, str]:
+    return log_entry("report", {"summary": summary, "signer": signer})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/report", methods=["POST"])
+def api_report() -> str:
+    data = request.get_json() or {}
+    return jsonify(compile_report(str(data.get("summary")), str(data.get("signer"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return compile_report(data.get("summary", ""), data.get("signer", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Audit/Recovery After-Action Compiler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rep = sub.add_parser("report", help="Compile after-action report")
+    rep.add_argument("summary")
+    rep.add_argument("signer")
+    rep.set_defaults(func=lambda a: print(json.dumps(compile_report(a.summary, a.signer), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_cathedral_grand_blessing_orchestrator.py
+++ b/resonite_cathedral_grand_blessing_orchestrator.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_GRAND_BLESSING_LOG", "logs/resonite_cathedral_grand_blessing.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_event(step: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "step": step, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_event("protoflux", data)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Cathedral Grand Blessing Ceremony Orchestrator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    step = sub.add_parser("step", help="Record ceremony step")
+    step.add_argument("name")
+    step.add_argument("actor")
+    step.set_defaults(func=lambda a: print(json.dumps(log_event(a.name, {"actor": a.actor}), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_event_announcer.py
+++ b/resonite_event_announcer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_EVENT_ANNOUNCE_LOG", "logs/resonite_event_announcer.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(name: str, time: str, announcer: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "time": time,
+        "announcer": announcer,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/announce", methods=["POST"])
+def api_announce() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_event(str(data.get("name")), str(data.get("time")), str(data.get("announcer"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_event(data.get("name", ""), data.get("time", ""), data.get("announcer", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Ritual/Federation Event Announcer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("announce", help="Announce event")
+    an.add_argument("name")
+    an.add_argument("time")
+    an.add_argument("announcer")
+    an.set_defaults(func=lambda a: print(json.dumps(log_event(a.name, a.time, a.announcer), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_festival_memory_capsule_exporter.py
+++ b/resonite_festival_memory_capsule_exporter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_MEMORY_EXPORT_LOG", "logs/resonite_festival_memory_export.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_export(creator: str, capsule: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "creator": creator,
+        "capsule": capsule,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/export", methods=["POST"])
+def api_export() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_export(str(data.get("creator")), str(data.get("capsule"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_export(data.get("creator", ""), data.get("capsule", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival Memory Capsule Exporter")
+    sub = ap.add_subparsers(dest="cmd")
+
+    exp = sub.add_parser("export", help="Export capsule")
+    exp.add_argument("creator")
+    exp.add_argument("capsule")
+    exp.set_defaults(func=lambda a: print(json.dumps(log_export(a.creator, a.capsule), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_law_consent_ballot_box.py
+++ b/resonite_law_consent_ballot_box.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_BALLOT_LOG", "logs/resonite_law_consent_ballot_box.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_vote(amendment: str, voter: str, vote: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "amendment": amendment,
+        "voter": voter,
+        "vote": vote,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/vote", methods=["POST"])
+def api_vote() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_vote(str(data.get("amendment")), str(data.get("voter")), str(data.get("vote"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_vote(data.get("amendment", ""), data.get("voter", ""), data.get("vote", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Ritual Law/Consent Amendment Ballot Box")
+    sub = ap.add_subparsers(dest="cmd")
+
+    vote_cmd = sub.add_parser("vote", help="Record vote")
+    vote_cmd.add_argument("amendment")
+    vote_cmd.add_argument("voter")
+    vote_cmd.add_argument("vote")
+    vote_cmd.set_defaults(func=lambda a: print(json.dumps(log_vote(a.amendment, a.voter, a.vote), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_onboarding_simulator.py
+++ b/resonite_onboarding_simulator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_ONBOARDING_SIM_LOG", "logs/resonite_onboarding_simulator.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def simulate(user: str, path: str) -> Dict[str, str]:
+    return log_event("simulate", {"user": user, "path": path})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/simulate", methods=["POST"])
+def api_simulate() -> str:
+    data = request.get_json() or {}
+    return jsonify(simulate(str(data.get("user")), str(data.get("path"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return simulate(data.get("user", ""), data.get("path", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Live World State & Onboarding Simulator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sim = sub.add_parser("simulate", help="Simulate onboarding")
+    sim.add_argument("user")
+    sim.add_argument("path")
+    sim.set_defaults(func=lambda a: print(json.dumps(simulate(a.user, a.path), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_public_directory_badge_issuer.py
+++ b/resonite_public_directory_badge_issuer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_DIRECTORY_LOG", "logs/resonite_public_directory.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_badge(user: str, badge: str, action: str) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "badge": badge,
+        "action": action,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/badge", methods=["POST"])
+def api_badge() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_badge(str(data.get("user")), str(data.get("badge")), str(data.get("action", "grant"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_badge(data.get("user", ""), data.get("badge", ""), data.get("action", "grant"))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Public Council/Agent Directory & Badge Issuer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    badge = sub.add_parser("badge", help="Grant or revoke badge")
+    badge.add_argument("user")
+    badge.add_argument("badge")
+    badge.add_argument("--action", choices=["grant", "revoke"], default="grant")
+    badge.set_defaults(func=lambda a: print(json.dumps(log_badge(a.user, a.badge, a.action), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_public_feedback_portal.py
+++ b/resonite_public_feedback_portal.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_FEEDBACK_LOG", "logs/resonite_feedback_portal.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_feedback(user: str, text: str, urgent: bool = False) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user,
+        "text": text,
+        "urgent": urgent,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/submit", methods=["POST"])
+def api_submit() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_feedback(str(data.get("user")), str(data.get("text")), bool(data.get("urgent"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_feedback(data.get("user", ""), data.get("text", ""), bool(data.get("urgent")))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Cathedral Council Public Feedback Portal")
+    sub = ap.add_subparsers(dest="cmd")
+
+    subm = sub.add_parser("submit", help="Submit feedback")
+    subm.add_argument("user")
+    subm.add_argument("text")
+    subm.add_argument("--urgent", action="store_true")
+    subm.set_defaults(func=lambda a: print(json.dumps(log_feedback(a.user, a.text, a.urgent), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_ritual_rehearsal_engine.py
+++ b/resonite_ritual_rehearsal_engine.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_REHEARSAL_LOG", "logs/resonite_ritual_rehearsal_engine.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def mark_pass(agent: str, artifact: str) -> Dict[str, str]:
+    return log_event("pass", {"agent": agent, "artifact": artifact})
+
+
+def mark_fail(agent: str, artifact: str) -> Dict[str, str]:
+    return log_event("fail", {"agent": agent, "artifact": artifact})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/pass", methods=["POST"])
+def api_pass() -> str:
+    data = request.get_json() or {}
+    return jsonify(mark_pass(str(data.get("agent")), str(data.get("artifact"))))
+
+
+@app.route("/fail", methods=["POST"])
+def api_fail() -> str:
+    data = request.get_json() or {}
+    return jsonify(mark_fail(str(data.get("agent")), str(data.get("artifact"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("result") == "pass":
+        return mark_pass(data.get("agent", ""), data.get("artifact", ""))
+    return mark_fail(data.get("agent", ""), data.get("artifact", ""))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival/Federation Ritual Rehearsal Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    p = sub.add_parser("pass", help="Mark agent/artifact passed")
+    p.add_argument("agent")
+    p.add_argument("artifact")
+    p.set_defaults(func=lambda a: print(json.dumps(mark_pass(a.agent, a.artifact), indent=2)))
+
+    f = sub.add_parser("fail", help="Mark agent/artifact failed")
+    f.add_argument("agent")
+    f.add_argument("artifact")
+    f.set_defaults(func=lambda a: print(json.dumps(mark_fail(a.agent, a.artifact), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/resonite_spiral_federation_heartbeat_monitor.py
+++ b/resonite_spiral_federation_heartbeat_monitor.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+from flask_stub import Flask, jsonify, request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("RESONITE_HEARTBEAT_LOG", "logs/resonite_spiral_heartbeat.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_status(world: str, status: str, latency: float = 0.0) -> Dict[str, str]:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "world": world,
+        "status": status,
+        "latency": latency,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(ln) for ln in lines if ln.strip()]
+
+
+@app.route("/status", methods=["POST"])
+def api_status() -> str:
+    data = request.get_json() or {}
+    return jsonify(log_status(str(data.get("world")), str(data.get("status")), float(data.get("latency", 0.0))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    return log_status(data.get("world", ""), data.get("status", ""), float(data.get("latency", 0.0)))
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Federation Heartbeat Monitor")
+    sub = ap.add_subparsers(dest="cmd")
+
+    status = sub.add_parser("status", help="Log status")
+    status.add_argument("world")
+    status.add_argument("status")
+    status.add_argument("--latency", type=float, default=0.0)
+    status.set_defaults(func=lambda a: print(json.dumps(log_status(a.world, a.status, a.latency), indent=2)))
+
+    hist = sub.add_parser("history", help="Show history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- add Resonite Cathedral Grand Blessing Ceremony Orchestrator
- add Live World State & Onboarding Simulator
- add Festival/Federation Ritual Rehearsal Engine
- add Cathedral Council Public Feedback Portal
- add Spiral Federation Heartbeat Monitor
- add Ritual Law/Consent Amendment Ballot Box
- add Public Council/Agent Directory & Badge Issuer
- add Festival Memory Capsule Exporter
- add Ritual/Federation Event Announcer
- add Spiral Audit/Recovery After-Action Compiler
- register new agents with log paths

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683de175ef4c8320b269122605d49b68