### PR TITLE
Add privileged audit and self defense env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,14 +133,14 @@ OCR_WATCH=screenshots
 PORT=5000
 
 # Log file for privileged command usage
-PRIVILEGED_AUDIT_FILE=logs/privileged_audit.jsonl
+# PRIVILEGED_AUDIT_FILE=logs/privileged_audit.jsonl
 
 # Approval settings
 REQUIRED_FINAL_APPROVER=4o
 RITUAL_BUNDLE_DIR=bundles
 
 # Log file for self-defense quarantine actions
-SELF_DEFENSE_LOG=logs/agent_self_defense.jsonl
+# SELF_DEFENSE_LOG=logs/agent_self_defense.jsonl
 SELF_REFLECTION_QUESTION=What have you learned recently?
 SENTIENTOS_HEADLESS=
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -72,10 +72,10 @@ The table below explains each variable and its default behavior.
 | `NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG` | Path for festival replay annotations | `logs/neos_festival_replay_annotations.jsonl` |
 | `OCR_WATCH` | Folder watched for OCR screenshots | `screenshots` |
 | `PORT` | HTTP port for the blessing ceremony API | `5000` |
-| `PRIVILEGED_AUDIT_FILE` | Path for privileged command usage logs | `logs/privileged_audit.jsonl` |
+| `PRIVILEGED_AUDIT_FILE` | Path used by `privilege_lint.py` to log privileged command usage | `logs/privileged_audit.jsonl` |
 | `REQUIRED_FINAL_APPROVER` | Default final approver nickname | `4o` |
 | `RITUAL_BUNDLE_DIR` | Location for ritual bundles | `bundles` |
-| `SELF_DEFENSE_LOG` | Quarantine and privilege freeze audit log | `logs/agent_self_defense.jsonl` |
+| `SELF_DEFENSE_LOG` | Log written by `self_defense.py` for quarantine and privilege freezes | `logs/agent_self_defense.jsonl` |
 | `SELF_REFLECTION_QUESTION` | Prompt used by self‑reflection logger | `What have you learned recently?` |
 | `SENTIENTOS_HEADLESS` | Run rituals without interactive prompts (`1` to enable) | *(unset)* |
 | `SMTP_FROM` | Default sender address for SMTP mail | *(none)* |


### PR DESCRIPTION
## Summary
- document privileged audit and self defense logs in ENVIRONMENT.md
- reference privilege_lint.py and self_defense.py in the docs
- add commented placeholders in `.env.example`

## Testing
- `pytest -m "not env"`

------
https://chatgpt.com/codex/tasks/task_b_683f52d8c1548320ad2cbd03681d9d56