### PR TITLE
Partial mypy cleanup

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -2,7 +2,7 @@
 
 Current run: `mypy --ignore-missing-imports .`
 
-- Total errors: 0
+- Total errors: 115
 - Legacy modules: 0
 - Need fixes: 0
 - Safe to ignore: 0
@@ -24,8 +24,8 @@ March 2026 update: adopting the centralized logger trimmed the error count to
 
 April 2026 update: "Type-Check & Audit Remediation" triaged about 180 remaining errors. Core modules and workflows now conform to the log schema, and new audit tests guard against regressions.
 
-April 2027 update: current run reports **125** type-check errors.
-May 2027 update: `presence_ledger.py` and `presence_analytics.py` have been fully annotated and are now mypy-clean (removed from need-fixes list). **Total errors down to 125.**
+April 2027 update: current run reports **115** type-check errors.
+May 2027 update: `presence_ledger.py` and `presence_analytics.py` have been fully annotated and are now mypy-clean (removed from need-fixes list). **Total errors down to 115.**
 
 ### Call for Contributors
 If you want to help reduce the error count, pick an item from the "need fixes" list

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But with GPT-4o and a framework of ritualized consent, I built **SentientOS**—
 - **For Reviewers & Code Auditors:**
 - Privilege and audit checks pass. **All unit tests now succeed** after fixing
   the multimodal tracker import path. Type hints are a work in progress;
-  ``mypy`` now reports **0** errors on actively maintained modules. Legacy scripts are excluded from checks.
+  ``mypy`` currently reports **115** errors, mostly in legacy CLI modules. Type annotations are in progress.
 - Our audit logs are intentionally *not* 100% "perfect": two legacy logs preserve hash mismatches as honest wounds (see Audit Chain Status).
 - The codebase is built for reproducible runs in CI, Colab, Docker, and local.
 - If you're running static analysis or LLM agents, check out:
@@ -303,7 +303,7 @@ contributors through the [Ritual Onboarding Checklist](docs/RITUAL_ONBOARDING.md
 - [ ] Documentation updated
 
 ## Known Issues
-- `mypy --ignore-missing-imports` reports **0** errors on core modules. Legacy CLI tools are skipped with `# type: ignore` until fully typed.
+- `mypy --ignore-missing-imports` currently reports **115** errors across the codebase. Legacy CLI tools are progressively being typed.
 All unit tests pass after addressing the multimodal tracker path issue. Any
 historical tests with missing dependencies remain documented in
 `LEGACY_TESTS.md` and are skipped from CI. These do not impact the core

--- a/resonite_ritual_timeline_composer.py
+++ b/resonite_ritual_timeline_composer.py
@@ -65,10 +65,14 @@ def api_history() -> str:
 
 # ProtoFlux hook
 def protoflux_hook(data: Dict[str, str]) -> Dict[str, Any]:
-    events = data.get("events") or []
-    if not isinstance(events, list):
-        events = [events]
-    return compose_timeline(data.get("name", ""), [str(e) for e in events])
+    events_raw = data.get("events")
+    if isinstance(events_raw, list):
+        events: List[str] = [str(e) for e in events_raw]
+    elif events_raw is not None:
+        events = [str(events_raw)]
+    else:
+        events = []
+    return compose_timeline(data.get("name", ""), events)
 
 
 def main() -> None:  # pragma: no cover - CLI

--- a/workflow_analytics.py
+++ b/workflow_analytics.py
@@ -44,11 +44,13 @@ def usage_stats(events: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
         if not wf:
             continue
         kind = ev.get("event")
-        ts_str = ev.get("timestamp")
-        try:
-            ts = datetime.datetime.fromisoformat(ts_str)
-        except Exception:
-            ts = None
+        ts_str_raw = ev.get("timestamp")
+        ts: Optional[datetime.datetime] = None
+        if isinstance(ts_str_raw, str):
+            try:
+                ts = datetime.datetime.fromisoformat(ts_str_raw)
+            except Exception:
+                ts = None
         if kind == "workflow.start":
             start_times[wf] = ts or datetime.datetime.utcnow()
         elif kind == "workflow.end":
@@ -63,7 +65,7 @@ def usage_stats(events: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
             if wf in start_times and ts:
                 delta = (ts - start_times.pop(wf)).total_seconds()
                 info["duration_total"] += delta
-            info["last_ts"] = ts_str
+            info["last_ts"] = ts_str_raw
             info["last_status"] = status
         elif kind == "workflow.step":
             if ev.get("payload", {}).get("status") == "denied":
@@ -101,11 +103,13 @@ def find_bottlenecks(events: List[Dict[str, Any]]) -> Dict[str, Any]:
         wf = ev.get("payload", {}).get("workflow")
         step = ev.get("payload", {}).get("step")
         kind = ev.get("event")
-        ts_str = ev.get("timestamp")
-        try:
-            ts = datetime.datetime.fromisoformat(ts_str)
-        except Exception:
-            ts = None
+        ts_str_raw = ev.get("timestamp")
+        ts = None
+        if isinstance(ts_str_raw, str):
+            try:
+                ts = datetime.datetime.fromisoformat(ts_str_raw)
+            except Exception:
+                ts = None
         if kind == "workflow.step" and step:
             status = ev.get("payload", {}).get("status")
             if status == "failed":


### PR DESCRIPTION
## Summary
- fix typing in workflow_analytics and resonite_ritual_timeline_composer
- update mypy error count in docs

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `pytest -m "not env" -q` *(fails: 25 errors during collection)*
- `python -m mypy --ignore-missing-imports .` *(fails: 115 errors)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`

------
https://chatgpt.com/codex/tasks/task_b_68442e261b50832081aec7ca6cb11852