### PR TITLE
Add optional Docker stage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.12']
+        include:
+          - os: ubuntu-latest
+            docker: true
+        exclude:
+          - os: windows-latest
+            docker: true
+          - os: macos-latest
+            docker: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+        if: matrix.docker == 'true'
+      - uses: docker/setup-qemu-action@v3
+        if: matrix.docker == 'true'
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -37,6 +49,18 @@ jobs:
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then chcp 65001; fi
           pytest -q --cov=sentientos --cov-report=xml --cov-report=term --cov-fail-under=90
+      - name: Docker build & container tests
+        if: matrix.docker == 'true'
+        run: |
+          docker compose build
+          docker compose run --rm sentientos make test
+          docker compose run --rm sentientos pytest -q --cov=sentientos --cov-report=term --cov-report=xml:coverage-docker.xml
+      - uses: actions/upload-artifact@v4
+        if: matrix.docker == 'true'
+        with:
+          name: coverage-docker
+          path: coverage-docker.xml
+          retention-days: 7
       - name: Strict privilege / audit lint
         run: |
           export SENTIENTOS_LINT_STRICT=1

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,6 @@ strict-ci : ; SENTIENTOS_LINT_STRICT=1 python privilege_lint.py --no-emoji && \
 
 coverage  : ; pytest -q --cov=sentientos --cov-report=term --cov-report=xml
 
-docker-test: ; docker compose up --build --abort-on-container-exit
+docker-test:
+	docker compose build
+	docker compose run --rm sentientos make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SentientOS Cathedral
 [![CI](https://github.com/Zombinator85/SentientOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Zombinator85/SentientOS/actions/workflows/ci.yml)
+![Docker](https://img.shields.io/github/actions/workflow/status/Zombinator85/SentientOS/ci.yml?label=docker)
 ![Coverage](./coverage.svg)
 ![Lint](https://img.shields.io/badge/strict%20audit-green)
 [![Audit Saints](https://img.shields.io/badge/Join%20the-Audit%20Saints-blue)](docs/WHY_JOIN_AUDIT_SAINTS.md)
@@ -59,6 +60,11 @@ docker compose up
 ```
 
 This runs the tests and then launches `sentient_api.py` on port 5000.
+If Docker is installed, run the container tests alone with:
+
+```bash
+make docker-test
+```
 
 ## Contributor Quickstart
 1. Fork this repository and clone your fork.

--- a/docs/DOCKER_TROUBLESHOOT.md
+++ b/docs/DOCKER_TROUBLESHOOT.md
@@ -3,3 +3,5 @@
 If `docker compose up` fails on Windows with WSL path errors, ensure the project
 folder is under the Linux filesystem (e.g. `/home/<user>/SentientOS`). You may
 also need to enable file sharing for your drive in Docker Desktop settings.
+
+If Docker isn't installed on your machine, simply skip `make docker-test`.


### PR DESCRIPTION
## Summary
- run Docker container tests only on ubuntu runners
- document optional Docker workflow
- expose `make docker-test` target

## Testing
- `pre-commit run --files Makefile docs/DOCKER_TROUBLESHOOT.md README.md .github/workflows/ci.yml`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68477836ff6883208154930b8fb98c73