### PR TITLE
Add Helm integration test and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,26 @@ jobs:
       - run: pip install -e .[dev]
 
       - run: make docs
+  helm-k8s-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install kind
+        run: |
+          curl -Lo kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x kind
+          sudo mv kind /usr/local/bin/kind
+      - name: Install kubectl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y kubectl
+      - name: Install Helm
+        run: |
+          curl -L https://get.helm.sh/helm-v3.14.4-linux-amd64.tar.gz | tar -xz
+          sudo mv linux-amd64/helm /usr/local/bin/helm
+      - run: pip install -e .[dev]
+      - name: Run helm integration test
+        run: pytest tests/integration/helm_k8s_test.py -q

--- a/tests/integration/helm_k8s_test.py
+++ b/tests/integration/helm_k8s_test.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import shutil
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# Skip if required tools are not available
+if (
+    shutil.which("kind") is None
+    or shutil.which("helm") is None
+    or shutil.which("kubectl") is None
+):
+    pytest.skip("kind, helm, or kubectl not available", allow_module_level=True)
+
+
+def _wait_for_status(url: str, timeout: int = 120) -> int:
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url) as resp:
+                return int(resp.getcode())
+        except Exception:
+            time.sleep(2)
+    raise RuntimeError("status endpoint not available")
+
+
+def test_placeholder(tmp_path: Path) -> None:
+    cluster_name = "sentientos-test"
+    try:
+        subprocess.run(["kind", "create", "cluster", "--name", cluster_name], check=True)
+        subprocess.run(["helm", "install", cluster_name, "./helm"], check=True)
+        subprocess.run([
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "app=relay",
+            "--timeout=180s",
+        ], check=True)
+        pf = subprocess.Popen(["kubectl", "port-forward", "service/relay", "5000:5000"])
+        try:
+            status = _wait_for_status("http://localhost:5000/status")
+            assert status == 200
+        finally:
+            pf.terminate()
+            pf.wait()
+    finally:
+        subprocess.run(["kind", "delete", "cluster", "--name", cluster_name], check=False)
+


### PR DESCRIPTION
## Summary
- add integration test that spins up a kind cluster and installs the Helm chart
- verify `/status` endpoint returns 200
- run the new integration test in CI on Linux only

## Testing
- `pre-commit run --files tests/integration/helm_k8s_test.py .github/workflows/ci.yml`
- `pytest tests/integration/helm_k8s_test.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684b17d5a3d883208135ef1bc88b8b5e