### PR TITLE
Add cathedral GUI via Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ python -m gui.cathedral_gui
 ```
 The standalone GUI `gui/cathedral_gui.py` allows editing `.env`, testing prompts, and exporting logs. It includes dropdowns for model selection and an emotion selector.
 
+For a lightweight Streamlit interface run:
+
+```bash
+streamlit run cathedral_gui.py
+```
+
 (Screenshot omitted due to binary file restrictions.)
 
 The new **● Record** button captures screen demos to `demos/YYYY-MM-DD-HHMM.mp4` with burned-in subtitles.

--- a/cathedral_gui.py
+++ b/cathedral_gui.py
@@ -1,0 +1,34 @@
+import streamlit as st
+
+SECTIONS = ["Blessings", "Memory Map", "Emotion State", "Ritual Log"]
+
+def main() -> None:
+    """Render the Cathedral GUI."""
+    st.set_page_config(page_title="Cathedral GUI")
+    st.sidebar.title("Navigation")
+    choice = st.sidebar.radio("Section", SECTIONS)
+    st.title("Cathedral GUI")
+
+    if choice == "Blessings":
+        st.subheader("Blessings")
+        st.write(
+            "Displays user blessing history, confirmation triggers, and upcoming ceremonies."
+        )
+    elif choice == "Memory Map":
+        st.subheader("Memory Map")
+        st.write(
+            "Shows indexed memory events with timestamp and priority indicators."
+        )
+    elif choice == "Emotion State":
+        st.subheader("Emotion State")
+        st.write(
+            "Visualizes current emotion vectors and mood deltas."
+        )
+    elif choice == "Ritual Log":
+        st.subheader("Ritual Log")
+        st.write(
+            "Offers an audit-style scroll of ceremonial activity, aligned with presence pulses."
+        )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold `cathedral_gui.py` as a Streamlit interface
- document how to launch it in the README

## Testing
- `pytest -q tests/test_gui_validation.py tests/test_gui_save.py` *(fails: ImportError and missing dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6851568ac35c83209c47c324bf9bf166