### PR TITLE
Fix banner lint issues and mypy

### DIFF
--- a/memory_cli.py
+++ b/memory_cli.py
@@ -4,6 +4,7 @@ import os
 import json
 import re
 from pathlib import Path
+from typing import Any
 import memory_manager as mm
 from api import actuator
 import notification
@@ -83,7 +84,7 @@ def list_memory(limit: int, since: str | None) -> None:
         except Exception:
             pass
     files = sorted(mm.RAW_PATH.glob("*.json"))
-    entries: list[tuple[str, dict]] = []
+    entries: list[tuple[str, dict[str, Any]]] = []
     for fp in files:
         try:
             data = json.loads(fp.read_text(encoding="utf-8"))

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -9,16 +9,10 @@ from scripts.auto_approve import prompt_yes_no
 import argparse
 import os
 
-"""Automatically bless audit mismatches found during verification."""
-
-# Automatically bless audit mismatches found during verification.
-
-# Automatically bless audit mismatches found during verification.
-
-# Automatically bless audit mismatches found during verification.
-
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+# Automatically bless audit mismatches found during verification.
 
 BLESSINGS_FILE = Path("SANCTUARY_BLESSINGS.jsonl")
 

--- a/scripts/auto_model_switcher.py
+++ b/scripts/auto_model_switcher.py
@@ -10,10 +10,9 @@ import yaml
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-# Switch models based on remaining quotas and configured fallbacks.
-
 require_admin_banner()
 require_lumos_approval()
+# Switch models based on remaining quotas and configured fallbacks.
 
 USAGE_FILE = Path("usage_monitor.jsonl")
 OUTPUT_FILE = Path("current_model.json")

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -6,16 +6,10 @@ from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""CLI tool to inject the SentientOS privilege banner into Python files."""
-
-# CLI tool to inject the SentientOS privilege banner into Python files.
-
-# CLI tool to inject the SentientOS privilege banner into Python files.
-
-# CLI tool to inject the SentientOS privilege banner into Python files.
-
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+# CLI tool to inject the SentientOS privilege banner into Python files.
 
 BANNER_LINES = [
     '"""Privilege Banner: This script requires admin and Lumos approval."""',

--- a/scripts/ci_self_check.py
+++ b/scripts/ci_self_check.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Run privileged CI self checks."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 import os
 import subprocess
 import sys
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 
 
 FILES_TO_TYPECHECK = [

--- a/scripts/daily_report_generator.py
+++ b/scripts/daily_report_generator.py
@@ -14,10 +14,9 @@ from email.message import EmailMessage
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-# Generate daily usage summaries and optionally email them.
-
 require_admin_banner()
 require_lumos_approval()
+# Generate daily usage summaries and optionally email them.
 
 
 def load_usage(path: Path, since: datetime) -> Dict[str, List[dict]]:

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -5,16 +5,10 @@ from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Check a Dockerfile for required SentientOS build packages."""
-
-# Check a Dockerfile for required SentientOS build packages.
-
-# Check a Dockerfile for required SentientOS build packages.
-
-# Check a Dockerfile for required SentientOS build packages.
-
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+# Check a Dockerfile for required SentientOS build packages.
 
 REQUIRED = ["build-essential", "libasound2", "python3.11"]
 

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -4,16 +4,10 @@ from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Generate a summary of known errors and how to resolve them."""
-
-# Generate a summary of known errors and how to resolve them.
-
-# Generate a summary of known errors and how to resolve them.
-
-# Generate a summary of known errors and how to resolve them.
-
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+# Generate a summary of known errors and how to resolve them.
 
 RITUAL_DOC = Path("RITUAL_FAILURES.md")
 AUDIT_DOC = Path("AUDIT_LOG_FIXES.md")

--- a/scripts/quota_alert.py
+++ b/scripts/quota_alert.py
@@ -11,10 +11,9 @@ import requests
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-# Send Slack alerts when model quotas run low.
-
 require_admin_banner()
 require_lumos_approval()
+# Send Slack alerts when model quotas run low.
 
 USAGE_FILE = Path("usage_monitor.jsonl")
 

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Summarize token usage and post to Slack."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import collections
 import datetime as dt
@@ -12,6 +12,11 @@ from pathlib import Path
 import requests
 
 from scripts.auto_approve import prompt_yes_no
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+# Summarize token usage and post to Slack.
 
 
 LOG_FILE = Path("logs/usage.jsonl")

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
-"""Automate release version bumping and tagging."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+# Automate release version bumping and tagging.
 import argparse
 import datetime as dt
 import os
@@ -21,7 +26,7 @@ CHANGELOG = Path("docs/CHANGELOG.md")
 def read_version() -> str:
     if PYPROJECT.exists():
         data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
-        return data["project"]["version"]
+        return str(data["project"]["version"])
     raise FileNotFoundError("pyproject.toml not found")
 
 

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,7 +1,7 @@
-"""Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
 

--- a/scripts/streamlit_dashboard.py
+++ b/scripts/streamlit_dashboard.py
@@ -11,10 +11,9 @@ import streamlit as st
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-# Streamlit dashboard for SentientOS usage and audit metrics.
-
 require_admin_banner()
 require_lumos_approval()
+# Streamlit dashboard for SentientOS usage and audit metrics.
 
 USAGE_FILE = Path("usage_data.json")
 AUDIT_LOG_DIR = Path("audit_logs")

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -7,16 +7,10 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Assist in resolving missing test imports by editing failing tests."""
-
-# Assist in resolving missing test imports by editing failing tests.
-
-# Assist in resolving missing test imports by editing failing tests.
-
-# Assist in resolving missing test imports by editing failing tests.
-
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+# Assist in resolving missing test imports by editing failing tests.
 
 __test__ = False
 

--- a/scripts/usage_monitor.py
+++ b/scripts/usage_monitor.py
@@ -13,10 +13,9 @@ import requests
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-# Monitor OpenAI model usage and log remaining quotas.
-
 require_admin_banner()
 require_lumos_approval()
+# Monitor OpenAI model usage and log remaining quotas.
 
 MODELS = ["o3", "o4-mini", "o4-mini-high", "GPT-4.1"]
 API_URL = "https://api.openai.com/dashboard/billing/usage"

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,5 +1,10 @@
+from admin_utils import require_admin_banner, require_lumos_approval
 import os
 import sys
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- add missing typing info in `memory_cli.py`
- reorder privilege banner calls for various scripts
- adjust tests to include privilege banner
- clean up release manager script and cast version to str

## Testing
- `mypy --strict memory_cli.py`
- `mypy --strict scripts/release_manager.py scripts/quota_reporter.py`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py | tail -n 20`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ | tail -n 20` *(fails: prev hash mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_6845ebcda5448320a4b06b3960ea1fdb