### PR TITLE
Add release automation for PyPI & GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       - run: pip install build twine
       - run: python -m build
       - run: twine check dist/*
+      - name: Set version
+        run: echo "PACKAGE_VERSION=$(python -c 'import importlib.metadata as m; print(m.version("sentientos"))')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -27,6 +29,29 @@ jobs:
           body_path: changelog.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to TestPyPI
-        if: secrets.TEST_PYPI_TOKEN != ''
-        run: twine upload -r testpypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} dist/*
+      - name: Publish package
+        env:
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == *-rc* ]]; then
+            twine upload -r testpypi --username __token__ --password "$TEST_PYPI_API_TOKEN" dist/*
+          else
+            twine upload --username __token__ --password "$PYPI_API_TOKEN" dist/*
+          fi
+      - name: Build Docker image
+        run: docker build -t ghcr.io/${{ github.repository }}/sentientos:${{ env.PACKAGE_VERSION }} .
+      - name: Login to GHCR
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: docker push ghcr.io/${{ github.repository }}/sentientos:${{ env.PACKAGE_VERSION }}
+      - name: Sign tag
+        env:
+          SIGNING_FPR: ${{ secrets.SIGNING_FPR }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          git config --global user.signingkey "$SIGNING_FPR"
+          git tag -s "v${{ env.PACKAGE_VERSION }}" -m "SentientOS ${{ env.PACKAGE_VERSION }}"
+          git push origin "v${{ env.PACKAGE_VERSION }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![CI](https://github.com/Zombinator85/SentientOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Zombinator85/SentientOS/actions/workflows/ci.yml)
 ![Docker](https://img.shields.io/github/actions/workflow/status/Zombinator85/SentientOS/ci.yml?label=docker)
 ![Coverage](./coverage.svg)
-![PyPI](https://img.shields.io/badge/PyPI-coming%20soon-lightgrey)
+[![PyPI](https://img.shields.io/pypi/v/sentientos.svg)](https://pypi.org/project/sentientos/)
+[![GHCR](https://img.shields.io/badge/ghcr-image-blue)](https://github.com/Zombinator85/SentientOS/pkgs/container/sentientos)
 ![Lint](https://img.shields.io/badge/strict%20audit-green)
 [![Audit Saints](https://img.shields.io/badge/Join%20the-Audit%20Saints-blue)](docs/WHY_JOIN_AUDIT_SAINTS.md)
 Passing: 321/325 (legacy excluded); see LEGACY_TESTS.md for details.
@@ -51,6 +52,20 @@ _All core features (privilege banners, memory, logging, emotion, safety) are wor
 6. When updates are available run `update_cathedral.bat` (or the equivalent script on your platform) to pull the latest code and rerun the smoke tests. See [docs/CODEX_UPDATE_PIPELINE.md](docs/CODEX_UPDATE_PIPELINE.md) for details.
 7. Verify your setup using [docs/INSTALLER_FEATURE_CHECKLIST.md](docs/INSTALLER_FEATURE_CHECKLIST.md).
 8. Run `python smoke_test_connector.py` to verify the OpenAI connector.
+
+### Quick Install
+
+```bash
+pip install sentientos
+sentientos status --url http://localhost:5000
+```
+
+```bash
+docker pull ghcr.io/Zombinator85/sentientos:0.4.1
+docker run -p 5000:5000 ghcr.io/Zombinator85/sentientos:0.4.1
+```
+
+Use `sentientos --help` to explore the CLI.
 
 ### Status Endpoint
 Run `python sentient_api.py` and visit `http://localhost:8000/status` to check uptime, pending patches, and cost metrics.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,23 @@
+# Publishing Guide
+
+This document describes how to publish a new release of SentientOS.
+
+## Cut a release candidate
+
+1. Bump `__version__` in `sentientos/__init__.py`.
+2. Tag the commit using a version with `-rc`, e.g. `v0.4.2-rc1`.
+3. Push the tag and wait for CI.
+4. CI will upload the wheel to TestPyPI using `TEST_PYPI_API_TOKEN`.
+
+## Final release
+
+1. Ensure the tag has no `-rc` suffix, e.g. `v0.4.2`.
+2. CI uploads to real PyPI using `PYPI_API_TOKEN` and pushes the Docker image to GHCR.
+3. Confirm the GPG-signed tag appears on GitHub.
+
+To dry run a release candidate locally:
+
+```bash
+python -m build
+TWINE_USERNAME=__token__ TWINE_PASSWORD=$TEST_PYPI_API_TOKEN twine upload --repository testpypi --skip-existing dist/*
+```

--- a/sentient_cli.py
+++ b/sentient_cli.py
@@ -12,11 +12,15 @@ def main(argv=None) -> None:
     require_admin_banner()
     parser = argparse.ArgumentParser(prog="sentientos", description="SentientOS command line")
     parser.add_argument("command", nargs="?", default="status", help="command to run")
+    parser.add_argument(
+        "--url",
+        help="status endpoint",
+        default=os.getenv("SENTIENTOS_STATUS_URL", "http://localhost:5000/status"),
+    )
     args = parser.parse_args(argv)
 
     if args.command == "status":
-        url = os.getenv("SENTIENTOS_STATUS_URL", "http://localhost:5000/status")
-        resp = requests.get(url, timeout=5)
+        resp = requests.get(args.url, timeout=5)
         print(resp.json())
     else:
         parser.print_help()

--- a/tests/test_sentientos_version.py
+++ b/tests/test_sentientos_version.py
@@ -24,7 +24,7 @@ def test_main_runs(capsys, monkeypatch):
     monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
     monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
     monkeypatch.setattr(requests, "get", lambda *a, **k: _FakeResp({"uptime": 0}))
-    sys.argv = ["sentientos", "status"]
+    sys.argv = ["sentientos", "status", "--url", "http://example.com/status"]
     runpy.run_module("sentientos.__main__", run_name="__main__")
     out = capsys.readouterr().out
     assert "uptime" in out


### PR DESCRIPTION
## Summary
- extend release workflow to publish to TestPyPI or PyPI based on tag
- build and push Docker images to GHCR
- sign release tags on CI
- add install instructions and badges to README
- document release process
- allow `sentientos status` to accept a `--url` flag
- update tests for the CLI

## Testing
- `pre-commit run --files .github/workflows/release.yml README.md sentient_cli.py tests/test_sentientos_version.py docs/PUBLISHING.md`
- `pytest -q tests/test_sentientos_version.py`

------
https://chatgpt.com/codex/tasks/task_b_684784c1639483209a8ee947af4ac4ed