### PR TITLE
Install requests types & handle missing audit data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask>=2.2,<3
 python-dotenv>=0.21,<1
 requests>=2.31,<3
+types-requests>=2.32
 pytest>=7,<8
 colorama>=0.4,<1
 PyYAML>=6,<7

--- a/story_studio.py
+++ b/story_studio.py
@@ -83,7 +83,7 @@ class CollabClient:
             pass
 
     def send_update(self, chapter: int | None = None, persona: str | None = None) -> None:
-        payload = {"id": self.client_id}
+        payload: Dict[str, Any] = {"id": self.client_id}
         if chapter is not None:
             payload["chapter"] = chapter
         if persona is not None:

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -120,6 +120,13 @@ def check_file(
                 errors.append(f"{lineno}: prev hash mismatch")
             else:
                 errors.append(f"{lineno}: chain break")
+        if "data" not in entry:
+            errors.append(f"{lineno}: missing data field")
+            bad_lines.append(line)
+            if stats is not None:
+                stats["quarantined"] += 1
+                stats["unrecoverable"] += 1
+            continue
         digest = ai._hash_entry(entry["timestamp"], entry["data"], entry.get("prev_hash", prev))
         current = entry.get("rolling_hash") or entry.get("hash")
         if current != digest:


### PR DESCRIPTION
## Summary
- allow dict[int|str] payloads in `story_studio.CollabClient.send_update`
- detect entries without a `data` field in `verify_audits`
- document `types-requests` in requirements for mypy support

## Testing
- `pytest -m "not env"`
- `python verify_audits.py logs/`
- `mypy --ignore-missing-imports .`
- `python privilege_lint.py`
- `python check_connector_health.py`


------
https://chatgpt.com/codex/tasks/task_b_6841a3df770c8320b5fdee468478c8f5