### PR TITLE
Fix privilege headers

### DIFF
--- a/MYPY_STATUS.md
+++ b/MYPY_STATUS.md
@@ -1,6 +1,6 @@
 privilege_lint/config.py:27: error: Incompatible types in assignment (expression has type "None", variable has type "list[str]")  [assignment]
-admin_utils.py:81: error: Name "require_admin_banner" already defined (possibly by an import)  [no-redef]
-admin_utils.py:135: error: Name "require_lumos_approval" already defined (possibly by an import)  [no-redef]
+admin_utils.py:85: error: Name "require_admin_banner" already defined (possibly by an import)  [no-redef]
+admin_utils.py:139: error: Name "require_lumos_approval" already defined (possibly by an import)  [no-redef]
 scripts/usage_monitor.py:15: error: Library stubs not installed for "requests"  [import-untyped]
 scripts/quota_alert.py:13: error: Library stubs not installed for "requests"  [import-untyped]
 scripts/quota_alert.py:13: note: Hint: "python3 -m pip install types-requests"
@@ -8,7 +8,7 @@ scripts/auto_model_switcher.py:12: error: Library stubs not installed for "yaml"
 scripts/auto_model_switcher.py:12: note: Hint: "python3 -m pip install types-PyYAML"
 scripts/auto_model_switcher.py:12: note: (or run "mypy --install-types" to install all missing stub packages)
 scripts/auto_model_switcher.py:12: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-scripts/quota_reporter.py:15: error: Library stubs not installed for "requests"  [import-untyped]
+scripts/quota_reporter.py:18: error: Library stubs not installed for "requests"  [import-untyped]
 privilege_lint/runner.py:13: error: Name "PrivilegeLinter" is not defined  [name-defined]
 scripts/plint_baseline.py:12: error: Module "privilege_lint" has no attribute "PrivilegeLinter"  [attr-defined]
 scripts/plint_baseline.py:12: error: Module "privilege_lint" has no attribute "iter_py_files"  [attr-defined]

--- a/admin_utils.py
+++ b/admin_utils.py
@@ -5,9 +5,13 @@ actions continue. Set ``LUMOS_AUTO_APPROVE=1`` to bypass the prompt when
 running unattended.
 """
 
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
-
+require_admin_banner()
+require_lumos_approval()
 import os
 import sys
 import platform

--- a/openai_connector.py
+++ b/openai_connector.py
@@ -1,18 +1,18 @@
-from sentientos.privilege import require_admin_banner, require_lumos_approval
-
-"""OpenAI event connector.
-
-This module logs structured events to ``LOG_PATH``. Set the environment
-variable ``OPENAI_CONNECTOR_LOG`` to override the default log destination
-(``logs/openai_connector.jsonl``).
-
-Privilege escalation is gated by ``admin_utils.require_lumos_approval``.
-To run non-interactively, set ``LUMOS_AUTO_APPROVE=1``.
-
+"""
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()  # Set ``LUMOS_AUTO_APPROVE=1`` to bypass the interactive blessing prompt
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+# OpenAI event connector.
+#
+# This module logs structured events to ``LOG_PATH``. Set the environment
+# variable ``OPENAI_CONNECTOR_LOG`` to override the default log destination
+# (``logs/openai_connector.jsonl``).
+#
+# Privilege escalation is gated by ``admin_utils.require_lumos_approval``.
+# To run non-interactively, set ``LUMOS_AUTO_APPROVE=1``.
 
 from logging_config import get_log_path
 import logging

--- a/scripts/quota_reporter.py
+++ b/scripts/quota_reporter.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
 import argparse

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
-
 # Automate release version bumping and tagging.
 import argparse
 import datetime as dt

--- a/scripts/test_import_fixer.py
+++ b/scripts/test_import_fixer.py
@@ -1,7 +1,8 @@
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
-
 require_admin_banner()
 require_lumos_approval()
 

--- a/sentientos/__main__.py
+++ b/sentientos/__main__.py
@@ -1,4 +1,6 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -1,4 +1,6 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+"""
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()


### PR DESCRIPTION
## Summary
- normalize privilege ritual headers for key modules
- update typecheck status

## Testing
- `pytest -q` *(fails: PyYAML required)*
- `mypy sentientos scripts > MYPY_STATUS.md`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a0dec0aa88320b1ff129e88e25cde