### PR TITLE
Enforce Lumos approval in privilege lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,17 +10,18 @@ Directly after your imports include the canonical banner docstring so future aud
 Add the following at the top of your script:
 
 ```python
-from admin_utils import require_admin_banner
+from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()  # Must immediately follow require_admin_banner()
 ```
 ## Reviewer Checklist
 
 - [ ] Docstring `"Sanctuary Privilege Ritual: Do not remove. See doctrine for details."` present after imports
  - [ ] `require_admin_banner()` invoked before any other logic
- - [ ] `require_lumos_approval()` called immediately after `require_admin_banner()`
+ - [ ] `require_lumos_approval()` called immediately after `require_admin_banner()` (lint fails otherwise)
  - [ ] Logs created using `logging_config.get_log_path()`
 
 Pull requests lacking these will fail CI and be rejected.

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -70,7 +70,7 @@ def _has_header(path: Path) -> bool:
 
 
 def _has_banner_call(path: Path) -> bool:
-    """Return True if ``require_admin_banner()`` immediately follows the banner docstring."""
+    """Return True if banner calls appear in the correct order."""
     lines = path.read_text(encoding="utf-8").splitlines()
     start = None
     for i, line in enumerate(lines):
@@ -89,10 +89,17 @@ def _has_banner_call(path: Path) -> bool:
                 break
         else:
             return False
+
     j = end + 1
     while j < len(lines) and not lines[j].strip():
         j += 1
-    return j < len(lines) and lines[j].strip().startswith("require_admin_banner()")
+    if j >= len(lines) or not lines[j].strip().startswith("require_admin_banner("):
+        return False
+
+    j += 1
+    while j < len(lines) and not lines[j].strip():
+        j += 1
+    return j < len(lines) and lines[j].strip().startswith("require_lumos_approval(")
 
 
 def check_file(path: Path) -> list[str]:
@@ -100,7 +107,9 @@ def check_file(path: Path) -> list[str]:
     if not _has_header(path):
         issues.append(f"{path}: missing privilege docstring after imports")
     if not _has_banner_call(path):
-        issues.append(f"{path}: require_admin_banner() must immediately follow the banner docstring")
+        issues.append(
+            f"{path}: require_admin_banner() and require_lumos_approval() must appear immediately after the banner docstring"
+        )
     return issues
 
 


### PR DESCRIPTION
## Summary
- update `privilege_lint` to require a `require_lumos_approval()` call right after `require_admin_banner()`
- document the new requirement in `CONTRIBUTING.md`

## Testing
- `python privilege_lint.py` *(fails: missing Lumos calls across many scripts)*
- `python verify_audits.py logs/`
- `pytest -m "not env"`


------
https://chatgpt.com/codex/tasks/task_b_6841c3a76a2c83209d91bcf3ab460dac