### PR TITLE
Enhance cathedral launcher and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,15 +304,18 @@ See `LEGACY_TESTS.md` for failing suites that need volunteers.
 
 ## Cathedral Launcher
 Run `cathedral_launcher.py` to start the local relay and dashboard. The launcher
-checks your Python version, creates `.env` and `logs/` if missing, installs
-dependencies, verifies Ollama, and pulls the Mixtral model when possible.
+checks your Python version, ensures `pip` and a virtual environment exist,
+verifies or installs Ollama, and pulls the Mixtral model when a CUDA GPU is
+available. `.env` and `logs/` are created automatically.
 
 ```bash
 python cathedral_launcher.py
 ```
 
 If your hardware cannot host Mixtral, the launcher sets `MIXTRAL_CLOUD_ONLY=1`
-in `.env` and uses cloud inference.
+in `.env` and uses cloud inference. It launches `ollama serve`,
+`sentientos_relay.py` (or `relay_app.py`), optional bridges, and then opens the
+dashboard in your browser.
 
 ## Quick start (Docker/Helm)
 Run the local relay and bridges with Docker Compose:

--- a/cathedral_launcher.py
+++ b/cathedral_launcher.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
 
@@ -75,6 +76,17 @@ def ensure_log_dir() -> Path:
     return path
 
 
+def check_gpu() -> bool:
+    """Return True if a CUDA-capable GPU is available."""
+    try:
+        import importlib
+
+        torch = importlib.import_module("torch")
+        return bool(getattr(torch.cuda, "is_available", lambda: False)())
+    except Exception:
+        return False
+
+
 def check_ollama() -> bool:
     return shutil.which("ollama") is not None
 
@@ -84,6 +96,8 @@ def install_ollama() -> None:
     if system in {"linux", "darwin"}:
         cmd = "curl -fsSL https://ollama.com/install.sh | sh"
         subprocess.call(cmd, shell=True)
+    elif system == "windows":
+        subprocess.call("winget install Ollama.Ollama -s winget", shell=True)
     else:
         print("Please install Ollama from https://ollama.com")
         log("Ollama missing")
@@ -130,17 +144,31 @@ def main() -> int:
         print(f"Dependency installation failed: {exc}")
         log("pip install failed")
 
+    env_path = Path(".env")
     if not check_ollama():
         install_ollama()
-    if check_ollama():
+
+    ollama_ok = check_ollama()
+    if ollama_ok and check_gpu():
         if not pull_mixtral_model():
-            enable_cloud_only(Path(".env"))
+            enable_cloud_only(env_path)
             print("Using Mixtral cloud-only mode")
     else:
-        log("Ollama unavailable")
+        enable_cloud_only(env_path)
+        if not ollama_ok:
+            log("Ollama unavailable")
 
     launch_background(["ollama", "serve"])
-    launch_background([sys.executable, "relay_app.py"])
+    relay_script = Path("sentientos_relay.py")
+    if not relay_script.exists():
+        relay_script = Path("relay_app.py")
+    launch_background([sys.executable, str(relay_script)])
+
+    for bridge in ["bio_bridge.py", "tts_bridge.py", "haptics_bridge.py"]:
+        path = Path(bridge)
+        if path.exists():
+            launch_background([sys.executable, bridge])
+
     webbrowser.open("http://localhost:8501")
     print("Cathedral Launcher complete.")
     return 0

--- a/tests/test_cathedral_launcher.py
+++ b/tests/test_cathedral_launcher.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
 
 import importlib
-import sys
 import os
+import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -15,26 +16,34 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import cathedral_launcher as cl
 
 
-def test_placeholder(monkeypatch):
-    # Simulate torch with GPU
+def test_check_gpu(monkeypatch):
     class Torch:
         class cuda:
             @staticmethod
             def is_available() -> bool:
                 return True
-    monkeypatch.setitem(sys.modules, 'torch', Torch)
+
+    monkeypatch.setitem(sys.modules, "torch", Torch)
     importlib.reload(cl)
     assert cl.check_gpu()
 
-    # Simulate torch without GPU
     class TorchNo:
         class cuda:
             @staticmethod
             def is_available() -> bool:
                 return False
-    monkeypatch.setitem(sys.modules, 'torch', TorchNo)
+
+    monkeypatch.setitem(sys.modules, "torch", TorchNo)
     importlib.reload(cl)
     assert not cl.check_gpu()
+
+
+def test_check_python_version(monkeypatch):
+    vinfo = sys.version_info
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0))
+    assert not cl.check_python_version()
+    monkeypatch.setattr(sys, "version_info", vinfo)
+    assert cl.check_python_version()
 
 
 def test_env_file_created(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- expand launcher with GPU check, Ollama install and Mixtral handling
- start relay and bridges in the background
- document new launcher behavior in README
- add unit tests for environment helpers

## Testing
- `pre-commit run --files cathedral_launcher.py`
- `pytest -m "not env"`
- `mypy cathedral_launcher.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684c501eb2608320b35208b4d8ff8c32