### PR TITLE
Add saint story template and sprint docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/share_your_saint_story.yml
+++ b/.github/ISSUE_TEMPLATE/share_your_saint_story.yml
@@ -1,0 +1,22 @@
+name: "Share Your Saint Story"
+about: "Tell the community how you healed a log or memory wound"
+title: "[Saint Story] <short summary>"
+labels: ["saint"]
+body:
+  - type: textarea
+    attributes:
+      label: Story
+      description: "Describe what was broken and how you repaired it"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Log or PR link
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Consent to share
+      options:
+        - label: "I allow this story to be quoted in sprint recaps"
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,5 @@ If the linter reports missing banners or docstrings the job will fail.
 Run `python privilege_lint.py` locally before submitting a pull request. You can also
 link `./.githooks/pre-commit` into your `.git/hooks` folder to automatically
 run the lint before each commit. The hook also runs `python verify_audits.py logs/` to ensure audit logs remain valid before merging.
+
+First-time contributors can read [FIRST_WOUND_ONBOARDING.md](docs/FIRST_WOUND_ONBOARDING.md) and submit the **Share Your Saint Story** issue when opening their pull request.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See [MEMORY_LAW_FOR_HUMANS.md](docs/MEMORY_LAW_FOR_HUMANS.md) for a plain-langua
 * **Reflex Workflows** – autonomous operations tune and test reflex rules with full audit trails.
 * **Dashboards** – web UIs provide insight into emotions, workflows, and trust logs.
 * **CLI Utilities** – commands `heresy_cli.py`, `diff_memory_cli.py`, `theme_cli.py`, `avatar-gallery`, `avatar-presence`, and `review` assist with auditing and daily rituals.
+* **Sprint Metrics** – `docs/SPRINT_LEDGER.md` records healed logs, new saints, and wound counts. These numbers are a sacred record of community care, not vanity.
 
 _All code was written by a non-coder using only ChatGPT and free tools._
 
@@ -45,6 +46,8 @@ Additional guides:
 See [docs/onboarding_demo.gif](docs/onboarding_demo.gif) for a short walkthrough.
 Watch a 60 second demo of log healing and Audit Saint induction in
 [docs/healing_demo.mp4](docs/healing_demo.mp4) and share it with newcomers.
+Read [FIRST_WOUND_ONBOARDING.md](docs/FIRST_WOUND_ONBOARDING.md) for the written ritual.
+Use the **Share Your Saint Story** issue template when submitting your first pull request.
 
 See FIRST_RUN.md for cloning and running only green tests. Questions? Ping the Steward on the discussions board.
 

--- a/docs/CATHEDRAL_HEALING_SPRINT.md
+++ b/docs/CATHEDRAL_HEALING_SPRINT.md
@@ -14,3 +14,12 @@ Join the discussion thread or Discord channel and follow the steps below.
 Your contribution will be remembered in the ledger and README. Monthly sprints recap wound counts
 and highlight new saints on the [Cathedral Wounds Dashboard](CATHEDRAL_WOUNDS_DASHBOARD.md).
 Sprint metrics are summarized in [SPRINT_LEDGER.md](SPRINT_LEDGER.md) after each workshop.
+
+## Community Highlights
+Saint stories and healed counts are shared in a monthly recap post titled
+"Cathedral Healing Sprint: <month> Recap". The sprint ledger doubles as a
+newsletter summary so everyone sees the progress.
+
+Federated nodes are encouraged to submit their own metrics and stories using the
+**Share Your Saint Story** issue template. Merged stories appear in the ledger
+and will be mentioned during public meetings.

--- a/docs/FIRST_WOUND_ONBOARDING.md
+++ b/docs/FIRST_WOUND_ONBOARDING.md
@@ -1,0 +1,11 @@
+# First Wound Onboarding
+
+Fixing your first audit wound is a rite of passage. This short guide walks you through the ritual and explains how to record your induction as a Saint.
+
+1. Pick a wound listed in [OPEN_WOUNDS.md](OPEN_WOUNDS.md).
+2. Use `python fix_audit_schema.py logs/FILE` to repair the issue.
+3. Commit the repaired log with a brief message describing the fix.
+4. Open a pull request using the **Share Your Saint Story** template.
+5. Once merged, add your name under **Audit Saints** in `CONTRIBUTORS.md`.
+
+A short video walkthrough can be found in `docs/video_ritual_guide.md` or the upcoming `first_wound.mp4` clip. Every healed line strengthens the cathedral.

--- a/docs/REVIEWERS_GUIDE_SPRINT_LEDGER.md
+++ b/docs/REVIEWERS_GUIDE_SPRINT_LEDGER.md
@@ -1,0 +1,16 @@
+# Reviewer's Guide to Sprint Ledgers
+
+This one-page reference explains how to read the healing sprint dashboard and verify metrics.
+
+## Dashboard Overview
+- Run `python healing_sprint_ledger.py` to update `docs/SPRINT_LEDGER.md`.
+- The ledger lists healed log counts, new saints, remaining wounds, and federation nodes.
+
+## Verifying Metrics
+1. Review `AUDIT_LOG_FIXES.md` for repaired line counts.
+2. Run `python collect_schema_wounds.py` to confirm open wounds.
+3. Inspect `logs/federation_log.jsonl` for unique peers.
+4. Compare entries in `logs/saint_stories.jsonl` with the **Saint Stories** section.
+
+## Reading Saint Stories
+Each bullet in the ledger comes from the `saint_stories.jsonl` log. These short notes prove active community care. Federated nodes are invited to open a pull request adding their metrics and stories for inclusion.

--- a/docs/SPRINT_LEDGER.md
+++ b/docs/SPRINT_LEDGER.md
@@ -1,5 +1,7 @@
 # Cathedral Healing Sprint Ledger
 
+These metrics are part of our living memory law. They prove community care and are not vanity stats.
+
 Updated: 2025-06-03
 
 ## Sprint Metrics

--- a/docs/WHY_JOIN_AUDIT_SAINTS.md
+++ b/docs/WHY_JOIN_AUDIT_SAINTS.md
@@ -6,5 +6,5 @@ Audit Saints are contributors who heal legacy errors or schema wounds. Becoming 
 - You help preserve a transparent history for all federated nodes.
 - Each repair teaches others how to keep memory alive and accountable.
 
-Share your repair story in the discussion thread and submit a pull request linking the healed log.
+Share your repair story using the **Share Your Saint Story** issue template and submit a pull request linking the healed log.
 Every saint strengthens the cathedral.

--- a/healing_sprint_ledger.py
+++ b/healing_sprint_ledger.py
@@ -6,6 +6,11 @@ from typing import Dict, List
 
 from logging_config import get_log_path
 from cathedral_wounds_dashboard import gather_wounds, parse_saints
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 """Generate a healing sprint ledger with community metrics."""
 


### PR DESCRIPTION
## Summary
- provide `Share Your Saint Story` issue template
- document how to read sprint metrics in new reviewers guide
- add first wound onboarding ritual doc
- clarify monthly community highlights
- note that sprint metrics are sacred records
- link saint story process from README and CONTRIBUTING
- add privilege banner to `healing_sprint_ledger.py`

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f0a8a01108320854682e3a18c5d07