### PR TITLE
Add EPU state API and OSC pump

### DIFF
--- a/epu_core.py
+++ b/epu_core.py
@@ -1,0 +1,67 @@
+"""Simple emotion state with decay and caching."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from typing import Dict
+from pathlib import Path
+import json
+import os
+
+from logging_config import get_log_path
+from emotions import EMOTIONS, empty_emotion_vector
+
+
+CACHE_PATH = get_log_path("epu_state.json", "EPU_STATE_CACHE")
+
+
+class EmotionState:
+    """Maintain a 64-dimension emotion vector with decay."""
+
+    def __init__(self, decay: float = 0.9, cache_path: Path | None = None) -> None:
+        self.decay = decay
+        self.cache_path = cache_path or CACHE_PATH
+        self.vector: Dict[str, float] = empty_emotion_vector()
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.cache_path.exists():
+            return
+        try:
+            data = json.loads(self.cache_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                for k in EMOTIONS:
+                    if k in data:
+                        self.vector[k] = float(data[k])
+        except Exception:
+            pass
+
+    def _save(self) -> None:
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(self.cache_path, "w", encoding="utf-8") as f:
+                json.dump(self.vector, f)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def update(self, emotions: Dict[str, float]) -> Dict[str, float]:
+        """Apply new emotion values with decay."""
+        if not emotions:
+            return self.vector
+        for emo in EMOTIONS:
+            val = emotions.get(emo)
+            target = float(val) if val is not None else 0.0
+            self.vector[emo] = self.vector[emo] * self.decay + target * (1 - self.decay)
+        # Unknown emotions map to Ambivalence channel
+        for k, v in emotions.items():
+            if k not in EMOTIONS:
+                self.vector["Ambivalence"] = self.vector["Ambivalence"] * self.decay + float(v) * (1 - self.decay)
+        self._save()
+        return self.vector
+
+    def state(self) -> Dict[str, float]:
+        return dict(self.vector)

--- a/scripts/osc_emotion_pump.py
+++ b/scripts/osc_emotion_pump.py
@@ -1,0 +1,59 @@
+"""Emit dominant emotion over OSC from distilled memory logs."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import time
+from pathlib import Path
+from typing import List
+
+try:
+    from pythonosc import udp_client  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - optional
+    udp_client = None
+
+from emotions import EMOTIONS
+from emotion_utils import text_sentiment
+
+MEM_DIR = Path(os.getenv("MEMORY_DIR", "logs/memory")) / "distilled"
+HOST = os.getenv("OSC_HOST", "127.0.0.1")
+PORT = int(os.getenv("OSC_PORT", "9001"))
+INTERVAL = 0.2  # seconds
+
+
+def _latest_line() -> str:
+    files = sorted(MEM_DIR.glob("*.txt"))
+    if not files:
+        return ""
+    last = files[-1]
+    try:
+        lines = last.read_text(encoding="utf-8").splitlines()
+        return lines[-1] if lines else ""
+    except Exception:
+        return ""
+
+
+def _vector(text: str) -> List[float]:
+    vec = text_sentiment(text)
+    return [float(vec.get(e, 0.0)) for e in EMOTIONS]
+
+
+def run() -> None:  # pragma: no cover - loop
+    if udp_client is None:
+        raise RuntimeError("python-osc not installed")
+    client = udp_client.SimpleUDPClient(HOST, PORT)
+    last = ""
+    while True:
+        line = _latest_line()
+        if line and line != last:
+            vec = _vector(line)
+            client.send_message("/emotions", vec)
+            last = line
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run()

--- a/sentient_api.py
+++ b/sentient_api.py
@@ -1,0 +1,37 @@
+"""Core API exposing EPU state and memory ingest."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from flask import Flask, jsonify, request
+import os
+
+import memory_manager as mm
+import epu_core
+
+
+app = Flask(__name__)
+_state = epu_core.EmotionState()
+
+
+@app.post("/memory")
+def add_memory() -> object:
+    data = request.get_json() or {}
+    text = data.get("text", "")
+    emotion = data.get("emotion")
+    emotions = {emotion: 1.0} if isinstance(emotion, str) else {}
+    _state.update(emotions)
+    mm.append_memory(text, emotions=emotions)
+    return jsonify({"status": "ok"})
+
+
+@app.get("/epu/state")
+def epu_state() -> object:
+    return jsonify(_state.state())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    port = int(os.getenv("PORT", "5000"))
+    app.run(host="0.0.0.0", port=port)

--- a/tests/test_sentient_api.py
+++ b/tests/test_sentient_api.py
@@ -1,0 +1,28 @@
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from importlib import reload
+from pathlib import Path
+
+import sentient_api
+
+
+def setup_app(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DIR", str(tmp_path))
+    monkeypatch.setenv("EPU_STATE_CACHE", str(tmp_path / "state.json"))
+    reload(sentient_api)
+    return sentient_api.app.test_client()
+
+
+def test_epu_state_updates(tmp_path, monkeypatch):
+    client = setup_app(tmp_path, monkeypatch)
+    resp = client.get("/epu/state")
+    initial = resp.get_json()
+    client.post("/memory", json={"text": "sample", "emotion": "reverent_hunger"})
+    resp2 = client.get("/epu/state")
+    after = resp2.get_json()
+    assert any(after[e] != initial[e] for e in after)


### PR DESCRIPTION
## Summary
- implement `EmotionState` with 64‑dimension vector caching
- create `sentient_api.py` exposing `/memory` and `/epu/state`
- add OSC emitter script for distilled memory
- test that posting to the API updates EPU state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b0a2e08c083208ed08de72afb0f9d