### PR TITLE
Fix legacy test imports

### DIFF
--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -1,7 +1,8 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
+from __future__ import annotations
+
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _

--- a/audit_chain.py
+++ b/audit_chain.py
@@ -1,9 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
 
 
 

--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,10 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
+
 from admin_utils import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
-from __future__ import annotations
+
+require_admin_banner()
+require_lumos_approval()
 
 import os
 import sys

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,7 +1,8 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
+from __future__ import annotations
+
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 #  _____  _             _
 # |  __ \| |           (_)
 # | |__) | |_   _  __ _ _ _ __   __ _
@@ -9,8 +10,7 @@ from __future__ import annotations
 # | |    | | |_| | (_| | | | | | (_| |
 # |_|    |_\__,_|\__, |_|_| |_|\__, |
 #                  __/ |         __/ |
-#                 |___/         |___/ 
-from __future__ import annotations
+#                 |___/         |___/
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()


### PR DESCRIPTION
## Summary
- reorder `__future__` imports in several modules
- update CLI files so tests run without syntax errors

## Testing
- `pytest tests/test_avatar_rituals.py tests/test_music.py -o addopts='' -q`

------
https://chatgpt.com/codex/tasks/task_b_6848b16963fc8320823c2712da07aa17