### PR TITLE
Integrate pulse monitoring and model inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "brainflow>=5,<6",
     "pyserial>=3,<4",
     "mypy>=1.5,<2",
+    "psutil>=5,<6",
+    "transformers>=4,<5",
 ]
 
 [project.optional-dependencies]

--- a/vow/init.py
+++ b/vow/init.py
@@ -4,18 +4,34 @@ import time
 from pathlib import Path
 from queue import Empty, Queue
 
+import psutil
+
 MOUNT_POINTS = [Path("/vow"), Path("/glow"), Path("/daemon"), Path("/pulse")]
 HEARTBEAT_LOG = Path("/daemon/logs/heartbeat.log")
 LEDGER_LOG = Path("/daemon/logs/ledger.jsonl")
+PULSE_FILE = Path("/pulse/system.json")
+
 SYSTEM_CONTEXT = ""
+MODEL = None
 
 def ensure_mounts() -> None:
     for path in MOUNT_POINTS:
         path.mkdir(parents=True, exist_ok=True)
 
 def load_model():
-    print("Loading GPT-OSS model (placeholder)")
-    return object()
+    """Load a small CPU-friendly language model.
+
+    Falls back to mock mode if the model cannot be loaded.
+    """
+    global MODEL
+    try:
+        from transformers import pipeline
+
+        MODEL = pipeline("text-generation", model="sshleifer/tiny-gpt2")
+        print("Model loaded successfully")
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Model load failed: {exc}")
+        MODEL = None
 
 def boot_message() -> None:
     global SYSTEM_CONTEXT
@@ -30,7 +46,21 @@ def mock_llm(user_input: str, context: str) -> str:
     return f"Lumos: {user_input}"
 
 def process_input(user_input: str) -> str:
-    return mock_llm(user_input, SYSTEM_CONTEXT)
+    if MODEL is None:
+        return mock_llm(user_input, SYSTEM_CONTEXT)
+    prompt = f"{SYSTEM_CONTEXT}\n{user_input}"
+    try:
+        result = MODEL(prompt, max_new_tokens=50)
+        return result[0]["generated_text"]
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Inference failed: {exc}")
+        return mock_llm(user_input, SYSTEM_CONTEXT)
+
+
+def shutdown_model() -> None:
+    """Release model resources."""
+    global MODEL
+    MODEL = None
 
 def heartbeat(stop: threading.Event) -> None:
     HEARTBEAT_LOG.parent.mkdir(parents=True, exist_ok=True)
@@ -51,11 +81,62 @@ def ledger_daemon(stop: threading.Event, queue: Queue) -> None:
                 if stop.is_set():
                     break
                 continue
+            entry["pulse"] = read_pulse_snapshot()
             log.write(json.dumps(entry) + "\n")
             log.flush()
             queue.task_done()
-        log.write(json.dumps({"event": "shutdown", "ts": time.strftime('%Y-%m-%d %H:%M:%S')}) + "\n")
+        log.write(
+            json.dumps(
+                {
+                    "event": "shutdown",
+                    "ts": time.strftime('%Y-%m-%d %H:%M:%S'),
+                    "pulse": read_pulse_snapshot(),
+                }
+            )
+            + "\n"
+        )
         log.flush()
+
+
+def read_temp_c() -> float:
+    """Read the first available system temperature in Celsius."""
+    base = Path("/sys/class/thermal")
+    for zone in base.glob("thermal_zone*/temp"):
+        try:
+            with open(zone, "r", encoding="utf-8") as f:
+                value = f.read().strip()
+            if value:
+                temp = int(value) / 1000.0
+                if temp > 0:
+                    return temp
+        except Exception:  # pragma: no cover - best effort
+            continue
+    return 0.0
+
+
+def pulse_daemon(stop: threading.Event) -> None:
+    """Write system stats to the pulse file approximately every 15 seconds."""
+    PULSE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    while not stop.is_set():
+        data = {
+            "ts": time.strftime('%Y-%m-%d %H:%M:%S'),
+            "cpu_percent": psutil.cpu_percent() if psutil else 0.0,
+            "ram_percent": psutil.virtual_memory().percent if psutil else 0.0,
+            "disk_percent": psutil.disk_usage("/").percent if psutil else 0.0,
+            "temp_c": read_temp_c(),
+        }
+        with open(PULSE_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        if stop.wait(15):
+            break
+
+
+def read_pulse_snapshot() -> dict:
+    try:
+        with open(PULSE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
 
 def main() -> None:
     ensure_mounts()
@@ -66,8 +147,10 @@ def main() -> None:
     ledger_queue: Queue = Queue()
     hb_thread = threading.Thread(target=heartbeat, args=(stop,), daemon=True)
     ld_thread = threading.Thread(target=ledger_daemon, args=(stop, ledger_queue), daemon=True)
+    pulse_thread = threading.Thread(target=pulse_daemon, args=(stop,), daemon=True)
     hb_thread.start()
     ld_thread.start()
+    pulse_thread.start()
 
     try:
         while True:
@@ -85,6 +168,8 @@ def main() -> None:
         stop.set()
         hb_thread.join()
         ld_thread.join()
+        pulse_thread.join()
+        shutdown_model()
         print("Shutting down...")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace mock LLM with HuggingFace `tiny-gpt2` pipeline and stub fallback
- add pulse daemon writing system stats to `/pulse/system.json`
- log pulse snapshots with each ledger entry and on shutdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af5b71d21c832083c922a7041bb074