### PR TITLE
Add docstring, cache, and license header lint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ audio_logs/*
 backups/
 logs/*.jsonl
 site/
+.privilege_lint.cache

--- a/README_dev.md
+++ b/README_dev.md
@@ -64,6 +64,17 @@ The linter scans files in parallel using a thread pool. On repositories of aroun
 1k files the run time should remain under two seconds. Use `--max-workers` to
 override the automatic worker count.
 
+### Docstring & License Rules
+Set `[lint.docstrings]` in the config to enforce Google or NumPy style docstrings on
+all public objects. When `insert_stub` is true, `--fix` inserts `"TODO:"` stubs for
+missing docstrings.
+
+`license_header` ensures a SPDX identifier or custom header appears near the top of
+each file.
+
+Runs automatically cache lint results in `.privilege_lint.cache`. Disable with
+`--no-cache`.
+
 Executable scripts must start with `#!/usr/bin/env python3` when shebang checks
 are enabled. Autofix mode can also set executable bits if `fix_mode` is true.
 

--- a/privilege_lint.toml.example
+++ b/privilege_lint.toml.example
@@ -6,6 +6,13 @@ fix_overwrite = false # true = in-place, false = .fixed copy
 enforce_type_hints = true
 exclude_private = true # ignore names starting '_'
 fail_on_missing_return = true
+license_header = "# SPDX-License-Identifier: MIT"
+cache = true
+
+[lint.docstrings]
+enforce = true
+style = "google" # or "numpy"
+insert_stub = true # auto-insert "TODO:" stub on --fix
 [lint.shebang]
 require = true
 fix_mode = true # auto-chmod +x

--- a/privilege_lint/cache.py
+++ b/privilege_lint/cache.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from dataclasses import asdict
+
+from privilege_lint.config import LintConfig
+
+CACHE_NAME = ".privilege_lint.cache"
+
+
+def _cfg_hash(cfg: LintConfig) -> str:
+    return hashlib.sha1(json.dumps(asdict(cfg), sort_keys=True).encode()).hexdigest()
+
+
+class LintCache:
+    def __init__(self, root: Path, cfg: LintConfig, enabled: bool = True) -> None:
+        self.root = root
+        self.enabled = enabled
+        self.cfg_hash = _cfg_hash(cfg)
+        self.path = root / CACHE_NAME
+        self.data: dict[str, dict] = {}
+        if enabled and self.path.exists():
+            try:
+                self.data = json.loads(self.path.read_text())
+            except Exception:
+                self.data = {}
+
+    def is_valid(self, path: Path) -> bool:
+        if not self.enabled:
+            return False
+        info = self.data.get(str(path))
+        if not info or info.get("cfg") != self.cfg_hash:
+            return False
+        stat = path.stat()
+        return info.get("mtime") == stat.st_mtime and info.get("size") == stat.st_size
+
+    def update(self, path: Path) -> None:
+        if not self.enabled:
+            return
+        stat = path.stat()
+        self.data[str(path)] = {"mtime": stat.st_mtime, "size": stat.st_size, "cfg": self.cfg_hash}
+
+    def save(self) -> None:
+        if self.enabled:
+            self.path.write_text(json.dumps(self.data, indent=2))

--- a/privilege_lint/config.py
+++ b/privilege_lint/config.py
@@ -17,6 +17,11 @@ class LintConfig:
     fail_on_missing_return: bool = True
     shebang_require: bool = False
     shebang_fix_mode: bool = False
+    docstrings_enforce: bool = False
+    docstring_style: str = "google"
+    docstring_insert_stub: bool = False
+    license_header: str | None = None
+    cache: bool = True
 
 
 _DEFAULT = LintConfig()
@@ -38,6 +43,7 @@ def load_config(start: Path | None = None) -> LintConfig:
             if cfg_path.exists():
                 data = _load_file(cfg_path).get("lint", {})
                 shebang = data.get("shebang", {})
+                docs = data.get("docstrings", {})
                 return LintConfig(
                     enforce_banner=bool(data.get("enforce_banner", _DEFAULT.enforce_banner)),
                     enforce_import_sort=bool(data.get("enforce_import_sort", _DEFAULT.enforce_import_sort)),
@@ -48,5 +54,10 @@ def load_config(start: Path | None = None) -> LintConfig:
                     fail_on_missing_return=bool(data.get("fail_on_missing_return", _DEFAULT.fail_on_missing_return)),
                     shebang_require=bool(shebang.get("require", _DEFAULT.shebang_require)),
                     shebang_fix_mode=bool(shebang.get("fix_mode", _DEFAULT.shebang_fix_mode)),
+                    docstrings_enforce=bool(docs.get("enforce", _DEFAULT.docstrings_enforce)),
+                    docstring_style=str(docs.get("style", _DEFAULT.docstring_style)),
+                    docstring_insert_stub=bool(docs.get("insert_stub", _DEFAULT.docstring_insert_stub)),
+                    license_header=data.get("license_header", _DEFAULT.license_header),
+                    cache=bool(data.get("cache", _DEFAULT.cache)),
                 )
     return _DEFAULT

--- a/privilege_lint/docstring_rules.py
+++ b/privilege_lint/docstring_rules.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _style_matches(doc: str, style: str) -> bool:
+    lines = [l.strip() for l in doc.splitlines()]
+    if style == "google":
+        return any(l.startswith("Args:") for l in lines)
+    if style == "numpy":
+        return any(l == "Parameters" for l in lines)
+    return True
+
+
+def validate_docstrings(lines: list[str], path: Path, style: str) -> list[str]:
+    """Return lint errors for docstrings."""
+    try:
+        tree = ast.parse("\n".join(lines))
+    except Exception:
+        return []
+
+    issues: list[str] = []
+
+    def check(node: ast.AST, name: str) -> None:
+        doc = ast.get_docstring(node)
+        lineno = getattr(node, "lineno", 1)
+        if not doc:
+            issues.append(f"{path}:{lineno} missing docstring")
+        elif not _style_matches(doc, style):
+            issues.append(f"{path}:{lineno} docstring not {style} style")
+
+    # module
+    check(tree, "<module>")
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name.startswith("_"):
+                continue
+            check(node, node.name)
+            if isinstance(node, ast.ClassDef):
+                for sub in node.body:
+                    if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)) and not sub.name.startswith("_"):
+                        check(sub, f"{node.name}.{sub.name}")
+
+    return issues
+
+
+def apply_fix_docstring_stub(path: Path, style: str) -> bool:
+    """Insert TODO docstring stubs for missing public docstrings."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    try:
+        tree = ast.parse("\n".join(lines))
+    except Exception:
+        return False
+
+    inserts: list[tuple[int, str]] = []
+
+    def stub(indent: int) -> str:
+        return " " * indent + '"""TODO:"""'
+
+    if not ast.get_docstring(tree):
+        inserts.append((0, stub(0)))
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name.startswith("_"):
+                continue
+            if not ast.get_docstring(node):
+                line = node.body[0].lineno if node.body else node.lineno + 1
+                indent = node.body[0].col_offset if node.body else node.col_offset + 4
+                inserts.append((line - 1, stub(indent)))
+            if isinstance(node, ast.ClassDef):
+                for sub in node.body:
+                    if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)) and not sub.name.startswith("_") and not ast.get_docstring(sub):
+                        line = sub.body[0].lineno if sub.body else sub.lineno + 1
+                        indent = sub.body[0].col_offset if sub.body else sub.col_offset + 4
+                        inserts.append((line - 1, stub(indent)))
+
+    if not inserts:
+        return False
+
+    for idx, text in sorted(inserts, reverse=True):
+        lines.insert(idx, text)
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True

--- a/privilege_lint/license_rules.py
+++ b/privilege_lint/license_rules.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DEFAULT_HEADER = "# SPDX-License-Identifier: MIT"
+
+
+def validate_license_header(lines: list[str], path: Path, header: str) -> list[str]:
+    idx = 0
+    if lines and lines[0].startswith("#!"):
+        idx = 1
+    if len(lines) <= idx or lines[idx].strip() != header:
+        return [f"{path}: missing license header"]
+    return []
+
+
+def apply_fix_license_header(lines: list[str], path: Path, header: str) -> bool:
+    idx = 0
+    if lines and lines[0].startswith("#!"):
+        idx = 1
+    if len(lines) <= idx or lines[idx].strip() != header:
+        lines.insert(idx, header)
+        return True
+    return False

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -18,9 +18,15 @@ def main(path: str = ".") -> None:
     linter = PrivilegeLinter()
     start = time.time()
     parallel_validate(linter, files)
-    dur = time.time() - start
-    print(f"Linted {len(files)} files in {dur:.2f}s")
+    cold = time.time() - start
+
+    start = time.time()
+    parallel_validate(linter, files)
+    warm = time.time() - start
+    hit_ratio = 1 - len([f for f in files if not linter.cache.is_valid(f)]) / len(files)
+    print(f"Cold: {cold:.2f}s, Warm: {warm:.2f}s, cache hit ratio {hit_ratio:.2f}")
 
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,22 @@
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from privilege_lint.cache import LintCache
+from privilege_lint.config import LintConfig
+import privilege_lint as pl
+
+
+def test_cache_hit(tmp_path: Path) -> None:
+    file = tmp_path / "a.py"
+    file.write_text("\n".join(pl.BANNER_ASCII + [pl.FUTURE_IMPORT]), encoding="utf-8")
+    cfg = LintConfig()
+    cache = LintCache(tmp_path, cfg, enabled=True)
+    linter = pl.PrivilegeLinter(cfg, project_root=tmp_path)
+    linter.cache = cache
+    assert not cache.is_valid(file)
+    linter.validate(file)
+    cache.update(file)
+    cache.save()
+    cache2 = LintCache(tmp_path, cfg, enabled=True)
+    assert cache2.is_valid(file)

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,27 @@
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+from privilege_lint.config import LintConfig
+
+
+def test_google_style(tmp_path: Path) -> None:
+    file = tmp_path / "mod.py"
+    file.write_text("\n".join(pl.BANNER_ASCII + [
+        pl.FUTURE_IMPORT,
+        'def foo(x):\n    """Doc.\n\n    Args:\n        x: value\n    """\n    return x'
+    ]), encoding="utf-8")
+    cfg = LintConfig(docstrings_enforce=True)
+    linter = pl.PrivilegeLinter(cfg)
+    assert linter.validate(file) == []
+
+
+def test_missing_stub(tmp_path: Path) -> None:
+    file = tmp_path / "bad.py"
+    file.write_text("\n".join(pl.BANNER_ASCII + [pl.FUTURE_IMPORT, 'def foo():\n    pass']), encoding="utf-8")
+    cfg = LintConfig(docstrings_enforce=True, docstring_insert_stub=True)
+    linter = pl.PrivilegeLinter(cfg)
+    assert linter.validate(file)
+    linter.apply_fix(file)
+    assert '"""TODO:' in file.read_text()

--- a/tests/test_license_header.py
+++ b/tests/test_license_header.py
@@ -1,0 +1,17 @@
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import privilege_lint as pl
+from privilege_lint.config import LintConfig
+
+
+def test_license_insertion(tmp_path: Path) -> None:
+    f = tmp_path / "script.py"
+    f.write_text("\n".join(["#!/usr/bin/env python3", "print('hi')"]), encoding="utf-8")
+    cfg = LintConfig(license_header="# SPDX-License-Identifier: MIT")
+    linter = pl.PrivilegeLinter(cfg, project_root=tmp_path)
+    assert linter.validate(f)
+    linter.apply_fix(f)
+    text = f.read_text()
+    assert "SPDX-License-Identifier" in text


### PR DESCRIPTION
## Summary
- implement docstring parsing module
- add lint-result caching and license header rule
- wire new checks into linter and config
- update developer docs and benchmark
- add unit tests for new rules

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py --quiet`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'colorama')*


------
https://chatgpt.com/codex/tasks/task_b_6846f40682a48320a2ab397b66bc7b2b