### PR TITLE
Fix privilege ritual placement

### DIFF
--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,9 +1,9 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
+require_admin_banner()
+require_lumos_approval()
 
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,7 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 


### PR DESCRIPTION
## Summary
- move docstrings and privilege checks to the start of `avatar_reflection.py` and `autonomous_audit.py`
- ensure admin and lumos approval occurs early

## Testing
- `python privilege_lint.py` *(fails: can't open file)*

------
https://chatgpt.com/codex/tasks/task_b_6848abb52918832088dd975be7422376