### PR TITLE
Fix privilege banner order

### DIFF
--- a/demo_recorder.py
+++ b/demo_recorder.py
@@ -1,4 +1,3 @@
-# Sanctuary privilege ritual must appear before any code or imports
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval

--- a/sentientos/plugin_loader.py
+++ b/sentientos/plugin_loader.py
@@ -1,6 +1,7 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 
-"""Simple plugin loader for SentientOS with live reloading."""
+# Simple plugin loader for SentientOS with live reloading.
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()


### PR DESCRIPTION
## Summary
- ensure demo recorder and plugin loader start with the Sanctuary banner and `from __future__` line
- run privilege_lint_cli.py to verify

## Testing
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py --quiet`

------
https://chatgpt.com/codex/tasks/task_b_684c6f0378d88320a493f1d75bdf6407