### PR TITLE
Add onboarding CLI helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1936,6 +1936,14 @@ No agent shall act in secret.
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/migration_ledger.jsonl
 ```
+```
+- Name: OnboardCLI
+  Type: CLI
+  Roles: Environment Checker
+  Privileges: log, read
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/onboard_cli.jsonl
+```
 ---
 
 ## 🏛️ Closing: The Sacred Law of Presence

--- a/FIRST_RUN.md
+++ b/FIRST_RUN.md
@@ -9,6 +9,7 @@ git clone <your-fork-url>
 cd SentientOS
 bash setup_env.sh
 pip install -r requirements.txt
+python onboard_cli.py --check
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ See [docs/README_FULL.md](docs/README_FULL.md) for the complete philosophy and u
 ## Contributor Quickstart
 1. Fork this repository and clone your fork.
 2. Install dependencies with `pip install -r requirements.txt` and `pip install -e .`.
-3. Run `python smoke_test_connector.py` to execute linting and unit tests.
-4. Run `python check_connector_health.py` to validate the connector endpoints.
-5. Commit your changes and open a pull request. CI logs summarize disconnects and payload errors.
-6. If tests fail, review `logs/openai_connector_health.jsonl` for details or see [docs/CONNECTOR_TROUBLESHOOTING.md](docs/CONNECTOR_TROUBLESHOOTING.md).
+3. Run `python onboard_cli.py --check` to validate your environment.
+4. Run `python smoke_test_connector.py` to execute linting and unit tests.
+5. Run `python check_connector_health.py` to validate the connector endpoints.
+6. Commit your changes and open a pull request. CI logs summarize disconnects and payload errors.
+7. If tests fail, review `logs/openai_connector_health.jsonl` for details or see [docs/CONNECTOR_TROUBLESHOOTING.md](docs/CONNECTOR_TROUBLESHOOTING.md).
 Additional guides:
 - [docs/OPEN_WOUNDS.md](docs/OPEN_WOUNDS.md) **Help Wanted: Memory Healing**
 - [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md)

--- a/onboard_cli.py
+++ b/onboard_cli.py
@@ -1,0 +1,62 @@
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+from logging_config import get_log_path
+
+
+def check_env() -> list[str]:
+    required = ["MEMORY_DIR", "AVATAR_DIR"]
+    issues = []
+    for var in required:
+        val = os.environ.get(var)
+        if not val:
+            issues.append(f"Missing environment variable: {var}")
+            continue
+        if not Path(val).exists():
+            issues.append(f"Directory missing for {var}: {val}")
+    return issues
+
+
+LOG_PATH = get_log_path("onboard_cli.jsonl", "ONBOARD_CLI_LOG")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:  # pragma: no cover - CLI helper
+    ap = argparse.ArgumentParser(description="SentientOS onboarding helper")
+    ap.add_argument("--check", action="store_true", help="validate environment variables and directories")
+    ap.add_argument("--setup", action="store_true", help="run setup_env.sh to prepare directories")
+    args = ap.parse_args()
+
+    if args.setup:
+        subprocess.call(["bash", "setup_env.sh"])
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"timestamp": datetime.utcnow().isoformat(), "event": "setup"}) + "\n")
+
+    if args.check:
+        issues = check_env()
+        if issues:
+            print("\n".join(issues))
+            with LOG_PATH.open("a", encoding="utf-8") as f:
+                f.write(json.dumps({"timestamp": datetime.utcnow().isoformat(), "event": "check_failed"}) + "\n")
+            return 1
+        print("Environment looks good. Run 'pytest -m \"not env\"' next.")
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"timestamp": datetime.utcnow().isoformat(), "event": "check_passed"}) + "\n")
+    else:
+        ap.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `onboard_cli.py` for quick environment checks
- reference the CLI in README and FIRST_RUN docs
- register new agent in `AGENTS.md`

## Testing
- `python privilege_lint.py`
- `pytest -m "not env" -q`
- `mypy --strict`
- `python verify_audits.py`
- `python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684475eb72108320a6dbdfa23d12a47e