### PR TITLE
Fix header imports and cleanup tests

### DIFF
--- a/audit_chain.py
+++ b/audit_chain.py
@@ -4,7 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 import argparse
 import datetime
 import hashlib

--- a/audit_immutability.py
+++ b/audit_immutability.py
@@ -4,7 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 from audit_chain import AuditEntry, append_entry, read_entries, verify, _hash_entry
 # Backwards compatibility wrapper around the new audit_chain module.
 

--- a/fix_audit_schema.py
+++ b/fix_audit_schema.py
@@ -4,14 +4,13 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 import json
 import datetime
 from logging_config import get_log_dir
 from pathlib import Path
 from typing import Callable, Dict, List
 
-Scan audit logs for schema drift and heal missing fields."""
+"""Scan audit logs for schema drift and heal missing fields."""
 
 SCHEMA_VERSION = "1.0"
 

--- a/tests/test_admin_utils.py
+++ b/tests/test_admin_utils.py
@@ -4,8 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-
 
 import sys
 import os
@@ -20,11 +18,13 @@ def test_is_admin_true():
     assert admin_utils.is_admin()
 
 
+def test_require_admin_banner(capsys, monkeypatch):
     logs = []
     monkeypatch.setattr(admin_utils, "is_admin", lambda: True)
     monkeypatch.setattr(admin_utils, "getpass", type("gp", (), {"getuser": lambda: "tester"}))
     monkeypatch.setattr(admin_utils.platform, "system", lambda: "Linux")
     monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append({"user": u, "platform": p, "tool": t, "status": s}))
+    admin_utils.require_admin_banner()
     out = capsys.readouterr().out
     assert "Sanctuary Privilege Status: [🛡️ Privileged]" in out
     assert logs and logs[0] == {"user": "tester", "platform": "Linux", "tool": "pytest", "status": "success"}
@@ -42,6 +42,7 @@ def test_require_admin_failure(monkeypatch):
 
 
 def test_require_admin_wrapper(monkeypatch):
+    monkeypatch.setattr(admin_utils, "require_admin_banner", lambda: (_ for _ in ()).throw(SystemExit))
     with pytest.raises(SystemExit), pytest.warns(DeprecationWarning):
         admin_utils.require_admin()
 
@@ -64,7 +65,9 @@ def test_privilege_logging(monkeypatch, platform_name, is_admin, expected):
     monkeypatch.setattr(admin_utils, "getpass", type("gp", (), {"getuser": lambda: "tester"}))
     monkeypatch.setattr(admin_utils.pl, "log_privilege", lambda u, p, t, s: logs.append({"user": u, "platform": p, "tool": t, "status": s}))
     if is_admin:
+        admin_utils.require_admin_banner()
     else:
         with pytest.raises(SystemExit):
+            admin_utils.require_admin_banner()
     assert logs and logs[0]["status"] == expected
     assert logs[0]["platform"] == platform_name

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -4,9 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-"""
-"""
-from __future__ import annotations
 import json
 import os
 from pathlib import Path


### PR DESCRIPTION
## Summary
- correct misplaced `from __future__` imports in several files
- repair the audit schema fixer docstring
- update admin utils test for valid syntax

## Testing
- `pre-commit run --all-files` *(fails: ModuleNotFoundError and mypy errors)*
- `pytest -m "not network" -q` *(fails: 73 errors during collection)*
- `mypy sentientos`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --no-input`

------
https://chatgpt.com/codex/tasks/task_b_684ace508034832088ce18242a45b295