### PR TITLE
Enforce immediate banner call in select CLIs

### DIFF
--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -6,13 +6,12 @@ from typing import Any
 
 import daily_theme
 from admin_utils import require_admin_banner
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
 try:
     import requests  # type: ignore
 except Exception:  # pragma: no cover - optional
     requests = None
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
 
 def post_affirmation(url: str, mood: str | None = None) -> dict[str, Any]:
     data = {
@@ -27,7 +26,6 @@ def post_affirmation(url: str, mood: str | None = None) -> dict[str, Any]:
 
 
 def main() -> None:
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Affirmation webhook")
     ap.add_argument("url")
     ap.add_argument("--mood")

--- a/anniversary_notifier.py
+++ b/anniversary_notifier.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from admin_utils import require_admin_banner
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
 
 ANNIVERSARY = os.getenv("CATHEDRAL_BIRTH", "2023-01-01")
 LOG_FILE = get_log_path("anniversary_log.jsonl")
@@ -27,5 +28,4 @@ def check_and_log() -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual
-    require_admin_banner()
     check_and_log()

--- a/archive_blessing.py
+++ b/archive_blessing.py
@@ -14,8 +14,8 @@ import audit_immutability as ai
 from log_utils import append_json, read_json
 
 from admin_utils import require_admin_banner
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
 
 LOG_PATH = get_log_path("archive_blessing.jsonl", "ARCHIVE_BLESSING_LOG")
 ARCHIVE_DIR = Path(os.getenv("ARCHIVE_DIR", "archives"))


### PR DESCRIPTION
## Summary
- ensure `require_admin_banner()` runs at module level in a few CLIs

## Testing
- `pytest tests/test_privilege_lint.py::test_banner_not_immediate -q`
- `pytest tests/test_admin_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_b_683f52dc3fe88320923237152cdc949e