### PR TITLE
Add ritual docstring lint test

### DIFF
--- a/scripts/__main__.py
+++ b/scripts/__main__.py
@@ -1,4 +1,5 @@
-"""Entry point for running SentientOS helper scripts."""
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+# Entry point for running SentientOS helper scripts.
 from __future__ import annotations
 
 from .new_cli import main

--- a/scripts/audit_chain_cleanser.py
+++ b/scripts/audit_chain_cleanser.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 import sys
 from pathlib import Path
 

--- a/scripts/osc_emotion_pump.py
+++ b/scripts/osc_emotion_pump.py
@@ -1,3 +1,4 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 """Emit dominant emotion over OSC from distilled memory logs."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval

--- a/sentientos/plugins/__init__.py
+++ b/sentientos/plugins/__init__.py
@@ -1,2 +1,3 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 """SentientOS plugin package."""
 

--- a/sentientos/privilege/__init__.py
+++ b/sentientos/privilege/__init__.py
@@ -1,5 +1,6 @@
-"""Public privilege hooks for SentientOS."""
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+# Public privilege hooks for SentientOS.
 
 from ..admin_utils import require_admin_banner, require_lumos_approval
 

--- a/sentientos/tts_bridge.py
+++ b/sentientos/tts_bridge.py
@@ -1,5 +1,5 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-
 """Optional text-to-speech bridge using edge-tts."""
 
 import asyncio

--- a/tests/test_ritual_docstring.py
+++ b/tests/test_ritual_docstring.py
@@ -1,0 +1,42 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import ast
+from pathlib import Path
+from typing import Iterable
+
+SANCTUARY_LINE = "Sanctuary Privilege Ritual: Do not remove. See doctrine for details."
+
+
+def iter_script_files() -> Iterable[Path]:
+    for folder in ("scripts", "sentientos"):
+        for path in Path(folder).rglob("*.py"):
+            yield path
+
+
+def test_sanctuary_docstring_present() -> None:
+    missing: list[Path] = []
+    for path in iter_script_files():
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        body = module.body
+        idx = 0
+        while idx < len(body) and isinstance(body[idx], ast.ImportFrom) and body[idx].module == "__future__":
+            idx += 1
+        if idx >= len(body):
+            missing.append(path)
+            continue
+        node = body[idx]
+        if not (
+            isinstance(node, ast.Expr)
+            and isinstance(getattr(node, "value", None), (ast.Str, ast.Constant))
+            and (
+                node.value.s if hasattr(node.value, "s") else node.value.value
+            )
+            == SANCTUARY_LINE
+        ):
+            missing.append(path)
+    assert not missing, f"Missing ritual docstring in: {', '.join(str(p) for p in missing)}"


### PR DESCRIPTION
## Summary
- ensure all core scripts start with the required ritual docstring
- add a regression test that scans `scripts/` and `sentientos/` to validate the docstring placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cd11b126c8320890cce02921e83ef