### PR TITLE
[codex:relay] extract start_cathedral

### DIFF
--- a/sentient_api.py
+++ b/sentient_api.py
@@ -127,6 +127,13 @@ def epu_state() -> object:
     return jsonify(_state.state())
 
 
+def start_cathedral() -> None:
+    """Launch the relay API server."""
+    port = int(os.getenv("PORT", "5000"))
+    print(f"~@ SentientOS now listening on port {port}.")
+    app.run(host="0.0.0.0", port=port)
+
+
 if __name__ == "__main__":  # pragma: no cover - manual
     import argparse
 
@@ -145,8 +152,6 @@ if __name__ == "__main__":  # pragma: no cover - manual
             f.write(f"[{ts}] Debug mode enabled.\n")
 
     if blessing_prompt():
-        port = int(os.getenv("PORT", "5000"))
-        print(f"~@ SentientOS now listening on port {port}.")
-        app.run(host="0.0.0.0", port=port)
+        start_cathedral()
     else:
         raise SystemExit("Lumos did not approve this action.")


### PR DESCRIPTION
## Summary
- factor out `start_cathedral()` in sentient_api
- call this function from the `__main__` guard so the blessing prompt only runs once

## Testing
- `mypy --strict --exclude tests sentientos`
- `pytest -q`
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py logs/ --strict`
- `LUMOS_AUTO_APPROVE=1 python -m scripts.audit_immutability_verifier` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6851fae5a1b883209c25d5e0f4fe6e8e