### PR TITLE
Add pre-commit installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           path: .mypy_cache
           key: ${{ runner.os }}-mypy-${{ hashFiles('**/pyproject.toml', 'mypy.ini') }}
 
-      - run: pip install pre-commit && pip install -e .[dev]
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - run: pip install -e .[dev]
 
       - name: Pre-commit
         run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- ensure pre-commit is installed as a dedicated step in CI
- keep pre-commit checks before the test suite

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest tests/test_placeholder.py`


------
https://chatgpt.com/codex/tasks/task_b_684b17d190ac8320b3b1383f03901f93