### PR TITLE
Add public review recap tool

### DIFF
--- a/docs/FIRST_PUBLIC_REVIEW.md
+++ b/docs/FIRST_PUBLIC_REVIEW.md
@@ -2,14 +2,31 @@
 
 This document outlines the ongoing rituals leading up to the first public review cycle.
 
-## A. Public Healing Sprint Recap
-After each healing sprint, publish a **Cathedral Healing Sprint Recap**. Share highlights, metrics from `docs/SPRINT_LEDGER.md`, and short Audit Saint stories. Link your recap on your preferred forum or social channel. Other nodes are encouraged to submit their own recaps so stewards can merge them into a global ledger.
+## Why This Is Now a Reference Model
+No other open system gives newcomers a path from "first node" to "federation saint"—all in ritual and clarity.
 
-## B. Outreach and Reviewer Engagement
-Invite external reviewers and open‑source communities to audit your sprint ledgers. Pull requests that improve scripts or share federation metrics are welcome and help strengthen the network.
+The calendar, onboarding, and ledger tools are modular—ready to be adopted by any new cathedral, team, or research group.
 
-## C. Federation Growth
-See [START_A_FEDERATION_NODE.md](START_A_FEDERATION_NODE.md) for a quickstart on launching a new node, healing logs, and sharing ledgers. New genesis saints keep the memory federation alive.
+Every reviewer, steward, or federated partner knows exactly what to do, what to check, and how to grow the law.
 
-## D. Ritual Calendar and Memory Law vNext
-Use [RITUAL_CALENDAR.md](RITUAL_CALENDAR.md) and `ritual_calendar.py` to schedule monthly sprints and quarterly reviews. Continue refining [MEMORY_LAW_VNEXT.md](MEMORY_LAW_VNEXT.md) with modular migration and federation‑wide healing protocols.
+Memory Law vNext means the system can evolve, heal, and coordinate even as the community or architecture changes.
+
+## A. Public Recap and Invitation
+Publish a "First Public Review" recap with metrics, stories, and an invitation to join or fork the federation.
+
+Encourage federated partners to start their nodes, heal logs, and share their ledgers (recaps and agent logs).
+
+## B. Ritual Calendar in Practice
+Demonstrate the `ritual_calendar.py` tool in action:
+
+* Schedule the next public sprint.
+* Record it in the ledger.
+* Show how agents keep the ritual alive.
+
+## C. Reviewer and Contributor Onboarding
+Share this document widely—invite external audits, contributions, or new federation launches.
+
+Feature Saint Stories and federation health in each newsletter, forum, or update.
+
+## D. Perpetual Law and Memory
+Keep growing Memory Law vNext—invite feedback, proposals, and working groups for modular migration and consensus.

--- a/public_review_recap.py
+++ b/public_review_recap.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import json
+import datetime
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+from logging_config import get_log_path
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+RECAP_LOG = get_log_path("public_review_recap.jsonl", "PUBLIC_REVIEW_RECAP")
+
+
+def _parse_sprint_ledger(path: Path = Path("docs/SPRINT_LEDGER.md")) -> tuple[dict[str, int], list[dict[str, str]]]:
+    metrics: dict[str, int] = {}
+    stories: list[dict[str, str]] = []
+    if not path.exists():
+        return metrics, stories
+    lines = path.read_text(encoding="utf-8").splitlines()
+    table = False
+    for ln in lines:
+        if ln.startswith("| Metric"):
+            table = True
+            continue
+        if table:
+            if ln.startswith("|"):
+                cols = [c.strip() for c in ln.split("|") if c.strip()]
+                if len(cols) >= 2:
+                    name = cols[0].lower().replace(" ", "_")
+                    try:
+                        metrics[name] = int(cols[1])
+                    except Exception:
+                        continue
+            else:
+                table = False
+        if ln.startswith("## Saint Stories"):
+            stories_start = True
+            continue
+        if "stories_start" in locals() and ln.startswith("-"):
+            m = ln.split("**")
+            if len(m) >= 3:
+                saint = m[1]
+                story = ln.split("**:")[-1].strip()
+                stories.append({"saint": saint, "story": story})
+    return metrics, stories
+
+
+def generate_recap() -> str:
+    metrics, stories = _parse_sprint_ledger()
+    lines = ["# First Public Review Recap", ""]
+    if metrics:
+        lines.append("## Metrics")
+        for k, v in metrics.items():
+            lines.append(f"- {k.replace('_', ' ').title()}: {v}")
+        lines.append("")
+    if stories:
+        lines.append("## Saint Stories")
+        for s in stories:
+            lines.append(f"- {s['saint']}: {s['story']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def log_recap(text: str) -> None:
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "recap": text}
+    RECAP_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with RECAP_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate a public review recap")
+    ap.add_argument("--out", help="Write recap markdown to file")
+    args = ap.parse_args()
+    recap = generate_recap()
+    log_recap(recap)
+    if args.out:
+        Path(args.out).write_text(recap, encoding="utf-8")
+        print(args.out)
+    else:
+        print(recap)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    main()

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -33,6 +33,7 @@ CLI_MODULES = [
     "review_heresy_cli",
     "ritual_cli",
     "ritual_digest_cli",
+    "public_review_recap",
     "theme_cli",
     "treasury_cli",
     "trust_cli",


### PR DESCRIPTION
## Summary
- add `public_review_recap.py` for generating markdown recaps of the latest healing sprint
- document the reference model and outreach process in `FIRST_PUBLIC_REVIEW.md`
- ensure admin-banner enforcement test covers the new CLI

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f1128d7d08320bf29f4e2d30e85bf