### PR TITLE
Fix log path defaults

### DIFF
--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,4 +1,4 @@
-from logging_config import get_log_path
+from logging_config import get_log_path, get_log_dir
 
 import argparse
 import json
@@ -71,7 +71,9 @@ def _mask(entry: Dict[str, Any]) -> Dict[str, Any]:
     return masked
 
 
-def scan_logs(log_dir: Path = Path("logs")) -> List[Dict[str, Any]]:
+def scan_logs(log_dir: Path | None = None) -> List[Dict[str, Any]]:
+    if log_dir is None:
+        log_dir = get_log_dir()
     anomalies: List[Dict[str, Any]] = []
     for fp in log_dir.glob("*.jsonl"):
         for idx, line in enumerate(fp.read_text(encoding="utf-8").splitlines(), 1):

--- a/fix_audit_schema.py
+++ b/fix_audit_schema.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import datetime
+from logging_config import get_log_dir
 from pathlib import Path
 from typing import Callable, Dict, List
 
@@ -82,7 +83,7 @@ def process_log(path: Path, on_apply: Callable[[], None] | None = None) -> Dict[
 
 def main() -> None:  # pragma: no cover - CLI
     require_admin_banner()
-    logs_dir = Path("logs")
+    logs_dir = get_log_dir()
     totals = {"fixed": 0, "flagged": 0, "untouched": 0}
     banner_shown = False
 

--- a/monthly_audit.py
+++ b/monthly_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import datetime
+from logging_config import get_log_dir
 from pathlib import Path
 
 from admin_utils import require_admin_banner
@@ -7,7 +8,7 @@ import verify_audits as va
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-LOG_DIR = Path("logs")
+LOG_DIR = get_log_dir()
 AUDIT_DOC = Path("docs/AUDIT_LOG.md")
 
 


### PR DESCRIPTION
## Summary
- `autonomous_audit.scan_logs` uses `get_log_dir()` when no directory is given
- `fix_audit_schema` and `monthly_audit` rely on `get_log_dir()` instead of hardcoded paths
- keep privilege linting satisfied

## Testing
- `python privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f34a0af188320b8eef848009db018