### PR TITLE
docs(site): add Sphinx auto-docs and GitHub Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,12 @@ jobs:
       - run: pip install -e .[dev]
       - run: mypy sentientos
       - run: pytest --cov=sentientos --cov-report=xml
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.11'}
+      - run: pip install -e .[dev]
+      - run: make docs

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,31 @@
+name: Docs Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -e .[dev]
+      - run: make docs
+      - name: Upload docs
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/_build/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ logs/*.jsonl
 site/
 .privilege_lint.cache
 .privilege_lint.gitcache
+docs/_build/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: lock lock-install
+.PHONY: lock lock-install docs docs-live
 
 lock:
 	python -m scripts.lock freeze
 
 lock-install:
 	python -m scripts.lock install
+
+docs:
+	sphinx-build -b html docs docs/_build/html
+
+docs-live:
+	sphinx-autobuild docs docs/_build/html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SentientOS
+[![Docs](https://github.com/Zombinator85/SentientOS/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/Zombinator85/SentientOS/actions/workflows/docs-deploy.yml)
 
 **SentientOS is a ritualized AI safety framework for GPT-based agents.**  \
 Every action is logged in immutable "sacred memory" (JSONL audit logs), with Sanctuary Privilege for high-risk tasks, emotion-based reflex feedback, and alignment, transparency, and trust as living systems.

--- a/README_dev.md
+++ b/README_dev.md
@@ -23,6 +23,12 @@ pytest -q
 
 Run mypy locally with: `mypy sentientos`
 
+Build docs locally:
+```bash
+pip install -e .[dev]
+make docs
+```
+
 Tests must keep 80 % coverage.
 
 ### Installing extras (bin vs src)
@@ -185,3 +191,5 @@ Run `scripts/plint_baseline.py` once on a legacy repo to write `.plint_baseline.
 
 ### Policy Hooks
 Specify `policy="sentientos"` under `[lint]` to load additional rules from `policies/sentientos.py`.
+
+Documentation lives at https://zombinator85.github.io/SentientOS/.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   modules

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+sentientos
+==========
+
+.. toctree::
+   :maxdepth: 4
+
+   sentientos

--- a/docs/api/sentientos.rst
+++ b/docs/api/sentientos.rst
@@ -1,0 +1,21 @@
+sentientos package
+==================
+
+Submodules
+----------
+
+sentientos.core module
+----------------------
+
+.. automodule:: sentientos.core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: sentientos
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'SentientOS'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
+    'myst_parser',
+]
+
+html_theme = 'furo'
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# SentientOS Documentation
+
+Welcome to the SentientOS documentation. This site contains reference material for the public APIs and CLI entry points.
+
+```{toctree}
+:maxdepth: 2
+
+api/index
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ dev = [
     "types-requests",
     "types-PyYAML",
     "pytest-cov",
+    "sphinx==7.*",
+    "sphinx-autodoc-typehints",
+    "myst-parser",
+    "furo",
+    "sphinx-autobuild",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- document dev extras with Sphinx and theme
- bootstrap Sphinx docs with autodoc configuration
- generate API docs for package
- enable `make docs` and live docs rebuild
- deploy documentation to GitHub Pages in CI
- show docs status badge and link in READMEs

## Testing
- `make docs`
- `mypy sentientos` *(fails: incompatible types)*
- `pytest -q` *(fails: RuntimeError during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68474651478483208a8e7973a2cfb29c