### PR TITLE
feat(cathedral-polish): ritual order, env sync, log path, TODOs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,3 +181,7 @@ WAKE_WORDS=Lumos
 WEBHOOK_CHECK_SEC=60
 WORKFLOW_REVIEW_DIR=workflows/review
 
+# Rate limiting for API calls
+# SENTIENTOS_RATE_LIMIT=            # requests/min (default 100)
+# SENTIENTOS_COST_LIMIT=            # dollars/day  (default 5)
+

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,5 +1,9 @@
-"""Analyze rendered avatars and log emotional context."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
 from logging_config import get_log_path
 
 import argparse
@@ -9,11 +13,8 @@ from datetime import datetime
 from pathlib import Path
 
 import emotion_utils as eu
+from PIL import Image, ImageStat
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 
 LOG_PATH = get_log_path("avatar_reflection.jsonl", "AVATAR_REFLECTION_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -25,13 +26,18 @@ MOODS = ["happy", "sad", "angry", "serene"]
 def analyze_image(image_path: Path) -> str:
     """Return a simple mood classification for an image."""
 
-    vec = eu.detect_image(str(image_path))
-    if vec.get("Joy", 0.0) > 0:
-        return "happy"
-    if vec.get("Sadness", 0.0) > 0:
-        return "sad"
-    if vec.get("Anger", 0.0) > 0:
+    try:
+        img = Image.open(image_path).convert("RGB")
+    except Exception:
+        return "serene"
+    stat = ImageStat.Stat(img)
+    r, g, b = stat.mean
+    if r > g and r > b:
         return "angry"
+    if b > r and b > g:
+        return "sad"
+    if g > r and g > b:
+        return "happy"
     return "serene"
 
 

--- a/check_connector_health.py
+++ b/check_connector_health.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+from logging_config import get_log_path
+
 from admin_utils import require_admin_banner, require_lumos_approval
 import openai_connector
 from flask_stub import Request
@@ -19,7 +21,7 @@ require_lumos_approval()
 def _setup() -> tuple[openai_connector.Flask.test_client, Path]:
     os.environ.setdefault("CONNECTOR_TOKEN", "token123")
     os.environ.setdefault("SSE_TIMEOUT", "0.2")
-    log_path = Path(os.getenv("OPENAI_CONNECTOR_LOG", "logs/openai_connector_health.jsonl"))
+    log_path = get_log_path("openai_connector_health.jsonl", "OPENAI_CONNECTOR_LOG")
     if log_path.exists():
         log_path.unlink()
     reload(openai_connector)

--- a/smoke_test_connector.py
+++ b/smoke_test_connector.py
@@ -32,7 +32,9 @@ for attempt in range(3):
         print(f"Retrying in {wait}s...")
         time.sleep(wait)
 
-log_path = Path(os.getenv("OPENAI_CONNECTOR_LOG", "logs/openai_connector.jsonl"))
+from logging_config import get_log_path
+
+log_path = get_log_path("openai_connector.jsonl", "OPENAI_CONNECTOR_LOG")
 if log_path.exists():
     with log_path.open() as f:
         lines = [json.loads(x) for x in f if x.strip()]

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,7 +1,11 @@
 import importlib
+import os
+import sys
 from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import avatar_reflection as ar
+from PIL import Image
 
 
 def test_reflection_log(tmp_path, monkeypatch):
@@ -20,9 +24,14 @@ def test_analyze_image(tmp_path, monkeypatch):
     monkeypatch.setenv("AVATAR_REFLECTION_LOG", str(log))
     importlib.reload(ar)
 
-    img = tmp_path / "smile.png"
-    img.write_text("data")
+    happy = tmp_path / "happy.png"
+    Image.new("RGB", (2, 2), (0, 255, 0)).save(happy)
+    sad = tmp_path / "sad.png"
+    Image.new("RGB", (2, 2), (0, 0, 255)).save(sad)
+    angry = tmp_path / "angry.png"
+    Image.new("RGB", (2, 2), (255, 0, 0)).save(angry)
 
-    mood = ar.analyze_image(img)
-    assert mood == "happy"
+    assert ar.analyze_image(happy) == "happy"
+    assert ar.analyze_image(sad) == "sad"
+    assert ar.analyze_image(angry) == "angry"
 

--- a/tests/test_avatar_relic_creator.py
+++ b/tests/test_avatar_relic_creator.py
@@ -1,6 +1,9 @@
 import importlib
 import json
+import os
+import sys
 from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import avatar_relic_creator as arc
 
@@ -21,9 +24,20 @@ def test_extract_records_memory(tmp_path, monkeypatch):
     mm.append_memory("hello from ava", tags=["ava"])
     mm.append_memory("other", tags=["bob"])
 
+    asset_dir = tmp_path / "avatars" / "ava"
+    asset_dir.mkdir(parents=True)
+    meta = asset_dir / "meta.txt"
+    meta.write_text("data")
+    monkeypatch.setenv("AVATAR_DIR", str(tmp_path / "avatars"))
+    monkeypatch.setenv("ARCHIVE_DIR", str(tmp_path / "arch"))
+
     entry = arc.extract("ava", "token")
     assert relic_log.exists()
     data = json.loads(relic_log.read_text().splitlines()[0])
     assert data["avatar"] == "ava"
     assert entry["info"]["fragments"] == ["hello from ava"]
+
+    relic_path = Path(os.environ["ARCHIVE_DIR"]) / "relics" / "ava" / "token"
+    assert (relic_path / "meta.txt").exists()
+    assert (relic_path / "manifest.json").exists()
 


### PR DESCRIPTION
## Summary
- move privilege ritual block ahead of imports
- centralize log paths via `logging_config.get_log_path`
- update privilege lint logic and tests
- expand example environment
- implement relic extraction and image analysis

## Testing
- `python privilege_lint.py`
- `pytest -q`
- `mypy --strict sentientos`
- `python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_68482b24bf3483208509c5e2ff7953a0