### PR TITLE
Add federation tools and contributor flow updates

### DIFF
--- a/.github/workflows/post_merge_feedback.yml
+++ b/.github/workflows/post_merge_feedback.yml
@@ -1,0 +1,23 @@
+name: Post-Merge Feedback Invitation
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  invite:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const msg = `Thank you @${author} for contributing! We'd love your feedback in the discussion board.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: msg
+            });

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ See FIRST_RUN.md for cloning and running only green tests. Questions? Ping the S
 ### Ask for a Buddy
 New contributors are invited to request a **buddy** for their first pull request or review. A buddy helps with environment setup, running `python verify_audits.py`, and general PR etiquette. Mention "buddy request" in your issue or discussion thread and a steward will pair you up.
 
+### What if pre-commit isn't available?
+Some systems cannot run git hooks. If `pre-commit` isn't working, run the checks manually before pushing:
+
+```bash
+python privilege_lint.py
+python verify_audits.py logs/
+pytest -m "not env"
+```
+Document any failures in your pull request description so reviewers know what to expect.
+
 ### Feedback Loop Ritual
 We maintain an open feedback form on the GitHub Discussions board. Share your first-run experience, documentation gaps, or ideas for new rituals. Stewards review submissions each month and incorporate improvements into future audits.
 ## Sanctuary Privilege Ritual
@@ -82,6 +92,15 @@ Run `python verify_audits.py` to check that the immutable logs listed in
 include a percentage of valid files so reviewers know when systemwide action is
 needed.
 The current ledger status is summarized in [docs/AUDIT_HEALTH_DASHBOARD.md](docs/AUDIT_HEALTH_DASHBOARD.md).
+
+## Federation Overview
+| Node | Audit Health |
+|------|-------------|
+| cathedral-main | 100% |
+
+Federated instances: **1**  
+Last steward rotation: **2026-01-01**
+See [Federation Conflict Resolution](docs/FEDERATION_CONFLICT_RESOLUTION.md) for how stewards handle diverging logs.
 
 ## Testing Quickstart
 Legacy tests are under review. To run the current green path:

--- a/audit_changelog_update.py
+++ b/audit_changelog_update.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+CHANGELOG = Path("docs/CHANGELOG.md")
+LEDGER = Path("docs/AUDIT_LEDGER.md")
+
+
+def append_entry(message: str) -> dict[str, str]:
+    now = datetime.utcnow()
+    month = now.strftime("%Y-%m")
+    cl_lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+    heading = f"## {month}"
+    if heading not in cl_lines:
+        cl_lines.extend(["", heading])
+    idx = cl_lines.index(heading) + 1
+    cl_lines.insert(idx, f"- {message}")
+    CHANGELOG.write_text("\n".join(cl_lines), encoding="utf-8")
+
+    ld_lines = LEDGER.read_text(encoding="utf-8").splitlines()
+    ld_lines.append(f"- {now.isoformat()} {message}")
+    LEDGER.write_text("\n".join(ld_lines), encoding="utf-8")
+    return {"timestamp": now.isoformat(), "message": message}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Append changelog and ledger entry")
+    ap.add_argument("message", help="summary message")
+    args = ap.parse_args()
+    entry = append_entry(args.message)
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/docs/FEDERATION_CONFLICT_RESOLUTION.md
+++ b/docs/FEDERATION_CONFLICT_RESOLUTION.md
@@ -1,0 +1,17 @@
+# Federation Conflict Resolution
+
+Federated nodes occasionally diverge when audits are performed at different times or a log segment is missing. Stewards compare the rolling hashes of each ledger to locate the first mismatch.
+
+## Manual Ritual
+1. Each steward runs `python verify_audits.py logs/ --repair` and shares their resulting hash summary.
+2. If hashes differ, use `ledger_conflict_resolver.py` to merge the two versions:
+   ```bash
+   python ledger_conflict_resolver.py nodeA_log.jsonl nodeB_log.jsonl merged.jsonl
+   ```
+3. Both stewards review `merged.jsonl`, sign off, and replace their local copy.
+4. Append a short note to `logs/migration_ledger.jsonl` describing the resolution.
+
+If the split represents a permanent fork in memory law, each steward may keep their version and mark the divergence with an entry in `migration_ledger.jsonl`.
+
+## Automated Helper
+`ledger_conflict_resolver.py` performs a simple prefix merge. It keeps the shared history and then appends the unique portion from the incoming log, recomputing rolling hashes along the way.

--- a/ledger_conflict_resolver.py
+++ b/ledger_conflict_resolver.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from admin_utils import require_admin_banner
+import audit_immutability as ai
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+
+def _load(path: Path) -> List[ai.AuditEntry]:
+    return ai.read_entries(path)
+
+
+def merge_logs(ours: Path, theirs: Path, dest: Path) -> Path:
+    """Merge two audit logs by common prefix."""
+    a = _load(ours)
+    b = _load(theirs)
+    i = 0
+    while i < min(len(a), len(b)) and a[i].rolling_hash == b[i].rolling_hash:
+        i += 1
+    merged = a[:i] + b[i:]
+    prev = "0" * 64
+    out: List[ai.AuditEntry] = []
+    for e in merged:
+        digest = ai._hash_entry(e.timestamp, e.data, prev)
+        out.append(ai.AuditEntry(e.timestamp, e.data, prev, digest))
+        prev = digest
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as f:
+        for e in out:
+            f.write(json.dumps(e.__dict__) + "\n")
+    return dest
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Federated ledger conflict resolver")
+    ap.add_argument("ours")
+    ap.add_argument("theirs")
+    ap.add_argument("dest")
+    args = ap.parse_args()
+    out = merge_logs(Path(args.ours), Path(args.theirs), Path(args.dest))
+    print(out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/legacy_log_converter.py
+++ b/legacy_log_converter.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+from admin_utils import require_admin_banner
+from logging_config import get_log_path
+import audit_immutability as ai
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+
+def _read_legacy(path: Path) -> List[Dict[str, object]]:
+    """Parse legacy log entries that may span multiple lines."""
+    raw_lines = path.read_text(encoding="utf-8").splitlines()
+    entries: List[Dict[str, object]] = []
+    buf = ""
+    for line in raw_lines:
+        if not line.strip():
+            continue
+        buf += line.strip()
+        try:
+            entry = json.loads(buf)
+        except json.JSONDecodeError:
+            buf += " "
+            continue
+        entries.append(entry)
+        buf = ""
+    if buf:
+        try:
+            entries.append(json.loads(buf))
+        except Exception:
+            pass
+    return entries
+
+
+def convert(path: Path, dest: Path | None = None) -> Path:
+    """Convert a legacy audit log into rolling-hash format."""
+    entries = _read_legacy(path)
+    prev = "0" * 64
+    converted: List[Dict[str, object]] = []
+    for e in entries:
+        ts = str(e.get("timestamp")) if "timestamp" in e else datetime.utcnow().isoformat()
+        data = {k: v for k, v in e.items() if k != "timestamp"}
+        digest = ai._hash_entry(ts, data, prev)
+        converted.append(
+            {
+                "timestamp": ts,
+                "data": data,
+                "prev_hash": prev,
+                "rolling_hash": digest,
+            }
+        )
+        prev = digest
+    dest = dest or path.with_suffix(path.suffix + ".converted")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as f:
+        for entry in converted:
+            f.write(json.dumps(entry) + "\n")
+    mig = get_log_path("migration_ledger.jsonl")
+    with mig.open("a", encoding="utf-8") as mf:
+        mf.write(
+            json.dumps({
+                "timestamp": datetime.utcnow().isoformat(),
+                "converted": str(path),
+                "output": str(dest),
+            })
+            + "\n"
+        )
+    return dest
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Legacy log converter")
+    ap.add_argument("log", help="legacy log file")
+    ap.add_argument("--out", help="destination path")
+    args = ap.parse_args()
+    out = convert(Path(args.log), Path(args.out) if args.out else None)
+    print(out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add legacy log conversion tool
- automate changelog updates via script
- document conflict resolution for federated ledgers
- add ledger conflict resolver helper script
- add federation metrics in README and mention pre-commit fallback
- welcome contributors post-merge via GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683eebdebcbc83209aac85619e3061aa