### PR TITLE
Reposition privilege ritual above imports

### DIFF
--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,5 +1,3 @@
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 
 Autonomous audit and recap generator for the SentientOS Cathedral.
@@ -12,8 +10,11 @@ customized with the ``AUTONOMOUS_AUDIT_LOG`` environment variable.
 Example:
     python autonomous_audit.py --report-dir public_reports
 """
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
 
 from logging_config import get_log_path, get_log_dir
 

--- a/avatar_dream_visualization.py
+++ b/avatar_dream_visualization.py
@@ -1,10 +1,12 @@
-from __future__ import annotations
-from logging_config import get_log_path
-
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+from __future__ import annotations
+from logging_config import get_log_path
 """Avatar Dream/Festival Visualization.
 
 Visualizes active/inactive avatar dreams, festival ceremonies, or mass rituals.

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,9 +1,9 @@
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
 
 from logging_config import get_log_path
 import argparse

--- a/avatar_performance_scoreboard.py
+++ b/avatar_performance_scoreboard.py
@@ -1,11 +1,14 @@
-from __future__ import annotations
-from logging_config import get_log_path
-
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 """Ritual Avatar Performance Scoreboard."""
+
+from __future__ import annotations
+from logging_config import get_log_path
 
 import argparse
 import json

--- a/blessing_checker.py
+++ b/blessing_checker.py
@@ -1,11 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 from logging_config import get_log_path
 import json
 from pathlib import Path
-
-from admin_utils import require_admin_banner, require_lumos_approval
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 BLESSING_LEDGER = get_log_path("blessing_ledger.jsonl")
 
 

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,14 +1,16 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 from logging_config import get_log_path
 import argparse
 import datetime
 import json
 from pathlib import Path
 from typing import Dict
-from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 CONFESSION_FILE = get_log_path("confessional_log.jsonl")
 HERESY_FILE = get_log_path("heresy_log.jsonl")
 

--- a/neos_artifact_blessing_reconciler.py
+++ b/neos_artifact_blessing_reconciler.py
@@ -1,10 +1,12 @@
-from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
-from logging_config import get_log_path
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+from __future__ import annotations
+from logging_config import get_log_path
 
 import argparse
 import json

--- a/ocr_activity_timeline.py
+++ b/ocr_activity_timeline.py
@@ -1,7 +1,9 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
 """Plot timeline of OCR activity over the last 24h."""
 import datetime
 import json

--- a/replay.py
+++ b/replay.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 import argparse
 import json
 import time
@@ -7,11 +14,6 @@ import zipfile
 import tempfile
 from typing import Any, List
 from flask_stub import Flask, jsonify, request
-from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 
 
 def run_dashboard(storyboard: str) -> Flask:

--- a/resonite_guest_agent_consent_feedback_wizard.py
+++ b/resonite_guest_agent_consent_feedback_wizard.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 from __future__ import annotations
 from logging_config import get_log_path
 import argparse
@@ -7,13 +14,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 LOG_PATH = get_log_path("resonite_consent_feedback_wizard.jsonl", "RESONITE_CONSENT_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- place Sanctuary docstring and privilege checks at the start of several scripts
- keep imports after `require_admin_banner()` and `require_lumos_approval()`

## Testing
- `SENTIENTOS_HEADLESS=1 python privilege_lint.py`
- `SENTIENTOS_HEADLESS=1 python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_68439c0cd39483209aff6b2161c3036a