### PR TITLE
Add mypy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Run privilege lint
         run: |
           python privilege_lint.py
+      - name: Run mypy
+        run: |
+          mypy --ignore-missing-imports .
       - name: Run tests
         run: |
           pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "mne>=1,<2",
     "brainflow>=5,<6",
     "pyserial>=3,<4",
+    "mypy>=1.5,<2",
 ]
 
 [project.scripts]
@@ -44,3 +45,10 @@ treasury = "treasury_cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["sentientos", "api"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+exclude = ["tests"]
+files = ["reflection_stream.py", "resonite_alliance_pact_engine.py"]
+follow_imports = "skip"

--- a/reflection_stream.py
+++ b/reflection_stream.py
@@ -16,8 +16,14 @@ def _now() -> str:
     return datetime.datetime.utcnow().isoformat()
 
 
-def log_event(source: str, event_type: str, cause: str, action: str,
-              explanation: str = "", data: Optional[Dict[str, any]] = None) -> str:
+def log_event(
+    source: str,
+    event_type: str,
+    cause: str,
+    action: str,
+    explanation: str = "",
+    data: Optional[Dict[str, Any]] = None,
+) -> str:
     """Append an entry to the reflection stream and return its id."""
     entry_id = uuid.uuid4().hex[:8]
     entry = {
@@ -48,11 +54,11 @@ def log_reflex_learn(data: Dict[str, Any]) -> str:
     return entry_id
 
 
-def recent(limit: int = 10) -> List[Dict[str, any]]:
+def recent(limit: int = 10) -> List[Dict[str, Any]]:
     if not STREAM_FILE.exists():
         return []
     lines = STREAM_FILE.read_text(encoding="utf-8").splitlines()
-    out: List[Dict[str, any]] = []
+    out: List[Dict[str, Any]] = []
     for line in lines[-limit:]:
         try:
             out.append(json.loads(line))
@@ -74,7 +80,7 @@ def recent_reflex_learn(limit: int = 10) -> List[Dict[str, Any]]:
     return out
 
 
-def get(entry_id: str) -> Optional[Dict[str, any]]:
+def get(entry_id: str) -> Optional[Dict[str, Any]]:
     if not STREAM_FILE.exists():
         return None
     with STREAM_FILE.open("r", encoding="utf-8") as f:
@@ -94,5 +100,6 @@ def stats() -> Dict[str, int]:
     counts: Dict[str, int] = {}
     for entry in recent(1000):
         typ = entry.get("event")
-        counts[typ] = counts.get(typ, 0) + 1
+        if isinstance(typ, str):
+            counts[typ] = counts.get(typ, 0) + 1
     return counts

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-socketio>=5,<6
 mne>=1,<2
 brainflow>=5,<6
 pyserial>=3,<4
+mypy>=1.5,<2

--- a/resonite_alliance_pact_engine.py
+++ b/resonite_alliance_pact_engine.py
@@ -27,8 +27,7 @@ def log_entry(action: str, data: Dict[str, str]) -> Dict[str, str]:
         **data,
     }
     with LOG_PATH.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "
-")
+        f.write(json.dumps(entry) + "\n")
     return entry
 
 


### PR DESCRIPTION
## Summary
- integrate mypy configuration and requirement
- run mypy in the CI workflow
- fix logging newline bug in `resonite_alliance_pact_engine.py`
- annotate `reflection_stream.py` and guard stats collection

## Testing
- `mypy`
- `pytest -q` *(fails: ImportError circular admin_utils)*

------
https://chatgpt.com/codex/tasks/task_b_683e2609e27c8320855a317ba15d97eb