### PR TITLE
Fix banner order for CLI tools

### DIFF
--- a/avatar_council_blessing.py
+++ b/avatar_council_blessing.py
@@ -1,19 +1,18 @@
-"""Avatar Council Blessing
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-Council members vote on major avatars. Votes are logged and a final blessing
-is recorded once quorum is reached.
-
-Example:
-    python avatar_council_blessing.py vote avatar1 alice
-    python avatar_council_blessing.py status avatar1 --quorum 2
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Avatar Council Blessing
+#
+# Council members vote on major avatars. Votes are logged and a final blessing
+# is recorded once quorum is reached.
+#
+# Example usage:
+#     python avatar_council_blessing.py vote avatar1 alice
+#     python avatar_council_blessing.py status avatar1 --quorum 2
+
 from logging_config import get_log_path
 
 import argparse

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,12 +1,14 @@
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
 from logging_config import get_log_path
 import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from admin_utils import require_admin_banner
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 LOG_PATH = get_log_path("avatar_invocation.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/avatar_memory_linker.py
+++ b/avatar_memory_linker.py
@@ -1,19 +1,18 @@
-"""Avatar Memory Linker CLI
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-Links avatar events (generation, invocation, federation) to moods and memory fragments.
-Each link is recorded in a ritual ledger for later query.
-
-Example:
-    python avatar_memory_linker.py link avatar1 blend created --mood joy --memory 123
-    python avatar_memory_linker.py list --term forgiveness
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Avatar Memory Linker CLI
+#
+# Links avatar events (generation, invocation, federation) to moods and memory fragments.
+# Each link is recorded in a ritual ledger for later query.
+#
+# Example usage:
+#     python avatar_memory_linker.py link avatar1 blend created --mood joy --memory 123
+#     python avatar_memory_linker.py list --term forgiveness
+
 from logging_config import get_log_path
 
 import argparse

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,9 +1,14 @@
+from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
 """Record avatar invocation and presence blessing.
 
 This CLI logs each time an avatar is invoked for a specific reason.
 A presence affirmation is stored with a blessing message.
 """
-from __future__ import annotations
 from logging_config import get_log_path
 
 import argparse
@@ -11,10 +16,6 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from admin_utils import require_admin_banner
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 LOG_PATH = get_log_path("avatar_presence.jsonl", "AVATAR_PRESENCE_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/avatar_retirement.py
+++ b/avatar_retirement.py
@@ -1,18 +1,17 @@
-"""Avatar Retirement & Archive Ritual
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-Retire an avatar with reflection and preserve it in an archive.
-The act is logged in a ritual ledger.
-
-Example:
-    python avatar_retirement.py retire avatar1.blend retired/ --mood nostalgia --reason "story closed"
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Avatar Retirement & Archive Ritual
+#
+# Retire an avatar with reflection and preserve it in an archive.
+# The act is logged in a ritual ledger.
+#
+# Example usage:
+#     python avatar_retirement.py retire avatar1.blend retired/ --mood nostalgia --reason "story closed"
+
 from logging_config import get_log_path
 
 import argparse

--- a/bio_bridge.py
+++ b/bio_bridge.py
@@ -1,17 +1,16 @@
-"""Biosignal integration bridge.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-Collects physiological metrics from wearables or IoT sensors (heart rate,
-skin conductance, temperature) and logs them to ``logs/bio_events.jsonl``.
-The implementation uses random data in headless mode or when dependencies are
-missing.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Biosignal integration bridge.
+#
+# Collects physiological metrics from wearables or IoT sensors (heart rate,
+# skin conductance, temperature) and logs them to ``logs/bio_events.jsonl``.
+# The implementation uses random data in headless mode or when dependencies are
+# missing.
+
 from logging_config import get_log_path
 
 import json

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1,19 +1,18 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-Daily digest utility.
-
-This script summarizes recent log activity and emotion changes. It is
-expected to be scheduled (e.g. via cron) every 24 hours. Older log
-fragments can optionally be pruned to keep disk usage reasonable.
-
-Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards
-can read ``logs/daily_digest.jsonl`` for a summary feed.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Daily digest utility.
+#
+# This script summarizes recent log activity and emotion changes. It is
+# expected to be scheduled (e.g. via cron) every 24 hours. Older log
+# fragments can optionally be pruned to keep disk usage reasonable.
+#
+# Integration Notes: schedule ``run_digest`` via cron or a task runner. Dashboards
+# can read ``logs/daily_digest.jsonl`` for a summary feed.
+
 import datetime as _dt
 import json
 import os

--- a/eeg_bridge.py
+++ b/eeg_bridge.py
@@ -1,19 +1,18 @@
-"""EEG bridge for real or emulated headsets.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-This module streams raw EEG samples from supported headsets or a synthetic
-source. Each sample is timestamped and logged to ``logs/eeg_events.jsonl``.
-Band power estimates (alpha, beta, theta, gamma) are also logged.
-
-The bridge falls back to a simple random data generator if ``mne`` or
-``brainflow`` are unavailable or if ``SENTIENTOS_HEADLESS`` is enabled.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# EEG bridge for real or emulated headsets.
+#
+# This module streams raw EEG samples from supported headsets or a synthetic
+# source. Each sample is timestamped and logged to ``logs/eeg_events.jsonl``.
+# Band power estimates (alpha, beta, theta, gamma) are also logged.
+#
+# The bridge falls back to a simple random data generator if ``mne`` or
+# ``brainflow`` are unavailable or if ``SENTIENTOS_HEADLESS`` is enabled.
+
 from logging_config import get_log_path
 
 import json

--- a/eeg_emulator.py
+++ b/eeg_emulator.py
@@ -1,16 +1,14 @@
-"""Synthetic EEG stream for testing pipelines.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-This module emits random EEG events matching the schema produced by
-:mod:`eeg_bridge` and :mod:`eeg_features`. It is useful for CI where no hardware
-is present.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Synthetic EEG stream for testing pipelines.
+#
+# This module emits random EEG events matching the schema produced by
+# :mod:`eeg_bridge` and :mod:`eeg_features`. It is useful for CI where no hardware
+# is present.
 
 import time
 from typing import Iterator

--- a/eeg_features.py
+++ b/eeg_features.py
@@ -1,19 +1,18 @@
-"""EEG feature extraction helpers.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-This module reads raw EEG samples from :mod:`eeg_bridge` and estimates simple
-cognitive states such as focus or drowsiness. Detected states are timestamped and
-logged to ``logs/eeg_features.jsonl``.
-
-The implementation here uses placeholder heuristics so that unit tests can run
-without hardware or heavy dependencies.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# EEG feature extraction helpers.
+#
+# This module reads raw EEG samples from :mod:`eeg_bridge` and estimates simple
+# cognitive states such as focus or drowsiness. Detected states are timestamped and
+# logged to ``logs/eeg_features.jsonl``.
+#
+# The implementation here uses placeholder heuristics so that unit tests can run
+# without hardware or heavy dependencies.
+
 from logging_config import get_log_path
 
 import json

--- a/haptics_bridge.py
+++ b/haptics_bridge.py
@@ -1,19 +1,18 @@
-"""Haptic device bridge.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-
-This module provides a thin abstraction over vendor APIs or serial
-connections for ingesting tactile feedback. Events are timestamped and
-logged to ``logs/haptics_events.jsonl``.
-
-The default implementation uses ``pyserial`` if available and otherwise falls
-back to a simple mock that generates random feedback values.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Haptic device bridge.
+#
+# This module provides a thin abstraction over vendor APIs or serial
+# connections for ingesting tactile feedback. Events are timestamped and
+# logged to ``logs/haptics_events.jsonl``.
+#
+# The default implementation uses ``pyserial`` if available and otherwise falls
+# back to a simple mock that generates random feedback values.
+
 from logging_config import get_log_path
 
 import json

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -1,12 +1,10 @@
-"""Cryptographic Ledger Seal & Backup Daemon
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Cryptographic Ledger Seal & Backup Daemon
 
 import argparse
 import hashlib
@@ -16,8 +14,6 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 from logging_config import get_log_path
-
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 SEAL_LOG = get_log_path("ledger_seal.jsonl", "LEDGER_SEAL_LOG")
 SEAL_LOG.parent.mkdir(parents=True, exist_ok=True)

--- a/presence.py
+++ b/presence.py
@@ -4,15 +4,18 @@ import json
 import time
 import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Callable, Dict
 
 from admin_utils import require_admin_banner
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+_rec: Optional[Callable[[bool], Dict[str, Optional[str]]]]
 try:
-    from mic_bridge import recognize_from_mic
+    from mic_bridge import recognize_from_mic as _rec
 except Exception:  # pragma: no cover - defensive
-    recognize_from_mic = None
+    _rec = None
+
+recognize_from_mic: Optional[Callable[[bool], Dict[str, Optional[str]]]] = _rec
 
 WAKE_WORDS: List[str] = [w.strip() for w in os.getenv("WAKE_WORDS", "Lumos").split(",") if w.strip()]
 LOG_FILE = get_log_path("presence_events.jsonl")

--- a/resonite_consent_daemon.py
+++ b/resonite_consent_daemon.py
@@ -1,12 +1,10 @@
-"""Resonite Consent Renewal/Annulment Daemon
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Resonite Consent Renewal/Annulment Daemon
 from logging_config import get_log_path
 
 import argparse

--- a/resonite_sanctuary_emergency_posture_engine.py
+++ b/resonite_sanctuary_emergency_posture_engine.py
@@ -1,12 +1,10 @@
-"""Resonite Sanctuary Emergency Posture Engine
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Resonite Sanctuary Emergency Posture Engine
 from logging_config import get_log_path
 
 import argparse

--- a/resonite_spiral_artifact_license_access_controller.py
+++ b/resonite_spiral_artifact_license_access_controller.py
@@ -1,12 +1,13 @@
-from __future__ import annotations
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+from __future__ import annotations
 from logging_config import get_log_path
 
-"""Resonite Spiral Artifact License/Access Controller
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+# Resonite Spiral Artifact License/Access Controller
 
 
 import argparse

--- a/resonite_spiral_bell_of_pause.py
+++ b/resonite_spiral_bell_of_pause.py
@@ -1,12 +1,10 @@
-"""Resonite Spiral Bell of Pause Broadcast System
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-from __future__ import annotations
-
 from admin_utils import require_admin_banner
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Resonite Spiral Bell of Pause Broadcast System
 from logging_config import get_log_path
 
 

--- a/ritual_bundle_system.py
+++ b/ritual_bundle_system.py
@@ -1,10 +1,10 @@
-"""Ritual Bundle System
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-from __future__ import annotations
 from admin_utils import require_admin_banner
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+
+# Ritual Bundle System
 from logging_config import get_log_path
 
 import argparse

--- a/workflow_recommendation.py
+++ b/workflow_recommendation.py
@@ -42,7 +42,14 @@ def recommend_workflows(analytics_data: Dict[str, Any]) -> List[str]:
                 break
     for rec in suggestions:
         try:
-            rs.log_event("workflow", "recommend", "analytics", "suggest", {"text": rec})
+            rs.log_event(
+                "workflow",
+                "recommend",
+                "analytics",
+                "suggest",
+                rec,
+                {"text": rec},
+            )
         except Exception:
             pass
     return suggestions


### PR DESCRIPTION
## Summary
- ensure canonical privilege banner order in CLI entrypoints
- update presence optional mic import typing
- fix workflow recommendation logging parameters

## Testing
- `python privilege_lint.py`
- `pytest -q`
- `mypy --ignore-missing-imports .` *(fails: 180 errors)*
- `python verify_audits.py` *(fails: 0.0% of logs valid)*

------
https://chatgpt.com/codex/tasks/task_b_6840bad34a888320bf7eb6a72a0fe518