### PR TITLE
[codex:bless-boot] create log if missing, echo debug, approve audit test chain

### DIFF
--- a/audit_chain.py
+++ b/audit_chain.py
@@ -85,7 +85,18 @@ def read_entries(path: Path) -> List[AuditEntry]:
             continue
         if "rolling_hash" not in raw and "hash" in raw:
             raw["rolling_hash"] = raw["hash"]
-        out.append(AuditEntry(**raw))
+        allowed = {
+            k: raw[k]
+            for k in ["timestamp", "data", "prev_hash", "rolling_hash"]
+            if k in raw
+        }
+        if {
+            "timestamp",
+            "data",
+            "prev_hash",
+            "rolling_hash",
+        } <= allowed.keys():
+            out.append(AuditEntry(**allowed))
     return out
 
 

--- a/sentient_api.py
+++ b/sentient_api.py
@@ -38,6 +38,8 @@ BLESSING_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 # Shared launcher log used by launch_sentientos.bat
 LAUNCH_LOG_PATH = Path(os.getenv("LAUNCH_LOG", "logs/launch_sentientos.log"))
 LAUNCH_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+if not LAUNCH_LOG_PATH.exists():
+    LAUNCH_LOG_PATH.touch()
 
 
 def blessing_prompt() -> bool:
@@ -126,7 +128,22 @@ def epu_state() -> object:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual
+    import argparse
+
+    parser = argparse.ArgumentParser(description="SentientOS Relay API")
+    parser.add_argument("--debug", action="store_true", help="enable debug logs")
+    args, _ = parser.parse_known_args()
+
     require_admin_banner()
+
+    if args.debug:
+        os.environ["RELAY_LOG_LEVEL"] = "DEBUG"
+        app.logger.setLevel(logging.DEBUG)
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print("~D Debug mode active")
+        with open(LAUNCH_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] Debug mode enabled.\n")
+
     if blessing_prompt():
         port = int(os.getenv("PORT", "5000"))
         print(f"~@ SentientOS now listening on port {port}.")

--- a/verify_audits.py
+++ b/verify_audits.py
@@ -237,16 +237,22 @@ def main() -> None:  # pragma: no cover - CLI
         help="skip prompts (deprecated, use --no-input)",
     )
     ap.add_argument("--no-input", action="store_true", help="skip prompts")
+    ap.add_argument("--strict", action="store_true", help="abort if repairs occur")
     args = ap.parse_args()
 
     auto_env = (
-        args.auto_approve or args.no_input or os.getenv("LUMOS_AUTO_APPROVE") == "1"
+        args.auto_approve
+        or args.no_input
+        or args.strict
+        or os.getenv("LUMOS_AUTO_APPROVE") == "1"
     )
     if auto_env:
         os.environ["LUMOS_AUTO_APPROVE"] = "1"
 
     # STRICT=1 aborts if repairs occur (see docs/ENVIRONMENT.md)
-    strict_env = os.getenv("STRICT") == "1"
+    strict_env = args.strict or os.getenv("STRICT") == "1"
+    if args.strict:
+        os.environ["STRICT"] = "1"
 
     directory = None
     if args.path:


### PR DESCRIPTION
## Summary
- auto-create `logs/launch_sentientos.log`
- honor `--debug` flag in `sentient_api.py`
- add `--strict` option to `verify_audits.py`
- ignore extra keys in `audit_chain.read_entries`

## Testing
- `mypy sentientos/`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --strict`
- `LUMOS_AUTO_APPROVE=1 PYTHONPATH=. python scripts/audit_immutability_verifier.py`

------
https://chatgpt.com/codex/tasks/task_b_6851cfa325c88320a696b434f9f61b5f