### PR TITLE
Add env hint for audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Cathedral CI
         run: python scripts/ci_self_check.py
+        env:
+          LUMOS_AUTO_APPROVE: '1'
 
       - uses: actions/cache@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,11 @@ errors:
 - name: Type check
   run: mypy --strict
 - name: Verify audits
-  run: python verify_audits.py logs/
+  run: LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/
 ```
+
+When running `verify_audits.py` manually, set `LUMOS_AUTO_APPROVE=1` or use
+`--no-input` to bypass the Lumos blessing prompt.
 
 ## Ritual Etiquette
 Commit messages should be calm and descriptive. Mention the module affected and the blessing performed.

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -217,7 +217,10 @@ def verify_audits(
 def main() -> None:  # pragma: no cover - CLI
     import argparse
 
-    ap = argparse.ArgumentParser(description="Audit log verifier")
+    ap = argparse.ArgumentParser(
+        description="Audit log verifier",
+        epilog="Set LUMOS_AUTO_APPROVE=1 to bypass prompts.",
+    )
     ap.add_argument("path", nargs="?", help="Log directory or single file")
     ap.add_argument(
         "--repair",


### PR DESCRIPTION
## Summary
- note LUMOS_AUTO_APPROVE in CONTRIBUTING
- export approval flag in CI workflow
- document env var in verify_audits help message

## Testing
- `pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md verify_audits.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e0a2758a883208c0ddd84afcc47a6