### PR TITLE
Fix tomli fallback comment

### DIFF
--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -19,7 +19,7 @@ from pathlib import Path
 try:
     import tomllib
 except Exception:  # Python <3.11
-    import tomli as tomllib  # type: ignore
+    import tomli as tomllib  # type: ignore[import-not-found]  # fallback for Python <3.11
 
 
 PYPROJECT = Path("pyproject.toml")


### PR DESCRIPTION
## Summary
- update the fallback import comment in `scripts/release_manager.py`

## Testing
- `pre-commit run --files scripts/release_manager.py` *(fails: ModuleNotFoundError: No module named 'sentientos', mypy no-redef)*

------
https://chatgpt.com/codex/tasks/task_b_684ad492f9348320884d6a7a9259a3ee