### PR TITLE
Ensure dev extras installed for tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,17 +25,17 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pip install -e .
+          pip install -e .[dev]
       - if: matrix.mode == 'bin-lock'
         run: |
           pip install -r requirements-lock.txt
           pip install -r requirements-dev.txt
-          pip install .
+          pip install -e .[dev]
       - if: matrix.mode == 'src-lock-full'
         run: |
           pip install -r requirements-src-lock.txt
           pip install -r requirements-dev.txt
-          pip install .
+          pip install -e .[dev]
       - name: privilege_lint
         run: python privilege_lint_cli.py
       - name: audit_verify

--- a/README_dev.md
+++ b/README_dev.md
@@ -4,7 +4,7 @@
 Add the banner, `from __future__ import annotations`, an optional docstring,
 and only then your other imports.
 
-🔧 Dev setup: `pip install -r requirements-dev.txt`
+🔧 Dev setup: `pip install -e .[dev]`
 
 Quick-start minimal:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,3 @@ types-PyYAML==6.0.12
 types-requests==2.31.0.10
 mypy>=1.16.0
 requests-mock>=1.11.0
-requests
-requests_mock
-PyYAML


### PR DESCRIPTION
## Summary
- remove duplicate packages in dev requirements
- install dev extras in lint workflow
- guide developers to install editable dev extras

## Testing
- `pre-commit run --files requirements-dev.txt .github/workflows/lint.yml README_dev.md` *(fails: SyntaxError in privilege_lint_cli.py)*

------
https://chatgpt.com/codex/tasks/task_b_6849c7d5f0b88320b7b268e37eae08d2