### PR TITLE
Improve connector resilience and onboarding

### DIFF
--- a/docs/CODEX_CUSTOM_CONNECTOR.md
+++ b/docs/CODEX_CUSTOM_CONNECTOR.md
@@ -16,6 +16,14 @@
 ## Canonical Recap
 SentientOS now exposes an authenticated SSE connector for real-time integration with OpenAI tools. The cathedral's event bus can emit and receive commands securely, laying the groundwork for universal memory and audit tracking across future projects.
 
+## Quick Start Checklist
+1. Copy `.env.example` to `.env` and set `CONNECTOR_TOKEN`.
+2. Ensure the desired `PORT` is open and not already in use.
+3. Launch `python openai_connector.py`.
+4. In a separate terminal run `python smoke_test_connector.py` to validate.
+5. Inspect `logs/openai_connector.jsonl` for `message` or `sse` events.
+6. When deploying to a cloud host, repeat the smoke test using the public URL.
+
 ## Integration
 1. Set `CONNECTOR_TOKEN` in your `.env` and ensure the `PORT` variable matches your deployment.
 2. Run `python openai_connector.py`.
@@ -24,5 +32,24 @@ SentientOS now exposes an authenticated SSE connector for real-time integration 
 5. `/sse` streams events as JSON lines prefixed with `data:`. Each message is logged with the client IP.
 6. Inspect `logs/openai_connector.jsonl` for authentication errors or connection problems.
 7. Restart the service if event streaming stalls or the log shows repeated failures.
+
+### Sample Payloads
+
+Successful request:
+
+```bash
+curl -X POST -H "Authorization: Bearer $CONNECTOR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"text": "hello"}' http://localhost:$PORT/message
+```
+
+Failure example (missing field):
+
+```bash
+curl -X POST -H "Authorization: Bearer $CONNECTOR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{}' http://localhost:$PORT/message
+# → {"error": "missing 'text' field"}
+```
 
 See [CONNECTOR_TROUBLESHOOTING.md](CONNECTOR_TROUBLESHOOTING.md) for additional tips and FAQs.

--- a/docs/CONNECTOR_TROUBLESHOOTING.md
+++ b/docs/CONNECTOR_TROUBLESHOOTING.md
@@ -6,6 +6,8 @@ This guide collects common issues seen when running `openai_connector.py` in dev
 - **Authentication failures** – ensure the `CONNECTOR_TOKEN` environment variable matches your client configuration.
 - **Stalled event streams** – restart the service if SSE clients stop receiving events.
 - **Log file growth** – the connector now rotates logs automatically. Check older files with the `.1` or `.2` suffix for history.
+- **Port already in use** – verify another service isn't bound to your chosen port.
+- **Token mismatch after redeploy** – some cloud hosts reset environment vars; double-check after updates.
 
 ## Test Commands
 Run the smoke test script to verify a deployment:
@@ -18,4 +20,5 @@ It executes `privilege_lint.py` and the connector tests.
 
 ## Reviewing Logs
 Log entries are written in JSON lines format to `logs/openai_connector.jsonl`. Each entry includes a timestamp, client IP, and event type (auth_error, message, or sse). Rotate logs are saved with numerical extensions.
+Check the most recent entries with `tail -n 5 logs/openai_connector.jsonl` and look for `disconnect` or `message_error` events when debugging clients. Older history lives in `openai_connector.jsonl.1`, `.2`, and so on.
 


### PR DESCRIPTION
## Summary
- add connection timeout and disconnect logging to connector
- validate message payloads with clearer errors
- retry/backoff logic for smoke test
- expand quick start guide and troubleshooting docs
- test disconnect and invalid message cases

## Testing
- `python3 privilege_lint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840f9e0506883209d62742796672ea1