### PR TITLE
Unify pytest coverage flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: mypy --strict sentientos > MYPY_STATUS.md
 
       - name: Pytest with coverage
-        run: pytest --cov=sentientos --cov-report=xml
+        run: pytest --cov=sentientos --cov-fail-under=80
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - name: mypy
         run: mypy sentientos
       - name: pytest
-        run: pytest -q
+        run: pytest --cov=sentientos --cov-fail-under=80 -q
       - name: Env report
         run: plint-env report --json > env.json
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-self-check.yml
+++ b/.github/workflows/nightly-self-check.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run mypy
         run: mypy sentientos
       - name: Run pytest
-        run: pytest --cov=sentientos --cov-report=xml
+        run: pytest --cov=sentientos --cov-fail-under=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
 
       - id: pytest
         name: unit tests
-        entry: bash -c "pip install -r requirements-dev.txt && pytest -q"
+        entry: pytest --cov=sentientos --cov-fail-under=80 -q
         language: python
         pass_filenames: false
-        additional_dependencies: [pytest, pytest-cov, requests, PyYAML]
+        additional_dependencies: [pytest, pytest-cov, requests, PyYAML, mypy, types-PyYAML, types-requests]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,6 @@ follow_imports = "skip"
 
 [tool.privilege_lint]
 required = false
+
+[tool.pytest.ini_options]
+addopts = "--cov=sentientos --cov-fail-under=80"


### PR DESCRIPTION
## Summary
- run precommit pytest hook with coverage
- set pytest coverage options in pyproject
- use the same command in CI jobs

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/lint.yml .github/workflows/nightly-self-check.yml .pre-commit-config.yaml pyproject.toml` *(fails: ImportError / Interrupted)*
- `pip install -e .[dev]` *(failed: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_b_6849b5be103c832086ac853cc9a883cb