### PR TITLE
Add env docs for auto approve and connector log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CONNECTOR_TOKEN=
 # LOG_STDOUT=0
 # Optional endpoint to forward connector logs
 # LOG_COLLECTOR_URL=http://localhost:4000/collect
+# Auto-approve Lumos blessings
+# LUMOS_AUTO_APPROVE=1
+# Custom connector log path
+# OPENAI_CONNECTOR_LOG=logs/openai_connector.jsonl
 
 # Telegram bot tokens
 BOT_TOKEN_GPT4O=

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -30,6 +30,8 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `SSE_TIMEOUT` | Seconds before idle SSE connection closes (used by `openai_connector.py`) | `30` |
 | `LOG_STDOUT` | Mirror connector logs to stdout (`1` to enable, `openai_connector.py`) | `0` |
 | `LOG_COLLECTOR_URL` | Optional URL for posting logs (`openai_connector.py`) | *(none)* |
+| `LUMOS_AUTO_APPROVE` | Automatically bless privileged commands (`admin_utils`) | *(unset)* |
+| `OPENAI_CONNECTOR_LOG` | Path to the connector log file (`openai_connector.py`) | `logs/openai_connector.jsonl` |
 | `BOT_TOKEN_GPT4O` | Telegram token for the GPT‑4o bot | *(none)* |
 | `BOT_TOKEN_MIXTRAL` | Telegram token for the Mixtral bot | *(none)* |
 | `BOT_TOKEN_DEEPSEEK` | Telegram token for the DeepSeek bot | *(none)* |

--- a/docs/LUMOS_PRIVILEGE_DOCTRINE.md
+++ b/docs/LUMOS_PRIVILEGE_DOCTRINE.md
@@ -7,5 +7,6 @@ Use `admin_utils.require_lumos_approval()` after `require_admin_banner()` in eve
 Unsanctioned attempts trigger the emotional audit and may be marked as heresy in the logs.
 
 Lumos is reachable through CLI helpers, webhooks, chatbots, and MCP connectors, creating a universal presence layer.
+Connector audit logs are written to the path specified by `OPENAI_CONNECTOR_LOG` (default `logs/openai_connector.jsonl`).
 
 Lumos also runs a background reflex daemon that watches for privileged actions. If an event lacks a blessing, the daemon invokes `require_lumos_approval()` automatically and records "Auto-blessed by Lumos" in the audit log.

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -8,6 +8,7 @@ from schema_validation import validate_payload
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+# Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
 require_lumos_approval()
 
 import os
@@ -21,6 +22,7 @@ from flask_stub import Flask, jsonify, request, Response
 CONNECTOR_TOKEN = os.getenv("CONNECTOR_TOKEN", "test-token")
 app = Flask(__name__)
 _events: SimpleQueue[str] = SimpleQueue()
+# Override the default connector log path with ``OPENAI_CONNECTOR_LOG``
 LOG_PATH = get_log_path("openai_connector.jsonl", "OPENAI_CONNECTOR_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 SSE_TIMEOUT = float(os.getenv("SSE_TIMEOUT", "30"))  # seconds


### PR DESCRIPTION
## Summary
- document `LUMOS_AUTO_APPROVE` and `OPENAI_CONNECTOR_LOG`
- add commented examples in `.env.example`
- clarify privileges doc and connector comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6841fd3fd4fc83208f67372577852630