### PR TITLE
Fix privilege banner order

### DIFF
--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 
 def latest_changelog(path: Path) -> str:
@@ -23,7 +24,7 @@ def latest_changelog(path: Path) -> str:
     return text.strip()
 
 
-def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+def run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[Any]:
     print(" ".join(cmd))
     return subprocess.run(cmd, check=True, **kwargs)
 

--- a/scripts/templates/cli_skeleton.py
+++ b/scripts/templates/cli_skeleton.py
@@ -1,5 +1,5 @@
-from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()


### PR DESCRIPTION
## Summary
- update privilege banner location in `cli_skeleton.py`
- annotate `publish_release.run` return type for mypy
- run fix_banner_order on entrypoints

## Testing
- `pre-commit run --files scripts/templates/cli_skeleton.py scripts/publish_release.py` *(fails: privilege-lint)*

------
https://chatgpt.com/codex/tasks/task_b_684b2881cd1c83208ba9efd6a5f3622f