### PR TITLE
Fix import order for CLI modules

### DIFF
--- a/anniversary_notifier.py
+++ b/anniversary_notifier.py
@@ -1,7 +1,8 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 """Anniversary notifier that logs cathedral anniversaries."""
 
 from logging_config import get_log_path

--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,8 +1,8 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from logging_config import get_log_path

--- a/archive_blessing.py
+++ b/archive_blessing.py
@@ -1,9 +1,9 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
-from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
+from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 
 import argparse
 import datetime

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -7,10 +7,6 @@ import argparse
 import json
 import sys
 from sentient_banner import (
-import treasury_federation as tf
-import ledger
-import mood_wall
-from pathlib import Path
     print_banner,
     print_closing,
     ENTRY_BANNER,
@@ -18,6 +14,10 @@ from pathlib import Path
     print_snapshot_banner,
     print_closing_recap,
 )
+import treasury_federation as tf
+import ledger
+import mood_wall
+from pathlib import Path
 def cmd_invite(args: argparse.Namespace) -> None:
     peer = args.peer
     email = args.email or ""

--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -21,6 +21,10 @@ from privilege_lint.data_rules import validate_json, validate_csv
 from privilege_lint.shebang_rules import validate_shebang, apply_fix as fix_shebang
 from privilege_lint.docstring_rules import validate_docstrings, apply_fix_docstring_stub
 from privilege_lint.license_rules import (
+    validate_license_header,
+    apply_fix_license_header,
+    DEFAULT_HEADER,
+)
 from privilege_lint.cache import LintCache
 from privilege_lint.runner import parallel_validate, DEFAULT_WORKERS
 from privilege_lint.template_rules import validate_template, parse_context
@@ -32,10 +36,6 @@ from privilege_lint.comment_controls import parse_controls, is_disabled
 from privilege_lint.metrics import MetricsCollector
 from privilege_lint.plugins import load_plugins
 from logging_config import get_log_path
-    validate_license_header,
-    apply_fix_license_header,
-    DEFAULT_HEADER,
-)
 # ── privilege_lint_cli.py ─────────────────────────────────────────
 
 

--- a/replay.py
+++ b/replay.py
@@ -1,8 +1,8 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 import argparse

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
-from __future__ import annotations
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 import argparse
 import collections
 import datetime as dt

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()
-require_lumos_approval()
-from __future__ import annotations
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
 
 # Automate release version bumping and tagging.
 import argparse

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,15 +1,16 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from admin_utils import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
+
 import argparse
 import re
 import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from admin_utils import require_admin_banner, require_lumos_approval
 
 # Assist in resolving missing test imports by editing failing tests.
 

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,18 +1,22 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from admin_utils import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
+
 from typing import TYPE_CHECKING
+
 from . import __version__
-if TYPE_CHECKING:
-else:
+
+if TYPE_CHECKING:  # pragma: no cover - placeholder for optional imports
+    pass
 
 
 def main() -> None:
+    """Entry point for the SentientOS package."""
     print(f"SentientOS {__version__}\nRun 'support' or 'ritual' for CLI tools.")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI invocation
     main()
-    pass


### PR DESCRIPTION
## Summary
- fix broken import blocks in privilege_lint_cli and several CLIs
- restore proper future import order for federation_cli and replay
- keep actuator and various scripts consistent with privilege linter rules
- clean up SentientOS `__main__` entrypoint

## Testing
- `pre-commit run --all-files` *(fails: tests and mypy errors)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --auto-repair --no-input`
- `pytest -q` *(fails: multiple tests fail)*
- `mypy sentientos`

------
https://chatgpt.com/codex/tasks/task_b_6849c7d67eac8320add76bd5fa9011d6