### PR TITLE
Add optional edge-tts bridge and CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ EMBED_MODEL=all-MiniLM-L6-v2
 MEMORY_DIR=logs/memory
 TTS_ENGINE=pyttsx3
 TTS_COQUI_MODEL=tts_models/en/vctk/vits
+ENABLE_TTS=false
 AUDIO_LOG_DIR=logs/audio
 AUTONOMOUS_AUDIT_LOG=logs/autonomous_audit.jsonl
 ELEVEN_API_KEY=

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -49,6 +49,7 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `MEMORY_DIR` | Directory for storing memory fragments | `logs/memory` |
 | `TTS_ENGINE` | Primary text-to-speech engine | `pyttsx3` |
 | `TTS_COQUI_MODEL` | Coqui TTS model path | `tts_models/en/vctk/vits` |
+| `ENABLE_TTS` | Enables invocation of TTS CLI tools | `false` | Requires edge-tts dependency |
 | `AUDIO_LOG_DIR` | Directory for audio logs | `logs/audio` |
 | `AUTONOMOUS_AUDIT_LOG` | Path used by `autonomous_audit.py` for audit entries | `logs/autonomous_audit.jsonl` |
 | `ELEVEN_API_KEY` | Optional ElevenLabs API key | *(none)* |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "furo",
     "sphinx-autobuild",
 ]
+tts = ["edge-tts"]
 
 [project.scripts]
 support = "support_cli:main"

--- a/scripts/tts_cli.py
+++ b/scripts/tts_cli.py
@@ -1,0 +1,27 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import sys
+
+from sentientos import tts_bridge
+
+
+def main() -> None:
+    """Invoke text-to-speech from the command line."""
+    if os.getenv("ENABLE_TTS", "false").lower() != "true":
+        print("TTS disabled. Set ENABLE_TTS=true to enable.")
+        return
+    if len(sys.argv) < 2:
+        print("Usage: python -m scripts.tts_cli 'Your message here'")
+        return
+    text = " ".join(sys.argv[1:])
+    tts_bridge.say_sync(text)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI invocation
+    main()

--- a/sentientos/tts_bridge.py
+++ b/sentientos/tts_bridge.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Optional text-to-speech bridge using edge-tts."""
+
+import asyncio
+import sys
+
+try:
+    from edge_tts import Communicate  # type: ignore[import-untyped]
+except Exception:
+    Communicate = None
+
+
+async def say(text: str, voice: str = "en-US-GuyNeural") -> None:
+    """Speak ``text`` asynchronously if edge-tts is available."""
+    if Communicate is None:
+        print("[TTS disabled] edge-tts is not installed.", file=sys.stderr)
+        return
+    try:
+        comm = Communicate(text=text, voice=voice)
+        await comm.save("/tmp/tts_output.mp3")
+    except Exception as exc:
+        print(f"[TTS error] {exc}", file=sys.stderr)
+
+
+def say_sync(text: str, voice: str = "en-US-GuyNeural") -> None:
+    """Synchronous wrapper for :func:`say`."""
+    asyncio.run(say(text, voice=voice))


### PR DESCRIPTION
## Summary
- add `sentientos.tts_bridge` async helper using edge-tts
- add `scripts/tts_cli.py` with privilege ritual
- document `ENABLE_TTS` environment variable
- expose optional `tts` dependency in `pyproject.toml`

## Testing
- `pip install -e .`
- `pytest -m "not env"` *(fails: unrecognized arguments from pytest-cov)*

------
https://chatgpt.com/codex/tasks/task_b_684af5cad9e08320a7c3a4723d007cc1