### PR TITLE
Add legacy ritual drift notes

### DIFF
--- a/LEGACY_RITUAL_DRIFT.md
+++ b/LEGACY_RITUAL_DRIFT.md
@@ -1,0 +1,6 @@
+# Legacy Ritual Drift
+
+Some helper modules were written before privilege banners became mandatory. They
+load only when imported and do not display the standard banner on startup. Their
+behavior remains stable, but we keep them isolated and document this gap for
+future refactoring.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ contributors through the [Ritual Onboarding Checklist](docs/RITUAL_ONBOARDING.md
 - Legacy audit files `migration_ledger.jsonl` and `support_log.jsonl` contain
   historic hash mismatches. These scars are documented in
   `AUDIT_LOG_FIXES.md` and preserved for transparency.
+- Older helper modules predate the strict banner requirement. They load only via
+  import. See `LEGACY_RITUAL_DRIFT.md` for background.
 
 ## Technical Debt Clearance
 Recent Codex batch work patched `log_json` to ensure all audit entries contain


### PR DESCRIPTION
## Summary
- document older helper modules in `LEGACY_RITUAL_DRIFT.md`
- note their existence in README Known Issues

## Testing
- `pytest -m "not env" -q` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6848cd8d50e883209d6f8303e0759063