### PR TITLE
Add GPU detection and cloud fallback

### DIFF
--- a/cathedral_launcher.py
+++ b/cathedral_launcher.py
@@ -75,8 +75,32 @@ def ensure_log_dir() -> Path:
     return path
 
 
+def check_gpu() -> bool:
+    try:
+        import torch  # type: ignore
+        has = torch.cuda.is_available()
+        log(f"gpu_available={has}")
+        return bool(has)
+    except Exception as exc:
+        log(f"gpu_check_failed: {exc}")
+        return False
+
+
+def prompt_cloud_inference(env_path: Path) -> None:
+    text = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    if "MIXTRAL_CLOUD_ONLY=1" in text:
+        return
+    resp = input("GPU not detected. Use cloud inference? [y/N] ")
+    if resp.strip().lower() in {"y", "yes"}:
+        enable_cloud_only(env_path)
+
+
 def check_ollama() -> bool:
-    return shutil.which("ollama") is not None
+    if shutil.which("ollama") is not None:
+        return True
+    print("Ollama binary not found. Install from https://ollama.com")
+    log("Ollama binary missing")
+    return False
 
 
 def install_ollama() -> None:
@@ -93,8 +117,16 @@ def pull_mixtral_model() -> bool:
     try:
         subprocess.check_call(["ollama", "pull", "mixtral"])
         return True
-    except Exception:
-        return False
+    except FileNotFoundError:
+        print("Cannot pull Mixtral model: ollama not found")
+        log("mixtral pull failed: ollama missing")
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to pull Mixtral model: {exc}")
+        log("mixtral pull failed")
+    except Exception as exc:  # pragma: no cover - unexpected
+        print(f"Unexpected error pulling Mixtral model: {exc}")
+        log("mixtral pull unexpected")
+    return False
 
 
 def enable_cloud_only(env_path: Path) -> None:
@@ -118,7 +150,7 @@ def launch_background(cmd: list[str], stdout: Optional[int] = subprocess.DEVNULL
 
 
 def main() -> int:
-    ensure_env_file()
+    env_path = ensure_env_file()
     ensure_log_dir()
     if not check_python_version():
         return 1
@@ -130,11 +162,14 @@ def main() -> int:
         print(f"Dependency installation failed: {exc}")
         log("pip install failed")
 
+    if not check_gpu():
+        prompt_cloud_inference(env_path)
+
     if not check_ollama():
         install_ollama()
     if check_ollama():
         if not pull_mixtral_model():
-            enable_cloud_only(Path(".env"))
+            enable_cloud_only(env_path)
             print("Using Mixtral cloud-only mode")
     else:
         log("Ollama unavailable")

--- a/tests/test_cathedral_launcher.py
+++ b/tests/test_cathedral_launcher.py
@@ -9,20 +9,21 @@ import importlib
 import sys
 import os
 from pathlib import Path
+import subprocess
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import cathedral_launcher as cl
 
 
-def test_placeholder(monkeypatch):
+def test_placeholder(monkeypatch, tmp_path, capsys):
     # Simulate torch with GPU
     class Torch:
         class cuda:
             @staticmethod
             def is_available() -> bool:
                 return True
-    monkeypatch.setitem(sys.modules, 'torch', Torch)
+    monkeypatch.setitem(sys.modules, "torch", Torch)
     importlib.reload(cl)
     assert cl.check_gpu()
 
@@ -32,9 +33,30 @@ def test_placeholder(monkeypatch):
             @staticmethod
             def is_available() -> bool:
                 return False
-    monkeypatch.setitem(sys.modules, 'torch', TorchNo)
+    monkeypatch.setitem(sys.modules, "torch", TorchNo)
     importlib.reload(cl)
     assert not cl.check_gpu()
+
+    env = tmp_path / ".env"
+    env.write_text("EXAMPLE=1")
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    cl.prompt_cloud_inference(env)
+    assert "MIXTRAL_CLOUD_ONLY=1" in env.read_text()
+
+    # second call should not prompt again
+    monkeypatch.setattr("builtins.input", lambda prompt="": (_ for _ in ()).throw(Exception("asked")))
+    cl.prompt_cloud_inference(env)
+    assert env.read_text().count("MIXTRAL_CLOUD_ONLY") == 1
+
+    monkeypatch.setattr(cl.shutil, "which", lambda name: None)
+    assert not cl.check_ollama()
+    out = capsys.readouterr().out
+    assert "Ollama binary not found" in out
+
+    monkeypatch.setattr(subprocess, "check_call", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    assert not cl.pull_mixtral_model()
+    out = capsys.readouterr().out
+    assert "ollama not found" in out
 
 
 def test_env_file_created(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- detect GPU presence with torch
- ask about cloud inference when no GPU is found and persist choice
- log and explain failures for missing ollama binary or Mixtral model
- test the new detection and prompting logic

## Testing
- `pre-commit run --files cathedral_launcher.py`
- `pytest -q`
- `mypy --strict`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684c502199c88320a03c9f7d603c2153