### PR TITLE
Add cycle-safe privilege wrappers

### DIFF
--- a/sentientos/privilege.py
+++ b/sentientos/privilege.py
@@ -1,14 +1,30 @@
-"""Privilege hooks — enforced by Sanctuary Doctrine.
+"""Cycle-safe privilege hooks.
 
-These wrappers lazily import the real admin_utils helpers at call-time,
-eliminating circular-import issues while satisfying static references.
+These wrappers import the actual helpers from admin_utils at call-time,
+preventing circular-import errors while satisfying static references.
 """
 
-def require_admin_banner() -> None:  # pragma: no cover
-    from admin_utils import require_admin_banner as _real
-    _real()
+from functools import wraps
 
 
-def require_lumos_approval() -> None:  # pragma: no cover
-    from admin_utils import require_lumos_approval as _real
-    _real()
+def _lazy(attr_name: str):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            from admin_utils import require_admin_banner, require_lumos_approval
+            real = require_admin_banner if attr_name == "require_admin_banner" else require_lumos_approval
+            return real(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+@_lazy("require_admin_banner")
+def require_admin_banner() -> None:
+    """Ensure admin banner has been acknowledged."""
+    return None
+
+
+@_lazy("require_lumos_approval")
+def require_lumos_approval() -> None:
+    """Require Lumos approval for privileged actions."""
+    return None


### PR DESCRIPTION
## Summary
- implement lazy privilege wrappers for cycle safety
- create empty `__init__.py` package marker

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: PyYAML required for tests)*
- `mypy sentientos` *(fails: Source file found twice under different module names)*
- `python verify_audits.py logs/ --no-input` *(fails: Lumos approval denied)*

------
https://chatgpt.com/codex/tasks/task_b_6849ee3144988320b236520f3032637b