### PR TITLE
Support Linux packaging in launcher

### DIFF
--- a/scripts/package_launcher.py
+++ b/scripts/package_launcher.py
@@ -119,7 +119,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Bundle cathedral launcher")
     parser.add_argument(
         "--platform",
-        choices=["auto", "windows", "mac"],
+        choices=["auto", "windows", "mac", "linux"],
         default="auto",
         help="Target platform",
     )


### PR DESCRIPTION
## Summary
- allow `--platform linux` in `package_launcher.py`

## Testing
- `pre-commit run --files scripts/package_launcher.py README.md`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint.py`


------
https://chatgpt.com/codex/tasks/task_b_6850523841088320bbdd951ad4c56b07