### PR TITLE
Run privilege lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pytest
+      - name: Run privilege lint
+        run: |
+          python privilege_lint.py
       - name: Run tests
         run: |
           pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 - [ ] `require_admin_banner()` invoked before any other logic
 
 Pull requests lacking these will fail CI and be rejected.
+CI runs `python privilege_lint.py` automatically before executing the test suite.
+If the linter reports missing banners or docstrings the job will fail.
 
-Run `python privilege_lint.py` before submitting a pull request. You can also
+Run `python privilege_lint.py` locally before submitting a pull request. You can also
 link `./.githooks/pre-commit` into your `.git/hooks` folder to automatically
 run the lint before each commit.


### PR DESCRIPTION
## Summary
- run `python privilege_lint.py` in the CI job before tests
- mention automatic linting in CONTRIBUTING docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dfd516ea08320a480055bfb335aa5