### PR TITLE
Centralize log directory configuration

### DIFF
--- a/avatar_personality_merge.py
+++ b/avatar_personality_merge.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from pathlib import Path
 from typing import Any
+
+from logging_config import get_log_path
 
 from admin_utils import require_admin_banner
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-LOG_PATH = Path("logs/avatar_merge.jsonl")
+LOG_PATH = get_log_path("avatar_merge.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+LOG_DIR_ENV = "SENTIENTOS_LOG_DIR"
+
+
+def get_log_dir() -> Path:
+    """Return the base directory for logs, creating it if needed."""
+    log_dir = Path(os.getenv(LOG_DIR_ENV, "logs"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def get_log_path(name: str, env_var: str | None = None) -> Path:
+    """Return a log file path.
+
+    If *env_var* is provided and that environment variable is set,
+    its value is used directly. Otherwise the path is relative to
+    the configured log directory.
+    """
+    if env_var and env_var in os.environ:
+        return Path(os.environ[env_var])
+    return get_log_dir() / name

--- a/presence_ledger.py
+++ b/presence_ledger.py
@@ -1,12 +1,13 @@
 import json
 import os
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List
+
+from logging_config import get_log_path
 
 import ledger
 
-LEDGER_PATH = Path(os.getenv("USER_PRESENCE_LOG", "logs/user_presence.jsonl"))
+LEDGER_PATH = get_log_path("user_presence.jsonl", "USER_PRESENCE_LOG")
 LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -74,7 +75,7 @@ def recent_privilege_attempts(limit: int = 5) -> List[Dict[str, str]]:
 
 def music_stats(limit: int = 100) -> Dict[str, Dict[str, float]]:
     """Return basic stats from the music ledger."""
-    music_path = Path("logs/music_log.jsonl")
+    music_path = get_log_path("music_log.jsonl")
     if not music_path.exists():
         return {"events": {}, "emotions": {}}
     lines = music_path.read_text(encoding="utf-8").splitlines()[-limit:]
@@ -96,7 +97,7 @@ def music_stats(limit: int = 100) -> Dict[str, Dict[str, float]]:
 
 def video_stats(limit: int = 100) -> Dict[str, Dict[str, float]]:
     """Return basic stats from the video ledger."""
-    video_path = Path("logs/video_log.jsonl")
+    video_path = get_log_path("video_log.jsonl")
     if not video_path.exists():
         return {"events": {}, "emotions": {}}
     lines = video_path.read_text(encoding="utf-8").splitlines()[-limit:]
@@ -123,7 +124,7 @@ def recap(limit: int = 20, user: str = "") -> Dict[str, object]:
     bless = 0
     reflections = 0
     mood_counts: Dict[str, int] = {}
-    music_path = Path("logs/music_log.jsonl")
+    music_path = get_log_path("music_log.jsonl")
     if music_path.exists():
         for ln in music_path.read_text(encoding="utf-8").splitlines()[-limit:]:
             try:

--- a/sabbath_reflection.py
+++ b/sabbath_reflection.py
@@ -3,11 +3,13 @@ import json
 from pathlib import Path
 from typing import List, Dict
 
+from logging_config import get_log_path
+
 import confessional_log as clog
 
-HERESY_LOG = Path("logs/heresy_log.jsonl")
-BLESS_LOG = Path("logs/support_log.jsonl")
-REPORT_PATH = Path("logs/ritual_sabbath.md")
+HERESY_LOG = get_log_path("heresy_log.jsonl")
+BLESS_LOG = get_log_path("support_log.jsonl")
+REPORT_PATH = get_log_path("ritual_sabbath.md")
 
 
 def _load_jsonl(path: Path) -> List[Dict]:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,25 @@
+import os
+from logging_config import get_log_dir, get_log_path, LOG_DIR_ENV
+
+
+def test_get_log_dir_default(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(LOG_DIR_ENV, raising=False)
+    path = get_log_dir()
+    assert path.resolve() == (tmp_path / "logs").resolve()
+    assert path.exists()
+
+
+def test_get_log_dir_env_override(tmp_path, monkeypatch):
+    custom = tmp_path / "mylogs"
+    monkeypatch.setenv(LOG_DIR_ENV, str(custom))
+    path = get_log_dir()
+    assert path.resolve() == custom.resolve()
+    assert path.exists()
+
+
+def test_get_log_path_specific_env(tmp_path, monkeypatch):
+    special = tmp_path / "special.log"
+    monkeypatch.setenv("SPECIAL_LOG", str(special))
+    result = get_log_path("fallback.log", "SPECIAL_LOG")
+    assert result == special


### PR DESCRIPTION
## Summary
- add new `logging_config` module with environment-variable support
- update `presence_ledger`, `sabbath_reflection`, and `avatar_personality_merge` to use new helper
- add tests for log path resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e04f40e8c8320b87da3a20105e935