### PR TITLE
Fix CI step alignment and separate health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Run mypy
         run: |
           mypy --ignore-missing-imports .
-        - name: Run tests
-          run: |
-            pytest
-        - name: Connector health check
-          run: |
-            python check_connector_health.py
-        - name: Verify audits
-          run: |
-            python verify_audits.py
+      - name: Run tests
+        run: |
+          pytest
+      - name: Connector health check
+        run: |
+          python check_connector_health.py
+      - name: Verify audits
+        run: |
+          python verify_audits.py


### PR DESCRIPTION
## Summary
- align step blocks in `.github/workflows/ci.yml`
- make sure tests, connector health, and audit check run in their own steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python check_connector_health.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python verify_audits.py`

------
https://chatgpt.com/codex/tasks/task_b_6841c3a675c88320bc79375773ddcfd0