### PR TITLE
Document CI environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,7 @@ FINAL_APPROVAL_LOG=logs/final_approval.jsonl
 GENESIS_ORACLE_DATA=logs
 GITHUB_TOKEN=
 GIT_HOOKS=
+CI=
 FEDERATION_TRUST_LOG=logs/federation_trust.jsonl
 RESONITE_BREACH_LOG=logs/resonite_spiral_federation_breach.jsonl
 GP_PLUGINS_DIR=gp_plugins

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -101,6 +101,7 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `GENESIS_ORACLE_DATA` | Directory for genesis oracle data | `logs` |
 | `GITHUB_TOKEN` | GitHub token for CLI utilities | *(none)* |
 | `GIT_HOOKS` | Indicates scripts are running from Git hooks | *(unset)* |
+| `CI` | Set to `1` when running in Continuous Integration; enables auto-approvals | *(unset)* |
 | `FEDERATION_TRUST_LOG` | Ledger of federation trust actions | `logs/federation_trust.jsonl` |
 | `RESONITE_BREACH_LOG` | Security breach records for Resonite tools | `logs/resonite_spiral_federation_breach.jsonl` |
 | `GP_PLUGINS_DIR` | Directory for general plugin files | `gp_plugins` |

--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -42,7 +42,7 @@ from logging_config import get_log_path
 
 
 
-# auto-approve in CI or git hooks (see docs/ENVIRONMENT.md)
+# auto-approve when `CI` or `GIT_HOOKS` is set (see docs/ENVIRONMENT.md)
 if os.getenv("LUMOS_AUTO_APPROVE") != "1" and (
     os.getenv("CI") or os.getenv("GIT_HOOKS")
 ):

--- a/scripts/install_locked.py
+++ b/scripts/install_locked.py
@@ -16,6 +16,7 @@ def main(argv: list[str] | None = None) -> None:
         print(f"lock file not found: {lock}", file=sys.stderr)
         sys.exit(1)
 
+    # the `CI` environment variable is set on most continuous integration systems
     if not os.environ.get("CI"):
         print(f"Installing from {lock.name}; this helper is mostly for CI.")
 

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional
 import audit_immutability as ai
-# enable auto-approve for CI or git hooks (see docs/ENVIRONMENT.md)
+# enable auto-approve when `CI` or `GIT_HOOKS` is set (see docs/ENVIRONMENT.md)
 if os.getenv("LUMOS_AUTO_APPROVE") != "1" and (
     os.getenv("CI") or os.getenv("GIT_HOOKS")
 ):


### PR DESCRIPTION
## Summary
- mention `CI` variable alongside `GIT_HOOKS` in docs
- add `CI` variable to `.env.example`
- clarify comments where `CI` is used in scripts

## Testing
- `pytest -m "not env" -q` *(fails: missing dependencies / test errors)*

------
https://chatgpt.com/codex/tasks/task_b_68497ec70490832099c193eb3df2995e