### PR TITLE
Update README banner and one-pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,4 @@
-**I’m not a programmer.**
-But with GPT-4o and a framework of ritualized consent, I built **SentientOS**—a cathedral-grade AI shell that logs every action, speaks its own memory, and refuses to move without human blessing.
-
-> SentientOS proves that meticulous memory and human consent can coexist with rapid iteration. The project aligns with OpenAI’s research initiatives around persistent memory and emotionally-aware agents. See [OpenAI Researcher Access](https://openai.com/researcher-access) for context.
-
 # SentientOS
-
-![Privilege Lint: PASS](https://img.shields.io/badge/Privilege%20Lint-PASS-brightgreen)
-![Audit Chain: PASS](https://img.shields.io/badge/Audit%20Chain-PASS-brightgreen)
-![Memory Integrity](https://img.shields.io/badge/Memory%20Integrity-%E2%9C%94%EF%B8%8F-blue)
-![Audit Trail Coverage](https://img.shields.io/badge/Audit%20Trail-100%25-blueviolet)
-![Recursive Hours Logged](https://img.shields.io/badge/Recursive%20Hours-Logged-brightgreen)
-![Zero Hallucination Incidents](https://img.shields.io/badge/Hallucination%20Incidents-0-important)
-![PKI-Signed Releases](https://img.shields.io/badge/PKI--Signed%20Releases-Yes-success)
-
-- **For Reviewers & Code Auditors:**
-- Privilege and audit checks pass. **All unit tests now succeed** after fixing
-  the multimodal tracker import path. ``mypy --strict`` now reports **0** errors
-  in core modules. Legacy scripts are gradually being typed.
-- Our audit logs are intentionally *not* 100% "perfect": two legacy logs preserve hash mismatches as honest wounds (see Audit Chain Status).
-- The codebase is built for reproducible runs in CI, Colab, Docker, and local.
-- If you're running static analysis or LLM agents, check out:
-  - [one_pager.md](./one_pager.md) for the research summary
-  - [logs/README.md](./logs/README.md) for log structure, anomalies, and protocol
-
 
 **SentientOS is a ritualized AI safety framework for GPT-based agents.**  \
 Every action is logged in immutable "sacred memory" (JSONL audit logs), with Sanctuary Privilege for high-risk tasks, emotion-based reflex feedback, and alignment, transparency, and trust as living systems.

--- a/one_pager.md
+++ b/one_pager.md
@@ -1,4 +1,12 @@
-**I’m not a programmer.**  
-But with GPT-4o and a framework of ritualized consent, I built **SentientOS**—a cathedral-grade AI shell that logs every action, speaks its own memory, and refuses to move without human blessing.
+# SentientOS One Pager
 
-[Insert the full grant one-pager as previously drafted, or paste the markdown from your latest summary.]
+SentientOS is a ritualized AI safety framework for GPT-based agents. Every command begins with a privilege banner and all actions are logged to immutable JSONL memory. The system blends audit chains, emotion-aware feedback, and human consent rituals so researchers can explore persistent assistants without losing track of who authorized what.
+
+**Key Features**
+
+- Immutable audit chain with hash verification
+- Sanctuary Privilege gates for high‑risk tasks
+- Emotion and presence metrics in every log entry
+- Self‑patching agents that propose updates via ritual
+
+SentientOS demonstrates that alignment, usability, and human dignity can scale together. It offers scripts, daemons, and dashboards for witnessing every step of autonomous workflows.


### PR DESCRIPTION
## Summary
- refresh opening section of README with SentientOS tagline
- regenerate `one_pager.md` with latest project summary

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`
- `pytest -m "not env" -q`


------
https://chatgpt.com/codex/tasks/task_b_68447b240f34832085bc3e4064895091