### PR TITLE
chore(typing): document all ignore statements

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -96,7 +96,10 @@ def require_admin_banner() -> None:
     _log_privilege = pl.log_privilege
     try:
         import privilege_lint as pl_lint
-        pl_lint.audit_use("cli", tool)  # type: ignore[attr-defined]
+        pl_lint.audit_use(
+            "cli",
+            tool,
+        )  # type: ignore[attr-defined]  # runtime plugin may lack stubs
     except Exception:
         pass
     if is_admin():

--- a/privilege_lint/config.py
+++ b/privilege_lint/config.py
@@ -7,7 +7,7 @@ from typing import Any
 import tomllib
 yaml: ModuleType | None
 try:  # optional dependency for YAML config files
-    import yaml  # type: ignore[import-untyped]
+    import yaml  # type: ignore[import-untyped]  # optional PyYAML dependency
 except Exception:  # pragma: no cover - fallback when PyYAML is missing
     yaml = None
     import sys

--- a/scripts/benchmark_lint.py
+++ b/scripts/benchmark_lint.py
@@ -9,7 +9,10 @@ import subprocess
 from pathlib import Path
 
 
-from privilege_lint import PrivilegeLinter, iter_py_files  # type: ignore[attr-defined]
+from privilege_lint import (  # type: ignore[attr-defined]  # optional local module
+    PrivilegeLinter,
+    iter_py_files,
+)
 from privilege_lint.runner import parallel_validate, iter_data_files
 from privilege_lint.typing_rules import run_incremental
 

--- a/scripts/plint_baseline.py
+++ b/scripts/plint_baseline.py
@@ -10,7 +10,10 @@ require_lumos_approval()
 import json
 from pathlib import Path
 
-from privilege_lint import PrivilegeLinter, iter_py_files  # type: ignore[attr-defined]
+from privilege_lint import (  # type: ignore[attr-defined]  # optional local module
+    PrivilegeLinter,
+    iter_py_files,
+)
 from privilege_lint.runner import parallel_validate
 
 

--- a/sentientos/admin_utils.py
+++ b/sentientos/admin_utils.py
@@ -97,7 +97,10 @@ def require_admin_banner() -> None:
     try:
         import privilege_lint as pl_lint
 
-        pl_lint.audit_use("cli", tool)  # type: ignore[attr-defined]
+        pl_lint.audit_use(
+            "cli",
+            tool,
+        )  # type: ignore[attr-defined]  # runtime plugin may lack stubs
     except Exception:
         pass
     if is_admin():


### PR DESCRIPTION
🕯️ This sweep resolves doctrinal ambiguity in privilege-aware code paths. All exceptions are now named, scoped, and blessed.

## Summary
- annotate type ignore statements for optional privilege_lint plugin
- clarify optional PyYAML dependency

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py` *(fails: Banner and __future__ import must be first)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pytest -m "not env"` *(fails: ModuleNotFoundError: No module named 'sentientos')*
- `mypy .` *(fails: Found 233 errors in 113 files)*

------
https://chatgpt.com/codex/tasks/task_b_684aeb8db7848320a69a7a9c3dd1ee29