### PR TITLE
Fix header order and pre-commit env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         pass_filenames: false
         env:
           LUMOS_AUTO_APPROVE: '1'
+          PYTHONPATH: "."
 
       - id: audit-verify
         name: audit log verify
@@ -16,24 +17,27 @@ repos:
         pass_filenames: false
         env:
           LUMOS_AUTO_APPROVE: '1'
+          PYTHONPATH: "."
 
       - id: mass-checker
         name: privilege banner mass check
         entry: python scripts/ritual_enforcer.py --mode check
         language: system
         pass_filenames: false
+        env:
+          PYTHONPATH: "."
 
       - id: pytest
         name: unit tests
         entry: pytest --cov=sentientos --cov-fail-under=80 -q
         language: python
         pass_filenames: false
+        env:
+          PYTHONPATH: "."
         additional_dependencies:
           - pytest
           - pytest-cov
           - requests
-          - requests_mock
-          - PyYAML
           - mypy
           - types-PyYAML
           - types-requests
@@ -46,7 +50,5 @@ repos:
           - pytest
           - pytest-cov
           - requests
-          - requests_mock
-          - PyYAML
           - types-PyYAML
           - types-requests

--- a/api/actuator.py
+++ b/api/actuator.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/replay.py
+++ b/replay.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/audit_blesser.py
+++ b/scripts/audit_blesser.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/audit_repair.py
+++ b/scripts/audit_repair.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/auto_approve.py
+++ b/scripts/auto_approve.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
-from sentientos.privilege import require_admin_banner, require_lumos_approval
-
 """Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
-
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 

--- a/scripts/auto_model_switcher.py
+++ b/scripts/auto_model_switcher.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import argparse
 import json

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import time
 import subprocess

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
 import argparse
 import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from sentientos.privilege import require_admin_banner, require_lumos_approval
-
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/ci_self_check.py
+++ b/scripts/ci_self_check.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/daily_report_generator.py
+++ b/scripts/daily_report_generator.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import argparse
 import json

--- a/scripts/dockerfile_verifier.py
+++ b/scripts/dockerfile_verifier.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path

--- a/scripts/error_guide_generator.py
+++ b/scripts/error_guide_generator.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 import re
 from pathlib import Path
 

--- a/scripts/fix_banner_order.py
+++ b/scripts/fix_banner_order.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Normalize privilege banners in CLI entrypoints."""
 from __future__ import annotations
+"""Normalize privilege banners in CLI entrypoints."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 import argparse

--- a/scripts/fix_entrypoint_banners.py
+++ b/scripts/fix_entrypoint_banners.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Rewrite CLI/daemon entry points to standard banner format."""
 from __future__ import annotations
+"""Rewrite CLI/daemon entry points to standard banner format."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 import pathlib

--- a/scripts/new_cli.py
+++ b/scripts/new_cli.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/quota_alert.py
+++ b/scripts/quota_alert.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import argparse
 import json

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/ritual_enforcer.py
+++ b/scripts/ritual_enforcer.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/streamlit_dashboard.py
+++ b/scripts/streamlit_dashboard.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import json
 from datetime import date

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,5 +1,5 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()

--- a/scripts/usage_monitor.py
+++ b/scripts/usage_monitor.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-from __future__ import annotations
 
 import argparse
 import json

--- a/sentientos/__init__.py
+++ b/sentientos/__init__.py
@@ -1,3 +1,5 @@
-from __future__ import annotations
+"""SentientOS core package."""
+# Expose privilege helpers for static analyzers
+from sentientos.privilege import require_admin_banner, require_lumos_approval  # noqa: F401
 
 __version__: str = "0.1.1"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""


### PR DESCRIPTION
## Summary
- expose privilege helpers in `sentientos.__init__`
- ensure pre-commit hooks set `PYTHONPATH`
- normalize privilege header order across scripts

## Testing
- `pip install -e .[dev]`
- `pre-commit run --all-files --show-diff-on-failure` *(fails: Unexpected key(s) present on local hooks)*
- `pytest -q` *(fails: 2 errors during collection)*
- `mypy sentientos scripts` *(fails: Source file found twice)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --no-input`

------
https://chatgpt.com/codex/tasks/task_b_6849f10324848320973fe1ef28d4b0b3