### PR TITLE
Fix import cycles and streamline entrypoints

### DIFF
--- a/avatar_council_blessing.py
+++ b/avatar_council_blessing.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Avatar Council Blessing
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -10,8 +9,11 @@ Example:
     python avatar_council_blessing.py vote avatar1 alice
     python avatar_council_blessing.py status avatar1 --quorum 2
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse

--- a/avatar_memory_linker.py
+++ b/avatar_memory_linker.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Avatar Memory Linker CLI
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -10,8 +9,11 @@ Example:
     python avatar_memory_linker.py link avatar1 blend created --mood joy --memory 123
     python avatar_memory_linker.py list --term forgiveness
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse

--- a/avatar_retirement.py
+++ b/avatar_retirement.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Avatar Retirement & Archive Ritual
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -9,8 +8,11 @@ The act is logged in a ritual ledger.
 Example:
     python avatar_retirement.py retire avatar1.blend retired/ --mood nostalgia --reason "story closed"
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse

--- a/bio_bridge.py
+++ b/bio_bridge.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Biosignal integration bridge.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -8,9 +7,11 @@ skin conductance, temperature) and logs them to ``logs/bio_events.jsonl``.
 The implementation uses random data in headless mode or when dependencies are
 missing.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import json

--- a/cathedral_const.py
+++ b/cathedral_const.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any, Dict
+
+from logging_config import get_log_path
+
+# Shared constants for logs and lightweight utilities
+PUBLIC_LOG: Path = get_log_path("public_rituals.jsonl", "PUBLIC_RITUAL_LOG")
+
+
+def log_json(path: Path, obj: Dict[str, Any]) -> None:
+    """Append a JSON object to the given log path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(obj) + "\n")

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 
 Daily digest utility.
@@ -10,10 +9,9 @@ fragments can optionally be pruned to keep disk usage reasonable.
 Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards
 can read ``logs/daily_digest.jsonl`` for a summary feed.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
 
+from admin_utils import require_admin_banner
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 import datetime as _dt

--- a/doctrine.py
+++ b/doctrine.py
@@ -1,3 +1,4 @@
+from cathedral_const import PUBLIC_LOG, log_json as cathedral_log_json
 from admin_utils import require_admin_banner
 from logging_config import get_log_path
 import argparse
@@ -17,7 +18,6 @@ DOCTRINE_PATH = Path(os.getenv("DOCTRINE_PATH", ROOT / "SENTIENTOS_LITURGY.txt")
 CONSENT_LOG = get_log_path("doctrine_consent.jsonl", "DOCTRINE_CONSENT_LOG")
 STATUS_LOG = get_log_path("doctrine_status.jsonl", "DOCTRINE_STATUS_LOG")
 AMEND_LOG = get_log_path("doctrine_amendments.jsonl", "DOCTRINE_AMEND_LOG")
-PUBLIC_LOG = get_log_path("public_rituals.jsonl", "PUBLIC_RITUAL_LOG")
 MASTER_CONFIG = Path(os.getenv("MASTER_CONFIG", ROOT / "config" / "master_files.json"))
 SIGNATURE_LOG = get_log_path("ritual_signatures.jsonl", "DOCTRINE_SIGNATURE_LOG")
 
@@ -72,8 +72,7 @@ def doctrine_hash() -> str:
 
 
 def log_json(path: Path, obj: Dict[str, Any]) -> None:
-    with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(obj) + "\n")
+    cathedral_log_json(path, obj)
 
 
 def consent_history(user: Optional[str] = None, n: int = 20) -> List[Dict[str, Any]]:

--- a/eeg_bridge.py
+++ b/eeg_bridge.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """EEG bridge for real or emulated headsets.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -10,9 +9,11 @@ Band power estimates (alpha, beta, theta, gamma) are also logged.
 The bridge falls back to a simple random data generator if ``mne`` or
 ``brainflow`` are unavailable or if ``SENTIENTOS_HEADLESS`` is enabled.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import json

--- a/eeg_emulator.py
+++ b/eeg_emulator.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Synthetic EEG stream for testing pipelines.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -7,9 +6,11 @@ This module emits random EEG events matching the schema produced by
 :mod:`eeg_bridge` and :mod:`eeg_features`. It is useful for CI where no hardware
 is present.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 import time
 from typing import Iterator

--- a/eeg_features.py
+++ b/eeg_features.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """EEG feature extraction helpers.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -10,9 +9,11 @@ logged to ``logs/eeg_features.jsonl``.
 The implementation here uses placeholder heuristics so that unit tests can run
 without hardware or heavy dependencies.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import json

--- a/haptics_bridge.py
+++ b/haptics_bridge.py
@@ -1,4 +1,3 @@
-from admin_utils import require_admin_banner
 """Haptic device bridge.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -10,9 +9,11 @@ logged to ``logs/haptics_events.jsonl``.
 The default implementation uses ``pyserial`` if available and otherwise falls
 back to a simple mock that generates random feedback values.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import json

--- a/ledger.py
+++ b/ledger.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from logging_config import get_log_path
 import json
 import hashlib
@@ -5,8 +6,17 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
+from cathedral_const import PUBLIC_LOG, log_json
 
-import doctrine
+class _DoctrineProxy:
+    PUBLIC_LOG = PUBLIC_LOG
+
+    @staticmethod
+    def log_json(path: Path, obj: Dict[str, Any]) -> None:
+        log_json(path, obj)
+
+doctrine = _DoctrineProxy()
+
 
 
 def _append(path: Path, entry: Dict[str, Any]) -> Dict[str, Any]:
@@ -256,8 +266,8 @@ def log_mood_blessing(
         "ritual": "Mood blessing recorded.",
     }
     _append(get_log_path("music_log.jsonl"), entry)
-    doctrine.log_json(
-        doctrine.PUBLIC_LOG,
+    log_json(
+        PUBLIC_LOG,
         {
             "time": time.time(),
             "event": "mood_blessing",

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -1,10 +1,12 @@
-from admin_utils import require_admin_banner
 """Cryptographic Ledger Seal & Backup Daemon
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 import argparse
 import hashlib

--- a/relationship_log.py
+++ b/relationship_log.py
@@ -1,3 +1,4 @@
+from cathedral_const import PUBLIC_LOG, log_json
 from logging_config import get_log_path
 import json
 import os
@@ -39,8 +40,8 @@ def log_event(
         f.write(json.dumps(entry) + "\n")
     # mirror to presence ledger and public feed
     pl.log(user, event, note)
-    doctrine.log_json(
-        doctrine.PUBLIC_LOG,
+    log_json(
+        PUBLIC_LOG,
         {"time": time.time(), "event": event, "user": user},
     )
     return entry_id
@@ -122,7 +123,7 @@ def generate_recap(user: str) -> str:
         f"{mem_count} memories, {len(affirmations)} affirmations and {len(amendments)} amendments were recorded."
     )
     log_event("recap", user, msg)
-    doctrine.log_json(doctrine.PUBLIC_LOG, {"time": time.time(), "event": "recap", "user": user, "summary": msg})
+    log_json(PUBLIC_LOG, {"time": time.time(), "event": "recap", "user": user, "summary": msg})
     return msg
 
 

--- a/resonite_consent_daemon.py
+++ b/resonite_consent_daemon.py
@@ -1,10 +1,12 @@
-from admin_utils import require_admin_banner
 """Resonite Consent Renewal/Annulment Daemon
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse

--- a/resonite_sanctuary_emergency_posture_engine.py
+++ b/resonite_sanctuary_emergency_posture_engine.py
@@ -1,10 +1,12 @@
-from admin_utils import require_admin_banner
 """Resonite Sanctuary Emergency Posture Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse

--- a/resonite_spiral_bell_of_pause.py
+++ b/resonite_spiral_bell_of_pause.py
@@ -1,10 +1,12 @@
-from admin_utils import require_admin_banner
 """Resonite Spiral Bell of Pause Broadcast System
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+
+from admin_utils import require_admin_banner
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 

--- a/ritual_bundle_system.py
+++ b/ritual_bundle_system.py
@@ -1,10 +1,10 @@
-from admin_utils import require_admin_banner
 """Ritual Bundle System
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from __future__ import annotations
+from admin_utils import require_admin_banner
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 from logging_config import get_log_path
 
 import argparse


### PR DESCRIPTION
## Summary
- break circular dependency between doctrine and admin_utils
- introduce `cathedral_const` for shared logging constants
- lazy-load presence ledger in `admin_utils`
- expose doctrine proxy in `ledger`
- normalize privilege banner ordering for various entrypoints
- place `__future__` imports after module docstrings
- update audit utilities and relationships to use new constants

## Testing
- `pytest -q`
- `python verify_audits.py --help`


------
https://chatgpt.com/codex/tasks/task_b_683fa3883ed48320a690dc1b98c07948