### PR TITLE
Use helper for connector log paths

### DIFF
--- a/check_connector_health.py
+++ b/check_connector_health.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 import openai_connector
@@ -19,7 +20,7 @@ require_lumos_approval()
 def _setup() -> tuple[openai_connector.Flask.test_client, Path]:
     os.environ.setdefault("CONNECTOR_TOKEN", "token123")
     os.environ.setdefault("SSE_TIMEOUT", "0.2")
-    log_path = Path(os.getenv("OPENAI_CONNECTOR_LOG", "logs/openai_connector_health.jsonl"))
+    log_path = get_log_path("openai_connector_health.jsonl", "OPENAI_CONNECTOR_LOG")
     if log_path.exists():
         log_path.unlink()
     reload(openai_connector)

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import argparse
+from logging_config import get_log_path
 from colorama import init, Fore, Style
 from sentient_banner import print_banner, print_closing
 from admin_utils import require_admin_banner, require_lumos_approval
@@ -19,7 +20,7 @@ COLOR_MAP = {
     "deepseek-ai/deepseek-r1-distill-llama-70b-free": Fore.CYAN,
 }
 
-DEFAULT_FILE = os.getenv("MEMORY_FILE", os.path.join("logs", "memory.jsonl"))
+DEFAULT_FILE = get_log_path("memory.jsonl", "MEMORY_FILE")
 
 
 def detect_color(entry: dict) -> str:

--- a/neos_festival_replay_annotation_editor.py
+++ b/neos_festival_replay_annotation_editor.py
@@ -11,9 +11,11 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
+from logging_config import get_log_path
 
-ANNOTATION_LOG = Path(
-    os.getenv("NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG", "logs/neos_festival_replay_annotations.jsonl")
+ANNOTATION_LOG = get_log_path(
+    "neos_festival_replay_annotations.jsonl",
+    "NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG",
 )
 ANNOTATION_LOG.parent.mkdir(parents=True, exist_ok=True)
 

--- a/smoke_test_connector.py
+++ b/smoke_test_connector.py
@@ -4,6 +4,7 @@ import time
 import json
 from pathlib import Path
 import os
+from logging_config import get_log_path
 import openai_connector
 
 print("Running connector smoke tests...")
@@ -32,7 +33,7 @@ for attempt in range(3):
         print(f"Retrying in {wait}s...")
         time.sleep(wait)
 
-log_path = Path(os.getenv("OPENAI_CONNECTOR_LOG", "logs/openai_connector.jsonl"))
+log_path = get_log_path("openai_connector.jsonl", "OPENAI_CONNECTOR_LOG")
 if log_path.exists():
     with log_path.open() as f:
         lines = [json.loads(x) for x in f if x.strip()]


### PR DESCRIPTION
## Summary
- cleanup CLI log paths with `logging_config.get_log_path`
- use helper in health check and smoke test
- ensure `memory_tail.py` and annotation editor honor log overrides

## Testing
- `bash setup_env.sh` *(fails: could not install dependencies)*
- `python privilege_lint.py`
- `python verify_audits.py logs/`
- `python check_connector_health.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `mypy --ignore-missing-imports .` *(fails: found 174 errors)*
- `pytest -m "not env"` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6841fd425e9083208761bf5d1efaf8ac