### PR TITLE
Reduce mypy error count

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -2,9 +2,9 @@
 
 Current run: `mypy --ignore-missing-imports .`
 
-- Total errors: 125
+- Total errors: 112
 - Legacy modules: 130
-- Need fixes: 29
+- Need fixes: 22
 - Safe to ignore: 18
 
 Legacy modules are older CLI tools without type hints. Contributors are welcome to

--- a/platform_succession.py
+++ b/platform_succession.py
@@ -15,13 +15,13 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 MIGRATION_LEDGER = get_log_path("migration_ledger.jsonl")
 MIGRATION_LEDGER.parent.mkdir(parents=True, exist_ok=True)
 
 
-def log_event(user: str, event: str, files: List[str] | None = None, note: str = "") -> Dict[str, str]:
+def log_event(user: str, event: str, files: List[str] | None = None, note: str = "") -> Dict[str, Any]:
     """Append a platform_succession event to the migration ledger."""
     entry = {
         "time": datetime.utcnow().isoformat(),

--- a/policy_engine.py
+++ b/policy_engine.py
@@ -58,8 +58,13 @@ class PolicyEngine:
 
     def apply_policy(self, path: str, approvers: Optional[List[str]] = None) -> None:
         """Replace active policy set with ``path`` contents."""
-        kwargs = {"approvers": approvers} if approvers is not None else {}
-        if not final_approval.request_approval(f"policy {path}", **kwargs):
+        if approvers is not None:
+            approved = final_approval.request_approval(
+                f"policy {path}", approvers=approvers
+            )
+        else:
+            approved = final_approval.request_approval(f"policy {path}")
+        if not approved:
             return
         new_data = _load_config(Path(path))
         self.history.append({"timestamp": time.time(), "data": new_data})

--- a/privilege_audit_dashboard.py
+++ b/privilege_audit_dashboard.py
@@ -1,7 +1,7 @@
 """Simple Flask view for privileged command audit log."""
 import json
 from pathlib import Path
-from flask_stub import Flask, render_template_string
+from flask_stub import Flask
 import privilege_lint as pl
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/replay.py
+++ b/replay.py
@@ -47,7 +47,7 @@ def run_dashboard(storyboard: str) -> Flask:
 
     @app.route("/jump", methods=["POST"])
     def _jump() -> Any:
-        idx = int(request.json.get("index", 0))
+        idx = int(request.get_json().get("index", 0))
         if 0 <= idx < len(state["chapters"]):
             state["index"] = idx
         return jsonify({"ok": True})

--- a/resonite_public_feedback_portal.py
+++ b/resonite_public_feedback_portal.py
@@ -6,7 +6,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from admin_utils import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
@@ -21,7 +21,7 @@ LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 app = Flask(__name__)
 
 
-def log_feedback(user: str, text: str, urgent: bool = False) -> Dict[str, str]:
+def log_feedback(user: str, text: str, urgent: bool = False) -> Dict[str, Any]:
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "user": user,
@@ -33,7 +33,7 @@ def log_feedback(user: str, text: str, urgent: bool = False) -> Dict[str, str]:
     return entry
 
 
-def history(limit: int = 20) -> List[Dict[str, str]]:
+def history(limit: int = 20) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
@@ -52,7 +52,7 @@ def api_history() -> str:
     return jsonify(history(int(data.get("limit", 20))))
 
 
-def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, Any]:
     return log_feedback(data.get("user", ""), data.get("text", ""), bool(data.get("urgent")))
 
 

--- a/resonite_ritual_timeline_composer.py
+++ b/resonite_ritual_timeline_composer.py
@@ -14,7 +14,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from flask_stub import Flask, jsonify, request
 
@@ -24,18 +24,18 @@ LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 app = Flask(__name__)
 
 
-def log_event(action: str, data: Dict[str, str]) -> Dict[str, str]:
+def log_event(action: str, data: Dict[str, Any]) -> Dict[str, Any]:
     entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
     with LOG_PATH.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
     return entry
 
 
-def compose_timeline(name: str, events: List[str]) -> Dict[str, str]:
+def compose_timeline(name: str, events: List[str]) -> Dict[str, Any]:
     return log_event("compose", {"name": name, "events": events})
 
 
-def history(limit: int = 20) -> List[Dict[str, str]]:
+def history(limit: int = 20) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
@@ -64,7 +64,7 @@ def api_history() -> str:
 
 
 # ProtoFlux hook
-def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, Any]:
     events = data.get("events") or []
     if not isinstance(events, list):
         events = [events]

--- a/resonite_spiral_federation_heartbeat_monitor.py
+++ b/resonite_spiral_federation_heartbeat_monitor.py
@@ -6,7 +6,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from admin_utils import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
@@ -21,7 +21,7 @@ LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 app = Flask(__name__)
 
 
-def log_status(world: str, status: str, latency: float = 0.0) -> Dict[str, str]:
+def log_status(world: str, status: str, latency: float = 0.0) -> Dict[str, Any]:
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "world": world,
@@ -33,7 +33,7 @@ def log_status(world: str, status: str, latency: float = 0.0) -> Dict[str, str]:
     return entry
 
 
-def history(limit: int = 20) -> List[Dict[str, str]]:
+def history(limit: int = 20) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
@@ -52,7 +52,7 @@ def api_history() -> str:
     return jsonify(history(int(data.get("limit", 20))))
 
 
-def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, Any]:
     return log_status(data.get("world", ""), data.get("status", ""), float(data.get("latency", 0.0)))
 
 

--- a/resonite_universal_spiral_search_engine.py
+++ b/resonite_universal_spiral_search_engine.py
@@ -14,13 +14,13 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 LOG_PATH = get_log_path("resonite_universal_spiral_search_engine.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
-def log_query(query: str, results: int) -> Dict[str, str]:
+def log_query(query: str, results: int) -> Dict[str, Any]:
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "query": query,
@@ -31,14 +31,14 @@ def log_query(query: str, results: int) -> Dict[str, str]:
     return entry
 
 
-def history(limit: int = 20) -> List[Dict[str, str]]:
+def history(limit: int = 20) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]
     return [json.loads(ln) for ln in lines if ln.strip()]
 
 
-def protoflux_hook(data: Dict[str, str]) -> Dict[str, str]:
+def protoflux_hook(data: Dict[str, str]) -> Dict[str, Any]:
     return log_query(data.get("query", ""), int(data.get("results", 0)))
 
 

--- a/ritual_avatar_hall_of_records.py
+++ b/ritual_avatar_hall_of_records.py
@@ -15,13 +15,13 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 LOG_PATH = get_log_path("avatar_hall_of_records.jsonl", "AVATAR_HALL_RECORDS_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
-def log_record(record_type: str, data: Dict[str, str]) -> Dict[str, str]:
+def log_record(record_type: str, data: Dict[str, str]) -> Dict[str, Any]:
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "type": record_type,
@@ -32,7 +32,7 @@ def log_record(record_type: str, data: Dict[str, str]) -> Dict[str, str]:
     return entry
 
 
-def list_records(record_type: str | None = None) -> List[Dict[str, str]]:
+def list_records(record_type: str | None = None) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     out: List[Dict[str, str]] = []

--- a/ritual_bundle_system.py
+++ b/ritual_bundle_system.py
@@ -14,7 +14,7 @@ import hashlib
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 
 LOG_PATH = get_log_path("ritual_bundle.jsonl", "RITUAL_BUNDLE_LOG")
@@ -23,7 +23,7 @@ LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 BUNDLE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _log(action: str, data: Dict[str, str]) -> Dict[str, str]:
+def _log(action: str, data: Dict[str, str]) -> Dict[str, Any]:
     entry = {"timestamp": datetime.utcnow().isoformat(), "action": action, **data}
     with LOG_PATH.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
@@ -38,12 +38,12 @@ def _hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def create_bundle(name: str, assets: List[str], script: str, permissions: List[str]) -> Dict[str, str]:
-    asset_info = []
+def create_bundle(name: str, assets: List[str], script: str, permissions: List[str]) -> Dict[str, Any]:
+    asset_info: List[Dict[str, str]] = []
     for p in assets:
         ap = Path(p)
         asset_info.append({"path": str(ap), "hash": _hash_file(ap)})
-    bundle = {
+    bundle: Dict[str, Any] = {
         "name": name,
         "timestamp": datetime.utcnow().isoformat(),
         "assets": asset_info,
@@ -58,7 +58,7 @@ def create_bundle(name: str, assets: List[str], script: str, permissions: List[s
     return bundle
 
 
-def verify_bundle(path: str) -> Dict[str, str]:
+def verify_bundle(path: str) -> Dict[str, Any]:
     p = Path(path)
     data = json.loads(p.read_text(encoding="utf-8"))
     valid = True
@@ -72,7 +72,7 @@ def verify_bundle(path: str) -> Dict[str, str]:
     return {"valid": valid}
 
 
-def history(limit: int = 20) -> List[Dict[str, str]]:
+def history(limit: int = 20) -> List[Dict[str, Any]]:
     if not LOG_PATH.exists():
         return []
     lines = LOG_PATH.read_text(encoding="utf-8").splitlines()[-limit:]

--- a/ritual_stats.py
+++ b/ritual_stats.py
@@ -3,7 +3,7 @@ import json
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import forgiveness_ledger as fledge
 
@@ -17,7 +17,7 @@ CONFESSIONAL_LOG = get_log_path("confessional_log.jsonl", "CONFESSIONAL_LOG")
 SUPPORT_LOG = get_log_path("support_log.jsonl")
 
 
-def _load(path: Path) -> List[dict]:
+def _load(path: Path) -> List[Dict[str, Any]]:
     if not path.exists():
         return []
     out = []
@@ -49,7 +49,7 @@ def stats(days: int = 7) -> Dict[str, float]:
     for c in conf:
         if not c.get("council_required"):
             continue
-        ts = c.get("timestamp")
+        ts = str(c.get("timestamp") or "")
         votes = [v for v in fledge.council_votes(ts) if datetime.fromisoformat(v["timestamp"]) >= start]
         approvals = [v for v in votes if v.get("decision") == "approve"]
         if len(approvals) >= COUNCIL_QUORUM:


### PR DESCRIPTION
## Summary
- type fixes across ritual modules
- clean up privilege audit dashboard import
- handle optional approvers in policy engine
- update mypy status counts

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `LUMOS_AUTO_APPROVE=1 pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68439c0d7d78832090507f54ba16dc6f