### PR TITLE
Fix privilege ritual docstring in bless_this_env.py

### DIFF
--- a/bless_this_env.py
+++ b/bless_this_env.py
@@ -1,3 +1,9 @@
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+
 import platform
 import subprocess
 import sys


### PR DESCRIPTION
## Summary
- ensure `bless_this_env.py` begins with the Sanctuary Privilege Ritual
- call `require_admin_banner()` and `require_lumos_approval()` before other imports

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`

------
https://chatgpt.com/codex/tasks/task_b_6842422753e883208b36b8f5ca87d5f7