### PR TITLE
Add connector health endpoint and schema validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,22 @@
+name: "Bug Report"
+about: "Report problems or unexpected behavior"
+title: "[Bug] <summary>"
+labels: ["bug"]
+body:
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Logs
+      description: "Paste relevant log lines or attach the file"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,14 @@
+name: "Feature Request"
+about: "Propose a new feature or improvement"
+title: "[Feature] <summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    attributes:
+      label: Proposal
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use Case
+      description: "Why is this feature valuable?"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Each pull request runs `privilege_lint.py`, `pytest`, `mypy`, and `check_connect
 Connector logs are summarized at the end of the workflow. Look for disconnect or
 `message_error` counts to diagnose issues.
 
+## How to Request Support
+If you run into problems with the connector or any ritual tool, open an issue
+using the **Bug Report** or **Feature Request** templates. Include log snippets,
+steps to reproduce, and your environment details. You can also email
+`support@sentientos.example.com` for private assistance.
+
 ### Feedback Loop Ritual
 We maintain an open feedback form on the GitHub Discussions board. Share your first-run experience, documentation gaps, or ideas for new rituals. Stewards review submissions each month and incorporate improvements into future audits.
 ## Sanctuary Privilege Ritual

--- a/check_connector_health.py
+++ b/check_connector_health.py
@@ -38,6 +38,11 @@ def main() -> None:
     assert _post(client, "/message", {"text": "hi"}, token) == 200
     assert _post(client, "/message", {"text": "hi"}, "wrong") == 403
     assert _post(client, "/message", None, token) == 400
+    assert json.loads(openai_connector.healthz()) == {"status": "ok"}
+    metric_text = openai_connector.metrics().data
+    if isinstance(metric_text, bytes):
+        metric_text = metric_text.decode()
+    assert "connections_total" in metric_text
 
     openai_connector.request = Request(None, {"Authorization": f"Bearer {token}"})
     resp = openai_connector.sse()

--- a/docs/CODEX_CUSTOM_CONNECTOR.md
+++ b/docs/CODEX_CUSTOM_CONNECTOR.md
@@ -52,4 +52,18 @@ curl -X POST -H "Authorization: Bearer $CONNECTOR_TOKEN" \
 # → {"error": "missing 'text' field"}
 ```
 
+### Schema Validation
+All requests are validated against a JSON schema. The `/message` payload must be:
+
+```json
+{"text": "string"}
+```
+
+Invalid payloads trigger a `schema_violation` log entry.
+
+### How to Request Support
+Open an issue using the **Bug Report** or **Feature Request** template and
+include the connector log excerpt and steps to reproduce. For private inquiries
+email `support@sentientos.example.com`.
+
 See [CONNECTOR_TROUBLESHOOTING.md](CONNECTOR_TROUBLESHOOTING.md) for additional tips and FAQs.

--- a/schema_validation.py
+++ b/schema_validation.py
@@ -1,0 +1,19 @@
+"""Minimal JSON payload validation helpers."""
+
+from typing import Any, Mapping, Tuple
+
+
+def validate_payload(data: Any, schema: Mapping[str, type]) -> Tuple[bool, str | None]:
+    """Validate ``data`` against ``schema``.
+
+    Schema is a mapping of field name to Python type. Missing or wrong types
+    return ``False`` and an error key.
+    """
+    if not isinstance(data, dict):
+        return False, "malformed_json"
+    for field, typ in schema.items():
+        if field not in data:
+            return False, "missing_field"
+        if not isinstance(data[field], typ):
+            return False, "invalid_type"
+    return True, None

--- a/smoke_test_connector.py
+++ b/smoke_test_connector.py
@@ -4,6 +4,7 @@ import time
 import json
 from pathlib import Path
 import os
+import openai_connector
 
 print("Running connector smoke tests...")
 
@@ -12,6 +13,12 @@ def run_once() -> None:
     check_call([sys.executable, "privilege_lint.py"])
     check_call([sys.executable, "-m", "pytest", "-q", "tests/test_openai_connector.py"])
     check_call([sys.executable, "check_connector_health.py"])
+    client = openai_connector.app.test_client()
+    assert json.loads(openai_connector.healthz()) == {"status": "ok"}
+    metrics = openai_connector.metrics().data
+    if isinstance(metrics, bytes):
+        metrics = metrics.decode()
+    assert "events_total" in metrics
 
 
 for attempt in range(3):


### PR DESCRIPTION
## Summary
- implement /healthz and /metrics endpoints with in-memory counters
- expand `_log_event` with optional stdout and HTTP sinks and metrics tracking
- centralize payload validation and log schema violations
- update connector docs and README with support instructions
- provide bug/feature issue templates
- add tests for health and schema validation

## Testing
- `python privilege_lint.py`
- `pytest -q`
- `mypy`
- `python check_connector_health.py`
- `python smoke_test_connector.py`
- `python verify_audits.py` *(fails: 0.0% of logs valid)*

------
https://chatgpt.com/codex/tasks/task_b_6841868b78b8832098488b4a0ca46ae8