### PR TITLE
Add admin banner tests for CLI and daemons

### DIFF
--- a/avatar_council_succession_daemon.py
+++ b/avatar_council_succession_daemon.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 from logging_config import get_log_path
+from admin_utils import require_admin_banner
 
 """Avatar Council Succession/Legacy Daemon.
 
 Automates and logs the succession or legacy process when avatars retire, merge,
 or are crowned anew. Ensures inheritances are not lost.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
 
 import argparse
@@ -38,6 +41,7 @@ def run_daemon(interval: float) -> None:
 
 
 def main() -> None:
+    require_admin_banner()
     ap = argparse.ArgumentParser(description="Avatar Council Succession Daemon")
     sub = ap.add_subparsers(dest="cmd")
 

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -11,11 +11,11 @@ import os
 import shutil
 from datetime import datetime
 from pathlib import Path
+from logging_config import get_log_path
 
 from admin_utils import require_admin_banner
 
-LOG_DIR = Path("logs")
-SEAL_LOG = LOG_DIR / "ledger_seal.jsonl"
+SEAL_LOG = get_log_path("ledger_seal.jsonl", "LEDGER_SEAL_LOG")
 SEAL_LOG.parent.mkdir(parents=True, exist_ok=True)
 BACKUP_DIR = Path(os.getenv("LEDGER_BACKUP_DIR", "backup"))
 BACKUP_DIR.mkdir(parents=True, exist_ok=True)

--- a/neos_ritual_law_audit_daemon.py
+++ b/neos_ritual_law_audit_daemon.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from logging_config import get_log_path
+from admin_utils import require_admin_banner
 
-"""NeosVR Ritual Law Audit & Remediation Daemon."""
+"""NeosVR Ritual Law Audit & Remediation Daemon.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 
 import argparse
 import json
@@ -41,6 +45,7 @@ def run_daemon(interval: float) -> None:
 
 
 def main() -> None:
+    require_admin_banner()
     ap = argparse.ArgumentParser(description="NeosVR Ritual Law Audit Daemon")
     sub = ap.add_subparsers(dest="cmd")
 

--- a/neos_teaching_festival_daemon.py
+++ b/neos_teaching_festival_daemon.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from logging_config import get_log_path
+from admin_utils import require_admin_banner
 
-"""NeosVR In-World Autonomous Teaching Festival."""
+"""NeosVR In-World Autonomous Teaching Festival.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 
 import argparse
 import json
@@ -43,6 +47,7 @@ def run_daemon(interval: float) -> None:
 
 
 def main() -> None:
+    require_admin_banner()
     ap = argparse.ArgumentParser(description="NeosVR Teaching Festival Daemon")
     sub = ap.add_subparsers(dest="cmd")
 

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -1,0 +1,82 @@
+import importlib
+import argparse
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import admin_utils
+import pytest
+
+CLI_MODULES = [
+    "affirmation_webhook_cli",
+    "avatar_invocation_cli",
+    "blessing_recap_cli",
+    "cathedral_liturgy_cli",
+    "diff_memory_cli",
+    "doctrine_cli",
+    "emotion_arc_cli",
+    "experiment_cli",
+    "federation_recap_cli",
+    "heartbeat_monitor_cli",
+    "heatmap_cli",
+    "heirloom_sync_cli",
+    "heresy_cli",
+    "memory_tomb_cli",
+    "neos_avatar_crowning_cli",
+    "neos_festival_law_vote_cli",
+    "neos_spiral_playback_cli",
+    "plugins_cli",
+    "reflect_cli",
+    "reflection_tag_cli",
+    "review_heresy_cli",
+    "ritual_cli",
+    "ritual_digest_cli",
+    "theme_cli",
+    "treasury_cli",
+    "trust_cli",
+]
+
+DAEMON_MODULES = {
+    "avatar_council_succession_daemon": "main",
+    "avatar_dream_daemon": "main",
+    "ledger_seal_daemon": "cli",
+    "neos_living_law_recursion_daemon": "main",
+    "neos_ritual_law_audit_daemon": "main",
+    "neos_teaching_festival_daemon": "main",
+    "resonite_consent_daemon": "main",
+    "resonite_presence_festival_spiral_diff_daemon": "main",
+    "spiral_dream_goal_daemon": "main",
+}
+
+@pytest.mark.parametrize("mod_name", CLI_MODULES)
+def test_cli_requires_admin(monkeypatch, mod_name):
+    calls = []
+    monkeypatch.setattr(admin_utils, "require_admin_banner", lambda: calls.append(True))
+    mod = importlib.import_module(mod_name)
+    if mod_name == "heartbeat_monitor_cli":
+        monkeypatch.setattr(mod, "monitor", lambda *a, **k: (_ for _ in ()).throw(SystemExit))
+        with pytest.raises(SystemExit):
+            mod.main()
+    elif mod_name == "federation_recap_cli":
+        with pytest.raises(Exception):
+            mod.main()
+    else:
+        monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda *a, **k: (_ for _ in ()).throw(SystemExit))
+        with pytest.raises(SystemExit):
+            mod.main()
+    assert calls
+
+@pytest.mark.parametrize("mod_name, func_name", DAEMON_MODULES.items())
+def test_daemon_requires_admin(monkeypatch, mod_name, func_name):
+    calls = []
+    monkeypatch.setattr(admin_utils, "require_admin_banner", lambda: calls.append(True))
+    mod = importlib.import_module(mod_name)
+    if mod_name == "resonite_presence_festival_spiral_diff_daemon":
+        monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda *a, **k: argparse.Namespace(world_a='a', world_b='b', user='u'))
+        monkeypatch.setattr(mod, "log_diff", lambda *a, **k: (_ for _ in ()).throw(SystemExit))
+        with pytest.raises(SystemExit):
+            getattr(mod, func_name)()
+    else:
+        monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda *a, **k: (_ for _ in ()).throw(SystemExit))
+        with pytest.raises(SystemExit):
+            getattr(mod, func_name)()
+    assert calls


### PR DESCRIPTION
## Summary
- ensure `ledger_seal_daemon` uses `get_log_path`
- add missing privilege docstrings and admin banner calls to several daemons
- add parameterised tests checking `require_admin_banner` for CLI/daemon entrypoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683e1d863ab88320936c9e4daf54a9ab