### PR TITLE
Update pytest dependencies in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,13 @@ repos:
     pass_filenames: false
   - id: pytest
     name: unit tests
-    entry: bash -c "pip install -r requirements-dev.txt && pytest -q"
-    language: system
+    entry: bash -c "pip install -e . && pytest -q"
+    language: python
+    additional_dependencies:
+      - pytest
+      - pytest-cov
+      - requests
+      - PyYAML
     pass_filenames: false
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.16.0


### PR DESCRIPTION
## Summary
- update pytest hook with additional dependencies

## Testing
- `pre-commit run pytest --all-files` *(fails: 77 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68488b4faf70832081da21565f7742bf