### PR TITLE
Fix missing admin banner imports

### DIFF
--- a/scripts/fix_banner_order.py
+++ b/scripts/fix_banner_order.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Normalize privilege banners in CLI entrypoints."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 
 import argparse
 import pathlib

--- a/scripts/fix_entrypoint_banners.py
+++ b/scripts/fix_entrypoint_banners.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Rewrite CLI/daemon entry points to standard banner format."""
 from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 
 import pathlib
 import re

--- a/tests/test_privilege_banner_autofix.py
+++ b/tests/test_privilege_banner_autofix.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 from pathlib import Path
+from admin_utils import require_admin_banner
 
 
 def test_autofix(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- fix banner enforcement scripts to import privilege checks
- update privilege banner autofix test import

## Testing
- `python -m py_compile scripts/fix_banner_order.py`
- `python -m py_compile scripts/fix_entrypoint_banners.py`
- `python -m py_compile tests/test_privilege_banner_autofix.py`
- `pre-commit run --all-files` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68491290d09083208d760f5382569e1f