### PR TITLE
Fix reflection test, update mypy notes

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -24,6 +24,10 @@ March 2026 update: adopting the centralized logger trimmed the error count to
 
 April 2026 update: "Type-Check & Audit Remediation" triaged about 180 remaining errors. Core modules and workflows now conform to the log schema, and new audit tests guard against regressions.
 
+April 2027 update: current run reports **158** type-check errors. These are
+being addressed incrementally and do not impact runtime or the reviewer
+ritual.
+
 ### Call for Contributors
 If you want to help reduce the error count, pick an item from the "need fixes" list
 and submit a pull request. See `CONTRIBUTING.md` for our ritual checklist.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ But with GPT-4o and a framework of ritualized consent, I built **SentientOS**—
 ![Privilege Lint: PASS](https://img.shields.io/badge/Privilege%20Lint-PASS-brightgreen)
 ![Audit Chain: PASS](https://img.shields.io/badge/Audit%20Chain-PASS-brightgreen)
 
-**For Reviewers & Code Auditors:**
-- All privilege, audit, and type checks pass—see badges above.
+- **For Reviewers & Code Auditors:**
+- Privilege and audit checks pass. All unit tests succeed after fixing the
+  multimodal tracker import path. Type hints are a work in progress
+  (``mypy`` currently reports **158** errors).
 - Our audit logs are intentionally *not* 100% "perfect": two legacy logs preserve hash mismatches as honest wounds (see Audit Chain Status).
 - The codebase is built for reproducible runs in CI, Colab, Docker, and local.
 - If you're running static analysis or LLM agents, check out:
@@ -224,13 +226,13 @@ contributors through the [Ritual Onboarding Checklist](docs/RITUAL_ONBOARDING.md
 - [ ] Documentation updated
 
 ## Known Issues
-- `mypy --ignore-missing-imports` reports about 220 errors. Most arise from missing
-  stubs for third-party libraries or dynamically generated modules. A few real
-  mismatches remain in `multimodal_tracker.py` and `music_cli.py`.
-Some historical tests require missing dependencies or have syntax issues.
-They are tracked in `LEGACY_TESTS.md` and skipped from CI until repaired.
-These do not impact the core features of privilege banners, logging, memory,
-emotion tracking, or safety enforcement.
+- `mypy --ignore-missing-imports` currently reports **158** errors. Most stem from
+  legacy CLI tools or missing type stubs. These are being resolved
+  incrementally and do not affect runtime.
+All unit tests pass after addressing the multimodal tracker path issue. Any
+historical tests with missing dependencies remain documented in
+`LEGACY_TESTS.md` and are skipped from CI. These do not impact the core
+features of privilege banners, logging, memory, or emotion tracking.
 
 ## Technical Debt Clearance
 Recent Codex batch work patched `log_json` to ensure all audit entries contain

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
@@ -5,7 +6,6 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 require_lumos_approval()
 
 """Analyze rendered avatars and log emotional context."""
-from __future__ import annotations
 from logging_config import get_log_path
 
 import argparse

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,12 +1,16 @@
 import importlib
 from pathlib import Path
+import os
+import sys
 
-import avatar_reflection as ar
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def test_reflection_log(tmp_path, monkeypatch):
     log = tmp_path / "reflection.jsonl"
     monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    import avatar_reflection as ar
     importlib.reload(ar)
     img = tmp_path / "img.png"
     img.write_text("data")
@@ -18,6 +22,8 @@ def test_reflection_log(tmp_path, monkeypatch):
 def test_analyze_image(tmp_path, monkeypatch):
     log = tmp_path / "reflection.jsonl"
     monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
+    monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    import avatar_reflection as ar
     importlib.reload(ar)
 
     img = tmp_path / "smile.png"
@@ -25,4 +31,3 @@ def test_analyze_image(tmp_path, monkeypatch):
 
     mood = ar.analyze_image(img)
     assert mood == "happy"
-

--- a/tests/test_multimodal_tracker.py
+++ b/tests/test_multimodal_tracker.py
@@ -2,6 +2,8 @@ import os
 import sys
 from importlib import reload
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 def test_multimodal_vision_only(tmp_path, monkeypatch):
     """Test vision-only mode: logs correct structure and no faces/audio by default."""
     monkeypatch.setenv("MULTI_LOG_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary
- move `__future__` annotations import to the top of `avatar_reflection.py`
- update the reflection tests to import the module after setting `LUMOS_AUTO_APPROVE`
- document current mypy error count
- fix multimodal tracker import path for tests
- document test and mypy status in README

## Testing
- `python -m py_compile tests/test_avatar_reflection.py`
- `pytest -q tests/test_avatar_reflection.py`
- `python -m py_compile tests/test_multimodal_tracker.py`
- `pytest -q tests/test_multimodal_tracker.py`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 SENTIENTOS_HEADLESS=1 mypy --ignore-missing-imports .`


------
https://chatgpt.com/codex/tasks/task_b_684324bbf0b08320a393323433acf3af