### PR TITLE
[codex:api] add single blessing prompt with logging

### DIFF
--- a/flask_stub.py
+++ b/flask_stub.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
-require_admin_banner()
-require_lumos_approval()
 import json
+import logging
 
 
 class Request:
@@ -31,6 +30,7 @@ class Response:
 class Flask:
     def __init__(self, name):
         self.view_funcs = {}
+        self.logger = logging.getLogger(name)
 
     def route(self, path, methods=None):
         def decorator(func):


### PR DESCRIPTION
## Summary
- avoid repeated lumos prompts in `sentient_api.py`
- log manual blessing and print start notice
- remove auto-approval calls from `flask_stub`
- add basic logger stub so API can set log level

## Testing
- `mypy scripts/ sentientos/` *(fails: Returning Any from function declared to return "dict[str, Any]" and other errors)*
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 STRICT=1 python verify_audits.py`
- `PYTHONPATH=. LUMOS_AUTO_APPROVE=1 python scripts/audit_immutability_verifier.py` *(fails: AuditEntry.__init__() got an unexpected keyword argument 'next_hash')*


------
https://chatgpt.com/codex/tasks/task_b_6851b7cd30a483208e7723978edc79b3