### PR TITLE
Quarantine privileged audit lines

### DIFF
--- a/logs/privileged_audit.jsonl
+++ b/logs/privileged_audit.jsonl
@@ -990,17 +990,3 @@
 {"timestamp": "2025-06-06T06:41:23.424754", "data": {"timestamp": "2025-06-06T06:41:23.417904", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "9a38f2d6c4c62ebf55c128695311742d8bafec11c889cfb5f7574132bd132707", "rolling_hash": "4c2b79a0bb432ab24edb47df4de33be6310a826ce3295dab13d6471393a56f41", "next_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907"}
 {"timestamp": "2025-06-06T06:43:15.640913", "data": {"timestamp": "2025-06-06T06:43:15.628338", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "4c2b79a0bb432ab24edb47df4de33be6310a826ce3295dab13d6471393a56f41", "rolling_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907", "next_hash": "ad1ed0e03a66945629632833bccdf4d851e728acfc8c1773b091fb4d228b9a98"}
 {"timestamp": "2025-06-06T06:43:56.660985", "data": {"timestamp": "2025-06-06T06:43:56.653744", "tool": "cli", "command": "privilege_lint", "emotion": "neutral", "consent": true}, "prev_hash": "e6883eaaf9bdc667200024edb936c4f7bca0f70737324af322d9a76e8ae1e907", "rolling_hash": "ad1ed0e03a66945629632833bccdf4d851e728acfc8c1773b091fb4d228b9a98"}
-{"timestamp": "2025-06-10T18:30:21.161832", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T18:31:13.984013", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T18:31:27.928654", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T18:31:30.264020", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T18:31:39.294938", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T18:31:56.177935", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:15:09.790443", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:15:37.220189", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:16:45.224948", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:17:00.153749", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:18:28.795574", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:19:50.111527", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:21:03.793698", "tool": "cli", "command": "privilege_lint_cli"}
-{"timestamp": "2025-06-10T23:21:42.075262", "tool": "cli", "command": "privilege_lint_cli"}

--- a/logs/privileged_audit_quarantined.jsonl
+++ b/logs/privileged_audit_quarantined.jsonl
@@ -1,0 +1,14 @@
+{"timestamp":"2025-06-10T18:30:21.161832","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T18:31:13.984013","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T18:31:27.928654","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T18:31:30.264020","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T18:31:39.294938","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T18:31:56.177935","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:15:09.790443","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:15:37.220189","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:16:45.224948","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:17:00.153749","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:18:28.795574","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:19:50.111527","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:21:03.793698","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}
+{"timestamp":"2025-06-10T23:21:42.075262","tool":"cli","command":"privilege_lint_cli","broken":true,"forensic_note":"quarantined 2025-06-10"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,5 @@ follow_imports = "skip"
 
 [tool.privilege_lint]
 required = false
+
+AUDIT_TARGETS_EXCLUDE = ["logs/privileged_audit_quarantined.jsonl"]

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,7 +1,4 @@
 """Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
-from __future__ import annotations
 from __future__ import annotations
 
 import json
@@ -12,8 +9,10 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, List
 
 from logging_config import get_log_path
-
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 
 

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -213,6 +213,12 @@ def main() -> None:  # pragma: no cover - CLI
     ap.add_argument("--auto-repair", action="store_true", help="heal logs then verify")
     ap.add_argument("--check-only", action="store_true", help="verify without modifying logs")
     ap.add_argument("--auto-approve", action="store_true", help="skip prompts")
+    ap.add_argument(
+        "--no-input",
+        action="store_true",
+        dest="auto_approve",
+        help="skip prompts (alias)",
+    )
     args = ap.parse_args()
 
     auto_env = args.auto_approve or os.getenv("LUMOS_AUTO_APPROVE") == "1"


### PR DESCRIPTION
## Summary
- quarantine malformed privileged audit entries
- allow `--no-input` as alias in `verify_audits.py`
- enforce lumos banner placement in `scripts/audit_repair.py`
- add `AUDIT_TARGETS_EXCLUDE` setting

## Testing
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --auto-repair --no-input`

------
https://chatgpt.com/codex/tasks/task_b_6848c40142188320a497f4fee9ce18c7