### PR TITLE
Add tone column heading to reasoning panel

### DIFF
--- a/reasoning_panel.py
+++ b/reasoning_panel.py
@@ -18,6 +18,7 @@ class ReasoningPanel(ft.UserControl):  # type: ignore[misc]
     def __init__(self, bus: ParliamentBus) -> None:
         super().__init__()
         self.bus = bus
+        self.tone_heading = ft.Text("Current Tone")
         self.timeline = ft.ListView(spacing=5, expand=True, auto_scroll=True)
         self.detail = ft.TextField(multiline=True, read_only=True, expand=True)
         self.canvas = Canvas(visible=False, expand=True)
@@ -33,7 +34,7 @@ class ReasoningPanel(ft.UserControl):  # type: ignore[misc]
             self.export_btn,
         ], expand=True)
         return ft.Row([
-            ft.Container(self.timeline, width=250),
+            ft.Container(ft.Column([self.tone_heading, self.timeline]), width=250),
             right,
         ], expand=True)
 

--- a/tests/test_emotion_fallback.py
+++ b/tests/test_emotion_fallback.py
@@ -100,4 +100,5 @@ def test_gui_observer(monkeypatch):
         except asyncio.CancelledError:
             pass
     asyncio.run(run())
+    assert panel.tone_heading.value == "Current Tone"
     assert panel.timeline.controls[0].trailing.value == "joy"


### PR DESCRIPTION
## Summary
- add `Current Tone` heading to reasoning panel
- verify heading in GUI observer test

## Testing
- `pytest -q`
- `mypy --strict`


------
https://chatgpt.com/codex/tasks/task_b_684cb1dab7808320a5283436a8e701a6