### PR TITLE
[codex:launcher] propagate bless result to launch log

### DIFF
--- a/launch_sentientos.bat
+++ b/launch_sentientos.bat
@@ -9,6 +9,7 @@ cd /d %SCRIPT_DIR%
 REM Ensure logs directory exists
 if not exist "%SCRIPT_DIR%logs" mkdir "%SCRIPT_DIR%logs"
 set LOGFILE=%SCRIPT_DIR%logs\launch_sentientos.log
+set LAUNCH_LOG=%LOGFILE%
 echo [%date% %time%] === SentientOS Launch Started === >> "%LOGFILE%"
 
 REM Parse optional flags

--- a/sentient_api.py
+++ b/sentient_api.py
@@ -35,6 +35,10 @@ if not LOG_PATH.exists():
 BLESSING_LOG_PATH = Path(os.getenv("BLESSING_LOG", "logs/blessings.jsonl"))
 BLESSING_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
+# Shared launcher log used by launch_sentientos.bat
+LAUNCH_LOG_PATH = Path(os.getenv("LAUNCH_LOG", "logs/launch_sentientos.log"))
+LAUNCH_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
 
 def blessing_prompt() -> bool:
     """Prompt for manual blessing and log the response."""
@@ -46,6 +50,9 @@ def blessing_prompt() -> bool:
         entry = {"timestamp": datetime.utcnow().isoformat(), "event": "manual_bless"}
         with open(BLESSING_LOG_PATH, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(LAUNCH_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] Blessing acknowledged.\n")
         return True
     return False
 


### PR DESCRIPTION
## Summary
- update `sentient_api.py` to write blessing confirmations to `logs/launch_sentientos.log`
- allow `launch_sentientos.bat` to pass the log path through `LAUNCH_LOG` env var

## Testing
- `mypy scripts/ sentientos/` *(fails: Found 125 errors)*
- `pytest -q`
- `python verify_audits.py --strict` *(fails: Lumos did not approve this action)*
- `PYTHONPATH=. python scripts/audit_immutability_verifier.py` *(fails: Lumos did not approve this action)*

------
https://chatgpt.com/codex/tasks/task_b_6851c1ba5d7c83208bf7ad731ca6c8c3