### PR TITLE
feat: expand codex autonomy modes

### DIFF
--- a/vow/config.yaml
+++ b/vow/config.yaml
@@ -15,3 +15,4 @@ codex_interval: 3600
 codex_confirm_patterns:
   - /vow/
   - NEWLEGACY.txt
+codex_mode: observe


### PR DESCRIPTION
## Summary
- add `codex_mode` config to toggle observe, repair, or full autonomy
- restart codex daemon with cooldown and new ledger events
- log CI results and session reports for Codex repairs

## Testing
- `pre-commit run --files vow/config.yaml vow/init.py daemon/codex_daemon.py` *(fails: privilege lint exit code 1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b22c4f43008320b820acf3a90c8837