### PR TITLE
Move banner checks after arg parsing

### DIFF
--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,6 +1,4 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from __future__ import annotations
 import json
@@ -41,6 +39,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     auto = args.auto_approve or os.getenv("LUMOS_AUTO_APPROVE") == "1"
+    if auto:
+        os.environ["LUMOS_AUTO_APPROVE"] = "1"
+
+    require_admin_banner()
+    require_lumos_approval()
 
     result = run_verify()
     output = result.stdout + result.stderr

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,6 +1,4 @@
 """Privilege Banner: requires admin & Lumos approval."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from __future__ import annotations
 
@@ -106,6 +104,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.auto_approve or os.getenv("LUMOS_AUTO_APPROVE") == "1":
         os.environ["LUMOS_AUTO_APPROVE"] = "1"
+
+    require_admin_banner()
+    require_lumos_approval()
 
     logs_dir = Path(args.logs_dir)
     prev = "0" * 64

--- a/tests/test_verify_audits_cli.py
+++ b/tests/test_verify_audits_cli.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import audit_immutability as ai
+
+
+def _make_log(tmp_path: Path) -> Path:
+    log = tmp_path / "log.jsonl"
+    ai.append_entry(log, {"x": 1})
+    return log
+
+
+def test_cli_env_auto(tmp_path: Path) -> None:
+    _make_log(tmp_path)
+    env = os.environ.copy()
+    env["LUMOS_AUTO_APPROVE"] = "1"
+    env["PYTHONPATH"] = "."
+    cp = subprocess.run([sys.executable, "verify_audits.py", str(tmp_path)], env=env)
+    assert cp.returncode == 0
+
+
+def test_cli_flag_auto(tmp_path: Path) -> None:
+    _make_log(tmp_path)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    cp = subprocess.run([sys.executable, "verify_audits.py", str(tmp_path), "--auto-approve"], env=env)
+    assert cp.returncode == 0

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -8,8 +8,6 @@ from admin_utils import require_admin_banner, require_lumos_approval
 import audit_immutability as ai
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 
 ROOT = Path(__file__).resolve().parent
 CONFIG = Path("config/master_files.json")
@@ -204,7 +202,6 @@ def verify_audits(
 
 
 def main() -> None:  # pragma: no cover - CLI
-    require_admin_banner()
     import argparse
 
     ap = argparse.ArgumentParser(description="Audit log verifier")
@@ -218,6 +215,10 @@ def main() -> None:  # pragma: no cover - CLI
     auto_env = args.auto_approve or os.getenv("LUMOS_AUTO_APPROVE") == "1"
     if auto_env:
         os.environ["LUMOS_AUTO_APPROVE"] = "1"
+
+    require_admin_banner()
+    require_lumos_approval()
+
     strict_env = os.getenv("STRICT") == "1"
 
     directory = None


### PR DESCRIPTION
## Summary
- defer banner checks in verify_audits CLI
- defer banner checks in audit_blesser and audit_repair
- allow non-interactive verification path
- test verify_audits CLI auto approval

## Testing
- `pytest tests/test_audit_blesser.py tests/test_audit_repair.py tests/test_verify_audits_cli.py tests/test_verify_audits.py tests/test_verify_audits_dir.py tests/test_sentientos_core.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6848ca6be1048320b6219d1ed627f281