### PR TITLE
Enhance avatar relic and reflection features

### DIFF
--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -6,7 +6,8 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from random import choice
+
+import emotion_utils as eu
 
 LOG_PATH = Path(os.getenv("AVATAR_REFLECTION_LOG", "logs/avatar_reflection.jsonl"))
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -16,9 +17,16 @@ MOODS = ["happy", "sad", "angry", "serene"]
 
 
 def analyze_image(image_path: Path) -> str:
-    """Return a placeholder mood classification for an image."""
-    # TODO: replace with real classifier
-    return choice(MOODS)
+    """Return a simple mood classification for an image."""
+
+    vec = eu.detect_image(str(image_path))
+    if vec.get("Joy", 0.0) > 0:
+        return "happy"
+    if vec.get("Sadness", 0.0) > 0:
+        return "sad"
+    if vec.get("Anger", 0.0) > 0:
+        return "angry"
+    return "serene"
 
 
 def log_reflection(image: str, mood: str, note: str = "") -> dict:

--- a/avatar_relic_creator.py
+++ b/avatar_relic_creator.py
@@ -26,9 +26,20 @@ def log_relic(avatar: str, relic: str, info: dict[str, Any]) -> dict[str, Any]:
 
 
 def extract(avatar: str, relic: str) -> dict[str, Any]:
-    """Placeholder for heirloom extraction."""
-    # TODO: export selected memory fragments
-    info = {"note": "relic placeholder"}
+    """Select memory fragments for ``avatar`` and persist them as a relic."""
+
+    fragments = []
+    try:
+        import memory_manager as mm
+
+        fragments = mm.search_by_tags([avatar], limit=5)
+    except Exception:  # pragma: no cover - optional dependency failures
+        fragments = []
+
+    info = {"fragments": [f.get("text", "") for f in fragments]}
+    if not info["fragments"]:
+        info["note"] = "relic placeholder"
+
     return log_relic(avatar, relic, info)
 
 

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -14,3 +14,15 @@ def test_reflection_log(tmp_path, monkeypatch):
     assert log.exists()
     assert len(log.read_text().splitlines()) == 1
 
+
+def test_analyze_image(tmp_path, monkeypatch):
+    log = tmp_path / "reflection.jsonl"
+    monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    importlib.reload(ar)
+
+    img = tmp_path / "smile.png"
+    img.write_text("data")
+
+    mood = ar.analyze_image(img)
+    assert mood == "happy"
+

--- a/tests/test_avatar_relic_creator.py
+++ b/tests/test_avatar_relic_creator.py
@@ -1,0 +1,29 @@
+import importlib
+import json
+from pathlib import Path
+
+import avatar_relic_creator as arc
+
+
+def test_extract_records_memory(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path / "mem"))
+    import memory_manager as mm
+    importlib.reload(mm)
+    importlib.reload(arc)
+    import avatar_artifact_gallery as aag
+    importlib.reload(aag)
+
+    relic_log = tmp_path / "relics.jsonl"
+    monkeypatch.setattr(arc, "LOG_PATH", relic_log, raising=False)
+    monkeypatch.setitem(aag.LOG_PATHS, "relic", relic_log)
+    arc.LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    mm.append_memory("hello from ava", tags=["ava"])
+    mm.append_memory("other", tags=["bob"])
+
+    entry = arc.extract("ava", "token")
+    assert relic_log.exists()
+    data = json.loads(relic_log.read_text().splitlines()[0])
+    assert data["avatar"] == "ava"
+    assert entry["info"]["fragments"] == ["hello from ava"]
+


### PR DESCRIPTION
## Summary
- select recent memory fragments when creating an avatar relic
- use `emotion_utils` to classify avatar reflection images
- test relic extraction behavior
- test image analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dfd5250788320a55a735ea1483ae2