### PR TITLE
Fix and log launch_sentientos.bat

### DIFF
--- a/launch_sentientos.bat
+++ b/launch_sentientos.bat
@@ -9,10 +9,11 @@ cd /d %SCRIPT_DIR%
 REM Ensure logs directory exists
 if not exist "%SCRIPT_DIR%logs" mkdir "%SCRIPT_DIR%logs"
 set LOGFILE=%SCRIPT_DIR%logs\launch_sentientos.log
+echo [%date% %time%] === SentientOS Launch Started === >> "%LOGFILE%"
 
 echo ~F Activating virtual environment (if exists)...
-if exist "%SCRIPT_DIR%venv\Scripts\activate.bat" (
-    call "%SCRIPT_DIR%venv\Scripts\activate.bat"
+if exist "%SCRIPT_DIR%.venv\Scripts\activate.bat" (
+    call "%SCRIPT_DIR%.venv\Scripts\activate.bat"
 )
 
 REM Optionally install requirements
@@ -22,16 +23,17 @@ if exist "%SCRIPT_DIR%requirements.txt" (
 )
 
 echo ~@ Starting SentientOS Relay (Flask)...
-start cmd /k python scripts\sentient_api.py
+start cmd /k python sentient_api.py
 
 echo ~D Starting Heartbeat (optional)...
 REM Uncomment if you want to start heartbeat daemon:
-REM start cmd /k python scripts\heartbeat_mixtral.py
+REM start cmd /k python heartbeat.py
 
 echo ~\ Starting Memory Digest Builder (optional)...
 REM Uncomment if you want to stream memory logs into digest:
-REM start cmd /k python scripts\digest_builder.py
+REM start cmd /k python digest_builder.py
 
 echo ~Y Cathedral boot sequence initiated. All relays glowing.
+echo [%date% %time%] SentientOS launch script complete. >> "%LOGFILE%"
 pause
 


### PR DESCRIPTION
## Summary
- fix virtualenv activation and script paths in `launch_sentientos.bat`
- hook up optional logging similar to `run_cathedral.bat`

## Testing
- `SENTIENTOS_HEADLESS=1 python privilege_lint_cli.py` *(fails: Banner and __future__ import must be first)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851aaa735108320b5b2f31902dea140