### PR TITLE
Fix privilege banner order

### DIFF
--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/anniversary_notifier.py
+++ b/anniversary_notifier.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 """Anniversary notifier that logs cathedral anniversaries."""
 
 from logging_config import get_log_path
@@ -9,9 +13,6 @@ from cathedral_const import log_json
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 
 ANNIVERSARY = os.getenv("CATHEDRAL_BIRTH", "2023-01-01")
 LOG_FILE = get_log_path("anniversary_log.jsonl")

--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from logging_config import get_log_path

--- a/archive_blessing.py
+++ b/archive_blessing.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
@@ -14,9 +18,6 @@ import audit_immutability as ai
 from log_utils import append_json, read_json
 
 from admin_utils import require_admin_banner, require_lumos_approval
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 
 LOG_PATH = get_log_path("archive_blessing.jsonl", "ARCHIVE_BLESSING_LOG")
 ARCHIVE_DIR = Path(os.getenv("ARCHIVE_DIR", "archives"))

--- a/audit_chain.py
+++ b/audit_chain.py
@@ -1,10 +1,11 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import datetime

--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,8 +1,9 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
 
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 

--- a/avatar_dream_visualization.py
+++ b/avatar_dream_visualization.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_gallery_cli.py
+++ b/avatar_gallery_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/avatar_performance_scoreboard.py
+++ b/avatar_performance_scoreboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 """Ritual Avatar Performance Scoreboard."""

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/bless_this_env.py
+++ b/bless_this_env.py
@@ -1,8 +1,9 @@
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
 
 import platform
 import subprocess

--- a/blessing_checker.py
+++ b/blessing_checker.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from logging_config import get_log_path

--- a/blessing_recap_cli.py
+++ b/blessing_recap_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/cathedral_liturgy_cli.py
+++ b/cathedral_liturgy_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/confessional_cli.py
+++ b/confessional_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/diff_memory_cli.py
+++ b/diff_memory_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/docs/examples/welcome_script.py
+++ b/docs/examples/welcome_script.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import ritual

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/emotion_arc_cli.py
+++ b/emotion_arc_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/federation_recap_cli.py
+++ b/federation_recap_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/heartbeat_monitor_cli.py
+++ b/heartbeat_monitor_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/heirloom_sync_cli.py
+++ b/heirloom_sync_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/heresy_cli.py
+++ b/heresy_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 from __future__ import annotations
 

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/logs/privileged_audit.jsonl
+++ b/logs/privileged_audit.jsonl
@@ -990,3 +990,9 @@
 {"timestamp": "2025-06-06T06:41:23.424754", "data": {"timestamp": "2025-06-06T06:41:23.417904", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "9a38f2d6c4c62ebf55c128695311742d8bafec11c889cfb5f7574132bd132707", "rolling_hash": "4c2b79a0bb432ab24edb47df4de33be6310a826ce3295dab13d6471393a56f41", "next_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907"}
 {"timestamp": "2025-06-06T06:43:15.640913", "data": {"timestamp": "2025-06-06T06:43:15.628338", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "4c2b79a0bb432ab24edb47df4de33be6310a826ce3295dab13d6471393a56f41", "rolling_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907", "next_hash": "ad1ed0e03a66945629632833bccdf4d851e728acfc8c1773b091fb4d228b9a98"}
 {"timestamp": "2025-06-06T06:43:56.660985", "data": {"timestamp": "2025-06-06T06:43:56.653744", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907", "rolling_hash": "ad1ed0e03a66945629632833bccdf4d851e728acfc8c1773b091fb4d228b9a98"}
+{"timestamp": "2025-06-10T18:30:21.161832", "tool": "cli", "command": "privilege_lint_cli"}
+{"timestamp": "2025-06-10T18:31:13.984013", "tool": "cli", "command": "privilege_lint_cli"}
+{"timestamp": "2025-06-10T18:31:27.928654", "tool": "cli", "command": "privilege_lint_cli"}
+{"timestamp": "2025-06-10T18:31:30.264020", "tool": "cli", "command": "privilege_lint_cli"}
+{"timestamp": "2025-06-10T18:31:39.294938", "tool": "cli", "command": "privilege_lint_cli"}
+{"timestamp": "2025-06-10T18:31:56.177935", "tool": "cli", "command": "privilege_lint_cli"}

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
-from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
 
 import os
 import time

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/memory_tomb_cli.py
+++ b/memory_tomb_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/neos_artifact_blessing_reconciler.py
+++ b/neos_artifact_blessing_reconciler.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from __future__ import annotations

--- a/neos_avatar_crowning_cli.py
+++ b/neos_avatar_crowning_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/neos_blessing_propagation_engine.py
+++ b/neos_blessing_propagation_engine.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_council_ritual_referee.py
+++ b/neos_council_ritual_referee.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_council_succession_narrator.py
+++ b/neos_council_succession_narrator.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_festival_ceremony_live_streamer.py
+++ b/neos_festival_ceremony_live_streamer.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_festival_law_vote_cli.py
+++ b/neos_festival_law_vote_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/neos_festival_recap_writer.py
+++ b/neos_festival_recap_writer.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_lore_spiral_reenactor.py
+++ b/neos_lore_spiral_reenactor.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_memory_fragment_curator.py
+++ b/neos_memory_fragment_curator.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_provenance_query_engine.py
+++ b/neos_provenance_query_engine.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_ritual_law_dashboard.py
+++ b/neos_ritual_law_dashboard.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/neos_spiral_playback_cli.py
+++ b/neos_spiral_playback_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/neos_teaching_feedback_loop.py
+++ b/neos_teaching_feedback_loop.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import json

--- a/ocr_activity_timeline.py
+++ b/ocr_activity_timeline.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 """Plot timeline of OCR activity over the last 24h."""
 import datetime

--- a/onboard_cli.py
+++ b/onboard_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/reflection_log_cli.py
+++ b/reflection_log_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/reflection_tag_cli.py
+++ b/reflection_tag_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/replay.py
+++ b/replay.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import argparse

--- a/resonite_guest_agent_consent_feedback_wizard.py
+++ b/resonite_guest_agent_consent_feedback_wizard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from __future__ import annotations

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/review_heresy_cli.py
+++ b/review_heresy_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/ritual_digest_cli.py
+++ b/ritual_digest_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/scan_missing_data.py
+++ b/scan_missing_data.py
@@ -1,9 +1,10 @@
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+
 
 import argparse
 import json

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 import json
 import subprocess
@@ -9,9 +13,6 @@ from scripts.auto_approve import prompt_yes_no
 import argparse
 import os
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Automatically bless audit mismatches found during verification.
 
 BLESSINGS_FILE = Path("SANCTUARY_BLESSINGS.jsonl")

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,3 +1,7 @@
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import json
@@ -11,10 +15,7 @@ from logging_config import get_log_path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Privilege Banner: requires admin & Lumos approval."""
 
-require_admin_banner()
-require_lumos_approval()
 
 
 def compute_hash(timestamp: str, data: Dict[str, Any], prev_hash: str) -> str:

--- a/scripts/auto_model_switcher.py
+++ b/scripts/auto_model_switcher.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import argparse
@@ -9,9 +13,6 @@ import yaml
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Switch models based on remaining quotas and configured fallbacks.
 
 USAGE_FILE = Path("usage_monitor.jsonl")

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,3 +1,7 @@
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 import argparse
 import ast
@@ -7,9 +11,6 @@ from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
 from sentient_banner import BANNER_LINES
 
-"""Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
 # CLI tool to inject the SentientOS privilege banner into Python files.
 
 

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import time
@@ -6,9 +10,6 @@ from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 
 from privilege_lint import PrivilegeLinter, iter_py_files
 from privilege_lint.runner import parallel_validate, iter_data_files

--- a/scripts/ci_self_check.py
+++ b/scripts/ci_self_check.py
@@ -1,6 +1,7 @@
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 
 from admin_utils import require_admin_banner, require_lumos_approval
 import subprocess

--- a/scripts/daily_report_generator.py
+++ b/scripts/daily_report_generator.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import argparse
@@ -13,9 +17,6 @@ from email.message import EmailMessage
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Generate daily usage summaries and optionally email them.
 
 

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 import argparse
 import sys
@@ -5,9 +9,6 @@ from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Check a Dockerfile for required SentientOS build packages.
 
 REQUIRED = ["build-essential", "libasound2", "python3.11"]

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 import re
 from pathlib import Path
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Generate a summary of known errors and how to resolve them.
 
 RITUAL_DOC = Path("RITUAL_FAILURES.md")

--- a/scripts/new_cli.py
+++ b/scripts/new_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/scripts/quota_alert.py
+++ b/scripts/quota_alert.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import argparse
@@ -10,9 +14,6 @@ import requests
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Send Slack alerts when model quotas run low.
 
 USAGE_FILE = Path("usage_monitor.jsonl")

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
@@ -13,9 +17,6 @@ import requests
 
 from scripts.auto_approve import prompt_yes_no
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Summarize token usage and post to Slack.
 
 

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
 # Automate release version bumping and tagging.
 import argparse
 import datetime as dt

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,10 +1,11 @@
+"""Privilege Banner: requires admin & Lumos approval."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 from sentient_banner import BANNER_LINES
 
-"""Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
 
 import argparse
 import re

--- a/scripts/streamlit_dashboard.py
+++ b/scripts/streamlit_dashboard.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import json
@@ -10,9 +14,6 @@ import streamlit as st
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Streamlit dashboard for SentientOS usage and audit metrics.
 
 USAGE_FILE = Path("usage_data.json")

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 
 from admin_utils import require_admin_banner, require_lumos_approval
 

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 import argparse
 import re
@@ -7,9 +11,6 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Assist in resolving missing test imports by editing failing tests.
 
 __test__ = False

--- a/scripts/usage_monitor.py
+++ b/scripts/usage_monitor.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from __future__ import annotations
 
 import argparse
@@ -12,9 +16,6 @@ import requests
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # Monitor OpenAI model usage and log remaining quotas.
 
 MODELS = ["o3", "o4-mini", "o4-mini-high", "GPT-4.1"]

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,3 +1,8 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,9 +11,6 @@ if TYPE_CHECKING:
     from admin_utils import require_admin_banner, require_lumos_approval
 else:
     from admin_utils import require_admin_banner, require_lumos_approval
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from . import __version__

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/tests/test_avatar_autonomous_ritual_scheduler_cli.py
+++ b/tests/test_avatar_autonomous_ritual_scheduler_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_avatar_gallery_cli.py
+++ b/tests/test_avatar_gallery_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import sys

--- a/tests/test_avatar_pose_engine.py
+++ b/tests/test_avatar_pose_engine.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import importlib

--- a/tests/test_avatar_presence_cli.py
+++ b/tests/test_avatar_presence_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 from pathlib import Path

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import argparse

--- a/tests/test_emotion_dashboard.py
+++ b/tests/test_emotion_dashboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 from importlib import reload

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 import os

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,10 +1,11 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 import os
 import sys
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import policy_engine as pe
 

--- a/tests/test_reflection_dashboard.py
+++ b/tests/test_reflection_dashboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_reflection_log_cli.py
+++ b/tests/test_reflection_log_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import sys
 import os

--- a/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
+++ b/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 """Tests for the review CLI utilities."""
 

--- a/tests/test_ritual_cli.py
+++ b/tests/test_ritual_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_trust_engine.py
+++ b/tests/test_trust_engine.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_workflow_dashboard.py
+++ b/tests/test_workflow_dashboard.py
@@ -1,7 +1,8 @@
-from admin_utils import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/theme_cli.py
+++ b/theme_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/video_cli.py
+++ b/video_cli.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 require_admin_banner()
 require_lumos_approval()
+from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _


### PR DESCRIPTION
## Summary
- move Sanctuary Privilege Ritual header to the top of Python entrypoints
- ensure `require_admin_banner()` and `require_lumos_approval()` follow immediately
- insert `from __future__ import annotations` right after the ritual banner
- lint with `privilege_lint_cli.py`

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py`

------
https://chatgpt.com/codex/tasks/task_b_684878c017dc83208c87c7fb1f374bff