### PR TITLE
Finalize bootstrap and model bridge

### DIFF
--- a/model_bridge.py
+++ b/model_bridge.py
@@ -1,6 +1,7 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()  # Sanctuary Privilege Ritual
 require_lumos_approval()
 """Dynamic model bridge for routing prompts to LLM backends."""
@@ -95,8 +96,8 @@ def send_message(
     prompt: str,
     history: Optional[List[Dict[str, str]]] | None = None,
     system_prompt: str | None = None,
-) -> str:
-    """Send ``prompt`` to the active model and return the response."""
+) -> Dict[str, object]:
+    """Send ``prompt`` to the active model and return a result dict."""
     wrapper = load_model()
     if system_prompt is None:
         system_prompt = os.getenv(
@@ -110,5 +111,11 @@ def send_message(
     start = time.time()
     response_text = wrapper(msgs)
     latency = time.time() - start
-    _log({"prompt": prompt, "response": response_text, "latency": latency})
-    return response_text
+    result = {
+        "response": response_text,
+        "model": _MODEL_SLUG,
+        "latency": latency,
+        "emotion": "reverent_attention",
+    }
+    _log({"prompt": prompt, **result})
+    return result

--- a/scripts/test_cathedral_boot.py
+++ b/scripts/test_cathedral_boot.py
@@ -62,11 +62,19 @@ def last_model_response() -> str | None:
 
 
 def main() -> None:
-    ok = check_ingest() and check_log() and check_status() and check_sse()
+    checks = {
+        "sse": check_sse(),
+        "ingest": check_ingest(),
+        "status": check_status(),
+    }
+    ok = all(checks.values()) and check_log()
     if ok:
         print("Cathedral boot checks passed")
     else:
-        print("Cathedral boot checks failed")
+        print("Cathedral boot checks failed:")
+        for name, result in checks.items():
+            if not result:
+                print(f" - {name} failed")
     resp = last_model_response()
     if resp:
         print("Last model reply:", resp[:80])


### PR DESCRIPTION
## Summary
- bootstrap script now restores missing stubs and records blessing
- model bridge returns rich dict responses and logs emotion
- boot tester clarifies failing checks

## Testing
- `pre-commit run --files scripts/bootstrap_cathedral.py scripts/test_cathedral_boot.py model_bridge.py` *(fails: mypy issues in unrelated files)*
- `LUMOS_AUTO_APPROVE=1 PYTHONPATH=. python scripts/test_cathedral_boot.py` *(fails: connection refused to localhost:5000)*

------
https://chatgpt.com/codex/tasks/task_b_684da5fb46908320b3caec95babfbea6