### PR TITLE
Improve mypy strictness in multimodal tracker

### DIFF
--- a/ledger.py
+++ b/ledger.py
@@ -392,7 +392,7 @@ def summarize_log(path: Path, limit: int = 3) -> Dict[str, Any]:
 summary = summarize_log
 
 
-def streamlit_widget(st_module) -> None:
+def streamlit_widget(st_module: Any) -> None:
     """Display ledger summary in a Streamlit dashboard."""
     sup = summarize_log(get_log_path("support_log.jsonl"))
     fed = summarize_log(get_log_path("federation_log.jsonl"))


### PR DESCRIPTION
## Summary
- annotate optional modules for voice recognition
- assert optional modules are available before use
- add missing return annotations in `PersonaMemory`
- annotate `process_once` and ledger `streamlit_widget`

## Testing
- `python privilege_lint.py`
- `pytest -q`
- `python -m mypy --ignore-missing-imports .`
- `python verify_audits.py`


------
https://chatgpt.com/codex/tasks/task_b_683f52d9c07883209f694845ff66879e