### PR TITLE
Fix cross-platform admin detection

### DIFF
--- a/admin_utils.py
+++ b/admin_utils.py
@@ -15,7 +15,7 @@ import platform
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     import presence_ledger as pl_module
@@ -76,8 +76,10 @@ def is_admin() -> bool:
             return bool(windll.shell32.IsUserAnAdmin())
         except Exception:
             return False
-    else:
-        return os.geteuid() == 0
+    geteuid: Callable[[], int] | None = getattr(os, "geteuid", None)
+    if geteuid is not None:
+        return geteuid() == 0
+    return False
 
 
 def require_admin_banner() -> None:


### PR DESCRIPTION
## Summary
- ensure `os.geteuid()` is used only when available
- sort imports

## Testing
- `pre-commit run --files admin_utils.py tests/test_admin_utils.py`
- `pytest -q tests/test_admin_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_68507affd6e08320a133734d634031b5