### PR TITLE
Implement ghapi-based GitHub bridge

### DIFF
--- a/docs/GITHUB_BRIDGE.md
+++ b/docs/GITHUB_BRIDGE.md
@@ -1,0 +1,19 @@
+# GitHub Bridge
+
+`github_bridge.py` provides a tiny wrapper around [ghapi](https://github.com/fastai/ghapi).
+Tokens are stored in the system keyring and validated for the scopes you request.
+No token value is ever logged or sent to a language model.
+
+Run the Streamlit dashboard to configure tokens:
+
+```bash
+streamlit run github_dashboard.py
+```
+
+Enter a model name, your personal access token and a comma separated list of
+required scopes. Press **Test & Save**. The bridge verifies the token by
+calling `GET /user` via ghapi and checking the `X-OAuth-Scopes` header. If the
+required scopes are present the token is saved in the keyring.
+
+Once saved you can search code, open issues and create pull requests through the
+GUI, respecting the selected checkboxes for read, write and PR actions.

--- a/github_dashboard.py
+++ b/github_dashboard.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import json
 
 try:
-    import streamlit as st  # type: ignore[import-untyped]
+    import streamlit as st
 except Exception:  # pragma: no cover - optional
     st = None
 
@@ -29,9 +29,14 @@ def run_app() -> None:
 
     model = st.text_input("Model name", "default")
     token = st.text_input("Token", type="password")
-    if st.button("Save Token") and token:
-        bridge.set_token(model, token)
-        st.success("Token saved")
+    scopes = st.text_input("Required Scopes", "repo")
+    if st.button("Test & Save") and token:
+        try:
+            bridge.set_token(model, token, scopes=[s.strip() for s in scopes.split(',') if s.strip()])
+        except Exception as e:
+            st.error(str(e))
+        else:
+            st.success("Token saved")
 
     read_scope = st.checkbox("Allow read", value=True)
     write_scope = st.checkbox("Allow write")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ brainflow>=5,<6
 colorama>=0.4,<1
 cryptography>=42,<43
 ghapi>=1,<2
+keyring>=24,<25
 httpx>=0.27,<1
 librosa>=0.10,<1
 mne>=1,<2

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -5,59 +5,82 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
 
-import json
 import sys
 import os
-from pathlib import Path
 from importlib import reload
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import github_bridge as gb
 
 
+from typing import Any
+
+
 class DummyApi:
     def __init__(self) -> None:
-        self.called: list[tuple[str, tuple, dict]] = []
+        self.called: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
         self.search = type("S", (), {"code": self._search})()
         self.issues = type("I", (), {"create": self._create_issue})()
         self.pulls = type("P", (), {"create": self._create_pr})()
+        self.users = type("U", (), {"get_authenticated": lambda self: None})()
+        self.recv_hdrs = {"X-OAuth-Scopes": "repo"}
 
-    def _search(self, *args, **kwargs):
+    def _search(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         self.called.append(("search", args, kwargs))
         return {"items": []}
 
-    def _create_issue(self, *args, **kwargs):
+    def _create_issue(self, *args: Any, **kwargs: Any) -> dict[str, str]:
         self.called.append(("issue", args, kwargs))
         return {"html_url": "http://example.com/i/1"}
 
-    def _create_pr(self, *args, **kwargs):
+    def _create_pr(self, *args: Any, **kwargs: Any) -> dict[str, str]:
         self.called.append(("pr", args, kwargs))
         return {"html_url": "http://example.com/p/1"}
 
 
-def test_token_persist(tmp_path, monkeypatch):
-    key = tmp_path / "k.key"
-    tok = tmp_path / "t.enc"
-    monkeypatch.setattr(gb, "KEY_FILE", key)
-    monkeypatch.setattr(gb, "TOKEN_FILE", tok)
+def _mock_keyring(monkeypatch: pytest.MonkeyPatch, store: dict[str, str]) -> None:
+    kr = type(
+        "KR",
+        (),
+        {
+            "set_password": lambda service, user, tok: store.__setitem__(user, tok),
+            "get_password": lambda service, user: store.get(user),
+        },
+    )
+    monkeypatch.setitem(sys.modules, "keyring", kr)
+
+
+def test_token_persist(monkeypatch: pytest.MonkeyPatch) -> None:
+    store: dict[str, str] = {}
+    _mock_keyring(monkeypatch, store)
     reload(gb)
-    bridge = gb.GitHubBridge(token_file=tok, key_file=key)
+    bridge = gb.GitHubBridge(service="svc")
     bridge.set_token("model", "abc")
-    assert tok.exists()
-    b2 = gb.GitHubBridge(token_file=tok, key_file=key)
-    assert b2.tokens["model"] == "abc"
+    b2 = gb.GitHubBridge(service="svc")
+    assert b2._token_for("model") == "abc"
 
 
-def test_api_calls(monkeypatch, tmp_path):
-    key = tmp_path / "k.key"
-    tok = tmp_path / "t.enc"
-    monkeypatch.setattr(gb, "KEY_FILE", key)
-    monkeypatch.setattr(gb, "TOKEN_FILE", tok)
+def test_scope_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    store: dict[str, str] = {}
+    _mock_keyring(monkeypatch, store)
     dummy = DummyApi()
     monkeypatch.setitem(sys.modules, "ghapi.all", type("M", (), {"GhApi": lambda token=None: dummy}))
     reload(gb)
-    bridge = gb.GitHubBridge(token_file=tok, key_file=key)
+    bridge = gb.GitHubBridge(service="svc")
+    bridge.set_token("m", "tok", scopes=["repo"])
+    with pytest.raises(ValueError):
+        bridge.set_token("m", "tok", scopes=["write"])
+
+
+def test_api_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    store: dict[str, str] = {}
+    _mock_keyring(monkeypatch, store)
+    dummy = DummyApi()
+    monkeypatch.setitem(sys.modules, "ghapi.all", type("M", (), {"GhApi": lambda token=None: dummy}))
+    reload(gb)
+    bridge = gb.GitHubBridge(service="svc")
     bridge.set_token("default", "tok")
     bridge.search_code("foo")
     bridge.create_issue("o/r", "t", "b")


### PR DESCRIPTION
## Summary
- move GitHub token storage to the system keyring
- validate provided scopes by inspecting ghapi response headers
- expose token & scope fields in `github_dashboard.py`
- add unit tests covering keyring integration
- document GitHub Bridge usage

## Testing
- `pre-commit run --files github_bridge.py github_dashboard.py tests/test_github_bridge.py docs/GITHUB_BRIDGE.md requirements.txt`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `mypy --strict github_bridge.py github_dashboard.py tests/test_github_bridge.py`


------
https://chatgpt.com/codex/tasks/task_b_684dbd58266483209866b6ae39240ea9