### PR TITLE
Ensure GUI profile reload

### DIFF
--- a/cathedral_gui.py
+++ b/cathedral_gui.py
@@ -272,6 +272,7 @@ class RelayGUI:
             out_lines.append(f"{k}={env[k]}")
         ENV_PATH.write_text("\n".join(out_lines))
         load_dotenv(ENV_PATH, override=True)
+        pm.switch_profile(self.profile_var.get())
 
     def start_relay(self) -> None:
         if self.proc:

--- a/tests/integration/test_env_reload.py
+++ b/tests/integration/test_env_reload.py
@@ -1,0 +1,44 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import subprocess
+import importlib
+import sys
+from pathlib import Path
+
+import profile_manager as pm
+
+
+def test_cli_reads_updated_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(pm)
+    monkeypatch.setattr(pm, "PROFILES_DIR", tmp_path / "profiles", raising=False)
+    pm.PROFILES_DIR.mkdir()
+    monkeypatch.setattr(pm, "CURRENT_FILE", pm.PROFILES_DIR / ".current", raising=False)
+    monkeypatch.setattr(pm, "HOME_CURRENT", tmp_path / ".sentientos_profile", raising=False)
+
+    pm.create_profile("default")
+    env_path = pm.PROFILES_DIR / "default" / ".env"
+    env_path.write_text("MODEL_SLUG=mixtral\n")
+    pm.switch_profile("default")
+
+    def run_cli() -> str:
+        cp = subprocess.run(
+            [sys.executable, "-c", "import os; print(os.getenv('MODEL_SLUG'))"],
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+        )
+        return cp.stdout.strip()
+
+    assert run_cli() == "mixtral"
+
+    env_path.write_text("MODEL_SLUG=openai/gpt-4o\n")
+    pm.switch_profile("default")
+
+    assert run_cli() == "openai/gpt-4o"

--- a/tests/test_gui_save.py
+++ b/tests/test_gui_save.py
@@ -1,0 +1,42 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import types
+import importlib
+
+import cathedral_gui as cg
+import profile_manager as pm
+
+
+def test_save_triggers_profile_switch(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+
+    importlib.reload(cg)
+    monkeypatch.setattr(cg, "ENV_PATH", env, raising=False)
+    monkeypatch.setitem(cg.__dict__, "END", "end")
+    monkeypatch.setattr(cg, "messagebox", types.SimpleNamespace(showerror=lambda *a, **k: None))
+
+    called = {}
+
+    def _switch(name: str) -> None:
+        called["name"] = name
+
+    monkeypatch.setattr(pm, "switch_profile", _switch)
+
+    gui = types.SimpleNamespace(
+        key_var=types.SimpleNamespace(get=lambda: "k"),
+        model_var=types.SimpleNamespace(get=lambda: cg.MODEL_OPTIONS[0]),
+        prompt_txt=types.SimpleNamespace(get=lambda *a, **k: "prompt"),
+        url_var=types.SimpleNamespace(get=lambda: "http://u"),
+        profile_var=types.SimpleNamespace(get=lambda: "default"),
+    )
+    cg.RelayGUI.save(gui)
+
+    assert called["name"] == "default"
+    data = env.read_text()
+    assert "MODEL_SLUG" in data


### PR DESCRIPTION
## Summary
- reload profile via profile_manager when saving GUI settings
- verify GUI save reloads profile
- check CLI uses updated `.env` values

## Testing
- `pre-commit run --files cathedral_gui.py tests/test_gui_save.py tests/integration/test_env_reload.py`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --no-input`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e03b7dd18832091bb4c20bc9b776e