### PR TITLE
Fix Unicode banner output in admin_utils

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -37,7 +37,12 @@ def print_privilege_banner(tool: str = "") -> None:
     user = getpass.getuser()
     plat = platform.system()
     status = "\U0001F6E1\uFE0F Privileged" if is_admin() else "\u26A0\uFE0F Not Privileged"
-    print(f"\U0001F6E1\uFE0F Sanctuary Privilege Status: [{status}]")
+    banner = f"\U0001F6E1\uFE0F Sanctuary Privilege Status: [{status}]"
+    try:
+        print(banner)
+    except UnicodeEncodeError:
+        enc = sys.stdout.encoding or "utf-8"
+        print(banner.encode(enc, errors="replace").decode(enc, errors="replace"))
     print(f"Current user: {user}")
     print(f"Platform: {plat}")
     if not is_admin():


### PR DESCRIPTION
## Summary
- handle UnicodeEncodeError when printing privilege banners

## Testing
- `SENTIENTOS_HEADLESS=1 LUMOS_AUTO_APPROVE=1 python privilege_lint.py`
- `SENTIENTOS_HEADLESS=1 LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_684765dfa13c83208dca8adce562f176