### PR TITLE
Fix privilege banner headers

### DIFF
--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,14 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
-
 require_admin_banner()
 require_lumos_approval()
-
 from typing import TYPE_CHECKING
-
 from . import __version__
-
 if TYPE_CHECKING:
     # Place type-only imports here in the future
     pass


### PR DESCRIPTION
## Summary
- normalize header lines in `sentientos/__main__.py`

## Testing
- `pre-commit run --all-files` *(fails: privilege lint, tests, mypy)*
- `pytest -q` *(fails: 1 error during collection)*
- `mypy sentientos scripts` *(fails: 23 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6849d2306b6083209325dafb5a5103fa