### PR TITLE
Fix duplicate import in council_onboarding

### DIFF
--- a/council_onboarding.py
+++ b/council_onboarding.py
@@ -7,7 +7,6 @@ require_lumos_approval()
 """Council Member Onboarding & Quorum Ritual
 
 """
-from __future__ import annotations
 from logging_config import get_log_path
 
 import argparse


### PR DESCRIPTION
## Summary
- remove the repeated `from __future__ import annotations` from `council_onboarding.py`

## Testing
- `pre-commit run --files council_onboarding.py`
- `pytest`
- `mypy`
- `python verify_audits.py logs/`


------
https://chatgpt.com/codex/tasks/task_b_684e0a26e570832084d07e9023f5709c