### PR TITLE
Fix privilege export cycle

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -162,3 +162,12 @@ def require_admin() -> None:
         stacklevel=2,
     )
     require_lumos_approval()
+
+
+__all__ = [
+    "is_admin",
+    "print_privilege_banner",
+    "require_admin_banner",
+    "require_lumos_approval",
+    "require_admin",
+]

--- a/sentientos/admin_utils.py
+++ b/sentientos/admin_utils.py
@@ -175,3 +175,12 @@ def require_admin() -> None:
     )
     require_lumos_approval()
 
+
+__all__ = [
+    "is_admin",
+    "print_privilege_banner",
+    "require_admin_banner",
+    "require_lumos_approval",
+    "require_admin",
+]
+

--- a/sentientos/privilege/__init__.py
+++ b/sentientos/privilege/__init__.py
@@ -2,7 +2,19 @@
 from __future__ import annotations
 # Public privilege hooks for SentientOS.
 
-from ..admin_utils import require_admin_banner, require_lumos_approval
+from ..admin_utils import (
+    is_admin,
+    print_privilege_banner,
+    require_admin,
+    require_admin_banner,
+    require_lumos_approval,
+)
 
-__all__ = ["require_admin_banner", "require_lumos_approval"]
+__all__ = [
+    "is_admin",
+    "print_privilege_banner",
+    "require_admin_banner",
+    "require_lumos_approval",
+    "require_admin",
+]
 


### PR DESCRIPTION
## Summary
- export admin helpers from `sentientos.privilege`
- define `__all__` lists in admin utilities

## Testing
- `pytest --collect-only -q`
- `pytest -q`
- `mypy sentientos/admin_utils.py sentientos/privilege/__init__.py admin_utils.py`
- `pre-commit run --files sentientos/admin_utils.py sentientos/privilege/__init__.py admin_utils.py` *(fails: mypy errors in unrelated files)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_684dbd556bc883208714f77a4e9ffdbe