### PR TITLE
Ensure CLI entrypoints start with privilege banner

### DIFF
--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -1,6 +1,16 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import argparse
 import json

--- a/avatar_gallery_cli.py
+++ b/avatar_gallery_cli.py
@@ -1,10 +1,17 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
-
-"""Simple CLI to view avatars and presence pulses."""
-
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
 from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 
 import argparse

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,4 +1,13 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,7 +1,16 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
 require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/blessing_recap_cli.py
+++ b/blessing_recap_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/cathedral_liturgy_cli.py
+++ b/cathedral_liturgy_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/confessional_cli.py
+++ b/confessional_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import os

--- a/diff_memory_cli.py
+++ b/diff_memory_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import memory_diff_audit as mda
 from admin_utils import require_admin_banner, require_lumos_approval

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import os

--- a/emotion_arc_cli.py
+++ b/emotion_arc_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import experiment_tracker as et
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import sys

--- a/federation_recap_cli.py
+++ b/federation_recap_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import json
 from pathlib import Path

--- a/heartbeat_monitor_cli.py
+++ b/heartbeat_monitor_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import time
 from pathlib import Path

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()

--- a/heirloom_sync_cli.py
+++ b/heirloom_sync_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/heresy_cli.py
+++ b/heresy_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import heresy_log

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,4 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
 from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import os
 import json

--- a/memory_tomb_cli.py
+++ b/memory_tomb_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 from pathlib import Path

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/neos_avatar_crowning_cli.py
+++ b/neos_avatar_crowning_cli.py
@@ -1,4 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
 from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 

--- a/neos_festival_law_vote_cli.py
+++ b/neos_festival_law_vote_cli.py
@@ -1,4 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
 from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 

--- a/neos_spiral_playback_cli.py
+++ b/neos_spiral_playback_cli.py
@@ -1,4 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
 from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 

--- a/onboard_cli.py
+++ b/onboard_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import plugin_framework as pf

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import reflection_stream as rs

--- a/reflection_log_cli.py
+++ b/reflection_log_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/reflection_tag_cli.py
+++ b/reflection_tag_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,4 +1,16 @@
-"""Review CLI for annotating and managing storyboard feedback."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import argparse
 from pathlib import Path

--- a/review_heresy_cli.py
+++ b/review_heresy_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 import os

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()

--- a/ritual_digest_cli.py
+++ b/ritual_digest_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import os
 import sys

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()

--- a/theme_cli.py
+++ b/theme_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import daily_theme
 from admin_utils import require_admin_banner, require_lumos_approval

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 import argparse
 import json
 from pathlib import Path

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,3 +1,17 @@
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
+
 from admin_utils import require_admin_banner, require_lumos_approval
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()

--- a/video_cli.py
+++ b/video_cli.py
@@ -1,4 +1,16 @@
-"""CLI to manage video logs and emotion snapshots."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/ 
+from __future__ import annotations
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 


### PR DESCRIPTION
## Summary
- add standard banner to all `*_cli.py` files
- ensure the header matches the required privilege ritual

## Testing
- `python privilege_lint.py *_cli.py`

------
https://chatgpt.com/codex/tasks/task_b_6848568381f48320af61502ce06ed3f0