### PR TITLE
Detect all entrypoint scripts in privilege_lint

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -141,8 +141,8 @@ def find_entrypoints(root: Path) -> list[Path]:
     """Return Python entrypoint files under ``root``."""
     files: set[Path] = set()
     for pattern in ENTRY_PATTERNS:
-        files.update(root.glob(pattern))
-    for path in root.glob("*.py"):
+        files.update(root.rglob(pattern))
+    for path in root.rglob("*.py"):
         if path in files:
             continue
         text = path.read_text(encoding="utf-8")

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -65,3 +65,28 @@ def test_missing_lumos_call(tmp_path):
     )
     issues = pl.check_file(path)
     assert any("require_lumos_approval()" in i for i in issues)
+
+
+def test_recursive_detection(tmp_path):
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    path = sub / "tool.py"
+    path.write_text("if __name__ == '__main__':\n    pass\n", encoding="utf-8")
+    files = pl.find_entrypoints(tmp_path)
+    assert path in files
+    issues = pl.check_file(path)
+    _assert_missing(issues)
+
+
+def test_non_cli_banner_not_immediate(tmp_path):
+    path = tmp_path / "tool.py"
+    path.write_text(
+        f'"{pl.DOCSTRING}"\n'
+        "print('hi')\n"
+        "require_admin_banner()\n"
+        "require_lumos_approval()\n"
+        "if __name__ == '__main__':\n    pass\n",
+        encoding="utf-8",
+    )
+    issues = pl.check_file(path)
+    assert any("require_admin_banner()" in i for i in issues)


### PR DESCRIPTION
## Summary
- scan the whole repo for entrypoints when running `privilege_lint.py`
- add tests for recursive detection and banner misplacement in non-CLI files

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `pytest -m "not env"`

------
https://chatgpt.com/codex/tasks/task_b_68439c0d32f48320a7fbb39c7ad9a7a7