### PR TITLE
Ensure admin banner stubbed early in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
+import builtins
+# The admin banner checks can exit the process during module import if not
+# stubbed ahead of time. Stub them here so test discovery doesn't trip the
+# privilege checks.
+builtins.require_admin_banner = lambda *a, **k: None
+builtins.require_lumos_approval = lambda *a, **k: None
+
 import importlib
 import pytest
 import sys
 import types
 from pathlib import Path
-import builtins
-
-# The admin banner checks can exit the process during module import if not
-# stubbed ahead of time.  Stub them here so test discovery doesn't trip the
-# privilege checks.
-builtins.require_admin_banner = lambda *a, **k: None
-builtins.require_lumos_approval = lambda *a, **k: None
 
 try:
     importlib.import_module('yaml')


### PR DESCRIPTION
## Summary
- stub admin banner requirement at module import time in tests

## Testing
- `pytest --collect-only` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6849b5be8b148320a8c34e53d81a12c7