### PR TITLE
Document hidden env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,116 @@ NEOS_BRIDGE_DIR=C:/SentientOS/neos
 BACKCHANNEL_GAP=6
 LEDGER_BACKUP_DIR=backup
 
+# Actuator configuration
+ACT_PLUGINS_DIR=plugins
+ACT_RATE_LIMIT=5
+ACT_SANDBOX=sandbox
+ACT_TEMPLATES=config/act_templates.yml
+ACT_WHITELIST=config/act_whitelist.yml
+
+# Archive and avatar directories
+ARCHIVE_DIR=archives
+AVATAR_DREAM_DIR=dreams
+AVATAR_GIFT_DIR=gifts
+AVATAR_RECEIVER_CMD=
+
+# Voice loop settings
+BACKCHANNEL_DELAY=5
+
+# Bridge watchdog
+BRIDGE_URLS=http://localhost:5000/relay
+BRIDGE_CHECK_SEC=5
+BRIDGE_RESTART_CMD=
+
+# Cathedral history
+CATHEDRAL_BIRTH=2023-01-01
+
+# Consent and council configs
+CONSENT_CONFIG=config/consent.json
+COUNCIL_CONFIG=config/council.json
+COUNCIL_QUORUM=2
+
+# Diary and digest paths
+DIARY_DIR=diaries
+DIGEST_KEEP_DAYS=7
+
+# Doctrine and editor settings
+DOCTRINE_PATH=SENTIENTOS_LITURGY.txt
+EDITOR=nano
+
+# Emergency mode
+EMERGENCY_STATE=state/emergency.lock
+
+# Emotion visualizer
+EMO_VIS_HOST=0.0.0.0
+EMO_VIS_PORT=9000
+
+# Feedback settings
+FEEDBACK_NO_PROMPT=
+FINAL_APPROVER_FILE=config/final_approvers.json
+
+# Genesis oracle
+GENESIS_ORACLE_DATA=logs
+
+# GitHub access
+GITHUB_TOKEN=
+
+# General plugin directory
+GP_PLUGINS_DIR=gp_plugins
+
+# Avatar heartbeat monitor
+HEARTBEAT_PORT=9001
+
+# Ritual enforcement
+MASTER_CHECK_IMMUTABLE=1
+MASTER_CONFIG=config/master_files.json
+MASTER_ENFORCE=
+
+# Memory utilities
+MEMORY_FILE=logs/memory.jsonl
+MULTI_LOG_DIR=
+NARRATOR_MODEL=facebook/bart-large-cnn
+
+# Neos exports
+NEOS_BLENDER_EXPORT_DIR=blender_exports
+NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG=logs/neos_festival_replay_annotations.jsonl
+
+# OCR pipeline
+OCR_WATCH=screenshots
+
+# API ports
+PORT=5000
+
+# Approval settings
+REQUIRED_FINAL_APPROVER=4o
+RITUAL_BUNDLE_DIR=bundles
+SELF_REFLECTION_QUESTION=What have you learned recently?
+SENTIENTOS_HEADLESS=
+
+# SMTP configuration
+SMTP_FROM=
+SMTP_HOST=
+SMTP_PASS=
+SMTP_PORT=25
+SMTP_USER=
+
+# Optional emotion model
+SOTA_EMOTION_MODEL=
+
+# Spiral law directory
+SPIRAL_LAW_SOURCE=logs
+
+# Telegram monitoring
+TELEGRAM_ADMIN=
+TELEGRAM_TOKEN=
+TELEGRAM_WEBHOOKS=
+
+# Default username
+USER=anon
+
+# Voice loop
+VOICE_MODEL=openai/gpt-4o
+WAKE_WORDS=Lumos
+WEBHOOK_CHECK_SEC=60
+WORKFLOW_REVIEW_DIR=workflows/review
+

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -32,4 +32,63 @@ The table below explains each variable and its default behavior.
 | `NEOS_BRIDGE_DIR` | Path to NeosVR bridge directory | `C:/SentientOS/neos` |
 | `BACKCHANNEL_GAP` | Seconds between backchannel polls | `6` |
 | `LEDGER_BACKUP_DIR` | Directory for ledger backups | `backup` |
+| `ACT_PLUGINS_DIR` | Directory containing actuator plugin files | `plugins` |
+| `ACT_RATE_LIMIT` | Seconds between actuator invocations | `5` |
+| `ACT_SANDBOX` | Working directory for sandboxed actions | `sandbox` |
+| `ACT_TEMPLATES` | YAML file describing actuator templates | `config/act_templates.yml` |
+| `ACT_WHITELIST` | Allowed actions for the actuator service | `config/act_whitelist.yml` |
+| `ARCHIVE_DIR` | Location for blessed archive exports | `archives` |
+| `AVATAR_DREAM_DIR` | Directory for avatar dream logs | `dreams` |
+| `AVATAR_GIFT_DIR` | Directory for generated artifact gifts | `gifts` |
+| `AVATAR_RECEIVER_CMD` | Command executed when heartbeat fails | *(none)* |
+| `BACKCHANNEL_DELAY` | Seconds of idle time before voice loop stops | `5` |
+| `BRIDGE_CHECK_SEC` | Interval for bridge watchdog checks | `5` |
+| `BRIDGE_RESTART_CMD` | Command used to restart the Neos bridge | *(none)* |
+| `BRIDGE_URLS` | Comma‑separated bridge URLs to monitor | `http://localhost:5000/relay` |
+| `CATHEDRAL_BIRTH` | ISO date of the cathedral founding | `2023-01-01` |
+| `CONSENT_CONFIG` | Path to consent dashboard config | `config/consent.json` |
+| `COUNCIL_CONFIG` | Path to council onboarding config | `config/council.json` |
+| `COUNCIL_QUORUM` | Minimum votes required for council actions | `2` |
+| `DIARY_DIR` | Location for multimodal diaries | `diaries` |
+| `DIGEST_KEEP_DAYS` | Retention days for daily digests | `7` |
+| `DOCTRINE_PATH` | Path to the SentientOS doctrine text | `SENTIENTOS_LITURGY.txt` |
+| `EDITOR` | Fallback editor for workflow tools | `nano` |
+| `EMERGENCY_STATE` | Lock file indicating emergency mode | `state/emergency.lock` |
+| `EMO_VIS_HOST` | Host for emotion visualizer | `0.0.0.0` |
+| `EMO_VIS_PORT` | Port for emotion visualizer | `9000` |
+| `FEEDBACK_NO_PROMPT` | Disable prompt during feedback capture | *(unset)* |
+| `FINAL_APPROVER_FILE` | JSON file listing final approvers | `config/final_approvers.json` |
+| `GENESIS_ORACLE_DATA` | Directory for genesis oracle data | `logs` |
+| `GITHUB_TOKEN` | GitHub token for CLI utilities | *(none)* |
+| `GP_PLUGINS_DIR` | Directory for general plugin files | `gp_plugins` |
+| `HEARTBEAT_PORT` | UDP port for avatar heartbeat messages | `9001` |
+| `MASTER_CHECK_IMMUTABLE` | Enforce immutability checks on rituals | `1` |
+| `MASTER_CONFIG` | Path to master file configuration | `config/master_files.json` |
+| `MASTER_ENFORCE` | Require master file enforcement (`1` to enable) | *(unset)* |
+| `MEMORY_FILE` | Default memory JSONL file for tail CLI | `logs/memory.jsonl` |
+| `MULTI_LOG_DIR` | Directory for multimodal tracker logs | *(none)* |
+| `NARRATOR_MODEL` | Summarization model for the narrator | `facebook/bart-large-cnn` |
+| `NEOS_BLENDER_EXPORT_DIR` | Directory for Neos Blender exports | `blender_exports` |
+| `NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG` | Path for festival replay annotations | `logs/neos_festival_replay_annotations.jsonl` |
+| `OCR_WATCH` | Folder watched for OCR screenshots | `screenshots` |
+| `PORT` | HTTP port for the blessing ceremony API | `5000` |
+| `REQUIRED_FINAL_APPROVER` | Default final approver nickname | `4o` |
+| `RITUAL_BUNDLE_DIR` | Location for ritual bundles | `bundles` |
+| `SELF_REFLECTION_QUESTION` | Prompt used by self‑reflection logger | `What have you learned recently?` |
+| `SENTIENTOS_HEADLESS` | Run rituals without interactive prompts (`1` to enable) | *(unset)* |
+| `SMTP_FROM` | Default sender address for SMTP mail | *(none)* |
+| `SMTP_HOST` | SMTP server hostname | *(none)* |
+| `SMTP_PASS` | SMTP password | *(none)* |
+| `SMTP_PORT` | SMTP server port | `25` |
+| `SMTP_USER` | SMTP user name | *(none)* |
+| `SOTA_EMOTION_MODEL` | Optional neural emotion model ID | *(none)* |
+| `SPIRAL_LAW_SOURCE` | Directory containing spiral law artifacts | `logs` |
+| `TELEGRAM_ADMIN` | Telegram ID for webhook status alerts | *(none)* |
+| `TELEGRAM_TOKEN` | Token for the Telegram bot | *(none)* |
+| `TELEGRAM_WEBHOOKS` | Comma‑separated webhook URLs to poll | *(none)* |
+| `USER` | Default user name when not provided | `anon` |
+| `VOICE_MODEL` | Model used for voice responses | `openai/gpt-4o` |
+| `WAKE_WORDS` | Wake words that trigger presence logging | `Lumos` |
+| `WEBHOOK_CHECK_SEC` | Seconds between webhook status checks | `60` |
+| `WORKFLOW_REVIEW_DIR` | Directory for submitted workflow reviews | `workflows/review` |
 


### PR DESCRIPTION
## Summary
- document missing environment variables
- add matching commented entries to `.env.example`

## Testing
- `python privilege_lint.py`
- `python verify_audits.py logs/` *(fails: hash mismatch)*
- `pytest -m "not env"`

------
https://chatgpt.com/codex/tasks/task_b_683f34a19ae48320baf7a8382c4b4071