### PR TITLE
Add health checks and wait script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,24 +5,100 @@ services:
     command: ["python", "-m", "http.server", "5000"]
     ports:
       - "5000:5000"
+    volumes:
+      - ./scripts:/scripts:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;\n\
+import time;\n\
+url='http://localhost:5000';\n\
+\n\
+try:\n\
+    urllib.request.urlopen(url)\n\
+    sys.exit(0)\n\
+except Exception:\n\
+    sys.exit(1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   bridge1:
     image: python:3.11-slim
-    command: ["python", "-m", "http.server", "9977"]
+    entrypoint: ["sh", "-c", "python /scripts/wait_for_health.py http://relay:5000 && python -m http.server 9977"]
     ports:
       - "9977:9977"
+    volumes:
+      - ./scripts:/scripts:ro
+    depends_on:
+      relay:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;\n\
+import time;\n\
+url='http://localhost:9977';\n\
+try:\n\
+    urllib.request.urlopen(url)\n\
+    sys.exit(0)\n\
+except Exception:\n\
+    sys.exit(1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   bridge2:
     image: python:3.11-slim
-    command: ["python", "-m", "http.server", "9988"]
+    entrypoint: ["sh", "-c", "python /scripts/wait_for_health.py http://relay:5000 && python -m http.server 9988"]
     ports:
       - "9988:9988"
+    volumes:
+      - ./scripts:/scripts:ro
+    depends_on:
+      relay:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;\n\
+import time;\n\
+url='http://localhost:9988';\n\
+try:\n\
+    urllib.request.urlopen(url)\n\
+    sys.exit(0)\n\
+except Exception:\n\
+    sys.exit(1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   bridge3:
     image: python:3.11-slim
-    command: ["python", "-m", "http.server", "9966"]
+    entrypoint: ["sh", "-c", "python /scripts/wait_for_health.py http://relay:5000 && python -m http.server 9966"]
     ports:
       - "9966:9966"
+    volumes:
+      - ./scripts:/scripts:ro
+    depends_on:
+      relay:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;\n\
+import time;\n\
+url='http://localhost:9966';\n\
+try:\n\
+    urllib.request.urlopen(url)\n\
+    sys.exit(0)\n\
+except Exception:\n\
+    sys.exit(1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   ngrok:
     image: ngrok/ngrok:alpine
     command: ["version"]
     ports:
       - "4040:4040"
       - "4041:4041"
+    volumes:
+      - ./scripts:/scripts:ro
+    healthcheck:
+      test: ["CMD", "ngrok", "version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/scripts/wait_for_health.py
+++ b/scripts/wait_for_health.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import sys
+import time
+from typing import Optional
+
+import requests
+
+
+def wait_for(url: str, timeout: float = 60.0, interval: float = 2.0) -> None:
+    """Poll ``url`` until an HTTP 200 is received or ``timeout`` seconds pass."""
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            response = requests.get(url, timeout=interval)
+            if response.ok:
+                return
+        except Exception:
+            pass
+        time.sleep(interval)
+    raise RuntimeError(f"service at {url} not healthy after {timeout} seconds")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("usage: wait_for_health.py <url> [timeout]", file=sys.stderr)
+        sys.exit(2)
+    url = argv[0]
+    timeout = float(argv[1]) if len(argv) > 1 else float(os.getenv("WAIT_TIMEOUT", "60"))
+    wait_for(url, timeout=timeout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        main()
+    except Exception as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add container health checks and bridging dependencies
- wait for services to be healthy before starting bridges

### Checklist
- [ ] `python privilege_lint_cli.py` passes
- [ ] `pytest` passes
- [x] `require_admin_banner()` and `require_lumos_approval()` present in new scripts
- [ ] Docs updated
- [ ] Reviewer sign-off recorded

------
https://chatgpt.com/codex/tasks/task_b_684b0f6b9c5c83209be130319257f79a