### PR TITLE
Add tag and push script

### DIFF
--- a/scripts/tag_and_push.sh
+++ b/scripts/tag_and_push.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git fetch origin
+git push origin main
+git tag -a "$TAG" -m "$MSG"
+git push origin "$TAG"


### PR DESCRIPTION
## Summary
- add a simple tag-and-push helper script

## Testing
- `python privilege_lint_cli.py` *(fails: Banner and __future__ import must be first)*
- `python verify_audits.py logs/` *(fails: chain break, missing data field)*
- `pytest -m "not env"`
- `mypy sentientos` *(fails: 5 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684b0f6ceec48320adf09ab5666131f1