### PR TITLE
Ensure privilege checks in presence ledger

### DIFF
--- a/presence_ledger.py
+++ b/presence_ledger.py
@@ -1,6 +1,10 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
 from logging_config import get_log_path
 import json
 import os


### PR DESCRIPTION
## Summary
- add `require_admin_banner()` and `require_lumos_approval()` to `presence_ledger.py`
- confirm other modules already invoke the required functions

## Testing
- `pre-commit run --files presence_ledger.py -v`
- `pytest -q`
- `mypy`
- `python verify_audits.py` *(fails: Lumos blessing required)*

------
https://chatgpt.com/codex/tasks/task_b_684ece2573bc832087f9ca6ca8288a66