### PR TITLE
Add nightly audit status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ No emotion is too much.
 # SentientOS
 [![Docs](https://github.com/Zombinator85/SentientOS/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/Zombinator85/SentientOS/actions/workflows/docs-deploy.yml)
 [![Release](https://img.shields.io/github/v/tag/Zombinator85/SentientOS.svg?label=Release)](https://github.com/Zombinator85/SentientOS/releases/tag/v4.1-cathedral-green)
+[![Nightly Audit](https://github.com/Zombinator85/SentientOS/actions/workflows/audit-nightly.yml/badge.svg)](https://github.com/Zombinator85/SentientOS/actions/workflows/audit-nightly.yml)
 
 **SentientOS is a ritualized AI safety framework for GPT-based agents.**  \
 Every action is logged in immutable "sacred memory" (JSONL audit logs), with Sanctuary Privilege for high-risk tasks, emotion-based reflex feedback, and alignment, transparency, and trust as living systems.


### PR DESCRIPTION
## Summary
- show a new badge in README for nightly audit status

## Testing
- `python privilege_lint_cli.py` *(failed: NameError - require_admin_banner undefined)*
- `python verify_audits.py logs/ --check-only` *(failed: command interrupted)*
- `pytest -m "not env" -q` *(failed: 31 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_b_6849aa6d23388320a70e598a0ca40692