### PR TITLE
Add audit verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,6 @@ jobs:
       - name: Run tests
         run: |
           pytest
+      - name: Verify audits
+        run: |
+          python verify_audits.py

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ LOG_PATH = get_log_path("example_tool.jsonl", "EXAMPLE_LOG")
 
 Hard-coded paths like `"logs/mytool.jsonl"` are discouraged.
 
+## Audit Verification
+Run `python verify_audits.py` to check that the immutable logs listed in
+`config/master_files.json` remain valid. Each path is printed with `valid` or
+`tampered`.
+
 ## Final Cathedral-Polish Steps
 - [ ] `python privilege_lint.py` passes
 - [ ] `pytest` passes

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+import audit_immutability as ai
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+ROOT = Path(__file__).resolve().parent
+CONFIG = Path("config/master_files.json")
+
+
+def _load_config() -> dict[str, str]:
+    if not CONFIG.exists():
+        return {}
+    try:
+        return json.loads(CONFIG.read_text())
+    except Exception:
+        return {}
+
+
+def verify_audits() -> dict[str, bool]:
+    results: dict[str, bool] = {}
+    data = _load_config()
+    for file in data.keys():
+        path = Path(file)
+        if not path.is_absolute():
+            path = ROOT / path
+        results[str(path)] = ai.verify(path)
+    return results
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    res = verify_audits()
+    for file, ok in res.items():
+        status = "valid" if ok else "tampered"
+        print(f"{file}: {status}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add script `verify_audits.py` to check logs with `audit_immutability.verify`
- run the new script in CI after the tests
- document audit verification in the README

## Testing
- `python privilege_lint.py`
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683e260ab4108320806a517a7ff95872