### PR TITLE
Add CLI skeleton template and helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ require_lumos_approval()
 
 from admin_utils import require_admin_banner, require_lumos_approval
 ```
+
+Use `scripts/templates/cli_skeleton.py` as the starting point for any new
+command-line interface. You can also run `python scripts/new_cli.py <name>` to
+copy the skeleton automatically.
 ## Reviewer Checklist
 
 - [ ] Docstring `"Sanctuary Privilege Ritual: Do not remove. See doctrine for details."` present at the very top

--- a/scripts/new_cli.py
+++ b/scripts/new_cli.py
@@ -1,0 +1,31 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+import argparse
+from pathlib import Path
+import shutil
+
+TEMPLATE = Path(__file__).resolve().parent / "templates" / "cli_skeleton.py"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create a new CLI from the skeleton")
+    parser.add_argument("name", help="Path of the new CLI script")
+    args = parser.parse_args(argv)
+
+    dest = Path(args.name).resolve()
+    if dest.exists():
+        print(f"Error: {dest} already exists.")
+        return 1
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(TEMPLATE, dest)
+    print(f"Created {dest} from skeleton")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,0 +1,8 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+# Add imports below this line
+


### PR DESCRIPTION
## Summary
- add `scripts/templates/cli_skeleton.py` containing the privilege banner and approval calls
- mention CLI skeleton and generator in CONTRIBUTING.md
- add helper `scripts/new_cli.py` to copy template

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py scripts/new_cli.py scripts/templates/cli_skeleton.py CONTRIBUTING.md`
- `LUMOS_AUTO_APPROVE=1 pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_68485196cc348320bb493582e2ba7da5