### PR TITLE
[codex:launcher] remove admin loop and run Flask after single blessing

### DIFF
--- a/sentient_api.py
+++ b/sentient_api.py
@@ -1,6 +1,6 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
-from sentientos.privilege import require_admin_banner, require_lumos_approval
+import sys
 
 """Relay API exposing memory ingestion and Emotion Processing Unit state."""
 
@@ -128,10 +128,10 @@ def epu_state() -> object:
 
 
 def start_cathedral() -> None:
-    """Launch the relay API server."""
-    port = int(os.getenv("PORT", "5000"))
-    print(f"~@ SentientOS now listening on port {port}.")
-    app.run(host="0.0.0.0", port=port)
+    """Launch the relay API server on port 5000."""
+    logging.basicConfig(level=logging.INFO)
+    logging.info("~@ SentientOS now listening on port 5000.")
+    app.run(host="0.0.0.0", port=5000)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual
@@ -140,8 +140,6 @@ if __name__ == "__main__":  # pragma: no cover - manual
     parser = argparse.ArgumentParser(description="SentientOS Relay API")
     parser.add_argument("--debug", action="store_true", help="enable debug logs")
     args, _ = parser.parse_known_args()
-
-    require_admin_banner()
 
     if args.debug:
         os.environ["RELAY_LOG_LEVEL"] = "DEBUG"
@@ -154,4 +152,5 @@ if __name__ == "__main__":  # pragma: no cover - manual
     if blessing_prompt():
         start_cathedral()
     else:
-        raise SystemExit("Lumos did not approve this action.")
+        print("🛑 Blessing required to proceed.")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- simplify main entrypoint in `sentient_api.py`
- run Flask on port 5000 after a single blessing prompt

## Testing
- `mypy scripts/ sentientos/`
- `pytest -q`
- `verify_audits --strict` *(fails: command not found)*
- `python scripts/audit_immutability_verifier.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6852dc20fefc8320ab518eafa26c58d8