### PR TITLE
Fix banner linting order

### DIFF
--- a/openai_connector.py
+++ b/openai_connector.py
@@ -1,22 +1,7 @@
-"""OpenAI event connector.
-
-This module logs structured events to ``LOG_PATH``. Set the environment
-variable ``OPENAI_CONNECTOR_LOG`` to override the default log destination
-(``logs/openai_connector.jsonl``).
-
-Privilege escalation is gated by ``admin_utils.require_lumos_approval``.
-To run non-interactively, set ``LUMOS_AUTO_APPROVE=1``.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
-
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import logging
 from logging.handlers import RotatingFileHandler
-
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()  # Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
 
 try:
     import requests
@@ -30,6 +15,21 @@ import time
 from datetime import datetime
 from queue import SimpleQueue
 from flask_stub import Flask, jsonify, request, Response
+
+"""OpenAI event connector.
+
+This module logs structured events to ``LOG_PATH``. Set the environment
+variable ``OPENAI_CONNECTOR_LOG`` to override the default log destination
+(``logs/openai_connector.jsonl``).
+
+Privilege escalation is gated by ``admin_utils.require_lumos_approval``.
+To run non-interactively, set ``LUMOS_AUTO_APPROVE=1``.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()  # Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
 
 CONNECTOR_TOKEN = os.getenv("CONNECTOR_TOKEN", "test-token")
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- reorder imports in `openai_connector.py`
- keep the docstring, admin banner, and lumos approval in canonical order

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`

------
https://chatgpt.com/codex/tasks/task_b_68422ce0a61083209ee346a190e17f38