### PR TITLE
Add Parliament tab and model selector

### DIFF
--- a/parliament_selector.py
+++ b/parliament_selector.py
@@ -1,0 +1,28 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+"""Utility class for reordering model chains."""
+
+from typing import List
+
+
+class ModelSelector:
+    """Maintain an ordered list of models."""
+
+    def __init__(self, models: List[str]) -> None:
+        self.models = list(models)
+
+    def move(self, src: int, dest: int) -> None:
+        """Move item at ``src`` to ``dest``."""
+        if src < 0 or src >= len(self.models):
+            return
+        dest = max(0, min(dest, len(self.models) - 1))
+        item = self.models.pop(src)
+        self.models.insert(dest, item)
+
+    def get_models(self) -> List[str]:
+        """Return the ordered model list."""
+        return list(self.models)

--- a/tests/test_parliament_selector.py
+++ b/tests/test_parliament_selector.py
@@ -1,0 +1,25 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import parliament_selector as ps
+
+
+def test_move_down():
+    sel = ps.ModelSelector(["a", "b", "c"])
+    sel.move(0, 2)
+    assert sel.get_models() == ["b", "c", "a"]
+
+
+def test_move_up():
+    sel = ps.ModelSelector(["a", "b", "c"])
+    sel.move(2, 0)
+    assert sel.get_models() == ["c", "a", "b"]
+
+def test_invalid_move():
+    sel = ps.ModelSelector(["a", "b"])
+    sel.move(5, 1)
+    assert sel.get_models() == ["a", "b"]


### PR DESCRIPTION
## Summary
- extend GUI with a new Parliament tab
- add `ModelSelector` helper for draggable model ordering
- emit `parliament_request` events to the async bus
- cover selector logic with unit tests

## Testing
- `pre-commit run --files cathedral_gui.py parliament_selector.py tests/test_parliament_selector.py -v`
- `pytest tests/test_parliament_selector.py -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --no-input`


------
https://chatgpt.com/codex/tasks/task_b_684dbd57e4308320b7ea0daa70128e98