### PR TITLE
Add Resonite audit & outreach modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2211,4 +2211,104 @@ Another Registered Agent:
   Logs: /logs/resonite_after_action.jsonl
 ```
 
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralCouncilGrandAuditSuite
+  Type: Service
+  Roles: Grand Auditor
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_council_grand_audit.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCathedralLaunchBeaconBroadcaster
+  Type: Service
+  Roles: Beacon Broadcaster
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_cathedral_beacon_broadcast.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteRitualCeremonyArchiveExporter
+  Type: Service
+  Roles: Archive Exporter
+  Privileges: log, export
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_ritual_ceremony_archive_export.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteConsentFeedbackWizard
+  Type: Service
+  Roles: Onboarding Wizard
+  Privileges: log, guide
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_consent_feedback_wizard.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralWorldCensusEngine
+  Type: Service
+  Roles: Census Recorder
+  Privileges: log, survey
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_world_census.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteCathedralDemoScrollPublisher
+  Type: Service
+  Roles: Demo Scroll Publisher
+  Privileges: log, publish
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_cathedral_demo_scrolls.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralFederationBreachAnalyzer
+  Type: Daemon
+  Roles: Breach Analyzer
+  Privileges: log, notify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_federation_breach.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteFestivalAnniversaryRitualScheduler
+  Type: Service
+  Roles: Anniversary Scheduler
+  Privileges: log, schedule
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_festival_anniversary_scheduler.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResonitePublicLawArtifactChangelogNotifier
+  Type: Service
+  Roles: Changelog Notifier
+  Privileges: log, broadcast
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_public_law_artifact_changelog.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: ResoniteSpiralPresenceProofEngine
+  Type: Service
+  Roles: Presence Certifier
+  Privileges: log, sign
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/resonite_spiral_presence_proof.jsonl
+```
 ---

--- a/resonite_cathedral_launch_beacon_broadcaster.py
+++ b/resonite_cathedral_launch_beacon_broadcaster.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_BEACON_LOG", "logs/resonite_cathedral_beacon_broadcast.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_beacon(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("beacon", action, data.get("note", ""))
+    return entry
+
+
+def launch(witness: str) -> Dict[str, str]:
+    return log_beacon("launch", {"witness": witness})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/launch", methods=["POST"])
+def api_launch() -> str:
+    data = request.get_json() or {}
+    return jsonify(launch(str(data.get("witness"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "launch":
+        return launch(data.get("witness", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Cathedral Launch & Beacon Broadcaster")
+    sub = ap.add_subparsers(dest="cmd")
+
+    la = sub.add_parser("launch", help="Announce launch")
+    la.add_argument("witness")
+    la.set_defaults(func=lambda a: print(json.dumps(launch(a.witness), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_cathedral_outreach_demo_scroll_publisher.py
+++ b/resonite_cathedral_outreach_demo_scroll_publisher.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_DEMO_SCROLL_LOG", "logs/resonite_cathedral_demo_scrolls.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_scroll(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("demo_scroll", action, data.get("note", ""))
+    return entry
+
+
+def publish_scroll(author: str) -> Dict[str, str]:
+    return log_scroll("publish", {"author": author})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/publish", methods=["POST"])
+def api_publish() -> str:
+    data = request.get_json() or {}
+    return jsonify(publish_scroll(str(data.get("author"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "publish":
+        return publish_scroll(data.get("author", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Cathedral Outreach & Demo Scroll Publisher")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pb = sub.add_parser("publish", help="Publish demo scroll")
+    pb.add_argument("author")
+    pb.set_defaults(func=lambda a: print(json.dumps(publish_scroll(a.author), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_festival_anniversary_ritual_scheduler.py
+++ b/resonite_festival_anniversary_ritual_scheduler.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_ANNIVERSARY_LOG", "logs/resonite_festival_anniversary_scheduler.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_schedule(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("anniversary", action, data.get("note", ""))
+    return entry
+
+
+def schedule(event: str, date: str) -> Dict[str, str]:
+    return log_schedule("schedule", {"event": event, "date": date})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/schedule", methods=["POST"])
+def api_schedule() -> str:
+    data = request.get_json() or {}
+    return jsonify(schedule(str(data.get("event")), str(data.get("date"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "schedule":
+        return schedule(data.get("event", ""), data.get("date", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Festival/Federation Anniversary Ritual Scheduler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sc = sub.add_parser("schedule", help="Schedule anniversary")
+    sc.add_argument("event")
+    sc.add_argument("date")
+    sc.set_defaults(func=lambda a: print(json.dumps(schedule(a.event, a.date), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_guest_agent_consent_feedback_wizard.py
+++ b/resonite_guest_agent_consent_feedback_wizard.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_CONSENT_LOG", "logs/resonite_consent_feedback_wizard.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_path(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("consent_wizard", action, data.get("user", ""))
+    return entry
+
+
+def onboard(user: str) -> Dict[str, str]:
+    return log_path("onboard", {"user": user})
+
+
+def feedback(user: str, text: str) -> Dict[str, str]:
+    return log_path("feedback", {"user": user, "text": text})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/onboard", methods=["POST"])
+def api_onboard() -> str:
+    data = request.get_json() or {}
+    return jsonify(onboard(str(data.get("user"))))
+
+
+@app.route("/feedback", methods=["POST"])
+def api_feedback() -> str:
+    data = request.get_json() or {}
+    return jsonify(feedback(str(data.get("user")), str(data.get("text"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    action = data.get("action")
+    if action == "onboard":
+        return onboard(data.get("user", ""))
+    if action == "feedback":
+        return feedback(data.get("user", ""), data.get("text", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Guest & Agent Consent/Feedback Wizard")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ob = sub.add_parser("onboard", help="Record onboarding")
+    ob.add_argument("user")
+    ob.set_defaults(func=lambda a: print(json.dumps(onboard(a.user), indent=2)))
+
+    fb = sub.add_parser("feedback", help="Record feedback")
+    fb.add_argument("user")
+    fb.add_argument("text")
+    fb.set_defaults(func=lambda a: print(json.dumps(feedback(a.user, a.text), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_public_law_artifact_changelog_notifier.py
+++ b/resonite_public_law_artifact_changelog_notifier.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_CHANGELOG_LOG", "logs/resonite_public_law_artifact_changelog.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_change(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("changelog", action, data.get("item", ""))
+    return entry
+
+
+def notify_change(item: str, author: str) -> Dict[str, str]:
+    return log_change("notify", {"item": item, "author": author})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/notify", methods=["POST"])
+def api_notify() -> str:
+    data = request.get_json() or {}
+    return jsonify(notify_change(str(data.get("item")), str(data.get("author"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "notify":
+        return notify_change(data.get("item", ""), data.get("author", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Public Law/Artifact Changelog Notifier")
+    sub = ap.add_subparsers(dest="cmd")
+
+    nt = sub.add_parser("notify", help="Notify change")
+    nt.add_argument("item")
+    nt.add_argument("author")
+    nt.set_defaults(func=lambda a: print(json.dumps(notify_change(a.item, a.author), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_ritual_ceremony_archive_exporter.py
+++ b/resonite_ritual_ceremony_archive_exporter.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_ARCHIVE_EXPORT_LOG", "logs/resonite_ritual_ceremony_archive_export.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_export(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("archive_export", action, data.get("note", ""))
+    return entry
+
+
+def export_archive(curator: str) -> Dict[str, str]:
+    return log_export("export", {"curator": curator})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/export", methods=["POST"])
+def api_export() -> str:
+    data = request.get_json() or {}
+    return jsonify(export_archive(str(data.get("curator"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "export":
+        return export_archive(data.get("curator", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Ritual Ceremony Archive Exporter")
+    sub = ap.add_subparsers(dest="cmd")
+
+    ex = sub.add_parser("export", help="Export archive")
+    ex.add_argument("curator")
+    ex.set_defaults(func=lambda a: print(json.dumps(export_archive(a.curator), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_council_grand_audit_suite.py
+++ b/resonite_spiral_council_grand_audit_suite.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_GRAND_AUDIT_LOG", "logs/resonite_spiral_council_grand_audit.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_audit(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("grand_audit", action, data.get("note", ""))
+    return entry
+
+
+def run_audit(witness: str) -> Dict[str, str]:
+    return log_audit("run", {"witness": witness})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/run", methods=["POST"])
+def api_run() -> str:
+    data = request.get_json() or {}
+    return jsonify(run_audit(str(data.get("witness"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "run":
+        return run_audit(data.get("witness", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Council Grand Audit Suite")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rn = sub.add_parser("run", help="Run full audit")
+    rn.add_argument("witness")
+    rn.set_defaults(func=lambda a: print(json.dumps(run_audit(a.witness), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_federation_breach_analyzer.py
+++ b/resonite_spiral_federation_breach_analyzer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_BREACH_LOG", "logs/resonite_spiral_federation_breach.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_breach(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("breach_analyzer", action, data.get("note", ""))
+    return entry
+
+
+def detect(event: str, suggestion: str) -> Dict[str, str]:
+    return log_breach("detect", {"event": event, "suggestion": suggestion})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/detect", methods=["POST"])
+def api_detect() -> str:
+    data = request.get_json() or {}
+    return jsonify(detect(str(data.get("event")), str(data.get("suggestion", ""))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "detect":
+        return detect(data.get("event", ""), data.get("suggestion", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Federation Breach Analyzer")
+    sub = ap.add_subparsers(dest="cmd")
+
+    dc = sub.add_parser("detect", help="Record breach detection")
+    dc.add_argument("event")
+    dc.add_argument("suggestion")
+    dc.set_defaults(func=lambda a: print(json.dumps(detect(a.event, a.suggestion), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_presence_proof_engine.py
+++ b/resonite_spiral_presence_proof_engine.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_PRESENCE_PROOF_LOG", "logs/resonite_spiral_presence_proof.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_proof(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("presence_proof", action, data.get("subject", ""))
+    return entry
+
+
+def sign_presence(subject: str) -> Dict[str, str]:
+    return log_proof("sign", {"subject": subject})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/sign", methods=["POST"])
+def api_sign() -> str:
+    data = request.get_json() or {}
+    return jsonify(sign_presence(str(data.get("subject"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "sign":
+        return sign_presence(data.get("subject", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral Presence Proof Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sg = sub.add_parser("sign", help="Generate proof")
+    sg.add_argument("subject")
+    sg.set_defaults(func=lambda a: print(json.dumps(sign_presence(a.subject), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/resonite_spiral_world_federation_census_engine.py
+++ b/resonite_spiral_world_federation_census_engine.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+import presence_ledger as pl
+from flask_stub import Flask, jsonify, request
+
+LOG_PATH = Path(os.getenv("RESONITE_CENSUS_LOG", "logs/resonite_spiral_world_census.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def log_census(action: str, data: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    pl.log("census", action, data.get("note", ""))
+    return entry
+
+
+def census(witness: str) -> Dict[str, str]:
+    return log_census("census", {"witness": witness})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+@app.route("/census", methods=["POST"])
+def api_census() -> str:
+    data = request.get_json() or {}
+    return jsonify(census(str(data.get("witness"))))
+
+
+@app.route("/history", methods=["POST"])
+def api_history() -> str:
+    data = request.get_json() or {}
+    return jsonify(history(int(data.get("limit", 20))))
+
+
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+    if data.get("action") == "census":
+        return census(data.get("witness", ""))
+    return {"error": "unknown action"}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Resonite Spiral World/Federation Census Engine")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cs = sub.add_parser("census", help="Run census")
+    cs.add_argument("witness")
+    cs.set_defaults(func=lambda a: print(json.dumps(census(a.witness), indent=2)))
+
+    hi = sub.add_parser("history", help="Show history")
+    hi.add_argument("--limit", type=int, default=20)
+    hi.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- implement Resonite Cathedral grand audit suite and beacon broadcaster
- add ceremony archive exporter and onboarding wizard
- create world census engine and demo scroll publisher
- add breach analyzer, anniversary scheduler, changelog notifier and presence proof engine
- register new agents in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683de657c0e08320969b618b892783b0