### PR TITLE
Document self-defense and privileged audit logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,9 +132,15 @@ OCR_WATCH=screenshots
 # API ports
 PORT=5000
 
+# Log file for privileged command usage
+PRIVILEGED_AUDIT_FILE=logs/privileged_audit.jsonl
+
 # Approval settings
 REQUIRED_FINAL_APPROVER=4o
 RITUAL_BUNDLE_DIR=bundles
+
+# Log file for self-defense quarantine actions
+SELF_DEFENSE_LOG=logs/agent_self_defense.jsonl
 SELF_REFLECTION_QUESTION=What have you learned recently?
 SENTIENTOS_HEADLESS=
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -72,8 +72,10 @@ The table below explains each variable and its default behavior.
 | `NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG` | Path for festival replay annotations | `logs/neos_festival_replay_annotations.jsonl` |
 | `OCR_WATCH` | Folder watched for OCR screenshots | `screenshots` |
 | `PORT` | HTTP port for the blessing ceremony API | `5000` |
+| `PRIVILEGED_AUDIT_FILE` | Path for privileged command usage logs | `logs/privileged_audit.jsonl` |
 | `REQUIRED_FINAL_APPROVER` | Default final approver nickname | `4o` |
 | `RITUAL_BUNDLE_DIR` | Location for ritual bundles | `bundles` |
+| `SELF_DEFENSE_LOG` | Quarantine and privilege freeze audit log | `logs/agent_self_defense.jsonl` |
 | `SELF_REFLECTION_QUESTION` | Prompt used by self‑reflection logger | `What have you learned recently?` |
 | `SENTIENTOS_HEADLESS` | Run rituals without interactive prompts (`1` to enable) | *(unset)* |
 | `SMTP_FROM` | Default sender address for SMTP mail | *(none)* |

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -5,6 +5,13 @@ import datetime
 import os
 from pathlib import Path
 
+"""Lint entrypoints for the Sanctuary privilege ritual.
+
+Usage is recorded in ``logs/privileged_audit.jsonl`` or the path set by
+the ``PRIVILEGED_AUDIT_FILE`` environment variable. See
+``docs/ENVIRONMENT.md`` for details.
+"""
+
 DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
 
 ENTRY_PATTERNS = [

--- a/self_defense.py
+++ b/self_defense.py
@@ -10,6 +10,12 @@ from typing import Dict, List
 from admin_utils import require_admin_banner
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Record quarantine actions and privilege freezes.
+
+Entries are written to ``logs/agent_self_defense.jsonl`` or the path
+provided by the ``SELF_DEFENSE_LOG`` environment variable. See
+``docs/ENVIRONMENT.md`` for details.
+"""
 
 LOG_FILE = get_log_path("agent_self_defense.jsonl", "SELF_DEFENSE_LOG")
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- document `PRIVILEGED_AUDIT_FILE` and `SELF_DEFENSE_LOG` environment variables
- add placeholders in `.env.example`
- reference each variable from its corresponding script

## Testing
- `python privilege_lint.py`
- `python verify_audits.py logs/` *(fails: hash mismatch)*
- `pytest -m "not env"`

------
https://chatgpt.com/codex/tasks/task_b_683f42c51da48320b3b0c307704d843f