### PR TITLE
Implement batch CLI scripts

### DIFF
--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
-import argparse
 import json
+import subprocess
 from datetime import datetime
 from pathlib import Path
-import subprocess
-from typing import List
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
+# Automatically bless audit mismatches found during verification.
+
 require_admin_banner()
 require_lumos_approval()
-
 
 BLESSINGS_FILE = Path("SANCTUARY_BLESSINGS.jsonl")
 
 
-def run_verify_audits(args: List[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, capture_output=True, text=True)
+def run_verify() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python", "verify_audits.py", "logs/"], capture_output=True, text=True
+    )
 
 
 def append_blessing() -> None:
@@ -33,11 +34,7 @@ def append_blessing() -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run verify_audits and bless mismatches")
-    parser.add_argument("log_dir", nargs="?", default="logs/", help="Directory of logs")
-    args = parser.parse_args()
-
-    result = run_verify_audits(["python", "verify_audits.py", args.log_dir])
+    result = run_verify()
     output = result.stdout + result.stderr
     print(output)
     if "prev hash mismatch" in output:

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,83 +1,99 @@
 from __future__ import annotations
-from pathlib import Path
-import shutil
 import argparse
-from datetime import datetime
+import ast
+import shutil
+from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
+# CLI tool to inject the SentientOS privilege banner into Python files.
+
 require_admin_banner()
 require_lumos_approval()
 
+BANNER_LINES = [
+    '"""Privilege Banner: This script requires admin and Lumos approval."""',
+    "require_admin_banner()",
+    "require_lumos_approval()",
+    "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
+]
 
-HEADER_TEMPLATE = (
-    '"""Privilege Banner: This script requires admin and Lumos approval."""\n'
-    'require_admin_banner()\n'
-    'require_lumos_approval()\n'
-    '# \U0001f56f\ufe0f Privilege ritual migrated {today} by Cathedral decree.\n'
-)
-
-ADMIN_IMPORT = (
-    "from admin_utils import require_admin_banner, require_lumos_approval\n"
-)
+IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
 
 
-def inject_banner(file_path: Path) -> None:
-    if not file_path.exists():
-        print(f"File not found: {file_path}")
+def inject_banner(path: Path) -> None:
+    if not path.exists():
+        print(f"File not found: {path}")
         return
-    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
-    shutil.copy2(file_path, backup_path)
+    backup = path.with_suffix(path.suffix + ".bak")
+    shutil.copy2(path, backup)
 
-    text = file_path.read_text(encoding="utf-8").splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
     shebang = ""
-    if text and text[0].startswith("#!"):
-        shebang = text.pop(0) + "\n"
+    if lines and lines[0].startswith("#!"):
+        shebang = lines.pop(0)
 
-    imports = []
-    remaining = []
-    for line in text:
-        stripped = line.lstrip()
-        if stripped.startswith("import ") or stripped.startswith("from "):
-            imports.append(line)
-        else:
-            remaining.append(line)
+    source = "\n".join(lines)
+    tree = ast.parse(source)
 
-    if ADMIN_IMPORT.strip() not in [imp.strip() for imp in imports]:
-        imports.insert(0, ADMIN_IMPORT.rstrip("\n"))
+    doc_line = None
+    first_import_line = None
+    import_ranges: list[int] = []
+    for node in tree.body:
+        if (
+            doc_line is None
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            doc_line = node.lineno
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            if first_import_line is None or node.lineno < first_import_line:
+                first_import_line = node.lineno
+            start = node.lineno
+            end = getattr(node, "end_lineno", node.lineno)
+            import_ranges.extend(range(start, end + 1))
 
-    header = HEADER_TEMPLATE.format(today=datetime.utcnow().date().isoformat())
-    new_lines = []
+    insertion_line = len(lines) + 1
+    if doc_line is not None:
+        insertion_line = doc_line
+    if first_import_line is not None:
+        insertion_line = min(insertion_line, first_import_line)
+
+    imports = [
+        lines[i - 1] for i in sorted(set(import_ranges)) if 0 <= i - 1 < len(lines)
+    ]
+    for i in sorted(set(import_ranges), reverse=True):
+        if 0 <= i - 1 < len(lines):
+            lines.pop(i - 1)
+
+    removed_before = len([i for i in import_ranges if i <= insertion_line - 1])
+    insertion_idx = max(0, insertion_line - 1 - removed_before)
+
+    new_lines: list[str] = []
     if shebang:
-        new_lines.append(shebang.rstrip("\n"))
-    new_lines.append(header.rstrip("\n"))
+        new_lines.append(shebang)
+    new_lines.extend(lines[:insertion_idx])
+    new_lines.append(IMPORT_LINE)
+    new_lines.extend(BANNER_LINES)
     new_lines.extend(imports)
-    new_lines.extend(remaining)
+    new_lines.extend(lines[insertion_idx:])
 
-    file_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    print(f"Updated {file_path}")
+    path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    print(f"Updated {path}")
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Inject privilege banner into multiple Python scripts"
-    )
+    parser = argparse.ArgumentParser(description="Inject privilege banner into files")
     parser.add_argument(
-        "file_list",
-        help="Text file containing newline separated file paths to process",
+        "--files", nargs="+", required=True, help="Python files to modify"
     )
     args = parser.parse_args()
-    file_list_path = Path(args.file_list)
-    if not file_list_path.exists():
-        print(f"List file not found: {file_list_path}")
-        return
-    for line in file_list_path.read_text(encoding="utf-8").splitlines():
-        path = Path(line.strip())
-        if path.suffix == "":
-            continue
-        inject_banner(path)
+
+    for file_path in args.files:
+        inject_banner(Path(file_path))
 
 
 if __name__ == "__main__":

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -7,27 +7,33 @@ from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
+# Check a Dockerfile for required SentientOS build packages.
+
 require_admin_banner()
 require_lumos_approval()
 
-REQUIRED_PACKAGES = ["build-essential", "libasound2", "python3.11"]
+REQUIRED = ["build-essential", "libasound2", "python3.11"]
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Verify Dockerfile contains required packages")
-    parser.add_argument("dockerfile", nargs="?", default="Dockerfile", help="Path to Dockerfile")
+    parser = argparse.ArgumentParser(
+        description="Verify required packages in Dockerfile"
+    )
+    parser.add_argument("--dockerfile", default="Dockerfile", help="Path to Dockerfile")
     args = parser.parse_args()
 
     path = Path(args.dockerfile)
     if not path.exists():
         print(f"Dockerfile not found: {path}")
         sys.exit(1)
+
     content = path.read_text(encoding="utf-8")
-    missing = [pkg for pkg in REQUIRED_PACKAGES if pkg not in content]
+    missing = [pkg for pkg in REQUIRED if pkg not in content]
     if missing:
         print("Missing packages: " + ", ".join(missing))
-        print("Consider adding them with apt-get install")
+        print("Hint: apt-get install " + " ".join(missing))
         sys.exit(1)
+
     sys.exit(0)
 
 

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -1,58 +1,58 @@
 from __future__ import annotations
-import argparse
 import re
 from pathlib import Path
-from typing import List, Tuple
 
-import sys
-sys.path.append(str(Path(__file__).resolve().parent.parent))
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
+# Generate a summary of known errors and how to resolve them.
+
 require_admin_banner()
 require_lumos_approval()
 
-RITUAL_DOC_LINK = "../RITUAL_FAILURES.md"
-AUDIT_DOC_LINK = "../AUDIT_LOG_FIXES.md"
+RITUAL_DOC = Path("RITUAL_FAILURES.md")
+AUDIT_DOC = Path("AUDIT_LOG_FIXES.md")
+OUTPUT = Path("docs/ERROR_RESOLUTION_SUMMARY.md")
+
+SCAR_RE = re.compile(r"^##\s*(.+)")
 
 
-ERROR_REGEX = re.compile(r"(?P<file>[\w/]+\.\w+).*?(mismatch|error|fail)", re.IGNORECASE)
-
-
-def parse_errors(content: str) -> List[Tuple[str, str]]:
-    results = []
-    for line in content.splitlines():
-        m = ERROR_REGEX.search(line)
+def parse_doc(path: Path) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    if not path.exists():
+        return entries
+    current_section = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = SCAR_RE.match(line)
         if m:
-            file = m.group('file')
-            if 'mismatch' in line:
-                err = 'prev hash mismatch'
-            else:
-                err = 'error'
-            results.append((file, err))
-    return results
+            current_section = m.group(1).strip()
+            continue
+        if "mismatch" in line.lower() or "deprecated" in line.lower():
+            entries.append((current_section or path.name, line.strip()))
+    return entries
+
+
+def build_table(rows: list[tuple[str, str]]) -> str:
+    header = [
+        "# Error Resolution Summary",
+        "",
+        "| Scar Location | Issue | Next Step |",
+        "|--------------|-------|-----------|",
+    ]
+    for loc, desc in rows:
+        if "deprecated" in desc.lower():
+            step = "See test_import_fixer for path update"
+        else:
+            step = "Legacy mismatch – no action"
+        header.append(f"| {loc} | {desc} | {step} |")
+    return "\n".join(header) + "\n"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate error resolution summary")
-    parser.add_argument("output", nargs="?", default="docs/ERROR_RESOLUTION_SUMMARY.md")
-    args = parser.parse_args()
-
-    entries = []
-    for doc in ["RITUAL_FAILURES.md", "AUDIT_LOG_FIXES.md"]:
-        path = Path(doc)
-        if path.exists():
-            entries.extend(parse_errors(path.read_text(encoding="utf-8")))
-
-    lines = ["# Error Resolution Summary", "", "| File/Test | Error | Command to Fix | Docs |", "|-----------|-------|---------------|------|"]
-    for file, err in entries:
-        cmd = f"python verify_audits.py {file}" if file.endswith('.jsonl') else "pytest"
-        doc_link = f"[{doc}](../{doc})" if (doc := 'RITUAL_FAILURES.md' if 'jsonl' in file else 'AUDIT_LOG_FIXES.md') else ''
-        lines.append(f"| {file} | {err} | {cmd} | {doc_link} |")
-
-    Path(args.output).write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"Wrote {args.output}")
+    rows = parse_doc(RITUAL_DOC) + parse_doc(AUDIT_DOC)
+    OUTPUT.write_text(build_table(rows), encoding="utf-8")
+    print(f"Wrote {OUTPUT}")
 
 
 if __name__ == "__main__":

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -9,82 +9,84 @@ from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
+# Assist in resolving missing test imports by editing failing tests.
+
 require_admin_banner()
 require_lumos_approval()
 
 __test__ = False
 
-ERROR_PATTERN = re.compile(r"ModuleNotFoundError: No module named '(?P<mod>[^']+)'")
+ERROR_RE = re.compile(r"(?:ModuleNotFoundError|ImportError):.*?'([^']+)'")
 
 
 def parse_missing_modules(log_path: Path) -> set[str]:
-    modules = set()
+    modules: set[str] = set()
     for line in log_path.read_text(encoding="utf-8").splitlines():
-        m = ERROR_PATTERN.search(line)
+        m = ERROR_RE.search(line)
         if m:
-            modules.add(m.group('mod'))
+            modules.add(m.group(1))
     return modules
 
 
-def find_tests_for_module(module: str) -> list[Path]:
-    tests = []
-    for path in Path('.').rglob('test_*.py'):
-        content = path.read_text(encoding='utf-8', errors='ignore')
-        if f"import {module}" in content or f"from {module} import" in content:
-            tests.append(path)
-    return tests
+def find_test_files(module: str) -> list[Path]:
+    results = []
+    for p in Path("tests").rglob("test_*.py"):
+        text = p.read_text(encoding="utf-8", errors="ignore")
+        if f"import {module}" in text or f"from {module} import" in text:
+            results.append(p)
+    return results
 
 
-def process_file(path: Path, module: str, replacement: str | None) -> str:
-    lines = path.read_text(encoding='utf-8').splitlines()
-    changed = False
+def patch_file(path: Path, module: str, replacement: str | None) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
     if replacement:
-        new_lines = []
-        for line in lines:
-            if line.lstrip().startswith(f"import {module}"):
-                new_lines.append(f"import {replacement}")
-                changed = True
-            elif line.lstrip().startswith(f"from {module} import"):
-                new_lines.append(line.replace(f"from {module} import", f"from {replacement} import"))
-                changed = True
-            else:
-                new_lines.append(line)
-        lines = new_lines
-    else:
-        skip_header = [
-            "import pytest",
-            f"pytest.skip('Module {module} missing; deprecated test — see RITUAL_FAILURES.md')",
+        updated = [
+            (
+                line.replace(f"import {module}", f"import {replacement}")
+                if line.lstrip().startswith(f"import {module}")
+                else (
+                    line.replace(f"from {module} import", f"from {replacement} import")
+                    if line.lstrip().startswith(f"from {module} import")
+                    else line
+                )
+            )
+            for line in lines
         ]
-        lines = skip_header + lines
-        changed = True
-    if changed:
-        path.write_text("\n".join(lines) + "\n", encoding='utf-8')
-    return "replaced" if replacement else "skipped"
+        action = "replaced"
+    else:
+        skip_lines = [
+            "import pytest",
+            f"pytest.skip(\"Missing module '{module}'; test deprecated — see RITUAL_FAILURES.md\")",
+        ]
+        updated = skip_lines + lines
+        action = "skipped"
+    path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+    return action
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Fix missing module imports in tests")
-    parser.add_argument("log_file", help="Pytest error log file")
+    parser = argparse.ArgumentParser(description="Fix missing imports in tests")
+    parser.add_argument("--log", required=True, help="Pytest error log file")
     args = parser.parse_args()
-    log_path = Path(args.log_file)
+
+    log_path = Path(args.log)
     if not log_path.exists():
         print(f"Log file not found: {log_path}")
         sys.exit(1)
 
     modules = parse_missing_modules(log_path)
-    summary = []
-    for mod in modules:
-        tests = find_tests_for_module(mod)
-        for test_file in tests:
-            print(f"Missing module '{mod}' found in {test_file}")
-            repl = input("Enter replacement import path or leave blank to skip test: ").strip()
-            action = process_file(test_file, mod, repl if repl else None)
+    summary: list[str] = []
+    for module in modules:
+        for test_file in find_test_files(module):
+            print(f"Missing module '{module}' in {test_file}")
+            repl = input("Replacement import path (leave blank to skip test): ").strip()
+            action = patch_file(test_file, module, repl or None)
             summary.append(f"{test_file}: {action}")
 
     if summary:
         print("\nSummary:")
-        for item in summary:
-            print(" -", item)
+        for entry in summary:
+            print(f" - {entry}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update banner_injector to insert privilege banner with `--files`
- update test_import_fixer with `--log` argument and safe test collection
- simplify audit_blesser invocation
- verify Dockerfile packages with optional `--dockerfile`
- generate ERROR_RESOLUTION_SUMMARY from docs
- restore sanctuary ritual docstrings

## Testing
- `pytest -m "not env"`
- `mypy --ignore-missing-imports .` *(fails: many errors)*
- `python privilege_lint.py` *(fails: requires interactive approval)*
- `python verify_audits.py logs/` *(fails: requires interactive approval)*
- `python check_connector_health.py` *(fails: requires interactive approval)*

------
https://chatgpt.com/codex/tasks/task_b_6844f188fbf883208fa677a054201165