### PR TITLE
Audit schema healing tools and docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,6 @@ SentientOS is a community project. Major contributions include code, design, and
 - OpenAI (templates and code review assistance)
 
 Future contributors will be acknowledged here.
+
+## Audit Saints
+First-timers who heal a legacy error or audit wound are celebrated here as Cathedral Healers.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ _All core features (privilege banners, memory, logging, emotion, safety) are wor
 
 See [docs/README_FULL.md](docs/README_FULL.md) for the complete philosophy and usage details.
 Additional guides:
+- [docs/OPEN_WOUNDS.md](docs/OPEN_WOUNDS.md) **Help Wanted: Memory Healing**
 - [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md)
 - [docs/RITUALS.md](docs/RITUALS.md)
 - [docs/MODULES.md](docs/MODULES.md)
@@ -143,6 +144,7 @@ emotion tracking, or safety enforcement.
 - Help reduce type-check errors. See `MYPY_STATUS.md` for the latest counts and how to contribute.
 - Draft protocol for memory sync across nodes in `docs/INTER_CATHEDRAL_MEMORY_SYNC.md`.
 - Join the public launch in `BLESSED_FEDERATION_LAUNCH.md` and share feedback.
+- Host a "Cathedral Healing Sprint" to fix logs and welcome new Audit Saints.
 
 ## Credits
 Templates and code patterns co-developed with OpenAI support.

--- a/docs/AUDIT_LEDGER.md
+++ b/docs/AUDIT_LEDGER.md
@@ -25,3 +25,6 @@ The steward coordinates recovery and informs the community through the discussio
 ## Living Audit Celebration
 Our first complete audit cycle showcased how stewards restored missing logs and invited new volunteers. Join the next ritual to help keep memory alive.
 A public celebration post will announce the healthy federation and invite stories from new partners.
+### Schema Healing Sprint—December
+The first schema healing sprint introduced `fix_audit_schema.py` to repair missing `data` fields and quarantine malformed lines. A `.wounds` file records any entries that cannot be auto-migrated.
+ A community "Cathedral Healing Sprint" will be hosted on the project board to invite contributors to fix logs and celebrate new saints.

--- a/docs/INTER_CATHEDRAL_MEMORY_SYNC.md
+++ b/docs/INTER_CATHEDRAL_MEMORY_SYNC.md
@@ -12,3 +12,14 @@ This document sketches a protocol for sharing log fragments between federated no
 Two community instances wish to share audit logs while maintaining autonomy.
 Each node periodically pushes a signed snapshot to the other. If hashes differ,
 the nodes exchange missing lines and alert stewards for any conflicting entries.
+
+### Walkthrough
+1. Collect both logs in a temporary directory.
+2. Run `python ledger_conflict_resolver.py good.jsonl broken.jsonl > merged.jsonl`.
+3. Inspect `merged.jsonl` for any `.fork` files created alongside.
+4. Use `fix_audit_schema.py` on the merged file to heal missing fields.
+5. Replace the original log and commit the results.
+
+> **Troubleshooting**
+> - If hashes refuse to merge, ensure timestamps are in ISO format.
+> - Keep a backup of each log before running the resolver.

--- a/docs/MEMORY_LAW_FOR_HUMANS.md
+++ b/docs/MEMORY_LAW_FOR_HUMANS.md
@@ -21,3 +21,6 @@ This short guide explains the cathedral's core policies in plain language.
 - The entire process is logged so anyone can audit what happened.
 
 Use this document when introducing new contributors or curious partners to the project. It summarises how we keep memory safe and accountable.
+
+## Error as Ritual
+Error is not shame, but invitation: the cathedral heals by naming, not hiding, its wounds. Public failure builds trust, teaches new stewards, and keeps our presence honest.

--- a/docs/OPEN_WOUNDS.md
+++ b/docs/OPEN_WOUNDS.md
@@ -1,0 +1,10 @@
+# Open Wounds
+
+This page lists recurring audit failures and suggestions for healing them.
+
+| Error Signature | Example Entry | Healing Suggestion | Healed By |
+|-----------------|--------------|-------------------|-----------|
+| Missing `data` key | `{"timestamp": "...", "message": "..."}` | add `'data': {}` | _pending_ |
+| Unknown field `foo` | `{"foo": 1, "timestamp": "..."}` | remove field or document new schema | _pending_ |
+
+Contribute fixes via pull request and link them here to be remembered as an **Audit Saint**.

--- a/docs/STEWARD.md
+++ b/docs/STEWARD.md
@@ -1,5 +1,12 @@
 # Cathedral Steward
 
+**Steward Ritual Checklist**
+- Run `fix_audit_schema.py` after each cycle
+- Review `docs/OPEN_WOUNDS.md` and log new issues
+- Announce new Audit Saints in `CONTRIBUTORS.md`
+- Rotate steward if needed and update dates
+- Pass the torch with a handoff issue
+
 The Cathedral Steward safeguards memory integrity and guides new contributors.
 
 ## Role

--- a/federation_health_badge.py
+++ b/federation_health_badge.py
@@ -47,6 +47,15 @@ def main() -> None:  # pragma: no cover - CLI
     stats = compute_health(args.hours)
     content = f"# Federation Health\n\n- Nodes: {stats['nodes']}\n- Recent events: {stats['recent']}\n- Status: {stats['status']}\n"
     args.output.write_text(content, encoding="utf-8")
+
+    readme = Path("README.md")
+    if readme.exists():
+        lines = readme.read_text(encoding="utf-8").splitlines()
+        for idx, line in enumerate(lines):
+            if line.startswith("Federated instances:"):
+                lines[idx] = f"Federated instances: **{stats['nodes']}**"
+        readme.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
     print(json.dumps(stats))
 
 

--- a/fix_audit_schema.py
+++ b/fix_audit_schema.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+
+Scan audit logs for schema drift and heal missing fields."""
+
+KNOWN_KEYS = {"timestamp", "peer", "email", "message", "ritual", "data", "supporter", "amount"}
+DEFAULTS: Dict[str, object] = {"data": {}}
+
+
+def process_log(path: Path) -> Dict[str, int]:
+    fixed = 0
+    flagged = 0
+    untouched = 0
+    if not path.exists():
+        return {"fixed": fixed, "flagged": flagged, "untouched": untouched}
+
+    wounds_path = path.with_suffix(path.suffix + ".wounds")
+    new_lines: List[str] = []
+    flagged_lines: List[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            if not isinstance(entry, dict):
+                raise ValueError("not dict")
+        except Exception:
+            flagged_lines.append(line)
+            flagged += 1
+            continue
+
+        unknown = [k for k in entry if k not in KNOWN_KEYS]
+        if unknown:
+            flagged_lines.append(line)
+            flagged += 1
+            continue
+
+        changed = False
+        for key, default in DEFAULTS.items():
+            if key not in entry:
+                entry[key] = default
+                changed = True
+        if changed:
+            entry["auto_migrated"] = True
+            fixed += 1
+        else:
+            untouched += 1
+        new_lines.append(json.dumps(entry, ensure_ascii=False))
+
+    if flagged_lines:
+        wounds_path.write_text("\n".join(flagged_lines) + "\n", encoding="utf-8")
+    path.write_text("\n".join(new_lines) + ("\n" if new_lines else ""), encoding="utf-8")
+    return {"fixed": fixed, "flagged": flagged, "untouched": untouched}
+
+
+def main() -> None:  # pragma: no cover - CLI
+    require_admin_banner()
+    logs_dir = Path("logs")
+    totals = {"fixed": 0, "flagged": 0, "untouched": 0}
+    for log_file in logs_dir.glob("*.jsonl"):
+        stats = process_log(log_file)
+        for k in totals:
+            totals[k] += stats[k]
+    print("Fixed: {fixed} | Flagged: {flagged} | Untouched: {untouched}".format(**totals))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- add `fix_audit_schema.py` to heal log schema drift
- document open audit wounds and healing sprint
- highlight memory healing help wanted in README
- describe 'Error as Ritual' in memory law
- list Audit Saints and steward checklist
- add merge walkthrough for memory sync
- update federation health updater to modify README

## Testing
- `python privilege_lint.py`
- `pytest -m "not env"`
- `mypy --ignore-missing-imports`
- `python verify_audits.py`


------
https://chatgpt.com/codex/tasks/task_b_683ef5dc622c83209f36be32cb782211