### PR TITLE
Update privilege linter

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -9,6 +9,8 @@ DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details
 ENTRY_PATTERNS = [
     "*_cli.py",
     "*_dashboard.py",
+    "*_daemon.py",
+    "*_engine.py",
     "collab_server.py",
     "autonomous_ops.py",
     "replay.py",
@@ -64,11 +66,23 @@ def check_file(path: Path) -> list[str]:
     return issues
 
 
+def find_entrypoints(root: Path) -> list[Path]:
+    """Return Python entrypoint files under ``root``."""
+    files: set[Path] = set()
+    for pattern in ENTRY_PATTERNS:
+        files.update(root.glob(pattern))
+    for path in root.glob("*.py"):
+        if path in files:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "__main__" in text or "argparse" in text:
+            files.add(path)
+    return sorted(files)
+
+
 def main() -> int:
     root = Path(__file__).resolve().parent
-    files = []
-    for pattern in ENTRY_PATTERNS:
-        files.extend(root.glob(pattern))
+    files = find_entrypoints(root)
     issues = []
     for path in files:
         issues.extend(check_file(path))

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+
+
+def _assert_missing(issues):
+    assert any("missing privilege docstring" in i for i in issues)
+    assert any("missing require_admin_banner()" in i for i in issues)
+
+
+def test_detect_daemon_pattern(tmp_path):
+    path = tmp_path / "worker_daemon.py"
+    path.write_text("print('hi')\n", encoding="utf-8")
+    files = pl.find_entrypoints(tmp_path)
+    assert path in files
+    issues = pl.check_file(path)
+    _assert_missing(issues)
+
+
+def test_detect_main_block(tmp_path):
+    path = tmp_path / "misc.py"
+    path.write_text("if __name__ == '__main__':\n    pass\n", encoding="utf-8")
+    files = pl.find_entrypoints(tmp_path)
+    assert path in files
+    issues = pl.check_file(path)
+    _assert_missing(issues)
+
+
+def test_detect_argparse_usage(tmp_path):
+    path = tmp_path / "helper.py"
+    path.write_text("import argparse\nparser = argparse.ArgumentParser()\n", encoding="utf-8")
+    files = pl.find_entrypoints(tmp_path)
+    assert path in files
+    issues = pl.check_file(path)
+    _assert_missing(issues)


### PR DESCRIPTION
## Summary
- broaden entrypoint patterns to include daemon and engine files
- scan for `__main__` blocks and argparse usage
- expose `find_entrypoints` for programmatic use
- test new detection behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683e04f219b48320a79ac36fb0b36e4b