### PR TITLE
Add log sealing utility and federation trust aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2623,3 +2623,13 @@ Another Registered Agent:
   Logs: /logs/audit_immutability.jsonl
 ```
 ---
+Another Registered Agent:
+
+```
+- Name: ArchiveBlessingCeremony
+  Type: CLI
+  Roles: Log Sealer
+  Privileges: log, verify
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/archive_blessing.jsonl
+```

--- a/archive_blessing.py
+++ b/archive_blessing.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import audit_immutability as ai
+from log_utils import append_json, read_json
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = Path(os.getenv("ARCHIVE_BLESSING_LOG", "logs/archive_blessing.jsonl"))
+ARCHIVE_DIR = Path(os.getenv("ARCHIVE_DIR", "archives"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def seal_log(log: Path, curator: str) -> Dict[str, str]:
+    """Verify and seal a log into the archive directory."""
+    verified = ai.verify(log)
+    digest = hashlib.sha256(log.read_bytes()).hexdigest()
+    ts = datetime.datetime.utcnow().isoformat()
+    name = f"{log.stem}_{ts.replace(':', '-')}.gz"
+    archive_path = ARCHIVE_DIR / name
+    with gzip.open(archive_path, "wb") as f:
+        f.write(log.read_bytes())
+    entry = {
+        "timestamp": ts,
+        "log": str(log),
+        "archive": str(archive_path),
+        "digest": digest,
+        "verified": verified,
+        "curator": curator,
+    }
+    append_json(LOG_PATH, entry)
+    return entry
+
+
+def history(limit: int = 20) -> List[Dict[str, str]]:
+    return read_json(LOG_PATH)[-limit:]
+
+
+def main() -> None:  # pragma: no cover - CLI
+    ap = argparse.ArgumentParser(description="Archive blessing ceremony")
+    sub = ap.add_subparsers(dest="cmd")
+
+    seal = sub.add_parser("seal", help="Seal a log file")
+    seal.add_argument("log")
+    seal.add_argument("curator")
+    seal.set_defaults(func=lambda a: print(json.dumps(seal_log(Path(a.log), a.curator), indent=2)))
+
+    hist = sub.add_parser("history", help="Show ceremony history")
+    hist.add_argument("--limit", type=int, default=20)
+    hist.set_defaults(func=lambda a: print(json.dumps(history(a.limit), indent=2)))
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/federation_trust_protocol.py
+++ b/federation_trust_protocol.py
@@ -92,6 +92,18 @@ def report_anomaly(node_id: str, reason: str) -> Node:
     _log("anomaly", node_id, {"reason": reason})
     return nd
 
+def join(node_id: str, key: str, blessing: str) -> Node:
+    """Alias for handshake used by CLI."""
+    return handshake(node_id, key, blessing)
+
+def leave(node_id: str, signatories: List[str]) -> Node:
+    """Alias for excommunicate used by CLI."""
+    return excommunicate(node_id, signatories)
+
+def revoke_trust(node_id: str, reason: str) -> Node:
+    """Alias for report_anomaly used by CLI."""
+    return report_anomaly(node_id, reason)
+
 def excommunicate(node_id: str, signatories: List[str]) -> Node:
     nodes = _load_nodes()
     if len(signatories) < 2:
@@ -138,6 +150,22 @@ def cli() -> None:
     ex.add_argument("node")
     ex.add_argument("signatories", nargs="+")
     ex.set_defaults(func=lambda a: print(json.dumps(asdict(excommunicate(a.node, a.signatories)), indent=2)))
+
+    jn = sub.add_parser("join", help="Join the federation")
+    jn.add_argument("node")
+    jn.add_argument("key")
+    jn.add_argument("blessing")
+    jn.set_defaults(func=lambda a: print(json.dumps(asdict(join(a.node, a.key, a.blessing)), indent=2)))
+
+    lv = sub.add_parser("leave", help="Leave the federation")
+    lv.add_argument("node")
+    lv.add_argument("signatories", nargs="+")
+    lv.set_defaults(func=lambda a: print(json.dumps(asdict(leave(a.node, a.signatories)), indent=2)))
+
+    rv = sub.add_parser("revoke-trust", help="Revoke trust of a node")
+    rv.add_argument("node")
+    rv.add_argument("reason")
+    rv.set_defaults(func=lambda a: print(json.dumps(asdict(revoke_trust(a.node, a.reason)), indent=2)))
 
     ls = sub.add_parser("list")
     ls.set_defaults(func=lambda a: print(json.dumps({k: asdict(v) for k, v in list_nodes().items()}, indent=2)))

--- a/tests/test_archive_blessing.py
+++ b/tests/test_archive_blessing.py
@@ -1,0 +1,22 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import audit_immutability as ai
+
+
+def test_seal_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARCHIVE_BLESSING_LOG", str(tmp_path / "blessing.jsonl"))
+    monkeypatch.setenv("ARCHIVE_DIR", str(tmp_path / "arch"))
+    import archive_blessing as ab
+    importlib.reload(ab)
+    log = tmp_path / "log.jsonl"
+    ai.append_entry(log, {"a": 1})
+    entry = ab.seal_log(log, "council")
+    assert Path(entry["archive"]).exists()
+    assert entry["verified"] is True
+    hist = ab.history()
+    assert hist and hist[-1]["curator"] == "council"

--- a/tests/test_federation_trust_protocol.py
+++ b/tests/test_federation_trust_protocol.py
@@ -1,6 +1,9 @@
 import importlib
 import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import federation_trust_protocol as ftp
 
@@ -13,12 +16,12 @@ def setup_env(tmp_path, monkeypatch):
 
 def test_handshake_and_excommunicate(tmp_path, monkeypatch):
     setup_env(tmp_path, monkeypatch)
-    node = ftp.handshake("node1", "key1", "blessed")
+    node = ftp.join("node1", "key1", "blessed")
     assert node.node_id == "node1"
     ftp.heartbeat("node1")
-    ftp.report_anomaly("node1", "rogue")
+    ftp.revoke_trust("node1", "rogue")
     assert not ftp.list_nodes()["node1"].active
-    ftp.excommunicate("node1", ["c1", "c2"])
+    ftp.leave("node1", ["c1", "c2"])
     data = ftp.list_nodes()["node1"]
     assert data.expelled
     log_file = Path(os.environ["FEDERATION_TRUST_LOG"])


### PR DESCRIPTION
## Summary
- add `archive_blessing.py` to seal logs into an archive with verification
- register `ArchiveBlessingCeremony` agent
- extend `federation_trust_protocol` with join/leave/revoke-trust aliases
- update tests for new functionality

## Testing
- `pytest tests/test_archive_blessing.py tests/test_federation_trust_protocol.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e07e1249083209ae4fd4ba3072c8a