### PR TITLE
Improve privilege lint entrypoint detection

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -4,6 +4,7 @@ import json
 from log_utils import append_json
 import datetime
 import os
+import re
 from pathlib import Path
 try:
     from admin_utils import require_admin_banner, require_lumos_approval
@@ -38,6 +39,9 @@ ENTRY_PATTERNS = [
     "replay.py",
     "experiments_api.py",
 ]
+
+MAIN_BLOCK_RE = re.compile(r"if __name__ == ['\"]__main__['\"]")
+ARGPARSE_RE = re.compile(r"\bargparse\b")
 
 DOCSTRING_SEARCH_LINES = 60
 
@@ -142,7 +146,7 @@ def find_entrypoints(root: Path) -> list[Path]:
         if path in files:
             continue
         text = path.read_text(encoding="utf-8")
-        if "__main__" in text or "argparse" in text:
+        if MAIN_BLOCK_RE.search(text) or ARGPARSE_RE.search(text):
             files.add(path)
     return sorted(files)
 

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -48,3 +48,20 @@ def test_banner_not_immediate(tmp_path):
     )
     issues = pl.check_file(path)
     assert any("require_admin_banner()" in i for i in issues)
+
+
+def test_missing_admin_banner(tmp_path):
+    path = tmp_path / "cli.py"
+    path.write_text(f"{pl.DOCSTRING}\nprint('hi')\n", encoding="utf-8")
+    issues = pl.check_file(path)
+    assert any("require_admin_banner()" in i for i in issues)
+
+
+def test_missing_lumos_call(tmp_path):
+    path = tmp_path / "cli.py"
+    path.write_text(
+        f"{pl.DOCSTRING}\nrequire_admin_banner()\n",
+        encoding="utf-8",
+    )
+    issues = pl.check_file(path)
+    assert any("require_lumos_approval()" in i for i in issues)


### PR DESCRIPTION
## Summary
- enhance privilege_lint entrypoint search using regexes for `if __name__ == "__main__"` and `argparse`
- test missing banner/lumos calls in privilege lint

## Testing
- `pytest tests/test_privilege_lint.py -q`
- `pytest -k privilege_lint -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6841fd4139708320b91c0a388f2e5360