### PR TITLE
Add architecture 4.5 diagram

### DIFF
--- a/docs/ARCHITECTURE_4_5.md
+++ b/docs/ARCHITECTURE_4_5.md
@@ -2,6 +2,8 @@
 
 SentientOS 4.5 introduces a refactored plugin loader, an explicit emotion loop, and updated container topology. This document summarizes those core pieces of infrastructure.
 
+<img src="ARCHITECTURE_4_5.svg" alt="Architecture 4.5 diagram" />
+
 ## Plugin Loader
 
 The plugin loader scans the `gp_plugins` directory for Python modules. Each module exposes a `register` hook that receives the `register_plugin` callback from `plugin_framework.py`. When loaded, plugins are validated for Sanctuary Privilege banners before activation. The loader tracks plugin health and supports dynamic reloads to minimize downtime.

--- a/docs/ARCHITECTURE_4_5.svg
+++ b/docs/ARCHITECTURE_4_5.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 150">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="black" />
+    </marker>
+  </defs>
+  <rect x="10" y="20" width="120" height="60" fill="#b3d9ff" stroke="black" />
+  <text x="20" y="55" font-size="14" font-family="sans-serif">Plugin Loader</text>
+  <rect x="150" y="20" width="120" height="60" fill="#ffd9b3" stroke="black" />
+  <text x="160" y="55" font-size="14" font-family="sans-serif">Emotion Loop</text>
+  <rect x="290" y="20" width="100" height="60" fill="#d9ffb3" stroke="black" />
+  <text x="300" y="55" font-size="14" font-family="sans-serif">Containers</text>
+  <line x1="130" y1="50" x2="150" y2="50" stroke="black" marker-end="url(#arrow)" />
+  <line x1="270" y1="50" x2="290" y2="50" stroke="black" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- include Architecture 4.5 SVG diagram
- reference the diagram from docs/ARCHITECTURE_4_5.md

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --no-input`
- `pytest -m "not env"`


------
https://chatgpt.com/codex/tasks/task_b_684b17db5ff0832080d154f0ffa46c52