### PR TITLE
Add cathedral launcher with environment checks and launch scripts

### DIFF
--- a/cathedral_launcher.py
+++ b/cathedral_launcher.py
@@ -78,7 +78,7 @@ def ensure_log_dir() -> Path:
 
 def check_gpu() -> bool:
     try:
-        import torch  # type: ignore
+        import torch
         has = torch.cuda.is_available()
         log(f"gpu_available={has}")
         return bool(has)


### PR DESCRIPTION
## Summary
- create cathedral launcher with GPU detection, Ollama install, and cloud fallback
- add Windows and Unix launcher scripts
- document the new launcher workflow
- add tests covering launcher utilities
- fix mypy unused ignore in cathedral launcher

## Testing
- `pre-commit run --files cathedral_launcher.py`
- `pytest -m "not env"`
- `mypy cathedral_launcher.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `pre-commit run --files launch_all_final.bat launch_all_final.sh README.md`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684c57f21b5c8320aec7afd5b7a909aa