### PR TITLE
fix logging path helpers

### DIFF
--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -7,6 +7,8 @@ import datetime
 from pathlib import Path
 from typing import Any, Dict, Tuple, List
 
+from logging_config import get_log_path
+
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Privilege Banner: requires admin & Lumos approval."""
@@ -78,7 +80,7 @@ def repair_log(path: Path, prev: str, *, check_only: bool = False) -> Tuple[str,
 
 def _log_summary(entries: List[Dict[str, Any]]) -> None:
     """Append a summary entry for this run."""
-    run_dir = Path("logs/repair_runs")
+    run_dir = get_log_path("repair_runs")
     run_dir.mkdir(parents=True, exist_ok=True)
     path = run_dir / f"{datetime.date.today():%Y-%m-%d}.json"
     with path.open("a", encoding="utf-8") as f:

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -7,7 +7,7 @@ import datetime as dt
 import json
 import os
 import time
-from pathlib import Path
+from logging_config import get_log_path
 
 import requests
 
@@ -19,7 +19,7 @@ require_lumos_approval()
 # Summarize token usage and post to Slack.
 
 
-LOG_FILE = Path("logs/usage.jsonl")
+LOG_FILE = get_log_path("usage.jsonl")
 
 
 def aggregate() -> dict[str, dict[str, int]]:

--- a/tests/test_quota_reporter.py
+++ b/tests/test_quota_reporter.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import json
-from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import importlib
 import scripts.quota_reporter as qr
 
 class DummyResp:
@@ -13,8 +13,10 @@ class DummyResp:
 
 
 def test_report(monkeypatch, tmp_path):
-    log = tmp_path / "logs" / "usage.jsonl"
-    log.parent.mkdir()
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    importlib.reload(qr)
+    log = qr.LOG_FILE
+    log.parent.mkdir(parents=True, exist_ok=True)
     entries = [
         {"timestamp": "2024-01-01T10:00:00", "model": "gpt", "usage": {"total_tokens": 10}},
         {"timestamp": "2024-01-01T11:00:00", "model": "gpt", "usage": {"total_tokens": 5}},


### PR DESCRIPTION
## Summary
- replace hard-coded log paths with `logging_config.get_log_path`
- refresh quota reporter test to handle new path logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68484823fed083209e3076c9c676ce5e