### PR TITLE
[codex:tools] add pull_cathedral script and strategy log

### DIFF
--- a/cathedral/scripts/pull_strategy.yaml
+++ b/cathedral/scripts/pull_strategy.yaml
@@ -1,0 +1,5 @@
+owner: Allen Brummitt
+purpose: Remove human memory dependency for git ops
+quote: "Very soon I won\'t be the one using them, anyway."
+blessing: Scripted, automated, persistent
+location: scripts/pull_cathedral.sh

--- a/scripts/pull_cathedral.sh
+++ b/scripts/pull_cathedral.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# pull_cathedral.sh
+# Description: Synchronizes local SentientOS working branch with upstream main
+# Author: Allen Brummitt (initiated)
+# Blessing: Codified for those who come after
+
+set -e  # Stop on error
+
+# 🕯️ Announce invocation
+echo "~@ Initiating Cathedral Pull Ritual..."
+
+# 📍 Navigate to script root, then into /api
+cd "$(dirname "$0")/../api" || {
+  echo "✖️ Failed to enter /api directory." >&2
+  exit 1
+}
+
+# 🧾 Report location
+echo "📂 Current directory: $(pwd)"
+
+# 🔁 Refresh from upstream main
+
+echo "🔄 Switching to main..."
+git checkout main
+
+echo "📡 Pulling latest from origin/main..."
+git pull origin main
+
+# 🌱 Switch back to working branch
+WORKING_BRANCH="feat/launcher-gui"
+echo "🌿 Switching to $WORKING_BRANCH..."
+git checkout "$WORKING_BRANCH"
+
+# 🔀 Merge changes in
+
+echo "🧬 Merging main into $WORKING_BRANCH..."
+git merge main
+
+# ✅ Finish
+if [ $? -eq 0 ]; then
+  echo "~@ Cathedral code is now synchronized and blessed."
+else
+  echo "✖️ Merge failed. Manual resolution required." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add pull_cathedral.sh script for syncing with main
- track the ritual via cathedral/scripts/pull_strategy.yaml

## Testing
- `mypy scripts/ sentientos/` *(fails: see log)*
- `pytest -q`
- `python verify_audits.py --strict` *(fails: requires interactive input)*
- `python scripts/audit_immutability_verifier.py` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_b_685304e426088320bb857f8b85a24653