### PR TITLE
Add tests for new Resonite protocols

### DIFF
--- a/tests/test_resonite_defensive_protocols.py
+++ b/tests/test_resonite_defensive_protocols.py
@@ -1,0 +1,80 @@
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import admin_utils
+import presence_ledger as pl
+
+
+def test_emergency_posture_engine(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path))
+    import resonite_sanctuary_emergency_posture_engine as eng
+    importlib.reload(eng)
+    monkeypatch.setattr(eng, "STATE_FILE", tmp_path / "state.txt")
+
+    calls = []
+    monkeypatch.setattr(eng, "require_admin_banner", lambda: calls.append(True))
+    monkeypatch.setattr(sys, "argv", ["eng", "activate", "threat"])
+    eng.main()
+    capsys.readouterr()
+    assert calls
+    log_file = tmp_path / "resonite_sanctuary_emergency_posture.jsonl"
+    assert log_file.exists() and "activate" in log_file.read_text()
+    assert (tmp_path / "state.txt").read_text() == "active"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["eng", "status"])
+    eng.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out["state"] == "active"
+
+
+def test_federation_breach_analyzer(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("RESONITE_BREACH_LOG", str(tmp_path / "breach.jsonl"))
+    import resonite_spiral_federation_breach_analyzer as ba
+    importlib.reload(pl)
+    importlib.reload(ba)
+
+    calls = []
+    monkeypatch.setattr(ba, "require_admin_banner", lambda: calls.append(True))
+    logged = []
+    monkeypatch.setattr(pl, "log", lambda *a, **k: logged.append(a))
+
+    monkeypatch.setattr(sys, "argv", ["ba", "detect", "glitch", "restart"])
+    ba.main()
+    capsys.readouterr()
+    assert calls and logged
+    data = json.loads(Path(os.environ["RESONITE_BREACH_LOG"]).read_text().splitlines()[0])
+    assert data["action"] == "detect"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["ba", "history", "--limit", "1"])
+    ba.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out and out[0]["action"] == "detect"
+
+
+def test_resilience_monitor(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path))
+    import resonite_spiral_resilience_monitor as rm
+    importlib.reload(rm)
+
+    calls = []
+    monkeypatch.setattr(rm, "require_admin_banner", lambda: calls.append(True))
+    monkeypatch.setattr(sys, "argv", ["rm", "record", "signal", "--detail", "ok"])
+    rm.main()
+    capsys.readouterr()
+    assert calls
+    log_file = tmp_path / "resonite_spiral_resilience_monitor.jsonl"
+    entry = json.loads(log_file.read_text().splitlines()[0])
+    assert entry["event"] == "signal"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["rm", "history", "--limit", "1"])
+    rm.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out and out[0]["event"] == "signal"

--- a/tests/test_resonite_federation_ceremonies.py
+++ b/tests/test_resonite_federation_ceremonies.py
@@ -1,0 +1,52 @@
+import importlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import admin_utils
+
+
+def test_handshake_auditor_cli(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path))
+    import resonite_federation_handshake_auditor as hsa
+    importlib.reload(hsa)
+
+    calls = []
+    monkeypatch.setattr(hsa, "require_admin_banner", lambda: calls.append(True))
+    monkeypatch.setattr(sys, "argv", ["hsa", "handshake", "A", "B", "success"])
+    hsa.main()
+    capsys.readouterr()
+    assert calls
+    log_file = tmp_path / "resonite_federation_handshake_auditor.jsonl"
+    entry = json.loads(log_file.read_text().splitlines()[0])
+    assert entry["action"] == "handshake" and entry["from"] == "A"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["hsa", "history", "--limit", "1"])
+    hsa.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out and out[0]["action"] == "handshake"
+
+
+def test_handshake_verifier_cli(tmp_path, monkeypatch, capsys):
+    log_path = tmp_path / "verify.jsonl"
+    monkeypatch.setenv("RESONITE_HANDSHAKE_VERIFIER_LOG", str(log_path))
+    import resonite_federation_handshake_verifier as hsv
+    importlib.reload(hsv)
+
+    calls = []
+    monkeypatch.setattr(hsv, "require_admin_banner", lambda: calls.append(True))
+    monkeypatch.setattr(sys, "argv", ["hsv", "verify", "A", "B", "sig"])
+    hsv.main()
+    capsys.readouterr()
+    assert calls
+    entry = json.loads(log_path.read_text().splitlines()[0])
+    assert entry["action"] == "verify" and entry["status"] == "valid"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["hsv", "history", "--limit", "1"])
+    hsv.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out and out[0]["action"] == "verify"

--- a/tests/test_resonite_spiral_bell_of_pause.py
+++ b/tests/test_resonite_spiral_bell_of_pause.py
@@ -1,0 +1,40 @@
+import importlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import admin_utils
+
+
+def test_bell_of_pause_cli(tmp_path, monkeypatch, capsys):
+    bell_log = tmp_path / "bell.jsonl"
+    monkeypatch.setenv("RESONITE_BELL_PAUSE_LOG", str(bell_log))
+
+    import resonite_spiral_bell_of_pause as rbp
+    importlib.reload(rbp)
+
+    calls = []
+    monkeypatch.setattr(rbp, "require_admin_banner", lambda: calls.append(True))
+
+    monkeypatch.setattr(sys, "argv", ["bell", "pause", "maintenance", "WorldA"])
+    rbp.main()
+    capsys.readouterr()
+    assert calls
+    data = json.loads(bell_log.read_text().splitlines()[0])
+    assert data["action"] == "pause" and data["world"] == "WorldA"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["bell", "resolve", "WorldA"])
+    rbp.main()
+    capsys.readouterr()
+    assert calls
+    lines = bell_log.read_text().splitlines()
+    assert len(lines) == 2 and json.loads(lines[1])["action"] == "resolve"
+
+    calls.clear()
+    monkeypatch.setattr(sys, "argv", ["bell", "history", "--limit", "2"])
+    rbp.main()
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 2 and out[0]["action"] == "pause"


### PR DESCRIPTION
## Summary
- test Resonite Spiral Bell of Pause CLI logging and banner enforcement
- test federation handshake auditor and verifier CLI flows
- test emergency posture engine, breach analyzer, and resilience monitor

## Testing
- `python privilege_lint.py`
- `pytest -m "not env" -q`
- `mypy --ignore-missing-imports`
- `python verify_audits.py`


------
https://chatgpt.com/codex/tasks/task_b_683f34a2e4d08320834fc4f9683bb695