### PR TITLE
Fix privilege banner placement

### DIFF
--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -111,7 +111,6 @@ def generate_report(report_dir: Path = PUBLIC_DIR) -> Path:
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI
-    require_admin_banner()
     p = argparse.ArgumentParser(description="Autonomous audit recap")
     p.add_argument("--last", type=int, default=0, help="show last N entries")
     p.add_argument(

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,20 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()
 require_lumos_approval()
+
 from __future__ import annotations
-#  _____  _             _
-# |  __ \| |           (_)
-# | |__) | |_   _  __ _ _ _ __   __ _
-# |  ___/| | | | |/ _` | | '_ \ / _` |
-# | |    | | |_| | (_| | | | | | (_| |
-# |_|    |_\__,_|\__, |_|_| |_|\__, |
-#                  __/ |         __/ |
-#                 |___/         |___/ 
-from __future__ import annotations
-"""Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
-# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
@@ -22,6 +10,7 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
+
 LOG_PATH = get_log_path("avatar_invocation.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
@@ -39,7 +28,6 @@ def log_invocation(line: str, mode: str, user: str = "") -> dict:
 
 
 def main() -> None:
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Avatar ritual invocation")
     ap.add_argument("line")
     ap.add_argument("--mode", default="voice")

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,19 +1,8 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
+
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
-#  _____  _             _
-# |  __ \| |           (_)
-# | |__) | |_   _  __ _ _ _ __   __ _
-# |  ___/| | | | |/ _` | | '_ \ / _` |
-# | |    | | |_| | (_| | | | | | (_| |
-# |_|    |_\__,_|\__, |_|_| |_|\__, |
-#                  __/ |         __/ |
-#                 |___/         |___/
-"""Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
-# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from admin_utils import require_admin_banner, require_lumos_approval
 
@@ -48,7 +37,6 @@ def log_invocation(path: str, reason: str, mode: str = "visual") -> dict:
 
 
 def main() -> None:
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Invoke avatar with blessing")
     ap.add_argument("avatar")
     ap.add_argument("reason")


### PR DESCRIPTION
## Summary
- relocate ritual docstring and banner calls in CLI entrypoints
- remove duplicate privilege calls inside `main()` functions

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py avatar_invocation_cli.py avatar_presence_cli.py autonomous_audit.py`

------
https://chatgpt.com/codex/tasks/task_b_6848b16984948320b54dd2d5b668a4db