### PR TITLE
Document autonomous audit log variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ MEMORY_DIR=logs/memory
 TTS_ENGINE=pyttsx3
 TTS_COQUI_MODEL=tts_models/en/vctk/vits
 AUDIO_LOG_DIR=logs/audio
+# AUTONOMOUS_AUDIT_LOG=logs/autonomous_audit.jsonl
 # Optional advanced TTS
 ELEVEN_API_KEY=
 ELEVEN_VOICE=Rachel

--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -16,6 +16,9 @@ Autonomous audit and recap generator for the SentientOS Cathedral.
 It scans logs and ledger files for anomalies and can produce a
 public-facing report with sensitive fields masked.
 
+The log file defaults to ``logs/autonomous_audit.jsonl`` and can be
+customized with the ``AUTONOMOUS_AUDIT_LOG`` environment variable.
+
 Example:
     python autonomous_audit.py --report-dir public_reports
 """

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -46,6 +46,7 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `TTS_ENGINE` | Primary text-to-speech engine | `pyttsx3` |
 | `TTS_COQUI_MODEL` | Coqui TTS model path | `tts_models/en/vctk/vits` |
 | `AUDIO_LOG_DIR` | Directory for audio logs | `logs/audio` |
+| `AUTONOMOUS_AUDIT_LOG` | Path used by `autonomous_audit.py` for audit entries | `logs/autonomous_audit.jsonl` |
 | `ELEVEN_API_KEY` | Optional ElevenLabs API key | *(none)* |
 | `ELEVEN_VOICE` | Default ElevenLabs voice | `Rachel` |
 | `BARK_SPEAKER` | Bark speaker ID | `v2/en_speaker_6` |


### PR DESCRIPTION
## Summary
- add `AUTONOMOUS_AUDIT_LOG` description in `docs/ENVIRONMENT.md`
- include example entry in `.env.example`
- mention the environment variable in `autonomous_audit.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68428c587f008320886c5a5150c6cbf2