### PR TITLE
Ensure privilege banners on CLI entrypoints

### DIFF
--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,3 +1,8 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
 from logging_config import get_log_path
 import os
 import json

--- a/docs/examples/welcome_script.py
+++ b/docs/examples/welcome_script.py
@@ -1,3 +1,8 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
 import ritual
 
 if __name__ == "__main__":

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -10,10 +10,8 @@ except Exception:  # pragma: no cover - optional dependency
 from schema_validation import validate_payload
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-# Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
-require_lumos_approval()
+require_lumos_approval()  # Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
 
 import os
 import json

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,3 +1,8 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
 from . import __version__
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add Sanctuary Privilege docstring and calls to api/actuator CLI
- fix banner order in openai_connector
- add ritual banner to sentientos `__main__`
- add example banner to docs welcome script

## Testing
- `python privilege_lint.py`

------
https://chatgpt.com/codex/tasks/task_b_684200ba1ef883208ea4bba7514ac486