### PR TITLE
Privilege ritual migration complete

### DIFF
--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,7 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
 from admin_utils import require_admin_banner, require_lumos_approval
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_admin_banner()
 require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from logging_config import get_log_path
 import os

--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 Autonomous audit and recap generator for the SentientOS Cathedral.
 It scans logs and ledger files for anomalies and can produce a

--- a/avatar_dream_visualization.py
+++ b/avatar_dream_visualization.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/avatar_performance_scoreboard.py
+++ b/avatar_performance_scoreboard.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/blessing_checker.py
+++ b/blessing_checker.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/docs/examples/welcome_script.py
+++ b/docs/examples/welcome_script.py
@@ -1,7 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
 from admin_utils import require_admin_banner, require_lumos_approval
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_admin_banner()
 require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import ritual
 

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 from __future__ import annotations
 
 import os

--- a/neos_artifact_blessing_reconciler.py
+++ b/neos_artifact_blessing_reconciler.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/ocr_activity_timeline.py
+++ b/ocr_activity_timeline.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/replay.py
+++ b/replay.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/resonite_guest_agent_consent_feedback_wizard.py
+++ b/resonite_guest_agent_consent_feedback_wizard.py
@@ -1,4 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,7 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: This script requires admin and Lumos approval."""
 from admin_utils import require_admin_banner, require_lumos_approval
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_admin_banner()
 require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from . import __version__
 

--- a/tests/test_avatar_autonomous_ritual_scheduler_cli.py
+++ b/tests/test_avatar_autonomous_ritual_scheduler_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_avatar_gallery_cli.py
+++ b/tests/test_avatar_gallery_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import sys
 from pathlib import Path

--- a/tests/test_avatar_pose_engine.py
+++ b/tests/test_avatar_pose_engine.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import importlib
 import sys

--- a/tests/test_avatar_presence_cli.py
+++ b/tests/test_avatar_presence_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 from pathlib import Path
 

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import argparse
 import os

--- a/tests/test_emotion_dashboard.py
+++ b/tests/test_emotion_dashboard.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 from importlib import reload
 import os

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import json

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 import os
 import sys

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import policy_engine as pe
 
 

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_reflection_dashboard.py
+++ b/tests/test_reflection_dashboard.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_reflection_log_cli.py
+++ b/tests/test_reflection_log_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import sys
 import os
 from importlib import reload

--- a/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
+++ b/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 """Tests for the review CLI utilities."""
 
 import json

--- a/tests/test_ritual_cli.py
+++ b/tests/test_ritual_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import json

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import importlib

--- a/tests/test_trust_engine.py
+++ b/tests/test_trust_engine.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_workflow_dashboard.py
+++ b/tests/test_workflow_dashboard.py
@@ -1,3 +1,8 @@
+"""Privilege Banner: This script requires admin and Lumos approval."""
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys
 import json


### PR DESCRIPTION
## Summary
- insert privilege banner at top of flagged scripts and tests
- bless all migrated files in RITUAL_FAILURES.md

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `pytest -m "not env" -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6844ca508ee08320b83886029cf62bd3