### PR TITLE
Add cross-platform launcher scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,16 @@ python -m gui.cathedral_gui
 ```
 
 ### ⚙️ CLI Launch
+Run the cross-platform launcher to start the full cathedral stack.
+
+#### Windows
+```bat
+run_cathedral.bat
+```
+
+#### macOS & Linux
 ```bash
-launch_sentientos.bat
+./run_cathedral.sh
 ```
 
 ### 🛠️ Bundled Launcher

--- a/run_cathedral.bat
+++ b/run_cathedral.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Cross-platform launcher for SentientOS
+REM Calls cathedral_launcher.py and logs to run_cathedral.log
+setlocal
+set LOGFILE=%~dp0run_cathedral.log
+set SCRIPT_DIR=%~dp0
+
+echo [%date% %time%] === Cathedral Launch Started === >> "%LOGFILE%"
+cd /d "%SCRIPT_DIR%"
+python cathedral_launcher.py >> "%LOGFILE%" 2>&1
+if errorlevel 1 (
+    echo [%date% %time%] ERROR: cathedral_launcher.py failed. >> "%LOGFILE%"
+    exit /b 1
+)
+
+echo [%date% %time%] Cathedral launch complete. >> "%LOGFILE%"
+endlocal

--- a/run_cathedral.sh
+++ b/run_cathedral.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Cross-platform launcher for SentientOS
+# Calls cathedral_launcher.py and logs to run_cathedral.log
+
+LOGFILE="$(dirname "$0")/run_cathedral.log"
+
+echo "$(date) === Cathedral Launch Started ===" >> "$LOGFILE"
+python cathedral_launcher.py >> "$LOGFILE" 2>&1
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "$(date) ERROR: cathedral_launcher.py failed." >> "$LOGFILE"
+  exit $ret
+fi
+
+echo "$(date) Cathedral launch complete." >> "$LOGFILE"


### PR DESCRIPTION
## Summary
- add run_cathedral.bat and run_cathedral.sh wrappers
- document cross‑platform launcher usage in README
- ensure launch_all_final.sh remains executable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ddd97b1f0832091f28bbb6755632f