### PR TITLE
Add bridge metadata to presence log

### DIFF
--- a/presence_ledger.py
+++ b/presence_ledger.py
@@ -15,6 +15,9 @@ from log_utils import append_json
 LEDGER_PATH: Path = get_log_path("user_presence.jsonl", "USER_PRESENCE_LOG")
 LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
 
+# Bridge metadata for presence entries
+BRIDGE_NAME = os.getenv("PRESENCE_BRIDGE", os.getenv("BRIDGE", "cli"))
+
 
 class StatsSummary(TypedDict):
     events: Dict[str, int]
@@ -41,19 +44,20 @@ class RecapData(TypedDict):
     milestones: List[str]
 
 
-def log(user: str, event: str, note: str = "") -> None:
+def log(user: str, event: str, note: str = "", bridge: str | None = None) -> None:
     """Record a general presence event."""
     entry = {
         "time": datetime.utcnow().isoformat(),
         "user": user,
         "event": event,
         "note": note,
+        "bridge": bridge or BRIDGE_NAME,
     }
     append_json(LEDGER_PATH, entry)
 
 
 def log_privilege(
-    user: str, platform: str, tool: str, status: str
+    user: str, platform: str, tool: str, status: str, bridge: str | None = None
 ) -> None:
     """Record a privilege check attempt."""
     entry = {
@@ -63,6 +67,7 @@ def log_privilege(
         "user": user,
         "platform": platform,
         "tool": tool,
+        "bridge": bridge or BRIDGE_NAME,
     }
     append_json(LEDGER_PATH, entry)
 

--- a/tests/test_model_presence_unity.py
+++ b/tests/test_model_presence_unity.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import json
+import importlib
+import os
+from pathlib import Path
+
+import presence_ledger as pl
+
+
+def test_presence_bridge_metadata(tmp_path, monkeypatch):
+    path = tmp_path / "user_presence.jsonl"
+    monkeypatch.setenv("USER_PRESENCE_LOG", str(path))
+    monkeypatch.setenv("PRESENCE_BRIDGE", "telegram")
+    importlib.reload(pl)
+    pl.log("alice", "greet")
+    pl.log_privilege("alice", "Linux", "tool", "success")
+    lines = [json.loads(x)["data"] for x in path.read_text().splitlines()]
+    assert all(entry.get("bridge") == "telegram" for entry in lines)

--- a/tests/test_presence_ledger.py
+++ b/tests/test_presence_ledger.py
@@ -38,6 +38,7 @@ def test_recent_privilege_attempts(tmp_path, monkeypatch):
 def test_log_privilege(tmp_path, monkeypatch):
     path = tmp_path / "user_presence.jsonl"
     monkeypatch.setenv("USER_PRESENCE_LOG", str(path))
+    monkeypatch.setenv("PRESENCE_BRIDGE", "test")
     import importlib
     importlib.reload(pl)
     pl.log_privilege("tester", "Linux", "tool", "success")
@@ -47,6 +48,7 @@ def test_log_privilege(tmp_path, monkeypatch):
     assert info["platform"] == "Linux"
     assert info["tool"] == "tool"
     assert info["status"] == "success"
+    assert info["bridge"] == "test"
 
 
 def test_music_stats(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- include `bridge` metadata in `presence_ledger` entries
- check bridge field in presence ledger tests
- add new test for presence log bridge metadata

## Testing
- `LUMOS_AUTO_APPROVE=1 pre-commit run --files presence_ledger.py tests/test_presence_ledger.py tests/test_model_presence_unity.py`
- `pytest -q`
- `mypy sentientos`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684e03b865688320a96fd5558e7b6335