### PR TITLE
Clean up privilege lint references

### DIFF
--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -1,4 +1,4 @@
-# ── privilege_lint.py ──────────────────────────────────────────────
+# ── privilege_lint_cli.py ─────────────────────────────────────────
 from __future__ import annotations
 
 import ast


### PR DESCRIPTION
## Summary
- adjust header comment in `privilege_lint_cli.py` to match file name
- confirm there is no `scripts/privilege_lint.py`

## Testing
- `mypy --strict sentientos`

------
https://chatgpt.com/codex/tasks/task_b_68488896346883208e4a80d62c742cd7