### PR TITLE
Add CLI privilege tests

### DIFF
--- a/avatar_autonomous_ritual_scheduler.py
+++ b/avatar_autonomous_ritual_scheduler.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
+from admin_utils import require_admin_banner
+
 REQUEST_LOG = Path(os.getenv("AVATAR_RITUAL_REQUEST_LOG", "logs/avatar_ritual_requests.jsonl"))
 APPROVAL_LOG = Path(os.getenv("AVATAR_RITUAL_APPROVAL_LOG", "logs/avatar_ritual_approved.jsonl"))
 REQUEST_LOG.parent.mkdir(parents=True, exist_ok=True)
@@ -55,6 +57,7 @@ def approve_request(index: int) -> Dict[str, str]:
 
 
 def main() -> None:
+    require_admin_banner()
     ap = argparse.ArgumentParser(description="Avatar Autonomous Ritual Scheduler")
     sub = ap.add_subparsers(dest="cmd")
 

--- a/tests/test_avatar_autonomous_ritual_scheduler_cli.py
+++ b/tests/test_avatar_autonomous_ritual_scheduler_cli.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import admin_utils
+
+
+def test_avatar_autonomous_scheduler_cli(tmp_path, monkeypatch):
+    req = tmp_path / "requests.jsonl"
+    apv = tmp_path / "approved.jsonl"
+    monkeypatch.setenv("AVATAR_RITUAL_REQUEST_LOG", str(req))
+    monkeypatch.setenv("AVATAR_RITUAL_APPROVAL_LOG", str(apv))
+
+    import avatar_autonomous_ritual_scheduler as ars
+    importlib.reload(ars)
+
+    calls = []
+    monkeypatch.setattr(ars, "require_admin_banner", lambda: calls.append(True))
+    monkeypatch.setattr(sys, "argv", ["ars", "request", "Bob", "dance"])
+    ars.main()
+    assert calls and calls[-1] is True
+    assert req.exists() and len(req.read_text().splitlines()) == 1
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["ars", "approve", "0"])
+    ars.main()
+    assert calls and len(calls) == 1
+    assert apv.exists() and len(apv.read_text().splitlines()) == 1
+

--- a/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
+++ b/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import importlib
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import admin_utils
+import presence_ledger as pl
+
+
+def test_resonite_beacon_cli(tmp_path, monkeypatch, capsys):
+    beacon = tmp_path / "beacon.jsonl"
+    presence = tmp_path / "presence.jsonl"
+    monkeypatch.setenv("RESONITE_BEACON_LOG", str(beacon))
+    monkeypatch.setenv("USER_PRESENCE_LOG", str(presence))
+
+    import resonite_cathedral_launch_beacon_broadcaster as rcl
+    importlib.reload(pl)
+    importlib.reload(rcl)
+
+    monkeypatch.setattr(pl, "log", lambda *a, **k: None)
+    calls = []
+    monkeypatch.setattr(rcl, "require_admin_banner", lambda: calls.append(True))
+
+    monkeypatch.setattr(sys, "argv", ["beacon", "launch", "Ada"])
+    rcl.main()
+    assert calls and beacon.exists() and len(beacon.read_text().splitlines()) == 1
+    capsys.readouterr()  # clear launch output
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["beacon", "history", "--limit", "1"])
+    rcl.main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert calls and data and data[0]["action"] == "launch"
+


### PR DESCRIPTION
## Summary
- require admin banner in `avatar_autonomous_ritual_scheduler`
- test privilege banner and log generation for avatar ritual scheduler CLI
- test privilege banner and log generation for cathedral beacon broadcaster CLI

## Testing
- `pytest -q tests/test_avatar_autonomous_ritual_scheduler_cli.py tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e0cb870148320a9c1699e96f4eca3