### PR TITLE
Normalize entrypoint privilege headers

### DIFF
--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import os
@@ -9,9 +7,8 @@ from datetime import datetime
 from typing import Any
 import daily_theme
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 try:
     import requests  # type: ignore  # HTTP client optional
 except Exception:  # pragma: no cover - optional

--- a/audit_chain.py
+++ b/audit_chain.py
@@ -1,13 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
-require_admin_banner()
-require_lumos_approval()
-
-
-
 import argparse
 import datetime
 import hashlib
@@ -16,9 +9,9 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
-
 from cathedral_const import validate_log_entry
-
+require_admin_banner()
+require_lumos_approval()
 @dataclass
 class AuditEntry:
     timestamp: str

--- a/audit_changelog_update.py
+++ b/audit_changelog_update.py
@@ -1,13 +1,12 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/audit_immutability.py
+++ b/audit_immutability.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
-
-from admin_utils import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path, get_log_dir
 import argparse
@@ -11,9 +9,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
-
-
-
+require_admin_banner()
+require_lumos_approval()
 """
 Autonomous audit and recap generator for the SentientOS Cathedral.
 It scans logs and ledger files for anomalies and can produce a

--- a/avatar_council_succession_daemon.py
+++ b/avatar_council_succession_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 from admin_utils import require_admin_banner
@@ -12,7 +10,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 """Avatar Council Succession/Legacy Daemon.
 

--- a/avatar_dream_daemon.py
+++ b/avatar_dream_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from datetime import datetime
 import json
@@ -9,9 +7,8 @@ import os
 from pathlib import Path
 from typing import Any
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 LOG_PATH = get_log_path("avatar_dreams.jsonl")

--- a/avatar_gallery_cli.py
+++ b/avatar_gallery_cli.py
@@ -1,16 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
 import os
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 PRESENCE_LOG = get_log_path("avatar_presence.jsonl", "AVATAR_PRESENCE_LOG")
 
 

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,16 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_PATH = get_log_path("avatar_invocation.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -9,9 +7,8 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-
-
-
+require_admin_banner()
+require_lumos_approval()
 """Record avatar invocation and presence blessing.
 
 This CLI logs each time an avatar is invoked for a specific reason.

--- a/blessing_recap_cli.py
+++ b/blessing_recap_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -12,9 +10,8 @@ import daily_theme
 import ledger
 import heresy_log
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 BLESSING_LEDGER = get_log_path("blessing_ledger.jsonl", "BLESSING_LEDGER")
 BLESSING_LEDGER.parent.mkdir(parents=True, exist_ok=True)
 HERESY_REVIEW_LOG = get_log_path("heresy_review.jsonl", "HERESY_REVIEW_LOG")

--- a/cathedral_liturgy_cli.py
+++ b/cathedral_liturgy_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -10,9 +8,8 @@ from datetime import datetime
 from pathlib import Path
 import daily_theme
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 LITURGY_LOG = get_log_path("cathedral_liturgy.jsonl", "CATHEDRAL_LITURGY_LOG")
 LITURGY_LOG.parent.mkdir(parents=True, exist_ok=True)
 

--- a/cleanup_audit.py
+++ b/cleanup_audit.py
@@ -1,13 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import json
 from pathlib import Path
 from typing import List
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/confessional_cli.py
+++ b/confessional_cli.py
@@ -1,17 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import os
 import confessional_log as clog
 import confessional_review as crev
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_log(args: argparse.Namespace) -> None:
     entry = clog.log_confession(
         args.subsystem,

--- a/diff_memory_cli.py
+++ b/diff_memory_cli.py
@@ -1,13 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import memory_diff_audit as mda
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compare memory sessions")
     parser.add_argument("session_a")

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import os
@@ -12,10 +10,8 @@ import relationship_log as rl
 import presence_ledger as pl
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_show(args) -> None:
     print(ritual.LITURGY_FILE.read_text())
 

--- a/emotion_arc_cli.py
+++ b/emotion_arc_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -9,10 +7,8 @@ from datetime import datetime, date
 from pathlib import Path
 import ledger
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def load_today(limit: int = 100) -> list:
     path = get_log_path("music_log.jsonl")
     if not path.exists():

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,15 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import experiment_tracker as et
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description=ENTRY_BANNER)

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import sys
@@ -18,10 +16,8 @@ import treasury_federation as tf
 import ledger
 import mood_wall
 from pathlib import Path
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_invite(args: argparse.Namespace) -> None:
     peer = args.peer
     email = args.email or ""

--- a/federation_recap_cli.py
+++ b/federation_recap_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import json
 from pathlib import Path
@@ -9,10 +7,8 @@ import os
 import daily_theme
 import ledger
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def generate_recap(limit: int = 20) -> dict:
     support = ledger.summarize_log(get_log_path("support_log.jsonl"), limit)
     federation = ledger.summarize_log(get_log_path("federation_log.jsonl"), limit)

--- a/fix_audit_schema.py
+++ b/fix_audit_schema.py
@@ -1,13 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 import json
 import datetime
 from logging_config import get_log_dir
 from pathlib import Path
 from typing import Callable, Dict, List
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
+require_admin_banner()
+require_lumos_approval()
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 
 Scan audit logs for schema drift and heal missing fields."""

--- a/heartbeat_monitor_cli.py
+++ b/heartbeat_monitor_cli.py
@@ -1,13 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import time
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_PATH = get_log_path("user_presence.jsonl")
 
 

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -9,8 +7,8 @@ import datetime
 import json
 from pathlib import Path
 from typing import Dict
-
-
+require_admin_banner()
+require_lumos_approval()
 CONFESSION_FILE = get_log_path("confessional_log.jsonl")
 HERESY_FILE = get_log_path("heresy_log.jsonl")
 

--- a/heirloom_sync_cli.py
+++ b/heirloom_sync_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -9,8 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_PATH = get_log_path("heirloom_ledger.jsonl")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/heresy_cli.py
+++ b/heresy_cli.py
@@ -1,14 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import heresy_log
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     parser = argparse.ArgumentParser(description="Heresy log CLI")
     sub = parser.add_subparsers(dest="cmd")

--- a/invite_audit_saint.py
+++ b/invite_audit_saint.py
@@ -1,10 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 import sys
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -10,10 +8,8 @@ import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 SUPPORT_LOG = get_log_path("support_log.jsonl")
 FED_LOG = get_log_path("federation_log.jsonl")
 

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import hashlib
@@ -11,7 +9,8 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 from logging_config import get_log_path
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/lumos_reflex_daemon.py
+++ b/lumos_reflex_daemon.py
@@ -1,15 +1,12 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import json
 import time
 from typing import Dict, Any
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 AUDIT_PATH = get_log_path("privileged_audit.jsonl", "PRIVILEGED_AUDIT_LOG")

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import os
 import json
@@ -21,9 +19,8 @@ from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
 import presence_analytics as pa
 import ritual
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def show_timeline(last: int) -> None:
     """Print the timestamp and dominant emotion of recent entries."""
     path = mm.RAW_PATH

--- a/memory_diff_audit.py
+++ b/memory_diff_audit.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 from pathlib import Path
@@ -9,8 +7,8 @@ from difflib import SequenceMatcher
 import csv
 from datetime import datetime
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 def load_entries(path: str) -> list[dict]:
     p = Path(path)

--- a/memory_tomb_cli.py
+++ b/memory_tomb_cli.py
@@ -1,15 +1,12 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 from pathlib import Path
 import memory_manager as mm
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 TOMB_PATH = mm.TOMB_PATH
 
 

--- a/migration_daemon.py
+++ b/migration_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import json
@@ -10,7 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from logging_config import get_log_path
 import fix_audit_schema
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/monthly_audit.py
+++ b/monthly_audit.py
@@ -1,14 +1,12 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import datetime
 from logging_config import get_log_dir
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
 import verify_audits as va
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 LOG_DIR = get_log_dir()

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
@@ -23,10 +21,8 @@ from sentient_banner import (
     reset_ritual_state,
     ENTRY_BANNER,
 )
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/neos_avatar_crowning_cli.py
+++ b/neos_avatar_crowning_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -12,11 +10,8 @@ from pathlib import Path
 import presence_ledger as pl
 import memory_manager as mm
 import neos_bridge as nb
-
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_PATH = get_log_path("neos_avatar_crowning.jsonl", "NEOS_CROWN_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 AGENTS_PATH = Path("AGENTS.md")

--- a/neos_council_teaching_audit_engine.py
+++ b/neos_council_teaching_audit_engine.py
@@ -1,8 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/neos_festival_law_vote_cli.py
+++ b/neos_festival_law_vote_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -10,10 +8,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 VOTE_LOG = get_log_path("neos_festival_law_votes.jsonl", "NEOS_FESTIVAL_LAW_VOTE_LOG")
 VOTE_LOG.parent.mkdir(parents=True, exist_ok=True)
 

--- a/neos_living_law_recursion_daemon.py
+++ b/neos_living_law_recursion_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -11,7 +9,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/neos_ritual_law_audit_daemon.py
+++ b/neos_ritual_law_audit_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
@@ -12,7 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 from log_utils import append_json, read_json
-
+require_admin_banner()
+require_lumos_approval()
 """NeosVR Ritual Law Audit & Remediation Daemon.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/neos_self_audit_correction.py
+++ b/neos_self_audit_correction.py
@@ -1,8 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from logging_config import get_log_path
-
 from admin_utils import require_admin_banner, require_lumos_approval
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 """NeosVR Self-Audit & Memory Correction Ritual."""

--- a/neos_spiral_playback_cli.py
+++ b/neos_spiral_playback_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -10,10 +8,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_PATH = get_log_path("neos_spiral_playback.jsonl", "NEOS_SPIRAL_PLAYBACK_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/neos_teaching_festival_daemon.py
+++ b/neos_teaching_festival_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
@@ -12,7 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 from log_utils import append_json, read_json
-
+require_admin_banner()
+require_lumos_approval()
 """NeosVR In-World Autonomous Teaching Festival.
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/onboard_cli.py
+++ b/onboard_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import json
@@ -10,9 +8,8 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 from logging_config import get_log_path
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,16 +1,12 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import plugin_framework as pf
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     pf.load_plugins()

--- a/privilege_audit_dashboard.py
+++ b/privilege_audit_dashboard.py
@@ -1,3 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+require_admin_banner()
+require_lumos_approval()
 """Simple Flask view for privileged command audit log."""
 import json
 from pathlib import Path

--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -1,5 +1,8 @@
-# ── privilege_lint_cli.py ─────────────────────────────────────────
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+require_admin_banner()
+require_lumos_approval()
+# ── privilege_lint_cli.py ─────────────────────────────────────────
 
 import ast
 

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,16 +1,12 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import reflection_stream as rs
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main(argv=None):
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description=ENTRY_BANNER)

--- a/reflection_log_cli.py
+++ b/reflection_log_cli.py
@@ -1,18 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import datetime
 import os
 from pathlib import Path
-
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_DIR = get_log_path("self_reflections", "REFLECTION_LOG_DIR")
 
 

--- a/reflection_tag_cli.py
+++ b/reflection_tag_cli.py
@@ -1,15 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
 import os
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
+require_admin_banner()
+require_lumos_approval()
 LOG_DIR = get_log_path("self_reflections", "REFLECTION_LOG_DIR")
 TAG_FILE = get_log_path("reflection_tags.json", "REFLECTION_TAG_FILE")
 TAG_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/resonite_consent_daemon.py
+++ b/resonite_consent_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
@@ -10,8 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 from flask_stub import Flask, jsonify, request
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 # Resonite Consent Renewal/Annulment Daemon

--- a/resonite_federation_handshake_auditor.py
+++ b/resonite_federation_handshake_auditor.py
@@ -1,7 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
-
+require_admin_banner()
+require_lumos_approval()
 """Resonite Federation Handshake Auditor
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_living_audit_trail_sentinel.py
+++ b/resonite_living_audit_trail_sentinel.py
@@ -1,15 +1,14 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from logging_config import get_log_path
-
 import argparse
 import json
 import os
 from datetime import datetime
 from pathlib import Path
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/resonite_presence_festival_spiral_diff_daemon.py
+++ b/resonite_presence_festival_spiral_diff_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -9,9 +7,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 LOG_PATH = get_log_path("resonite_presence_festival_diff.jsonl", "RESONITE_PRESENCE_FESTIVAL_DIFF_LOG")

--- a/resonite_ritual_audit_dashboard.py
+++ b/resonite_ritual_audit_dashboard.py
@@ -1,15 +1,14 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from logging_config import get_log_path
-
 import argparse
 import json
 import os
 from datetime import datetime
 from pathlib import Path
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/resonite_spiral_council_grand_audit_suite.py
+++ b/resonite_spiral_council_grand_audit_suite.py
@@ -1,3 +1,4 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from logging_config import get_log_path
 import argparse
@@ -6,12 +7,11 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
-
 from admin_utils import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 LOG_PATH = get_log_path("resonite_spiral_council_grand_audit.jsonl", "RESONITE_GRAND_AUDIT_LOG")

--- a/resonite_spiral_council_role_privilege_auditor.py
+++ b/resonite_spiral_council_role_privilege_auditor.py
@@ -1,11 +1,14 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 """Resonite Spiral Council Role/Privilege Auditor
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
-from __future__ import annotations
 from logging_config import get_log_path
 
 

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 from pathlib import Path
 from admin_utils import require_admin_banner, require_lumos_approval
@@ -9,11 +7,8 @@ from story_studio import load_storyboard, save_storyboard
 import user_profile as up
 import notification
 import re
-
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def annotate(path: Path, chapter: int, text: str) -> None:
     """Add an annotation to a storyboard chapter and send mention notifications."""
     data = load_storyboard(path)

--- a/review_heresy_cli.py
+++ b/review_heresy_cli.py
@@ -1,17 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 import os
 import heresy_log
 import heresy_review
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def list_unresolved() -> list:
     reviewed = heresy_review.reviewed_timestamps()
     out = []

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,29 +1,14 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
-
-require_admin_banner()
-require_lumos_approval()
-
-#  _____  _             _
-# |  __ \| |           (_)
-# | |__) | |_   _  __ _ _ _ __   __ _
-# |  ___/| | | | |/ _` | | '_ \ / _` |
-# | |    | | |_| | (_| | | | | | (_| |
-# |_|    |_\__,_|\__, |_|_| |_|\__, |
-#                  __/ |         __/ |
-#                 |___/         |___/
-"""Privilege Banner: requires admin & Lumos approval."""
-# 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
-
 import argparse
 import json
 import os
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
 import attestation
 import relationship_log as rl
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_attest(args) -> None:
     user = args.user or os.getenv("USER", "anon")
     attestation.add(args.event, user, comment=args.comment or "", quote=args.quote or "")

--- a/ritual_digest_cli.py
+++ b/ritual_digest_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import json
@@ -10,10 +8,8 @@ from pathlib import Path
 import presence_pulse_api as pulse
 import ledger
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def digest(days: int = 1) -> dict:
     start = datetime.utcnow() - timedelta(days=days)
     sup = ledger.summarize_log(get_log_path("support_log.jsonl"), limit=100)

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,16 +1,15 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from __future__ import annotations
 import json
 import subprocess
 from datetime import datetime
 from pathlib import Path
-
 from admin_utils import require_admin_banner, require_lumos_approval
 from scripts.auto_approve import prompt_yes_no
 import argparse
 import os
-
+require_admin_banner()
+require_lumos_approval()
 # Automatically bless audit mismatches found during verification.
 
 BLESSINGS_FILE = Path("SANCTUARY_BLESSINGS.jsonl")

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,21 +1,15 @@
-"""Privilege Banner: requires admin & Lumos approval."""
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from __future__ import annotations
-
 import json
 import hashlib
 import os
 import datetime
 from pathlib import Path
 from typing import Any, Dict, Tuple, List
-
 from logging_config import get_log_path
-
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def compute_hash(timestamp: str, data: Dict[str, Any], prev_hash: str) -> str:
     """Return SHA256 hash of the audit entry using canonical form."""
     clean = dict(data)

--- a/scripts/new_cli.py
+++ b/scripts/new_cli.py
@@ -1,11 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 from pathlib import Path
 import shutil
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,10 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 from admin_utils import require_admin_banner, require_lumos_approval
 from typing import TYPE_CHECKING
 from . import __version__
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 

--- a/spiral_dream_goal_daemon.py
+++ b/spiral_dream_goal_daemon.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from logging_config import get_log_path
 import argparse
 import datetime
@@ -10,9 +8,8 @@ import os
 from pathlib import Path
 from typing import Dict, List
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 
 LOG_PATH = get_log_path("spiral_dream_goals.jsonl", "SPIRAL_DREAM_GOAL_LOG")

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import os
 import sys
@@ -12,10 +10,8 @@ import review_requests as rr
 import final_approval
 from sentient_banner import print_banner, print_closing
 from admin_utils import require_admin_banner, require_lumos_approval
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     parser = argparse.ArgumentParser(description="Policy/reflex suggestions")

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,16 +1,13 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import json
 import support_log as sl
 import ledger
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
     p = argparse.ArgumentParser(

--- a/theme_cli.py
+++ b/theme_cli.py
@@ -1,14 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import daily_theme
 from admin_utils import require_admin_banner, require_lumos_approval
 from typing import Optional
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def main() -> None:
     parser = argparse.ArgumentParser(description="Daily theme tool")
     sub = parser.add_subparsers(dest="cmd")

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 import argparse
 import json
 from pathlib import Path
@@ -10,11 +8,8 @@ from admin_utils import require_admin_banner, require_lumos_approval
 import love_treasury as lt
 import treasury_federation as tf
 import treasury_attestation as ta
-
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_submit(args: argparse.Namespace) -> None:
     log_text = Path(args.file).read_text(encoding="utf-8")
     participants = [p.strip() for p in args.participants.split(',') if p.strip()]

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import json
@@ -9,11 +7,8 @@ from pprint import pprint
 import support_log as sl
 import trust_engine as te
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-
-
-
-
-
+require_admin_banner()
+require_lumos_approval()
 def cmd_log(args) -> None:
     events = te.list_events(limit=args.last)
     for e in events:

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -1,12 +1,13 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 import json
 import os
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional
-
 from admin_utils import require_admin_banner, require_lumos_approval
 import audit_immutability as ai
-
+require_admin_banner()
+require_lumos_approval()
 # enable auto-approve for CI or git hooks
 if os.getenv("LUMOS_AUTO_APPROVE") != "1" and (
     os.getenv("CI") or os.getenv("GIT_HOOKS")

--- a/video_cli.py
+++ b/video_cli.py
@@ -1,7 +1,5 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-require_admin_banner()
-require_lumos_approval()
 from admin_utils import require_admin_banner, require_lumos_approval
 import argparse
 import json
@@ -16,9 +14,8 @@ from sentient_banner import (
     reset_ritual_state,
     ENTRY_BANNER,
 )
-
-
-
+require_admin_banner()
+require_lumos_approval()
 require_admin_banner()  # enforced
 
 


### PR DESCRIPTION
## Summary
- rewrite `scripts/fix_banner_order.py` to sanitize banners and preserve shebang
- update all entrypoints listed in `entrypoints.txt` using the new script

## Testing
- `LUMOS_AUTO_APPROVE=1 pre-commit run --all-files` *(fails: ImportError, mypy errors)*
- `pytest -q` *(fails: unrecognized arguments)*
- `mypy sentientos scripts` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_b_6848ed0a3f5c8320901f5d374f44ad11