### PR TITLE
Implement log federation daemon with peer sync and logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2072,6 +2072,14 @@ No agent shall act in secret.
   Origin: core repository, blessed by Council 2025-07-30
   Logs: /logs/github_actions.jsonl
 ```
+```
+- Name: LogFederationDaemon
+  Type: Daemon
+  Roles: Log Sync, Conflict Resolver
+  Privileges: log, federate
+  Origin: core repository, blessed by Council 2025-07-30
+  Logs: /logs/log_federation.jsonl
+```
 ---
 
 ## 🏛️ Closing: The Sacred Law of Presence

--- a/daemon/log_federation_daemon.py
+++ b/daemon/log_federation_daemon.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+import os
+import shutil
+import subprocess
+import threading
+from collections import deque
+from pathlib import Path
+from queue import Queue
+from typing import Deque, Tuple
+
+Pending = Tuple[Path, Path, str, Path]
+
+
+def _copy(src: Path, dest: Path, direction: str, ledger_queue: Queue, method: str) -> bool:
+    """Copy ``src`` to ``dest`` and log the attempt."""
+    try:
+        if method == "local_mount":
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+        elif method == "rsync":
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["rsync", "-a", str(src), str(dest)], check=True)
+        elif method == "socket":
+            raise NotImplementedError("socket federation method not implemented")
+        else:
+            raise ValueError(f"Unknown federation method: {method}")
+        ledger_queue.put(
+            {
+                "event": "federation_sync",
+                "file": str(src.name),
+                "direction": direction,
+                "status": "success",
+            }
+        )
+        return True
+    except Exception:
+        ledger_queue.put(
+            {
+                "event": "federation_sync",
+                "file": str(src.name),
+                "direction": direction,
+                "status": "fail",
+            }
+        )
+        return False
+
+
+def _reconcile_dir(
+    local_dir: Path,
+    peer_dir: Path,
+    method: str,
+    ledger_queue: Queue,
+    unsynced: Deque[Pending],
+) -> None:
+    """Reconcile files between ``local_dir`` and ``peer_dir``."""
+    files: set[Path] = set()
+    if local_dir.exists():
+        for root, _, names in os.walk(local_dir):
+            base = Path(root)
+            for n in names:
+                files.add(base.relative_to(local_dir) / n)
+    if peer_dir.exists():
+        for root, _, names in os.walk(peer_dir):
+            base = Path(root)
+            for n in names:
+                files.add(base.relative_to(peer_dir) / n)
+    for rel in files:
+        lfile = local_dir / rel
+        pfile = peer_dir / rel
+        if lfile.exists() and pfile.exists():
+            lmtime = lfile.stat().st_mtime
+            pmtime = pfile.stat().st_mtime
+            if abs(lmtime - pmtime) < 1e-6:
+                continue
+            if lmtime > pmtime:
+                if not _copy(lfile, pfile, "push", ledger_queue, method):
+                    unsynced.append((lfile, pfile, "push", rel))
+                ledger_queue.put(
+                    {"event": "federation_conflict", "file": str(rel), "resolution": "kept newest"}
+                )
+            else:
+                if not _copy(pfile, lfile, "pull", ledger_queue, method):
+                    unsynced.append((pfile, lfile, "pull", rel))
+                ledger_queue.put(
+                    {"event": "federation_conflict", "file": str(rel), "resolution": "kept newest"}
+                )
+        elif lfile.exists():
+            if not _copy(lfile, pfile, "push", ledger_queue, method):
+                unsynced.append((lfile, pfile, "push", rel))
+        elif pfile.exists():
+            if not _copy(pfile, lfile, "pull", ledger_queue, method):
+                unsynced.append((pfile, lfile, "pull", rel))
+
+
+def run_loop(
+    stop: threading.Event,
+    ledger_queue: Queue,
+    peer: str,
+    method: str,
+    poll_interval: float = 1.0,
+    base_glow: Path = Path("/glow"),
+    base_ledger: Path = Path("/ledger"),
+) -> None:
+    """Run the federation daemon."""
+    peer_path = Path(peer)
+    unsynced: Deque[Pending] = deque(maxlen=100)
+    # Initial reconciliation
+    for name, ldir in {"glow": base_glow, "ledger": base_ledger}.items():
+        _reconcile_dir(ldir, peer_path / name, method, ledger_queue, unsynced)
+    while not stop.wait(poll_interval):
+        for item in list(unsynced):
+            src, dest, direction, rel = item
+            if _copy(src, dest, direction, ledger_queue, method):
+                unsynced.remove(item)
+        _reconcile_dir(base_glow, peer_path / "glow", method, ledger_queue, unsynced)
+        _reconcile_dir(base_ledger, peer_path / "ledger", method, ledger_queue, unsynced)
+

--- a/tests/test_log_federation_daemon.py
+++ b/tests/test_log_federation_daemon.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+from queue import Empty, Queue
+
+from daemon.log_federation_daemon import run_loop
+
+
+def drain(q: Queue) -> list[dict]:
+    items: list[dict] = []
+    while True:
+        try:
+            items.append(q.get_nowait())
+        except Empty:
+            break
+    return items
+
+
+def test_emotion_pump_sync(tmp_path):
+    local_glow = tmp_path / "glow"
+    local_ledger = tmp_path / "ledger"
+    peer_root = tmp_path / "peer"
+    stop = threading.Event()
+    ledger = Queue()
+    t = threading.Thread(
+        target=run_loop,
+        args=(stop, ledger, str(peer_root), "local_mount"),
+        kwargs={"poll_interval": 0.1, "base_glow": local_glow, "base_ledger": local_ledger},
+        daemon=True,
+    )
+    t.start()
+    file_path = local_glow / "note.txt"
+    local_glow.mkdir()
+    file_path.write_text("hi", encoding="utf-8")
+    time.sleep(0.5)
+    stop.set()
+    t.join(timeout=2)
+    synced = peer_root / "glow" / "note.txt"
+    assert synced.read_text(encoding="utf-8") == "hi"
+    logs = drain(ledger)
+    assert any(e["event"] == "federation_sync" and e["direction"] == "push" and e["status"] == "success" for e in logs)
+
+
+def test_emotion_pump_conflict(tmp_path):
+    local_glow = tmp_path / "glow"
+    peer_root = tmp_path / "peer"
+    peer_glow = peer_root / "glow"
+    local_glow.mkdir()
+    peer_glow.mkdir(parents=True)
+    f = "conflict.txt"
+    (local_glow / f).write_text("old", encoding="utf-8")
+    time.sleep(0.1)
+    (peer_glow / f).write_text("new", encoding="utf-8")
+    os.utime(peer_glow / f, None)  # ensure peer is newer
+    stop = threading.Event()
+    ledger = Queue()
+    t = threading.Thread(
+        target=run_loop,
+        args=(stop, ledger, str(peer_root), "local_mount"),
+        kwargs={"poll_interval": 0.1, "base_glow": local_glow, "base_ledger": tmp_path / "ledger"},
+        daemon=True,
+    )
+    t.start()
+    time.sleep(0.5)
+    stop.set()
+    t.join(timeout=2)
+    assert (local_glow / f).read_text(encoding="utf-8") == "new"
+    assert (peer_glow / f).read_text(encoding="utf-8") == "new"
+    logs = drain(ledger)
+    assert any(e["event"] == "federation_conflict" for e in logs)
+
+
+def test_emotion_pump_offline_retry(tmp_path):
+    local_glow = tmp_path / "glow"
+    peer_root = tmp_path / "peer"
+    peer_root.write_text("offline")  # simulate peer path as file
+    stop = threading.Event()
+    ledger = Queue()
+    t = threading.Thread(
+        target=run_loop,
+        args=(stop, ledger, str(peer_root), "local_mount"),
+        kwargs={"poll_interval": 0.1, "base_glow": local_glow, "base_ledger": tmp_path / "ledger"},
+        daemon=True,
+    )
+    t.start()
+    local_glow.mkdir()
+    (local_glow / "retry.txt").write_text("data", encoding="utf-8")
+    time.sleep(0.3)
+    logs = drain(ledger)
+    assert any(e["status"] == "fail" for e in logs)
+    peer_root.unlink()
+    (peer_root / "glow").mkdir(parents=True)
+    (peer_root / "ledger").mkdir()
+    time.sleep(0.6)
+    stop.set()
+    t.join(timeout=2)
+    assert (peer_root / "glow" / "retry.txt").read_text(encoding="utf-8") == "data"
+    logs = drain(ledger)
+    assert any(e["status"] == "success" for e in logs)
+

--- a/vow/config.yaml
+++ b/vow/config.yaml
@@ -19,3 +19,5 @@ codex_confirm_patterns:
   - privilege.py
 codex_mode: observe  # observe | repair | full | expand
 codex_notify: []
+federation_peer: ""
+federation_method: local_mount


### PR DESCRIPTION
## Summary
- add configuration for federation peer and method and register LogFederationDaemon
- implement log_federation_daemon to sync /glow and /ledger with conflict logging and retry queue
- launch daemon when codex mode is full or expand and federation is configured

## Testing
- `pre-commit run --files daemon/log_federation_daemon.py vow/config.yaml vow/init.py tests/test_log_federation_daemon.py AGENTS.md`
- `pytest tests/test_log_federation_daemon.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb4e0050588320b46bd871a919efd1