### PR TITLE
Reduce mypy error count

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -2,7 +2,7 @@
 
 Current run: `mypy --ignore-missing-imports .`
 
-- Total errors: 219
+- Total errors: 180
 - Legacy modules: 150
 - Need fixes: 50
 - Safe to ignore: 19

--- a/workflow_dashboard.py
+++ b/workflow_dashboard.py
@@ -3,7 +3,7 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, TypedDict
 
 try:
     import yaml  # type: ignore
@@ -40,8 +40,15 @@ def record_feedback(workflow: str, helpful: bool) -> None:
     notification.send("workflow.feedback", {"workflow": workflow, "helpful": helpful})
 
 
-def load_metrics(name: str, last: int = 200) -> Dict[str, Any]:
-    data = {
+class Metrics(TypedDict):
+    success: int
+    failed: int
+    last_status: Optional[str]
+    last_ts: Optional[str]
+
+
+def load_metrics(name: str, last: int = 200) -> Metrics:
+    data: Metrics = {
         "success": 0,
         "failed": 0,
         "last_status": None,


### PR DESCRIPTION
## Summary
- refine workflow metrics typing and add TypedDict
- make self-healing manager attributes typed
- cast event fields as strings
- clarify optional tts bridge module handling
- tighten emotion metrics logic
- document new mypy error count

## Testing
- `mypy --ignore-missing-imports .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f793417f08320b355c2f4a1d02055