### PR TITLE
Add ledger-backed enforcement to network daemon

### DIFF
--- a/network_daemon.py
+++ b/network_daemon.py
@@ -7,6 +7,8 @@ collecting emitted events in memory for inspection.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, List
 
@@ -18,9 +20,10 @@ class NetworkDaemon:
     ----------
     config:
         Configuration dictionary. Relevant keys:
-        ``network_policies`` with ``allowed_ports``, ``blocked_ports`` and
-        ``bandwidth_limit`` (kbps) as well as ``federation_peer_ip`` and
-        ``log_dir`` for event logging.
+        ``network_policies`` may include ``allowed_ports``, ``blocked_ports``,
+        ``bandwidth_limit`` (kbps) and structured ``rules`` for enforcement.
+        ``federation_peer_ip`` and ``log_dir`` configure detection logging
+        while ``enforcement_enabled`` toggles ledger-backed enforcement.
     """
 
     def __init__(self, config: dict) -> None:
@@ -28,15 +31,161 @@ class NetworkDaemon:
         self.allowed_ports = set(policies.get("allowed_ports", []))
         self.blocked_ports = set(policies.get("blocked_ports", []))
         self.bandwidth_limit = float(policies.get("bandwidth_limit", 0))
+        self.policy_rules = self._load_policy_rules(policies)
         self.peer_ip = config.get("federation_peer_ip")
         self.log_dir = Path(config.get("log_dir", "."))
         self.uptime_threshold = float(config.get("uptime_threshold", 300))
+        self.enforcement_enabled = bool(config.get("enforcement_enabled", False))
+        self.ledger_path = Path("/daemon/logs/codex.jsonl")
+        self._resync_rule = self._build_rule(
+            "federation", "peer_unreachable", "resync", source="builtin"
+        )
 
         self.events: List[str] = []
         self.resync_queued = False
         self._iface_uptime: Dict[str, float] = {}
         self._iface_event_emitted: Dict[str, bool] = {}
         self._last_checked: float | None = None
+
+    # ------------------------------------------------------------------
+    # Policy helpers
+    def _build_rule(
+        self, rule_type: str, value: object, action: str, *, source: str
+    ) -> Dict[str, object]:
+        """Create a normalized policy rule representation."""
+
+        description_value: str
+        if rule_type == "bandwidth":
+            try:
+                description_value = f"{float(value):g}"
+            except (TypeError, ValueError):
+                description_value = str(value)
+        else:
+            description_value = str(value)
+
+        description = f"{rule_type}={description_value}:{action}"
+        if rule_type == "bandwidth":
+            description = f"{rule_type}>{description_value}:{action}"
+
+        return {
+            "type": rule_type,
+            "value": value,
+            "action": action,
+            "source": source,
+            "description": description,
+        }
+
+    def _load_policy_rules(self, policies: dict) -> List[Dict[str, object]]:
+        """Normalise policy definitions from configuration."""
+
+        rules: List[Dict[str, object]] = []
+
+        for entry in policies.get("rules", []):
+            if not isinstance(entry, dict):
+                continue
+            action = entry.get("action")
+            if action not in {"block", "throttle", "resync"}:
+                continue
+            if "port" in entry:
+                try:
+                    port_value = int(entry["port"])
+                except (TypeError, ValueError):
+                    continue
+                rules.append(
+                    self._build_rule("port", port_value, action, source="rules")
+                )
+            elif "bandwidth" in entry:
+                try:
+                    bandwidth_value = float(entry["bandwidth"])
+                except (TypeError, ValueError):
+                    continue
+                rules.append(
+                    self._build_rule("bandwidth", bandwidth_value, action, source="rules")
+                )
+            elif entry.get("type") == "federation":
+                rules.append(
+                    self._build_rule(
+                        "federation",
+                        entry.get("value", "peer_unreachable"),
+                        action,
+                        source="rules",
+                    )
+                )
+
+        for port in self.blocked_ports:
+            if not any(r["type"] == "port" and r["value"] == port for r in rules):
+                rules.append(
+                    self._build_rule("port", port, "block", source="blocked_ports")
+                )
+
+        if self.bandwidth_limit:
+            if not any(r["type"] == "bandwidth" for r in rules):
+                rules.append(
+                    self._build_rule(
+                        "bandwidth",
+                        float(self.bandwidth_limit),
+                        "throttle",
+                        source="bandwidth_limit",
+                    )
+                )
+
+        return rules
+
+    def _match_rules(self, rule_type: str, metric_value: object) -> List[Dict[str, object]]:
+        """Retrieve policy rules triggered by the provided metric value."""
+
+        matches: List[Dict[str, object]] = []
+        for rule in self.policy_rules:
+            if rule["type"] != rule_type:
+                continue
+            if rule_type == "bandwidth":
+                try:
+                    if float(metric_value) > float(rule["value"]):
+                        matches.append(rule)
+                except (TypeError, ValueError):
+                    continue
+            else:
+                if rule["value"] == metric_value:
+                    matches.append(rule)
+        return matches
+
+    def _maybe_enforce(
+        self, interface: str, rule: Dict[str, object], detail: str | None = None
+    ) -> None:
+        """Simulate enforcement and emit a ledger event when enabled."""
+
+        if not self.enforcement_enabled:
+            return
+
+        action = str(rule.get("action", "observe"))
+        policy_description = str(rule.get("description", "unknown_policy"))
+        detail_message = f" detail={detail}" if detail else ""
+        self._log(
+            f"enforcement:{interface}:{policy_description}:{action}{detail_message}"
+        )
+        self._emit_ledger_event(interface, policy_description, action, detail)
+
+    def _emit_ledger_event(
+        self, interface: str, policy: str, action: str, detail: str | None
+    ) -> None:
+        """Append an enforcement record to the Codex ledger sink."""
+
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "interface": interface,
+            "policy": policy,
+            "action": action,
+        }
+        if detail is not None:
+            event["detail"] = detail
+
+        try:
+            self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.ledger_path.open("a", encoding="utf-8") as ledger_file:
+                ledger_file.write(json.dumps(event) + "\n")
+        except Exception:
+            # Ledger failures should not interrupt daemon behaviour.
+            pass
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -53,25 +202,47 @@ class NetworkDaemon:
 
     # ------------------------------------------------------------------
     # Event checks
-    def _check_bandwidth(self, usage_kbps: float) -> None:
+    def _check_bandwidth(self, usage_kbps: float, interface: str = "aggregate") -> None:
         """Emit an event if bandwidth exceeds the configured limit."""
-        # Only log when usage exceeds limit
-        if self.bandwidth_limit and usage_kbps > self.bandwidth_limit:
-            self._log(f"bandwidth_saturation:{usage_kbps}")
 
-    def _check_ports(self, open_ports: Iterable[int]) -> None:
+        matches = self._match_rules("bandwidth", usage_kbps)
+        if matches or (self.bandwidth_limit and usage_kbps > self.bandwidth_limit):
+            self._log(f"bandwidth_saturation:{usage_kbps}")
+        for rule in matches:
+            self._maybe_enforce(interface, rule, f"usage_kbps={usage_kbps}")
+
+    def _check_ports(self, open_ports: Iterable[int], interface: str = "unknown") -> None:
         """Inspect open ports and emit events for unexpected or blocked ones."""
         for port in open_ports:
+            matches = self._match_rules("port", port)
+            if matches:
+                primary_action = str(matches[0].get("action"))
+                event = "blocked_port" if primary_action == "block" else "port_policy_violation"
+                self._log(f"{event}:{port}")
+                for rule in matches:
+                    self._maybe_enforce(interface, rule, f"port={port}")
+                continue
+
             if port in self.blocked_ports:
                 self._log(f"blocked_port:{port}")
+                self._maybe_enforce(
+                    interface,
+                    self._build_rule("port", port, "block", source="blocked_ports"),
+                    f"port={port}",
+                )
             elif port not in self.allowed_ports:
                 self._log(f"unexpected_port:{port}")
 
-    def _check_federation(self, reachable: bool) -> None:
+    def _check_federation(self, reachable: bool, interface: str = "federation_link") -> None:
         """Mark resync if federation peer is unreachable."""
         if not reachable:
             self.resync_queued = True
             self._log("federation_link_down")
+            matches = self._match_rules("federation", self._resync_rule["value"])
+            if not matches:
+                matches = [self._resync_rule]
+            for rule in matches:
+                self._maybe_enforce(interface, rule, "peer_unreachable")
 
     def _check_uptime(self, status: Dict[str, bool], now: float) -> None:
         """Track interface uptime and emit events when threshold exceeded."""

--- a/tests/test_network_daemon.py
+++ b/tests/test_network_daemon.py
@@ -1,43 +1,104 @@
+"""Tests for the lightweight :mod:`network_daemon` module."""
+
+from __future__ import annotations
+
+import copy
+import json
+from contextlib import suppress
+from pathlib import Path
+
 import pytest
 
 from network_daemon import NetworkDaemon
 
 
+LEDGER_PATH = Path("/daemon/logs/codex.jsonl")
+
+
+def _read_ledger() -> list[dict]:
+    """Return parsed ledger events for assertions."""
+
+    if not LEDGER_PATH.exists():
+        return []
+    with LEDGER_PATH.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+@pytest.fixture(autouse=True)
+def clean_ledger():
+    """Ensure each test observes a clean ledger file."""
+
+    with suppress(FileNotFoundError):
+        LEDGER_PATH.unlink()
+    yield
+    with suppress(FileNotFoundError):
+        LEDGER_PATH.unlink()
+
+
 @pytest.fixture
-def daemon(tmp_path):
-    """Provide a NetworkDaemon with a minimal config for testing."""
-    config = {
+def base_config(tmp_path):
+    """Provide a reusable configuration dictionary."""
+
+    return {
         "network_policies": {
             "allowed_ports": [80, 443],
             "blocked_ports": [23],
             "bandwidth_limit": 1000,  # kbps
+            "rules": [
+                {"port": 23, "action": "block"},
+                {"bandwidth": 1000, "action": "throttle"},
+            ],
         },
         "federation_peer_ip": "192.0.2.10",
         "log_dir": tmp_path,
     }
+
+
+@pytest.fixture
+def daemon(base_config):
+    """Network daemon fixture with enforcement disabled by default."""
+
+    config = copy.deepcopy(base_config)
+    config["enforcement_enabled"] = False
     return NetworkDaemon(config)
+
+
+@pytest.fixture
+def make_daemon(base_config):
+    """Factory for daemons with configurable enforcement mode."""
+
+    def _factory(enforcement_enabled: bool = True) -> NetworkDaemon:
+        config = copy.deepcopy(base_config)
+        config["enforcement_enabled"] = enforcement_enabled
+        return NetworkDaemon(config)
+
+    return _factory
 
 
 def test_bandwidth_event_emits(daemon):
     """Bandwidth over the limit should emit a saturation event."""
+
     daemon._check_bandwidth(1500)
     assert any("bandwidth_saturation" in e for e in daemon.events)
 
 
 def test_unexpected_port_block(daemon):
     """Unexpected ports should be flagged in the event log."""
+
     daemon._check_ports([22, 80])
     assert any("unexpected_port" in e for e in daemon.events)
 
 
 def test_federation_resync_trigger(daemon):
     """Unreachable peers should trigger a resync request."""
+
     daemon._check_federation(False)
     assert daemon.resync_queued is True
 
 
 def test_no_uptime_event_below_threshold(daemon):
     """Interfaces below threshold should not emit uptime events."""
+
     daemon._check_uptime({"eth0": True}, 0)
     daemon._check_uptime({"eth0": True}, 299)
     assert not any("uptime_event" in e for e in daemon.events)
@@ -45,6 +106,7 @@ def test_no_uptime_event_below_threshold(daemon):
 
 def test_uptime_event_triggers_once(daemon):
     """An uptime event fires once when threshold is crossed."""
+
     daemon._check_uptime({"eth0": True}, 0)
     daemon._check_uptime({"eth0": True}, 301)
     daemon._check_uptime({"eth0": True}, 400)
@@ -54,6 +116,7 @@ def test_uptime_event_triggers_once(daemon):
 
 def test_multiple_interfaces_tracked_independently(daemon):
     """Each interface maintains its own uptime tracking."""
+
     daemon._check_uptime({"eth0": True, "wlan0": True}, 0)
     daemon._check_uptime({"eth0": True, "wlan0": False}, 301)
     daemon._check_uptime({"eth0": True, "wlan0": False}, 400)
@@ -63,3 +126,43 @@ def test_multiple_interfaces_tracked_independently(daemon):
     assert len([e for e in events if "eth0" in e]) == 1
     assert len([e for e in events if "wlan0" in e]) == 1
 
+
+def test_policy_violation_generates_ledger_entry(make_daemon):
+    """Blocked ports should generate ledger-backed enforcement records."""
+
+    daemon = make_daemon(enforcement_enabled=True)
+    daemon._check_ports([23], interface="eth0")
+
+    entries = _read_ledger()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["interface"] == "eth0"
+    assert entry["action"] == "block"
+    assert "port=23" in entry["policy"]
+
+
+def test_enforcement_mode_toggle_suppresses_ledger(make_daemon):
+    """Observe-only mode should not write enforcement events to the ledger."""
+
+    daemon = make_daemon(enforcement_enabled=False)
+    daemon._check_ports([23], interface="eth0")
+    daemon._check_bandwidth(1500, interface="eth0")
+    daemon._check_federation(False)
+
+    assert _read_ledger() == []
+
+
+def test_multiple_violations_logged_independently(make_daemon):
+    """Distinct violations should emit separate ledger events."""
+
+    daemon = make_daemon(enforcement_enabled=True)
+    daemon._check_ports([23], interface="eth0")
+    daemon._check_bandwidth(1500, interface="eth0")
+    daemon._check_federation(False)
+
+    entries = _read_ledger()
+    actions = [entry["action"] for entry in entries]
+    assert len(entries) == 3
+    assert actions.count("block") == 1
+    assert "throttle" in actions
+    assert "resync" in actions


### PR DESCRIPTION
## Summary
- extend the network daemon with policy rule normalization, optional enforcement, and ledger event emission
- add configurable enforcement toggle and ledger logging for blocked ports, throttling, and federation resync events
- update the network daemon test suite to validate ledger entries and enforcement behaviours

## Testing
- pytest tests/test_network_daemon.py

------
https://chatgpt.com/codex/tasks/task_b_68caf4fe95dc83209863fb1c211aec3c