### PR TITLE
Expand privilege lint coverage

### DIFF
--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -38,3 +38,21 @@ def test_bad_future_position(tmp_path: Path) -> None:
     linter = pl.PrivilegeLinter()
     issues = linter.validate(path)
     assert any("Banner and __future__ import" in i for i in issues)
+
+
+def test_main_block_in_tests_scanned(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    f = tests_dir / "cli.py"
+    f.write_text('if __name__ == "__main__":\n    pass\n', encoding="utf-8")
+    rc = pl.main([str(tmp_path), "--quiet"])
+    assert rc == 1
+
+
+def test_argparse_usage_in_tests_scanned(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    f = tests_dir / "cli.py"
+    f.write_text('import argparse\nargparse.ArgumentParser()\n', encoding="utf-8")
+    rc = pl.main([str(tmp_path), "--quiet"])
+    assert rc == 1


### PR DESCRIPTION
## Summary
- broaden lint scanning to include `tests` files that contain entrypoints
- test that `__main__` or `argparse` usage triggers a banner error

## Testing
- `python privilege_lint.py --quiet`
- `python verify_audits.py logs/`
- `pytest -m "not env" -q` *(fails: NameError during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6848568469d08320855f0b3ac2d7181b