### PR TITLE
Fix legacy tests and dependencies

### DIFF
--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1,16 +1,20 @@
-from admin_utils import require_admin_banner
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-"""Daily digest utility.
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+
+Daily digest utility.
 
 This script summarizes recent log activity and emotion changes. It is
 expected to be scheduled (e.g. via cron) every 24 hours. Older log
 fragments can optionally be pruned to keep disk usage reasonable.
 
-Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards can read ``logs/daily_digest.jsonl`` for a summary feed.
+Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards
+can read ``logs/daily_digest.jsonl`` for a summary feed.
 """
 
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 import datetime as _dt
 import json
 import os

--- a/tests/test_emotion_dashboard.py
+++ b/tests/test_emotion_dashboard.py
@@ -1,8 +1,10 @@
 import json
 from importlib import reload
+import os
+import sys
 import pytest
 
-pytestmark = pytest.mark.xfail(reason="emotion_dashboard imports broken", strict=False)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 def test_load_and_query(tmp_path):
     log = tmp_path / "vision.jsonl"

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -4,8 +4,6 @@ import importlib
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import support_cli
 import pytest
-
-pytestmark = pytest.mark.xfail(reason="support CLI legacy mode", strict=False)
 import support_log
 import sentient_banner as sb
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 import pytest
 
-pytestmark = pytest.mark.xfail(reason="video CLI legacy dependencies", strict=False)
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import ledger


### PR DESCRIPTION
## Summary
- move `__future__` import to top of `daily_digest`
- enable avatar-related tests and stub admin_utils per test
- remove obsolete xfail markers and ensure import paths

## Testing
- `pytest tests/test_emotion_dashboard.py tests/test_video.py tests/test_support_cli.py tests/test_avatar_todo_fixes.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f52db03c483208f6f0e554622d6a5