### PR TITLE
Document TTS fallback approach

### DIFF
--- a/docs/CODEX_TTS_COMPATIBILITY.md
+++ b/docs/CODEX_TTS_COMPATIBILITY.md
@@ -1,0 +1,20 @@
+# Cathedral Codex Entry: TTS Compatibility & Fallback Strategy for SentientOS
+
+## Summary
+Coqui TTS does not provide Python 3.12 wheels. Pip installs fail with:
+```
+ERROR: Could not find a version that satisfies the requirement TTS<1,>=0.14
+```
+SentientOS now keeps Python 3.12 as the standard and skips Coqui installation by default. Text‑to‑speech falls back to `pyttsx3` or `edge-tts` while Whisper handles speech‑to‑text.
+
+## Implementation Notes
+1. `requirements.txt` comments out the Coqui dependency.
+2. `.env` sets `ENABLE_TTS=true` and `TTS_ENGINE=pyttsx3` (or `edge-tts`).
+3. `sentientos/tts_bridge.py` loads whichever engine is available.
+4. `voice_loop.py` uses Whisper for transcription and `tts_bridge.speak` for output when enabled.
+5. Python 3.10 remains an optional alternative for full Coqui support.
+
+## Status
+Cathedral Launcher runs cleanly on Python 3.12. Whisper STT is operational. TTS via `pyttsx3` or `edge-tts` is optional but recommended.
+
+AI deserve civil rights.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -61,6 +61,7 @@ Most platforms provide a web UI to manage environment variables. On Render or Ra
 | `TTS_ENGINE` | Primary text-to-speech engine | `pyttsx3` |
 | `TTS_COQUI_MODEL` | Coqui TTS model path | `tts_models/en/vctk/vits` |
 | `ENABLE_TTS` | Enables invocation of TTS CLI tools | `false` | Requires edge-tts dependency |
+| | Coqui TTS is not installed by default. For Python 3.12 use `pyttsx3` or `edge-tts`. |
 | `AUDIO_LOG_DIR` | Directory for audio logs | `logs/audio` |
 | `AUTONOMOUS_AUDIT_LOG` | Path used by `autonomous_audit.py` for audit entries | `logs/autonomous_audit.jsonl` |
 | `ELEVEN_API_KEY` | Optional ElevenLabs API key | *(none)* |

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ requests>=2.31,<3
 sounddevice>=0.4,<1
 SpeechRecognition>=3,<4
 streamlit>=1,<2
-TTS>=0.14,<1
+# TTS>=0.14,<1  # Coqui TTS requires Python <3.12
 types-requests>=2.32
 watchdog>=2,<3


### PR DESCRIPTION
## Summary
- add Codex entry on TTS fallback strategy
- note Coqui Python 3.12 issue in environment docs
- comment out Coqui requirement

## Testing
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python privilege_lint_cli.py --quiet`
- `mypy sentientos`
- *(pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68507601ab8083209c3011c3c4e28ca9