### PR TITLE
Add Parliament demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,24 @@ jobs:
       - name: Pytest with coverage
         run: pytest
 
+      - name: Run parliament demo
+        run: |
+          mkdir -p demos
+          SENTIENTOS_HEADLESS=1 python scripts/demo_parliament.py
+          ls -t demos/*.mp4 | tail -n +4 | xargs -r rm --
+
+      - name: Upload demos
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo
+          path: demos/*.mp4
+
+      - name: Remove old demo artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/actions/artifacts --paginate -q '.artifacts | sort_by(.created_at) | reverse | map(select(.name=="demo")) | .[3:] | .[].id' | xargs -r -I{} gh api repos/${{ github.repository }}/actions/artifacts/{} -X DELETE
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Run `python .env.sync.autofill.py` to create `.env` with safe defaults.
 python scripts/test_cathedral_boot.py
 ```
 
+## 🏛️ Parliament Demo
+Run a short headless demonstration and record it as an MP4:
+
+```bash
+SENTIENTOS_HEADLESS=1 python scripts/demo_parliament.py
+```
+The output file is stored in the `demos/` directory.
+
 ### 🕯️ Blessing Example
 ```json
 {

--- a/scripts/demo_parliament.py
+++ b/scripts/demo_parliament.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+"""Headless Parliament demo using the global reasoning bus.
+
+Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
+"""
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+
+import asyncio
+import os
+
+
+import reasoning_engine as re
+import parliament_bus
+import demo_recorder as dr
+
+
+async def model_one(msg: str) -> str:
+    return msg + "1"
+
+
+async def model_two(msg: str) -> str:
+    return msg + "2"
+
+
+async def model_three(msg: str) -> str:
+    return msg + "3"
+
+
+async def run_demo() -> None:
+    os.environ["SENTIENTOS_HEADLESS"] = "1"
+
+    re.register_model("one", model_one)
+    re.register_model("two", model_two)
+    re.register_model("three", model_three)
+
+    recorder = dr.DemoRecorder()
+    recorder.start()
+
+    prompt = "parliament demo"
+    message = prompt
+    turn_id = 0
+    for cycle in range(2):
+        await re.parliament(message, ["one", "two", "three"], profile="default")
+        while not re.parliament_bus.empty():
+            turn = re.parliament_bus.get()
+            turn_id += 1
+            await parliament_bus.bus.publish({
+                "cycle": cycle + 1,
+                "agent": turn.model,
+                "turn_id": turn_id,
+                "message": turn.message,
+                "reply": turn.reply,
+                "emotion": turn.emotion,
+            })
+        message = turn.reply
+
+    recorder.stop()
+    out_path = recorder.export()
+    print(f"Demo saved to {out_path}")
+
+
+def main() -> None:
+    asyncio.run(run_demo())
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a headless Parliament demo script under `scripts`
- keep latest demo artifacts in CI
- describe demo usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684de5078e388320a520dbdd8a404029