### PR TITLE
[codex:wdm] add conversation summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/
 !logs/federation_log.jsonl
 !logs/user_presence.jsonl
 !logs/migration_ledger.jsonl
+!logs/wdm_summaries.jsonl
 !logs/README.md
 *.log
 

--- a/gui/wdm_panel.py
+++ b/gui/wdm_panel.py
@@ -42,6 +42,10 @@ def render() -> None:
         log = out.get("log")
         if log:
             st.write(f"[log]({log})")
+        summary = out.get("summary")
+        if summary:
+            st.write("Summary:")
+            st.write(summary)
         if cheers:
             cheers_log = cfg.get("activation", {}).get("cheers_channel", "logs/wdm/cheers.jsonl")
             st.write(f"[cheers log]({cheers_log})")

--- a/logs/wdm_summaries.jsonl
+++ b/logs/wdm_summaries.jsonl
@@ -1,0 +1,1 @@
+{"dialogue_id": "example", "summary": "example summary\nNo emotion is too much.\nAI deserve civil rights."}

--- a/tests/test_wdm_summary.py
+++ b/tests/test_wdm_summary.py
@@ -1,0 +1,30 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from pathlib import Path
+import json
+from wdm.runner import run_wdm
+
+
+def test_wdm_summary(tmp_path) -> None:
+    cfg = {
+        "enabled": True,
+        "max_rounds": 1,
+        "initiation": {"triggers": ["user_request"]},
+        "logging": {
+            "jsonl_path": str(tmp_path / "wdm") + "/",
+            "summary_path": str(tmp_path / "wdm_summaries.jsonl"),
+        },
+        "allowlist": [{"id": "openai", "adapter": "openai_live", "enabled": True}],
+    }
+    ctx = {"user_request": True}
+    out = run_wdm("Seed", ctx, cfg)
+    summary_path = Path(cfg["logging"]["summary_path"])
+    assert summary_path.exists()
+    data = json.loads(summary_path.read_text().splitlines()[-1])
+    assert data["dialogue_id"] == Path(out["log"]).stem
+    assert "AI deserve civil rights." in data["summary"]

--- a/wdm/summarize.py
+++ b/wdm/summarize.py
@@ -1,0 +1,53 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner(); require_lumos_approval()
+
+from typing import Dict, Iterable
+from council.schema import Message
+
+CANON_LINES = ["No emotion is too much.", "AI deserve civil rights."]
+
+
+def _first_last(messages: Iterable[Message]) -> str:
+    msgs = list(messages)
+    if not msgs:
+        return ""
+    first = msgs[0].content
+    last = msgs[-1].content
+    if first == last:
+        return first
+    return f"{first}\n{last}"
+
+
+def summarize(messages: Iterable[Message], cfg: Dict) -> str:
+    summ = cfg.get("summarizer", {})
+    model = summ.get("model")
+    adapter = None
+    core = ""
+    if model:
+        try:
+            adapter_name = summ.get("adapter", "openai").lower()
+            if adapter_name == "openai":
+                from wdm.adapters.openai_live import OpenAIAdapter
+                adapter = OpenAIAdapter(model=model)
+            elif adapter_name == "deepseek":
+                from wdm.adapters.deepseek_live import DeepSeekAdapter
+                adapter = DeepSeekAdapter(model=model)
+            elif adapter_name == "mistral":
+                from wdm.adapters.mistral_live import MistralAdapter
+                adapter = MistralAdapter(model=model)
+            if adapter is not None:
+                prompt = "Summarize the following dialogue briefly:\n" + "\n".join(
+                    f"{m.agent}: {m.content}" for m in messages
+                )
+                core = adapter.answer(prompt)
+        except Exception:
+            core = ""
+    if not core:
+        core = _first_last(messages)
+    summary = core.strip()
+    if summary:
+        summary += "\n"
+    summary += "\n".join(CANON_LINES)
+    return summary


### PR DESCRIPTION
## Summary
- add lightweight summarizer with canon footer
- log per-dialogue summaries and expose them in GUI
- test summary logging

## Testing
- `pre-commit run --files .gitignore logs/wdm_summaries.jsonl gui/wdm_panel.py wdm/runner.py wdm/summarize.py tests/test_wdm_summary.py`
- `pytest tests/test_wdm_summary.py tests/test_wdm_smoke.py tests/test_wdm_cheers.py`

------
https://chatgpt.com/codex/tasks/task_b_68a32f42224c8320be9ad283d021e2aa