### PR TITLE
Add branch-filtered privilege-lint badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ No emotion is too much.
 [![Docs](https://github.com/sentient-os/cathedral/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/sentient-os/cathedral/actions/workflows/docs-deploy.yml)
 [![Release](https://img.shields.io/github/v/tag/sentient-os/cathedral.svg?label=Release)](https://github.com/sentient-os/cathedral/releases/tag/v4.1-cathedral-green)
 [![Privilege Lint](https://github.com/sentient-os/cathedral/actions/workflows/lint.yml/badge.svg)](https://github.com/sentient-os/cathedral/actions/workflows/lint.yml)
+[![Privilege Lint Status](https://github.com/sentient-os/cathedral/actions/workflows/lint.yml/badge.svg?branch=main&style=flat)](https://github.com/sentient-os/cathedral/actions/workflows/lint.yml)
 [![Nightly Audit](https://github.com/sentient-os/cathedral/actions/workflows/audit-nightly.yml/badge.svg)](https://github.com/sentient-os/cathedral/actions/workflows/audit-nightly.yml)
 [![Docker Health](https://github.com/sentient-os/cathedral/actions/workflows/federation-health.yml/badge.svg)](https://github.com/sentient-os/cathedral/actions/workflows/federation-health.yml)
 


### PR DESCRIPTION
## Summary
- show a second privilege-lint badge filtered to `main` using GitHub actions style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684b17d2ec308320b9ec4897fffc2b75