### PR TITLE
fix: type annotate weekly mood digest

### DIFF
--- a/weekly_mood_digest.py
+++ b/weekly_mood_digest.py
@@ -12,7 +12,7 @@ require_lumos_approval()
 LOG_PATH = get_log_path("music_log.jsonl")
 
 
-def digest_week() -> dict:
+def digest_week() -> Dict[str, float]:
     cutoff = datetime.utcnow() - timedelta(days=7)
     counts: Dict[str, float] = {}
     if LOG_PATH.exists():


### PR DESCRIPTION
## Summary
- type annotate `digest_week` return type
- ensure counts is declared before use

## Testing
- `mypy weekly_mood_digest.py`

------
https://chatgpt.com/codex/tasks/task_b_6843670d7024832087533505c644facf