### PR TITLE
Enforce banner placement

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -53,17 +53,38 @@ def _has_header(path: Path) -> bool:
     return DOCSTRING in search_block
 
 
-def _has_banner_call(text: str) -> bool:
-    return "require_admin_banner()" in text
+def _has_banner_call(path: Path) -> bool:
+    """Return True if ``require_admin_banner()`` immediately follows the banner docstring."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if DOCSTRING in line:
+            start = i
+            break
+    if start is None:
+        return False
+    end = start
+    if lines[start].count('"""') >= 2:
+        end = start
+    else:
+        for j in range(start + 1, len(lines)):
+            if '"""' in lines[j]:
+                end = j
+                break
+        else:
+            return False
+    j = end + 1
+    while j < len(lines) and not lines[j].strip():
+        j += 1
+    return j < len(lines) and lines[j].strip().startswith("require_admin_banner()")
 
 
 def check_file(path: Path) -> list[str]:
-    text = path.read_text(encoding="utf-8")
     issues = []
     if not _has_header(path):
         issues.append(f"{path}: missing privilege docstring after imports")
-    if not _has_banner_call(text):
-        issues.append(f"{path}: missing require_admin_banner() call")
+    if not _has_banner_call(path):
+        issues.append(f"{path}: require_admin_banner() must immediately follow the banner docstring")
     return issues
 
 

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -7,7 +7,7 @@ import privilege_lint as pl
 
 def _assert_missing(issues):
     assert any("missing privilege docstring" in i for i in issues)
-    assert any("missing require_admin_banner()" in i for i in issues)
+    assert any("require_admin_banner()" in i for i in issues)
 
 
 def test_detect_daemon_pattern(tmp_path):
@@ -35,3 +35,16 @@ def test_detect_argparse_usage(tmp_path):
     assert path in files
     issues = pl.check_file(path)
     _assert_missing(issues)
+
+
+def test_banner_not_immediate(tmp_path):
+    path = tmp_path / "cli.py"
+    path.write_text(
+        "from admin_utils import require_admin_banner\n"
+        f'"{pl.DOCSTRING}"\n'
+        "print('hi')\n"
+        "require_admin_banner()\n",
+        encoding="utf-8",
+    )
+    issues = pl.check_file(path)
+    assert any("require_admin_banner()" in i for i in issues)


### PR DESCRIPTION
## Summary
- check that require_admin_banner() immediately follows the privilege banner
- adjust privilege lint tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f42c905108320a650da1a38b94e0a