### PR TITLE
Fix future import location

### DIFF
--- a/installer/setup_installer.py
+++ b/installer/setup_installer.py
@@ -1,10 +1,9 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 
 
 


### PR DESCRIPTION
## Summary
- move `from __future__ import annotations` to top of `setup_installer.py`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68491a1282248320bc314739f4c1281c