### PR TITLE
Refactor log paths and fix entrypoint imports

### DIFF
--- a/config/reflex_rules.json
+++ b/config/reflex_rules.json
@@ -2,7 +2,7 @@
   {
     "name": "bridge_stability_monitor",
     "trigger": "file_change",
-    "path": "logs/bridge_watchdog.jsonl",
+    "path": "${SENTIENTOS_LOG_DIR}/bridge_watchdog.jsonl",
     "actions": [
       {"type": "pycall", "func": "reflex_rules:bridge_restart_check"}
     ]

--- a/config/trust_policy.yml
+++ b/config/trust_policy.yml
@@ -1,5 +1,5 @@
 # Example trust policy configuration
-log_dir: logs/trust
+log_dir: ${SENTIENTOS_LOG_DIR}/trust
 policies:
   suppress_anger: true
   max_volume: 0.8

--- a/genesis_oracle.py
+++ b/genesis_oracle.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from logging_config import get_log_path
+from logging_config import get_log_path, get_log_dir
 
 import argparse
 import datetime
@@ -14,7 +14,7 @@ from admin_utils import require_admin_banner
 
 LOG_PATH = get_log_path("genesis_oracle.jsonl", "GENESIS_ORACLE_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-DATA_DIR = Path(os.getenv("GENESIS_ORACLE_DATA", "logs"))
+DATA_DIR = Path(os.getenv("GENESIS_ORACLE_DATA", str(get_log_dir())))
 
 
 def query_origin(obj: str) -> Dict[str, str]:

--- a/multimodal_tracker.py
+++ b/multimodal_tracker.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 from pathlib import Path
+from logging_config import get_log_dir
 from typing import Any, Dict, List, Optional
 from utils import is_headless
 
@@ -64,7 +65,9 @@ class MultiModalEmotionTracker:
         if HEADLESS:
             enable_vision = False
             enable_voice = False
-        self.log_dir = Path(output_dir or os.getenv("MULTI_LOG_DIR", "logs/multimodal"))
+        default_dir = get_log_dir() / "multimodal"
+        env_dir = os.getenv("MULTI_LOG_DIR")
+        self.log_dir = Path(output_dir or env_dir or default_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
         if enable_vision:
             try:

--- a/narrator.py
+++ b/narrator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from admin_utils import require_admin_banner
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
@@ -17,8 +19,6 @@ synthesis with Coqui TTS, pyttsx3 or other engines. Set
 ``SENTIENTOS_HEADLESS=1`` to disable audio output in tests or headless
 systems.
 """
-
-from __future__ import annotations
 
 import argparse
 import datetime as _dt

--- a/neos_federation_presence_ledger_exporter.py
+++ b/neos_federation_presence_ledger_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from admin_utils import require_admin_banner
+from logging_config import get_log_path
 
 import argparse
 import json
@@ -12,8 +13,9 @@ from typing import List
 
 import presence_ledger as pl
 
-LOG_PATH = Path(
-    os.getenv("NEOS_FEDERATION_PRESENCE_EXPORT_LOG", "logs/neos_federation_presence_export.jsonl")
+LOG_PATH = get_log_path(
+    "neos_federation_presence_export.jsonl",
+    "NEOS_FEDERATION_PRESENCE_EXPORT_LOG",
 )
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/policy_engine.py
+++ b/policy_engine.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
 from admin_utils import require_admin_banner
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-"""Modular policy, gesture, and persona engine."""
-
-from __future__ import annotations
+# Modular policy, gesture, and persona engine.
 
 import json
 import time

--- a/spiral_law_chronicle_compiler.py
+++ b/spiral_law_chronicle_compiler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from logging_config import get_log_path
+from logging_config import get_log_path, get_log_dir
 
 import argparse
 import datetime
@@ -14,7 +14,7 @@ from admin_utils import require_admin_banner
 
 LOG_PATH = get_log_path("spiral_law_chronicle.jsonl", "SPIRAL_LAW_CHRONICLE_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-SOURCE_DIR = Path(os.getenv("SPIRAL_LAW_SOURCE", "logs"))
+SOURCE_DIR = Path(os.getenv("SPIRAL_LAW_SOURCE", str(get_log_dir())))
 
 
 def compile_law() -> Dict[str, str]:

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -33,6 +33,9 @@ CLI_MODULES = [
     "theme_cli",
     "treasury_cli",
     "trust_cli",
+    "genesis_oracle",
+    "neos_federation_presence_ledger_exporter",
+    "spiral_law_chronicle_compiler",
 ]
 
 DAEMON_MODULES = {


### PR DESCRIPTION
## Summary
- unify log directories via `get_log_dir()` and `get_log_path()` helpers
- clean up `__future__` import placement for narrator and policy engine
- update logging paths in config files
- extend CLI banner tests for new modules

## Testing
- `python privilege_lint.py`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683e1a6166a48320a007652a67626693