### PR TITLE
Update release workflow for draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,14 @@ jobs:
         with:
           name: docker_digests
           path: docker_digests.txt
+      - name: Create Draft GitHub Release
+        if: github.event_name == 'pull_request'
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          body_path: release_notes.txt
+          files: |
+            dist/*.whl
       - name: Create GitHub Release
         if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- generate SBOM and Docker digest during publishing
- create draft GitHub releases on pull requests
- publish sbom.json and docker_digests.txt on real releases

## Testing
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py --quiet`

------
https://chatgpt.com/codex/tasks/task_b_684b212a1b288320b6a5d51b58d5322b