### PR TITLE
Refactor log directory usage

### DIFF
--- a/daily_digest.py
+++ b/daily_digest.py
@@ -8,12 +8,11 @@ Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards
 """
 
 from __future__ import annotations
-from logging_config import get_log_path
-
 import datetime as _dt
 import json
 import os
 from pathlib import Path
+from logging_config import get_log_path
 from typing import Dict, List
 
 DIGEST_LOG = get_log_path("daily_digest.jsonl", "DAILY_DIGEST_LOG")
@@ -47,7 +46,7 @@ def _summarize_file(path: Path, since: _dt.datetime) -> int:
 
 def run_digest(period_hours: int = 24) -> Dict[str, int]:
     cutoff = _dt.datetime.utcnow() - _dt.timedelta(hours=period_hours)
-    logs_dir = Path("logs")
+    logs_dir = get_log_path("")
     summary: Dict[str, int] = {}
     for fp in logs_dir.rglob("*.jsonl"):
         if fp.name == DIGEST_LOG.name:

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -11,11 +11,11 @@ import os
 import shutil
 from datetime import datetime
 from pathlib import Path
+from logging_config import get_log_path
 
 from admin_utils import require_admin_banner
 
-LOG_DIR = Path("logs")
-SEAL_LOG = LOG_DIR / "ledger_seal.jsonl"
+SEAL_LOG = get_log_path("ledger_seal.jsonl")
 SEAL_LOG.parent.mkdir(parents=True, exist_ok=True)
 BACKUP_DIR = Path(os.getenv("LEDGER_BACKUP_DIR", "backup"))
 BACKUP_DIR.mkdir(parents=True, exist_ok=True)

--- a/narrator.py
+++ b/narrator.py
@@ -22,6 +22,7 @@ import datetime as _dt
 import json
 import os
 from pathlib import Path
+from logging_config import get_log_path
 from typing import Any, Dict, List
 
 try:  # summarisation backend
@@ -34,7 +35,7 @@ try:
 except Exception:  # pragma: no cover - optional
     tts_bridge = None
 
-DEFAULT_LOG_DIR = Path("logs")
+DEFAULT_LOG_DIR = get_log_path("")
 MEMORY_LOG = "memory.jsonl"
 REFLECTION_LOG = "reflection.jsonl"
 EMOTION_LOG = "emotions.jsonl"

--- a/vision_tracker.py
+++ b/vision_tracker.py
@@ -3,6 +3,7 @@ import json
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from logging_config import get_log_path
 from utils import is_headless
 
 HEADLESS = is_headless()
@@ -52,7 +53,10 @@ class FaceEmotionTracker:
         output_file: str | None = None,
         feedback: "FeedbackManager | None" = None,
     ) -> None:
-        self.log_path = Path(output_file or os.getenv("VISION_LOG", "logs/vision/vision.jsonl"))
+        if output_file:
+            self.log_path = Path(output_file)
+        else:
+            self.log_path = get_log_path("vision/vision.jsonl", "VISION_LOG")
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         if HEADLESS:
             self.cap = None


### PR DESCRIPTION
## Notes
- replaced raw `logs` paths in runtime modules with `logging_config.get_log_path`
- updated ledger seal, daily digest, narrator and vision tracker modules

## Summary
- replaced `Path("logs")` with `get_log_path("")`
- switched ledger seal daemon to use `get_log_path` for ledger log
- updated narrator and vision tracker initialisation to use `get_log_path`
- all tests continue to pass


------
https://chatgpt.com/codex/tasks/task_b_683e1d844cc48320b96a338c54b0e1e1