### PR TITLE
Document auto approval and connector log variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ CONNECTOR_TOKEN=
 # LOG_STDOUT=0
 # Optional endpoint to forward connector logs
 # LOG_COLLECTOR_URL=http://localhost:4000/collect
-# Auto-approve Lumos blessings
+# Auto-approve Lumos blessings (set to 1)
 # LUMOS_AUTO_APPROVE=1
 # Custom connector log path
 # OPENAI_CONNECTOR_LOG=logs/openai_connector.jsonl

--- a/admin_utils.py
+++ b/admin_utils.py
@@ -1,3 +1,10 @@
+"""Privilege helper utilities.
+
+``require_lumos_approval`` prompts for a Lumos blessing before privileged
+actions continue. Set ``LUMOS_AUTO_APPROVE=1`` to bypass the prompt when
+running unattended.
+"""
+
 import os
 import sys
 import platform

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -30,8 +30,8 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `SSE_TIMEOUT` | Seconds before idle SSE connection closes (used by `openai_connector.py`) | `30` |
 | `LOG_STDOUT` | Mirror connector logs to stdout (`1` to enable, `openai_connector.py`) | `0` |
 | `LOG_COLLECTOR_URL` | Optional URL for posting logs (`openai_connector.py`) | *(none)* |
-| `LUMOS_AUTO_APPROVE` | Automatically bless privileged commands (`admin_utils`) | *(unset)* |
-| `OPENAI_CONNECTOR_LOG` | Path to the connector log file (`openai_connector.py`) | `logs/openai_connector.jsonl` |
+| `LUMOS_AUTO_APPROVE` | Set to `1` to automatically bless privileged commands (`admin_utils`) | *(unset)* |
+| `OPENAI_CONNECTOR_LOG` | Path to the connector log file used by `openai_connector.py` | `logs/openai_connector.jsonl` |
 | `BOT_TOKEN_GPT4O` | Telegram token for the GPT‑4o bot | *(none)* |
 | `BOT_TOKEN_MIXTRAL` | Telegram token for the Mixtral bot | *(none)* |
 | `BOT_TOKEN_DEEPSEEK` | Telegram token for the DeepSeek bot | *(none)* |

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -9,10 +9,19 @@ except Exception:  # pragma: no cover - optional dependency
     requests = None
 from schema_validation import validate_payload
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""OpenAI event connector.
+
+This module logs structured events to ``LOG_PATH``. Set the environment
+variable ``OPENAI_CONNECTOR_LOG`` to override the default log destination
+(``logs/openai_connector.jsonl``).
+
+Privilege escalation is gated by ``admin_utils.require_lumos_approval``.
+To run non-interactively, set ``LUMOS_AUTO_APPROVE=1``.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-# Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
 require_lumos_approval()
 
 import os
@@ -27,6 +36,7 @@ CONNECTOR_TOKEN = os.getenv("CONNECTOR_TOKEN", "test-token")
 app = Flask(__name__)
 _events: SimpleQueue[str] = SimpleQueue()
 # Override the default connector log path with ``OPENAI_CONNECTOR_LOG``
+# (defaults to ``logs/openai_connector.jsonl``)
 LOG_PATH = get_log_path("openai_connector.jsonl", "OPENAI_CONNECTOR_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 SSE_TIMEOUT = float(os.getenv("SSE_TIMEOUT", "30"))  # seconds


### PR DESCRIPTION
## Summary
- document `LUMOS_AUTO_APPROVE` and `OPENAI_CONNECTOR_LOG` in environment docs
- clarify sample usage in `.env.example`
- note these variables in `openai_connector.py` and `admin_utils.py`

## Testing
- `pytest -m "not env" -q`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`
- `mypy --ignore-missing-imports .` *(fails: 174 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684200b8a2208320961b3054152e44a5