### PR TITLE
Enable docs search with awesome theme

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -28,6 +28,8 @@ Build docs locally:
 pip install -e .[dev]
 make docs
 ```
+The Sphinx Awesome theme includes a search box. Open `docs/_build/html/index.html`
+in your browser and try it out.
 
 Tests must keep 80 % coverage.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,10 @@ extensions = [
     'myst_parser',
 ]
 
-html_theme = 'furo'
+html_theme = 'sphinxawesome_theme'
+
+# Enable basic search with the Sphinx Awesome theme
+extensions.append('sphinxawesome_theme.highlighting')
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Welcome to the SentientOS documentation. This site contains reference material for the public APIs and CLI entry points.
 
+Use the search box in the upper left to quickly find topics.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "sphinx==7.*",
     "sphinx-autodoc-typehints",
     "myst-parser",
-    "furo",
+    "sphinxawesome-theme",
     "sphinx-autobuild",
 ]
 tts = ["edge-tts"]


### PR DESCRIPTION
## Summary
- switch Sphinx theme to `sphinxawesome_theme`
- note new search box in docs
- mention search when building docs locally
- add theme to dev dependencies

## Testing
- `pytest -q`
- `mypy sentientos` *(fails: Incompatible types in assignment)*
- `make docs`

------
https://chatgpt.com/codex/tasks/task_b_684b17d82de48320a59ac6450cc3e03a