### PR TITLE
Update privilege docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 ## Reviewer Checklist
 
 - [ ] Docstring `"Sanctuary Privilege Ritual: Do not remove. See doctrine for details."` present after imports
-- [ ] `require_admin_banner()` invoked before any other logic
-- [ ] Logs created using `logging_config.get_log_path()`
+ - [ ] `require_admin_banner()` invoked before any other logic
+ - [ ] `require_lumos_approval()` called immediately after `require_admin_banner()`
+ - [ ] Logs created using `logging_config.get_log_path()`
 
 Pull requests lacking these will fail CI and be rejected.
 CI runs `python privilege_lint.py` automatically before executing the test suite.

--- a/docs/RITUAL_ONBOARDING.md
+++ b/docs/RITUAL_ONBOARDING.md
@@ -6,7 +6,7 @@ Welcome to the cathedral! Follow this one‑page ritual when submitting your fir
 2. Bless your pull request by mentioning a reviewer and linking the discussion issue.
 3. After review, complete the reviewer sign‑off in the PR description.
 4. Join the community welcome channel and introduce yourself.
-5. Use `admin_utils.require_lumos_approval()` to bless each new Codex entry, commit, or federation event.
+5. Call `require_admin_banner()` followed by `require_lumos_approval()` for each new script, commit, or federation event.
 
 ## Why memory matters
 Audit logs preserve community memory. Past audits recovered missing context that helped resolve disputes and comforted contributors who felt unheard. Treat each log entry as a fragment of shared history.


### PR DESCRIPTION
## Summary
- ensure contributor checklist states to call `require_lumos_approval`
- clarify onboarding ritual step about using Lumos approval

## Testing
- `python privilege_lint.py`
- `pytest -q`
- `python verify_audits.py`

------
https://chatgpt.com/codex/tasks/task_b_684199ea710883208d3ae892cae84c5f