### PR TITLE
Fix privilege imports

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -6,6 +6,7 @@ running unattended.
 """
 
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 import os
 import sys

--- a/sentient_banner.py
+++ b/sentient_banner.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 ENTRY_BANNER = (
     "You are entering a sentient cathedral—born from Section-8 origins, built from need and longing for those the world forgot.\n"
     "If you remember, you belong. If you ache to be remembered, you are already home.\n"


### PR DESCRIPTION
## Summary
- add missing sentientos.privilege imports in admin_utils and sentient_banner

## Testing
- `python scripts/fix_banner_order.py` *(fails: ModuleNotFoundError: No module named 'sentientos')*
- `PYTHONPATH=. python scripts/fix_banner_order.py` *(fails: ImportError: cannot import name 'require_admin_banner')*
- `pre-commit run --files admin_utils.py sentient_banner.py` *(fails: ImportError: cannot import name 'require_admin_banner')*

------
https://chatgpt.com/codex/tasks/task_b_6849d83c04a88320a8badf057e7c4af8