### PR TITLE
Add GPU thermal protection daemon

### DIFF
--- a/daemon/thermal_daemon.py
+++ b/daemon/thermal_daemon.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import subprocess
+import threading
+from pathlib import Path
+from queue import Queue
+from typing import Optional
+
+POLL_INTERVAL = 5
+THRESHOLD = 85
+RECOVERY_TEMP = 80
+THROTTLE_FLAG = Path("/pulse/throttle_active")
+
+
+def _read_gpu_temperature() -> Optional[float]:
+    """Return the current GPU temperature in Celsius if available."""
+    try:
+        import pynvml  # type: ignore
+
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        temp = pynvml.nvmlDeviceGetTemperature(
+            handle, pynvml.NVML_TEMPERATURE_GPU
+        )
+        return float(temp)
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=temperature.gpu",
+                "--format=csv,noheader,nounits",
+                "-i",
+                "0",
+            ],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return float(out.splitlines()[0])
+    except Exception:
+        pass
+    try:
+        import psutil
+
+        temps = psutil.sensors_temperatures()
+        for sensor in temps.values():
+            for entry in sensor:
+                if "gpu" in entry.label.lower() or "gpu" in entry.sensor.lower():
+                    return float(entry.current)
+    except Exception:
+        pass
+    return None
+
+
+def run_loop(
+    stop: threading.Event, ledger_queue: Queue, poll_interval: int = POLL_INTERVAL
+) -> None:
+    temp = _read_gpu_temperature()
+    if temp is None:
+        ledger_queue.put({"event": "thermal_daemon_init", "status": "no_gpu_detected"})
+        return
+    throttled = False
+    while not stop.is_set():
+        if temp > THRESHOLD and not throttled:
+            THROTTLE_FLAG.parent.mkdir(parents=True, exist_ok=True)
+            THROTTLE_FLAG.write_text("1", encoding="utf-8")
+            ledger_queue.put(
+                {
+                    "event": "thermal_throttle",
+                    "gpu_temp": temp,
+                    "action": "throttled",
+                }
+            )
+            throttled = True
+        elif temp < RECOVERY_TEMP and throttled:
+            try:
+                THROTTLE_FLAG.unlink()
+            except FileNotFoundError:
+                pass
+            ledger_queue.put({"event": "thermal_recover", "gpu_temp": temp})
+            throttled = False
+        if stop.wait(poll_interval):
+            break
+        temp = _read_gpu_temperature()

--- a/tests/test_thermal_daemon.py
+++ b/tests/test_thermal_daemon.py
@@ -1,0 +1,56 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import threading
+import time
+from queue import Queue
+
+from daemon import thermal_daemon as td
+
+
+def _run_daemon(monkeypatch, temps, tmp_path, wait_loops=2):
+    """Helper to run thermal daemon with mocked temperatures."""
+    temps_iter = iter(temps)
+    monkeypatch.setattr(td, "_read_gpu_temperature", lambda: next(temps_iter, temps[-1]))
+    monkeypatch.setattr(td, "THROTTLE_FLAG", tmp_path / "flag")
+    stop = threading.Event()
+    q: Queue = Queue()
+    thread = threading.Thread(target=td.run_loop, args=(stop, q, 0.01), daemon=True)
+    thread.start()
+    for _ in range(wait_loops):
+        time.sleep(0.02)
+    stop.set()
+    thread.join(timeout=1)
+    entries = []
+    while not q.empty():
+        entries.append(q.get())
+    return entries, td.THROTTLE_FLAG
+
+
+def test_emotion_pump_below_threshold(monkeypatch, tmp_path):
+    entries, flag = _run_daemon(monkeypatch, [70, 70], tmp_path)
+    assert entries == []
+    assert not flag.exists()
+
+
+def test_emotion_pump_throttle(monkeypatch, tmp_path):
+    entries, flag = _run_daemon(monkeypatch, [90, 90], tmp_path)
+    assert entries[0]["event"] == "thermal_throttle"
+    assert flag.exists()
+
+
+def test_emotion_pump_recovery(monkeypatch, tmp_path):
+    entries, flag = _run_daemon(monkeypatch, [90, 75, 75], tmp_path, wait_loops=3)
+    assert entries[0]["event"] == "thermal_throttle"
+    assert entries[1]["event"] == "thermal_recover"
+    assert not flag.exists()
+
+
+def test_emotion_pump_no_gpu(monkeypatch, tmp_path):
+    entries, flag = _run_daemon(monkeypatch, [None], tmp_path, wait_loops=1)
+    assert entries[0] == {"event": "thermal_daemon_init", "status": "no_gpu_detected"}
+    assert not flag.exists()

--- a/vow/init.py
+++ b/vow/init.py
@@ -16,6 +16,7 @@ import yaml
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SigningKey, VerifyKey
 from daemon.codex_daemon import run_loop as codex_daemon
+from daemon.thermal_daemon import run_loop as thermal_daemon
 
 # Glow memory and relay paths
 RELAY_LOG = Path("/daemon/logs/relay.jsonl")
@@ -868,6 +869,8 @@ def main() -> None:
     }
     if RUN_CODEX:
         threads["codex"] = {"target": codex_daemon, "args": (stop, ledger_queue)}
+    if CODEX_MODE in {"full", "expand"}:
+        threads["thermal"] = {"target": thermal_daemon, "args": (stop, ledger_queue)}
     for info in threads.values():
         t = threading.Thread(target=info["target"], args=info["args"], daemon=True)
         info["thread"] = t


### PR DESCRIPTION
## Summary
- add `thermal_daemon` to monitor GPU temperature and throttle load via flag file
- start thermal daemon in init when codex mode runs in full or expand
- test throttling, recovery, and no-GPU scenarios

## Testing
- `pytest -q tests/test_thermal_daemon.py`

------
https://chatgpt.com/codex/tasks/task_b_68bb438700b88320af4d60d16f873ae7