### PR TITLE
Add privilege lint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: pip install pre-commit && pip install -e .[dev]
       - name: Pre-commit
         run: pre-commit run --all-files
+      - name: Privilege lint
+        run: python privilege_lint.py
       - name: Verify audits
         run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
       - run: mypy sentientos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ SentientOS welcomes contributions that honor privilege banners, immutable memory
 
 
 All new scripts must start with the Sanctuary Privilege Ritual docstring, followed by `require_admin_banner()` and `require_lumos_approval()`, before any imports. See README for exact syntax.
-These calls must appear before any imports and are enforced by privilege_lint_cli.py.
+These calls must appear before any imports and are enforced by `privilege_lint.py`.
 
 ```python
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
@@ -26,9 +26,9 @@ copy the skeleton automatically.
 
 Pull requests lacking these will fail CI and be rejected.
 CI runs `pre-commit run --all-files` automatically before executing the test suite.
-If any hook (`privilege-lint`, `audit-verify`, or `pytest-args`) fails, the job will fail.
+It then executes `python privilege_lint.py` before running tests. If any hook (`privilege-lint`, `audit-verify`, or `pytest-args`) fails, or if the linter reports violations, the job will fail.
 
-Run `python privilege_lint_cli.py` locally before submitting a pull request. You can also
+Run `python privilege_lint.py` locally before submitting a pull request. You can also
 link `./.githooks/pre-commit` into your `.git/hooks` folder to automatically
 run the lint before each commit. The hook also runs `python verify_audits.py logs/` to ensure audit logs remain valid before merging.
 
@@ -57,10 +57,10 @@ CI also runs mypy and docs build along with tests:
 ```yaml
 - name: Enforce privilege rituals
   run: python scripts/ritual_enforcer.py --mode fix
+- name: Privilege lint
+  run: LUMOS_AUTO_APPROVE=1 python privilege_lint.py
 - name: Run tests
   run: pytest -q
-- name: Privilege lint
-  run: LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py
 - name: Verify audits
   run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
 - name: Type check

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -1,0 +1,12 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
+
+from admin_utils import require_admin_banner, require_lumos_approval
+import sys
+
+from privilege_lint_cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- create `privilege_lint.py` wrapper script
- run linter in CI before tests
- document requirement in CONTRIBUTING

## Testing
- `pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md privilege_lint.py` *(fails: mypy errors)*
- `pytest -k ci_self_check -q` *(fails: syntax errors during collection)*


------
https://chatgpt.com/codex/tasks/task_b_6848abb90a1483208b958c14988e74fb