### PR TITLE
Add HTTP libs for testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,10 @@ repos:
         entry: bash -c "pip install -r requirements-dev.txt && pytest -q"
         language: python
         pass_filenames: false
-        additional_dependencies: [pytest, pytest-cov, requests, PyYAML]
+        additional_dependencies: [pytest, pytest-cov, requests, requests_mock, PyYAML]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.0
     hooks:
       - id: mypy
-        additional_dependencies: [pytest, pytest-cov, requests, PyYAML, types-PyYAML, types-requests]
+        additional_dependencies: [pytest, pytest-cov, requests, requests_mock, PyYAML, types-PyYAML, types-requests]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,6 @@ types-PyYAML==6.0.12
 types-requests==2.31.0.10
 mypy>=1.16.0
 requests-mock>=1.11.0
+requests
+requests_mock
+PyYAML


### PR DESCRIPTION
## Summary
- add requests libraries to requirements-dev.txt
- use requests_mock in pre-commit config

## Testing
- `python privilege_lint_cli.py` *(fails: NameError require_admin_banner)*
- `python verify_audits.py logs/` *(fails: NameError require_admin_banner)*
- `pytest -m "not env"` *(fails: 30 errors during collection)*
- `mypy .` *(fails: syntax error in sentientos/__main__.py)*

------
https://chatgpt.com/codex/tasks/task_b_6849b5be3044832092df0e6aa72d511a