### PR TITLE
Add presence log and profile bridge propagation

### DIFF
--- a/plugins/escalate.py
+++ b/plugins/escalate.py
@@ -8,13 +8,15 @@ require_lumos_approval()
 from api.actuator import BaseActuator
 import memory_manager as mm
 import plugin_framework as pf
+import presence_ledger as pl
 
 
 def register(gui: "CathedralGUI") -> None:
     class EscalateActuator(BaseActuator):
         def execute(self, intent):
             text = f"Escalation for {intent.get('goal')}: {intent.get('text','')}"
-            mm.append_memory(text, tags=["escalation"], source="escalate")
-            return {"escalated": intent.get('goal')}
+            fid = mm.append_memory(text, tags=["escalation"], source="escalate")
+            pl.log("plugin", "escalate", text)
+            return {"escalated": intent.get('goal'), "log_id": fid}
 
     pf.register_plugin('escalate', EscalateActuator())

--- a/presence_ledger.py
+++ b/presence_ledger.py
@@ -14,6 +14,8 @@ from log_utils import append_json
 
 LEDGER_PATH: Path = get_log_path("user_presence.jsonl", "USER_PRESENCE_LOG")
 LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+PRESENCE_LOG: Path = get_log_path("presence_log.jsonl", "PRESENCE_LOG")
+PRESENCE_LOG.parent.mkdir(parents=True, exist_ok=True)
 
 # Bridge metadata for presence entries
 BRIDGE_NAME = os.getenv("PRESENCE_BRIDGE", os.getenv("BRIDGE", "cli"))
@@ -54,6 +56,7 @@ def log(user: str, event: str, note: str = "", bridge: str | None = None) -> Non
         "bridge": bridge or BRIDGE_NAME,
     }
     append_json(LEDGER_PATH, entry)
+    append_json(PRESENCE_LOG, entry)
 
 
 def log_privilege(
@@ -70,6 +73,7 @@ def log_privilege(
         "bridge": bridge or BRIDGE_NAME,
     }
     append_json(LEDGER_PATH, entry)
+    append_json(PRESENCE_LOG, entry)
 
 
 def history(user: str, limit: int = 20) -> List[Dict[str, str]]:

--- a/profile_manager.py
+++ b/profile_manager.py
@@ -71,6 +71,15 @@ def restart_bridges() -> None:
         pass
 
 
+def _propagate_memory_dir(path: Path) -> None:
+    """Notify bridges of the active memory directory."""
+    try:
+        import notification
+        notification.send("profile.switch", {"memory_dir": str(path.resolve())})
+    except Exception:
+        pass
+
+
 def switch_profile(name: str) -> None:
     env = load_env(name)
     for k, v in env.items():
@@ -83,6 +92,7 @@ def switch_profile(name: str) -> None:
     sb.set_current_profile(name)
     flush_agents()
     restart_bridges()
+    _propagate_memory_dir(mem_dir)
 
 
 def create_profile(name: str) -> Path:

--- a/tests/test_model_presence_unity.py
+++ b/tests/test_model_presence_unity.py
@@ -14,10 +14,14 @@ import presence_ledger as pl
 
 def test_presence_bridge_metadata(tmp_path, monkeypatch):
     path = tmp_path / "user_presence.jsonl"
+    full = tmp_path / "presence_log.jsonl"
     monkeypatch.setenv("USER_PRESENCE_LOG", str(path))
+    monkeypatch.setenv("PRESENCE_LOG", str(full))
     monkeypatch.setenv("PRESENCE_BRIDGE", "telegram")
     importlib.reload(pl)
     pl.log("alice", "greet")
     pl.log_privilege("alice", "Linux", "tool", "success")
     lines = [json.loads(x)["data"] for x in path.read_text().splitlines()]
     assert all(entry.get("bridge") == "telegram" for entry in lines)
+    entries = [json.loads(x)["data"] for x in full.read_text().splitlines()]
+    assert len(entries) == len(lines)

--- a/tests/test_plugin_memory_log.py
+++ b/tests/test_plugin_memory_log.py
@@ -1,0 +1,36 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner()
+require_lumos_approval()
+
+import json
+import importlib
+import datetime
+import os
+from pathlib import Path
+
+
+def test_plugin_memory_logged(tmp_path, monkeypatch):
+    mem_dir = tmp_path / "mem"
+    monkeypatch.setenv("MEMORY_DIR", str(mem_dir))
+    monkeypatch.setenv("USER_PRESENCE_LOG", str(tmp_path / "user_presence.jsonl"))
+    monkeypatch.setenv("PRESENCE_LOG", str(tmp_path / "presence_log.jsonl"))
+    monkeypatch.setenv("PRESENCE_BRIDGE", "test_plugin")
+    monkeypatch.setenv("SENTIENTOS_HEADLESS", "1")
+    import plugin_framework as pf
+    import presence_ledger as pl
+    import memory_manager as mm
+    import plugins.escalate as escalate
+    importlib.reload(pl)
+    importlib.reload(mm)
+    importlib.reload(pf)
+    escalate.register(None)
+    pf.run_plugin("escalate", {"goal": "bridge", "text": "check"})
+    mm.summarize_memory()
+    day = datetime.date.today().isoformat()
+    summary = mem_dir / "distilled" / f"{day}.txt"
+    assert summary.exists()
+    log_file = tmp_path / "presence_log.jsonl"
+    entries = [json.loads(l)["data"] for l in log_file.read_text().splitlines()]
+    assert any(e.get("bridge") == "test_plugin" for e in entries)

--- a/tests/test_profiles_swap.py
+++ b/tests/test_profiles_swap.py
@@ -20,9 +20,10 @@ def test_placeholder(tmp_path, monkeypatch):
     monkeypatch.setattr(pm, "CURRENT_FILE", pm.PROFILES_DIR / ".current", raising=False)
     monkeypatch.setattr(pm, "HOME_CURRENT", tmp_path / ".sentientos_profile", raising=False)
 
-    called = {"flush": 0, "restart": 0, "profile": None}
+    called = {"flush": 0, "restart": 0, "profile": None, "prop": None}
     monkeypatch.setattr(pm, "flush_agents", lambda: called.__setitem__("flush", called["flush"] + 1))
     monkeypatch.setattr(pm, "restart_bridges", lambda: called.__setitem__("restart", called["restart"] + 1))
+    monkeypatch.setattr(pm, "_propagate_memory_dir", lambda p: called.__setitem__("prop", str(p)))
     monkeypatch.setattr(sb, "set_current_profile", lambda name: called.__setitem__("profile", name), raising=False)
 
     pm.create_profile("a")
@@ -38,4 +39,5 @@ def test_placeholder(tmp_path, monkeypatch):
     assert called["profile"] == "b"
     assert called["flush"] == 2
     assert called["restart"] == 2
+    assert called["prop"] == str(pm.PROFILES_DIR / "b" / "memory")
     assert Path(pm.HOME_CURRENT).read_text().strip() == "b"


### PR DESCRIPTION
## Summary
- create presence_log.jsonl and log presence events there
- propagate memory directory path via notification when switching profile
- log escalate plugin activity to presence log and return memory id
- test bridge presence logging and plugin memory summarization

## Testing
- `pre-commit run --files presence_ledger.py plugins/escalate.py profile_manager.py tests/test_model_presence_unity.py tests/test_plugin_memory_log.py tests/test_profiles_swap.py`
- `pytest -q`
- `python verify_audits.py` *(fails: requires input)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a285d0c8320bce2509872607b3e