### PR TITLE
Add package launcher instructions and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,21 @@ The launcher creates `.env` and `logs/` if missing, checks for Ollama,
 pulls the Mixtral model when possible, and then opens the local dashboard.
 
 ### 🛠️ Bundled Launcher
-Create packaged executables for your platform:
+Create packaged executables for any platform:
 ```bash
+# Automatically detect the current system
+python scripts/package_launcher.py --platform auto
+
 # Windows
 python scripts/package_launcher.py --platform windows
 
 # macOS (attempts notarization if APPLE_ID and APPLE_PASSWORD are set)
 python scripts/package_launcher.py --platform mac
+
+# Linux
+python scripts/package_launcher.py --platform linux
 ```
-The binaries are placed in `dist/` and run without a Python install.
+The resulting binary or app is placed in `dist/` and runs without a Python install.
 
 ### 📡 Endpoints
 | Route   | Purpose                |

--- a/docs/INSTALLER_FEATURE_CHECKLIST.md
+++ b/docs/INSTALLER_FEATURE_CHECKLIST.md
@@ -31,6 +31,7 @@ The 4.5 series launcher was smoke tested on Windows 11, macOS 14, and Ubuntu 22.
 * Missing Python, GPU issues, or invalid API keys now show helper text in the GUI.
 * `RELAY_LOG_LEVEL` controls INFO/DEBUG output for the relay.
 * The installer checks GitHub Releases and warns if a newer version is available.
+* Run `python scripts/package_launcher.py --platform auto` and confirm a file appears in `dist/`.
 * Latest smoke test results:
   * Windows 11 – pass
   * macOS 14 – pass

--- a/tests/test_package_launcher.py
+++ b/tests/test_package_launcher.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.package_launcher as package_launcher
+
+
+def test_placeholder(tmp_path, monkeypatch):
+    dist = tmp_path / "dist"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["package_launcher.py", "--platform", "auto"])
+
+    def fake_call(cmd, *a, **k):
+        dist.mkdir(exist_ok=True)
+        (dist / "dummy").write_text("ok")
+        return 0
+
+    monkeypatch.setattr(subprocess, "check_call", fake_call)
+    importlib.reload(package_launcher)
+    assert package_launcher.main() == 0
+    assert any(dist.iterdir())


### PR DESCRIPTION
## Summary
- explain how to build launchers for Windows, macOS, Linux, and auto platform
- verify packaging in INSTALLER_FEATURE_CHECKLIST
- add regression test for `scripts/package_launcher.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e0a2864ac8320936a7caeb6d253a2