### PR TITLE
Add relay server and network pulse metrics

### DIFF
--- a/relay_server.py
+++ b/relay_server.py
@@ -1,0 +1,62 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+import json
+import time
+from pathlib import Path
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+require_admin_banner()
+require_lumos_approval()
+
+try:  # pragma: no cover - best effort
+    from transformers import pipeline
+
+    MODEL = pipeline("text-generation", model="distilgpt2")
+except Exception:  # pragma: no cover - best effort
+    MODEL = None
+
+
+LOG_PATH = Path("relay_logs.jsonl")
+app = FastAPI()
+
+
+class RelayRequest(BaseModel):
+    task: str
+    context: str = ""
+
+
+@app.post("/relay")
+def relay(req: RelayRequest) -> dict:
+    prompt = f"{req.context}\n{req.task}".strip()
+    if MODEL is not None:
+        try:  # pragma: no cover - best effort
+            result = MODEL(prompt, max_new_tokens=50)
+            output = result[0]["generated_text"]
+        except Exception:  # pragma: no cover - best effort
+            output = f"Echo: {req.task}"
+    else:
+        output = f"Echo: {req.task}"
+    response = {"output": output}
+    with open(LOG_PATH, "a", encoding="utf-8") as log:
+        log.write(
+            json.dumps(
+                {
+                    "ts": time.strftime('%Y-%m-%d %H:%M:%S'),
+                    "request": req.dict(),
+                    "response": response,
+                }
+            )
+            + "\n"
+        )
+    return response
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=5000)
+


### PR DESCRIPTION
## Summary
- extend pulse daemon with network bandwidth and relay status
- integrate relay server usage with latency tracking and ledger logging
- add minimal FastAPI relay server logging to `relay_logs.jsonl`

## Testing
- `pytest`
- `pre-commit run --files vow/init.py relay_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68af876b6cc88320b64aa41e8be5fad5