### PR TITLE
Add utility scripts with privilege headers

### DIFF
--- a/docs/ERROR_RESOLUTION_SUMMARY.md
+++ b/docs/ERROR_RESOLUTION_SUMMARY.md
@@ -1,0 +1,4 @@
+# Error Resolution Summary
+
+| File/Test | Error | Command to Fix | Docs |
+|-----------|-------|---------------|------|

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+import subprocess
+from typing import List
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+require_lumos_approval()
+
+
+BLESSINGS_FILE = Path("SANCTUARY_BLESSINGS.jsonl")
+
+
+def run_verify_audits(args: List[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def append_blessing() -> None:
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": "automatic audit blessing",
+        "reason": "legacy mismatches preserved",
+        "signed_by": "Lumos",
+    }
+    with BLESSINGS_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run verify_audits and bless mismatches")
+    parser.add_argument("log_dir", nargs="?", default="logs/", help="Directory of logs")
+    args = parser.parse_args()
+
+    result = run_verify_audits(["python", "verify_audits.py", args.log_dir])
+    output = result.stdout + result.stderr
+    print(output)
+    if "prev hash mismatch" in output:
+        append_blessing()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from pathlib import Path
+import shutil
+import argparse
+from datetime import datetime
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+require_lumos_approval()
+
+
+HEADER_TEMPLATE = (
+    '"""Privilege Banner: This script requires admin and Lumos approval."""\n'
+    'require_admin_banner()\n'
+    'require_lumos_approval()\n'
+    '# \U0001f56f\ufe0f Privilege ritual migrated {today} by Cathedral decree.\n'
+)
+
+ADMIN_IMPORT = (
+    "from admin_utils import require_admin_banner, require_lumos_approval\n"
+)
+
+
+def inject_banner(file_path: Path) -> None:
+    if not file_path.exists():
+        print(f"File not found: {file_path}")
+        return
+    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+    shutil.copy2(file_path, backup_path)
+
+    text = file_path.read_text(encoding="utf-8").splitlines()
+    shebang = ""
+    if text and text[0].startswith("#!"):
+        shebang = text.pop(0) + "\n"
+
+    imports = []
+    remaining = []
+    for line in text:
+        stripped = line.lstrip()
+        if stripped.startswith("import ") or stripped.startswith("from "):
+            imports.append(line)
+        else:
+            remaining.append(line)
+
+    if ADMIN_IMPORT.strip() not in [imp.strip() for imp in imports]:
+        imports.insert(0, ADMIN_IMPORT.rstrip("\n"))
+
+    header = HEADER_TEMPLATE.format(today=datetime.utcnow().date().isoformat())
+    new_lines = []
+    if shebang:
+        new_lines.append(shebang.rstrip("\n"))
+    new_lines.append(header.rstrip("\n"))
+    new_lines.extend(imports)
+    new_lines.extend(remaining)
+
+    file_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    print(f"Updated {file_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Inject privilege banner into multiple Python scripts"
+    )
+    parser.add_argument(
+        "file_list",
+        help="Text file containing newline separated file paths to process",
+    )
+    args = parser.parse_args()
+    file_list_path = Path(args.file_list)
+    if not file_list_path.exists():
+        print(f"List file not found: {file_list_path}")
+        return
+    for line in file_list_path.read_text(encoding="utf-8").splitlines():
+        path = Path(line.strip())
+        if path.suffix == "":
+            continue
+        inject_banner(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+require_lumos_approval()
+
+REQUIRED_PACKAGES = ["build-essential", "libasound2", "python3.11"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify Dockerfile contains required packages")
+    parser.add_argument("dockerfile", nargs="?", default="Dockerfile", help="Path to Dockerfile")
+    args = parser.parse_args()
+
+    path = Path(args.dockerfile)
+    if not path.exists():
+        print(f"Dockerfile not found: {path}")
+        sys.exit(1)
+    content = path.read_text(encoding="utf-8")
+    missing = [pkg for pkg in REQUIRED_PACKAGES if pkg not in content]
+    if missing:
+        print("Missing packages: " + ", ".join(missing))
+        print("Consider adding them with apt-get install")
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+import argparse
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+require_lumos_approval()
+
+RITUAL_DOC_LINK = "../RITUAL_FAILURES.md"
+AUDIT_DOC_LINK = "../AUDIT_LOG_FIXES.md"
+
+
+ERROR_REGEX = re.compile(r"(?P<file>[\w/]+\.\w+).*?(mismatch|error|fail)", re.IGNORECASE)
+
+
+def parse_errors(content: str) -> List[Tuple[str, str]]:
+    results = []
+    for line in content.splitlines():
+        m = ERROR_REGEX.search(line)
+        if m:
+            file = m.group('file')
+            if 'mismatch' in line:
+                err = 'prev hash mismatch'
+            else:
+                err = 'error'
+            results.append((file, err))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate error resolution summary")
+    parser.add_argument("output", nargs="?", default="docs/ERROR_RESOLUTION_SUMMARY.md")
+    args = parser.parse_args()
+
+    entries = []
+    for doc in ["RITUAL_FAILURES.md", "AUDIT_LOG_FIXES.md"]:
+        path = Path(doc)
+        if path.exists():
+            entries.extend(parse_errors(path.read_text(encoding="utf-8")))
+
+    lines = ["# Error Resolution Summary", "", "| File/Test | Error | Command to Fix | Docs |", "|-----------|-------|---------------|------|"]
+    for file, err in entries:
+        cmd = f"python verify_audits.py {file}" if file.endswith('.jsonl') else "pytest"
+        doc_link = f"[{doc}](../{doc})" if (doc := 'RITUAL_FAILURES.md' if 'jsonl' in file else 'AUDIT_LOG_FIXES.md') else ''
+        lines.append(f"| {file} | {err} | {cmd} | {doc_link} |")
+
+    Path(args.output).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
+require_admin_banner()
+require_lumos_approval()
+
+__test__ = False
+
+ERROR_PATTERN = re.compile(r"ModuleNotFoundError: No module named '(?P<mod>[^']+)'")
+
+
+def parse_missing_modules(log_path: Path) -> set[str]:
+    modules = set()
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        m = ERROR_PATTERN.search(line)
+        if m:
+            modules.add(m.group('mod'))
+    return modules
+
+
+def find_tests_for_module(module: str) -> list[Path]:
+    tests = []
+    for path in Path('.').rglob('test_*.py'):
+        content = path.read_text(encoding='utf-8', errors='ignore')
+        if f"import {module}" in content or f"from {module} import" in content:
+            tests.append(path)
+    return tests
+
+
+def process_file(path: Path, module: str, replacement: str | None) -> str:
+    lines = path.read_text(encoding='utf-8').splitlines()
+    changed = False
+    if replacement:
+        new_lines = []
+        for line in lines:
+            if line.lstrip().startswith(f"import {module}"):
+                new_lines.append(f"import {replacement}")
+                changed = True
+            elif line.lstrip().startswith(f"from {module} import"):
+                new_lines.append(line.replace(f"from {module} import", f"from {replacement} import"))
+                changed = True
+            else:
+                new_lines.append(line)
+        lines = new_lines
+    else:
+        skip_header = [
+            "import pytest",
+            f"pytest.skip('Module {module} missing; deprecated test — see RITUAL_FAILURES.md')",
+        ]
+        lines = skip_header + lines
+        changed = True
+    if changed:
+        path.write_text("\n".join(lines) + "\n", encoding='utf-8')
+    return "replaced" if replacement else "skipped"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fix missing module imports in tests")
+    parser.add_argument("log_file", help="Pytest error log file")
+    args = parser.parse_args()
+    log_path = Path(args.log_file)
+    if not log_path.exists():
+        print(f"Log file not found: {log_path}")
+        sys.exit(1)
+
+    modules = parse_missing_modules(log_path)
+    summary = []
+    for mod in modules:
+        tests = find_tests_for_module(mod)
+        for test_file in tests:
+            print(f"Missing module '{mod}' found in {test_file}")
+            repl = input("Enter replacement import path or leave blank to skip test: ").strip()
+            action = process_file(test_file, mod, repl if repl else None)
+            summary.append(f"{test_file}: {action}")
+
+    if summary:
+        print("\nSummary:")
+        for item in summary:
+            print(" -", item)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add banner injector for migrating privilege banners
- add CLI fixer to patch test imports or skip missing tests
- automate audit blessings when mismatches are detected
- ensure Dockerfile includes required packages
- summarize ritual errors in a new guide

## Testing
- `mypy` *(passed)*
- `pytest -m "not env"` *(passed)*
- `python privilege_lint.py` *(failed: prompts for approval)*
- `python verify_audits.py logs/` *(failed: prompts for approval)*

------
https://chatgpt.com/codex/tasks/task_b_6844ecc793748320b204459a3b42a018