### PR TITLE
Improve GitHub tagging script

### DIFF
--- a/scripts/tag_and_push.sh
+++ b/scripts/tag_and_push.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+remote_url=$(git remote get-url origin 2>/dev/null || true)
+if [[ -z "$remote_url" || ! "$remote_url" =~ ^git@github.com:.+/.+\.git$ ]]; then
+  echo "Remote 'origin' missing or not a GitHub SSH URL." >&2
+  echo "Run: git remote add origin git@github.com:<user>/<repo>.git" >&2
+  exit 1
+fi
+
 git fetch origin
 git push origin main
 git tag -a "$TAG" -m "$MSG"
 git push origin "$TAG"
+
+repo_path=${remote_url#git@github.com:}
+repo_path=${repo_path%.git}
+echo "https://github.com/$repo_path/releases/tag/$TAG"


### PR DESCRIPTION
## Summary
- check for an `origin` remote pointing at GitHub before tagging
- show a helpful message when `origin` is missing
- print the tag URL after pushing

## Testing
- `pytest -q`
- `python privilege_lint_cli.py` *(fails: `Lumos blessing required`)*

------
https://chatgpt.com/codex/tasks/task_b_684b2128cb2c832094267bdcdf543d62