### PR TITLE
feat(docs,types): add MkDocs, enforce Mypy, update agent registry and contributing guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,10 @@ jobs:
       - name: Verify audits
         run: |
           LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
+      - name: Type check
+        run: mypy --strict
+      - name: Build Docs
+        run: python scripts/build_docs.py
+      - name: Deploy Docs (optional)
+        if: github.event_name == "push" && github.ref == "refs/heads/main"
+        run: mkdocs gh-deploy --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Agent Index
 - **Core Services**: FederationTrustProtocol, AgentSelfDefenseProtocol
-- **Audit & Ritual CLIs**: AuditImmutabilityVerifier, RitualCalendar, ArchiveBlessingCeremony
+- **Audit & Ritual CLIs**: AuditImmutabilityVerifier, RitualCalendar, ArchiveBlessingCeremony, RitualEnforcerCLI, AutoApproveHelper, AuditBlesserCLI, MemoryCLI, MemoryTail
 - **Daemons & Schedulers**: MigrationDaemon, AvatarFederationHeartbeatMonitor
 
 ### Table of Contents
@@ -1943,6 +1943,46 @@ No agent shall act in secret.
   Privileges: log, read
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/onboard_cli.jsonl
+```
+```
+- Name: RitualEnforcerCLI
+  Type: CLI
+  Roles: Banner Fixer, Prompt Migrator
+  Privileges: read, write
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/ritual_enforcer.jsonl
+```
+```
+- Name: AutoApproveHelper
+  Type: Helper
+  Roles: Interactive Prompt Override
+  Privileges: read
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/auto_approve.jsonl
+```
+```
+- Name: AuditBlesserCLI
+  Type: CLI
+  Roles: Audit Blesser
+  Privileges: log, write
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/audit_blesser.jsonl
+```
+```
+- Name: MemoryCLI
+  Type: CLI
+  Roles: Memory Manager, Analyzer
+  Privileges: read, write
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/memory_cli.jsonl
+```
+```
+- Name: MemoryTail
+  Type: CLI
+  Roles: Memory Tail Viewer
+  Privileges: read
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/memory_tail.jsonl
 ```
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,27 @@ External plug-ins and extensions interact with core audit logs. To contribute on
 - Include a module-level docstring describing its behavior and permissions.
 - Use the trust engine logging helpers; avoid direct file writes.
 - Document any external dependencies in your pull request.
+
+## Documentation & Types
+Run `python scripts/build_docs.py` to build the documentation site. Ensure `mypy --strict` runs without errors.
+
+### MkDocs preview
+Use `mkdocs serve` to preview docs locally.
+
+### CI Workflow
+CI also runs mypy and docs build along with tests:
+
+```yaml
+- name: Enforce privilege rituals
+  run: python scripts/ritual_enforcer.py --mode fix
+- name: Run tests
+  run: pytest -q
+- name: Privilege lint
+  run: LUMOS_AUTO_APPROVE=1 python privilege_lint.py
+- name: Verify audits
+  run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
+- name: Type check
+  run: mypy --strict
+- name: Build Docs
+  run: python scripts/build_docs.py
+```

--- a/audit_log/README.md
+++ b/audit_log/README.md
@@ -1,0 +1,5 @@
+# Audit Chain
+
+This directory documents the audit chain structure and how to inspect logs.
+
+All JSONL files in `logs/` form a cryptographically verified chain. Use `verify_audits.py` to confirm integrity.

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import argparse
 import os
 import json
@@ -8,6 +9,7 @@ from api import actuator
 import notification
 import self_patcher
 import final_approval
+import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
 import presence_analytics as pa
@@ -93,7 +95,7 @@ def show_goals(status: str) -> None:
             line += f" | {g['critique']}"
         print(line)
 
-def main():
+def main() -> None:
     require_admin_banner()
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import time
 import json
@@ -12,8 +13,7 @@ require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. 
 require_lumos_approval()
 
 init()
-
-COLOR_MAP = {
+COLOR_MAP: dict[str, str] = {
     "heartbeat": Fore.YELLOW,
     "openai/gpt-4o": Fore.GREEN,
     "mixtral": Fore.MAGENTA,
@@ -23,18 +23,21 @@ COLOR_MAP = {
 DEFAULT_FILE = get_log_path("memory.jsonl", "MEMORY_FILE")
 
 
-def detect_color(entry: dict) -> str:
+from typing import Any, Dict
+
+
+def detect_color(entry: dict[str, Any]) -> str:
     source = (entry.get("source") or "").lower()
     tags = [t.lower() for t in entry.get("tags", [])]
     if source in COLOR_MAP:
-        return COLOR_MAP[source]
+        return str(COLOR_MAP[source])
     for t in tags:
         if t in COLOR_MAP:
-            return COLOR_MAP[t]
-    return Fore.WHITE
+            return str(COLOR_MAP[t])
+    return str(Fore.WHITE)
 
 
-def dominant_emotion(entry: dict) -> str | None:
+def dominant_emotion(entry: dict[str, Any]) -> str | None:
     emotions = entry.get("emotions")
     if isinstance(emotions, dict) and emotions:
         emo, score = max(emotions.items(), key=lambda x: x[1])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: SentientOS
+nav:
+  - Home: README.md
+  - One Pager: one_pager.md
+  - Rituals: docs/rituals.md
+  - Audit Chain: audit_log/README.md
+  - Agents: AGENTS.md
+  - Error Resolution: docs/ERROR_RESOLUTION_GUIDE.md
+theme: readthedocs

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+exclude = tests
+files = reflection_stream.py, resonite_alliance_pact_engine.py, scripts/ritual_enforcer.py, scripts/auto_approve.py, scripts/audit_blesser.py, memory_cli.py, memory_tail.py
+follow_imports = skip
+
+[mypy-scripts.ritual_enforcer]
+ignore_missing_imports = False
+
+[mypy-scripts.auto_approve]
+ignore_missing_imports = False
+
+[mypy-scripts.audit_blesser]
+ignore_missing_imports = False
+
+[mypy-memory_cli]
+ignore_missing_imports = False
+
+[mypy-memory_tail]
+ignore_missing_imports = False

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+
+def main(argv: list[str] | None = None) -> int:
+    config = Path("mkdocs.yml")
+    if not config.exists():
+        print("mkdocs.yml not found", file=sys.stderr)
+        return 1
+    result = subprocess.run(["mkdocs", "build", "--clean"], capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return result.returncode
+    site_dir = Path("site")
+    pages = sorted(p.relative_to(site_dir) for p in site_dir.rglob("*.html"))
+    print(f"Generated {len(pages)} pages:")
+    for p in pages:
+        print(f"- {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- establish MkDocs site config and docs builder
- enforce strict type checking for new utilities via mypy.ini
- register new CLI agents
- document doc build and mypy workflow
- extend CI for type checks and docs build

## Testing
- `pytest -q`
- `mypy --strict`
- `LUMOS_AUTO_APPROVE=1 python scripts/build_docs.py`

------
https://chatgpt.com/codex/tasks/task_b_6845db3c69f88320bfa66ed9f212519e