### PR TITLE
codex/code-multitenant-auth-and-limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Use `sentientos --help` to explore the CLI.
 ### Status Endpoint
 Run `python sentient_api.py` and visit `http://localhost:8000/status` to check uptime, pending patches, and cost metrics.
 
+### Multi-Tenant mode
+Generate an API key with `python scripts/generate_api_key.py <tenant>` and send requests using:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8000/status
+```
+
 See [docs/README_FULL.md](docs/README_FULL.md) for the complete philosophy and usage details.
 
 ### Run locally with Docker

--- a/deploy/helm/sentientos/templates/deployment.yaml
+++ b/deploy/helm/sentientos/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
           ports:
             - containerPort: 5000
             - containerPort: 9100
+          volumeMounts:
+            - name: auth-keys
+              mountPath: /app/keys.yaml
+              subPath: keys.yaml
           readinessProbe:
             httpGet:
               path: /status
@@ -35,3 +39,7 @@ spec:
               path: /metrics
               port: 9100
           resources: {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: auth-keys
+          secret:
+            secretName: {{ include "sentientos.fullname" . }}-auth

--- a/deploy/helm/sentientos/templates/ingress.yaml
+++ b/deploy/helm/sentientos/templates/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "sentientos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_input_headers "X-Sentient-Tenant: $http_x_sentient_tenant";
 spec:
   rules:
     - http:

--- a/deploy/helm/sentientos/values.yaml
+++ b/deploy/helm/sentientos/values.yaml
@@ -13,5 +13,8 @@ service:
   type: ClusterIP
   port: 5000
 
+tenantLimits: {}
+authKeys: []
+
 ingress:
   enabled: false

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,3 +1,5 @@
 # Observability
 
 When deployed on Kubernetes, SentientOS exposes Prometheus metrics on port 9100. If you use the `kube-prometheus-stack`, create a `ServiceMonitor` pointing at the `sentientos` service to scrape metrics.
+
+Each request increments `sentientos_tenant_requests_total{tenant="..."}` and updates `sentientos_tenant_cost_usd{tenant="..."}`. Use Grafana filters with `{{ tenant }}` in the legend to view per-tenant usage.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Notes
+
+API keys are stored in a YAML file mapped by tenant slug to a SHA-256 token hash.
+Use `scripts/generate_api_key.py` to generate a token and distribute the plain
+text to the tenant. Rotate keys by editing `keys.yaml` and reloading the
+application. We recommend encrypting the YAML with `sops` or a similar tool when
+committing to Git.

--- a/scripts/generate_api_key.py
+++ b/scripts/generate_api_key.py
@@ -1,0 +1,17 @@
+import argparse
+import secrets
+import hashlib
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate API key")
+    ap.add_argument("tenant")
+    args = ap.parse_args()
+    token = secrets.token_hex(16)
+    print(f"tenant: {args.tenant}")
+    print(f"token: {token}")
+    print(f"hash: {hashlib.sha256(token.encode()).hexdigest()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sentient_api.py
+++ b/sentient_api.py
@@ -1,7 +1,11 @@
 import os
 import time
-from flask import Flask, jsonify
+from typing import Any
+
+from flask import Flask, jsonify, Response, g
+from prometheus_client import Gauge, generate_latest
 from admin_utils import require_admin_banner, require_lumos_approval
+import tenant_middleware as tm
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
@@ -10,6 +14,27 @@ require_lumos_approval()
 START_TS = time.time()
 
 app = Flask(__name__)
+
+REQUEST_GAUGE = Gauge(
+    "sentientos_tenant_requests_total",
+    "Number of requests per tenant",
+    ["tenant"],
+)
+COST_GAUGE = Gauge(
+    "sentientos_tenant_cost_usd",
+    "Accumulated cost per tenant",
+    ["tenant"],
+)
+
+
+@app.before_request
+def _apply_tenant() -> None:
+    tenant = tm.get_tenant_id()
+    g.tenant_id = tenant
+    tm.rate_limit()
+    tm.check_cost_limit()
+    REQUEST_GAUGE.labels(tenant=tenant).inc()
+    COST_GAUGE.labels(tenant=tenant).set(tm.tenant_cost_metric().get(tenant, 0.0))
 
 
 def _pending_patches() -> int:
@@ -22,15 +47,24 @@ def _cost_today() -> float:
 
 
 @app.get("/status")
-def status() -> "flask.Response":
+def status() -> Response:
     uptime = int(time.time() - START_TS)
+    tenant = getattr(g, "tenant_id", "public")
+    tenant_cost = tm.tenant_cost_metric().get(tenant, 0.0)
+    remaining = max(0, tm.TENANT_RATE_LIMIT - len(tm._request_windows.get(tenant, [])))
     return jsonify(
         {
             "uptime": uptime,
             "pending_patches": _pending_patches(),
-            "cost_today": _cost_today(),
+            "cost_today": tenant_cost,
+            "rate_remaining": remaining,
         }
     )
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), mimetype="text/plain")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI

--- a/tenant_middleware.py
+++ b/tenant_middleware.py
@@ -1,0 +1,89 @@
+import os
+import time
+import hashlib
+from collections import defaultdict, deque
+from typing import Dict
+
+from flask import g, request, abort
+
+TENANT_DAILY_LIMIT = float(os.getenv("TENANT_DAILY_LIMIT", "2"))
+TENANT_RATE_LIMIT = int(os.getenv("TENANT_RATE_LIMIT", "60"))
+TENANT_RATE_WINDOW = int(os.getenv("TENANT_RATE_WINDOW", "60"))
+
+_keys: Dict[str, str] | None = None
+_request_windows: Dict[str, deque[float]] = defaultdict(deque)
+_daily_cost: Dict[str, float] = defaultdict(float)
+
+
+def _load_keys() -> Dict[str, str]:
+    path = os.getenv("SENTIENTOS_KEYS_FILE", "keys.yaml")
+    if not os.path.exists(path):
+        return {}
+    import yaml
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _ensure_keys_loaded() -> None:
+    global _keys
+    if _keys is None:
+        _keys = _load_keys()
+
+
+def get_tenant_id() -> str:
+    _ensure_keys_loaded()
+    allow_anon = os.getenv("SENTIENTOS_ALLOW_ANON") == "1"
+    auth = request.headers.get("Authorization")
+    if not auth:
+        if allow_anon:
+            return request.headers.get("X-Sentient-Tenant", "public")
+        abort(401)
+    if not auth.startswith("Bearer "):
+        abort(401)
+    token = auth.split(" ", 1)[1]
+    if _keys:
+        for tenant, thash in _keys.items():
+            if _hash(token) == thash:
+                return tenant
+    abort(401)
+
+
+def tenant_context() -> None:
+    tenant_id = request.headers.get("X-Sentient-Tenant", "public")
+    g.tenant_id = tenant_id
+
+
+def rate_limit() -> None:
+    tenant = getattr(g, "tenant_id", "public")
+    now = time.time()
+    window = _request_windows[tenant]
+    while window and now - window[0] > TENANT_RATE_WINDOW:
+        window.popleft()
+    if len(window) >= TENANT_RATE_LIMIT:
+        abort(429)
+    window.append(now)
+
+
+def add_cost(amount: float, tenant: str | None = None) -> None:
+    tenant = tenant or getattr(g, "tenant_id", "public")
+    _daily_cost[tenant] += amount
+
+
+def check_cost_limit() -> None:
+    tenant = getattr(g, "tenant_id", "public")
+    if _daily_cost[tenant] > TENANT_DAILY_LIMIT:
+        abort(503)
+
+
+def tenant_requests_metric() -> Dict[str, float]:
+    return {t: float(len(w)) for t, w in _request_windows.items()}
+
+
+def tenant_cost_metric() -> Dict[str, float]:
+    return dict(_daily_cost)

--- a/tests/test_auth_missing.py
+++ b/tests/test_auth_missing.py
@@ -1,0 +1,26 @@
+import importlib
+import hashlib
+from pathlib import Path
+
+import sentient_api
+import tenant_middleware as tm
+from prometheus_client import REGISTRY
+
+
+def setup_client(tmp_path, monkeypatch):
+    key_file = tmp_path / "keys.yaml"
+    token = "secret"
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    key_file.write_text(f"tenant1: {token_hash}\n")
+    monkeypatch.setenv("SENTIENTOS_KEYS_FILE", str(key_file))
+    monkeypatch.delenv("SENTIENTOS_ALLOW_ANON", raising=False)
+    importlib.reload(tm)
+    REGISTRY._names_to_collectors.clear()
+    importlib.reload(sentient_api)
+    return sentient_api.app.test_client()
+
+
+def test_auth_missing(tmp_path, monkeypatch):
+    client = setup_client(tmp_path, monkeypatch)
+    resp = client.get("/status")
+    assert resp.status_code == 401

--- a/tests/test_status_coverage.py
+++ b/tests/test_status_coverage.py
@@ -1,11 +1,14 @@
 import os
 import importlib
 import sentient_api
+from prometheus_client import REGISTRY
 
 
 def test_status_coverage(monkeypatch):
     monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
     monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    monkeypatch.setenv("SENTIENTOS_ALLOW_ANON", "1")
+    REGISTRY._names_to_collectors.clear()
     importlib.reload(sentient_api)
     with sentient_api.app.test_client() as client:
         resp = client.get("/status")

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -3,9 +3,12 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import sentient_api
+from prometheus_client import REGISTRY
 
 
 def test_status_endpoint():
+    os.environ["SENTIENTOS_ALLOW_ANON"] = "1"
+    REGISTRY._names_to_collectors.clear()
     with sentient_api.app.test_client() as client:
         resp = client.get('/status')
         data = resp.get_json()

--- a/tests/test_tenant_cost_panic.py
+++ b/tests/test_tenant_cost_panic.py
@@ -1,0 +1,24 @@
+import importlib
+
+import sentient_api
+import tenant_middleware as tm
+from prometheus_client import REGISTRY
+
+
+def setup_client(monkeypatch):
+    monkeypatch.setenv("SENTIENTOS_ALLOW_ANON", "1")
+    monkeypatch.setenv("TENANT_DAILY_LIMIT", "1")
+    importlib.reload(tm)
+    tm._daily_cost.clear()
+    REGISTRY._names_to_collectors.clear()
+    importlib.reload(sentient_api)
+    return sentient_api.app.test_client()
+
+
+def test_tenant_cost_panic(monkeypatch):
+    client = setup_client(monkeypatch)
+    tm._daily_cost["t1"] = 2.0
+    resp = client.get("/status", headers={"X-Sentient-Tenant": "t1"})
+    assert resp.status_code == 503
+    resp2 = client.get("/status", headers={"X-Sentient-Tenant": "t2"})
+    assert resp2.status_code == 200

--- a/tests/test_tenant_rate_limit.py
+++ b/tests/test_tenant_rate_limit.py
@@ -1,0 +1,26 @@
+import importlib
+
+import sentient_api
+import tenant_middleware as tm
+from prometheus_client import REGISTRY
+
+
+def setup_client(monkeypatch):
+    monkeypatch.setenv("SENTIENTOS_ALLOW_ANON", "1")
+    monkeypatch.setenv("TENANT_RATE_LIMIT", "2")
+    importlib.reload(tm)
+    REGISTRY._names_to_collectors.clear()
+    importlib.reload(sentient_api)
+    return sentient_api.app.test_client()
+
+
+def test_tenant_rate_limit(monkeypatch):
+    client = setup_client(monkeypatch)
+    h1 = {"X-Sentient-Tenant": "t1"}
+    h2 = {"X-Sentient-Tenant": "t2"}
+    client.get("/status", headers=h1)
+    client.get("/status", headers=h1)
+    resp = client.get("/status", headers=h1)
+    assert resp.status_code == 429
+    resp2 = client.get("/status", headers=h2)
+    assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- add multi-tenant request context, rate & cost limit tracker
- secure API keys with generation script
- expose per-tenant Prometheus metrics and update /status
- document tenant mode and security notes
- helm charts mount key secret and expose tenant values
- test tenant rate-limit, cost panic, and auth failure

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q prometheus_client`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6847942da93c8320abfbbc924893d23a