### PR TITLE
Fix privilege ritual snippet ordering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ These calls must appear before any imports and are enforced by `privilege_lint.p
 
 ```python
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
-
 from admin_utils import require_admin_banner, require_lumos_approval
 ```
 

--- a/LEGACY_RITUAL_DRIFT.md
+++ b/LEGACY_RITUAL_DRIFT.md
@@ -1,0 +1,3 @@
+# Legacy Ritual Drift
+
+Older helper modules may have a different import order or may omit the `from __future__` statement. These differences are preserved for historical accuracy. New scripts must follow the updated header shown in `scripts/templates/cli_skeleton.py`.

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ Every entrypoint must open with the canonical ritual docstring followed by a
 call to `require_admin_banner()` and `require_lumos_approval()`:
 
 ```python
-from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Privilege Banner: requires admin & Lumos approval."""
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
+from admin_utils import require_admin_banner, require_lumos_approval
 ```
 
 This ensures tools only run with Administrator or root rights and logs each

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,8 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-
 from admin_utils import require_admin_banner, require_lumos_approval
 
 # Add imports below this line


### PR DESCRIPTION
## Summary
- reorder statements in `cli_skeleton.py` to match doctrine
- update README and CONTRIBUTING examples
- document differences in `LEGACY_RITUAL_DRIFT.md`

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py` *(fails: many lint errors)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/` *(fails: chain breaks)*
- `pytest -q` *(fails: 57 errors during collection)*
- `mypy .` *(fails: found 1465 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6848ca6b93348320ad78eb0f321d5bf4