### PR TITLE
Add audit chain check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,11 @@ jobs:
       - name: Verify audits
         run: |
           python verify_audits.py
+      - name: Verify audit chain
+        run: |
+          LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ > audit_chain.txt
+          cat audit_chain.txt
+          if grep -q "chain break" audit_chain.txt; then
+            echo "Audit chain broken"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ contributors through the [Ritual Onboarding Checklist](docs/RITUAL_ONBOARDING.md
 - [ ] Docstring and `require_admin_banner()` present in new entrypoints
 - [ ] All log files created via `get_log_path()`
 - [ ] `python verify_audits.py` passes
+- [ ] `python verify_audits.py logs/` shows no `chain break`
 - [ ] Documentation updated
 
 ## Known Issues


### PR DESCRIPTION
## Summary
- run audit verification against `logs/` in CI
- fail if any chain break appears
- document the verification requirement in Final Cathedral-Polish Steps

## Testing
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `mypy --ignore-missing-imports .` *(execution interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_6841fd441db48320b976d1297cdd938b