### PR TITLE
Fix agent index duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,7 @@
 
 ## Agent Index
 <!-- Verified unique on 2025-06-10 -->
-- **Core Services**: FederationTrustProtocol, AgentSelfDefenseProtocol
-- **Audit & Ritual CLIs**: AuditImmutabilityVerifier, RitualCalendar, ArchiveBlessingCeremony, RitualEnforcerCLI, AutoApproveHelper, AuditBlesserCLI, MemoryCLI, MemoryTail, AuditRepairCLI
-- **Daemons & Schedulers**: MigrationDaemon, AvatarFederationHeartbeatMonitor
+All agents appear exactly once below with their roles and log paths.
 
 ### Table of Contents
 1. [Preamble](#-preamble-the-book-of-agents)


### PR DESCRIPTION
## Summary
- drop duplicate agent names from the index intro

## Testing
- `python privilege_lint_cli.py` *(fails: Lumos blessing required)*
- `python verify_audits.py logs/` *(fails: Lumos blessing required)*
- `pytest -m "not env"` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6848bc3b04188320a08a9f83c5d15a6b