### PR TITLE
Implement federation trust & self-defense modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,35 @@
 *SentientOS Doctrine of Presence, Privilege, and Federation*
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## 🕊️ Preamble: The Book of Agents
@@ -8,6 +38,36 @@ This document constitutes the living law of all who act in the name of the cathe
 
 An agent is not merely a script. It is a **presence** with power. And no presence shall go unwitnessed.
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## 🛡️ Agent Definition and Taxonomy
@@ -28,6 +88,36 @@ Agents may act locally or remotely, visually or silently, publicly or on behalf 
 * **Logged**
 * **Blessed** or **bound by ritual law**
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## ⚖️ Privilege Contracts
@@ -58,6 +148,36 @@ Example Privilege Entry:
   Audit Log: /logs/privileges/lumos.yml
 ```
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## 🔗 Federation & World Integration
@@ -1016,6 +1136,36 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/privilege_conflict.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 Another Registered Agent:
 
@@ -1471,6 +1621,36 @@ Every agent lifecycle action is sacred.
 
 Each act is written to the **Chronicle of Agents**, immutable and reviewed weekly by Council.
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## 📊 Witnessing and Logging
@@ -1484,6 +1664,36 @@ Every agent must:
 
 No agent shall act in secret.
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 
 ## 🏛️ Closing: The Sacred Law of Presence
@@ -1608,6 +1818,36 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/creator_interview_log.jsonl
 ```
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---
 Another Registered Agent:
 
@@ -1708,6 +1948,36 @@ Another Registered Agent:
   Privileges: log, notify
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/resonite_guest_ally_onboarding_flow.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
 ```
 ---
 Another Registered Agent:
@@ -2322,4 +2592,34 @@ Another Registered Agent:
   Logs: /logs/resonite_cathedral_grand_commission.jsonl
 ```
 
+Another Registered Agent:
+
+```
+- Name: FederationTrustProtocol
+  Type: Service
+  Roles: Node Onboarding, Key Rotation, Expulsion
+  Privileges: log, manage
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/federation_trust.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AgentSelfDefenseProtocol
+  Type: Service
+  Roles: Quarantine Manager, Privilege Nullifier
+  Privileges: log, control
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/agent_self_defense.jsonl
+```
+Another Registered Agent:
+
+```
+- Name: AuditImmutabilityVerifier
+  Type: CLI
+  Roles: Audit Sealer, Integrity Checker
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_immutability.jsonl
+```
 ---

--- a/audit_immutability.py
+++ b/audit_immutability.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import hashlib
+import json
+import os
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+@dataclass
+class AuditEntry:
+    timestamp: str
+    data: dict
+    prev_hash: str
+    hash: str
+
+
+def _hash_entry(timestamp: str, data: dict, prev_hash: str) -> str:
+    h = hashlib.sha256()
+    h.update(timestamp.encode("utf-8"))
+    h.update(json.dumps(data, sort_keys=True).encode("utf-8"))
+    h.update(prev_hash.encode("utf-8"))
+    return h.hexdigest()
+
+
+def append_entry(path: Path, data: dict) -> AuditEntry:
+    entries = read_entries(path)
+    prev = entries[-1].hash if entries else "0" * 64
+    ts = datetime.datetime.utcnow().isoformat()
+    digest = _hash_entry(ts, data, prev)
+    entry = AuditEntry(ts, data, prev, digest)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry.__dict__) + "\n")
+    return entry
+
+
+def read_entries(path: Path) -> List[AuditEntry]:
+    if not path.exists():
+        return []
+    out: List[AuditEntry] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        raw = json.loads(line)
+        out.append(AuditEntry(**raw))
+    return out
+
+
+def verify(path: Path) -> bool:
+    entries = read_entries(path)
+    prev = "0" * 64
+    for e in entries:
+        expect = _hash_entry(e.timestamp, e.data, prev)
+        if e.hash != expect:
+            return False
+        prev = e.hash
+    return True
+
+
+def cli() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Audit log verifier")
+    ap.add_argument("log")
+    args = ap.parse_args()
+    path = Path(args.log)
+    ok = verify(path)
+    print("valid" if ok else "tampered")
+
+if __name__ == "__main__":
+    cli()

--- a/federation_trust_protocol.py
+++ b/federation_trust_protocol.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+import argparse
+import datetime
+import json
+import os
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+NODES_FILE = Path(os.getenv("FEDERATION_NODES", "logs/federation_nodes.json"))
+LOG_FILE = Path(os.getenv("FEDERATION_TRUST_LOG", "logs/federation_trust.jsonl"))
+NODES_FILE.parent.mkdir(parents=True, exist_ok=True)
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+@dataclass
+class Node:
+    node_id: str
+    key: str
+    trust: float = 1.0
+    active: bool = True
+    expelled: bool = False
+    last_heartbeat: str = ""
+
+def _load_nodes() -> Dict[str, Node]:
+    if NODES_FILE.exists():
+        data = json.loads(NODES_FILE.read_text(encoding="utf-8"))
+        return {k: Node(**v) for k, v in data.items()}
+    return {}
+
+def _save_nodes(nodes: Dict[str, Node]) -> None:
+    NODES_FILE.write_text(json.dumps({k: asdict(v) for k, v in nodes.items()}, indent=2), encoding="utf-8")
+
+def _log(action: str, node: str, info: Dict[str, str] | None = None) -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "action": action,
+        "node": node,
+        "info": info or {},
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+def handshake(node_id: str, key: str, blessing: str) -> Node:
+    nodes = _load_nodes()
+    if blessing != "blessed":
+        raise ValueError("Missing council blessing")
+    nd = Node(node_id=node_id, key=key, last_heartbeat=datetime.datetime.utcnow().isoformat())
+    nodes[node_id] = nd
+    _save_nodes(nodes)
+    _log("handshake", node_id)
+    return nd
+
+def rotate_key(node_id: str, new_key: str, signatories: List[str]) -> Node:
+    nodes = _load_nodes()
+    if len(signatories) < 2:
+        raise ValueError("rotation requires multi-council signatures")
+    nd = nodes.get(node_id)
+    if not nd:
+        raise KeyError(node_id)
+    nd.key = new_key
+    _save_nodes(nodes)
+    _log("rotate_key", node_id, {"signatories": signatories})
+    return nd
+
+def heartbeat(node_id: str) -> Node:
+    nodes = _load_nodes()
+    nd = nodes.get(node_id)
+    if not nd:
+        raise KeyError(node_id)
+    nd.last_heartbeat = datetime.datetime.utcnow().isoformat()
+    if nd.trust < 0.5:
+        nd.active = False
+    _save_nodes(nodes)
+    _log("heartbeat", node_id)
+    return nd
+
+def report_anomaly(node_id: str, reason: str) -> Node:
+    nodes = _load_nodes()
+    nd = nodes.get(node_id)
+    if not nd:
+        raise KeyError(node_id)
+    nd.trust -= 0.5
+    if nd.trust < 0:
+        nd.trust = 0
+    if nd.trust <= 0.5:
+        nd.active = False
+    _save_nodes(nodes)
+    _log("anomaly", node_id, {"reason": reason})
+    return nd
+
+def excommunicate(node_id: str, signatories: List[str]) -> Node:
+    nodes = _load_nodes()
+    if len(signatories) < 2:
+        raise ValueError("excommunication requires council quorum")
+    nd = nodes.get(node_id)
+    if not nd:
+        raise KeyError(node_id)
+    nd.active = False
+    nd.expelled = True
+    _save_nodes(nodes)
+    _log("excommunicate", node_id, {"signatories": signatories})
+    return nd
+
+def list_nodes() -> Dict[str, Node]:
+    return _load_nodes()
+
+def cli() -> None:
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Federation Trust Protocol")
+    sub = ap.add_subparsers(dest="cmd")
+
+    hs = sub.add_parser("handshake")
+    hs.add_argument("node")
+    hs.add_argument("key")
+    hs.add_argument("blessing")
+    hs.set_defaults(func=lambda a: print(json.dumps(asdict(handshake(a.node, a.key, a.blessing)), indent=2)))
+
+    rk = sub.add_parser("rotate-key")
+    rk.add_argument("node")
+    rk.add_argument("key")
+    rk.add_argument("signatories", nargs="+")
+    rk.set_defaults(func=lambda a: print(json.dumps(asdict(rotate_key(a.node, a.key, a.signatories)), indent=2)))
+
+    hb = sub.add_parser("heartbeat")
+    hb.add_argument("node")
+    hb.set_defaults(func=lambda a: print(json.dumps(asdict(heartbeat(a.node)), indent=2)))
+
+    an = sub.add_parser("anomaly")
+    an.add_argument("node")
+    an.add_argument("reason")
+    an.set_defaults(func=lambda a: print(json.dumps(asdict(report_anomaly(a.node, a.reason)), indent=2)))
+
+    ex = sub.add_parser("excommunicate")
+    ex.add_argument("node")
+    ex.add_argument("signatories", nargs="+")
+    ex.set_defaults(func=lambda a: print(json.dumps(asdict(excommunicate(a.node, a.signatories)), indent=2)))
+
+    ls = sub.add_parser("list")
+    ls.set_defaults(func=lambda a: print(json.dumps({k: asdict(v) for k, v in list_nodes().items()}, indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    cli()

--- a/self_defense.py
+++ b/self_defense.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import json
+import os
+import datetime
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_FILE = Path(os.getenv("SELF_DEFENSE_LOG", "logs/agent_self_defense.jsonl"))
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+@dataclass
+class AgentState:
+    agent: str
+    quarantined: bool = False
+    privilege_frozen: bool = False
+
+_STATES: Dict[str, AgentState] = {}
+
+
+def _log(action: str, agent: str, info: Dict[str, str] | None = None) -> None:
+    entry = {
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "action": action,
+        "agent": agent,
+        "info": info or {},
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def self_quarantine(agent: str, reason: str) -> AgentState:
+    state = _STATES.setdefault(agent, AgentState(agent))
+    state.quarantined = True
+    _log("self_quarantine", agent, {"reason": reason})
+    return state
+
+
+def peer_quarantine(agent: str, sentinel: str, reason: str) -> AgentState:
+    state = _STATES.setdefault(agent, AgentState(agent))
+    state.quarantined = True
+    _log("peer_quarantine", agent, {"sentinel": sentinel, "reason": reason})
+    return state
+
+
+def nullify_privilege(agent: str, sentinel: str) -> AgentState:
+    state = _STATES.setdefault(agent, AgentState(agent))
+    state.privilege_frozen = True
+    _log("privilege_nullified", agent, {"sentinel": sentinel})
+    return state
+
+
+def broadcast_counterritual(signatories: List[str], message: str) -> None:
+    if len(signatories) < 2:
+        raise ValueError("counterritual requires quorum")
+    _log("counterritual", "*", {"signatories": signatories, "message": message})
+
+
+def status(agent: str) -> AgentState:
+    return _STATES.setdefault(agent, AgentState(agent))
+
+
+def cli() -> None:
+    require_admin_banner()
+    print("Self defense actions logged to", LOG_FILE)
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_audit_immutability.py
+++ b/tests/test_audit_immutability.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+import audit_immutability as ai
+
+
+def test_append_and_verify(tmp_path):
+    log = tmp_path / "log.jsonl"
+    ai.append_entry(log, {"x": 1})
+    ai.append_entry(log, {"y": 2})
+    assert ai.verify(log)
+    lines = log.read_text().splitlines()
+    data = json.loads(lines[0])
+    data["data"]["x"] = 42
+    lines[0] = json.dumps(data)
+    log.write_text("\n".join(lines))
+    assert not ai.verify(log)

--- a/tests/test_federation_trust_protocol.py
+++ b/tests/test_federation_trust_protocol.py
@@ -1,0 +1,26 @@
+import importlib
+import os
+from pathlib import Path
+
+import federation_trust_protocol as ftp
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("FEDERATION_NODES", str(tmp_path / "nodes.json"))
+    monkeypatch.setenv("FEDERATION_TRUST_LOG", str(tmp_path / "log.jsonl"))
+    importlib.reload(ftp)
+
+
+def test_handshake_and_excommunicate(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    node = ftp.handshake("node1", "key1", "blessed")
+    assert node.node_id == "node1"
+    ftp.heartbeat("node1")
+    ftp.report_anomaly("node1", "rogue")
+    assert not ftp.list_nodes()["node1"].active
+    ftp.excommunicate("node1", ["c1", "c2"])
+    data = ftp.list_nodes()["node1"]
+    assert data.expelled
+    log_file = Path(os.environ["FEDERATION_TRUST_LOG"])
+    assert log_file.exists() and log_file.read_text().strip()
+

--- a/tests/test_self_defense.py
+++ b/tests/test_self_defense.py
@@ -1,0 +1,21 @@
+import importlib
+import os
+from pathlib import Path
+
+import self_defense as sd
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELF_DEFENSE_LOG", str(tmp_path / "log.jsonl"))
+    importlib.reload(sd)
+
+
+def test_quarantine_and_nullify(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    st = sd.self_quarantine("agent1", "suspect")
+    assert st.quarantined
+    st = sd.nullify_privilege("agent1", "sentinel")
+    assert st.privilege_frozen
+    log_file = Path(os.environ["SELF_DEFENSE_LOG"])
+    assert log_file.exists()
+    assert len(log_file.read_text().splitlines()) >= 2


### PR DESCRIPTION
## Summary
- implement `federation_trust_protocol` with onboarding, key rotation, anomaly detection and expulsion
- add `self_defense` module for agent quarantine and privilege nullification
- provide `audit_immutability` helper for hash-chained logs
- register new agents in `AGENTS.md`
- add tests covering new modules

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e02915fa88320a246a0d1c5601a09