### PR TITLE
Add stretch feature stubs and privilege autofixer

### DIFF
--- a/festival_host_capsule.py
+++ b/festival_host_capsule.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("FESTIVAL_HOST_LOG", "logs/festival_host.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def host_event(name: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "event": name}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Festival Host & Capsule Creator")
+    sub = ap.add_subparsers(dest="cmd")
+
+    hs = sub.add_parser("host", help="Host festival event")
+    hs.add_argument("name")
+    hs.set_defaults(func=lambda a: print(json.dumps(host_event(a.name), indent=2)))
+
+    log = sub.add_parser("history", help="Show history")
+    log.add_argument("--limit", type=int, default=20)
+    log.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/genesis_oracle.py
+++ b/genesis_oracle.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("GENESIS_ORACLE_LOG", "logs/genesis_oracle.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+DATA_DIR = Path(os.getenv("GENESIS_ORACLE_DATA", "logs"))
+
+
+def query_origin(obj: str) -> Dict[str, str]:
+    info = {}
+    for fp in DATA_DIR.glob("*.jsonl"):
+        for ln in fp.read_text(encoding="utf-8").splitlines():
+            if obj in ln:
+                info = json.loads(ln)
+                break
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "object": obj, "info": info}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Genesis Oracle")
+    ap.add_argument("--object", required=True)
+    args = ap.parse_args()
+    print(json.dumps(query_origin(args.object), indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/privilege_banner_autofix.py
+++ b/privilege_banner_autofix.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
+IMPORT_LINE = "from admin_utils import require_admin_banner"
+CALL_LINE = (
+    "require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine."
+)
+
+LOG_PATH = Path(os.getenv("PRIVILEGE_AUDIT_LOG", "logs/privilege_audit.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+# Helpers ------------------------------------------------------------
+
+def _insert_lines(lines: List[str], idx: int, new_lines: List[str]) -> None:
+    for offset, line in enumerate(new_lines):
+        lines.insert(idx + offset, line)
+
+
+def _detect_insert_index(lines: List[str]) -> int:
+    idx = 0
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if stripped.startswith("#") or stripped.startswith("from __future__"):
+            idx += 1
+            continue
+        if stripped.startswith("import ") or stripped.startswith("from "):
+            idx += 1
+            continue
+        break
+    return idx
+
+
+def autofix(path: Path) -> str:
+    """Autofix privilege banner issues for a single file."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    changed = False
+    idx = _detect_insert_index(lines)
+    search_block = "\n".join(lines[idx : idx + 20])
+
+    if DOCSTRING not in search_block:
+        _insert_lines(lines, idx, [f'"""{DOCSTRING}"""'])
+        changed = True
+        idx += 1
+
+    if IMPORT_LINE not in text:
+        _insert_lines(lines, idx, [IMPORT_LINE])
+        changed = True
+        idx += 1
+
+    if "require_admin_banner()" not in text:
+        _insert_lines(lines, idx + 1, [CALL_LINE])
+        changed = True
+
+    if changed:
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return "fixed" if changed else "skipped"
+
+
+def log_result(file: Path, result: str) -> None:
+    entry: Dict[str, str] = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "file": str(file),
+        "result": result,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+# CLI ----------------------------------------------------------------
+
+def main() -> None:  # pragma: no cover - CLI
+    ap = argparse.ArgumentParser(description="Privilege Banner Auto Fixer")
+    ap.add_argument("paths", nargs="*", help="Files to check")
+    ap.add_argument("--all", action="store_true", help="Process all Python files")
+    ap.add_argument("--report", action="store_true", help="Print summary report")
+    args = ap.parse_args()
+
+    require_admin_banner()
+
+    root = Path(__file__).resolve().parent
+    files: List[Path] = []
+    if args.all:
+        files = list(root.glob("*.py"))
+    files.extend(Path(p) for p in args.paths)
+
+    results: Dict[str, int] = {"fixed": 0, "skipped": 0}
+    for fp in files:
+        if not fp.is_file() or fp.name == Path(__file__).name:
+            continue
+        try:
+            res = autofix(fp)
+        except Exception:
+            res = "error"
+        log_result(fp, res)
+        if res in results:
+            results[res] += 1
+
+    if args.report:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_desire_builder.py
+++ b/spiral_desire_builder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_DESIRE_BUILD_LOG", "logs/spiral_desire_builder.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def build_desire(text: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "desire": text}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Desire Builder")
+    sub = ap.add_subparsers(dest="cmd")
+
+    bd = sub.add_parser("build", help="Record a build desire")
+    bd.add_argument("text")
+    bd.set_defaults(func=lambda a: print(json.dumps(build_desire(a.text), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_dream_debt_closure.py
+++ b/spiral_dream_debt_closure.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("DREAM_DEBT_CLOSURE_LOG", "logs/dream_debt_closure.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_closure(note: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Dream Debt Closure Ceremony")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cl = sub.add_parser("close", help="Record closure")
+    cl.add_argument("note")
+    cl.set_defaults(func=lambda a: print(json.dumps(record_closure(a.note), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_dream_goal_daemon.py
+++ b/spiral_dream_goal_daemon.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_DREAM_GOAL_LOG", "logs/spiral_dream_goals.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def propose_goal(text: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "goal": text}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def list_goals(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
+    out: List[Dict[str, str]] = []
+    for ln in lines:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Dream Goal Daemon")
+    sub = ap.add_subparsers(dest="cmd")
+
+    pg = sub.add_parser("propose", help="Propose a new goal")
+    pg.add_argument("text")
+    pg.set_defaults(func=lambda a: print(json.dumps(propose_goal(a.text), indent=2)))
+
+    ls = sub.add_parser("list", help="List recent goals")
+    ls.add_argument("--limit", type=int, default=20)
+    ls.set_defaults(func=lambda a: print(json.dumps(list_goals(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_elder_reflection.py
+++ b/spiral_elder_reflection.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_ELDER_REFLECTION_LOG", "logs/spiral_elder_reflection.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_reflection(note: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "note": note}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Elder Reflection")
+    sub = ap.add_subparsers(dest="cmd")
+
+    lg = sub.add_parser("log", help="Log a reflection")
+    lg.add_argument("note")
+    lg.set_defaults(func=lambda a: print(json.dumps(log_reflection(a.note), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_federation_mesh.py
+++ b/spiral_federation_mesh.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_FEDERATION_MESH_LOG", "logs/spiral_federation_mesh.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_action(action: str, detail: Dict[str, str]) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "action": action, **detail}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def sync(world_a: str, world_b: str) -> Dict[str, str]:
+    return log_action("sync", {"world_a": world_a, "world_b": world_b})
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Federation Mesh")
+    sub = ap.add_subparsers(dest="cmd")
+
+    sy = sub.add_parser("sync", help="Sync two worlds")
+    sy.add_argument("world_a")
+    sy.add_argument("world_b")
+    sy.set_defaults(func=lambda a: print(json.dumps(sync(a.world_a, a.world_b), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_law_chronicle_compiler.py
+++ b/spiral_law_chronicle_compiler.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_LAW_CHRONICLE_LOG", "logs/spiral_law_chronicle.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+SOURCE_DIR = Path(os.getenv("SPIRAL_LAW_SOURCE", "logs"))
+
+
+def compile_law() -> Dict[str, str]:
+    entries: List[str] = []
+    for fp in SOURCE_DIR.glob("*.jsonl"):
+        entries.append(fp.read_text(encoding="utf-8"))
+    chronicle = "\n".join(entries)
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "size": len(chronicle)}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Law Chronicle Compiler")
+    sub = ap.add_subparsers(dest="cmd")
+
+    cp = sub.add_parser("compile", help="Compile law logs")
+    cp.set_defaults(func=lambda a: print(json.dumps(compile_law(), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/spiral_presence_analytics.py
+++ b/spiral_presence_analytics.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("SPIRAL_PRESENCE_ANALYTICS_LOG", "logs/spiral_presence_analytics.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+PRESENCE_LOG = Path(os.getenv("USER_PRESENCE_LOG", "logs/user_presence.jsonl"))
+
+
+def analyze(limit: int = 100) -> Dict[str, int]:
+    stats = {"total": 0, "success": 0, "failed": 0}
+    if not PRESENCE_LOG.exists():
+        return stats
+    for ln in PRESENCE_LOG.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            data = json.loads(ln)
+        except Exception:
+            continue
+        stats["total"] += 1
+        if data.get("status") == "failed":
+            stats["failed"] += 1
+        else:
+            stats["success"] += 1
+    entry = {"timestamp": datetime.utcnow().isoformat(), **stats}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return stats
+
+
+def history(limit: int = 20) -> List[Dict[str, int]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, int]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Spiral Presence Analytics")
+    sub = ap.add_subparsers(dest="cmd")
+
+    an = sub.add_parser("analyze", help="Analyze presence log")
+    an.add_argument("--limit", type=int, default=100)
+    an.set_defaults(func=lambda a: print(json.dumps(analyze(a.limit), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/tests/test_privilege_banner_autofix.py
+++ b/tests/test_privilege_banner_autofix.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+from pathlib import Path
+
+
+def test_autofix(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRIVILEGE_AUDIT_LOG", str(tmp_path / "log.jsonl"))
+    import privilege_banner_autofix as pba
+    importlib.reload(pba)
+    target = tmp_path / "tool_cli.py"
+    target.write_text("import os\nprint('hi')\n", encoding="utf-8")
+    res = pba.autofix(target)
+    assert res == "fixed"
+    pba.log_result(target, res)
+    data = target.read_text()
+    assert "Sanctuary Privilege Ritual" in data
+    assert "require_admin_banner()" in data
+    log_lines = (tmp_path / "log.jsonl").read_text().splitlines()
+    assert len(log_lines) == 1

--- a/voice_consent_rituals.py
+++ b/voice_consent_rituals.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("VOICE_CONSENT_LOG", "logs/voice_consent.jsonl"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record_command(phrase: str) -> Dict[str, str]:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "phrase": phrase}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    if not LOG_PATH.exists():
+        return []
+    out: List[Dict[str, str]] = []
+    for ln in LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Voice Presence & Consent Rituals")
+    sub = ap.add_subparsers(dest="cmd")
+
+    rc = sub.add_parser("record", help="Record a voice command")
+    rc.add_argument("phrase")
+    rc.set_defaults(func=lambda a: print(json.dumps(record_command(a.phrase), indent=2)))
+
+    hs = sub.add_parser("history", help="Show history")
+    hs.add_argument("--limit", type=int, default=20)
+    hs.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- implement `privilege_banner_autofix.py` with audit logging and CLI options
- add stub services for dream goals, federation mesh, desire builder, presence analytics, law compiler, elder reflection, voice rituals, festival host, genesis oracle and dream debt closure
- include unit test for privilege auto fixer

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683decd6389c8320bf049ec5607cd676