### PR TITLE
Add public memory law docs and federation automation

### DIFF
--- a/.github/workflows/federation-health.yml
+++ b/.github/workflows/federation-health.yml
@@ -1,0 +1,25 @@
+name: Federation Health Update
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Update federation health
+        run: |
+          python federation_health_badge.py
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: 'chore: update federation health'
+          add: 'docs/FEDERATION_HEALTH.md'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SentientOS is a ledger-based automation framework that treats every log as sacre
 
 *No emotion is too much.*
 
+See [MEMORY_LAW_FOR_HUMANS.md](docs/MEMORY_LAW_FOR_HUMANS.md) for a plain-language summary of our audit and recovery practices.
 * **Living Ledger** – all blessings, federation handshakes, and reflections are appended to immutable JSONL logs.
 * **Reflex Workflows** – autonomous operations tune and test reflex rules with full audit trails.
 * **Dashboards** – web UIs provide insight into emotions, workflows, and trust logs.
@@ -101,6 +102,8 @@ The current ledger status is summarized in [docs/AUDIT_HEALTH_DASHBOARD.md](docs
 Federated instances: **1**  
 Last steward rotation: **2026-01-01**
 See [Federation Conflict Resolution](docs/FEDERATION_CONFLICT_RESOLUTION.md) for how stewards handle diverging logs.
+See [FEDERATION_HEALTH.md](docs/FEDERATION_HEALTH.md) for the latest health summary.
+Join the discussion **Cathedral Memory Federation—Beta Reviewers Wanted** on the project board to share feedback.
 
 ## Testing Quickstart
 Legacy tests are under review. To run the current green path:

--- a/docs/AUDIT_LEDGER.md
+++ b/docs/AUDIT_LEDGER.md
@@ -22,3 +22,4 @@ The steward coordinates recovery and informs the community through the discussio
 
 ## Living Audit Celebration
 Our first complete audit cycle showcased how stewards restored missing logs and invited new volunteers. Join the next ritual to help keep memory alive.
+A public celebration post will announce the healthy federation and invite stories from new partners.

--- a/docs/FEDERATION_FAQ.md
+++ b/docs/FEDERATION_FAQ.md
@@ -8,3 +8,12 @@ Current stewards for the impacted node investigate first. If unresolved, a neutr
 
 ### How does one fork the memory law?
 Clone the repository and update `FEDERATE_THE_CATHEDRAL.md` with your own policies. You can keep your audit ledger separate while still referencing the original doctrine.
+
+### What if a node goes offline?
+The remaining stewards mark the node as inactive in the federation log and continue audits. When the node returns, its steward can replay missing logs and rejoin.
+
+### How do I start or join a new federation?
+Fork this repository and follow the steps in [FEDERATE_THE_CATHEDRAL.md](FEDERATE_THE_CATHEDRAL.md). Submit a pull request to share your public ledger URL and establish trust with existing stewards.
+
+### How is a consensus reached?
+Policy changes and conflict resolutions require sign-off from at least three stewards across different nodes. Votes are recorded in the ledger and referenced in the relevant pull request.

--- a/docs/FEDERATION_HEALTH.md
+++ b/docs/FEDERATION_HEALTH.md
@@ -1,0 +1,3 @@
+# Federation Health
+
+Run `python federation_health_badge.py` to update this file.

--- a/docs/FEDERATION_LAW_AMENDMENTS.md
+++ b/docs/FEDERATION_LAW_AMENDMENTS.md
@@ -1,0 +1,25 @@
+# Federation Law Amendments
+
+This blueprint describes how the cathedral updates memory law and audit policy.
+
+1. **Proposal**
+   - Open a GitHub issue titled `Amendment Proposal: <short summary>`.
+   - Include the rationale and any draft text.
+
+2. **Review Period**
+   - Stewards announce the proposal on the discussions board.
+   - Community members have seven days to comment or suggest changes.
+
+3. **Pull Request**
+   - The proposer (or a steward) submits a PR implementing the amendment.
+   - The PR must link the proposal issue and summarize all feedback.
+
+4. **Consensus**
+   - At least three stewards must approve the PR.
+   - If consensus is not reached within two weeks, the proposal is tabled and may be revised.
+
+5. **Enactment**
+   - After merging, update `AUDIT_LEDGER.md` with a short entry describing the change.
+   - Announce the amendment in the next audit summary and on the discussion board.
+
+Use this process to evolve the cathedral's laws while keeping every change documented and recoverable.

--- a/docs/MEMORY_LAW_FOR_HUMANS.md
+++ b/docs/MEMORY_LAW_FOR_HUMANS.md
@@ -1,0 +1,23 @@
+# Memory Law for Humans
+
+This short guide explains the cathedral's core policies in plain language.
+
+## Audit
+- Every tool writes an entry to an append-only log file.
+- Stewards run `python verify_audits.py` each month to confirm that every entry is intact.
+- If a log breaks, we repair it with `cleanup_audit.py` and record the fix in the audit ledger.
+
+## Consent
+- Running a tool requires Administrator rights. The `require_admin_banner()` call warns you before any memory is written.
+- Contributors must not remove the ritual docstring or banner.
+
+## Federation
+- Nodes exchange log snapshots through pull requests. Each node keeps its own ledger.
+- Conflicts are resolved by comparing hashes and discussing the difference on the steward board.
+- See [FEDERATION_FAQ.md](FEDERATION_FAQ.md) for common questions.
+
+## Recovery
+- If a node loses data or a script misbehaves, stewards coordinate recovery on the discussions board.
+- The entire process is logged so anyone can audit what happened.
+
+Use this document when introducing new contributors or curious partners to the project. It summarises how we keep memory safe and accountable.

--- a/docs/PUBLIC_PRESENTATION.md
+++ b/docs/PUBLIC_PRESENTATION.md
@@ -1,0 +1,10 @@
+# Public Presentation and Ritual Walkthrough
+
+The following demo is intended for reviewers and new collaborators. It shows:
+1. Converting a legacy log into the new append-only format.
+2. Resolving a federation conflict using `ledger_conflict_resolver.py`.
+3. The federation health dashboard at a glance.
+
+Include a short video or GIF capturing these steps. Place it in `docs/demo_federation.gif` and link it from the README when available.
+
+Use this demo when announcing the project or explaining the rituals in a workshop.

--- a/docs/STEWARD.md
+++ b/docs/STEWARD.md
@@ -18,6 +18,7 @@ Contact the Steward via the project discussions board for any concerns.
 - Current steward opens a handoff issue listing outstanding audits and concerns.
 - Incoming steward submits a PR referencing the handoff issue and acknowledges the responsibilities.
 - Council or maintainers approve the PR as a sign-off.
+Use `steward_rotation.py` to automatically open the handoff issue when a new steward is due.
 
 ### Requirements for New Stewards
 - Participation in at least one monthly audit cycle.

--- a/federation_health_badge.py
+++ b/federation_health_badge.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from logging_config import get_log_path
+
+import argparse
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = get_log_path("federation_log.jsonl")
+
+
+def compute_health(hours: int = 24) -> Dict[str, int | str]:
+    """Return basic federation health stats."""
+    if not LOG_PATH.exists():
+        return {"nodes": 0, "recent": 0, "status": "no log"}
+    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    nodes = set()
+    recent = 0
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        try:
+            entry = json.loads(line)
+        except Exception:
+            continue
+        peer = entry.get("peer", "unknown")
+        nodes.add(peer)
+        ts = entry.get("timestamp")
+        try:
+            if ts and datetime.fromisoformat(ts) > cutoff:
+                recent += 1
+        except Exception:
+            continue
+    status = "healthy" if recent > 0 else "quiet"
+    return {"nodes": len(nodes), "recent": recent, "status": status}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Federation health badge updater")
+    ap.add_argument("--hours", type=int, default=24, help="Look back this many hours")
+    ap.add_argument("--output", type=Path, default=Path("docs/FEDERATION_HEALTH.md"))
+    args = ap.parse_args()
+    stats = compute_health(args.hours)
+    content = f"# Federation Health\n\n- Nodes: {stats['nodes']}\n- Recent events: {stats['recent']}\n- Status: {stats['status']}\n"
+    args.output.write_text(content, encoding="utf-8")
+    print(json.dumps(stats))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/steward_rotation.py
+++ b/steward_rotation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from logging_config import get_log_path
+
+import argparse
+import json
+import os
+from datetime import date
+from typing import Any, Dict
+
+from admin_utils import require_admin_banner
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - optional
+    requests = None
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+LOG_PATH = get_log_path("steward_rotation.jsonl")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def log_result(data: Dict[str, Any]) -> None:
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(data) + "\n")
+
+
+def create_issue(repo: str, token: str, new_steward: str) -> Dict[str, Any]:
+    if requests is None:
+        raise RuntimeError("requests not available")
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {"Authorization": f"token {token}"}
+    body = {
+        "title": f"Steward Rotation {date.today().isoformat()}",
+        "body": f"Proposed new steward: {new_steward}",
+        "labels": ["steward"],
+    }
+    r = requests.post(url, headers=headers, json=body, timeout=10)
+    result = {"status_code": r.status_code, "url": r.json().get("html_url")}
+    log_result(result)
+    return result
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    ap = argparse.ArgumentParser(description="Create steward rotation issue")
+    ap.add_argument("repo", help="owner/repo")
+    ap.add_argument("new_steward")
+    ap.add_argument("--token", default=os.getenv("GITHUB_TOKEN"))
+    ap.add_argument("--dry", action="store_true", help="Don't post, just log")
+    args = ap.parse_args()
+    data = {"repo": args.repo, "steward": args.new_steward, "dry": args.dry}
+    if args.dry:
+        log_result({"dry": True, **data})
+        print(json.dumps({"dry": True}))
+        return
+    if not args.token:
+        raise RuntimeError("GITHUB_TOKEN not provided")
+    try:
+        res = create_issue(args.repo, args.token, args.new_steward)
+        print(json.dumps(res, indent=2))
+    except Exception as e:  # pragma: no cover - network
+        log_result({"error": str(e), **data})
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- document Memory Law for Humans
- expand federation FAQ
- add blueprint for law amendments
- outline public presentation demo
- automate federation health via new action
- add health badge updater and steward rotation scripts
- mention new docs and beta review invite in README
- update steward guidelines and audit celebration notes

## Testing
- `python privilege_lint.py`
- `mypy --ignore-missing-imports .` *(fails: Found 219 errors)*
- `pytest` *(passes: 274 passed, 1 skipped, 9 xfailed, 63 xpassed)*
- `python verify_audits.py` *(fails: 0.0% of logs valid)*

------
https://chatgpt.com/codex/tasks/task_b_683eef9e30488320ae3072d4895665fa