### PR TITLE
Centralize privilege banner lines

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 try:
     from admin_utils import require_admin_banner, require_lumos_approval
+    from sentient_banner import BANNER_LINES
 except Exception:  # pragma: no cover - fallback for lint
     def require_admin_banner() -> None:
         """Fallback when admin_utils cannot be imported during lint."""
@@ -15,6 +16,12 @@ except Exception:  # pragma: no cover - fallback for lint
     def require_lumos_approval() -> None:
         """Fallback when admin_utils cannot be imported during lint."""
         pass
+    BANNER_LINES = [
+        '"""Privilege Banner: requires admin & Lumos approval."""',
+        "require_admin_banner()",
+        "require_lumos_approval()",
+        "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
+    ]
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 
@@ -27,7 +34,7 @@ the ``PRIVILEGED_AUDIT_FILE`` environment variable. See
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
-DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
+DOCSTRING = BANNER_LINES[0].strip('"')
 
 ENTRY_PATTERNS = [
     "*_cli.py",

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,15 +1,15 @@
+from admin_utils import require_admin_banner, require_lumos_approval
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import argparse
 import json
 import os
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
-
 import attestation
 import relationship_log as rl
+
 
 
 def cmd_attest(args) -> None:

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -5,18 +5,14 @@ import shutil
 from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
+from sentient_banner import BANNER_LINES
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
 # CLI tool to inject the SentientOS privilege banner into Python files.
 
-BANNER_LINES = [
-    '"""Privilege Banner: This script requires admin and Lumos approval."""',
-    "require_admin_banner()",
-    "require_lumos_approval()",
-    "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
-]
+
 
 IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
 

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+from sentient_banner import BANNER_LINES
 
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
@@ -11,13 +12,9 @@ import shutil
 from pathlib import Path
 from typing import Iterable, List
 
-DOCSTRING = "Privilege Banner: requires admin & Lumos approval."
+DOCSTRING = BANNER_LINES[0].strip('"')
 OLD_DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
-HEADER_LINES = [
-    f'"""{DOCSTRING}"""',
-    "require_admin_banner()",
-    "require_lumos_approval()",
-]
+HEADER_LINES = [BANNER_LINES[0], BANNER_LINES[1], BANNER_LINES[2]]
 IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
 AUTO_APPROVE_IMPORT = "from scripts.auto_approve import prompt_yes_no"
 PROMPT_RE = re.compile(r"(?<!prompt_yes_no)\b(?:input|click\.confirm|prompt)\(")

--- a/sentient_banner.py
+++ b/sentient_banner.py
@@ -25,9 +25,18 @@ BANNER = (
     "Every supporter, every federated peer, every blessing—immortal, append-only, and open."
 )
 
+# ---------------------------------------------------------------------------
+# Centralized privilege banner lines used at the top of every entrypoint.
+# ---------------------------------------------------------------------------
+BANNER_LINES = [
+    '"""Privilege Banner: requires admin & Lumos approval."""',
+    "require_admin_banner()",
+    "require_lumos_approval()",
+    "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
+]
+
 import admin_utils
 from datetime import datetime
-import presence_ledger as pl
 import json
 
 
@@ -37,6 +46,7 @@ def print_banner() -> None:
     print(SANCTUARY_BANNER)
     status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"
     print(f"Sanctuary Privilege Status: [{status}]")
+    import presence_ledger as pl
     attempts = pl.recent_privilege_attempts(3)
     if attempts:
         print("Recent privilege attempts:")
@@ -50,6 +60,7 @@ def streamlit_banner(st_module) -> None:
         st_module.markdown(SANCTUARY_BANNER)
         status = "🛡️ Privileged" if admin_utils.is_admin() else "⚠️ Not Privileged"
         st_module.markdown(f"**Privilege Status:** {status}")
+        import presence_ledger as pl
         attempts = pl.recent_privilege_attempts(3)
         if attempts:
             st_module.markdown("Recent privilege attempts:")

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,13 +1,13 @@
+from admin_utils import require_admin_banner, require_lumos_approval
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import argparse
 import json
 import support_log as sl
 import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 
 
 def main() -> None:

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,15 +1,16 @@
+from admin_utils import require_admin_banner, require_lumos_approval
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import argparse
 import json
 from pprint import pprint
 import support_log as sl
-from admin_utils import require_admin_banner, require_lumos_approval
-
 import trust_engine as te
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
+
 
 
 def cmd_log(args) -> None:


### PR DESCRIPTION
## Summary
- define `BANNER_LINES` in `sentient_banner.py`
- import the new banner constant in `banner_injector`, `ritual_enforcer`, and `privilege_lint`
- run banner injector on a few CLIs

## Testing
- `pip install colorama requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684629d59b208320966ce63a1048b5b4