### PR TITLE
Add pulse bus infrastructure for daemon events

### DIFF
--- a/sentientos/daemons/__init__.py
+++ b/sentientos/daemons/__init__.py
@@ -1,0 +1,7 @@
+"""Utility daemons and shared infrastructure for SentientOS."""
+
+from __future__ import annotations
+
+from . import pulse_bus
+
+__all__ = ["pulse_bus"]

--- a/sentientos/daemons/integrity_daemon.py
+++ b/sentientos/daemons/integrity_daemon.py
@@ -1,0 +1,32 @@
+"""Stub integrity daemon that listens to pulse bus events."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from . import pulse_bus
+
+
+class IntegrityDaemon:
+    """Minimal daemon that records every pulse broadcast."""
+
+    def __init__(self) -> None:
+        self.received_events: List[dict] = []
+        self.messages: List[str] = []
+        self._subscription: pulse_bus.PulseSubscription | None = pulse_bus.subscribe(
+            self._handle_event
+        )
+
+    def _handle_event(self, event: dict) -> None:
+        self.received_events.append(event)
+        message = json.dumps(event, sort_keys=True)
+        self.messages.append(message)
+        print(f"[IntegrityDaemon] {message}")
+
+    def stop(self) -> None:
+        """Unsubscribe from the pulse bus."""
+
+        if self._subscription and self._subscription.active:
+            self._subscription.unsubscribe()
+            self._subscription = None

--- a/sentientos/daemons/pulse_bus.py
+++ b/sentientos/daemons/pulse_bus.py
@@ -1,0 +1,158 @@
+"""In-memory event bus allowing daemons to broadcast live pulse updates."""
+
+from __future__ import annotations
+
+import copy
+from collections import deque
+from threading import Lock
+from typing import Callable, Deque, Dict, Iterable, List
+
+PulseEvent = Dict[str, object]
+EventHandler = Callable[[PulseEvent], None]
+
+_REQUIRED_FIELDS = {"timestamp", "source_daemon", "event_type", "payload"}
+
+
+class PulseSubscription:
+    """Represents a registered handler on the :mod:`pulse_bus`."""
+
+    def __init__(self, bus: "_PulseBus", handler: EventHandler) -> None:
+        self._bus = bus
+        self._handler = handler
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        """Return whether the subscription is currently active."""
+
+        return self._active
+
+    def unsubscribe(self) -> None:
+        """Detach the underlying handler from the pulse bus."""
+
+        if self._active:
+            self._bus._unsubscribe(self._handler)
+            self._active = False
+
+
+class _PulseBus:
+    """Simple publish/subscribe bus backed by an in-memory queue."""
+
+    def __init__(self) -> None:
+        self._events: Deque[PulseEvent] = deque()
+        self._subscribers: List[EventHandler] = []
+        self._lock = Lock()
+
+    def publish(self, event: PulseEvent) -> PulseEvent:
+        """Publish ``event`` to all subscribers after validation."""
+
+        normalized = self._normalize_event(event)
+        with self._lock:
+            self._events.append(normalized)
+            subscribers = list(self._subscribers)
+        for handler in subscribers:
+            handler(copy.deepcopy(normalized))
+        return copy.deepcopy(normalized)
+
+    def subscribe(self, handler: EventHandler) -> PulseSubscription:
+        """Register ``handler`` and replay pending events immediately."""
+
+        if not callable(handler):  # pragma: no cover - defensive branch
+            raise TypeError("Pulse handlers must be callable")
+
+        with self._lock:
+            self._subscribers.append(handler)
+            replay = [copy.deepcopy(evt) for evt in self._events]
+        for event in replay:
+            handler(event)
+        return PulseSubscription(self, handler)
+
+    def pending_events(self) -> List[PulseEvent]:
+        """Return a snapshot of queued events without consuming them."""
+
+        with self._lock:
+            return [copy.deepcopy(evt) for evt in self._events]
+
+    def consume(self, count: int | None = None) -> List[PulseEvent]:
+        """Remove and return up to ``count`` events from the queue."""
+
+        with self._lock:
+            if count is None or count >= len(self._events):
+                events: Iterable[PulseEvent] = list(self._events)
+                self._events.clear()
+            else:
+                events = [self._events.popleft() for _ in range(count)]
+        return [copy.deepcopy(evt) for evt in events]
+
+    def reset(self) -> None:
+        """Clear the queue and any registered subscribers."""
+
+        with self._lock:
+            self._events.clear()
+            self._subscribers.clear()
+
+    def _normalize_event(self, event: PulseEvent) -> PulseEvent:
+        if not isinstance(event, dict):
+            raise TypeError("Pulse events must be dictionaries")
+        normalized = copy.deepcopy(event)
+        missing = _REQUIRED_FIELDS - normalized.keys()
+        if missing:
+            missing_list = ", ".join(sorted(missing))
+            raise ValueError(f"Pulse events require fields: {missing_list}")
+        payload = normalized.get("payload")
+        if not isinstance(payload, dict):
+            raise TypeError("Pulse event payload must be a dictionary")
+        timestamp = normalized.get("timestamp")
+        if not isinstance(timestamp, str):
+            normalized["timestamp"] = str(timestamp)
+        normalized["source_daemon"] = str(normalized["source_daemon"])
+        normalized["event_type"] = str(normalized["event_type"])
+        return normalized
+
+    def _unsubscribe(self, handler: EventHandler) -> None:
+        with self._lock:
+            self._subscribers = [h for h in self._subscribers if h is not handler]
+
+
+_BUS = _PulseBus()
+
+
+def publish(event: PulseEvent) -> PulseEvent:
+    """Publish ``event`` to the global pulse bus."""
+
+    return _BUS.publish(event)
+
+
+def subscribe(handler: EventHandler) -> PulseSubscription:
+    """Subscribe ``handler`` to receive future pulse events."""
+
+    return _BUS.subscribe(handler)
+
+
+def pending_events() -> List[PulseEvent]:
+    """Return a copy of queued pulse events without removing them."""
+
+    return _BUS.pending_events()
+
+
+def consume_events(count: int | None = None) -> List[PulseEvent]:
+    """Remove and return up to ``count`` events from the queue."""
+
+    return _BUS.consume(count)
+
+
+def reset() -> None:
+    """Clear all queued events and registered subscribers."""
+
+    _BUS.reset()
+
+
+__all__ = [
+    "PulseEvent",
+    "PulseSubscription",
+    "publish",
+    "subscribe",
+    "pending_events",
+    "consume_events",
+    "reset",
+]

--- a/tests/test_pulse_bus.py
+++ b/tests/test_pulse_bus.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import copy
+import json
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from network_daemon import NetworkDaemon
+from sentientos.daemons import pulse_bus
+from sentientos.daemons.integrity_daemon import IntegrityDaemon
+
+LEDGER_PATH = Path("/daemon/logs/codex.jsonl")
+
+
+@pytest.fixture(autouse=True)
+def reset_bus():
+    pulse_bus.reset()
+    with suppress(FileNotFoundError):
+        LEDGER_PATH.unlink()
+    yield
+    pulse_bus.reset()
+    with suppress(FileNotFoundError):
+        LEDGER_PATH.unlink()
+
+
+@pytest.fixture
+def base_config(tmp_path):
+    return {
+        "network_policies": {
+            "allowed_ports": [80, 443],
+            "blocked_ports": [23],
+            "bandwidth_limit": 1000,
+            "rules": [
+                {"port": 23, "action": "block"},
+                {"bandwidth": 1000, "action": "throttle"},
+            ],
+        },
+        "federation_peer_ip": "192.0.2.10",
+        "log_dir": tmp_path,
+    }
+
+
+def _build_event(event_type: str = "heartbeat") -> dict:
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source_daemon": "test",
+        "event_type": event_type,
+        "payload": {"message": "ok"},
+    }
+
+
+def test_multiple_subscribers_receive_events():
+    integrity = IntegrityDaemon()
+    direct_events: list[dict] = []
+    pulse_bus.subscribe(lambda event: direct_events.append(event))
+
+    published = _build_event()
+    pulse_bus.publish(published)
+
+    assert direct_events and direct_events[0]["event_type"] == "heartbeat"
+    assert integrity.received_events and integrity.received_events[0]["event_type"] == "heartbeat"
+    integrity.stop()
+
+
+def test_events_persist_until_consumed():
+    published = _build_event("persist_test")
+    pulse_bus.publish(published)
+
+    pending = pulse_bus.pending_events()
+    assert pending and pending[0]["event_type"] == "persist_test"
+
+    consumed = pulse_bus.consume_events()
+    assert consumed == pending
+    assert pulse_bus.pending_events() == []
+
+
+def test_network_daemon_publishes_to_pulse(base_config):
+    config = copy.deepcopy(base_config)
+    config["enforcement_enabled"] = True
+    daemon = NetworkDaemon(config)
+
+    daemon._check_ports([23], interface="eth0")
+
+    with LEDGER_PATH.open("r", encoding="utf-8") as handle:
+        ledger_entries = [json.loads(line) for line in handle if line.strip()]
+
+    events = pulse_bus.pending_events()
+    enforcement_events = [evt for evt in events if evt["event_type"] == "enforcement"]
+    port_events = [evt for evt in events if evt["event_type"] == "port_violation"]
+
+    assert enforcement_events, "Network daemon should emit enforcement pulse events"
+    assert port_events, "Network daemon should emit port violation pulse events"
+
+    assert enforcement_events[0]["source_daemon"] == "network"
+    assert enforcement_events[0]["payload"] == ledger_entries[0]
+    assert "port=23" in enforcement_events[0]["payload"]["policy"]
+    assert port_events[0]["payload"]["policy"].startswith("port=23")


### PR DESCRIPTION
## Summary
- add an in-memory pulse bus module with a stub integrity daemon for multi-subscriber broadcasts
- emit structured policy events from the network daemon and hook the Codex daemon to trigger immediate self-repair checks on critical pulses
- cover the pulse bus and updated network daemon behaviour with new and expanded unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cafe53aec48320ba8c470bd23b8e5a