### PR TITLE
Add contributor templates and governance docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit_ethics_concern.yml
+++ b/.github/ISSUE_TEMPLATE/audit_ethics_concern.yml
@@ -1,0 +1,17 @@
+name: "Audit or Ethics Concern"
+about: "Report a potential breach, privacy issue, or ethical problem"
+title: "[Audit] <summary>"
+labels: ["audit"]
+body:
+  - type: textarea
+    attributes:
+      label: Concern
+      description: "Describe the issue in detail"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Suggested resolution
+  - type: input
+    attributes:
+      label: Related logs or links

--- a/.github/ISSUE_TEMPLATE/privilege_question.yml
+++ b/.github/ISSUE_TEMPLATE/privilege_question.yml
@@ -1,0 +1,25 @@
+name: "Privilege Logic Question"
+about: "Ask about privilege checks or escalate an unexpected denial"
+title: "[Privilege] <short summary>"
+labels: ["privilege"]
+body:
+  - type: textarea
+    attributes:
+      label: Scenario
+      description: "Describe the command or action you attempted."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Log reference
+      description: "Link to or paste the relevant log line"

--- a/.github/ISSUE_TEMPLATE/tag_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/tag_proposal.yml
@@ -1,0 +1,29 @@
+name: "New Tag Proposal"
+about: "Suggest a new emotional or core value tag"
+title: "[Tag] <name>"
+labels: ["tag"]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: "What does this tag represent?"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Color
+      description: "Hex value or color word"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Example usage
+      description: "Link or describe an example"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Discussion link
+      description: "Issue or conversation that led to this proposal"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+Provide a short description of your changes and link the related issue.
+
+### Tag Proposal Fields
+- **Tag name:**
+- **Color:**
+- **Example:**
+- **Issue/Discussion link:**
+
+Ensure `python privilege_lint.py` and tests pass before requesting review.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,8 @@
+# Contributors
+
+SentientOS is a community project. Major contributions include code, design, and governance discussions.
+
+- Allen Murphy (maintainer)
+- OpenAI (templates and code review assistance)
+
+Future contributors will be acknowledged here.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Additional guides:
 - [docs/RITUALS.md](docs/RITUALS.md)
 - [docs/MODULES.md](docs/MODULES.md)
 
+- [docs/TAG_EXTENSION_GUIDE.md](docs/TAG_EXTENSION_GUIDE.md)
 ## Sanctuary Privilege Ritual
 Every entrypoint must open with the canonical ritual docstring followed by a
 call to `require_admin_banner()`:
@@ -79,6 +80,9 @@ Run `python verify_audits.py` to check that the immutable logs listed in
   mocks.
 - These do not impact the core features of privilege banners, logging, memory,
   emotion tracking, or safety enforcement.
+## Credits
+Templates and code patterns co-developed with OpenAI support.
+
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/agent_privilege_policy_engine.py
+++ b/agent_privilege_policy_engine.py
@@ -1,6 +1,7 @@
 """Agent Privilege Policy Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+# Templates and code patterns co-developed with OpenAI support
 """
 from __future__ import annotations
 from logging_config import get_log_path

--- a/docs/AUDIT_PROCESS.md
+++ b/docs/AUDIT_PROCESS.md
@@ -1,0 +1,20 @@
+# Audit Process
+
+This document outlines how the SentientOS community reviews logs and resolves concerns.
+
+## Schedule
+Audits occur monthly and whenever a security or ethics issue is raised. Rolling verification scripts (`verify_audits.py`) can be run at any time.
+
+## Review Steps
+1. Reviewers fetch the latest logs from `logs/`.
+2. Each entry is hashed and compared against the manifest in `config/master_files.json`.
+3. Findings and concerns are logged to `logs/audit_discussion.jsonl`.
+4. Decisions are recorded with reviewer names and a SHA-256 rolling hash.
+
+## Flagging & Resolving Issues
+- Contributors may open an **Audit or Ethics Concern** issue.
+- Reviewers discuss and note their resolution in the issue thread.
+- Once resolved, the conclusion is appended to the audit log and linked from the issue.
+
+## Participate
+Anyone can request an audit by filing an issue or contacting maintainers listed in [CONTRIBUTORS.md](../CONTRIBUTORS.md).

--- a/docs/TAG_EXTENSION_GUIDE.md
+++ b/docs/TAG_EXTENSION_GUIDE.md
@@ -1,0 +1,41 @@
+# Tag Extension Guide
+
+This guide explains how to propose new emotional or core value tags for the SentientOS project. Templates and code patterns co-developed with OpenAI support.
+
+## Purpose & Principles
+- Keep the emotional tag list concise and respectful.
+- Ensure every tag improves clarity for memory search and reflection.
+
+## Step-by-Step Tag Addition
+1. Review [CONTRIBUTING.md](../CONTRIBUTING.md) and existing tags in `tags.py`.
+2. Open a new issue using the **New Tag Proposal** template.
+3. Create a branch and update `tags.py` with the new tag.
+4. Add an entry in `docs/TAG_EXTENSION_GUIDE.md` if special notes apply.
+5. Submit a pull request using the provided template.
+
+## Ethics & Boundaries Checklist
+- Does the tag respect consent and privacy?
+- Could it be misused to shame or exclude?
+- Is reviewer sign off recorded?
+
+## Tag Glossary & Auditing
+Every tag is documented in `TAGS.md` with a short description and the approving reviewer. Audit tools scan logs for tag usage and compare with this glossary.
+
+## Example PR & Reviewer Checklist
+- [ ] Description, color, and usage example provided.
+- [ ] Link to discussion or issue.
+- [ ] `python privilege_lint.py` passes.
+- [ ] Reviewer confirms `tags.py` updated and docs built.
+
+## Support & Escalation
+Questions can be posted in the `#governance` channel or filed as an **Audit or Ethics Concern** issue. See [AUDIT_PROCESS.md](AUDIT_PROCESS.md) for details.
+
+## FAQ
+**Q:** Can I rename a tag?
+**A:** Use the proposal template so downstream logs can be migrated.
+
+## Common Mistakes
+- Adding a tag without updating `TAGS.md`.
+- Forgetting to run `privilege_lint.py` before opening the PR.
+- Skipping reviewer sign-off in the pull request.
+

--- a/docs/examples/sample_governance_log.jsonl
+++ b/docs/examples/sample_governance_log.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"privilege":"update","privileged_by":"alice","privilege_reason":"initial setup","privileged_at":"2025-06-01T00:00:00","consent_expiry":"2025-07-01T00:00:00","sha256":"abc123","rolling_hash":"abc123"}
+{"id":2,"tag":"joy","reviewer":"bob","approved":true,"sha256":"def456","rolling_hash":"789def"}
+{"id":3,"audit":"monthly","reviewer":"carol","sha256":"fedcba","rolling_hash":"456fed"}

--- a/tags.py
+++ b/tags.py
@@ -1,0 +1,22 @@
+"""SentientOS emotional tags module.
+
+Reference: [docs/TAG_EXTENSION_GUIDE.md](docs/TAG_EXTENSION_GUIDE.md)
+Templates and code patterns co-developed with OpenAI support.
+"""
+from __future__ import annotations
+from typing import List, Dict
+
+EMOTIONAL_TAGS: List[Dict[str, object]] = [
+    {"tag": "joy", "color": "yellow", "reviewer": "core", "approved": True},
+    {"tag": "sadness", "color": "blue", "reviewer": "core", "approved": True},
+]
+
+
+def list_tags() -> List[Dict[str, object]]:
+    """Return the list of emotional tags.
+
+    Example:
+        >>> for t in list_tags():
+        ...     print(t["tag"])
+    """
+    return EMOTIONAL_TAGS


### PR DESCRIPTION
## Summary
- acknowledge OpenAI support in README and privilege policy engine
- add tag extension guide and audit process docs
- create issue and PR templates for tags, privilege questions, and audit concerns
- provide sample governance log snippet and add CONTRIBUTORS list
- new `tags.py` module documents how to extend emotional tags

## Testing
- `python privilege_lint.py`
- `pytest -q tests/test_privilege_*`
- `mypy --ignore-missing-imports`
- `python verify_audits.py` *(fails: JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_b_683e53695b1483208e6bf6b873b5874e