### PR TITLE
Repair audit log chain and enforce check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Pre-commit
         run: pre-commit run --all-files
       - name: Verify audits
-        run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --repair
+        run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
       - run: mypy sentientos
       - run: pytest --cov=sentientos --cov-report=xml
 

--- a/AUDIT_LOG_FIXES.md
+++ b/AUDIT_LOG_FIXES.md
@@ -17,6 +17,9 @@ Add entries below with date and notes:
   living logs are whole. Old, unrecoverable files should be moved to a
   `legacy/` subdirectory so verification scripts run only on healthy memory.
 - 2025-06-10 verify_audits.py run: no chain breaks detected; logs fully valid.
+- 2025-06-10 verify_audits.py --repair run: privileged_audit.jsonl healed; 0 new
+  issues found. The prior truncated section (lines 993-1075) remains unrecoverab
+  le with 83 lines removed.
 
 ## migration_ledger.jsonl
 - Wound at entry #1: prev hash mismatch.


### PR DESCRIPTION
## Summary
- run `verify_audits.py logs/ --repair`
- log privileged audit fix in `AUDIT_LOG_FIXES.md`
- make CI explicitly run `verify_audits.py logs/`

## Testing
- `python privilege_lint_cli.py` *(fails: No module named 'yaml')*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pytest -q -m "not env" tests/test_verify_audits.py` *(fails: PyYAML required for tests)*

------
https://chatgpt.com/codex/tasks/task_b_684878bff8788320a948b527dba99dd1