### PR TITLE
Add live plugin loader

### DIFF
--- a/gui_stub.py
+++ b/gui_stub.py
@@ -1,0 +1,27 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from typing import Any, List
+
+
+class CathedralGUI:
+    """Minimal stub GUI used by plugins."""
+
+    def __init__(self) -> None:
+        self.panels: List[Any] = []
+
+    def add_panel(self, panel: Any) -> None:
+        """Register a new panel widget."""
+        self.panels.append(panel)
+
+    def update(self) -> None:  # Flet compatible
+        """Trigger UI update."""
+        pass
+
+    def refresh(self) -> None:  # PySide compatible
+        """Refresh stacked widget."""
+        self.update()

--- a/plugins/escalate.py
+++ b/plugins/escalate.py
@@ -7,11 +7,14 @@ require_lumos_approval()
 """Plugin that logs escalation events."""
 from api.actuator import BaseActuator
 import memory_manager as mm
+import plugin_framework as pf
 
-def register(reg):
+
+def register(gui: "CathedralGUI") -> None:
     class EscalateActuator(BaseActuator):
         def execute(self, intent):
             text = f"Escalation for {intent.get('goal')}: {intent.get('text','')}"
             mm.append_memory(text, tags=["escalation"], source="escalate")
             return {"escalated": intent.get('goal')}
-    reg('escalate', EscalateActuator())
+
+    pf.register_plugin('escalate', EscalateActuator())

--- a/plugins/hello.py
+++ b/plugins/hello.py
@@ -11,10 +11,13 @@ used in the test-suite to demonstrate plugin discovery.
 """
 
 from api.actuator import BaseActuator
+import plugin_framework as pf
 
-def register(reg):
+
+def register(gui: "CathedralGUI") -> None:
     class HelloActuator(BaseActuator):
         def execute(self, intent):
             name = intent.get('name', 'world')
             return {'hello': name}
-    reg('hello', HelloActuator())
+
+    pf.register_plugin('hello', HelloActuator())

--- a/plugins/pycall.py
+++ b/plugins/pycall.py
@@ -7,9 +7,10 @@ require_lumos_approval()
 """Execute a local Python function via the actuator framework."""
 from importlib import import_module
 from api.actuator import BaseActuator
+import plugin_framework as pf
 
 
-def register(reg):
+def register(gui: "CathedralGUI") -> None:
     class PyCallActuator(BaseActuator):
         def execute(self, intent):
             target = intent.get("func")
@@ -22,4 +23,4 @@ def register(reg):
             kwargs = intent.get("kwargs", {})
             return {"result": func(*args, **kwargs)}
 
-    reg("pycall", PyCallActuator())
+    pf.register_plugin("pycall", PyCallActuator())

--- a/sentientos/plugin_loader.py
+++ b/sentientos/plugin_loader.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
-"""Simple plugin loader for SentientOS."""
+"""Simple plugin loader for SentientOS with live reloading."""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import importlib
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Dict
+from gui_stub import CathedralGUI
+
+try:  # optional watchdog dependency
+    from watchdog.observers import Observer  # type: ignore[import-untyped]
+    from watchdog.events import FileSystemEventHandler  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - optional dependency
+    Observer = None  # type: ignore[assignment]
+    FileSystemEventHandler = object  # type: ignore[assignment]
 
 import argparse
 from importlib.metadata import entry_points
-from typing import Any, Iterable
 
 
 class PluginBus:
@@ -16,6 +34,181 @@ class PluginBus:
     def register(self, name: str, plugin: Any) -> None:
         """Register a plugin under ``name``."""
         self.plugins[name] = plugin
+
+
+class PluginLoader:
+    """Watch a plugins directory and load modules on changes."""
+
+    def __init__(self, gui: "CathedralGUI", directory: str = "plugins") -> None:
+        self.gui = gui
+        self.directory = Path(directory)
+        self.bus = PluginBus()
+        self.modules: Dict[str, Any] = {}
+        self.errors: Dict[str, str] = {}
+        self.trusted_only = True
+        self.observer: Observer | None = None
+        self._start()
+
+    # watcher setup
+    def _start(self) -> None:
+        self.directory.mkdir(exist_ok=True)
+        self._load_existing()
+        if Observer is None:
+            return
+
+        class Handler(FileSystemEventHandler):
+            def __init__(self, outer: "PluginLoader") -> None:
+                self.outer = outer
+
+            def on_modified(self, event) -> None:  # type: ignore[override]
+                self.outer._handle(event)
+
+            def on_created(self, event) -> None:  # type: ignore[override]
+                self.outer._handle(event)
+
+        self.observer = Observer()
+        self.observer.schedule(Handler(self), str(self.directory), recursive=False)
+        self.observer.start()
+
+    def stop(self) -> None:
+        if self.observer:
+            self.observer.stop()
+            self.observer.join()
+
+    def _handle(self, event) -> None:
+        path = Path(event.src_path)
+        if path.suffix == ".py":
+            self._load_plugin(path.stem)
+
+    def _load_existing(self) -> None:
+        for fp in self.directory.glob("*.py"):
+            self._load_plugin(fp.stem)
+
+    def _load_plugin(self, name: str) -> None:
+        mod_name = f"{self.directory.name}.{name}"
+        try:
+            if mod_name in sys.modules:
+                mod = importlib.reload(sys.modules[mod_name])
+            else:
+                spec = importlib.util.spec_from_file_location(mod_name, self.directory / f"{name}.py")
+                if not spec or not spec.loader:
+                    raise ImportError(mod_name)
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[mod_name] = mod
+                spec.loader.exec_module(mod)  # type: ignore[arg-type]
+
+            if self.trusted_only and not getattr(mod, "TRUSTED", True):
+                self.errors[name] = "untrusted"
+                return
+
+            reg = getattr(mod, "register", None)
+            if callable(reg):
+                reg(self.gui)
+                self.modules[name] = mod
+                self.errors.pop(name, None)
+            else:
+                self.errors[name] = "missing register()"
+        except Exception as e:  # pragma: no cover - load failures
+            self.errors[name] = str(e)
+
+        self._refresh()
+
+    def _refresh(self) -> None:
+        if hasattr(self.gui, "update"):
+            try:
+                self.gui.update()  # type: ignore[call-arg]
+            except Exception:
+                pass
+        elif hasattr(self.gui, "refresh"):
+            try:
+                self.gui.refresh()  # type: ignore[call-arg]
+            except Exception:
+                pass
+
+    def active_plugins(self) -> list[str]:
+        return list(self.modules.keys())
+
+    def error_log(self) -> Dict[str, str]:
+        return dict(self.errors)
+
+def set_trusted_only(self, value: bool) -> None:
+    self.trusted_only = value
+    self._load_existing()
+
+
+class PluginPanel:
+    """Simple GUI panel showing plugin status."""
+
+    def __init__(self, loader: PluginLoader) -> None:
+        self.loader = loader
+        self.gui = loader.gui
+
+        self._mode = None
+        self.control = None
+        try:  # prefer Flet if available
+            import flet as ft  # type: ignore[import-untyped]
+            self._mode = "flet"
+            self._ft = ft
+            self.plugin_list = ft.Column()
+            self.error_list = ft.Column()
+            self.toggle = ft.Checkbox(label="Trusted only", value=True)
+            self.toggle.on_change = self._toggle  # type: ignore[attr-defined]
+            self.control = ft.Column([
+                ft.Text("Plugins"),
+                self.plugin_list,
+                ft.Text("Errors"),
+                self.error_list,
+                self.toggle,
+            ])
+        except Exception:
+            try:
+                from PySide6.QtWidgets import (
+                    QWidget,
+                    QVBoxLayout,
+                    QListWidget,
+                    QLabel,
+                    QCheckBox,
+                )  # type: ignore[import-untyped]
+
+                self._mode = "pyside"
+                self.widget = QWidget()
+                layout = QVBoxLayout(self.widget)
+                layout.addWidget(QLabel("Plugins"))
+                self.plugin_list = QListWidget()
+                layout.addWidget(self.plugin_list)
+                layout.addWidget(QLabel("Errors"))
+                self.error_list = QListWidget()
+                layout.addWidget(self.error_list)
+                self.toggle = QCheckBox("Trusted only")
+                self.toggle.setChecked(True)
+                self.toggle.stateChanged.connect(self._toggle)
+                layout.addWidget(self.toggle)
+                self.control = self.widget
+            except Exception:
+                self._mode = "none"
+        self.refresh()
+
+    def _toggle(self, *args) -> None:
+        if self._mode == "flet":
+            self.loader.set_trusted_only(self.toggle.value)
+        elif self._mode == "pyside":
+            self.loader.set_trusted_only(self.toggle.isChecked())
+        else:
+            self.loader.set_trusted_only(not self.loader.trusted_only)
+        self.refresh()
+
+    def refresh(self) -> None:
+        active = self.loader.active_plugins()
+        errors = self.loader.error_log()
+        if self._mode == "flet":
+            self.plugin_list.controls = [self._ft.Text(n) for n in active]
+            self.error_list.controls = [self._ft.Text(f"{k}: {v}") for k, v in errors.items()]
+        elif self._mode == "pyside":
+            self.plugin_list.clear()
+            self.plugin_list.addItems(active)
+            self.error_list.clear()
+            self.error_list.addItems([f"{k}: {v}" for k, v in errors.items()])
+        self.loader._refresh()
 
 
 def load_plugins(bus: PluginBus, *, load: bool = True) -> Iterable[str]:
@@ -48,6 +241,17 @@ def main(argv: list[str] | None = None) -> None:
         for name in names:
             print(name)
         return
+
+    gui = CathedralGUI()
+    loader = PluginLoader(gui)
+    panel = PluginPanel(loader)
+    gui.add_panel(panel.control)
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        loader.stop()
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry


### PR DESCRIPTION
## Summary
- add watchdog-powered plugin loader
- show plugin info via Flet or PySide panel
- implement CathedralGUI stub
- update sample plugins to new register(gui) API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c627f070c832094c23808481c86bd