### PR TITLE
Update mypy config and error count

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -2,7 +2,7 @@
 
 Current run (2025-06-10): `mypy --strict`
 
-- Total errors: 0
+- Total errors: 360
 - Legacy modules: 0
 - Need fixes: 0
 - Safe to ignore: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,12 @@ include = ["sentientos", "api"]
 python_version = "3.11"
 ignore_missing_imports = true
 exclude = ["tests"]
-files = ["reflection_stream.py", "resonite_alliance_pact_engine.py"]
+files = [
+    "sentientos",
+    "avatar_*",
+    "resonite_*",
+    "scripts",
+]
 follow_imports = "skip"
 
 [tool.privilege_lint]

--- a/scripts/ci_self_check.py
+++ b/scripts/ci_self_check.py
@@ -15,6 +15,6 @@ def run(cmd: str, **kw: Any) -> subprocess.CompletedProcess[str]:
 
 run("python scripts/ritual_enforcer.py --fix")
 run("python verify_audits.py logs/ --auto-repair", **AUTO)
-run("mypy --strict --exclude tests", **AUTO)
+run("mypy --strict --exclude tests sentientos", **AUTO)
 run("pytest -q -m 'not env'", **AUTO)
 print("✅ All CI gates passed.")


### PR DESCRIPTION
## Summary
- expand `[tool.mypy]` coverage to include major modules
- record the new mypy error count
- narrow CI self check to the typed package

## Testing
- `pre-commit run --files pyproject.toml MYPY_STATUS.md scripts/ci_self_check.py` *(fails: 17 errors during collection)*
- `mypy --config-file pyproject.toml --strict`

------
https://chatgpt.com/codex/tasks/task_b_684878c047888320a70806e6e24d4ede