### PR TITLE
Add migration daemon for automatic schema healing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2375,3 +2375,13 @@ Another Registered Agent:
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/ritual_calendar.json
 ```
+Another Registered Agent:
+
+```
+- Name: MigrationDaemon
+  Type: Daemon
+  Roles: Schema Healer, Ledger Writer
+  Privileges: log, migrate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/migration_ledger.jsonl
+```

--- a/docs/STEWARD.md
+++ b/docs/STEWARD.md
@@ -1,11 +1,12 @@
 # Cathedral Steward
 
-**Steward Ritual Checklist**
-- Run `fix_audit_schema.py` after each cycle
+-**Steward Ritual Checklist**
+- Schedule `migration_daemon.py` (or run `fix_audit_schema.py`) after each cycle
 - Review `docs/OPEN_WOUNDS.md` and log new issues
 - Announce new Audit Saints in `CONTRIBUTORS.md`
 - Rotate steward if needed and update dates
 - Pass the torch with a handoff issue
+- Publish or review `logs/migration_ledger.jsonl` each month
 
 The Cathedral Steward safeguards memory integrity and guides new contributors.
 

--- a/migration_daemon.py
+++ b/migration_daemon.py
@@ -1,0 +1,65 @@
+from admin_utils import require_admin_banner
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+"""Automated daemon to apply schema migrations on a schedule.
+
+This tool runs ``fix_audit_schema.process_log`` on every ``.jsonl`` log file
+in the given directory. Any healed entries are recorded in
+``logs/migration_ledger.jsonl``. Intended to run periodically via ``cron``
+or another task scheduler.
+"""
+
+import argparse
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+from logging_config import get_log_path
+import fix_audit_schema
+
+LEDGER = get_log_path("migration_ledger.jsonl")
+LEDGER.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _record_fix(path: Path, count: int) -> None:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "file": str(path),
+        "action": f"auto_migrated_entries({count})",
+    }
+    with LEDGER.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _run_once(target: Path) -> None:
+    files = [target] if target.is_file() else sorted(target.glob("*.jsonl"))
+    for fp in files:
+        stats = fix_audit_schema.process_log(fp)
+        if stats.get("fixed"):
+            _record_fix(fp, stats["fixed"])
+
+
+def run_daemon(target: Path, interval: float) -> None:
+    while True:
+        _run_once(target)
+        time.sleep(interval)
+
+
+def main() -> None:  # pragma: no cover - CLI
+    ap = argparse.ArgumentParser(description="Auto-migrate logs on a schedule")
+    ap.add_argument("--target", default="logs", help="File or directory to process")
+    ap.add_argument("--interval", type=float, default=3600.0, help="Seconds between runs")
+    ap.add_argument("--once", action="store_true", help="Run once instead of looping")
+    args = ap.parse_args()
+    target = Path(args.target)
+    if args.once:
+        _run_once(target)
+    else:
+        run_daemon(target, args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `migration_daemon.py` for scheduled schema healing
- register `MigrationDaemon` in `AGENTS.md`
- update steward checklist with cron guidance and ledger transparency

## Testing
- `python privilege_lint.py`
- `python verify_audits.py logs/` *(fails: KeyError: 'data')*
- `pytest -m "not env"`

------
https://chatgpt.com/codex/tasks/task_b_683f22e9b8cc8320b6cd58c3e880aef5