### PR TITLE
Add setup script for dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ Audit chain is now auto-healed during CI. A nightly workflow also runs `python v
 - **No more "audio storms" on boot—only fresh logs autoplay**
 - **Shell quirks and first-run hiccups handled**
 
-## Quick Start
+## Getting Started
 Clone, bless, and run:
 ```bash
 git clone https://github.com/sentient-os/cathedral.git
 cd cathedral
+./environment/setup_requirements.sh
 ./bless.sh && ./up.sh
 ```
 `bless.sh` asks for consent before any action:
@@ -98,6 +99,7 @@ fi
 1. Ensure your system has Python **3.11+** and install `build-essential` and
    `libasound2` (or equivalent audio libraries) so optional TTS features work.
 2. Install the pinned dependencies with `pip install -r requirements.txt`.
+   Then run `./environment/setup_requirements.sh` to install development tools.
    The list includes `types-requests`, providing type hints for the
    `requests` library so that `mypy` runs cleanly.
 3. Install the project in editable mode using `pip install -e .`.

--- a/environment/setup_requirements.sh
+++ b/environment/setup_requirements.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$ROOT_DIR/requirements-dev.txt" ]; then
+    python3 -m pip install -r "$ROOT_DIR/requirements-dev.txt"
+else
+    python3 -m pip install pyyaml pytest mypy pre-commit
+fi


### PR DESCRIPTION
## Summary
- create `setup_requirements.sh` to install dev tools
- instruct contributors to run the script in the Getting Started section

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pytest -m "not env"`
- `mypy --ignore-missing-imports .`


------
https://chatgpt.com/codex/tasks/task_b_684a2e75238c8320b6457a6aecb3bac1