### PR TITLE
Document Neos permission logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,11 @@ NARRATOR_MODEL=facebook/bart-large-cnn
 # Neos exports
 NEOS_BLENDER_EXPORT_DIR=blender_exports
 NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG=logs/neos_festival_replay_annotations.jsonl
+# Optional Neos logs
+# NEOS_ASSET_LOG=logs/neos_model_assets.jsonl
+# NEOS_SCRIPT_REQUEST_LOG=logs/neos_script_requests.jsonl
+# NEOS_PERMISSION_COUNCIL_LOG=logs/neos_permission_council.jsonl
+# NEOS_CURRICULUM_REVIEW_LOG=logs/neos_curriculum_review.jsonl
 
 # OCR pipeline
 OCR_WATCH=screenshots

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -97,6 +97,10 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `NARRATOR_MODEL` | Summarization model for the narrator | `facebook/bart-large-cnn` |
 | `NEOS_BLENDER_EXPORT_DIR` | Directory for Neos Blender exports | `blender_exports` |
 | `NEOS_FESTIVAL_REPLAY_ANNOTATION_LOG` | Path for festival replay annotations | `logs/neos_festival_replay_annotations.jsonl` |
+| `NEOS_ASSET_LOG` | Path for generated model asset records | `logs/neos_model_assets.jsonl` |
+| `NEOS_SCRIPT_REQUEST_LOG` | Path for model script requests | `logs/neos_script_requests.jsonl` |
+| `NEOS_PERMISSION_COUNCIL_LOG` | Path for permission council approvals | `logs/neos_permission_council.jsonl` |
+| `NEOS_CURRICULUM_REVIEW_LOG` | Path for curriculum review results | `logs/neos_curriculum_review.jsonl` |
 | `OCR_WATCH` | Folder watched for OCR screenshots | `screenshots` |
 | `PORT` | HTTP port for the blessing ceremony API | `5000` |
 | `PRIVILEGED_AUDIT_FILE` | Path used by `privilege_lint.py` to log privileged command usage | `logs/privileged_audit.jsonl` |

--- a/neos_curriculum_reviewer.py
+++ b/neos_curriculum_reviewer.py
@@ -6,6 +6,13 @@ from logging_config import get_log_path
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
+"""Review festival or onboarding curriculum files.
+
+Results are written to ``logs/neos_curriculum_review.jsonl`` or the path
+defined by ``NEOS_CURRICULUM_REVIEW_LOG``. See ``docs/ENVIRONMENT.md`` for
+details.
+"""
+
 import argparse
 import json
 import os

--- a/neos_lorebook_writer.py
+++ b/neos_lorebook_writer.py
@@ -6,6 +6,13 @@ from logging_config import get_log_path
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
+"""Compile lorebook entries from Neos activity logs.
+
+The permission council log is read from ``logs/neos_permission_council.jsonl``
+or the path provided by ``NEOS_PERMISSION_COUNCIL_LOG``. See
+``docs/ENVIRONMENT.md`` for details.
+"""
+
 import argparse
 import json
 import os

--- a/neos_model_asset_generator.py
+++ b/neos_model_asset_generator.py
@@ -6,6 +6,12 @@ from logging_config import get_log_path
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
+"""Record autonomous asset generation events.
+
+Entries are written to ``logs/neos_model_assets.jsonl`` or the path
+specified by ``NEOS_ASSET_LOG``. See ``docs/ENVIRONMENT.md`` for details.
+"""
+
 import argparse
 import json
 import os

--- a/neos_model_script_builder.py
+++ b/neos_model_script_builder.py
@@ -6,6 +6,13 @@ from logging_config import get_log_path
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
+"""Handle model-initiated script build requests.
+
+Requests are logged to ``logs/neos_script_requests.jsonl`` or the path
+set by ``NEOS_SCRIPT_REQUEST_LOG``. See ``docs/ENVIRONMENT.md`` for
+details.
+"""
+
 import argparse
 import json
 import os

--- a/neos_permission_council.py
+++ b/neos_permission_council.py
@@ -6,6 +6,14 @@ from logging_config import get_log_path
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
+"""Approve Neos model assets and script requests.
+
+Decisions are logged to ``logs/neos_permission_council.jsonl`` or the path
+from ``NEOS_PERMISSION_COUNCIL_LOG``. Pending items are read from the
+``NEOS_ASSET_LOG`` and ``NEOS_SCRIPT_REQUEST_LOG`` files. See
+``docs/ENVIRONMENT.md`` for details.
+"""
+
 import argparse
 import json
 import os


### PR DESCRIPTION
## Summary
- document additional Neos log paths in ENVIRONMENT.md
- show commented examples in `.env.example`
- reference new variables in Neos modules

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `LUMOS_AUTO_APPROVE=1 pytest -m "not env"`
- `mypy --ignore-missing-imports`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`


------
https://chatgpt.com/codex/tasks/task_b_684359ed17bc832088deb75cc1f8c1c8