### PR TITLE
Add lint warn mode with strict option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         run: pre-commit run --all-files
       - name: Run tests
         run: pytest -q --cov=sentientos --cov-report=xml --cov-report=term --cov-fail-under=90
+      - name: Strict privilege / audit lint
+        run: |
+          export SENTIENTOS_LINT_STRICT=1
+          python privilege_lint.py --no-emoji
+          python verify_audits.py logs/ --no-emoji
       - name: Run mypy
         run: mypy --strict sentientos
       - name: Coverage guard

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ repos:
 - repo: local
   hooks:
   - id: privilege-lint
-    name: privilege lint
-    entry: python privilege_lint.py
+    name: privilege-lint (non-strict)
+    entry: python privilege_lint.py --no-emoji
     language: system
     pass_filenames: false
   - id: audit-verify
-    name: audit log verify
-    entry: python verify_audits.py
+    name: audit-verify (non-strict)
+    entry: python verify_audits.py logs/ --no-emoji
     language: system
     pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Run `python privilege_lint.py` locally before submitting a pull request. You can
 link `./.githooks/pre-commit` into your `.git/hooks` folder to automatically
 run the lint before each commit. After cloning, run `pre-commit install` to set up the hooks.
 The hook also runs `python verify_audits.py logs/` to ensure audit logs remain valid before merging.
+If you modify audit logs, run the linters in strict mode locally by setting `SENTIENTOS_LINT_STRICT=1`.
 
 First-time contributors can read [FIRST_WOUND_ONBOARDING.md](docs/FIRST_WOUND_ONBOARDING.md) and submit the **Share Your Saint Story** issue when opening their pull request.
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -1,0 +1,14 @@
+# Development Lint Modes
+
+Pre-commit hooks run the privilege and audit linters in a warning mode so legacy
+logs don't block everyday work. Failures are shown in yellow but the commit will
+continue. To enforce strict linting you can pass `--strict` or set the
+environment variable `SENTIENTOS_LINT_STRICT=1`.
+
+Example:
+
+```bash
+export SENTIENTOS_LINT_STRICT=1
+python privilege_lint.py --no-emoji
+python verify_audits.py logs/ --no-emoji
+```

--- a/tests/test_privilege_lint_exit.py
+++ b/tests/test_privilege_lint_exit.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import privilege_lint as pl
+
+
+def test_exit_zero(monkeypatch):
+    monkeypatch.setattr(pl, "find_entrypoints", lambda root: [])
+    monkeypatch.setattr(sys, "argv", ["privilege_lint.py"])
+    with pytest.raises(SystemExit) as exc:
+        sys.exit(pl.main())
+    assert exc.value.code == 0

--- a/tests/test_privilege_lint_strict.py
+++ b/tests/test_privilege_lint_strict.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import privilege_lint as pl
+
+
+def test_strict_exit_one(tmp_path, monkeypatch):
+    bad = tmp_path / "tool_cli.py"
+    bad.write_text("print('hi')\n", encoding="utf-8")
+    monkeypatch.setattr(pl, "find_entrypoints", lambda root: [bad])
+    monkeypatch.setenv("SENTIENTOS_LINT_STRICT", "1")
+    monkeypatch.setattr(sys, "argv", ["privilege_lint.py"])
+    with pytest.raises(SystemExit) as exc:
+        sys.exit(pl.main())
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- add `--strict` flag and CI env toggle for `privilege_lint.py`
- extend `verify_audits.py` with matching `--strict` logic and colored output
- run lint hooks in non-strict mode by default
- run strict lint stage in CI
- document lint modes and update contributor guide
- add unit tests for new lint behaviors

## Testing
- `pre-commit run --files privilege_lint.py verify_audits.py .pre-commit-config.yaml .github/workflows/ci.yml tests/test_privilege_lint_exit.py tests/test_privilege_lint_strict.py README_dev.md CONTRIBUTING.md`
- `pytest tests/test_privilege_lint_exit.py tests/test_privilege_lint_strict.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68476dab2e1083209a2c540a4733bac2