### PR TITLE
Add nightly self check workflow

### DIFF
--- a/.github/workflows/nightly-self-check.yml
+++ b/.github/workflows/nightly-self-check.yml
@@ -1,0 +1,28 @@
+name: Nightly Self Check
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  self-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -e .[dev]
+      - name: Verify audits
+        run: python verify_audits.py logs/
+        env:
+          LUMOS_AUTO_APPROVE: '1'
+      - name: Privilege lint
+        run: python privilege_lint_cli.py
+        env:
+          LUMOS_AUTO_APPROVE: '1'
+      - name: Run mypy
+        run: mypy sentientos
+      - name: Run pytest
+        run: pytest --cov=sentientos --cov-report=xml


### PR DESCRIPTION
## Summary
- add a nightly workflow to run audits, privilege lint, mypy and tests

## Testing
- `python privilege_lint_cli.py` *(fails: NameError)*
- `python verify_audits.py logs/ --no-input` *(fails: many chain break errors)*
- `mypy sentientos`
- `pytest -m "not env"` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68491b071c348320a979fc2e879dcaaf