### PR TITLE
Update log typing in self_defense

### DIFF
--- a/self_defense.py
+++ b/self_defense.py
@@ -5,7 +5,7 @@ import os
 import datetime
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
@@ -31,7 +31,7 @@ class AgentState:
 _STATES: Dict[str, AgentState] = {}
 
 
-def _log(action: str, agent: str, info: Dict[str, str] | None = None) -> None:
+def _log(action: str, agent: str, info: Dict[str, Any] | None = None) -> None:
     entry = {
         "timestamp": datetime.datetime.utcnow().isoformat(),
         "action": action,


### PR DESCRIPTION
## Summary
- accept `Dict[str, Any]` for `_log` info in `self_defense`

## Testing
- `python privilege_lint.py` *(fails: requires admin input)*
- `pytest`
- `mypy --ignore-missing-imports`
- `mypy self_defense.py`
- `python check_connector_health.py` *(fails: requires admin input)*
- `python verify_audits.py` *(fails: requires admin input)*

------
https://chatgpt.com/codex/tasks/task_b_6843671422288320be1d36cde1655050