### PR TITLE
Add audio recording for demo turns

### DIFF
--- a/sentientos/parliament_bus.py
+++ b/sentientos/parliament_bus.py
@@ -14,8 +14,10 @@ from typing import AsyncGenerator
 @dataclass
 class Turn:
     """Represents a speaker turn on the parliament floor."""
+
     speaker: str
     text: str
+    audio_path: str | None = None
 
 
 class ParliamentBus:


### PR DESCRIPTION
## Summary
- extend Turn dataclass with an `audio_path` field
- record audio files under `demos/audio/<cycle_id>/<turn_id>` in `tts_bridge`
- update DemoRecorder to capture audio paths for subtitle export

## Testing
- `python privilege_lint_cli.py` *(fails: Banner and import order issues)*
- `pytest -m "not env"`
- `mypy sentientos` *(fails: 23 errors in plugin_loader.py)*
- `python verify_audits.py`
- `python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684c6b37a5d08320821721940d6f2089