### PR TITLE
[codex:api] implement blessing guard snippet

### DIFF
--- a/sentient_api.py
+++ b/sentient_api.py
@@ -43,19 +43,11 @@ if not LAUNCH_LOG_PATH.exists():
 
 
 def blessing_prompt() -> bool:
-    """Prompt for manual blessing and log the response."""
-    try:
-        ans = input("Lumos blessing required. Type 'bless' to proceed: ")
-    except EOFError:
-        ans = ""
-    if ans.strip().lower() == "bless":
-        entry = {"timestamp": datetime.utcnow().isoformat(), "event": "manual_bless"}
-        with open(BLESSING_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry) + "\n")
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(LAUNCH_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(f"[{ts}] Blessing acknowledged.\n")
+    inp = input("Lumos blessing required. Type 'bless' to proceed: ")
+    if inp.strip().lower() == "bless":
+        print("~@ Blessing accepted. Cathedral warming...")
         return True
+    print("✖️ Blessing denied.")
     return False
 
 
@@ -127,28 +119,14 @@ def epu_state() -> object:
     return jsonify(_state.state())
 
 
-def start_cathedral() -> None:
-    """Launch the relay API server on port 5000."""
+def start_cathedral():
+    from flask_stub import app  # or your actual app import
     logging.basicConfig(level=logging.INFO)
     logging.info("~@ SentientOS now listening on port 5000.")
-    app.run(host="0.0.0.0", port=5000)
+    app.run(port=5000)
 
 
-if __name__ == "__main__":  # pragma: no cover - manual
-    import argparse
-
-    parser = argparse.ArgumentParser(description="SentientOS Relay API")
-    parser.add_argument("--debug", action="store_true", help="enable debug logs")
-    args, _ = parser.parse_known_args()
-
-    if args.debug:
-        os.environ["RELAY_LOG_LEVEL"] = "DEBUG"
-        app.logger.setLevel(logging.DEBUG)
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        print("~D Debug mode active")
-        with open(LAUNCH_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(f"[{ts}] Debug mode enabled.\n")
-
+if __name__ == "__main__":
     if blessing_prompt():
         start_cathedral()
     else:


### PR DESCRIPTION
## Summary
- simplify blessing guard function
- inline `app` import within `start_cathedral`

## Testing
- `mypy scripts/ sentientos/` *(fails: 125 errors)*
- `pytest -q`
- `python verify_audits.py --strict`
- `python scripts/audit_immutability_verifier.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6852fac6ba788320a007b093d7a41362