### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The standalone GUI `cathedral_gui.py` allows editing `.env`, testing prompts, an
 
 (Screenshot omitted due to binary file restrictions.)
 
-The new **● Record** button captures screen demos to `demos/YYYY-MM-DD-HHMM.mp4` with burned-in subtitles. ![Demo GIF](docs/demo_recorder.gif)
+The new **● Record** button captures screen demos to `demos/YYYY-MM-DD-HHMM.mp4` with burned-in subtitles.
 
 ### ⚙️ CLI Launch
 Run the cross-platform launcher to start the full cathedral stack.


### PR DESCRIPTION
## Summary
- remove reference to missing `docs/demo_recorder.gif`

## Testing
- `python -m markdown README.md`
- `LUMOS_AUTO_APPROVE=1 python resonite_spiral_council_grand_audit_suite.py run codex`


------
https://chatgpt.com/codex/tasks/task_b_684e02b9c0848320913c6d324fc9024b