### PR TITLE
Fix duplicate __future__ imports

### DIFF
--- a/tests/test_presence_ledger.py
+++ b/tests/test_presence_ledger.py
@@ -4,7 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 
 
 from logging_config import get_log_path

--- a/unified_memory_indexer.py
+++ b/unified_memory_indexer.py
@@ -4,18 +4,16 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-"""Unified Memory/Knowledge Indexer
 
-"""
-from __future__ import annotations
 from logging_config import get_log_path
-
 import argparse
 import json
 import os
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
+
+
 
 
 LOG_PATH = get_log_path("memory_index.log", "MEMORY_INDEX_LOG")


### PR DESCRIPTION
## Summary
- remove redundant future import in tests
- clean up unified_memory_indexer header

## Testing
- `pre-commit run --files unified_memory_indexer.py tests/test_presence_ledger.py`
- `pytest`
- `mypy`
- `python verify_audits.py logs/ --no-input`

------
https://chatgpt.com/codex/tasks/task_b_68505236be548320a3d6153c6e5df83b