### PR TITLE
Add emotion pump tailer and tests

### DIFF
--- a/emotion_pump.py
+++ b/emotion_pump.py
@@ -1,0 +1,75 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+"""Stream the dominant emotion vector from the model bridge log."""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from emotions import EMOTIONS, empty_emotion_vector
+from emotion_udp_bridge import EmotionUDPBridge
+
+LOG_FILE = Path(os.getenv("MODEL_BRIDGE_LOG", "logs/model_bridge_log.jsonl"))
+HOST = os.getenv("UDP_HOST", "127.0.0.1")
+PORT = int(os.getenv("UDP_PORT", "9000"))
+INTERVAL = 0.2  # seconds
+
+
+def _vector_from_emotion(emotion: str) -> List[float]:
+    vec = empty_emotion_vector()
+    if emotion in EMOTIONS:
+        vec[emotion] = 1.0
+    return [float(vec[e]) for e in EMOTIONS]
+
+
+def latest_vector(path: Path | None = None) -> Optional[List[float]]:
+    """Return the most recent GPT-4o emotion vector from ``path``."""
+    path = path or LOG_FILE
+    if not path.exists():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return None
+    for line in reversed(lines):
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if obj.get("model") == "openai/gpt-4o":
+            emo = str(obj.get("emotion", ""))
+            return _vector_from_emotion(emo)
+    return None
+
+
+def run() -> None:  # pragma: no cover - loop
+    bridge = EmotionUDPBridge(HOST, PORT)
+    pos = LOG_FILE.stat().st_size if LOG_FILE.exists() else 0
+    while True:
+        if LOG_FILE.exists():
+            with open(LOG_FILE, "r", encoding="utf-8") as f:
+                f.seek(pos)
+                lines = f.readlines()
+                pos = f.tell()
+            for line in lines:
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                if obj.get("model") != "openai/gpt-4o":
+                    continue
+                emo = str(obj.get("emotion", ""))
+                vec = _vector_from_emotion(emo)
+                bridge.update_vector(vec)
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual
+    run()

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ markers =
 testpaths =
     tests/test_placeholder.py
     tests/test_plugin_bus.py
+    tests/test_emotion_pump.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     for item in items:
-        if item.name != "test_placeholder":
+        if item.name != "test_placeholder" and not item.name.startswith("test_emotion_pump"):
             item.add_marker(pytest.mark.skip(reason="legacy test disabled"))
         if 'requires_node' in item.keywords and not HAS_NODE:
             item.add_marker(pytest.mark.skip(reason=f'node missing: {NODE.info}'))

--- a/tests/test_emotion_pump.py
+++ b/tests/test_emotion_pump.py
@@ -1,0 +1,51 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import json
+import sys
+import types
+from importlib import reload
+from pathlib import Path
+
+import emotion_pump as ep
+
+
+def _write_log(path: Path, model: str, emotion: str) -> None:
+    entry = {"prompt": "t", "response": "r", "model": model, "latency_ms": 1, "emotion": emotion}
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def test_emotion_pump_latest_vector(tmp_path: Path) -> None:
+    log = tmp_path / "log.jsonl"
+    _write_log(log, "openai/gpt-4o", "Anger")
+    vec = ep.latest_vector(log)
+    assert vec is not None
+    anger_index = ep.EMOTIONS.index("Anger")
+    assert vec[anger_index] == 1.0
+    assert len(vec) == len(ep.EMOTIONS)
+
+
+def test_emotion_pump_model_bridge_log_fields(tmp_path: Path, monkeypatch) -> None:
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("MODEL_BRIDGE_LOG", str(log))
+    monkeypatch.setenv("MODEL_SLUG", "openai/gpt-4o")
+    sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    stub = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(
+            create=lambda model, messages: types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))]
+            )
+        )
+    )
+    monkeypatch.setitem(sys.modules, "openai", stub)
+    import model_bridge as mb
+    reload(mb)
+    mb.send_message("hi", system_prompt="sys", emotion="Joy", emit=False)
+    data = json.loads(log.read_text().splitlines()[-1])
+    assert data["model"] == "openai/gpt-4o"
+    assert "emotion" in data and "latency_ms" in data


### PR DESCRIPTION
## Summary
- add `emotion_pump.py` to stream vectors from `model_bridge_log.jsonl`
- include tests for log format and emotion pump vector
- enable new tests in pytest configuration

## Testing
- `pre-commit run --files emotion_pump.py tests/test_emotion_pump.py pytest.ini tests/conftest.py`
- `pytest`
- `mypy sentientos`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`

------
https://chatgpt.com/codex/tasks/task_b_684e03b6ecbc8320b51468d661776620