### PR TITLE
Add ritual enforcer CLI

### DIFF
--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,24 +1,23 @@
+"""Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
 require_admin_banner()
 require_lumos_approval()
 
 import argparse
-import os
 import re
 import shutil
 from pathlib import Path
 from typing import Iterable, List
 
-DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
-IMPORT_LINE = (
-    "from admin_utils import require_admin_banner, require_lumos_approval"
-)
+DOCSTRING = "Sanctuary Privilege Banner: This script requires admin & Lumos approval."
+OLD_DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
+IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
 AUTO_APPROVE_IMPORT = "from scripts.auto_approve import prompt_yes_no"
-PROMPT_RE = re.compile(r"\binput\(")
+PROMPT_RE = re.compile(r"(?<!prompt_yes_no)\b(?:input|click\.confirm|prompt)\(")
+
+"""CLI tool to enforce privilege banners and migrate interactive prompts."""
 
 
 class FileReport:
@@ -42,39 +41,36 @@ def _has_banner(path: Path) -> bool:
 
 
 def _fix_banner(lines: List[str]) -> List[str]:
+    """Return file lines with the privilege banner inserted."""
     shebang = ""
     if lines and lines[0].startswith("#!"):
         shebang = lines.pop(0)
-    lines = [
+    # remove existing banners or related imports
+    cleaned = [
         l
         for l in lines
         if l.strip() not in {
             DOCSTRING,
+            OLD_DOCSTRING,
             "require_admin_banner()",
             "require_lumos_approval()",
             IMPORT_LINE,
         }
     ]
-    insert_idx = 0
-    for i, line in enumerate(lines):
-        if line.startswith("import ") or line.startswith("from ") or line.strip().startswith("\"\"\""):
-            break
-        if line.strip():
-            break
-        insert_idx = i + 1
     new_lines: List[str] = []
     if shebang:
         new_lines.append(shebang)
-    new_lines.extend(lines[:insert_idx])
+    # insert banner at the very top
+    new_lines.append(DOCSTRING)
     new_lines.append(IMPORT_LINE)
-    new_lines.append(DOCSTRING if DOCSTRING.startswith('"') else f'"{DOCSTRING}"')
     new_lines.append("require_admin_banner()")
     new_lines.append("require_lumos_approval()")
-    new_lines.extend(lines[insert_idx:])
+    new_lines.extend(cleaned)
     return new_lines
 
 
 def _replace_prompts(lines: List[str]) -> List[str]:
+    """Replace interactive prompts with ``prompt_yes_no``."""
     has_import = any(AUTO_APPROVE_IMPORT in l for l in lines)
     new_lines: List[str] = []
     changed = False
@@ -96,17 +92,21 @@ def _replace_prompts(lines: List[str]) -> List[str]:
 
 def process_file(path: Path, mode: str, backup_dir: Path | None) -> FileReport:
     report = FileReport(path)
-    lines = path.read_text(encoding="utf-8").splitlines()
-    original = lines[:]
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception as exc:
+        report.issues.append(f"read error: {exc}")
+        return report
 
     if not _has_banner(path):
-        report.issues.append("missing banner")
+        report.issues.append("missing banner at line 1")
         if mode == "fix":
             lines = _fix_banner(lines)
             report.modified = True
 
-    if any(PROMPT_RE.search(l) for l in lines):
-        report.issues.append("interactive prompt")
+    prompt_lines = [i + 1 for i, l in enumerate(lines) if PROMPT_RE.search(l)]
+    if prompt_lines:
+        report.issues.append("interactive prompts at lines " + ", ".join(map(str, prompt_lines)))
         if mode == "fix":
             lines = _replace_prompts(lines)
             report.modified = True
@@ -115,7 +115,8 @@ def process_file(path: Path, mode: str, backup_dir: Path | None) -> FileReport:
         if backup_dir:
             backup_dir.mkdir(parents=True, exist_ok=True)
             backup_path = backup_dir / f"{path.name}.bak"
-            shutil.copy2(path, backup_path)
+            if not backup_path.exists():
+                shutil.copy2(path, backup_path)
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     return report
@@ -125,7 +126,7 @@ def expand_files(patterns: Iterable[str]) -> List[Path]:
     files: List[Path] = []
     for pat in patterns:
         files.extend(Path().glob(pat))
-    return [p for p in files if p.is_file()]
+    return [p for p in files if p.is_file() and p.name != "__init__.py"]
 
 
 def main(argv: List[str] | None = None) -> int:
@@ -147,21 +148,27 @@ def main(argv: List[str] | None = None) -> int:
     parser.add_argument(
         "--backup-dir",
         type=Path,
+        default=Path("backups"),
         help="Directory for backups when fixing files",
     )
     args = parser.parse_args(argv)
 
     files = expand_files(args.files)
-    reports = [process_file(f, args.mode, args.backup_dir) for f in files]
+    backup_dir = args.backup_dir if args.mode == "fix" else None
+    reports = [process_file(f, args.mode, backup_dir) for f in files]
 
-    issues = sum(len(r.issues) > 0 for r in reports)
+    issue_count = sum(bool(r.issues) for r in reports)
     modified = sum(r.modified for r in reports)
 
-    print(f"Checked {len(files)} files, found {issues} with issues.")
-    if args.mode == "fix":
-        print(f"Modified {modified} files.")
+    for r in reports:
+        if r.issues and args.mode == "check":
+            print(f"{r.path}: {'; '.join(r.issues)}")
 
-    return 1 if issues and args.mode == "check" else 0
+    print(
+        f"Scanned {len(files)} files. Issues found: {issue_count}. Files fixed: {modified}."
+    )
+
+    return 0 if (args.mode == "fix" or issue_count == 0) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `scripts/ritual_enforcer.py` to enforce privilege banners and migrate prompts

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py` *(fails: missing privilege docstrings)*
- `pytest -m "not env"`
- `mypy --strict`
- `LUMOS_AUTO_APPROVE=1 python check_connector_health.py`


------
https://chatgpt.com/codex/tasks/task_b_6845a905c4c0832090286d2047650417