### PR TITLE
Improve connector automation and contributor docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
       - name: Run mypy
         run: |
           mypy --ignore-missing-imports .
-      - name: Run tests
-        run: |
-          pytest
-      - name: Verify audits
-        run: |
-          python verify_audits.py
+        - name: Run tests
+          run: |
+            pytest
+        - name: Connector health check
+          run: |
+            python check_connector_health.py
+        - name: Verify audits
+          run: |
+            python verify_audits.py

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ _All core features (privilege banners, memory, logging, emotion, safety) are wor
 8. Run `python smoke_test_connector.py` to verify the OpenAI connector.
 
 See [docs/README_FULL.md](docs/README_FULL.md) for the complete philosophy and usage details.
+
+## Contributor Quickstart
+1. Fork this repository and clone your fork.
+2. Install dependencies with `pip install -r requirements.txt` and `pip install -e .`.
+3. Run `python smoke_test_connector.py` to execute linting and unit tests.
+4. Run `python check_connector_health.py` to validate the connector endpoints.
+5. Commit your changes and open a pull request. CI logs summarize disconnects and payload errors.
+6. If tests fail, review `logs/openai_connector_health.jsonl` for details or see [docs/CONNECTOR_TROUBLESHOOTING.md](docs/CONNECTOR_TROUBLESHOOTING.md).
 Additional guides:
 - [docs/OPEN_WOUNDS.md](docs/OPEN_WOUNDS.md) **Help Wanted: Memory Healing**
 - [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md)
@@ -70,6 +78,11 @@ python verify_audits.py logs/
 pytest -m "not env"
 ```
 Document any failures in your pull request description so reviewers know what to expect.
+
+### CI Expectations
+Each pull request runs `privilege_lint.py`, `pytest`, `mypy`, and `check_connector_health.py`.
+Connector logs are summarized at the end of the workflow. Look for disconnect or
+`message_error` counts to diagnose issues.
 
 ### Feedback Loop Ritual
 We maintain an open feedback form on the GitHub Discussions board. Share your first-run experience, documentation gaps, or ideas for new rituals. Stewards review submissions each month and incorporate improvements into future audits.

--- a/check_connector_health.py
+++ b/check_connector_health.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from importlib import reload
+import json
+import os
+import sys
+from pathlib import Path
+
+from admin_utils import require_admin_banner
+import openai_connector
+from flask_stub import Request
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced by doctrine
+
+
+def _setup() -> tuple[openai_connector.Flask.test_client, Path]:
+    os.environ.setdefault("CONNECTOR_TOKEN", "token123")
+    os.environ.setdefault("SSE_TIMEOUT", "0.2")
+    log_path = Path(os.getenv("OPENAI_CONNECTOR_LOG", "logs/openai_connector_health.jsonl"))
+    if log_path.exists():
+        log_path.unlink()
+    reload(openai_connector)
+    return openai_connector.app.test_client(), log_path
+
+
+def _post(client, path: str, data: object, token: str | None) -> int:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    resp = client.post(path, json=data, headers=headers)
+    return resp.status_code
+
+
+def main() -> None:
+    client, log_path = _setup()
+    token = os.environ["CONNECTOR_TOKEN"]
+
+    assert _post(client, "/message", {"text": "hi"}, token) == 200
+    assert _post(client, "/message", {"text": "hi"}, "wrong") == 403
+    assert _post(client, "/message", None, token) == 400
+
+    openai_connector.request = Request(None, {"Authorization": f"Bearer {token}"})
+    resp = openai_connector.sse()
+    status = resp.status_code if hasattr(resp, "status_code") else resp[1]
+    assert status == 200
+    data_line = next(resp.data)
+    payload = json.loads(data_line.split("data: ", 1)[1])
+    assert payload["data"] == {"text": "hi"}
+
+    openai_connector.request = Request(None, {"Authorization": "Bearer wrong"})
+    assert (openai_connector.sse()[1]) == 403
+    openai_connector.request = Request(None, {})
+    assert (openai_connector.sse()[1]) == 403
+
+    counts: dict[str, int] = {}
+    if log_path.exists():
+        for line in log_path.read_text().splitlines():
+            if line.strip():
+                event = json.loads(line)["event"]
+                counts[event] = counts.get(event, 0) + 1
+    print("log summary", counts)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual script
+    try:
+        main()
+    except AssertionError:
+        print("health check failed", file=sys.stderr)
+        sys.exit(1)

--- a/smoke_test_connector.py
+++ b/smoke_test_connector.py
@@ -1,4 +1,4 @@
-from subprocess import check_call, CalledProcessError
+from subprocess import CalledProcessError, check_call
 import sys
 import time
 import json
@@ -11,6 +11,7 @@ print("Running connector smoke tests...")
 def run_once() -> None:
     check_call([sys.executable, "privilege_lint.py"])
     check_call([sys.executable, "-m", "pytest", "-q", "tests/test_openai_connector.py"])
+    check_call([sys.executable, "check_connector_health.py"])
 
 
 for attempt in range(3):


### PR DESCRIPTION
## Summary
- add `check_connector_health.py` for automated connector validation
- extend smoke test to include health check
- log connector events with `_log_event`
- document contributor quickstart and CI expectations
- run health check in CI workflow

## Testing
- `python3 privilege_lint.py`
- `pytest -q`
- `python check_connector_health.py`
- `python smoke_test_connector.py`

------
https://chatgpt.com/codex/tasks/task_b_68410440f9208320afdd61dcc6251f91