### PR TITLE
feat(lint): add repo-wide scan & --fix autofix to privilege_lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   hooks:
   - id: privilege-lint
     name: privilege lint
-    entry: python privilege_lint.py
+    entry: python privilege_lint.py --quiet
     language: system
     pass_filenames: false
   - id: audit-verify

--- a/README_dev.md
+++ b/README_dev.md
@@ -17,9 +17,24 @@ Canonical banner:
 #                 |___/         |___/ 
 ```
 
-Run the linter before committing:
+Run the linter before committing. With no arguments it scans the repository root.
+Use `--fix` to rewrite files in-place and `--quiet` for pre-commit hooks:
 
 ```bash
-python privilege_lint.py
+python privilege_lint.py           # scan repo
+python privilege_lint.py src/      # scan a directory
+python privilege_lint.py --fix src/    # rewrite issues
+```
+
+Sample `.pre-commit-config.yaml` hook:
+
+```yaml
+repos:
+- repo: local
+  hooks:
+  - id: privilege-lint
+    entry: python privilege_lint.py --quiet
+    language: system
+    pass_filenames: false
 ```
 

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -12,7 +12,8 @@ def test_good_order(tmp_path: Path) -> None:
         'import os',
     ])
     path.write_text(content, encoding="utf-8")
-    assert pl.check_file(path) == []
+    linter = pl.PrivilegeLinter()
+    assert linter.validate(path) == []
 
 
 def test_missing_docstring(tmp_path: Path) -> None:
@@ -22,7 +23,8 @@ def test_missing_docstring(tmp_path: Path) -> None:
         'import os',
     ])
     path.write_text(content, encoding="utf-8")
-    assert pl.check_file(path) == []
+    linter = pl.PrivilegeLinter()
+    assert linter.validate(path) == []
 
 
 def test_bad_future_position(tmp_path: Path) -> None:
@@ -33,5 +35,6 @@ def test_bad_future_position(tmp_path: Path) -> None:
         'import os',
     ])
     path.write_text(content, encoding="utf-8")
-    issues = pl.check_file(path)
+    linter = pl.PrivilegeLinter()
+    issues = linter.validate(path)
     assert any("Banner and __future__ import" in i for i in issues)

--- a/tests/test_privilege_lint_autofix.py
+++ b/tests/test_privilege_lint_autofix.py
@@ -1,0 +1,34 @@
+import os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+
+
+def test_autofix_inserts_banner(tmp_path: Path) -> None:
+    file = tmp_path / "tool.py"
+    file.write_text(f"{pl.FUTURE_IMPORT}\n'\"doc\"'\n", encoding="utf-8")
+    linter = pl.PrivilegeLinter()
+    linter.apply_fix(file)
+    lines = file.read_text().splitlines()
+    assert lines[0] == pl.BANNER_ASCII[0]
+
+
+def test_autofix_moves_future(tmp_path: Path) -> None:
+    file = tmp_path / "tool.py"
+    content = "\n".join(pl.BANNER_ASCII + ['"doc"', pl.FUTURE_IMPORT, 'import os'])
+    file.write_text(content, encoding="utf-8")
+    linter = pl.PrivilegeLinter()
+    linter.apply_fix(file)
+    lines = file.read_text().splitlines()
+    assert lines[len(pl.BANNER_ASCII)] == pl.FUTURE_IMPORT
+
+
+def test_directory_scan(tmp_path: Path) -> None:
+    sub = tmp_path / "pkg"
+    sub.mkdir()
+    f = sub / "bad.py"
+    f.write_text("import os\n'\"doc\"'\n", encoding="utf-8")
+    rc = pl.main([str(tmp_path), "--quiet"])
+    assert rc == 1


### PR DESCRIPTION
## Summary
- extend `privilege_lint.py` with recursive directory scanning
- add `--fix` and `--quiet` flags
- implement `PrivilegeLinter` class with `apply_fix`
- update pre-commit config to run lint quietly
- document new behaviour and hook setup
- add tests for autofix features

## Testing
- `pytest -m "not env" -q`

------
https://chatgpt.com/codex/tasks/task_b_6846e73bae7c832081bb4d82c526a8e4