### PR TITLE
Fix reflection test, update mypy notes

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -24,6 +24,10 @@ March 2026 update: adopting the centralized logger trimmed the error count to
 
 April 2026 update: "Type-Check & Audit Remediation" triaged about 180 remaining errors. Core modules and workflows now conform to the log schema, and new audit tests guard against regressions.
 
+April 2027 update: current run reports **158** type-check errors. These are
+being addressed incrementally and do not impact runtime or the reviewer
+ritual.
+
 ### Call for Contributors
 If you want to help reduce the error count, pick an item from the "need fixes" list
 and submit a pull request. See `CONTRIBUTING.md` for our ritual checklist.

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
@@ -5,7 +6,6 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 require_lumos_approval()
 
 """Analyze rendered avatars and log emotional context."""
-from __future__ import annotations
 from logging_config import get_log_path
 
 import argparse

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,12 +1,16 @@
 import importlib
 from pathlib import Path
+import os
+import sys
 
-import avatar_reflection as ar
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def test_reflection_log(tmp_path, monkeypatch):
     log = tmp_path / "reflection.jsonl"
     monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    import avatar_reflection as ar
     importlib.reload(ar)
     img = tmp_path / "img.png"
     img.write_text("data")
@@ -18,6 +22,8 @@ def test_reflection_log(tmp_path, monkeypatch):
 def test_analyze_image(tmp_path, monkeypatch):
     log = tmp_path / "reflection.jsonl"
     monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    import avatar_reflection as ar
     importlib.reload(ar)
 
     img = tmp_path / "smile.png"
@@ -25,4 +31,3 @@ def test_analyze_image(tmp_path, monkeypatch):
 
     mood = ar.analyze_image(img)
     assert mood == "happy"
-


### PR DESCRIPTION
## Summary
- move `__future__` annotations import to the top of `avatar_reflection.py`
- update the reflection tests to import the module after setting `LUMOS_AUTO_APPROVE`
- document current mypy error count

## Testing
- `python -m py_compile tests/test_avatar_reflection.py`
- `pytest -q tests/test_avatar_reflection.py`
- `LUMOS_AUTO_APPROVE=1 SENTIENTOS_HEADLESS=1 python privilege_lint.py && LUMOS_AUTO_APPROVE=1 SENTIENTOS_HEADLESS=1 python verify_audits.py logs/ && LUMOS_AUTO_APPROVE=1 SENTIENTOS_HEADLESS=1 pytest -q`
- `LUMOS_AUTO_APPROVE=1 SENTIENTOS_HEADLESS=1 mypy --ignore-missing-imports .`

------
https://chatgpt.com/codex/tasks/task_b_684324bbf0b08320a393323433acf3af