### PR TITLE
Document types-requests in setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ These are intentionally preserved as transparent evidence of system evolution. N
 
 ## Quick Start
 1. Install the pinned dependencies with `pip install -r requirements.txt`.
+   The list includes `types-requests`, providing type hints for the
+   `requests` library so that `mypy` runs cleanly.
 2. Install the project in editable mode using `pip install -e .`.
 3. Run `python installer/setup_installer.py` and follow the prompts.
 4. Launch a tool, e.g. `support --help`.


### PR DESCRIPTION
## Summary
- mention `types-requests` in the quick-start instructions

## Testing
- `mypy bridge_watchdog.py`
- `pytest -q` *(fails: KeyboardInterrupt)*
- `python check_connector_health.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6843670e11348320bbf7fa312fb93607