### PR TITLE
Add explicit lint and test steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,16 @@ jobs:
       - run: pip install pre-commit && pip install -e .[dev]
       - name: Pre-commit
         run: pre-commit run --all-files
-      - name: Privilege lint
-        run: python privilege_lint.py
-      - name: Verify audits
-        run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
-      - run: mypy sentientos
-      - run: pytest --cov=sentientos --cov-report=xml
+      - name: privilege_lint
+        run: python privilege_lint_cli.py
+      - name: audit_verify
+        run: python verify_audits.py logs/
+        env:
+          LUMOS_AUTO_APPROVE: '1'
+      - name: mypy
+        run: mypy sentientos
+      - name: pytest
+        run: pytest --cov=sentientos --cov-report=xml
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,16 +22,29 @@ jobs:
         with:
           go-version: '1.22'
       - if: matrix.mode == 'core'
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install -e .
       - if: matrix.mode == 'bin-lock'
         run: |
           pip install -r requirements-lock.txt
+          pip install -r requirements-dev.txt
           pip install .
       - if: matrix.mode == 'src-lock-full'
         run: |
           pip install -r requirements-src-lock.txt
+          pip install -r requirements-dev.txt
           pip install .
-      - id: tests
+      - name: privilege_lint
+        run: python privilege_lint_cli.py
+      - name: audit_verify
+        run: python verify_audits.py logs/
+        env:
+          LUMOS_AUTO_APPROVE: '1'
+      - name: mypy
+        run: mypy sentientos
+      - name: pytest
         run: pytest -q
       - name: Env report
         run: plint-env report --json > env.json


### PR DESCRIPTION
## Summary
- run privilege lint, audit verify, mypy and pytest in CI workflow
- ensure lint matrix installs dev requirements

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/lint.yml` *(fails: E   SyntaxError: from __future__ imports must occur at the beginning of the file)*
- `pytest` *(failed to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68491b025a3c832095c505acd1a70938