### PR TITLE
Fix __main__ TYPE_CHECKING block

### DIFF
--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -5,9 +5,10 @@ require_admin_banner()
 require_lumos_approval()
 from typing import TYPE_CHECKING
 from . import __version__
-if TYPE_CHECKING:
-else:
 
+if TYPE_CHECKING:
+    # Place type-only imports here in the future
+    pass
 
 def main() -> None:
     print(f"SentientOS {__version__}\nRun 'support' or 'ritual' for CLI tools.")


### PR DESCRIPTION
## Summary
- clean up stray `if TYPE_CHECKING` block in `sentientos/__main__.py`
- keep a placeholder for type-only imports

## Testing
- `python -m py_compile sentientos/__main__.py`

------
https://chatgpt.com/codex/tasks/task_b_6849c7d41de88320af8714478c444921