### PR TITLE
Update environment docs

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 Actions continue. Set ``LUMOS_AUTO_APPROVE=1`` to bypass the prompt when
 running unattended.
+See ``docs/ENVIRONMENT.md`` for configuration details.
 """
 
 import getpass

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,6 +1,7 @@
 # Environment Variables
 
 SentientOS tools read configuration from `.env`. Copy `.env.example` to `.env` and update the values as needed.
+Every variable shown below also appears in `.env.example` with the same default value.
 The table below explains each variable and its default behavior.
 
 ### Generating a Secure `CONNECTOR_TOKEN`

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -20,6 +20,8 @@ import emotion_memory as em
 # Optional upgrade: use simple embedding vectors instead of bag-of-words
 USE_EMBEDDINGS = os.getenv("USE_EMBEDDINGS", "0") == "1"
 
+# Root folder for persistent memory fragments. The ``MEMORY_DIR`` environment
+# variable is described in ``docs/ENVIRONMENT.md``.
 MEMORY_DIR = get_log_path("memory", "MEMORY_DIR")
 RAW_PATH = MEMORY_DIR / "raw"
 DAY_PATH = MEMORY_DIR / "distilled"

--- a/scripts/auto_approve.py
+++ b/scripts/auto_approve.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
+# Controlled by the ``LUMOS_AUTO_APPROVE`` setting documented in
+# ``docs/ENVIRONMENT.md``.
+
 require_admin_banner()
 require_lumos_approval()
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- mention `.env.example` in ENVIRONMENT docs
- clarify `LUMOS_AUTO_APPROVE` usage in `admin_utils.py` and `scripts/auto_approve.py`
- comment on `MEMORY_DIR` usage in `memory_manager.py`

## Testing
- `pre-commit run --files docs/ENVIRONMENT.md .env.example` *(fails: ModuleNotFoundError: No module named 'sentientos')*

------
https://chatgpt.com/codex/tasks/task_b_684ace4e599c83209874e2d55ebd52f6