### PR TITLE
feat(federation): add federation layer for presence logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,12 @@ API: GET /presence  (returns recent presence entries)
 In addition to summary presence logs, WDM now emits live events to `logs/presence_stream.jsonl`:
 - start / update / end entries
 API: GET /presence/stream (SSE endpoint for dashboards)
+
+## Federation Presence
+SentientOS can now pull heartbeat and presence data from multiple nodes into `logs/federation_log.jsonl`.
+
+Configure peers in `config/federation.yaml`.
+
+Run `python scripts/federation_puller.py`.
+
+API: GET `/federation`

--- a/api/federation_api.py
+++ b/api/federation_api.py
@@ -1,0 +1,19 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+require_admin_banner(); require_lumos_approval()
+
+import json
+from pathlib import Path
+from fastapi import FastAPI
+
+app = FastAPI(title="Federation API")
+
+
+@app.get("/federation")
+def get_federation(limit: int = 10):
+    path = Path("logs/federation_log.jsonl")
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()[-limit:]
+    return [json.loads(l) for l in lines if l.strip()]

--- a/config/federation.yaml
+++ b/config/federation.yaml
@@ -1,0 +1,3 @@
+peers:
+  - url: "http://node1.local:8000/presence"
+  - url: "http://node2.local:8000/presence"

--- a/gui/cathedral_gui.py
+++ b/gui/cathedral_gui.py
@@ -133,6 +133,22 @@ def run_streamlit() -> None:
         elapsed = int(time.time() - active_start)
         sidebar.write(f"Active now ({elapsed}s)")
 
+    fed_path = Path("logs/federation_log.jsonl")
+    if fed_path.exists():
+        lines = fed_path.read_text().splitlines()
+        if lines:
+            sidebar.subheader("Federated Presence")
+            for line in lines[-5:][::-1]:
+                try:
+                    entry = json.loads(line)
+                except Exception:
+                    continue
+                ts = entry.get("end_ts") or entry.get("start_ts")
+                ts_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts)) if ts else "unknown"
+                agents = ", ".join(entry.get("agents", []))
+                src = entry.get("source", "unknown")
+                sidebar.write(f"[{src}] {entry.get('dialogue_id')} ({agents}) {ts_str}")
+
     if page == "WDM":
         wdm_panel.render()
         return

--- a/scripts/federation_puller.py
+++ b/scripts/federation_puller.py
@@ -1,0 +1,94 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import json
+import time
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import requests  # type: ignore[import-untyped]
+import yaml
+
+CONFIG_PATH = Path("config/federation.yaml")
+LOG_PATH = Path("logs/federation_log.jsonl")
+
+
+def load_peers(config_path: Path = CONFIG_PATH) -> list[str]:
+    """Return list of peer presence URLs from config."""
+    if not config_path.exists():
+        return []
+    try:
+        data = yaml.safe_load(config_path.read_text()) or {}
+    except Exception:
+        return []
+    return [p.get("url", "") for p in data.get("peers", []) if p.get("url")]
+
+
+def load_seen(log_path: Path = LOG_PATH) -> set[Tuple[str, str]]:
+    """Load existing dialogue_id/source pairs to avoid duplicates."""
+    seen: set[Tuple[str, str]] = set()
+    if log_path.exists():
+        for line in log_path.read_text().splitlines():
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            did = data.get("dialogue_id")
+            src = data.get("source")
+            if did and src:
+                seen.add((did, src))
+    return seen
+
+
+def poll_peers(
+    peers: Iterable[str], log_path: Path = LOG_PATH, seen: set[Tuple[str, str]] | None = None
+) -> None:
+    """Fetch presence from peers and append new entries to the federation log."""
+    if seen is None:
+        seen = load_seen(log_path)
+    new_lines: list[str] = []
+    for url in peers:
+        try:
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+            items = resp.json()
+        except Exception:
+            continue
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            did = item.get("dialogue_id")
+            if not did:
+                continue
+            key = (did, url)
+            if key in seen:
+                continue
+            seen.add(key)
+            entry = dict(item)
+            entry["source"] = url
+            new_lines.append(json.dumps(entry))
+    if new_lines:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            for line in new_lines:
+                fh.write(line + "\n")
+
+
+def main() -> None:
+    peers = load_peers()
+    seen = load_seen()
+    while True:
+        poll_peers(peers, LOG_PATH, seen)
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_federation_pull.py
+++ b/tests/test_federation_pull.py
@@ -1,0 +1,44 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import json
+import types
+
+import scripts.federation_puller as fp
+
+
+def test_puller_writes_log(tmp_path, monkeypatch):
+    log = tmp_path / "federation_log.jsonl"
+    peer = "http://node1/presence"
+    data = [
+        {"dialogue_id": "a", "agents": ["x"], "end_ts": 1.0},
+        {"dialogue_id": "b", "agents": ["y"], "end_ts": 2.0},
+    ]
+
+    class DummyResp:
+        def __init__(self, payload):
+            self.payload = payload
+        def raise_for_status(self):
+            return None
+        def json(self):
+            return self.payload
+
+    def fake_get(url, timeout=5):
+        assert url == peer
+        return DummyResp(data)
+
+    monkeypatch.setattr(fp, "LOG_PATH", log)
+    monkeypatch.setattr(fp, "requests", types.SimpleNamespace(get=fake_get))
+
+    seen: set[tuple[str, str]] = set()
+    fp.poll_peers([peer], log_path=log, seen=seen)
+    fp.poll_peers([peer], log_path=log, seen=seen)
+
+    lines = log.read_text().splitlines()
+    assert len(lines) == 2
+    entries = [json.loads(l) for l in lines]
+    assert all(e["source"] == peer for e in entries)


### PR DESCRIPTION
## Summary
- add federation_puller script to aggregate presence signals from peers
- expose /federation endpoint serving federated presence log
- surface federated presence in GUI and documentation

## Testing
- `pre-commit run --files README.md gui/cathedral_gui.py api/federation_api.py scripts/federation_puller.py tests/test_federation_pull.py config/federation.yaml`
- `pytest tests/test_federation_pull.py` *(skipped: privilege requirements)*

------
https://chatgpt.com/codex/tasks/task_b_68a363308764832088d10196cdce81b5