### PR TITLE
Add cross-platform packaging instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: lock lock-install docs docs-live
+.PHONY: package package-windows package-mac
 
 lock:
 	python -m scripts.lock freeze
@@ -11,3 +12,12 @@ docs:
 
 docs-live:
 	sphinx-autobuild docs docs/_build/html
+
+package:
+	python scripts/package_launcher.py
+
+package-windows:
+	python scripts/package_launcher.py --platform windows
+
+package-mac:
+	python scripts/package_launcher.py --platform mac

--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ launch_sentientos.bat
 ```
 
 ### 🛠️ Bundled Launcher
-Build a standalone executable with:
+Create packaged executables for your platform:
 ```bash
-python scripts/package_launcher.py
+# Windows
+python scripts/package_launcher.py --platform windows
+
+# macOS (attempts notarization if APPLE_ID and APPLE_PASSWORD are set)
+python scripts/package_launcher.py --platform mac
 ```
-The binary is placed in `dist/` and runs without a Python install.
+The binaries are placed in `dist/` and run without a Python install.
 
 ### 📡 Endpoints
 | Route   | Purpose                |

--- a/scripts/package_launcher.py
+++ b/scripts/package_launcher.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+import argparse
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -25,7 +28,17 @@ def regenerate_entry() -> None:
         subprocess.call([sys.executable, str(script), "cathedral_launcher.py"])
 
 
-def package() -> int:
+def run(cmd: list[str]) -> int:
+    try:
+        subprocess.check_call(cmd)
+        return 0
+    except subprocess.CalledProcessError as exc:
+        log(f"packaging_failed:{exc}")
+        regenerate_entry()
+        return 1
+
+
+def package_windows() -> int:
     cmd = [
         sys.executable,
         "-m",
@@ -37,19 +50,96 @@ def package() -> int:
         "cathedral_launcher",
         "cathedral_launcher.py",
     ]
+    res = run(cmd)
+    if res == 0:
+        log("packaged_windows_ok")
+    return res
+
+
+def notarize_mac(app_path: Path) -> None:
+    if not shutil.which("codesign"):
+        log("codesign_missing")
+        return
     try:
-        subprocess.check_call(cmd)
-        log("packaged_ok")
-        return 0
+        subprocess.check_call(["codesign", "--force", "--deep", "--sign", "-", str(app_path)])
     except subprocess.CalledProcessError as exc:
-        log(f"packaging_failed:{exc}")
-        regenerate_entry()
-        return 1
+        log(f"codesign_failed:{exc}")
+        return
+    if shutil.which("xcrun") and os.environ.get("APPLE_ID") and os.environ.get("APPLE_PASSWORD"):
+        zip_path = shutil.make_archive(str(app_path), "zip", root_dir=app_path)
+        try:
+            subprocess.check_call([
+                "xcrun",
+                "altool",
+                "--notarize-app",
+                "--primary-bundle-id",
+                "sentientos.cathedral",
+                "--username",
+                os.environ["APPLE_ID"],
+                "--password",
+                os.environ["APPLE_PASSWORD"],
+                "--file",
+                zip_path,
+            ])
+            log("notarization_ok")
+        except subprocess.CalledProcessError as exc:
+            log(f"notarization_failed:{exc}")
+    else:
+        log("notarization_skipped")
+
+
+def package_mac() -> int:
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--onefile",
+        "--windowed",
+        "--distpath",
+        "dist",
+        "--name",
+        "cathedral_launcher",
+        "cathedral_launcher.py",
+    ]
+    res = run(cmd)
+    if res == 0:
+        app = Path("dist") / "cathedral_launcher.app"
+        if app.exists():
+            notarize_mac(app)
+        log("packaged_mac_ok")
+    return res
+
+
+def package_linux() -> int:
+    return package_windows()
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description="Bundle cathedral launcher")
+    parser.add_argument(
+        "--platform",
+        choices=["auto", "windows", "mac"],
+        default="auto",
+        help="Target platform",
+    )
+    args = parser.parse_args()
+
     Path("dist").mkdir(exist_ok=True)
-    return package()
+
+    plat = args.platform
+    if plat == "auto":
+        if sys.platform.startswith("win"):
+            plat = "windows"
+        elif sys.platform == "darwin":
+            plat = "mac"
+        else:
+            plat = "linux"
+
+    if plat == "windows":
+        return package_windows()
+    if plat == "mac":
+        return package_mac()
+    return package_linux()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand `scripts/package_launcher.py` with Windows and macOS build targets and optional notarization
- add packaging targets to the `Makefile`
- document launcher packaging (screenshot removed)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ddd97fc2c83209a8841e008e06b68