### PR TITLE
Add launcher documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ python -m gui.cathedral_gui
 launch_sentientos.bat
 ```
 
+### 🏰 Cathedral Launcher
+Automatically set up the environment and start all services:
+```bash
+python cathedral_launcher.py
+```
+The launcher creates `.env` and `logs/` if missing, checks for Ollama,
+pulls the Mixtral model when possible, and then opens the local dashboard.
+
 ### 🛠️ Bundled Launcher
 Build a standalone executable with:
 ```bash

--- a/tests/test_cathedral_launcher.py
+++ b/tests/test_cathedral_launcher.py
@@ -88,3 +88,27 @@ def test_log_dir_created(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     path = cl.ensure_log_dir()
     assert path.exists()
+
+
+def test_log_written(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "launcher.log"
+    monkeypatch.setattr(cl, "LOG_PATH", target)
+    cl.log("hello")
+    assert target.read_text().strip() == "hello"
+
+
+def test_ensure_virtualenv(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "prefix", "/usr")
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    called = {}
+
+    def fake_create(path, *, with_pip=True):
+        called["path"] = path
+        called["with_pip"] = with_pip
+
+    monkeypatch.setattr(cl.venv, "create", fake_create)
+    cl.ensure_virtualenv()
+    assert called["path"] == tmp_path / ".venv"


### PR DESCRIPTION
## Summary
- document the cathedral launcher in the README
- extend cathedral launcher tests for log writing and virtualenv

## Testing
- `pre-commit run --files README.md tests/test_cathedral_launcher.py -v`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ddd96f6508320a4347de73e1d1d1e