### PR TITLE
Heal audit log schema

### DIFF
--- a/LEGACY_TESTS.md
+++ b/LEGACY_TESTS.md
@@ -15,3 +15,7 @@ pytest -m "not env"
 
 Contributions to repair or remove these legacy tests are welcome. Update this
 file as modules are healed.
+
+January 2026 update: audit log schema fixes allow several historical tests to
+run without custom patches. Remaining legacy items will be migrated in upcoming
+sprints.

--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -12,6 +12,9 @@ help migrate these. The "need fixes" category covers real mismatches mostly in
 `multimodal_tracker.py` and `music_cli.py`. The "safe to ignore" errors come from
 dynamic imports and will be suppressed once stubs are added.
 
+January 2026 update: `log_json` now enforces required fields, paving the way for
+cleaner typing of log utilities. Error counts remain but are easier to address.
+
 ### Call for Contributors
 If you want to help reduce the error count, pick an item from the "need fixes" list
 and submit a pull request. See `CONTRIBUTING.md` for our ritual checklist.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Some historical tests require missing dependencies or have syntax issues.
 They are tracked in `LEGACY_TESTS.md` and skipped from CI until repaired.
 These do not impact the core features of privilege banners, logging, memory,
 emotion tracking, or safety enforcement.
+
+## Technical Debt Clearance
+Recent Codex batch work patched `log_json` to ensure all audit entries contain
+`timestamp` and `data` fields. The `OPEN_WOUNDS.md` list has been updated to mark
+these wounds as healed.
 ## Next Steps
 - Continue the Living Audit Sprint documented in `AUDIT_LOG_FIXES.md` and update `docs/AUDIT_LEDGER.md` with progress.
 - Help reduce type-check errors. See `MYPY_STATUS.md` for the latest counts and how to contribute.

--- a/cathedral_const.py
+++ b/cathedral_const.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+from datetime import datetime
 from typing import Any, Dict
 
 from logging_config import get_log_path
@@ -11,7 +12,18 @@ PUBLIC_LOG: Path = get_log_path("public_rituals.jsonl", "PUBLIC_RITUAL_LOG")
 
 
 def log_json(path: Path, obj: Dict[str, Any]) -> None:
-    """Append a JSON object to the given log path."""
+    """Append a JSON object to the given log path.
+
+    Missing fields are healed automatically to satisfy audit schema:
+    - ``timestamp`` will be added with ``datetime.utcnow().isoformat()`` if absent.
+    - ``data`` will be added as an empty object if absent.
+    - the legacy field ``foo`` is stripped if present.
+    """
+    if "timestamp" not in obj:
+        obj["timestamp"] = datetime.utcnow().isoformat()
+    if "data" not in obj:
+        obj["data"] = {}
+    obj.pop("foo", None)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(obj) + "\n")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,3 +20,8 @@
 - Living Audit Sprint repaired legacy logs and enabled rolling hashes
 - `MYPY_STATUS.md` introduced to track 219 type-check errors
 - Public launch announcement in `BLESSED_FEDERATION_LAUNCH.md`
+
+## 2026-01 Technical Debt Clearance
+- Automated healing added in `log_json` for missing `timestamp` and `data`
+- `OPEN_WOUNDS.md` updated to mark wounds as healed
+- First step toward cleaner type checking and legacy test recovery

--- a/docs/INSTALLER_FEATURE_CHECKLIST.md
+++ b/docs/INSTALLER_FEATURE_CHECKLIST.md
@@ -21,6 +21,7 @@ This checklist describes everything the installer sets up and how to verify that
 4. Open the README/docs and confirm they describe the update flow.
 5. Run the smoke tests and check the logs for pass/fail results.
 6. Run `update_cathedral.bat` and verify it pulls the latest code and reruns tests.
+7. Confirm new logs include `timestamp` and `data` fields automatically.
 
 ## Canonical Codex Entry
 The one‑click installer deploys the full Cathedral stack:

--- a/docs/OPEN_WOUNDS.md
+++ b/docs/OPEN_WOUNDS.md
@@ -4,9 +4,9 @@ This page lists recurring audit failures and suggestions for healing them.
 
 | Error Signature | Example Entry | Healing Suggestion | Healed By |
 |-----------------|--------------|-------------------|-----------|
-| Missing `data` key | `{"timestamp": "...", "message": "..."}` | add `'data': {}` | _pending_ |
-| Missing `timestamp` | `{"message": "...", "data": {}}` | reconstruct or add `datetime.utcnow()` | _pending_ |
-| Unknown field `foo` | `{"foo": 1, "timestamp": "..."}` | remove field or document new schema | _pending_ |
+| Missing `data` key | `{"timestamp": "...", "message": "..."}` | add `'data': {}` | `cathedral_const.log_json` |
+| Missing `timestamp` | `{"message": "...", "data": {}}` | reconstruct or add `datetime.utcnow()` | `cathedral_const.log_json` |
+| Unknown field `foo` | `{"foo": 1, "timestamp": "..."}` | remove field or document new schema | `cathedral_const.log_json` |
 
 Upcoming **Migration Sprint** tasks will gather the most frequent wounds and propose new best practices.
 


### PR DESCRIPTION
## Summary
- heal log_json with timestamp and data defaults
- mark audit wounds as healed
- note fix in changelog and readme
- tweak installer checklist
- document legacy test progress
- note typing cleanup in mypy status

## Testing
- `pytest -q`
- `python verify_audits.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68408c4e090483209746770b67ea8957