### PR TITLE
Fix admin_utils docstring order

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+
 """Privilege helper utilities.
 
 ``require_lumos_approval`` prompts for a Lumos blessing before privileged
 actions continue. Set ``LUMOS_AUTO_APPROVE=1`` to bypass the prompt when
 running unattended.
-"""
-
-"""
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 """
 
 from sentientos.privilege import require_admin_banner, require_lumos_approval


### PR DESCRIPTION
## Summary
- ensure the Sanctuary privilege docstring sits directly after the future import
- keep the module description following it

## Testing
- `python -m py_compile scripts/admin_utils.py` *(fails: file not found)*
- `python -m py_compile admin_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_684a2e6aa950832088619cd0146a142a