### PR TITLE
Ensure Sanctuary headers for tests

### DIFF
--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from importlib import reload

--- a/tests/test_admin_utils.py
+++ b/tests/test_admin_utils.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sys
 import os
 import pytest

--- a/tests/test_archive_blessing.py
+++ b/tests/test_archive_blessing.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 import sys

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import love_treasury as lt
 import treasury_attestation as ta

--- a/tests/test_audit_blesser.py
+++ b/tests/test_audit_blesser.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_audit_chain_tamper.py
+++ b/tests/test_audit_chain_tamper.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 from pathlib import Path
 import pytest

--- a/tests/test_audit_immutability.py
+++ b/tests/test_audit_immutability.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 from pathlib import Path
 import audit_immutability as ai

--- a/tests/test_audit_repair.py
+++ b/tests/test_audit_repair.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_auto_approve.py
+++ b/tests/test_auto_approve.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from importlib import reload

--- a/tests/test_autonomous_audit.py
+++ b/tests/test_autonomous_audit.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import hashlib
 import os

--- a/tests/test_avatar_artifact_gallery.py
+++ b/tests/test_avatar_artifact_gallery.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import sys

--- a/tests/test_avatar_autonomous_ritual_scheduler_cli.py
+++ b/tests/test_avatar_autonomous_ritual_scheduler_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_avatar_emotional_feedback.py
+++ b/tests/test_avatar_emotional_feedback.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 from pathlib import Path
 

--- a/tests/test_avatar_federation.py
+++ b/tests/test_avatar_federation.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 from pathlib import Path
 

--- a/tests/test_avatar_gallery_cli.py
+++ b/tests/test_avatar_gallery_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import sys

--- a/tests/test_avatar_genesis.py
+++ b/tests/test_avatar_genesis.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import sys
 import types

--- a/tests/test_avatar_mood_evolution.py
+++ b/tests/test_avatar_mood_evolution.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import os

--- a/tests/test_avatar_pose_engine.py
+++ b/tests/test_avatar_pose_engine.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import importlib

--- a/tests/test_avatar_presence_cli.py
+++ b/tests/test_avatar_presence_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 from pathlib import Path

--- a/tests/test_avatar_presence_pulse_animation.py
+++ b/tests/test_avatar_presence_pulse_animation.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import sys
 import types

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 from pathlib import Path
 import os

--- a/tests/test_avatar_relic_creator.py
+++ b/tests/test_avatar_relic_creator.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 from pathlib import Path

--- a/tests/test_avatar_rituals.py
+++ b/tests/test_avatar_rituals.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import sys
 from pathlib import Path

--- a/tests/test_avatar_todo_fixes.py
+++ b/tests/test_avatar_todo_fixes.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import os

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_cache_speed.py
+++ b/tests/test_cache_speed.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import subprocess

--- a/tests/test_ci_self_check.py
+++ b/tests/test_ci_self_check.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_cleanup_audit.py
+++ b/tests/test_cleanup_audit.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 from pathlib import Path
 

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import importlib
 import argparse

--- a/tests/test_collab.py
+++ b/tests/test_collab.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import threading
 import time
 import json

--- a/tests/test_confessional.py
+++ b/tests/test_confessional.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_cross_lang.py
+++ b/tests/test_cross_lang.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import subprocess

--- a/tests/test_data_rules.py
+++ b/tests/test_data_rules.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys, json
 from pathlib import Path
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_doctrine_runtime.py
+++ b/tests/test_doctrine_runtime.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 import sys

--- a/tests/test_emotion_dashboard.py
+++ b/tests/test_emotion_dashboard.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 from importlib import reload

--- a/tests/test_emotion_memory.py
+++ b/tests/test_emotion_memory.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import emotion_memory as em
 
 def test_average_emotion():

--- a/tests/test_emotion_utils.py
+++ b/tests/test_emotion_utils.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import tempfile
 import wave
 from importlib import reload

--- a/tests/test_env_json.py
+++ b/tests/test_env_json.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import subprocess
 import sys

--- a/tests/test_env_report.py
+++ b/tests/test_env_report.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from privilege_lint.env import report
 
 

--- a/tests/test_experiment_tracker.py
+++ b/tests/test_experiment_tracker.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import love_treasury as lt
 import treasury_federation as tf

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_federation_invite.py
+++ b/tests/test_federation_invite.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import json
 import importlib

--- a/tests/test_federation_trust_protocol.py
+++ b/tests/test_federation_trust_protocol.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 import sys

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import time
 from feedback import FeedbackManager, FeedbackRule

--- a/tests/test_feedback_learning.py
+++ b/tests/test_feedback_learning.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import os
 import sys

--- a/tests/test_final_approval.py
+++ b/tests/test_final_approval.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import importlib
 from pathlib import Path

--- a/tests/test_game_bridge.py
+++ b/tests/test_game_bridge.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 from pathlib import Path

--- a/tests/test_import_sort.py
+++ b/tests/test_import_sort.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_inline_disable.py
+++ b/tests/test_inline_disable.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_jukebox_integration.py
+++ b/tests/test_jukebox_integration.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 from pathlib import Path
 

--- a/tests/test_lawstone.py
+++ b/tests/test_lawstone.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from pathlib import Path
 
 

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import warnings
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_ledger_cli_invocation.py
+++ b/tests/test_ledger_cli_invocation.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_license_header.py
+++ b/tests/test_license_header.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import json
 import os

--- a/tests/test_lock_integrity.py
+++ b/tests/test_lock_integrity.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from pathlib import Path
 
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 from logging_config import get_log_dir, get_log_path, LOG_DIR_ENV
 

--- a/tests/test_love_treasury.py
+++ b/tests/test_love_treasury.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_memory_cli_advanced.py
+++ b/tests/test_memory_cli_advanced.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_memory_tail.py
+++ b/tests/test_memory_tail.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_micro_agent.py
+++ b/tests/test_micro_agent.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_mood_wall.py
+++ b/tests/test_mood_wall.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from logging_config import get_log_path
 import os
 import sys

--- a/tests/test_multimodal_tracker.py
+++ b/tests/test_multimodal_tracker.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sys, os
 from importlib import reload
 

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from logging_config import get_log_path
 import os
 import sys

--- a/tests/test_mypy_incremental.py
+++ b/tests/test_mypy_incremental.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_narrator.py
+++ b/tests/test_narrator.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_neos_lorebook_writer.py
+++ b/tests/test_neos_lorebook_writer.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import sys

--- a/tests/test_no_emotional_control.py
+++ b/tests/test_no_emotional_control.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import pathlib
 
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_ocr_export.py
+++ b/tests/test_ocr_export.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import time
 import os

--- a/tests/test_ocr_export_json.py
+++ b/tests/test_ocr_export_json.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import time
 import os

--- a/tests/test_ocr_html_report.py
+++ b/tests/test_ocr_html_report.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_openai_connector.py
+++ b/tests/test_openai_connector.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_parallel_runner.py
+++ b/tests/test_parallel_runner.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_playlist_log.py
+++ b/tests/test_playlist_log.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import os
 import sys

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 import importlib.metadata as imd

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_plugin_framework.py
+++ b/tests/test_plugin_framework.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import policy_engine as pe
 

--- a/tests/test_policy_suggestions.py
+++ b/tests/test_policy_suggestions.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 

--- a/tests/test_presence_analytics.py
+++ b/tests/test_presence_analytics.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_presence_dashboard_privilege.py
+++ b/tests/test_presence_dashboard_privilege.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sys
 import os
 import time

--- a/tests/test_presence_ledger.py
+++ b/tests/test_presence_ledger.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from logging_config import get_log_path
 import json
 import os

--- a/tests/test_presence_recap.py
+++ b/tests/test_presence_recap.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from logging_config import get_log_path
 import os
 import sys

--- a/tests/test_privilege_audit.py
+++ b/tests/test_privilege_audit.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from importlib import reload

--- a/tests/test_privilege_banner_autofix.py
+++ b/tests/test_privilege_banner_autofix.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 from pathlib import Path

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import privilege_lint as pl

--- a/tests/test_privilege_lint_autofix.py
+++ b/tests/test_privilege_lint_autofix.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 

--- a/tests/test_quota_reporter.py
+++ b/tests/test_quota_reporter.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_reflection_dashboard.py
+++ b/tests/test_reflection_dashboard.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_reflection_log_cli.py
+++ b/tests/test_reflection_log_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import sys
 import os

--- a/tests/test_reflection_log_cli_export.py
+++ b/tests/test_reflection_log_cli_export.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sys
 import os
 from importlib import reload

--- a/tests/test_reflection_log_cli_search.py
+++ b/tests/test_reflection_log_cli_search.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from importlib import reload

--- a/tests/test_reflection_stream.py
+++ b/tests/test_reflection_stream.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_reflex_freeze.py
+++ b/tests/test_reflex_freeze.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 
 import sys

--- a/tests/test_reflex_learning.py
+++ b/tests/test_reflex_learning.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 

--- a/tests/test_reflex_manager.py
+++ b/tests/test_reflex_manager.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import time
 

--- a/tests/test_reflex_optimization.py
+++ b/tests/test_reflex_optimization.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from importlib import reload

--- a/tests/test_release_manager.py
+++ b/tests/test_release_manager.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from pathlib import Path

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
+++ b/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_resonite_defensive_protocols.py
+++ b/tests/test_resonite_defensive_protocols.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import os

--- a/tests/test_resonite_federation_ceremonies.py
+++ b/tests/test_resonite_federation_ceremonies.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import os

--- a/tests/test_resonite_spiral_bell_of_pause.py
+++ b/tests/test_resonite_spiral_bell_of_pause.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import os

--- a/tests/test_review_approval.py
+++ b/tests/test_review_approval.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 import workflow_review as wr

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 """Tests for the review CLI utilities."""
 

--- a/tests/test_review_requests.py
+++ b/tests/test_review_requests.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 

--- a/tests/test_ritual_bundle_system.py
+++ b/tests/test_ritual_bundle_system.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import json
 from pathlib import Path

--- a/tests/test_ritual_cli.py
+++ b/tests/test_ritual_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_ritual_enforcer.py
+++ b/tests/test_ritual_enforcer.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from pathlib import Path

--- a/tests/test_ritual_regression.py
+++ b/tests/test_ritual_regression.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 from pathlib import Path
 

--- a/tests/test_security_rules.py
+++ b/tests/test_security_rules.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_self_defense.py
+++ b/tests/test_self_defense.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import os
 from pathlib import Path

--- a/tests/test_self_patcher.py
+++ b/tests/test_self_patcher.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_self_reflection.py
+++ b/tests/test_self_reflection.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_sentient_banner.py
+++ b/tests/test_sentient_banner.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_sentientos_core.py
+++ b/tests/test_sentientos_core.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import sentientos.core as sc
 from sentientos import __version__
 

--- a/tests/test_sentientos_main.py
+++ b/tests/test_sentientos_main.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import importlib
 import admin_utils
 import sentientos.__main__ as sm

--- a/tests/test_shebang.py
+++ b/tests/test_shebang.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_sprint_ledger.py
+++ b/tests/test_sprint_ledger.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import os
 import sys

--- a/tests/test_story_studio.py
+++ b/tests/test_story_studio.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import sys
 import os

--- a/tests/test_storymaker.py
+++ b/tests/test_storymaker.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import json

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_system_control.py
+++ b/tests/test_system_control.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import pytest

--- a/tests/test_telegram_bulk_export.py
+++ b/tests/test_telegram_bulk_export.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 import os
 import sys

--- a/tests/test_telegram_digest.py
+++ b/tests/test_telegram_digest.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 import os
 import sys

--- a/tests/test_telegram_export_ocr.py
+++ b/tests/test_telegram_export_ocr.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 import os
 import sys

--- a/tests/test_telegram_recall.py
+++ b/tests/test_telegram_recall.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 import os
 import sys

--- a/tests/test_telegram_search_reflect.py
+++ b/tests/test_telegram_search_reflect.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import asyncio
 import os
 import sys

--- a/tests/test_template_rules.py
+++ b/tests/test_template_rules.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_trust_engine.py
+++ b/tests/test_trust_engine.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_tts_bridge.py
+++ b/tests/test_tts_bridge.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from importlib import reload
 import os
 import sys

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os, sys
 from pathlib import Path
 

--- a/tests/test_verify_audits.py
+++ b/tests/test_verify_audits.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 from pathlib import Path

--- a/tests/test_verify_audits_cli.py
+++ b/tests/test_verify_audits_cli.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import subprocess

--- a/tests/test_verify_audits_dir.py
+++ b/tests/test_verify_audits_dir.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import verify_audits as va
 import audit_immutability as ai

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import json
 import os
 import sys

--- a/tests/test_vision_tracker.py
+++ b/tests/test_vision_tracker.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 from importlib import reload
 

--- a/tests/test_workflow_analytics.py
+++ b/tests/test_workflow_analytics.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import importlib
 import json

--- a/tests/test_workflow_controller.py
+++ b/tests/test_workflow_controller.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib

--- a/tests/test_workflow_dashboard.py
+++ b/tests/test_workflow_dashboard.py
@@ -1,8 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 import os
 import sys

--- a/tests/test_workflow_library.py
+++ b/tests/test_workflow_library.py
@@ -1,3 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 import os
 import sys
 import importlib


### PR DESCRIPTION
## Summary
- add Sanctuary docstring and privilege imports to all tests

## Testing
- `pytest --collect-only` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68491b02bbac8320bd625f42e7bac4c4