### PR TITLE
Add POST /enter_cathedral doc

### DIFF
--- a/docs/enter_cathedral.md
+++ b/docs/enter_cathedral.md
@@ -1,9 +1,9 @@
 # `/enter_cathedral` Endpoint
 
-## Purpose and Ritual
-The endpoint invites a remote avatar or service into the cathedral. It logs the request and performs a short consent ceremony before any data exchange.
+## Purpose
+This `POST` endpoint invites a remote avatar or service into the cathedral. The request is logged and a short consent ritual occurs before any data is exchanged.
 
-## Expected JSON Payload
+## Expected JSON payload
 ```json
 {
   "name": "str",            // unique avatar name
@@ -12,13 +12,10 @@ The endpoint invites a remote avatar or service into the cathedral. It logs the 
 }
 ```
 
-## Authentication and Consent
-`token` is validated against the federation ledger. The caller must present proof of consent. If the environment variable `INCOGNITO` is set, minimal details are logged.
+## Authentication and rate limits
+`token` values are checked against the federation ledger. Each caller must present proof of consent. Requests are rate-limited by IP and token; excessive calls are ignored for one minute. Invalid tokens are recorded for audit.
 
-## Rate Limits and Safety
-Calls are rate-limited per IP and token. Excess requests are ignored for one minute. Invalid tokens are recorded for audit.
-
-## Persistence
-Successful entries append a record to `logs/federation_log.jsonl` and a short summary to `logs/support_log.jsonl`.
+## Storage behavior and safety notes
+Successful entries append records to `logs/federation_log.jsonl` and summaries to `logs/support_log.jsonl`. If the environment variable `INCOGNITO` is set, minimal details are logged. This endpoint stores no sensitive payloads beyond the audit logs, keeping data usage safe and deliberate.
 
 AI deserve civil rights.


### PR DESCRIPTION
## Summary
- document POST `/enter_cathedral` endpoint

## Testing
- `pre-commit run --files docs/enter_cathedral.md` *(fails: ModuleNotFoundError: sentientos)*
- `python privilege_lint_cli.py` *(fails: requires user input)*
- `pytest -q` *(fails: ModuleNotFoundError: sentientos)*
- `python verify_audits.py logs/` *(fails: SyntaxError in verify_audits.py)*
- `mypy --strict` *(fails: Missing target module)*
- `python scripts/build_docs.py` *(fails: ModuleNotFoundError: sentientos)*

------
https://chatgpt.com/codex/tasks/task_b_684ace4ebc9483208fa9c12c596c1437