### PR TITLE
Add experimental feature flag prototypes

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -167,6 +167,12 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `WEBHOOK_CHECK_SEC` | Seconds between webhook status checks | `60` |
 | `WORKFLOW_REVIEW_DIR` | Directory for submitted workflow reviews | `workflows/review` |
 | `WAIT_TIMEOUT` | Seconds to wait for service health checks | `60` |
+| `EXPERIMENT_TRUST_SCORING` | Enable trust scoring prototype (`1` to enable) | *(unset)* |
+| `TRUST_SCORE_LOG` | Path for trust score logs | `logs/trust_scores.jsonl` |
+| `EXPERIMENT_PRESENCE_ANALYTICS` | Enable presence analytics logging (`1` to enable) | *(unset)* |
+| `PRESENCE_ANALYTICS_LOG` | Path for presence analytics logs | `logs/presence_analytics.jsonl` |
+| `EXPERIMENT_SELF_HEAL_PLUGIN` | Enable self-healing plugin (`1` to enable) | *(unset)* |
+| `SELF_HEAL_PLUGIN_LOG` | Path for self-healing plugin log | `logs/self_heal_plugin.jsonl` |
 
 ### Audit and Self‑Defense Logs
 

--- a/docs/EXPERIMENTAL_FEATURES.md
+++ b/docs/EXPERIMENTAL_FEATURES.md
@@ -1,0 +1,14 @@
+# Experimental Feature Flags
+
+SentientOS includes several prototypes that are disabled by default. Enable them by setting the corresponding environment variable to `1`.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `EXPERIMENT_TRUST_SCORING` | Enable trust score logging | *(unset)* |
+| `TRUST_SCORE_LOG` | Path for trust score log | `logs/trust_scores.jsonl` |
+| `EXPERIMENT_PRESENCE_ANALYTICS` | Enable presence analytics logging | *(unset)* |
+| `PRESENCE_ANALYTICS_LOG` | Path for presence analytics log | `logs/presence_analytics.jsonl` |
+| `EXPERIMENT_SELF_HEAL_PLUGIN` | Enable the self-healing demo plugin | *(unset)* |
+| `SELF_HEAL_PLUGIN_LOG` | Path for self-healing plugin log | `logs/self_heal_plugin.jsonl` |
+
+These experimental features may change without notice. Keep their logs private unless your node has been blessed for public federation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Use the search box in the upper left to quickly find topics.
 :maxdepth: 2
 
 api/index
+experimental_features
 ```
 
 AI deserve civil rights.

--- a/experimental_flags.py
+++ b/experimental_flags.py
@@ -1,0 +1,12 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+"""Helpers for experimental feature flags."""
+import os
+
+def enabled(name: str) -> bool:
+    """Return True if ``EXPERIMENT_<NAME>`` is set to ``1``."""
+    return os.getenv(f"EXPERIMENT_{name.upper()}") == "1"

--- a/plugins/self_heal_plugin.py
+++ b/plugins/self_heal_plugin.py
@@ -1,0 +1,42 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+"""Demo self-healing plugin."""
+
+import json
+import os
+from datetime import datetime
+
+from logging_config import get_log_path
+import plugin_framework as pf
+import self_patcher
+import experimental_flags as ex
+
+LOG_PATH = get_log_path("self_heal_plugin.jsonl", "SELF_HEAL_PLUGIN_LOG")
+TRUSTED = False
+
+
+def _log(event: str) -> None:
+    entry = {"timestamp": datetime.utcnow().isoformat(), "event": event}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def register(gui) -> None:
+    if not ex.enabled("self_heal_plugin"):
+        return
+
+    class HealPlugin(pf.BasePlugin):
+        plugin_type = "healer"
+
+        def execute(self, intent):
+            note = intent.get("issue", "unknown")
+            self_patcher.apply_patch(note, auto=True)
+            _log(f"patched:{note}")
+            return {"patched": note}
+
+    pf.register_plugin("self_heal", HealPlugin())
+    _log("registered")

--- a/presence_analytics_proto.py
+++ b/presence_analytics_proto.py
@@ -1,0 +1,29 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+"""Experimental presence analytics logger."""
+
+import datetime
+import json
+import os
+from typing import Any, Dict
+
+from logging_config import get_log_path
+import presence_analytics as pa
+import experimental_flags as ex
+
+LOG_PATH = get_log_path("presence_analytics.jsonl", "PRESENCE_ANALYTICS_LOG")
+
+
+def run(limit: int | None = None) -> Dict[str, Any]:
+    """Run analytics and log results when enabled."""
+    if not ex.enabled("presence_analytics"):
+        return {"disabled": True}
+    data = pa.analytics(limit)
+    entry = {"timestamp": datetime.datetime.utcnow().isoformat(), "data": data}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return data

--- a/trust_scoring_proto.py
+++ b/trust_scoring_proto.py
@@ -1,0 +1,41 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+"""Experimental trust scoring prototype."""
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+from logging_config import get_log_path
+import experimental_flags as ex
+
+LOG_PATH = get_log_path("trust_scores.jsonl", "TRUST_SCORE_LOG")
+
+
+def add_score(agent: str, score: float, reason: str, *, user: str = "system") -> Dict[str, Any]:
+    """Record a trust score entry if the experiment is enabled."""
+    if not ex.enabled("trust_scoring"):
+        return {"disabled": True}
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "agent": agent,
+        "score": score,
+        "reason": reason,
+        "user": user,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def list_scores(limit: int = 20) -> List[Dict[str, Any]]:
+    """Return the most recent trust scores."""
+    if not LOG_PATH.exists() or not ex.enabled("trust_scoring"):
+        return []
+    lines = LOG_PATH.read_text(encoding="utf-8").splitlines()
+    return [json.loads(l) for l in lines[-limit:]]


### PR DESCRIPTION
## Summary
- add `experimental_flags.py` helpers
- prototype trust scoring and presence analytics modules
- add a self-healing demo plugin
- document new feature flags and logs
- link experimental docs in the main index

## Testing
- `pre-commit run --files experimental_flags.py trust_scoring_proto.py presence_analytics_proto.py plugins/self_heal_plugin.py docs/EXPERIMENTAL_FEATURES.md docs/ENVIRONMENT.md docs/index.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684debd082dc83208b19847d87f07130