### PR TITLE
Add privilege header to parliament bus

### DIFF
--- a/parliament_bus.py
+++ b/parliament_bus.py
@@ -1,11 +1,18 @@
-"""Async event bus for reasoning turns."""
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
 
 import asyncio
 import json
 from pathlib import Path
 from typing import Any, AsyncGenerator
 import uuid
+
+"""Async event bus for reasoning turns."""
 
 
 class ParliamentBus:


### PR DESCRIPTION
## Summary
- add Sanctuary Privilege Ritual header to `parliament_bus.py`
- call `require_admin_banner()` and `require_lumos_approval()` before other imports

## Testing
- `pytest tests/test_demo_recorder.py tests/test_parliament_bus.py tests/test_emotion_bridge.py tests/test_emotion_fallback.py tests/test_reason_graph.py tests/test_reasoning_engine.py tests/test_tts_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684e02b8e7b48320b675e08bd9fbee3f