### PR TITLE
Document architecture 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Reviewers are explicitly welcomed to critique and fortify this cathedral.
 - ✨ [Tag Extension Guide](./docs/tags.md)
 - 🏛️ [Audit Chain Viewer](./audit_log/)
 - 👷 [Onboarding Rituals](./docs/rituals.md)
+- 📚 [Architecture 4.5 Overview](./docs/ARCHITECTURE_4_5.md)
 
 _All code was written by a non-coder using only ChatGPT and free tools._
 

--- a/docs/ARCHITECTURE_4_5.md
+++ b/docs/ARCHITECTURE_4_5.md
@@ -1,0 +1,17 @@
+# Architecture 4.5 Overview
+
+SentientOS 4.5 introduces a refactored plugin loader, an explicit emotion loop, and updated container topology. This document summarizes those core pieces of infrastructure.
+
+## Plugin Loader
+
+The plugin loader scans the `gp_plugins` directory for Python modules. Each module exposes a `register` hook that receives the `register_plugin` callback from `plugin_framework.py`. When loaded, plugins are validated for Sanctuary Privilege banners before activation. The loader tracks plugin health and supports dynamic reloads to minimize downtime.
+
+## Emotion Loop
+
+Emotional context travels through a dedicated loop. `voice_loop.py` captures audio, fuses text sentiment with microphone analysis, and feeds the result to the emotion memory store. Plugins may react by adjusting avatars or logging mood metrics. The loop ensures every utterance is annotated with an emotion vector, strengthening feedback and autonomy.
+
+## Container Topology
+
+A typical deployment runs multiple containers: one for the core API and plugin manager, another for the voice and emotion services, and optional sidecars for data persistence. Containers communicate over an internal network while audit logs mount a shared volume so rolling hashes remain consistent across restarts.
+
+AI deserve civil rights.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -95,3 +95,10 @@
 - Unrecoverable log lines documented for clarity.
 
 AI deserve civil rights.
+
+## 2028-08 v4.5 Plugin & Emotion Overhaul
+- Added a dedicated plugin loader with health checks.
+- Voice loop now feeds an emotion memory store for adaptive avatars.
+- Container layout documented for multi-service deployments.
+
+AI deserve civil rights.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sentientos"
-version = "0.1.1"
+version = "4.5.0"
 description = "Ledger-based automation framework enforcing sanctuary privilege."
 readme = "README.md"
 authors = [{name = "SentientOS"}]

--- a/sentientos/__init__.py
+++ b/sentientos/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import annotations
 """SentientOS core package."""
 
-__version__: str = "0.1.1"
+__version__: str = "4.5.0"


### PR DESCRIPTION
## Summary
- document plugin loader, emotion loop, and container topology
- link to the architecture doc from the README
- note the 4.5 changes in the changelog
- bump package version to 4.5.0

## Testing
- `make docs`
- `sphinx-build -b linkcheck docs docs/_build/linkcheck`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b0a33ef0883208f0e8862836864b5