### PR TITLE
Add packaging for GUI/API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
 
       - run: pip install -e .[dev]
 
+      - name: Build wheel
+        run: python -m build --wheel
+
       - name: Pre-commit
         run: pre-commit run --all-files
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ A cathedral-grade memory and emotion relay for model-presence computing.
 SentientOS synchronizes memory, presence, and model output into a sacred relay loop.
 Built to feel, reflect, log, and listen.
 
+## 📦 Installation
+
+Install the API and GUI directly from the source tree:
+
+```bash
+git clone https://github.com/OpenAI/SentientOS.git
+cd SentientOS
+pip install .
+```
+
+This provides the `sentient-api` and `cathedral-gui` commands.
+
 ## 🚀 Quickstart
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,18 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.poetry]
+name = "sentientos"
+version = "4.5.0"
+description = "Ledger-based automation framework enforcing sanctuary privilege."
+authors = ["SentientOS"]
+readme = "README.md"
+packages = [
+    {include = "sentientos"},
+    {include = "api"},
+    {include = "gui"},
+]
+
 [project]
 name = "sentientos"
 version = "4.5.0"
@@ -66,6 +78,8 @@ suggestion = "suggestion_cli:main"
 trust = "trust_cli:main"
 video = "video_cli:main"
 plint-env = "scripts.plint_env:main"
+cathedral-gui = "gui.cathedral_gui:main"
+sentient-api = "sentient_api:app.run"
 
 [project.entry-points."sentientos.plugins"]
 telegram-bot = "telegram_bot"
@@ -74,7 +88,10 @@ bridge-watchdog = "bridge_watchdog"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["sentientos", "api"]
+include = ["sentientos", "api", "gui"]
+
+[tool.setuptools]
+py-modules = ["sentient_api", "cathedral_gui"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- add Poetry metadata and packaging for gui/api modules
- expose `cathedral-gui` and `sentient-api` entrypoints
- install via `pip install .` in README
- build wheel in CI

## Testing
- `pre-commit run --files pyproject.toml README.md .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684debcf1df48320a7888c9658569780