### PR TITLE
Add service health check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
       docker:
         image: docker:dind
         options: --privileged
+        ports:
+          - 2375:2375
+    env:
+      DOCKER_HOST: tcp://localhost:2375
+      DOCKER_TLS_CERTDIR: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -55,6 +60,9 @@ jobs:
 
       - name: Start Docker services
         run: docker compose --project-name sentientos-ci up --build -d
+
+      - name: Wait for service health
+        run: python scripts/wait_for_health.py --url http://localhost:5000/status --max-wait 60
 
       - name: Mypy strict check
         run: mypy --strict sentientos > MYPY_STATUS.md

--- a/privilege_lint/config.py
+++ b/privilege_lint/config.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 import tomllib
+yaml: Any
 try:  # optional dependency for YAML config files
-    import yaml  # type: ignore[import-untyped]  # justified: optional PyYAML dependency
+    import yaml
 except Exception:  # pragma: no cover - fallback when PyYAML is missing
     yaml = None
     import sys

--- a/scripts/wait_for_health.py
+++ b/scripts/wait_for_health.py
@@ -4,6 +4,7 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 
+import argparse
 import os
 import sys
 import time
@@ -26,14 +27,21 @@ def wait_for(url: str, timeout: float = 60.0, interval: float = 2.0) -> None:
     raise RuntimeError(f"service at {url} not healthy after {timeout} seconds")
 
 
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Wait for a service health endpoint")
+    parser.add_argument("--url", required=True, help="URL of the status endpoint")
+    parser.add_argument(
+        "--max-wait",
+        type=float,
+        default=float(os.getenv("WAIT_TIMEOUT", "60")),
+        help="Maximum time in seconds to wait for service health",
+    )
+    return parser.parse_args(argv)
+
+
 def main(argv: Optional[list[str]] = None) -> None:
-    argv = argv or sys.argv[1:]
-    if not argv:
-        print("usage: wait_for_health.py <url> [timeout]", file=sys.stderr)
-        sys.exit(2)
-    url = argv[0]
-    timeout = float(argv[1]) if len(argv) > 1 else float(os.getenv("WAIT_TIMEOUT", "60"))
-    wait_for(url, timeout=timeout)
+    args = parse_args(argv or sys.argv[1:])
+    wait_for(args.url, timeout=args.max_wait)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- update wait_for_health script with CLI options
- ensure docker-in-docker is accessible in CI
- run a health check after docker services start
- fix mypy complaint in privilege_lint config

## Testing
- `pre-commit run --files scripts/wait_for_health.py .github/workflows/ci.yml privilege_lint/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b212923ac832082f4242dd127d1f5