### PR TITLE
Integrate env sync into bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ launch_sentientos.bat
 | `/status` | Uptime + log summary  |
 
 ### 🔧 Environment (.env)
+Run `python .env.sync.autofill.py` to create `.env` with safe defaults.
 | Key             | Example                 |
 | --------------- | ----------------------- |
 | OPENAI_API_KEY  | sk-...                  |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-SentientOS tools read configuration from `.env`. Copy `.env.example` to `.env` and update the values as needed.
+SentientOS tools read configuration from `.env`. Run `python .env.sync.autofill.py` to seed the file or copy `.env.example` and update the values as needed.
 Every variable shown below also appears in `.env.example` with the same default value.
 The table below explains each variable and its default behavior.
 

--- a/scripts/bootstrap_cathedral.py
+++ b/scripts/bootstrap_cathedral.py
@@ -1,8 +1,11 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
+
+from scripts.env_sync_autofill import autofill_env
 
 # Bootstrap helper to set up SentientOS with minimal fuss.
 
@@ -43,34 +46,6 @@ def install_requirements() -> None:
         print("Cython fallback failed")
 
 
-def autofill_env() -> None:
-    env_path = Path(".env")
-    if env_path.exists():
-        text = env_path.read_text(encoding="utf-8")
-        lines = text.splitlines()
-    else:
-        lines = []
-    data = {}
-    mapping = {
-        "OPENAI_API_KEY": "",
-        "MODEL_SLUG": "openai/gpt-4o",
-        "SYSTEM_PROMPT": "You are Lumos...",
-        "ENABLE_TTS": "true",
-        "TTS_ENGINE": "pyttsx3",
-    }
-    keys = {ln.split("=", 1)[0] for ln in lines if "=" in ln and not ln.strip().startswith("#")}
-    for k, v in mapping.items():
-        if k not in keys:
-            lines.append(f"{k}={v}")
-            data[k] = v
-    if data:
-        env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        entry = {
-            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
-            "added": data,
-        }
-        with ENV_LOG.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry) + "\n")
 
 
 _STUBS = {


### PR DESCRIPTION
## Summary
- update README & ENVIRONMENT docs with env sync instructions
- use scripts.env_sync_autofill in `bootstrap_cathedral.py`

## Testing
- `pre-commit run --files README.md docs/ENVIRONMENT.md scripts/bootstrap_cathedral.py`

------
https://chatgpt.com/codex/tasks/task_b_684db264d30c832092d932e3f0e9aab6