### PR TITLE
Add audit chain status disclosure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/
 !logs/federation_log.jsonl
 !logs/user_presence.jsonl
 !logs/migration_ledger.jsonl
+!logs/README.md
 *.log
 
 # Local environment files

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ _All code was written by a non-coder using only ChatGPT and free tools._
 _Some type-check and unit-test failures remain, mostly related to older CLI stubs and missing environment mocks. Full explanation in [Known Issues](#known-issues) below._
 
 _All core features (privilege banners, memory, logging, emotion, safety) are working and reviewable._
+## Audit Chain Status
+All current and operational logs validate as unbroken audit chains.
+Two legacy logs (`migration_ledger.jsonl` and `support_log.jsonl`) display a single prev hash mismatch each, reflecting system state transitions before adoption of the immutable chain protocol.
+These are intentionally preserved as transparent evidence of system evolution. No logs are ever silently overwritten or hidden.
+
 
 ## Cathedral TTS Log System
 - **Every new log is spoken aloud (if live)**

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,1 @@
+This directory stores audit logs in JSONL format. Two legacy files (`migration_ledger.jsonl` and `support_log.jsonl`) each contain a historical `prev hash` mismatch that predates the immutable chain protocol. These entries remain untouched for transparency; no logs are ever overwritten or hidden.


### PR DESCRIPTION
## Summary
- disclose audit chain status and legacy log note in README
- add README in logs for transparency
- track logs/README.md in Git

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py` *(fails: missing privilege docstring)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pytest -m "not env"`
- `mypy --ignore-missing-imports`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`


------
https://chatgpt.com/codex/tasks/task_b_68422ce29b808320a6c462ab2775dfd1