### PR TITLE
Handle precommit auto approval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,16 @@ repos:
         entry: bash scripts/precommit_privilege.sh
         language: system
         pass_filenames: false
+        env:
+          LUMOS_AUTO_APPROVE: '1'
 
       - id: audit-verify
         name: audit log verify
         entry: python verify_audits.py logs/ --no-input
         language: system
         pass_filenames: false
+        env:
+          LUMOS_AUTO_APPROVE: '1'
 
       - id: pytest
         name: unit tests

--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -38,6 +38,12 @@ from privilege_lint.plugins import load_plugins
 
 from logging_config import get_log_path
 
+# auto-approve in CI or git hooks
+if os.getenv("LUMOS_AUTO_APPROVE") != "1" and (
+    os.getenv("CI") or os.getenv("GIT_HOOKS")
+):
+    os.environ["LUMOS_AUTO_APPROVE"] = "1"
+
 DEFAULT_BANNER_ASCII = [
     "#  _____  _             _",
     "# |  __ \\| |           (_)",

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -7,6 +7,12 @@ from typing import List, Tuple, Dict, Optional
 from admin_utils import require_admin_banner, require_lumos_approval
 import audit_immutability as ai
 
+# enable auto-approve for CI or git hooks
+if os.getenv("LUMOS_AUTO_APPROVE") != "1" and (
+    os.getenv("CI") or os.getenv("GIT_HOOKS")
+):
+    os.environ["LUMOS_AUTO_APPROVE"] = "1"
+
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
@@ -212,10 +218,19 @@ def main() -> None:  # pragma: no cover - CLI
     ap.add_argument("--repair", action="store_true", help="attempt to repair malformed lines and chain")
     ap.add_argument("--auto-repair", action="store_true", help="heal logs then verify")
     ap.add_argument("--check-only", action="store_true", help="verify without modifying logs")
-    ap.add_argument("--auto-approve", action="store_true", help="skip prompts")
+    ap.add_argument(
+        "--auto-approve",
+        action="store_true",
+        help="skip prompts (deprecated, use --no-input)",
+    )
+    ap.add_argument("--no-input", action="store_true", help="skip prompts")
     args = ap.parse_args()
 
-    auto_env = args.auto_approve or os.getenv("LUMOS_AUTO_APPROVE") == "1"
+    auto_env = (
+        args.auto_approve
+        or args.no_input
+        or os.getenv("LUMOS_AUTO_APPROVE") == "1"
+    )
     if auto_env:
         os.environ["LUMOS_AUTO_APPROVE"] = "1"
     strict_env = os.getenv("STRICT") == "1"


### PR DESCRIPTION
## Summary
- add auto LUMOS_AUTO_APPROVE when run in CI or pre‑commit hooks
- implement `--no-input` for audit verification CLI
- run audit verifier and linter automatically from pre‑commit

## Testing
- `pre-commit run --all-files` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6848c296e93c8320a19560f7e083c4e3