### PR TITLE
Add network test marker and HTTP mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Legacy tests are under review. To run the current green path:
 ```bash
 bash setup_env.sh
 pytest -m "not env"
+pytest -m network --run-network  # optional HTTP tests
 ```
 
 For a comprehensive pre-submit routine, run:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
     env: tests requiring specific environment
+    network: tests that mock HTTP calls
 addopts = --cov=sentientos --cov-fail-under=80

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ colorama>=0.4.6
 types-PyYAML==6.0.12
 types-requests==2.31.0.10
 mypy>=1.16.0
+requests-mock>=1.11.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,16 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'requires_node: skip if node missing')
     config.addinivalue_line('markers', 'requires_go: skip if go missing')
     config.addinivalue_line('markers', 'requires_dmypy: skip if dmypy missing')
+    config.addinivalue_line('markers', 'network: tests that mock HTTP calls')
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--run-network',
+        action='store_true',
+        default=False,
+        help='run tests marked as network'
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -49,3 +59,5 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.skip(reason=f'go missing: {GO.info}'))
         if 'requires_dmypy' in item.keywords and not HAS_DMYPY:
             item.add_marker(pytest.mark.skip(reason=f'dmypy missing: {DMYPY.info}'))
+        if 'network' in item.keywords and not config.getoption('--run-network'):
+            item.add_marker(pytest.mark.skip(reason='network test skipped: add --run-network to run'))

--- a/tests/test_network_tools.py
+++ b/tests/test_network_tools.py
@@ -1,0 +1,45 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+import requests
+import sys
+sys.modules['requests'] = requests
+import requests_mock
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+@pytest.mark.network
+def test_ping_peer(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, 'requests', requests)
+    import federation_handshake as fh
+    importlib.reload(fh)
+    log = tmp_path / "handshake.jsonl"
+    monkeypatch.setattr(fh, 'LEDGER', log)
+    url = 'http://peer/ping'
+    with requests_mock.Mocker() as m:
+        m.get(url, status_code=200)
+        entry = fh.ping_peer(url)
+    assert entry['status'] == '200'
+    assert log.exists()
+
+@pytest.mark.network
+def test_webhook_alert(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, 'requests', requests)
+    monkeypatch.setenv('TELEGRAM_WEBHOOKS', '')
+    monkeypatch.setenv('TELEGRAM_TOKEN', 'tok')
+    monkeypatch.setenv('TELEGRAM_ADMIN', '1')
+    import webhook_status_monitor as wsm
+    importlib.reload(wsm)
+    log = tmp_path / 'webhook.jsonl'
+    monkeypatch.setattr(wsm, 'LOG_FILE', log)
+    url = 'http://peer/hook'
+    with requests_mock.Mocker() as m:
+        m.get(url, status_code=500)
+        post_mock = m.post('https://api.telegram.org/bottok/sendMessage', status_code=200)
+        status = wsm._check(url)
+        assert status == 500
+        wsm._send_alert(url, status)
+    assert post_mock.called
+


### PR DESCRIPTION
## Summary
- introduce `network` marker in pytest config
- add option `--run-network` in conftest with skip logic
- document how to run optional HTTP tests
- add requests-mock to dev requirements
- implement simple network tests using requests-mock

## Testing
- `pytest -m "not env"` *(fails: ImportError and coverage errors)*
- `pytest tests/test_network_tools.py -m network --run-network -vv` *(fails: coverage errors)*

------
https://chatgpt.com/codex/tasks/task_b_684977dc33b8832082f8393c89553f44