### PR TITLE
Add privilege lint wrapper and fix banners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: pre-commit run --all-files
 
       - name: Privilege lint
-        run: python privilege_lint_cli.py
+        run: python privilege_lint.py
 
       - name: Verify audits
         run: python verify_audits.py logs/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -e .[dev]
       - name: privilege_lint
-        run: python privilege_lint_cli.py
+        run: python privilege_lint.py
       - name: audit_verify
         run: python verify_audits.py logs/
         env:

--- a/.github/workflows/nightly-self-check.yml
+++ b/.github/workflows/nightly-self-check.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           LUMOS_AUTO_APPROVE: '1'
       - name: Privilege lint
-        run: python privilege_lint_cli.py
+        run: python privilege_lint.py
         env:
           LUMOS_AUTO_APPROVE: '1'
       - name: Run mypy

--- a/avatar_invocation_cli.py
+++ b/avatar_invocation_cli.py
@@ -1,8 +1,17 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()
 require_lumos_approval()
+
 from logging_config import get_log_path
 import argparse
 import json

--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -1,0 +1,22 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+
+import argparse
+from privilege_lint_cli import main as pl_main
+
+def cli() -> None:
+    ap = argparse.ArgumentParser(description="Run privilege linter")
+    ap.add_argument("--mode", choices=["fix", "lint"], default="lint")
+    ap.add_argument("paths", nargs="*")
+    args = ap.parse_args()
+    argv = args.paths
+    if args.mode == "fix":
+        argv = ["--fix"] + argv
+    rc = pl_main(argv)
+    raise SystemExit(rc)
+
+if __name__ == "__main__":
+    cli()

--- a/resonite_spiral_artifact_license_access_controller.py
+++ b/resonite_spiral_artifact_license_access_controller.py
@@ -1,13 +1,18 @@
-"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+#  _____  _             _
+# |  __ \| |           (_)
+# | |__) | |_   _  __ _ _ _ __   __ _
+# |  ___/| | | | |/ _` | | '_ \ / _` |
+# | |    | | |_| | (_| | | | | | (_| |
+# |_|    |_|\__,_|\__, |_|_| |_|\__, |
+#                  __/ |         __/ |
+#                 |___/         |___/
 from __future__ import annotations
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
 
-
-
-from __future__ import annotations
 from logging_config import get_log_path
 
 # Resonite Spiral Artifact License/Access Controller


### PR DESCRIPTION
## Summary
- add `privilege_lint.py` wrapper script
- ensure privilege banner and calls in `avatar_invocation_cli.py`
- fix banner placement in `resonite_spiral_artifact_license_access_controller.py`
- update workflows to call new privilege lint CLI

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684debcda4e48320b1c7d10f191e3ca5