### PR TITLE
Fix privilege imports

### DIFF
--- a/sentientos/privilege.py
+++ b/sentientos/privilege.py
@@ -1,0 +1,11 @@
+"""Privilege hooks — enforced by Sanctuary Doctrine."""
+
+
+def require_admin_banner() -> None:
+    import admin_utils
+    admin_utils.require_admin_banner()
+
+
+def require_lumos_approval() -> None:
+    import admin_utils
+    admin_utils.require_lumos_approval()

--- a/sentientos/privilege/__init__.py
+++ b/sentientos/privilege/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from admin_utils import require_admin_banner, require_lumos_approval
-
-__all__ = ["require_admin_banner", "require_lumos_approval"]


### PR DESCRIPTION
## Summary
- replace `sentientos.privilege` package with a module
- runtime-import admin hooks to avoid circular imports

## Testing
- `pre-commit run --files sentientos/privilege.py` *(fails: privilege banner mass check, unit tests)*
- `pytest -k test_is_admin_true` *(fails: unrecognized arguments)*


------
https://chatgpt.com/codex/tasks/task_b_6849e18484a88320925d0f7aea3502fa