### PR TITLE
feat(lint): parallel runner, type-hint enforcement & shebang autofix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint Benchmark
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - name: Lint runtime check
+        run: |
+          python - <<'PY'
+import time, subprocess, sys
+start = time.time()
+subprocess.run([sys.executable, '-m', 'privilege_lint'], check=True)
+elapsed = time.time() - start
+print(f"lint runtime: {elapsed:.2f}s")
+if elapsed > 3:
+    raise SystemExit('Linter too slow')
+PY

--- a/README_dev.md
+++ b/README_dev.md
@@ -49,8 +49,21 @@ enforce_banner = true
 enforce_import_sort = true
 banner_file = "BANNER_ASCII.txt"
 fix_overwrite = false
+enforce_type_hints = true
+exclude_private = true
+fail_on_missing_return = true
+[lint.shebang]
+require = true
+fix_mode = true
 ```
 
 When `fix_overwrite` is `false`, running `python privilege_lint.py --fix` writes
 changes to `file.py.fixed` instead of overwriting the original.
+
+The linter scans files in parallel using a thread pool. On repositories of around
+1k files the run time should remain under two seconds. Use `--max-workers` to
+override the automatic worker count.
+
+Executable scripts must start with `#!/usr/bin/env python3` when shebang checks
+are enabled. Autofix mode can also set executable bits if `fix_mode` is true.
 

--- a/privilege_lint.toml.example
+++ b/privilege_lint.toml.example
@@ -3,3 +3,9 @@ enforce_banner = true
 enforce_import_sort = true
 banner_file = "BANNER_ASCII.txt"
 fix_overwrite = false # true = in-place, false = .fixed copy
+enforce_type_hints = true
+exclude_private = true # ignore names starting '_'
+fail_on_missing_return = true
+[lint.shebang]
+require = true
+fix_mode = true # auto-chmod +x

--- a/privilege_lint/config.py
+++ b/privilege_lint/config.py
@@ -12,6 +12,11 @@ class LintConfig:
     enforce_import_sort: bool = False
     banner_file: str | None = None
     fix_overwrite: bool = True
+    enforce_type_hints: bool = False
+    exclude_private: bool = True
+    fail_on_missing_return: bool = True
+    shebang_require: bool = False
+    shebang_fix_mode: bool = False
 
 
 _DEFAULT = LintConfig()
@@ -32,10 +37,16 @@ def load_config(start: Path | None = None) -> LintConfig:
             cfg_path = folder / name
             if cfg_path.exists():
                 data = _load_file(cfg_path).get("lint", {})
+                shebang = data.get("shebang", {})
                 return LintConfig(
                     enforce_banner=bool(data.get("enforce_banner", _DEFAULT.enforce_banner)),
                     enforce_import_sort=bool(data.get("enforce_import_sort", _DEFAULT.enforce_import_sort)),
                     banner_file=data.get("banner_file", _DEFAULT.banner_file),
                     fix_overwrite=bool(data.get("fix_overwrite", _DEFAULT.fix_overwrite)),
+                    enforce_type_hints=bool(data.get("enforce_type_hints", _DEFAULT.enforce_type_hints)),
+                    exclude_private=bool(data.get("exclude_private", _DEFAULT.exclude_private)),
+                    fail_on_missing_return=bool(data.get("fail_on_missing_return", _DEFAULT.fail_on_missing_return)),
+                    shebang_require=bool(shebang.get("require", _DEFAULT.shebang_require)),
+                    shebang_fix_mode=bool(shebang.get("fix_mode", _DEFAULT.shebang_fix_mode)),
                 )
     return _DEFAULT

--- a/privilege_lint/runner.py
+++ b/privilege_lint/runner.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from multiprocessing import cpu_count
+from pathlib import Path
+from typing import Sequence, Iterable
+
+
+DEFAULT_WORKERS = max(cpu_count() - 1, 1)
+
+
+def parallel_validate(linter: "PrivilegeLinter", files: Sequence[Path], max_workers: int | None = None) -> list[str]:
+    """Validate files in parallel using threads."""
+    workers = max_workers if max_workers is not None else DEFAULT_WORKERS
+    issues: list[str] = []
+    with ThreadPoolExecutor(max_workers=workers) as exe:
+        futures = {exe.submit(linter.validate, f): f for f in files}
+        for fut in as_completed(futures):
+            issues.extend(fut.result())
+    return issues

--- a/privilege_lint/shebang_rules.py
+++ b/privilege_lint/shebang_rules.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+SHEBANG = "#!/usr/bin/env python3"
+
+
+def validate_shebang(path: Path, require: bool) -> list[str]:
+    """Ensure executable scripts have the correct shebang."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_shebang = bool(lines) and lines[0].startswith("#!")
+    is_exec = os.access(path, os.X_OK)
+    errors: list[str] = []
+    if is_exec or has_shebang:
+        if not has_shebang or lines[0].strip() != SHEBANG:
+            if require:
+                errors.append(f"{path}: invalid shebang")
+        if require and not is_exec:
+            errors.append(f"{path}: not executable")
+    return errors
+
+
+def apply_fix(path: Path, fix_mode: bool) -> bool:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    changed = False
+    if not lines or lines[0].strip() != SHEBANG:
+        lines.insert(0, SHEBANG)
+        changed = True
+    if changed:
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    if fix_mode:
+        mode = path.stat().st_mode
+        if not (mode & 0o111):
+            path.chmod(mode | 0o755)
+    return changed

--- a/privilege_lint/typehint_rules.py
+++ b/privilege_lint/typehint_rules.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _func_has_hints(fn: ast.FunctionDef, fail_on_missing_return: bool) -> bool:
+    for arg in list(fn.args.args) + list(fn.args.kwonlyargs):
+        if arg.annotation is None:
+            return False
+    if fn.args.vararg and fn.args.vararg.annotation is None:
+        return False
+    if fn.args.kwarg and fn.args.kwarg.annotation is None:
+        return False
+    if fail_on_missing_return and fn.returns is None:
+        return False
+    return True
+
+
+def validate_type_hints(
+    lines: list[str],
+    path: Path,
+    *,
+    exclude_private: bool,
+    fail_on_missing_return: bool,
+) -> list[str]:
+    """Return type hint coverage issues for a file."""
+    issues: list[str] = []
+    try:
+        tree = ast.parse("\n".join(lines))
+    except SyntaxError:
+        return issues
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            if exclude_private and node.name.startswith("_"):
+                continue
+            if not _func_has_hints(node, fail_on_missing_return):
+                issues.append(f"{path}:{node.lineno} missing type hints in {node.name}")
+        elif isinstance(node, ast.ClassDef):
+            if exclude_private and node.name.startswith("_"):
+                continue
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef):
+                    if exclude_private and item.name.startswith("_"):
+                        continue
+                    if not _func_has_hints(item, fail_on_missing_return):
+                        issues.append(
+                            f"{path}:{item.lineno} missing type hints in {node.name}.{item.name}"
+                        )
+    return issues

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+
+from privilege_lint import PrivilegeLinter, iter_py_files
+from privilege_lint.runner import parallel_validate
+
+
+def main(path: str = ".") -> None:
+    files = iter_py_files([path])
+    linter = PrivilegeLinter()
+    start = time.time()
+    parallel_validate(linter, files)
+    dur = time.time() - start
+    print(f"Linted {len(files)} files in {dur:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parallel_runner.py
+++ b/tests/test_parallel_runner.py
@@ -1,0 +1,21 @@
+import os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+from privilege_lint.runner import parallel_validate
+
+
+def test_parallel_matches_serial(tmp_path: Path) -> None:
+    paths = []
+    for i in range(20):
+        p = tmp_path / f"f{i}.py"
+        p.write_text("\n".join(pl.BANNER_ASCII + [pl.FUTURE_IMPORT, 'import os']), encoding="utf-8")
+        paths.append(p)
+    linter = pl.PrivilegeLinter()
+    serial: list[str] = []
+    for f in paths:
+        serial.extend(linter.validate(f))
+    parallel = parallel_validate(linter, paths, max_workers=4)
+    assert sorted(serial) == sorted(parallel)

--- a/tests/test_shebang.py
+++ b/tests/test_shebang.py
@@ -1,0 +1,30 @@
+import os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+from privilege_lint.shebang_rules import SHEBANG
+
+
+def test_shebang_autofix(tmp_path: Path) -> None:
+    file = tmp_path / "tool.py"
+    file.write_text(f"{pl.FUTURE_IMPORT}\n", encoding="utf-8")
+    file.chmod(0o644)
+    cfg = pl.LintConfig(shebang_require=True, shebang_fix_mode=True)
+    linter = pl.PrivilegeLinter(cfg)
+    linter.apply_fix(file)
+    lines = file.read_text().splitlines()
+    assert lines[0] == SHEBANG
+    assert os.access(file, os.X_OK)
+
+
+def test_shebang_validate(tmp_path: Path) -> None:
+    file = tmp_path / "tool.py"
+    file.write_text(f"{pl.FUTURE_IMPORT}\n", encoding="utf-8")
+    file.chmod(0o755)
+    cfg = pl.LintConfig(shebang_require=True)
+    linter = pl.PrivilegeLinter(cfg)
+    issues = linter.validate(file)
+    assert any("invalid shebang" in i for i in issues)
+

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -1,0 +1,27 @@
+import os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+
+
+def _mk_file(tmp_path: Path, text: str) -> Path:
+    file = tmp_path / "mod.py"
+    file.write_text("\n".join(pl.BANNER_ASCII + [pl.FUTURE_IMPORT, text]), encoding="utf-8")
+    return file
+
+
+def test_type_hint_violation(tmp_path: Path) -> None:
+    cfg = pl.LintConfig(enforce_type_hints=True)
+    linter = pl.PrivilegeLinter(cfg)
+    path = _mk_file(tmp_path, "def foo(x): return x")
+    issues = linter.validate(path)
+    assert any("missing type hints" in i for i in issues)
+
+
+def test_type_hint_ok(tmp_path: Path) -> None:
+    cfg = pl.LintConfig(enforce_type_hints=True)
+    linter = pl.PrivilegeLinter(cfg)
+    path = _mk_file(tmp_path, "def foo(x: int) -> int: return x")
+    assert linter.validate(path) == []


### PR DESCRIPTION
## Summary
- add configurable linter options for type hints and shebangs
- support parallel validation with `runner.parallel_validate`
- implement shebang and type-hint rules
- expose new CLI flags and update example config and docs
- create benchmark script and CI lint runtime check
- add unit tests for new behaviour

## Testing
- `pip install -q pyyaml colorama requests`
- `pytest tests/test_type_hints.py tests/test_shebang.py tests/test_parallel_runner.py tests/test_privilege_lint.py tests/test_privilege_lint_autofix.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846f1ccc4708320ae95dad509494de2