### PR TITLE
Fix duplicate future import

### DIFF
--- a/blessing_pipeline.py
+++ b/blessing_pipeline.py
@@ -7,7 +7,6 @@ require_lumos_approval()
 """Autonomous Blessing/Approval Pipeline
 
 """
-from __future__ import annotations
 from logging_config import get_log_path
 
 import argparse


### PR DESCRIPTION
## Summary
- remove duplicate __future__ import from blessing_pipeline.py

## Testing
- `pre-commit run --files blessing_pipeline.py` *(fails: privilege-lint missing)*
- `pytest`
- `mypy`
- `python verify_audits.py logs/` *(fails: requires interactive approval)*

------
https://chatgpt.com/codex/tasks/task_b_684ece24d1b48320865fab39ea6978fa