### PR TITLE
Add cathedral launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,18 @@ For a comprehensive pre-submit routine, run:
 
 See `LEGACY_TESTS.md` for failing suites that need volunteers.
 
+## Cathedral Launcher
+Run `cathedral_launcher.py` to start the local relay and dashboard. The launcher
+checks your Python version, creates `.env` and `logs/` if missing, installs
+dependencies, verifies Ollama, and pulls the Mixtral model when possible.
+
+```bash
+python cathedral_launcher.py
+```
+
+If your hardware cannot host Mixtral, the launcher sets `MIXTRAL_CLOUD_ONLY=1`
+in `.env` and uses cloud inference.
+
 ## Quick start (Docker/Helm)
 Run the local relay and bridges with Docker Compose:
 

--- a/cathedral_launcher.py
+++ b/cathedral_launcher.py
@@ -1,0 +1,150 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import platform
+import subprocess
+import sys
+import shutil
+import venv
+from pathlib import Path
+import webbrowser
+from typing import Optional
+
+from logging_config import get_log_path
+
+
+MIN_VERSION = (3, 11)
+LOG_PATH = get_log_path("cathedral_launcher.log")
+
+
+def log(msg: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(msg + "\n")
+
+
+def check_python_version() -> bool:
+    if sys.version_info < MIN_VERSION:
+        log("Python 3.11+ required")
+        print("Python 3.11+ is required")
+        return False
+    return True
+
+
+def ensure_pip() -> None:
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "--version"], stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        subprocess.check_call([sys.executable, "-m", "ensurepip", "--upgrade"])
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
+
+
+def ensure_virtualenv() -> None:
+    if sys.prefix == sys.base_prefix and os.getenv("VIRTUAL_ENV") is None:
+        venv_dir = Path(".venv")
+        log("Creating virtual environment")
+        venv.create(venv_dir, with_pip=True)
+        print(f"Virtual environment created at {venv_dir}")
+
+
+def install_requirements() -> None:
+    req = Path("requirements.txt")
+    if req.exists():
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(req)])
+
+
+def ensure_env_file() -> Path:
+    env = Path(".env")
+    if not env.exists():
+        example = Path(".env.example")
+        if example.exists():
+            env.write_text(example.read_text())
+        else:
+            env.touch()
+        log("Created .env from example")
+    return env
+
+
+def ensure_log_dir() -> Path:
+    path = get_log_path("dummy").parent
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def check_ollama() -> bool:
+    return shutil.which("ollama") is not None
+
+
+def install_ollama() -> None:
+    system = platform.system().lower()
+    if system in {"linux", "darwin"}:
+        cmd = "curl -fsSL https://ollama.com/install.sh | sh"
+        subprocess.call(cmd, shell=True)
+    else:
+        print("Please install Ollama from https://ollama.com")
+        log("Ollama missing")
+
+
+def pull_mixtral_model() -> bool:
+    try:
+        subprocess.check_call(["ollama", "pull", "mixtral"])
+        return True
+    except Exception:
+        return False
+
+
+def enable_cloud_only(env_path: Path) -> None:
+    lines: list[str] = []
+    if env_path.exists():
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+    updated = False
+    for i, line in enumerate(lines):
+        if line.startswith("MIXTRAL_CLOUD_ONLY"):
+            lines[i] = "MIXTRAL_CLOUD_ONLY=1"
+            updated = True
+            break
+    if not updated:
+        lines.append("MIXTRAL_CLOUD_ONLY=1")
+    env_path.write_text("\n".join(lines))
+    log("Enabled Mixtral cloud-only mode")
+
+
+def launch_background(cmd: list[str], stdout: Optional[int] = subprocess.DEVNULL) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(cmd, stdout=stdout, stderr=stdout)
+
+
+def main() -> int:
+    ensure_env_file()
+    ensure_log_dir()
+    if not check_python_version():
+        return 1
+    ensure_pip()
+    ensure_virtualenv()
+    try:
+        install_requirements()
+    except subprocess.CalledProcessError as exc:
+        print(f"Dependency installation failed: {exc}")
+        log("pip install failed")
+
+    if not check_ollama():
+        install_ollama()
+    if check_ollama():
+        if not pull_mixtral_model():
+            enable_cloud_only(Path(".env"))
+            print("Using Mixtral cloud-only mode")
+    else:
+        log("Ollama unavailable")
+
+    launch_background(["ollama", "serve"])
+    launch_background([sys.executable, "relay_app.py"])
+    webbrowser.open("http://localhost:8501")
+    print("Cathedral Launcher complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cathedral_launcher.py
+++ b/tests/test_cathedral_launcher.py
@@ -1,0 +1,29 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from pathlib import Path
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import cathedral_launcher as cl
+
+
+def test_env_file_created(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env.example").write_text("EXAMPLE=1")
+    env = cl.ensure_env_file()
+    assert env.exists()
+    assert env.read_text() == "EXAMPLE=1"
+
+
+def test_log_dir_created(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = cl.ensure_log_dir()
+    assert path.exists()
+


### PR DESCRIPTION
## Summary
- add `cathedral_launcher.py` with environment checks and Mixtral cloud toggle
- create tests for launcher setup
- document launcher usage in `README`

## Testing
- `pre-commit run --files cathedral_launcher.py tests/test_cathedral_launcher.py README.md`
- `pytest`
- `mypy`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684c366b04fc832094deaeaf0e6df9aa