### PR TITLE
Remove redundant admin banner calls

### DIFF
--- a/avatar_federation_join.py
+++ b/avatar_federation_join.py
@@ -60,7 +60,6 @@ def onboard(info: Dict[str, Any]) -> None:
 
 
 def main() -> None:  # pragma: no cover - CLI
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Join a SentientOS federation")
     ap.add_argument("--name", help="node name")
     ap.add_argument("--schema", help="node schema version")

--- a/federation_trust_protocol.py
+++ b/federation_trust_protocol.py
@@ -124,7 +124,6 @@ def list_nodes() -> Dict[str, Node]:
     return _load_nodes()
 
 def cli() -> None:
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Federation Trust Protocol")
     sub = ap.add_subparsers(dest="cmd")
 

--- a/neos_self_healing_agent.py
+++ b/neos_self_healing_agent.py
@@ -43,7 +43,6 @@ def history(limit: int = 20) -> List[Dict[str, str]]:
 
 
 def run_loop(interval: float = 60.0) -> None:
-    require_admin_banner()
     while True:
         # Placeholder: real implementation would scan world state for issues
         time.sleep(interval)

--- a/resonite_artifact_memory_federation_gateway.py
+++ b/resonite_artifact_memory_federation_gateway.py
@@ -30,13 +30,11 @@ def log_exchange(action: str, artifact: str, peer: str) -> dict:
 
 
 def export_artifact(path: str, peer: str) -> None:
-    require_admin_banner()
     entry = log_exchange("export", path, peer)
     print(json.dumps(entry, indent=2))
 
 
 def import_artifact(path: str, peer: str) -> None:
-    require_admin_banner()
     entry = log_exchange("import", path, peer)
     print(json.dumps(entry, indent=2))
 

--- a/resonite_autonomous_avatar_artifact_creator.py
+++ b/resonite_autonomous_avatar_artifact_creator.py
@@ -31,7 +31,6 @@ def log_creation(kind: str, name: str, user: str) -> dict:
 
 
 def create(kind: str, name: str, user: str) -> None:
-    require_admin_banner()
     entry = log_creation(kind, name, user)
     print(json.dumps(entry, indent=2))
 

--- a/resonite_avatar_artifact_live_federation_broadcaster.py
+++ b/resonite_avatar_artifact_live_federation_broadcaster.py
@@ -29,7 +29,6 @@ def log_broadcast(action: str, artifact: str, peer: str) -> None:
 
 
 def broadcast(artifact: str, peer: str) -> None:
-    require_admin_banner()
     log_broadcast("broadcast", artifact, peer)
     print(json.dumps({"artifact": artifact, "peer": peer}, indent=2))
 

--- a/resonite_ceremony_festival_storyteller.py
+++ b/resonite_ceremony_festival_storyteller.py
@@ -25,7 +25,6 @@ def log_story(title: str, content: str) -> dict:
 
 
 def narrate(title: str, content: str) -> None:
-    require_admin_banner()
     entry = log_story(title, content)
     print(json.dumps(entry, indent=2))
 

--- a/resonite_creative_council_engine.py
+++ b/resonite_creative_council_engine.py
@@ -30,13 +30,11 @@ def log_proposal(user: str, proposal: str, vote: str | None = None) -> dict:
 
 
 def submit_proposal(user: str, text: str) -> None:
-    require_admin_banner()
     entry = log_proposal(user, text)
     print(json.dumps(entry, indent=2))
 
 
 def vote(user: str, proposal: str, decision: str) -> None:
-    require_admin_banner()
     entry = log_proposal(user, proposal, decision)
     print(json.dumps(entry, indent=2))
 

--- a/resonite_law_federation_spiral_diff_engine.py
+++ b/resonite_law_federation_spiral_diff_engine.py
@@ -29,7 +29,6 @@ def log_diff(source: str, target: str, result: str) -> None:
 
 
 def diff(source: str, target: str) -> None:
-    require_admin_banner()
     # Placeholder comparison logic
     result = "match" if source == target else "drift"
     log_diff(source, target, result)

--- a/resonite_living_ritual_dashboard.py
+++ b/resonite_living_ritual_dashboard.py
@@ -28,7 +28,6 @@ def log_event(event: str, data: dict) -> None:
 
 
 def run_dashboard() -> None:
-    require_admin_banner()
     if st is None:
         print("Streamlit not installed.")
         return

--- a/resonite_presence_artifact_provenance_explorer.py
+++ b/resonite_presence_artifact_provenance_explorer.py
@@ -36,7 +36,6 @@ def log_query(user: str, artifact: str) -> None:
 
 
 def explore(user: str, artifact: str) -> None:
-    require_admin_banner()
     log_query(user, artifact)
     data = query(artifact)
     if data:

--- a/resonite_spiral_healing_engine.py
+++ b/resonite_spiral_healing_engine.py
@@ -30,13 +30,11 @@ def log_patch(artifact: str, action: str, user: str) -> dict:
 
 
 def heal(artifact: str, user: str) -> None:
-    require_admin_banner()
     entry = log_patch(artifact, "heal", user)
     print(json.dumps(entry, indent=2))
 
 
 def rollback(artifact: str, user: str) -> None:
-    require_admin_banner()
     entry = log_patch(artifact, "rollback", user)
     print(json.dumps(entry, indent=2))
 

--- a/resonite_spiral_onboarding_engine.py
+++ b/resonite_spiral_onboarding_engine.py
@@ -25,7 +25,6 @@ def log_step(user: str, step: str) -> dict:
 
 
 def run_spiral(user: str) -> None:
-    require_admin_banner()
     steps = [
         "declare_intent",
         "council_invocation",

--- a/schema_migrate.py
+++ b/schema_migrate.py
@@ -80,7 +80,6 @@ def migrate_file(path: Path) -> Dict[str, int]:
 
 
 def main() -> None:  # pragma: no cover - CLI
-    require_admin_banner()
     ap = argparse.ArgumentParser(description="Upgrade data files to latest schema")
     ap.add_argument("target", help="File or directory to migrate")
     args = ap.parse_args()

--- a/self_defense.py
+++ b/self_defense.py
@@ -75,7 +75,6 @@ def status(agent: str) -> AgentState:
 
 
 def cli() -> None:
-    require_admin_banner()
     print("Self defense actions logged to", LOG_FILE)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove extra require_admin_banner() calls from several privileged tools
- keep single call after the privilege banner in each script

## Testing
- `pre-commit run --files avatar_federation_join.py federation_trust_protocol.py neos_self_healing_agent.py resonite_artifact_memory_federation_gateway.py resonite_autonomous_avatar_artifact_creator.py resonite_avatar_artifact_live_federation_broadcaster.py resonite_ceremony_festival_storyteller.py resonite_creative_council_engine.py resonite_law_federation_spiral_diff_engine.py resonite_living_ritual_dashboard.py resonite_presence_artifact_provenance_explorer.py resonite_spiral_healing_engine.py resonite_spiral_onboarding_engine.py schema_migrate.py self_defense.py video_cli.py mood_wall.py reflection_dashboard.py` *(fails: ModuleNotFoundError: No module named 'sentientos')*

------
https://chatgpt.com/codex/tasks/task_b_684ace4d68a88320b731fe914b02a4b1