### PR TITLE
Refactor banner constants

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import re
 from pathlib import Path
+from sentient_banner import BANNER_LINES
 try:
     from admin_utils import require_admin_banner, require_lumos_approval
 except Exception:  # pragma: no cover - fallback for lint

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -5,18 +5,12 @@ import shutil
 from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
+from sentient_banner import BANNER_LINES
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
 # CLI tool to inject the SentientOS privilege banner into Python files.
-
-BANNER_LINES = [
-    '"""Privilege Banner: This script requires admin and Lumos approval."""',
-    "require_admin_banner()",
-    "require_lumos_approval()",
-    "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
-]
 
 IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
 

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+from sentient_banner import BANNER_LINES
 
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()

--- a/sentient_banner.py
+++ b/sentient_banner.py
@@ -27,12 +27,19 @@ BANNER = (
 
 import admin_utils
 from datetime import datetime
-import presence_ledger as pl
 import json
+
+BANNER_LINES = [
+    '"""Privilege Banner: requires admin & Lumos approval."""',
+    "require_admin_banner()",
+    "require_lumos_approval()",
+    "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
+]
 
 
 def print_banner() -> None:
     """Print the entry banner, privilege status, and recent attempts."""
+    import presence_ledger as pl
     print(ENTRY_BANNER)
     print(SANCTUARY_BANNER)
     status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"
@@ -46,6 +53,7 @@ def print_banner() -> None:
 def streamlit_banner(st_module) -> None:
     """Display the entry and sanctuary banners using a Streamlit module if available."""
     if hasattr(st_module, "markdown"):
+        import presence_ledger as pl
         st_module.markdown(ENTRY_BANNER)
         st_module.markdown(SANCTUARY_BANNER)
         status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"


### PR DESCRIPTION
## Summary
- add shared `BANNER_LINES` constant in `sentient_banner.py`
- import `BANNER_LINES` in banner tooling scripts

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py` *(fails: missing privilege docstrings)*
- `pytest -m "not env"` *(fails: missing dependencies)*
- `mypy` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_b_68462436d2e483208ed88dff03e379f0