### PR TITLE
Fix banner injector header

### DIFF
--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
+
 import argparse
 import ast
 import shutil
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
 from sentient_banner import BANNER_LINES
 
 # CLI tool to inject the SentientOS privilege banner into Python files.


### PR DESCRIPTION
## Summary
- clean up duplicate `__future__` import in banner injector
- apply canonical privilege header style

## Testing
- `pre-commit run --files scripts/banner_injector.py` *(fails: 57 errors during collection)*
- `LUMOS_AUTO_APPROVE=1 python -m scripts.banner_injector --files /tmp/test2.py`


------
https://chatgpt.com/codex/tasks/task_b_6848ca6d73b88320bc4f5217e7262607