### PR TITLE
[codex:vow] add config and release seal scaffolding

### DIFF
--- a/vow/config.yaml
+++ b/vow/config.yaml
@@ -1,0 +1,12 @@
+model_path: /models
+fallback_order:
+  - "120b"
+  - "20b"
+  - "13b"
+  - "mock"
+prune_retention_days: 30
+sync_interval: 300
+confirmation_rules:
+  - rm
+  - shutdown
+  - format


### PR DESCRIPTION
## Summary
- load settings from `/vow/config.yaml` to drive model fallback order, retention window, sync interval, and confirmation prompts
- add boot integrity check and signed release banner
- log `release_seal` events on shutdown

## Testing
- `mypy scripts/ sentientos/` *(fails: missing stubs and annotation errors)*
- `pytest -q`
- `verify_audits --strict` *(command not found)*
- `python scripts/audit_immutability_verifier.py` *(fails: ModuleNotFoundError: sentientos)*

------
https://chatgpt.com/codex/tasks/task_b_68b21323ddf4832085de476bf14277b5