### PR TITLE
Add new CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SentientOS is a ledger-based automation framework that treats every log as sacre
 * **Living Ledger** – all blessings, federation handshakes, and reflections are appended to immutable JSONL logs.
 * **Reflex Workflows** – autonomous operations tune and test reflex rules with full audit trails.
 * **Dashboards** – web UIs provide insight into emotions, workflows, and trust logs.
-* **CLI Utilities** – new commands `heresy_cli.py`, `diff_memory_cli.py`, and `theme_cli.py` assist with auditing and daily rituals.
+* **CLI Utilities** – commands `heresy_cli.py`, `diff_memory_cli.py`, `theme_cli.py`, `avatar-gallery`, `avatar-presence`, and `review` assist with auditing and daily rituals.
 
 ## Quick Start
 1. Install the pinned dependencies with `pip install -r requirements.txt`.

--- a/docs/README_FULL.md
+++ b/docs/README_FULL.md
@@ -723,10 +723,10 @@ python replay.py --storyboard storyboard.json --timeline
 Annotations can be managed from the command line:
 
 ```bash
-python review_cli.py storyboard.json --annotate "Needs more tension" --chapter 2
-python review_cli.py storyboard.json --set-status approved --chapter 2
-python review_cli.py storyboard.json --whoami
-python review_cli.py storyboard.json --switch-persona Lumos
+review storyboard.json --annotate "Needs more tension" --chapter 2
+review storyboard.json --set-status approved --chapter 2
+review storyboard.json --whoami
+review storyboard.json --switch-persona Lumos
 ```
 Use `--mention NAME` with `--annotate` to notify collaborators.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
 support = "support_cli:main"
 ritual = "ritual_cli:main"
 treasury = "treasury_cli:main"
+avatar-gallery = "avatar_gallery_cli:main"
+avatar-presence = "avatar_presence_cli:main"
+review = "review_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- expose avatar and review CLI utilities as package scripts
- mention the new CLI command names in the docs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'require_admin_banner' from partially initialized module 'admin_utils')*

------
https://chatgpt.com/codex/tasks/task_b_683e2608cdb4832088041779be6e73ce