### PR TITLE
Implement parliament reasoning engine

### DIFF
--- a/reasoning_engine.py
+++ b/reasoning_engine.py
@@ -1,0 +1,52 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import asyncio
+from dataclasses import dataclass
+from queue import SimpleQueue
+from typing import Awaitable, Callable, Dict, List
+
+
+@dataclass
+class Turn:
+    """One exchange between a model and the parliament."""
+
+    model: str
+    message: str
+    reply: str
+
+
+# Global bus collecting all turns processed by ``parliament``
+parliament_bus: "SimpleQueue[Turn]" = SimpleQueue()
+
+# Registry of model wrapper functions
+ModelFunc = Callable[[str], Awaitable[str]]
+MODEL_REGISTRY: Dict[str, ModelFunc] = {}
+
+
+def register_model(name: str, func: ModelFunc) -> None:
+    """Register a model wrapper under ``name``."""
+    MODEL_REGISTRY[name] = func
+
+
+async def _call_model(model: str, message: str) -> str:
+    fn = MODEL_REGISTRY.get(model)
+    if fn is None:
+        raise ValueError(f"Unknown model: {model}")
+    return await fn(message)
+
+
+async def parliament(prompt: str, chain: List[str], cycles: int = 1) -> str:
+    """Run a model chain for a number of cycles publishing each turn."""
+    message = prompt
+    for _ in range(cycles):
+        for model in chain:
+            reply = await _call_model(model, message)
+            parliament_bus.put(Turn(model=model, message=message, reply=reply))
+            message = reply
+    return message

--- a/tests/test_reasoning_engine.py
+++ b/tests/test_reasoning_engine.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+from __future__ import annotations
+
+import asyncio
+import os
+from queue import SimpleQueue
+
+import reasoning_engine as re
+
+
+async def model_a(msg: str) -> str:
+    return msg + "1"
+
+
+async def model_b(msg: str) -> str:
+    return msg + "2"
+
+
+def test_parliament(monkeypatch):
+    monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
+    re.register_model("a", model_a)
+    re.register_model("b", model_b)
+    # clear bus
+    while not re.parliament_bus.empty():
+        re.parliament_bus.get()
+    result = asyncio.run(re.parliament("a", ["a", "b"], cycles=2))
+    turns = []
+    while not re.parliament_bus.empty():
+        turns.append(re.parliament_bus.get())
+    assert result == "a1212"
+    assert len(turns) == 4
+    assert turns[0].model == "a" and turns[0].reply == "a1"
+    assert turns[-1].model == "b" and turns[-1].reply == "a1212"


### PR DESCRIPTION
## Summary
- add `reasoning_engine.py` with async parliament implementation
- register simple model functions in tests and verify message chaining

## Testing
- `python privilege_lint_cli.py reasoning_engine.py tests/test_reasoning_engine.py`
- `pytest -q`
- `mypy reasoning_engine.py`
- `python check_connector_health.py`

------
https://chatgpt.com/codex/tasks/task_b_684c6271bca483208fb8cfdc487bd75e