### PR TITLE
Add demo playback preview

### DIFF
--- a/demo_recorder.py
+++ b/demo_recorder.py
@@ -27,14 +27,21 @@ except Exception:  # pragma: no cover - optional dependency
     mss = None
 
 try:
-    import pyautogui  # type: ignore[import-untyped]
+    import pyautogui
 except Exception:  # pragma: no cover - optional dependency
     pyautogui = None
 
 try:
     import tkinter as tk
 except Exception:  # pragma: no cover - headless env
-    tk = None  # type: ignore
+    tk = None  # type: ignore[assignment]
+
+try:
+    from pydub import AudioSegment
+    from pydub.playback import play as _play_audio
+except Exception:  # pragma: no cover - optional dependency
+    AudioSegment = None
+    _play_audio = None
 
 import tts_bridge
 import parliament_bus
@@ -85,7 +92,12 @@ class DemoRecorder:
             return
         self._running = True
 
-        def speak_capture(text: str, voice=None, save_path=None, emotions=None):
+        def speak_capture(
+            text: str,
+            voice: str | None = None,
+            save_path: str | None = None,
+            emotions: Any | None = None,
+        ) -> str | None:
             if save_path is None:
                 self._turn_id += 1
                 ext = '.wav' if tts_bridge.ENGINE_TYPE in {'bark', 'coqui'} else '.mp3'
@@ -98,7 +110,7 @@ class DemoRecorder:
                 self.turns.append({'text': text, 'audio_path': str(path)})
             return path
 
-        tts_bridge.speak = speak_capture  # type: ignore[assignment]
+        tts_bridge.speak = speak_capture
         self._thread = threading.Thread(target=self._record_loop, daemon=True)
         self._thread.start()
 
@@ -108,7 +120,7 @@ class DemoRecorder:
         self._running = False
         if self._thread is not None:
             self._thread.join()
-        tts_bridge.speak = self._orig_speak  # type: ignore[assignment]
+        tts_bridge.speak = self._orig_speak
 
     def export(self) -> Path:
         if not self.frames:
@@ -170,6 +182,44 @@ _STATUS: tk.StringVar | None = None
 _REC: DemoRecorder | None = None
 
 
+def _find_last_demo() -> Path | None:
+    demos = sorted(
+        Path("demos").glob("*.mp4"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return demos[0] if demos else None
+
+
+def _playback_meter(path: Path) -> None:
+    if AudioSegment is None or _play_audio is None or tk is None or _GUI is None:
+        raise RuntimeError("Preview requires ffmpeg or pydub")
+
+    audio = AudioSegment.from_file(path)
+    meter = tk.Toplevel(_GUI)
+    meter.title("Playback Meter")
+    canvas = tk.Canvas(meter, width=300, height=50)
+    canvas.pack(fill="both", expand=True)
+
+    chunk_ms = 100
+    chunks = [audio[i : i + chunk_ms] for i in range(0, len(audio), chunk_ms)]
+    max_amp = audio.max_possible_amplitude or 1
+
+    def update_meter(idx: int = 0) -> None:
+        if idx >= len(chunks):
+            meter.destroy()
+            return
+        chunk = chunks[idx]
+        level = chunk.rms / max_amp
+        canvas.delete("bar")
+        canvas.create_rectangle(0, 50 - level * 50, 300, 50, fill="green", tags="bar")
+        meter.after(chunk_ms, update_meter, idx + 1)
+
+    threading.Thread(target=_play_audio, args=(audio,), daemon=True).start()
+    update_meter()
+
+
+
 def _setup_gui() -> None:
     global _GUI, _STATUS, _REC
     if tk is None:
@@ -179,17 +229,17 @@ def _setup_gui() -> None:
     _STATUS = tk.StringVar(value="Idle")
     _REC = DemoRecorder()
 
-    def on_record():
+    def on_record() -> None:
         assert _REC is not None and _STATUS is not None
         _REC.start()
         _STATUS.set("Recording")
 
-    def on_stop():
+    def on_stop() -> None:
         assert _REC is not None and _STATUS is not None
         _REC.stop()
         _STATUS.set("Stopped")
 
-    def on_export():
+    def on_export() -> None:
         assert _REC is not None and _STATUS is not None
         try:
             path = _REC.export()
@@ -197,10 +247,28 @@ def _setup_gui() -> None:
         except Exception as exc:
             _STATUS.set(str(exc))
 
+    def on_preview() -> None:
+        assert _STATUS is not None
+        demo = _find_last_demo()
+        if demo is None:
+            _STATUS.set("No demo found")
+            return
+        try:
+            subprocess.run(["ffplay", "-autoexit", str(demo)], check=True)
+            _STATUS.set(f"Played {demo.name}")
+            return
+        except Exception:
+            try:
+                _playback_meter(demo)
+                _STATUS.set(f"Playing {demo.name}")
+            except Exception as exc:
+                _STATUS.set(str(exc))
+
     tk.Label(_GUI, textvariable=_STATUS).pack()
     tk.Button(_GUI, text="Record", command=on_record).pack(fill="x")
     tk.Button(_GUI, text="Stop", command=on_stop).pack(fill="x")
     tk.Button(_GUI, text="Export", command=on_export).pack(fill="x")
+    tk.Button(_GUI, text="\u25B6 Preview Last Demo", command=on_preview).pack(fill="x")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual demo


### PR DESCRIPTION
## Summary
- improve demo_recorder to preview the last demo
- fallback to pydub playback with a simple meter

## Testing
- `pytest -q`
- `mypy --ignore-missing-imports demo_recorder.py`

------
https://chatgpt.com/codex/tasks/task_b_684c6f1a87648320b36557e4b3a39db1