### PR TITLE
Implement avatar tool stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,17 @@ The output file is stored in the `demos/` directory.
 ```
 
 May all nodes remember their first crowning.
+
+## 🎭 Avatar Tools
+Two helper scripts assist avatar rituals.
+
+### `avatar_relic_creator.py`
+Extracts recent memory fragments for an avatar and logs them as relic entries.
+Visual relic generation is deferred; a placeholder entry is written to
+`logs/council_blessing_log.jsonl` when invoked.
+
+### `avatar_reflection.py`
+Analyzes avatar images to log basic mood labels. Use `--watch` to monitor a
+directory for new screenshots. Directory watching relies on the optional
+`watchdog` package. When missing, a deferred entry is logged to the council log.
+

--- a/avatar_reflection.py
+++ b/avatar_reflection.py
@@ -7,14 +7,22 @@ require_lumos_approval()
 from __future__ import annotations
 
 
-"""Analyze rendered avatars and log emotional context."""
+"""Analyze rendered avatars and log emotional context.
+
+Directory watching and advanced emotion models are deferred. When the optional
+``watchdog`` package or vision models are missing, a stub entry is written to
+``logs/council_blessing_log.jsonl``.
+"""
 from logging_config import get_log_path
 
 import argparse
 import json
 import os
+import time
 from datetime import datetime
 from pathlib import Path
+from typing import List
+import warnings
 
 import emotion_utils as eu
 
@@ -53,14 +61,66 @@ def log_reflection(image: str, mood: str, note: str = "") -> dict:
     return entry
 
 
+def process_directory(dir_path: Path) -> List[dict]:
+    """Analyze all image files in ``dir_path`` and log reflections."""
+    results: List[dict] = []
+    if not dir_path.exists():
+        warnings.warn(f"reflection directory {dir_path} missing")
+        log_reflection(str(dir_path), "serene", "directory missing – deferred")
+        return results
+    for item in sorted(dir_path.iterdir()):
+        if item.suffix.lower() not in {".png", ".jpg", ".jpeg"}:
+            continue
+        mood = analyze_image(item)
+        results.append(log_reflection(str(item), mood))
+    return results
+
+
+def watch(dir_path: Path, interval: float = 2.0) -> None:  # pragma: no cover - runtime loop
+    """Watch ``dir_path`` for new images and log reflections."""
+    try:
+        from watchdog.observers import Observer  # type: ignore[import-untyped]
+        from watchdog.events import FileSystemEventHandler  # type: ignore[import-untyped]
+    except Exception:
+        warnings.warn("watchdog not installed; watch loop disabled")
+        log_reflection(str(dir_path), "serene", "watchdog missing – feature deferred")
+        return
+
+    class Handler(FileSystemEventHandler):
+        def on_created(self, event) -> None:  # type: ignore[override]
+            if event.is_directory:
+                return
+            path = Path(event.src_path)
+            if path.suffix.lower() not in {".png", ".jpg", ".jpeg"}:
+                return
+            mood = analyze_image(path)
+            log_reflection(str(path), mood, "auto")
+
+    observer = Observer()
+    observer.schedule(Handler(), str(dir_path), recursive=False)
+    observer.start()
+    try:
+        while True:
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Reflect on rendered avatar image")
-    ap.add_argument("image")
+    ap.add_argument("image", nargs="?")
     ap.add_argument("--note", default="")
+    ap.add_argument("--watch", action="store_true", help="watch a directory")
     args = ap.parse_args()
-    mood = analyze_image(Path(args.image))
-    entry = log_reflection(args.image, mood, args.note)
-    print(json.dumps(entry, indent=2))
+    if args.watch and args.image:
+        watch(Path(args.image))
+    else:
+        if not args.image:
+            ap.error("image path required")
+        mood = analyze_image(Path(args.image))
+        entry = log_reflection(args.image, mood, args.note)
+        print(json.dumps(entry, indent=2))
 
 
 if __name__ == "__main__":

--- a/avatar_relic_creator.py
+++ b/avatar_relic_creator.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+import warnings
 
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
@@ -14,6 +15,14 @@ require_lumos_approval()
 
 LOG_PATH = get_log_path("avatar_relics.jsonl", "AVATAR_RELIC_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+COUNCIL_LOG = get_log_path("council_blessing_log.jsonl")
+
+"""Create and log avatar relics.
+
+Fragments are pulled from ``memory_manager`` and recorded. Visual asset
+creation remains a stub. When invoked a council blessing entry is written to
+``logs/council_blessing_log.jsonl``.
+"""
 
 
 def log_relic(avatar: str, relic: str, info: dict[str, Any]) -> dict[str, Any]:
@@ -26,6 +35,19 @@ def log_relic(avatar: str, relic: str, info: dict[str, Any]) -> dict[str, Any]:
     with LOG_PATH.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
     return entry
+
+
+def generate_visual_relic(entry: dict[str, Any]) -> None:
+    """Placeholder for future 3D relic generation."""
+    warnings.warn("visual relic generation not implemented")
+    council = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "event": "relic-stub",
+        "avatar": entry.get("avatar"),
+        "relic": entry.get("relic"),
+    }
+    with COUNCIL_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(council) + "\n")
 
 
 def extract(avatar: str, relic: str) -> dict[str, Any]:
@@ -43,7 +65,9 @@ def extract(avatar: str, relic: str) -> dict[str, Any]:
     if not info["fragments"]:
         info["note"] = "relic placeholder"
 
-    return log_relic(avatar, relic, info)
+    entry = log_relic(avatar, relic, info)
+    generate_visual_relic(entry)
+    return entry
 
 
 def main() -> None:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -87,6 +87,8 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `AVATAR_MEMORY_LINK_LOG` | Path for avatar memory link records | `logs/avatar_memory_link.jsonl` |
 | `AVATAR_COUNCIL_LOG` | Council voting history for avatars | `logs/avatar_council_log.jsonl` |
 | `AVATAR_RETIRE_LOG` | Log of avatar retirement events | `logs/avatar_retirement.jsonl` |
+| `AVATAR_RELIC_LOG` | Path for avatar relic entries | `logs/avatar_relics.jsonl` |
+| `AVATAR_REFLECTION_LOG` | Path for avatar mood reflections | `logs/avatar_reflection.jsonl` |
 | `BACKCHANNEL_DELAY` | Seconds of idle time before voice loop stops | `5` |
 | `BRIDGE_CHECK_SEC` | Interval for bridge watchdog checks | `5` |
 | `BRIDGE_RESTART_CMD` | Command used to restart the Neos bridge | *(none)* |


### PR DESCRIPTION
## Summary
- expand `avatar_reflection.py` with directory processing and watch stub
- log council-blessing entries when advanced features are missing
- stub visual relic generation in `avatar_relic_creator.py`
- document avatar tools in README
- document new environment variables `AVATAR_RELIC_LOG` and `AVATAR_REFLECTION_LOG`

## Testing
- `pytest -q`
- `mypy avatar_relic_creator.py avatar_reflection.py` *(fails: many repo-wide type errors)*

------
https://chatgpt.com/codex/tasks/task_b_684debce2a348320978736265170628d