### PR TITLE
Implement emotion fallback refactor

### DIFF
--- a/emotion_fallback.py
+++ b/emotion_fallback.py
@@ -10,18 +10,14 @@ from pathlib import Path
 from typing import Dict
 import yaml
 
-DEFAULT_WEIGHTS: Dict[str, Dict[str, float]] = {
-    "default": {"Joy": 0.6, "Optimism": 0.4},
-    "template": {"Joy": 0.6, "Optimism": 0.4},
-}
-
 
 def get_fallback_emotion_weights(profile_name: str) -> Dict[str, float]:
     """Return fallback emotion weights for ``profile_name``."""
     path = Path("profiles") / profile_name / "fallback_emotion.yaml"
-    if not path.exists():
-        return dict(DEFAULT_WEIGHTS.get(profile_name, DEFAULT_WEIGHTS.get("default", {})))
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    if not isinstance(data, dict):
-        return dict(DEFAULT_WEIGHTS.get(profile_name, DEFAULT_WEIGHTS.get("default", {})))
-    return {str(k): float(v) for k, v in data.items()}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return {str(k): float(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}

--- a/profile_manager.py
+++ b/profile_manager.py
@@ -79,7 +79,7 @@ def create_profile(name: str) -> Path:
         (dest / '.env').write_text('', encoding='utf-8')
         (dest / 'config.yaml').write_text('name: ' + name, encoding='utf-8')
         (dest / 'fallback_emotion.yaml').write_text(
-            'Joy: 0.6\nOptimism: 0.4\n',
+            'analytical: 0.4\ncurious: 0.6\n',
             encoding='utf-8',
         )
     return dest

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -1,1 +1,2 @@
 name: Template
+model_controls_emotion: false

--- a/profiles/default/fallback_emotion.yaml
+++ b/profiles/default/fallback_emotion.yaml
@@ -1,2 +1,2 @@
-Joy: 0.6
-Optimism: 0.4
+analytical: 0.4
+curious: 0.6

--- a/profiles/template/config.yaml
+++ b/profiles/template/config.yaml
@@ -1,1 +1,2 @@
 name: Template
+model_controls_emotion: false

--- a/profiles/template/fallback_emotion.yaml
+++ b/profiles/template/fallback_emotion.yaml
@@ -1,2 +1,2 @@
-Joy: 0.6
-Optimism: 0.4
+analytical: 0.4
+curious: 0.6

--- a/tests/test_reasoning_engine.py
+++ b/tests/test_reasoning_engine.py
@@ -29,14 +29,14 @@ def test_parliament(monkeypatch):
     # clear bus
     while not re.parliament_bus.empty():
         re.parliament_bus.get()
-    result = asyncio.run(re.parliament("a", ["a", "b"], cycles=2))
+    result = asyncio.run(re.parliament("a", ["a", "b"], profile="default"))
     turns = []
     while not re.parliament_bus.empty():
         turns.append(re.parliament_bus.get())
-    assert result == "a1212"
-    assert len(turns) == 4
+    assert result == "a12"
+    assert len(turns) == 2
     assert turns[0].model == "a" and turns[0].reply == "a1"
-    assert turns[-1].model == "b" and turns[-1].reply == "a1212"
+    assert turns[-1].model == "b" and turns[-1].reply == "a12"
 
 
 def test_persona_emotion(tmp_path, monkeypatch):
@@ -53,7 +53,6 @@ def test_persona_emotion(tmp_path, monkeypatch):
         re.parliament(
             "x",
             ["a"],
-            cycles=1,
             profile="test",
             agent_emotion_map=None,
             rng=rng,


### PR DESCRIPTION
## Summary
- update fallback emotion defaults
- return empty dict for missing fallback emotion file
- include model_controls_emotion flag in profiles
- simplify parliament API and update emotion resolution
- adjust tests for new API

## Testing
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c87d8666083209de5bac6f25b5c03