### PR TITLE
Sanctuary header sweep (scoped)

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -1,9 +1,17 @@
+privilege_lint/config.py:27: error: Incompatible types in assignment (expression has type "None", variable has type "list[str]")  [assignment]
 admin_utils.py:81: error: Name "require_admin_banner" already defined (possibly by an import)  [no-redef]
 admin_utils.py:135: error: Name "require_lumos_approval" already defined (possibly by an import)  [no-redef]
-privilege_lint/config.py:27: error: Incompatible types in assignment (expression has type "None", variable has type "list[str]")  [assignment]
+scripts/usage_monitor.py:15: error: Library stubs not installed for "requests"  [import-untyped]
+scripts/quota_alert.py:13: error: Library stubs not installed for "requests"  [import-untyped]
+scripts/quota_alert.py:13: note: Hint: "python3 -m pip install types-requests"
+scripts/auto_model_switcher.py:12: error: Library stubs not installed for "yaml"  [import-untyped]
+scripts/auto_model_switcher.py:12: note: Hint: "python3 -m pip install types-PyYAML"
+scripts/auto_model_switcher.py:12: note: (or run "mypy --install-types" to install all missing stub packages)
+scripts/auto_model_switcher.py:12: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+scripts/quota_reporter.py:15: error: Library stubs not installed for "requests"  [import-untyped]
 privilege_lint/runner.py:13: error: Name "PrivilegeLinter" is not defined  [name-defined]
-scripts/plint_baseline.py:7: error: Module "privilege_lint" has no attribute "PrivilegeLinter"  [attr-defined]
-scripts/plint_baseline.py:7: error: Module "privilege_lint" has no attribute "iter_py_files"  [attr-defined]
+scripts/plint_baseline.py:12: error: Module "privilege_lint" has no attribute "PrivilegeLinter"  [attr-defined]
+scripts/plint_baseline.py:12: error: Module "privilege_lint" has no attribute "iter_py_files"  [attr-defined]
 scripts/benchmark_lint.py:14: error: Module "privilege_lint" has no attribute "PrivilegeLinter"  [attr-defined]
 scripts/benchmark_lint.py:14: error: Module "privilege_lint" has no attribute "iter_py_files"  [attr-defined]
-Found 8 errors in 5 files (checked 35 source files)
+Found 12 errors in 9 files (checked 35 source files)

--- a/scripts/auto_approve.py
+++ b/scripts/auto_approve.py
@@ -1,8 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-"""Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
+"""Sanctuary Privilege Banner: This script requires admin & Lumos approval."""
 
 import os
 

--- a/scripts/banner_injector.py
+++ b/scripts/banner_injector.py
@@ -1,10 +1,10 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
-"""Privilege Banner: requires admin & Lumos approval."""
 require_admin_banner()
 require_lumos_approval()
+"""Privilege Banner: requires admin & Lumos approval."""
 
 import argparse
 import ast

--- a/scripts/gen_lock.py
+++ b/scripts/gen_lock.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 import argparse
 import shutil

--- a/scripts/install_extras.py
+++ b/scripts/install_extras.py
@@ -1,4 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 import argparse
 import importlib

--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -1,4 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 """Lock management helper.
 
 Usage:

--- a/scripts/plint_baseline.py
+++ b/scripts/plint_baseline.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 import json
 from pathlib import Path

--- a/scripts/plint_env.py
+++ b/scripts/plint_env.py
@@ -1,4 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 from privilege_lint.env import main
 

--- a/sentientos/core.py
+++ b/sentientos/core.py
@@ -1,4 +1,9 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 from dataclasses import dataclass
 


### PR DESCRIPTION
## Summary
- insert canonical privilege header in auto_approve, banner_injector, gen_lock, install_extras, lock, plint_baseline, plint_env, and sentientos/core
- update `MYPY_STATUS.md`

## Testing
- `mypy sentientos scripts > MYPY_STATUS.md`
- `pytest -q || echo '⚠️ Tests failed'`
- `pre-commit run --all-files || echo '⚠️ Pre-commit failed'`


------
https://chatgpt.com/codex/tasks/task_b_684a09811a648320a07627ac024d91a7