### PR TITLE
Implement ParliamentBus

### DIFF
--- a/sentientos/parliament_bus.py
+++ b/sentientos/parliament_bus.py
@@ -1,0 +1,45 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncGenerator
+
+
+@dataclass
+class Turn:
+    """Represents a speaker turn on the parliament floor."""
+
+    speaker: str
+    text: str
+
+
+class ParliamentBus:
+    """Async publish/subscribe bus for :class:`Turn` messages."""
+
+    def __init__(self) -> None:
+        self._queues: list[asyncio.Queue[Turn]] = []
+        self._lock = asyncio.Lock()
+
+    async def publish(self, turn: Turn) -> None:
+        """Publish ``turn`` to all subscribers."""
+        async with self._lock:
+            queues = list(self._queues)
+        for q in queues:
+            q.put_nowait(turn)
+
+    async def subscribe(self) -> AsyncGenerator[Turn, None]:
+        """Yield turns as they arrive until the consumer stops."""
+        q: asyncio.Queue[Turn] = asyncio.Queue()
+        async with self._lock:
+            self._queues.append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            async with self._lock:
+                self._queues.remove(q)

--- a/tests/test_parliament_bus.py
+++ b/tests/test_parliament_bus.py
@@ -1,0 +1,40 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import asyncio
+from sentientos.parliament_bus import ParliamentBus, Turn
+
+
+def test_multi_pub_sub() -> None:
+    async def runner() -> None:
+        bus = ParliamentBus()
+        turns_a = [Turn("A", str(i)) for i in range(2)]
+        turns_b = [Turn("B", str(i)) for i in range(2)]
+        all_turns = turns_a + turns_b
+        r1: list[Turn] = []
+        r2: list[Turn] = []
+
+        async def consume(dest: list[Turn]) -> None:
+            async for t in bus.subscribe():
+                dest.append(t)
+                if len(dest) >= len(all_turns):
+                    break
+
+        async def produce(items: list[Turn]) -> None:
+            for t in items:
+                await bus.publish(t)
+
+        await asyncio.gather(
+            consume(r1),
+            consume(r2),
+            produce(turns_a),
+            produce(turns_b),
+        )
+        assert r1 == all_turns
+        assert r2 == all_turns
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add `parliament_bus.py` implementing async publish/subscribe
- test multi-producer/multi-consumer semantics

## Testing
- `pytest -q`
- `mypy sentientos/parliament_bus.py tests/test_parliament_bus.py`


------
https://chatgpt.com/codex/tasks/task_b_684c61f798e4832080b94544854979ee