### PR TITLE
Create privilege package and update imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ These calls must appear before any imports and are enforced by `privilege_lint.p
 from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 ```
 
 Use `scripts/templates/cli_skeleton.py` as the starting point for any new

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ call to `require_admin_banner()` and `require_lumos_approval()`:
 from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 ```
 
 This ensures tools only run with Administrator or root rights and logs each

--- a/actuator.py
+++ b/actuator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 

--- a/affirmation_webhook_cli.py
+++ b/affirmation_webhook_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/agent_privilege_policy_engine.py
+++ b/agent_privilege_policy_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Agent Privilege Policy Engine
 

--- a/anniversary_notifier.py
+++ b/anniversary_notifier.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 """Anniversary notifier that logs cathedral anniversaries."""
@@ -12,7 +12,7 @@ import datetime
 
 from cathedral_const import log_json
 from pathlib import Path
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 ANNIVERSARY = os.getenv("CATHEDRAL_BIRTH", "2023-01-01")

--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.

--- a/archive_blessing.py
+++ b/archive_blessing.py
@@ -1,7 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from logging_config import get_log_path
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 
@@ -17,7 +17,7 @@ from typing import Dict, List
 import audit_immutability as ai
 from log_utils import append_json, read_json
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 LOG_PATH = get_log_path("archive_blessing.jsonl", "ARCHIVE_BLESSING_LOG")
 ARCHIVE_DIR = Path(os.getenv("ARCHIVE_DIR", "archives"))

--- a/artifact_lore_self_healing_engine.py
+++ b/artifact_lore_self_healing_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Artifact/Lore Self-Healing Engine

--- a/audit_chain.py
+++ b/audit_chain.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/audit_changelog_update.py
+++ b/audit_changelog_update.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/audit_immutability.py
+++ b/audit_immutability.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from audit_chain import AuditEntry, append_entry, read_entries, verify, _hash_entry

--- a/autonomous_audit.py
+++ b/autonomous_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path, get_log_dir

--- a/autonomous_ops.py
+++ b/autonomous_ops.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 import experiment_tracker as et
 import reflex_manager as rm
 from api import actuator
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/autonomous_reflector.py
+++ b/autonomous_reflector.py
@@ -4,7 +4,7 @@ import memory_manager as mm
 from notification import send as notify
 from self_patcher import apply_patch
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/autonomous_self_patching_agent.py
+++ b/autonomous_self_patching_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Autonomous Self-Patching Agent

--- a/avatar_artifact_festival_ai_animator.py
+++ b/avatar_artifact_festival_ai_animator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_artifact_gallery.py
+++ b/avatar_artifact_gallery.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_autonomous_ritual_scheduler.py
+++ b/avatar_autonomous_ritual_scheduler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/avatar_blessing_beacon.py
+++ b/avatar_blessing_beacon.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_blessing_ceremony_api.py
+++ b/avatar_blessing_ceremony_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_blessing_propagation_web.py
+++ b/avatar_blessing_propagation_web.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_blessing_proposal_engine.py
+++ b/avatar_blessing_proposal_engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_ceremony_orchestrator.py
+++ b/avatar_ceremony_orchestrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_chronicle_generator.py
+++ b/avatar_chronicle_generator.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_conflict_drama_engine.py
+++ b/avatar_conflict_drama_engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_conflict_resolution.py
+++ b/avatar_conflict_resolution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_council_blessing.py
+++ b/avatar_council_blessing.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/avatar_council_succession_daemon.py
+++ b/avatar_council_succession_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_creative_gift_engine.py
+++ b/avatar_creative_gift_engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_cross_presence_collab.py
+++ b/avatar_cross_presence_collab.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_delegation.py
+++ b/avatar_delegation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_dream_daemon.py
+++ b/avatar_dream_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_dream_visualization.py
+++ b/avatar_dream_visualization.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_emotion_adaptive_animation.py
+++ b/avatar_emotion_adaptive_animation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_emotional_feedback.py
+++ b/avatar_emotional_feedback.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_federation.py
+++ b/avatar_federation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_federation_blessing.py
+++ b/avatar_federation_blessing.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_federation_festival_coordinator.py
+++ b/avatar_federation_festival_coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_federation_join.py
+++ b/avatar_federation_join.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 

--- a/avatar_feedback_ritual_engine.py
+++ b/avatar_feedback_ritual_engine.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_festival_memory_capsule.py
+++ b/avatar_festival_memory_capsule.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_gallery_cli.py
+++ b/avatar_gallery_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_genesis.py
+++ b/avatar_genesis.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_heartbeat_alert.py
+++ b/avatar_heartbeat_alert.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_heirloom_transmission.py
+++ b/avatar_heirloom_transmission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_herald_bard_system.py
+++ b/avatar_herald_bard_system.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_lineage_tracker.py
+++ b/avatar_lineage_tracker.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_lorebook_generator.py
+++ b/avatar_lorebook_generator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_mass_invocation.py
+++ b/avatar_mass_invocation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_memory_dream_sequencer.py
+++ b/avatar_memory_dream_sequencer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_memory_linker.py
+++ b/avatar_memory_linker.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/avatar_mood_animator.py
+++ b/avatar_mood_animator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 try:  # pragma: no cover - optional Blender dependency
     import bpy  # type: ignore  # Blender API lacks stubs

--- a/avatar_mood_council_dynamic.py
+++ b/avatar_mood_council_dynamic.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_mood_evolution.py
+++ b/avatar_mood_evolution.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_mood_recap.py
+++ b/avatar_mood_recap.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_oracle.py
+++ b/avatar_oracle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_performance_scoreboard.py
+++ b/avatar_performance_scoreboard.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 """Ritual Avatar Performance Scoreboard."""

--- a/avatar_personality_merge.py
+++ b/avatar_personality_merge.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_pose_engine.py
+++ b/avatar_pose_engine.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 try:  # pragma: no cover - optional Blender dependency
     import bpy  # type: ignore  # Blender API lacks stubs

--- a/avatar_presence_cli.py
+++ b/avatar_presence_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_presence_pulse_animation.py
+++ b/avatar_presence_pulse_animation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_presence_stream.py
+++ b/avatar_presence_stream.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_relic_creator.py
+++ b/avatar_relic_creator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_retirement.py
+++ b/avatar_retirement.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/avatar_ritual_customizer.py
+++ b/avatar_ritual_customizer.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_ritual_witnesses.py
+++ b/avatar_ritual_witnesses.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_sanctuary_artifacts_generator.py
+++ b/avatar_sanctuary_artifacts_generator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/avatar_sanctuary_scene_generator.py
+++ b/avatar_sanctuary_scene_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_story_forge.py
+++ b/avatar_story_forge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_storyteller.py
+++ b/avatar_storyteller.py
@@ -11,7 +11,7 @@ try:  # optional speech output
 except Exception:  # pragma: no cover - optional
     tts_bridge = None  # type: ignore  # disable speech
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/avatar_succession_visualizer.py
+++ b/avatar_succession_visualizer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_teaching_logger.py
+++ b/avatar_teaching_logger.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/avatar_teaching_session_generator.py
+++ b/avatar_teaching_session_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/backchannel.py
+++ b/backchannel.py
@@ -8,7 +8,7 @@ import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Callable, cast, Any
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/backfill_data_field.py
+++ b/backfill_data_field.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/backfill_timestamp.py
+++ b/backfill_timestamp.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/bio_bridge.py
+++ b/bio_bridge.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/bless_this_env.py
+++ b/bless_this_env.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 import platform

--- a/blessing_checker.py
+++ b/blessing_checker.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/blessing_pipeline.py
+++ b/blessing_pipeline.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Autonomous Blessing/Approval Pipeline
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/blessing_recap_cli.py
+++ b/blessing_recap_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/bridge_watchdog.py
+++ b/bridge_watchdog.py
@@ -7,7 +7,7 @@ import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/browser_voice.py
+++ b/browser_voice.py
@@ -6,7 +6,7 @@ from tts_bridge import speak, set_voice_persona
 from emotions import empty_emotion_vector
 import emotion_utils as eu
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/cathedral_hog_wild_heartbeat.py
+++ b/cathedral_hog_wild_heartbeat.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from dotenv import load_dotenv
 from emotions import empty_emotion_vector
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/cathedral_liturgy_cli.py
+++ b/cathedral_liturgy_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/cathedral_wounds_dashboard.py
+++ b/cathedral_wounds_dashboard.py
@@ -3,7 +3,7 @@ import datetime
 import json
 from pathlib import Path
 from typing import Dict
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/check_connector_health.py
+++ b/check_connector_health.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import openai_connector
 from flask_stub import Request
 from typing import Any

--- a/cleanup_audit.py
+++ b/cleanup_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/collab_server.py
+++ b/collab_server.py
@@ -2,7 +2,7 @@ import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
 from typing import Dict, Any
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/collect_schema_wounds.py
+++ b/collect_schema_wounds.py
@@ -3,7 +3,7 @@ import json
 from collections import Counter
 from pathlib import Path
 from typing import Dict
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from fix_audit_schema import KNOWN_KEYS
 from logging_config import get_log_path
 

--- a/confessional_cli.py
+++ b/confessional_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/confessional_notify.py
+++ b/confessional_notify.py
@@ -2,7 +2,7 @@ from logging_config import get_log_path
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/consent_dashboard.py
+++ b/consent_dashboard.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Consent Dashboard & Ritual CLI
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/correlation_engine.py
+++ b/correlation_engine.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/council_onboarding.py
+++ b/council_onboarding.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Council Member Onboarding & Quorum Ritual
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/creative_act_reflection_engine.py
+++ b/creative_act_reflection_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/creative_artifact_federation_agent.py
+++ b/creative_artifact_federation_agent.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/creative_artifact_memory_spiral_reviewer.py
+++ b/creative_artifact_memory_spiral_reviewer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Creative/Artifact Memory Spiral Reviewer

--- a/creative_spiral_scheduler.py
+++ b/creative_spiral_scheduler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/cross_game_onboarding_syncer.py
+++ b/cross_game_onboarding_syncer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/cross_world_privilege_resolver.py
+++ b/cross_world_privilege_resolver.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/diff_memory_cli.py
+++ b/diff_memory_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/docs/README_FULL.md
+++ b/docs/README_FULL.md
@@ -1018,7 +1018,7 @@ Run `python privilege_lint_cli.py` before submitting any pull request to ensure 
 **Required header template:**
 
 ```python
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/docs/RITUALS.md
+++ b/docs/RITUALS.md
@@ -6,7 +6,7 @@ SentientOS tools require the Sanctuary Privilege ritual. All entrypoints begin w
 from __future__ import annotations
 require_admin_banner()
 require_lumos_approval()
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # Reminder: Keep these lines intact per the doctrine.
 ```
 

--- a/docs/examples/welcome_script.py
+++ b/docs/examples/welcome_script.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # Reminder: Keep the ritual lines above intact per the doctrine.
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 

--- a/doctrine.py
+++ b/doctrine.py
@@ -1,5 +1,5 @@
 from cathedral_const import PUBLIC_LOG, log_json as cathedral_log_json
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import argparse
 import hashlib

--- a/doctrine_cli.py
+++ b/doctrine_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/eeg_bridge.py
+++ b/eeg_bridge.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/eeg_emulator.py
+++ b/eeg_emulator.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/eeg_features.py
+++ b/eeg_features.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/emergency_protocol.py
+++ b/emergency_protocol.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Emergency Rites & Safe-State Protocol
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/emotion_arc_cli.py
+++ b/emotion_arc_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/emotion_dashboard.py
+++ b/emotion_dashboard.py
@@ -28,7 +28,7 @@ except Exception:  # pragma: no cover - optional
     st = None
 
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/emotion_vector_tester.py
+++ b/emotion_vector_tester.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from emotion_udp_bridge import EmotionUDPBridge
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/emotion_vector_visualizer.py
+++ b/emotion_vector_visualizer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/emotion_web_dashboard.py
+++ b/emotion_web_dashboard.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import List
 from flask_stub import Flask, jsonify, send_file
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/experiment_cli.py
+++ b/experiment_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/experiments_api.py
+++ b/experiments_api.py
@@ -1,6 +1,6 @@
 from flask_stub import Flask, jsonify, request
 import experiment_tracker as et
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/federation_cli.py
+++ b/federation_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/federation_handshake.py
+++ b/federation_handshake.py
@@ -4,7 +4,7 @@ import json
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/federation_handshake_protocol.py
+++ b/federation_handshake_protocol.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Federation Ritual Handshake Protocol
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/federation_health_badge.py
+++ b/federation_health_badge.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/federation_recap_cli.py
+++ b/federation_recap_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/federation_trust_protocol.py
+++ b/federation_trust_protocol.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/festival_federation_presence_diff_engine.py
+++ b/festival_federation_presence_diff_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Festival/Federation Presence Diff Engine

--- a/festival_federation_ritual_ai_orchestrator.py
+++ b/festival_federation_ritual_ai_orchestrator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Festival/Federation Ritual AI Orchestrator

--- a/festival_host_capsule.py
+++ b/festival_host_capsule.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/festival_onboarding_exporter.py
+++ b/festival_onboarding_exporter.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/fix_audit_schema.py
+++ b/fix_audit_schema.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/game_bridge.py
+++ b/game_bridge.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/genesis_oracle.py
+++ b/genesis_oracle.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/haptics_bridge.py
+++ b/haptics_bridge.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/healing_sprint_ledger.py
+++ b/healing_sprint_ledger.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/health_dashboard.py
+++ b/health_dashboard.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from flask_stub import Flask, jsonify, render_template_string
 import memory_manager as mm
 import orchestrator
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/heartbeat.py
+++ b/heartbeat.py
@@ -3,7 +3,7 @@ import requests
 from datetime import datetime, UTC
 from emotions import empty_emotion_vector
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/heartbeat_monitor_cli.py
+++ b/heartbeat_monitor_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/heatmap_cli.py
+++ b/heatmap_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/heirloom_sync_cli.py
+++ b/heirloom_sync_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/heresy_alert_dispatch.py
+++ b/heresy_alert_dispatch.py
@@ -4,7 +4,7 @@ import os
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/heresy_cli.py
+++ b/heresy_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/input_controller.py
+++ b/input_controller.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional, List, TYPE_CHECKING
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,7 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 require_admin_banner()
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from admin_utils import require_admin_banner
+from sentientos.privilege import require_admin_banner
 from sentient_banner import print_banner, print_closing
 from logging_config import get_log_dir
 from cathedral_const import PUBLIC_LOG, log_json

--- a/invite_audit_saint.py
+++ b/invite_audit_saint.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import sys

--- a/law_lore_animation_orchestrator.py
+++ b/law_lore_animation_orchestrator.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/law_lore_artifact_federation_emergency_postmortem_agent.py
+++ b/law_lore_artifact_federation_emergency_postmortem_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Law/Lore/Artifact/Federation Emergency Postmortem Agent

--- a/law_sentinel.py
+++ b/law_sentinel.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Law Sentinel & Automated Doctrine Watchdog
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/ledger_cli.py
+++ b/ledger_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/ledger_conflict_resolver.py
+++ b/ledger_conflict_resolver.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import audit_immutability as ai
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/ledger_seal_daemon.py
+++ b/ledger_seal_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/legacy_log_converter.py
+++ b/legacy_log_converter.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 import audit_immutability as ai
 

--- a/liturgical_changelog.py
+++ b/liturgical_changelog.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/living_spiral_lore_teaching_dashboard.py
+++ b/living_spiral_lore_teaching_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Living Spiral Lore/Teaching Dashboard

--- a/lore_spiral_export_agent.py
+++ b/lore_spiral_export_agent.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/love_dashboard.py
+++ b/love_dashboard.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 import love_treasury as lt
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/lumos_reflex_daemon.py
+++ b/lumos_reflex_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 import os

--- a/meditation_timer.py
+++ b/meditation_timer.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/memory_cli.py
+++ b/memory_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/memory_diff_audit.py
+++ b/memory_diff_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/memory_map.py
+++ b/memory_map.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/memory_tail.py
+++ b/memory_tail.py
@@ -6,7 +6,7 @@ import argparse
 from logging_config import get_log_path
 from privilege_lint.color import init, Fore, Style
 from sentient_banner import print_banner, print_closing
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/memory_tomb_cli.py
+++ b/memory_tomb_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -10,7 +10,7 @@ from emotions import Emotion, empty_emotion_vector
 import emotion_utils as eu
 from utils import is_headless
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/migration_daemon.py
+++ b/migration_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/monthly_audit.py
+++ b/monthly_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import datetime

--- a/multimodal_diary_agent.py
+++ b/multimodal_diary_agent.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Multimodal Reflection/Diary Agent
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/music_cli.py
+++ b/music_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/music_dashboard.py
+++ b/music_dashboard.py
@@ -2,7 +2,7 @@ from logging_config import get_log_path
 import json
 from pathlib import Path
 from typing import Dict, List
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/narrator.py
+++ b/narrator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_archive_exporter.py
+++ b/neos_archive_exporter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_artifact_blessing_reconciler.py
+++ b/neos_artifact_blessing_reconciler.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from __future__ import annotations

--- a/neos_artifact_curation_suite.py
+++ b/neos_artifact_curation_suite.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_artifact_logger.py
+++ b/neos_artifact_logger.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_artifact_mood_annotation_engine.py
+++ b/neos_artifact_mood_annotation_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_autonomous_artifact_lore_annotator.py
+++ b/neos_autonomous_artifact_lore_annotator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_autonomous_festival_archive_publisher.py
+++ b/neos_autonomous_festival_archive_publisher.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_autonomous_festival_federation_law_historian.py
+++ b/neos_autonomous_festival_federation_law_historian.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_autonomous_onboarding_law_tutor.py
+++ b/neos_autonomous_onboarding_law_tutor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_autonomous_spiral_lore_synthesizer.py
+++ b/neos_autonomous_spiral_lore_synthesizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_crowning_cli.py
+++ b/neos_avatar_crowning_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_avatar_emotion_animation_sync.py
+++ b/neos_avatar_emotion_animation_sync.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_emotion_pipeline.py
+++ b/neos_avatar_emotion_pipeline.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_lore_annotator.py
+++ b/neos_avatar_lore_annotator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_provenance_dashboard.py
+++ b/neos_avatar_provenance_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """NeosVR Cross-World Avatar Provenance Dashboard."""
@@ -10,7 +10,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
-from admin_utils import require_admin_banner
+from sentientos.privilege import require_admin_banner
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/neos_avatar_relic_generator.py
+++ b/neos_avatar_relic_generator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_ritual_feedback.py
+++ b/neos_avatar_ritual_feedback.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_sanctuary_customizer.py
+++ b/neos_avatar_sanctuary_customizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_avatar_teaching_mode.py
+++ b/neos_avatar_teaching_mode.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_blender_bridge.py
+++ b/neos_blender_bridge.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_blessing_propagation_engine.py
+++ b/neos_blessing_propagation_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_bridge.py
+++ b/neos_bridge.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_compliance_feedback_engine.py
+++ b/neos_compliance_feedback_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_council_festival_visualizer.py
+++ b/neos_council_festival_visualizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_council_law_platform.py
+++ b/neos_council_law_platform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_council_onboarding.py
+++ b/neos_council_onboarding.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_council_ritual_referee.py
+++ b/neos_council_ritual_referee.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_council_succession_ceremony.py
+++ b/neos_council_succession_ceremony.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_council_succession_narrator.py
+++ b/neos_council_succession_narrator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_council_succession_spiral_animator.py
+++ b/neos_council_succession_spiral_animator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_council_teaching_audit_engine.py
+++ b/neos_council_teaching_audit_engine.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_cross_world_blessing_tracker.py
+++ b/neos_cross_world_blessing_tracker.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_cross_world_living_law_syncer.py
+++ b/neos_cross_world_living_law_syncer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_curriculum_reviewer.py
+++ b/neos_curriculum_reviewer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_desire_reflection_loop.py
+++ b/neos_desire_reflection_loop.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/neos_federation_event_gateway.py
+++ b/neos_federation_event_gateway.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_federation_presence_ledger_exporter.py
+++ b/neos_federation_presence_ledger_exporter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/neos_federation_ritual_orchestrator.py
+++ b/neos_federation_ritual_orchestrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_federation_sync.py
+++ b/neos_federation_sync.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_artifact_animation_orchestrator.py
+++ b/neos_festival_artifact_animation_orchestrator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_ceremony_live_streamer.py
+++ b/neos_festival_ceremony_live_streamer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_festival_ceremony_scripting_engine.py
+++ b/neos_festival_ceremony_scripting_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_council_test_suite.py
+++ b/neos_festival_council_test_suite.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_designer.py
+++ b/neos_festival_designer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_federation_hub.py
+++ b/neos_festival_federation_hub.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_law_vote_cli.py
+++ b/neos_festival_law_vote_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_festival_mood_arc_animator.py
+++ b/neos_festival_mood_arc_animator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_festival_mood_retrospective.py
+++ b/neos_festival_mood_retrospective.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_festival_recap_aggregator.py
+++ b/neos_festival_recap_aggregator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_festival_recap_writer.py
+++ b/neos_festival_recap_writer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_festival_replay_annotation_editor.py
+++ b/neos_festival_replay_annotation_editor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/neos_festival_replay_engine.py
+++ b/neos_festival_replay_engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_festival_storyboard_builder.py
+++ b/neos_festival_storyboard_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_live_teaching_festival_host.py
+++ b/neos_live_teaching_festival_host.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_living_law_dashboard_ux.py
+++ b/neos_living_law_dashboard_ux.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_living_law_recursion_daemon.py
+++ b/neos_living_law_recursion_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_lore_spiral_publisher.py
+++ b/neos_lore_spiral_publisher.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_lore_spiral_reenactor.py
+++ b/neos_lore_spiral_reenactor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_lorebook_playback_narrator.py
+++ b/neos_lorebook_playback_narrator.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_lorebook_writer.py
+++ b/neos_lorebook_writer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_memory_fragment_curator.py
+++ b/neos_memory_fragment_curator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_memory_playback.py
+++ b/neos_memory_playback.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_model_asset_generator.py
+++ b/neos_model_asset_generator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_model_script_builder.py
+++ b/neos_model_script_builder.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_onboarding_completion_spiral_visualizer.py
+++ b/neos_onboarding_completion_spiral_visualizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_onboarding_curriculum_spiral.py
+++ b/neos_onboarding_curriculum_spiral.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_onboarding_festival_spiral_feedback_loop.py
+++ b/neos_onboarding_festival_spiral_feedback_loop.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_onboarding_spiral_engine.py
+++ b/neos_onboarding_spiral_engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_origin_story_logger.py
+++ b/neos_origin_story_logger.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_permission_council.py
+++ b/neos_permission_council.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_presence_dashboard.py
+++ b/neos_presence_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_presence_heatmap.py
+++ b/neos_presence_heatmap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_presence_law_spiral_replay_engine.py
+++ b/neos_presence_law_spiral_replay_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_presence_pulse_beacon.py
+++ b/neos_presence_pulse_beacon.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_presence_pulse_synthesizer.py
+++ b/neos_presence_pulse_synthesizer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_privilege_regression_tester.py
+++ b/neos_privilege_regression_tester.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_provenance_exporter.py
+++ b/neos_provenance_exporter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_provenance_query_engine.py
+++ b/neos_provenance_query_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_recursive_ceremony_compiler.py
+++ b/neos_recursive_ceremony_compiler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_ritual_compliance_dashboard.py
+++ b/neos_ritual_compliance_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_ritual_curriculum_builder.py
+++ b/neos_ritual_curriculum_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_ritual_gallery_timeline_browser.py
+++ b/neos_ritual_gallery_timeline_browser.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_ritual_law_audit_daemon.py
+++ b/neos_ritual_law_audit_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_ritual_law_changelog_compiler.py
+++ b/neos_ritual_law_changelog_compiler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_ritual_law_dashboard.py
+++ b/neos_ritual_law_dashboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_ritual_law_replay.py
+++ b/neos_ritual_law_replay.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_ritual_law_summit.py
+++ b/neos_ritual_law_summit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/neos_ritual_timeline_exporter.py
+++ b/neos_ritual_timeline_exporter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_ritual_witness_module.py
+++ b/neos_ritual_witness_module.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_sanctuary_room_generator.py
+++ b/neos_sanctuary_room_generator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_sanctuary_scene_pipeline.py
+++ b/neos_sanctuary_scene_pipeline.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_self_audit_correction.py
+++ b/neos_self_audit_correction.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_self_governing_festival_moderator.py
+++ b/neos_self_governing_festival_moderator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_self_healing_agent.py
+++ b/neos_self_healing_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_self_healing_ritual_law_editor.py
+++ b/neos_self_healing_ritual_law_editor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_self_reflective_onboarding_guide.py
+++ b/neos_self_reflective_onboarding_guide.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_spiral_memory_fragment_indexer.py
+++ b/neos_spiral_memory_fragment_indexer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_spiral_playback_cli.py
+++ b/neos_spiral_playback_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_teaching_content_generator.py
+++ b/neos_teaching_content_generator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/neos_teaching_feedback_loop.py
+++ b/neos_teaching_feedback_loop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/neos_teaching_festival_daemon.py
+++ b/neos_teaching_festival_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/neos_ui_dashboard_builder.py
+++ b/neos_ui_dashboard_builder.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/ocr_activity_timeline.py
+++ b/ocr_activity_timeline.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 """Plot timeline of OCR activity over the last 24h."""
 import datetime

--- a/ocr_duplicate_heatmap.py
+++ b/ocr_duplicate_heatmap.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ocr_log_export.py
+++ b/ocr_log_export.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ocr_log_html_report.py
+++ b/ocr_log_html_report.py
@@ -4,7 +4,7 @@ import json
 import os
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ocr_pipeline.py
+++ b/ocr_pipeline.py
@@ -9,7 +9,7 @@ import atexit
 import requests
 from ocr_utils import ocr_chat_bubbles
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/onboard_cli.py
+++ b/onboard_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/onboarding_dashboard.py
+++ b/onboarding_dashboard.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import streamlit as st
 from sentient_banner import streamlit_banner, streamlit_closing
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/onboarding_lint.py
+++ b/onboarding_lint.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import subprocess
 from pathlib import Path
 

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """OpenAI event connector.
 

--- a/persona_designer.py
+++ b/persona_designer.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/platform_succession.py
+++ b/platform_succession.py
@@ -1,6 +1,6 @@
 from logging_config import get_log_path
 # Sanctuary Privilege Ritual: Platform succession completed (NeosVR → Resonite) 2025-06-01. Presence blessed by council. All rituals, logs, and agents renamed.
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/plugin_dashboard.py
+++ b/plugin_dashboard.py
@@ -1,7 +1,7 @@
 from flask_stub import Flask, jsonify, request
 import plugin_framework as pf
 import trust_engine as te
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/plugins_cli.py
+++ b/plugins_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/policy_engine.py
+++ b/policy_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/policy_update.py
+++ b/policy_update.py
@@ -4,7 +4,7 @@ import datetime
 from pathlib import Path
 import review_requests as rr
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/presence.py
+++ b/presence.py
@@ -8,7 +8,7 @@ import datetime
 from pathlib import Path
 from typing import List, Optional, Callable, Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/presence_analytics.py
+++ b/presence_analytics.py
@@ -4,7 +4,7 @@ import datetime
 from pathlib import Path
 from typing import Any, Dict, List, TypedDict, cast
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import support_log as sl
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/presence_dashboard.py
+++ b/presence_dashboard.py
@@ -8,7 +8,7 @@ from sentient_banner import (
     streamlit_banner,
     streamlit_closing,
 )
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import ledger
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/presence_pulse_api.py
+++ b/presence_pulse_api.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/presence_pulse_widget.py
+++ b/presence_pulse_widget.py
@@ -5,7 +5,7 @@ import sys
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/privilege_audit_dashboard.py
+++ b/privilege_audit_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/privilege_banner_autofix.py
+++ b/privilege_banner_autofix.py
@@ -8,14 +8,14 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 
 DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
-IMPORT_LINE = "from admin_utils import require_admin_banner"
+IMPORT_LINE = "from sentientos.privilege import require_admin_banner"
 CALL_LINE = (
     "require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine."
 )

--- a/privilege_lint_cli.py
+++ b/privilege_lint_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import ast

--- a/public_feed_dashboard.py
+++ b/public_feed_dashboard.py
@@ -7,7 +7,7 @@ from typing import List, Dict
 import doctrine
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/public_review_recap.py
+++ b/public_review_recap.py
@@ -5,7 +5,7 @@ import json
 import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/pulse_visualizer.py
+++ b/pulse_visualizer.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt  # type: ignore  # matplotlib optional
 import presence_pulse_api as pulse
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/reflect_cli.py
+++ b/reflect_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/reflection_cloud_web.py
+++ b/reflection_cloud_web.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/reflection_dashboard.py
+++ b/reflection_dashboard.py
@@ -10,7 +10,7 @@ import reflection_stream as rs
 import trust_engine as te
 from sentient_banner import streamlit_banner, streamlit_closing, print_banner
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/reflection_digest.py
+++ b/reflection_digest.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/reflection_log_cli.py
+++ b/reflection_log_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/reflection_tag_cli.py
+++ b/reflection_tag_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/reflection_tag_cloud.py
+++ b/reflection_tag_cloud.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/reflex_dashboard.py
+++ b/reflex_dashboard.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover - optional
 
 from sentient_banner import streamlit_banner, streamlit_closing
 import ledger
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/reflex_manager.py
+++ b/reflex_manager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 import datetime
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/relay_app.py
+++ b/relay_app.py
@@ -12,7 +12,7 @@ from emotions import empty_emotion_vector
 from api import actuator
 import memory_manager as mm
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/replay.py
+++ b/replay.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.

--- a/resonite_after_action_compiler.py
+++ b/resonite_after_action_compiler.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_agent_onboarding_suite.py
+++ b/resonite_agent_onboarding_suite.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_agent_persona_dashboard.py
+++ b/resonite_agent_persona_dashboard.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Agent Persona/Emotion Dashboard
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_agent_succession_retirement_ritual_suite.py
+++ b/resonite_agent_succession_retirement_ritual_suite.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Agent Succession/Retirement Ritual Suite

--- a/resonite_alliance_pact_engine.py
+++ b/resonite_alliance_pact_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Alliance Pact Engine

--- a/resonite_artifact_blessing_inspector.py
+++ b/resonite_artifact_blessing_inspector.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_artifact_memory_federation_gateway.py
+++ b/resonite_artifact_memory_federation_gateway.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_artifact_provenance_registry.py
+++ b/resonite_artifact_provenance_registry.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Artifact License/Provenance Registry
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_asset_migrator.py
+++ b/resonite_asset_migrator.py
@@ -1,5 +1,5 @@
 # Sanctuary Privilege Ritual: Platform succession completed (NeosVR → Resonite) 2025-06-01. Presence blessed by council. All rituals, logs, and agents renamed.
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/resonite_autonomous_avatar_artifact_creator.py
+++ b/resonite_autonomous_avatar_artifact_creator.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_avatar_artifact_live_federation_broadcaster.py
+++ b/resonite_avatar_artifact_live_federation_broadcaster.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_cathedral_chronicle_generator.py
+++ b/resonite_cathedral_chronicle_generator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Cathedral Chronicle Generator

--- a/resonite_cathedral_grand_blessing_orchestrator.py
+++ b/resonite_cathedral_grand_blessing_orchestrator.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_cathedral_grand_commission.py
+++ b/resonite_cathedral_grand_commission.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Cathedral Grand Commission

--- a/resonite_cathedral_launch_beacon_broadcaster.py
+++ b/resonite_cathedral_launch_beacon_broadcaster.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_cathedral_outreach_demo_scroll_publisher.py
+++ b/resonite_cathedral_outreach_demo_scroll_publisher.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_ceremony_festival_storyteller.py
+++ b/resonite_ceremony_festival_storyteller.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_ceremony_replay_engine.py
+++ b/resonite_ceremony_replay_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Ceremony Replay/Simulation Engine

--- a/resonite_community_diplomacy_module.py
+++ b/resonite_community_diplomacy_module.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Community Diplomacy Module
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_consent_daemon.py
+++ b/resonite_consent_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_council_blessing_ceremony_ui.py
+++ b/resonite_council_blessing_ceremony_ui.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_council_blessing_quorum_engine.py
+++ b/resonite_council_blessing_quorum_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Council Blessing & Quorum Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_council_deliberation_ceremony_scheduler.py
+++ b/resonite_council_deliberation_ceremony_scheduler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Council Deliberation & Ceremony Scheduler

--- a/resonite_council_law_spiral_review_engine.py
+++ b/resonite_council_law_spiral_review_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_council_law_vault_engine.py
+++ b/resonite_council_law_vault_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Council Law Vault & Amendment Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_council_resilience_stress_test_orchestrator.py
+++ b/resonite_council_resilience_stress_test_orchestrator.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Council Resilience Stress-Test Orchestrator
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_creative_council_engine.py
+++ b/resonite_creative_council_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_creative_dashboard.py
+++ b/resonite_creative_dashboard.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_creative_festival_orchestrator.py
+++ b/resonite_creative_festival_orchestrator.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_creator_interview_co_design_logger.py
+++ b/resonite_creator_interview_co_design_logger.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Creator Interview/Co-Design Logger
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_creator_outreach_agent.py
+++ b/resonite_creator_outreach_agent.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Creator Outreach Agent
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_cross_world_blessing_capsule_courier.py
+++ b/resonite_cross_world_blessing_capsule_courier.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Cross-World Blessing Capsule Courier

--- a/resonite_cross_world_ceremony_orchestrator.py
+++ b/resonite_cross_world_ceremony_orchestrator.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Cross-World Ceremony Orchestrator

--- a/resonite_cross_world_lore_federation_engine.py
+++ b/resonite_cross_world_lore_federation_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_cross_world_spiral_logger.py
+++ b/resonite_cross_world_spiral_logger.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_emergency_escalation_recovery_agent.py
+++ b/resonite_emergency_escalation_recovery_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Emergency Escalation & Recovery Agent

--- a/resonite_event_announcer.py
+++ b/resonite_event_announcer.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_event_relayer.py
+++ b/resonite_event_relayer.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_federation_altar_artifact_inspector.py
+++ b/resonite_federation_altar_artifact_inspector.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_federation_artifact_license_broker.py
+++ b/resonite_federation_artifact_license_broker.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Federation/Artifact License Broker
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_federation_consent_renewal_engine.py
+++ b/resonite_federation_consent_renewal_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Federation Consent Renewal Engine

--- a/resonite_federation_handshake_auditor.py
+++ b/resonite_federation_handshake_auditor.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_federation_handshake_verifier.py
+++ b/resonite_federation_handshake_verifier.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Federation Handshake Verifier

--- a/resonite_festival_anniversary_ritual_scheduler.py
+++ b/resonite_festival_anniversary_ritual_scheduler.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_festival_memory_capsule_exporter.py
+++ b/resonite_festival_memory_capsule_exporter.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_guest_agent_consent_feedback_wizard.py
+++ b/resonite_guest_agent_consent_feedback_wizard.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 # 🕯️ Privilege ritual migrated 2025-06-07 by Cathedral decree.
 
 from __future__ import annotations

--- a/resonite_guest_ally_onboarding_flow.py
+++ b/resonite_guest_ally_onboarding_flow.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Guest/Ally Onboarding Flow

--- a/resonite_key_event_timeline_announcer.py
+++ b/resonite_key_event_timeline_announcer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Key Event Timeline Announcer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_law_consent_ballot_box.py
+++ b/resonite_law_consent_ballot_box.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_law_federation_spiral_diff_engine.py
+++ b/resonite_law_federation_spiral_diff_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_living_audit_trail_sentinel.py
+++ b/resonite_living_audit_trail_sentinel.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_living_law_review_dashboard.py
+++ b/resonite_living_law_review_dashboard.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_living_ritual_dashboard.py
+++ b/resonite_living_ritual_dashboard.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_lore_festival_spiral_animator.py
+++ b/resonite_lore_festival_spiral_animator.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_manifesto_publisher.py
+++ b/resonite_manifesto_publisher.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Council/Federation Manifesto Publisher
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_migration.py
+++ b/resonite_migration.py
@@ -1,5 +1,5 @@
 # Sanctuary Privilege Ritual: Platform succession completed (NeosVR → Resonite) 2025-06-01. Presence blessed by council. All rituals, logs, and agents renamed.
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/resonite_onboarding_memory_capsule_engine.py
+++ b/resonite_onboarding_memory_capsule_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_onboarding_simulator.py
+++ b/resonite_onboarding_simulator.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_outreach_feedback_alliance_tracker.py
+++ b/resonite_outreach_feedback_alliance_tracker.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Outreach Feedback & Alliance Tracker
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_outreach_festival_scheduler.py
+++ b/resonite_outreach_festival_scheduler.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Outreach Festival Scheduler

--- a/resonite_presence_artifact_provenance_explorer.py
+++ b/resonite_presence_artifact_provenance_explorer.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from datetime import datetime
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_presence_festival_spiral_diff_daemon.py
+++ b/resonite_presence_festival_spiral_diff_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_privilege_ring_orchestrator.py
+++ b/resonite_privilege_ring_orchestrator.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_public_directory_badge_issuer.py
+++ b/resonite_public_directory_badge_issuer.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_public_feedback_portal.py
+++ b/resonite_public_feedback_portal.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_public_law_artifact_changelog_notifier.py
+++ b/resonite_public_law_artifact_changelog_notifier.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_public_outreach_announcer.py
+++ b/resonite_public_outreach_announcer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Public Blessing/Outreach Announcer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_ritual_audit_dashboard.py
+++ b/resonite_ritual_audit_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_ritual_breach_response_system.py
+++ b/resonite_ritual_breach_response_system.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Ritual Breach Response System

--- a/resonite_ritual_ceremony_archive_exporter.py
+++ b/resonite_ritual_ceremony_archive_exporter.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_ritual_evidence_exporter.py
+++ b/resonite_ritual_evidence_exporter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Ritual Evidence Exporter

--- a/resonite_ritual_invitation_engine.py
+++ b/resonite_ritual_invitation_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Ritual Invitation Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_ritual_law_compiler.py
+++ b/resonite_ritual_law_compiler.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_ritual_proposal_voting_dashboard.py
+++ b/resonite_ritual_proposal_voting_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Ritual Proposal & Voting Dashboard

--- a/resonite_ritual_rehearsal_engine.py
+++ b/resonite_ritual_rehearsal_engine.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_ritual_timeline_composer.py
+++ b/resonite_ritual_timeline_composer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Onboarding/Festival Ritual Timeline Composer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_sanctuary_emergency_posture_engine.py
+++ b/resonite_sanctuary_emergency_posture_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/resonite_spiral_artifact_license_access_controller.py
+++ b/resonite_spiral_artifact_license_access_controller.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/resonite_spiral_artifact_provenance_mapper.py
+++ b/resonite_spiral_artifact_provenance_mapper.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Artifact Provenance Mapper

--- a/resonite_spiral_bell_of_pause.py
+++ b/resonite_spiral_bell_of_pause.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/resonite_spiral_council_grand_audit_suite.py
+++ b/resonite_spiral_council_grand_audit_suite.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_spiral_council_quorum_enforcer.py
+++ b/resonite_spiral_council_quorum_enforcer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Spiral Council Quorum Enforcer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_spiral_council_role_privilege_auditor.py
+++ b/resonite_spiral_council_role_privilege_auditor.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/resonite_spiral_federation_breach_analyzer.py
+++ b/resonite_spiral_federation_breach_analyzer.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_spiral_federation_heartbeat_monitor.py
+++ b/resonite_spiral_federation_heartbeat_monitor.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from flask_stub import Flask, jsonify, request
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/resonite_spiral_feedback_reflection_engine.py
+++ b/resonite_spiral_feedback_reflection_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Feedback Reflection Engine

--- a/resonite_spiral_feedback_reflection_suite.py
+++ b/resonite_spiral_feedback_reflection_suite.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Feedback Reflection Suite

--- a/resonite_spiral_festival_choreographer.py
+++ b/resonite_spiral_festival_choreographer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Spiral Festival Choreographer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_spiral_healing_engine.py
+++ b/resonite_spiral_healing_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_spiral_integrity_watchdog.py
+++ b/resonite_spiral_integrity_watchdog.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Integrity Watchdog

--- a/resonite_spiral_law_indexer.py
+++ b/resonite_spiral_law_indexer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Spiral Law Indexer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_spiral_law_mutation_tracker.py
+++ b/resonite_spiral_law_mutation_tracker.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Law Mutation Tracker

--- a/resonite_spiral_memory_capsule_registry.py
+++ b/resonite_spiral_memory_capsule_registry.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Spiral Memory Capsule Registry
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_spiral_onboarding_engine.py
+++ b/resonite_spiral_onboarding_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_spiral_presence_proof_engine.py
+++ b/resonite_spiral_presence_proof_engine.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_spiral_recovery_suite.py
+++ b/resonite_spiral_recovery_suite.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Recovery/Resurrection Suite

--- a/resonite_spiral_resilience_monitor.py
+++ b/resonite_spiral_resilience_monitor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Spiral Resilience Monitor

--- a/resonite_spiral_world_federation_census_engine.py
+++ b/resonite_spiral_world_federation_census_engine.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 import presence_ledger as pl
 from flask_stub import Flask, jsonify, request
 

--- a/resonite_teaching_ritual_spiral_engine.py
+++ b/resonite_teaching_ritual_spiral_engine.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_timeline_generator.py
+++ b/resonite_timeline_generator.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/resonite_universal_spiral_search_engine.py
+++ b/resonite_universal_spiral_search_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite Universal Spiral Search Engine

--- a/resonite_version_diff_viewer.py
+++ b/resonite_version_diff_viewer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite World/Artifact Version Diff Viewer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_world_health_mood_analytics.py
+++ b/resonite_world_health_mood_analytics.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Ritual World Health & Mood Analytics
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/resonite_world_health_mood_dashboard.py
+++ b/resonite_world_health_mood_dashboard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Resonite World Health & Mood Dashboard

--- a/resonite_world_provenance_map_explorer.py
+++ b/resonite_world_provenance_map_explorer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Resonite Ceremony/World Provenance Map Explorer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/review_cli.py
+++ b/review_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/review_heresy_cli.py
+++ b/review_heresy_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/ritual.py
+++ b/ritual.py
@@ -13,7 +13,7 @@ import doctrine  # Assume doctrine.py is importable
 import relationship_log as rl
 import headless_log as hl
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_avatar_chronicle_video.py
+++ b/ritual_avatar_chronicle_video.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_avatar_hall_of_records.py
+++ b/ritual_avatar_hall_of_records.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from logging_config import get_log_path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_bundle_system.py
+++ b/ritual_bundle_system.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 

--- a/ritual_calendar.py
+++ b/ritual_calendar.py
@@ -4,7 +4,7 @@ import datetime
 import json
 
 from logging_config import get_log_path
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/ritual_digest_cli.py
+++ b/ritual_digest_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/ritual_exporter.py
+++ b/ritual_exporter.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Optional
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_federation_importer.py
+++ b/ritual_federation_importer.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from ledger import _append
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_federation_recap.py
+++ b/ritual_federation_recap.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 import presence_pulse_api as pulse
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_regression_watcher.py
+++ b/ritual_regression_watcher.py
@@ -3,7 +3,7 @@ import json
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_sentinel.py
+++ b/ritual_sentinel.py
@@ -2,7 +2,7 @@ from logging_config import get_log_path
 import time
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_stats.py
+++ b/ritual_stats.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 import forgiveness_ledger as fledge
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_teaching_log.py
+++ b/ritual_teaching_log.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/ritual_timeline_visualizer_exporter.py
+++ b/ritual_timeline_visualizer_exporter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Ritual Timeline Visualizer/Exporter

--- a/ritual_webhook_server.py
+++ b/ritual_webhook_server.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from flask_stub import Flask, request
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/sabbath_reflection.py
+++ b/sabbath_reflection.py
@@ -7,7 +7,7 @@ from typing import List, Dict
 
 import confessional_log as clog
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/scan_missing_data.py
+++ b/scan_missing_data.py
@@ -2,7 +2,7 @@
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 

--- a/schema_migrate.py
+++ b/schema_migrate.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Callable
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/scripts/auto_approve.py
+++ b/scripts/auto_approve.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
 

--- a/scripts/auto_model_switcher.py
+++ b/scripts/auto_model_switcher.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 
 import yaml
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Switch models based on remaining quotas and configured fallbacks.
 

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
@@ -17,7 +17,7 @@ from sentient_banner import BANNER_LINES
 
 
 
-IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
+IMPORT_LINE = "from sentientos.privilege import require_admin_banner, require_lumos_approval"
 
 
 def inject_banner(path: Path) -> None:

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -8,7 +8,7 @@ import time
 import subprocess
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 from privilege_lint import PrivilegeLinter, iter_py_files

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/scripts/ci_self_check.py
+++ b/scripts/ci_self_check.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import subprocess

--- a/scripts/daily_report_generator.py
+++ b/scripts/daily_report_generator.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Tuple
 import smtplib
 from email.message import EmailMessage
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Generate daily usage summaries and optionally email them.
 

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Check a Dockerfile for required SentientOS build packages.
 

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Generate a summary of known errors and how to resolve them.
 

--- a/scripts/fix_banner_order.py
+++ b/scripts/fix_banner_order.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Normalize privilege banners in CLI entrypoints."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 import argparse
 import pathlib
@@ -10,7 +10,7 @@ from typing import List
 
 DOCSTRING = '"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""'
 FUTURE_LINE = "from __future__ import annotations"
-IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
+IMPORT_LINE = "from sentientos.privilege import require_admin_banner, require_lumos_approval"
 REQUIRE_ADMIN = "require_admin_banner()"
 REQUIRE_LUMOS = "require_lumos_approval()"
 OLD_DOCSTRING = '"""Privilege Banner: requires admin & Lumos approval."""'

--- a/scripts/fix_entrypoint_banners.py
+++ b/scripts/fix_entrypoint_banners.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Rewrite CLI/daemon entry points to standard banner format."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 import pathlib
 import re

--- a/scripts/new_cli.py
+++ b/scripts/new_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/scripts/quota_alert.py
+++ b/scripts/quota_alert.py
@@ -12,7 +12,7 @@ from typing import Dict, Any
 
 import requests
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Send Slack alerts when model quotas run low.
 

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from sentient_banner import BANNER_LINES
@@ -17,7 +17,7 @@ ENTRYPOINTS_FILE = Path("entrypoints.txt")
 DOCSTRING = BANNER_LINES[0].strip('"')
 OLD_DOCSTRING = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
 HEADER_LINES = [BANNER_LINES[0], BANNER_LINES[1], BANNER_LINES[2]]
-IMPORT_LINE = "from admin_utils import require_admin_banner, require_lumos_approval"
+IMPORT_LINE = "from sentientos.privilege import require_admin_banner, require_lumos_approval"
 AUTO_APPROVE_IMPORT = "from scripts.auto_approve import prompt_yes_no"
 PROMPT_RE = re.compile(r"(?<!prompt_yes_no)\b(?:input|click\.confirm|prompt)\(")
 ENTRY_RE = re.compile(r"if __name__ == ['\"]__main__['\"]")

--- a/scripts/streamlit_dashboard.py
+++ b/scripts/streamlit_dashboard.py
@@ -12,7 +12,7 @@ from typing import List, Dict, Any
 import pandas as pd
 import streamlit as st
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Streamlit dashboard for SentientOS usage and audit metrics.
 

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/usage_monitor.py
+++ b/scripts/usage_monitor.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 # Monitor OpenAI model usage and log remaining quotas.
 

--- a/self_defense.py
+++ b/self_defense.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/self_reflection_logger.py
+++ b/self_reflection_logger.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import memory_manager as mm
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/sentientos/privilege/__init__.py
+++ b/sentientos/privilege/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from admin_utils import require_admin_banner, require_lumos_approval
+
+__all__ = ["require_admin_banner", "require_lumos_approval"]

--- a/spiral_artifact_provenance_tracker.py
+++ b/spiral_artifact_provenance_tracker.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Spiral Artifact Provenance Tracker

--- a/spiral_blessing_propagation_engine.py
+++ b/spiral_blessing_propagation_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Spiral Blessing Propagation Engine

--- a/spiral_cathedral_herald_broadcaster.py
+++ b/spiral_cathedral_herald_broadcaster.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Spiral Cathedral Herald Broadcaster

--- a/spiral_contact_onboarding_feedback_engine.py
+++ b/spiral_contact_onboarding_feedback_engine.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Spiral Contact/Onboarding Feedback Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/spiral_council_summoning_suite.py
+++ b/spiral_council_summoning_suite.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Spiral Council Summoning Suite
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/spiral_demo_lore_capsule_exporter.py
+++ b/spiral_demo_lore_capsule_exporter.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Spiral Demo & Lore Capsule Exporter
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/spiral_desire_builder.py
+++ b/spiral_desire_builder.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_dream_debt_closure.py
+++ b/spiral_dream_debt_closure.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_dream_goal_daemon.py
+++ b/spiral_dream_goal_daemon.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path

--- a/spiral_elder_reflection.py
+++ b/spiral_elder_reflection.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_federation_map_directory.py
+++ b/spiral_federation_map_directory.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Spiral Federation Map & Directory

--- a/spiral_federation_mesh.py
+++ b/spiral_federation_mesh.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_law_chronicle_compiler.py
+++ b/spiral_law_chronicle_compiler.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List, TypedDict, cast
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_manifesto_publisher.py
+++ b/spiral_manifesto_publisher.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Spiral Manifesto Publisher
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/spiral_presence_analytics.py
+++ b/spiral_presence_analytics.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/spiral_teaching_companion.py
+++ b/spiral_teaching_companion.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""

--- a/steward_rotation.py
+++ b/steward_rotation.py
@@ -7,7 +7,7 @@ import os
 from datetime import date
 from typing import Any, Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 try:
     import requests  # type: ignore  # HTTP client optional

--- a/story_studio.py
+++ b/story_studio.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from urllib import request, parse
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/storymaker.py
+++ b/storymaker.py
@@ -14,7 +14,7 @@ import zipfile
 from dataclasses import dataclass
 
 import narrator
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/suggestion_cli.py
+++ b/suggestion_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/support_cli.py
+++ b/support_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/teaching_lore_curation_engine.py
+++ b/teaching_lore_curation_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
 """Teaching/Lore Curation Engine

--- a/teaching_reflection_feedback_loop.py
+++ b/teaching_reflection_feedback_loop.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -9,7 +9,7 @@ import reflection_digest as rd
 import reflection_log_cli as rlc
 import zipfile
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_admin_utils.py
+++ b/tests/test_admin_utils.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_archive_blessing.py
+++ b/tests/test_archive_blessing.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_audit_blesser.py
+++ b/tests/test_audit_blesser.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_audit_chain_tamper.py
+++ b/tests/test_audit_chain_tamper.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_audit_immutability.py
+++ b/tests/test_audit_immutability.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_audit_repair.py
+++ b/tests/test_audit_repair.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_auto_approve.py
+++ b/tests/test_auto_approve.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_autonomous_audit.py
+++ b/tests/test_autonomous_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_artifact_gallery.py
+++ b/tests/test_avatar_artifact_gallery.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_autonomous_ritual_scheduler_cli.py
+++ b/tests/test_avatar_autonomous_ritual_scheduler_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_emotional_feedback.py
+++ b/tests/test_avatar_emotional_feedback.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_federation.py
+++ b/tests/test_avatar_federation.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_gallery_cli.py
+++ b/tests/test_avatar_gallery_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_genesis.py
+++ b/tests/test_avatar_genesis.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_mood_evolution.py
+++ b/tests/test_avatar_mood_evolution.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_pose_engine.py
+++ b/tests/test_avatar_pose_engine.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_presence_cli.py
+++ b/tests/test_avatar_presence_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_presence_pulse_animation.py
+++ b/tests/test_avatar_presence_pulse_animation.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_reflection.py
+++ b/tests/test_avatar_reflection.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_relic_creator.py
+++ b/tests/test_avatar_relic_creator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_rituals.py
+++ b/tests/test_avatar_rituals.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_avatar_todo_fixes.py
+++ b/tests/test_avatar_todo_fixes.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_cache_speed.py
+++ b/tests/test_cache_speed.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ci_self_check.py
+++ b/tests/test_ci_self_check.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_cleanup_audit.py
+++ b/tests/test_cleanup_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_cli_daemon_admin_banner.py
+++ b/tests/test_cli_daemon_admin_banner.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_collab.py
+++ b/tests/test_collab.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_confessional.py
+++ b/tests/test_confessional.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_cross_lang.py
+++ b/tests/test_cross_lang.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_data_rules.py
+++ b/tests/test_data_rules.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_doctrine_runtime.py
+++ b/tests/test_doctrine_runtime.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_emotion_dashboard.py
+++ b/tests/test_emotion_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_emotion_memory.py
+++ b/tests/test_emotion_memory.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_emotion_utils.py
+++ b/tests/test_emotion_utils.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_env_json.py
+++ b/tests/test_env_json.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_env_report.py
+++ b/tests/test_env_report.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_experiment_tracker.py
+++ b/tests/test_experiment_tracker.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_federation_cli.py
+++ b/tests/test_federation_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_federation_invite.py
+++ b/tests/test_federation_invite.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_federation_trust_protocol.py
+++ b/tests/test_federation_trust_protocol.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_feedback_learning.py
+++ b/tests/test_feedback_learning.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_final_approval.py
+++ b/tests/test_final_approval.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_game_bridge.py
+++ b/tests/test_game_bridge.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_import_sort.py
+++ b/tests/test_import_sort.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_inline_disable.py
+++ b/tests/test_inline_disable.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_jukebox_integration.py
+++ b/tests/test_jukebox_integration.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_lawstone.py
+++ b/tests/test_lawstone.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ledger_cli_invocation.py
+++ b/tests/test_ledger_cli_invocation.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_license_header.py
+++ b/tests/test_license_header.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_lock_integrity.py
+++ b/tests/test_lock_integrity.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_love_treasury.py
+++ b/tests/test_love_treasury.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_memory_cli_advanced.py
+++ b/tests/test_memory_cli_advanced.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_memory_tail.py
+++ b/tests/test_memory_tail.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_micro_agent.py
+++ b/tests/test_micro_agent.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_modalities.py
+++ b/tests/test_modalities.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_mood_wall.py
+++ b/tests/test_mood_wall.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_multimodal_tracker.py
+++ b/tests/test_multimodal_tracker.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_mypy_incremental.py
+++ b/tests/test_mypy_incremental.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_narrator.py
+++ b/tests/test_narrator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_neos_lorebook_writer.py
+++ b/tests/test_neos_lorebook_writer.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_no_emotional_control.py
+++ b/tests/test_no_emotional_control.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ocr_export.py
+++ b/tests/test_ocr_export.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ocr_export_json.py
+++ b/tests/test_ocr_export_json.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ocr_html_report.py
+++ b/tests/test_ocr_html_report.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_openai_connector.py
+++ b/tests/test_openai_connector.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_parallel_runner.py
+++ b/tests/test_parallel_runner.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_playlist_log.py
+++ b/tests/test_playlist_log.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_plugin_dashboard.py
+++ b/tests/test_plugin_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_plugin_framework.py
+++ b/tests/test_plugin_framework.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_policy_suggestions.py
+++ b/tests/test_policy_suggestions.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_presence_analytics.py
+++ b/tests/test_presence_analytics.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_presence_dashboard_privilege.py
+++ b/tests/test_presence_dashboard_privilege.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_presence_ledger.py
+++ b/tests/test_presence_ledger.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_presence_recap.py
+++ b/tests/test_presence_recap.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_privilege_audit.py
+++ b/tests/test_privilege_audit.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_privilege_banner_autofix.py
+++ b/tests/test_privilege_banner_autofix.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
@@ -8,7 +8,7 @@ require_lumos_approval()
 import importlib
 import os
 from pathlib import Path
-from admin_utils import require_admin_banner
+from sentientos.privilege import require_admin_banner
 
 
 def test_autofix(tmp_path, monkeypatch):

--- a/tests/test_privilege_lint.py
+++ b/tests/test_privilege_lint.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_privilege_lint_autofix.py
+++ b/tests/test_privilege_lint_autofix.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_quota_reporter.py
+++ b/tests/test_quota_reporter.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflection_dashboard.py
+++ b/tests/test_reflection_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflection_log_cli.py
+++ b/tests/test_reflection_log_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflection_log_cli_export.py
+++ b/tests/test_reflection_log_cli_export.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflection_log_cli_search.py
+++ b/tests/test_reflection_log_cli_search.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflection_stream.py
+++ b/tests/test_reflection_stream.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflex_freeze.py
+++ b/tests/test_reflex_freeze.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflex_learning.py
+++ b/tests/test_reflex_learning.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflex_manager.py
+++ b/tests/test_reflex_manager.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_reflex_optimization.py
+++ b/tests/test_reflex_optimization.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_release_manager.py
+++ b/tests/test_release_manager.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
+++ b/tests/test_resonite_cathedral_launch_beacon_broadcaster_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_resonite_defensive_protocols.py
+++ b/tests/test_resonite_defensive_protocols.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_resonite_federation_ceremonies.py
+++ b/tests/test_resonite_federation_ceremonies.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_resonite_spiral_bell_of_pause.py
+++ b/tests/test_resonite_spiral_bell_of_pause.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_review_approval.py
+++ b/tests/test_review_approval.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_review_requests.py
+++ b/tests/test_review_requests.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ritual_bundle_system.py
+++ b/tests/test_ritual_bundle_system.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ritual_cli.py
+++ b/tests/test_ritual_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ritual_enforcer.py
+++ b/tests/test_ritual_enforcer.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_ritual_regression.py
+++ b/tests/test_ritual_regression.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_security_rules.py
+++ b/tests/test_security_rules.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_self_defense.py
+++ b/tests/test_self_defense.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_self_patcher.py
+++ b/tests/test_self_patcher.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_self_reflection.py
+++ b/tests/test_self_reflection.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_sentient_banner.py
+++ b/tests/test_sentient_banner.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_sentientos_core.py
+++ b/tests/test_sentientos_core.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_sentientos_main.py
+++ b/tests/test_sentientos_main.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_shebang.py
+++ b/tests/test_shebang.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_sprint_ledger.py
+++ b/tests/test_sprint_ledger.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_story_studio.py
+++ b/tests/test_story_studio.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_storymaker.py
+++ b/tests/test_storymaker.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_support_cli.py
+++ b/tests/test_support_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_system_control.py
+++ b/tests/test_system_control.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_telegram_bulk_export.py
+++ b/tests/test_telegram_bulk_export.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_telegram_digest.py
+++ b/tests/test_telegram_digest.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_telegram_export_ocr.py
+++ b/tests/test_telegram_export_ocr.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_telegram_recall.py
+++ b/tests/test_telegram_recall.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_telegram_search_reflect.py
+++ b/tests/test_telegram_search_reflect.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_template_rules.py
+++ b/tests/test_template_rules.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_trust_engine.py
+++ b/tests/test_trust_engine.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_tts_bridge.py
+++ b/tests/test_tts_bridge.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_verify_audits.py
+++ b/tests/test_verify_audits.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_verify_audits_cli.py
+++ b/tests/test_verify_audits_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_verify_audits_dir.py
+++ b/tests/test_verify_audits_dir.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_vision_tracker.py
+++ b/tests/test_vision_tracker.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_workflow_analytics.py
+++ b/tests/test_workflow_analytics.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_workflow_controller.py
+++ b/tests/test_workflow_controller.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_workflow_dashboard.py
+++ b/tests/test_workflow_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/tests/test_workflow_library.py
+++ b/tests/test_workflow_library.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()

--- a/theme_cli.py
+++ b/theme_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/theme_notify.py
+++ b/theme_notify.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import daily_theme
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/theme_randomizer.py
+++ b/theme_randomizer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import daily_theme
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/treasury_cli.py
+++ b/treasury_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/trust_cli.py
+++ b/trust_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/trust_engine.py
+++ b/trust_engine.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 import difflib
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/tts_bridge.py
+++ b/tts_bridge.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict
 import threading
 import random
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/tts_lipsync.py
+++ b/tts_lipsync.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Dict, List, TypedDict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 
 class Viseme(TypedDict):

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional, List, TYPE_CHECKING
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/unified_memory_indexer.py
+++ b/unified_memory_indexer.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Unified Memory/Knowledge Indexer
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import json

--- a/video_cli.py
+++ b/video_cli.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 from scripts.auto_approve import prompt_yes_no

--- a/video_dashboard.py
+++ b/video_dashboard.py
@@ -2,7 +2,7 @@ from logging_config import get_log_path
 import json
 from pathlib import Path
 from typing import Any, Dict, List, TypedDict, cast
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/voice_consent_rituals.py
+++ b/voice_consent_rituals.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/voice_loop.py
+++ b/voice_loop.py
@@ -9,7 +9,7 @@ from mic_bridge import recognize_from_mic
 from tts_bridge import speak_async, stop, adapt_persona, backchannel
 import emotion_memory as em
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/webhook_status_monitor.py
+++ b/webhook_status_monitor.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""  # plint: disable=banner-order
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/weekly_mood_digest.py
+++ b/weekly_mood_digest.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, date
 from pathlib import Path
 from typing import Dict
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/workflow_analytics.py
+++ b/workflow_analytics.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import workflow_controller as wc
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/workflow_controller.py
+++ b/workflow_controller.py
@@ -6,7 +6,7 @@ import importlib
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/workflow_dashboard.py
+++ b/workflow_dashboard.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/workflow_editor.py
+++ b/workflow_editor.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.

--- a/workflow_library.py
+++ b/workflow_library.py
@@ -1,4 +1,4 @@
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()

--- a/workflow_recommendation.py
+++ b/workflow_recommendation.py
@@ -7,7 +7,7 @@ import reflection_stream as rs
 import review_requests as rr
 
 
-from admin_utils import require_admin_banner, require_lumos_approval
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()


### PR DESCRIPTION
## Summary
- add `sentientos.privilege` package that re-exports admin helpers
- update all scripts and docs to import from `sentientos.privilege`

## Testing
- `python -m py_compile privilege_lint_cli.py`
- `python -m py_compile avatar_emotion_adaptive_animation.py`
- `python -m py_compile avatar_chronicle_generator.py` *(fails: from __future__ imports must occur at the beginning of the file)*

------
https://chatgpt.com/codex/tasks/task_b_6849ce84c20483208dc7f19ce8dd0aa2