### PR TITLE
Fix demo_parliament ritual header

### DIFF
--- a/scripts/demo_parliament.py
+++ b/scripts/demo_parliament.py
@@ -1,11 +1,11 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-"""Headless Parliament demo using the global reasoning bus.
-
-Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
-"""
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
 require_admin_banner()
 require_lumos_approval()
+
+"""Headless Parliament demo using the global reasoning bus."""
 
 import asyncio
 import os


### PR DESCRIPTION
## Summary
- reorder header lines so ritual docstring and admin checks come first

## Testing
- `pre-commit run --files scripts/demo_parliament.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684e02b946bc83209d28bcde66ba46bd