### PR TITLE
Add GitHub issue/PR helpers with GUI

### DIFF
--- a/docs/GITHUB_BRIDGE.md
+++ b/docs/GITHUB_BRIDGE.md
@@ -4,10 +4,13 @@
 Tokens are stored in the system keyring and validated for the scopes you request.
 No token value is ever logged or sent to a language model.
 
-Run the Streamlit dashboard to configure tokens:
+Run the Streamlit dashboard to configure tokens. A simpler GUI composer and PR wizard is also available:
 
 ```bash
 streamlit run github_dashboard.py
+```
+```bash
+streamlit run github_gui.py
 ```
 
 Enter a model name, your personal access token and a comma separated list of

--- a/github_bridge.py
+++ b/github_bridge.py
@@ -91,6 +91,7 @@ class GitHubBridge:
         return api.search.code(q=query, **kwargs)
 
     def create_issue(self, repo: str, title: str, body: str, *, model: str = "default", **kwargs: Any) -> Any:
+        require_lumos_approval()
         owner, repo_name = repo.split("/")
         api = self._api(model)
         self._log("create_issue", {"repo": repo, "title": title, "model": model})
@@ -107,6 +108,7 @@ class GitHubBridge:
         model: str = "default",
         **kwargs: Any,
     ) -> Any:
+        require_lumos_approval()
         owner, repo_name = repo.split("/")
         api = self._api(model)
         self._log(
@@ -114,4 +116,33 @@ class GitHubBridge:
             {"repo": repo, "title": title, "head": head, "base": base, "model": model},
         )
         return api.pulls.create(owner, repo_name, title=title, body=body, head=head, base=base, **kwargs)
+
+
+def create_issue(repo: str, title: str, body: str, *, token: str, **kwargs: Any) -> Any:
+    """Create an issue directly via :class:`GhApi`. Requires Lumos approval."""
+    require_lumos_approval()
+    if GhApi is None:
+        raise RuntimeError("ghapi not available")
+    owner, repo_name = repo.split("/")
+    api = GhApi(token=token)
+    return api.issues.create(owner, repo_name, title=title, body=body, **kwargs)
+
+
+def create_pull_request(
+    repo: str,
+    title: str,
+    body: str,
+    head: str,
+    base: str,
+    *,
+    token: str,
+    **kwargs: Any,
+) -> Any:
+    """Create a pull request directly via :class:`GhApi`. Requires Lumos approval."""
+    require_lumos_approval()
+    if GhApi is None:
+        raise RuntimeError("ghapi not available")
+    owner, repo_name = repo.split("/")
+    api = GhApi(token=token)
+    return api.pulls.create(owner, repo_name, title=title, body=body, head=head, base=base, **kwargs)
 

--- a/github_gui.py
+++ b/github_gui.py
@@ -1,0 +1,49 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+"""Simple GUI for creating GitHub issues and pull requests."""
+
+try:
+    import streamlit as st  # pragma: no cover - optional
+except Exception:  # pragma: no cover - optional
+    st = None
+
+from github_bridge import create_issue, create_pull_request
+
+
+def run_app() -> None:
+    if st is None:
+        print("streamlit not available")
+        return
+
+    st.title("GitHub Composer")
+
+    action = st.radio("Action", ["Issue", "Pull Request"])
+    repo = st.text_input("Repo (owner/repo)")
+    token = st.text_input("Token", type="password")
+
+    title = st.text_input("Title")
+    body = st.text_area("Body")
+
+    if action == "Pull Request":
+        head = st.text_input("Head Branch")
+        base = st.text_input("Base Branch")
+
+    if st.button("Submit") and repo and title and token:
+        try:
+            if action == "Issue":
+                issue = create_issue(repo, title, body, token=token)
+                st.write(issue.get("html_url"))
+            else:
+                pr = create_pull_request(repo, title, body, head, base, token=token)
+                st.write(pr.get("html_url"))
+        except Exception as e:  # pragma: no cover - network
+            st.error(str(e))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run_app()

--- a/tests/test_github_bridge.py
+++ b/tests/test_github_bridge.py
@@ -87,3 +87,19 @@ def test_api_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     bridge.create_pr("o/r", "t", "b", "h", "base")
     kinds = [c[0] for c in dummy.called]
     assert kinds == ["search", "issue", "pr"]
+
+
+def test_standalone_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = DummyApi()
+    monkeypatch.setitem(sys.modules, "ghapi.all", type("M", (), {"GhApi": lambda token=None: dummy}))
+    reload(gb)
+    gb.create_issue("o/r", "t", "b", token="tok")
+    gb.create_pull_request("o/r", "t", "b", "h", "base", token="tok")
+    assert dummy.called == [
+        ("issue", ("o", "r"), {"title": "t", "body": "b"}),
+        (
+            "pr",
+            ("o", "r"),
+            {"title": "t", "body": "b", "head": "h", "base": "base"},
+        ),
+    ]


### PR DESCRIPTION
## Summary
- extend `GitHubBridge` to request Lumos approval for issue/PR actions
- add standalone helpers `create_issue` and `create_pull_request`
- implement simple Streamlit GUI for issue composer and PR wizard
- document new utility in GitHub bridge docs
- test helper functions with mocked `GhApi`

## Testing
- `pytest tests/test_github_bridge.py::test_standalone_helpers -vv`
- `pytest tests/test_placeholder.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684de5040d30832091a6d25325044bf8