### PR TITLE
feat(banner): centralize BANNER_LINES constant

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -19,13 +19,6 @@ except Exception:  # pragma: no cover - fallback for lint
         """Fallback when admin_utils cannot be imported during lint."""
         pass
 
-    # Local fallback banner lines (if import fails)
-    BANNER_LINES = [
-        '"""Privilege Banner: requires admin & Lumos approval."""',
-        "require_admin_banner()",
-        "require_lumos_approval()",
-        "# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.",
-    ]
 
 
 """Lint entrypoints for the Sanctuary privilege ritual.

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
 from sentient_banner import BANNER_LINES
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
 # CLI tool to inject the SentientOS privilege banner into Python files.


### PR DESCRIPTION
## Summary
- centralize banner definition for banner injector
- drop fallback constant from privilege lint

## Testing
- `python scripts/ritual_enforcer.py --mode check --files scripts/banner_injector.py scripts/ritual_enforcer.py privilege_lint.py` *(fails: missing banner at line 1)*

------
https://chatgpt.com/codex/tasks/task_b_68463dc1d1bc832095148655272ab596