### PR TITLE
[codex:pulse] add priority filtering for pulse bus

### DIFF
--- a/sentientos/daemons/__init__.py
+++ b/sentientos/daemons/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import pulse_bus
+from . import monitoring_daemon, pulse_bus
 
-__all__ = ["pulse_bus"]
+__all__ = ["pulse_bus", "monitoring_daemon"]

--- a/sentientos/daemons/integrity_daemon.py
+++ b/sentientos/daemons/integrity_daemon.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import List
 
 from . import pulse_bus
@@ -12,24 +13,48 @@ class IntegrityDaemon:
     """Minimal daemon that records every pulse broadcast."""
 
     def __init__(self) -> None:
-        self.received_events: List[dict] = []
+        self.received_events: List[dict[str, object]] = []
         self.messages: List[str] = []
-        self.invalid_events: List[dict] = []
+        self.invalid_events: List[dict[str, object]] = []
+        self.alerts: List[dict[str, object]] = []
         self._subscription: pulse_bus.PulseSubscription | None = pulse_bus.subscribe(
             self._handle_event
         )
 
-    def _handle_event(self, event: dict) -> None:
+    def _handle_event(self, event: dict[str, object]) -> None:
         self.received_events.append(event)
         message = json.dumps(event, sort_keys=True)
         self.messages.append(message)
+        priority = str(event.get("priority", "info")).lower()
         if pulse_bus.verify(event):
             print(f"[IntegrityDaemon] {message}")
+            if priority == "critical":
+                self.alerts.append(event)
+                print(f"[IntegrityDaemon][ALERT] {message}")
             return
         warning = f"INVALID SIGNATURE: {message}"
         self.invalid_events.append(event)
         self.messages.append(warning)
+        self.alerts.append(event)
         print(f"[IntegrityDaemon] {warning}")
+        violation_timestamp = datetime.now(timezone.utc).isoformat()
+        payload = {
+            "timestamp": violation_timestamp,
+            "source_event": {
+                "source_daemon": str(event.get("source_daemon", "unknown")),
+                "event_type": str(event.get("event_type", "unknown")),
+            },
+            "detail": "signature_mismatch",
+        }
+        pulse_bus.publish(
+            {
+                "timestamp": violation_timestamp,
+                "source_daemon": "integrity",
+                "event_type": "integrity_violation",
+                "priority": "critical",
+                "payload": payload,
+            }
+        )
 
     def stop(self) -> None:
         """Unsubscribe from the pulse bus."""

--- a/sentientos/daemons/monitoring_daemon.py
+++ b/sentientos/daemons/monitoring_daemon.py
@@ -1,0 +1,40 @@
+"""Monitoring daemon that surfaces higher priority pulse bus events."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from . import pulse_bus
+
+
+class MonitoringDaemon:
+    """Simple subscriber that highlights warning and critical pulses."""
+
+    def __init__(self) -> None:
+        self.events: List[dict[str, object]] = []
+        self.messages: List[str] = []
+        self.warning_events: List[dict[str, object]] = []
+        self.critical_events: List[dict[str, object]] = []
+        self._subscription: pulse_bus.PulseSubscription | None = pulse_bus.subscribe(
+            self._handle_event,
+            priorities=("warning", "critical"),
+        )
+
+    def _handle_event(self, event: dict[str, object]) -> None:
+        priority = str(event.get("priority", "info")).lower()
+        self.events.append(event)
+        message = json.dumps(event, sort_keys=True)
+        self.messages.append(message)
+        if priority == "warning":
+            self.warning_events.append(event)
+        elif priority == "critical":
+            self.critical_events.append(event)
+        print(f"[MonitoringDaemon] {message}")
+
+    def stop(self) -> None:
+        """Unsubscribe from the pulse bus."""
+
+        if self._subscription and self._subscription.active:
+            self._subscription.unsubscribe()
+            self._subscription = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,11 @@ def configure_pulse_environment(tmp_path, monkeypatch):
 
 
 def pytest_collection_modifyitems(config, items):
-    allowed_modules = {"tests.test_network_daemon", "tests.test_pulse_persistence"}
+    allowed_modules = {
+        "tests.test_network_daemon",
+        "tests.test_pulse_persistence",
+        "tests.test_pulse_priority",
+    }
     for item in items:
         if (
             item.name != "test_placeholder"

--- a/tests/test_pulse_bus.py
+++ b/tests/test_pulse_bus.py
@@ -61,7 +61,9 @@ def test_multiple_subscribers_receive_events():
     pulse_bus.publish(published)
 
     assert direct_events and direct_events[0]["event_type"] == "heartbeat"
+    assert direct_events[0]["priority"] == "info"
     assert integrity.received_events and integrity.received_events[0]["event_type"] == "heartbeat"
+    assert integrity.received_events[0]["priority"] == "info"
     integrity.stop()
 
 
@@ -71,6 +73,7 @@ def test_events_persist_until_consumed():
 
     pending = pulse_bus.pending_events()
     assert pending and pending[0]["event_type"] == "persist_test"
+    assert pending[0]["priority"] == "info"
 
     consumed = pulse_bus.consume_events()
     assert consumed == pending
@@ -97,4 +100,6 @@ def test_network_daemon_publishes_to_pulse(base_config):
     assert enforcement_events[0]["source_daemon"] == "network"
     assert enforcement_events[0]["payload"] == ledger_entries[0]
     assert "port=23" in enforcement_events[0]["payload"]["policy"]
+    assert enforcement_events[0]["priority"] == "critical"
     assert port_events[0]["payload"]["policy"].startswith("port=23")
+    assert port_events[0]["priority"] == "info"

--- a/tests/test_pulse_persistence.py
+++ b/tests/test_pulse_persistence.py
@@ -41,11 +41,13 @@ def test_event_persisted_with_signature() -> None:
     published = pulse_bus.publish(_build_event(ts, event_type="persist", value=1))
 
     assert "signature" in published and published["signature"]
+    assert published["priority"] == "info"
 
     entries = _history_entries()
     assert len(entries) == 1
     stored = entries[0]
     assert stored["signature"] == published["signature"]
+    assert stored["priority"] == "info"
     assert pulse_bus.verify(stored) is True
 
 

--- a/tests/test_pulse_priority.py
+++ b/tests/test_pulse_priority.py
@@ -1,0 +1,161 @@
+"""Tests covering pulse priority routing and integrations."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import threading
+import time
+from datetime import datetime, timezone
+from queue import Queue
+from typing import List
+
+import pytest
+
+from sentientos.daemons import pulse_bus
+from sentientos.daemons.integrity_daemon import IntegrityDaemon
+from sentientos.daemons.monitoring_daemon import MonitoringDaemon
+
+
+@pytest.fixture(autouse=True)
+def reset_bus() -> None:
+    pulse_bus.reset()
+    yield
+    pulse_bus.reset()
+
+
+def _build_event(event_type: str, *, priority: str | None = None) -> dict:
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source_daemon": "test",
+        "event_type": event_type,
+        "payload": {"event": event_type},
+    }
+    if priority is not None:
+        event["priority"] = priority
+    return event
+
+
+def test_priority_filter_delivers_expected_events() -> None:
+    """Subscribers receive only the priorities they register for."""
+
+    critical_events: List[dict] = []
+    info_events: List[dict] = []
+
+    pulse_bus.subscribe(lambda evt: critical_events.append(evt), priorities=["critical"])
+    pulse_bus.subscribe(lambda evt: info_events.append(evt), priorities=["info"])
+
+    pulse_bus.publish(_build_event("info_event"))
+    pulse_bus.publish(_build_event("critical_event", priority="critical"))
+
+    assert [evt["event_type"] for evt in critical_events] == ["critical_event"]
+    assert [evt["event_type"] for evt in info_events] == ["info_event"]
+
+
+def test_default_priority_is_info_for_unfiltered_subscribers() -> None:
+    """Subscribers without filters should observe all events with default info priority."""
+
+    received: List[dict] = []
+    pulse_bus.subscribe(lambda evt: received.append(evt))
+
+    pulse_bus.publish(_build_event("default"))
+    pulse_bus.publish(_build_event("warning", priority="warning"))
+
+    priorities = [evt["priority"] for evt in received]
+    assert priorities == ["info", "warning"]
+
+
+def test_integrity_daemon_emits_critical_on_signature_mismatch() -> None:
+    """Integrity daemon publishes a critical pulse when verification fails."""
+
+    valid = pulse_bus.publish(_build_event("heartbeat"))
+    integrity = IntegrityDaemon()
+    captured: List[dict] = []
+    subscription = pulse_bus.subscribe(captured.append, priorities=["critical"])
+
+    tampered = copy.deepcopy(valid)
+    tampered["payload"]["event"] = "tampered"
+
+    integrity._handle_event(tampered)
+
+    assert integrity.invalid_events
+    assert captured and captured[-1]["event_type"] == "integrity_violation"
+    assert captured[-1]["priority"] == "critical"
+    assert any(evt.get("event_type") == "integrity_violation" for evt in integrity.alerts)
+
+    subscription.unsubscribe()
+    integrity.stop()
+
+
+def test_monitoring_daemon_tracks_warning_and_critical() -> None:
+    """Monitoring daemon surfaces warning and critical pulses."""
+
+    monitor = MonitoringDaemon()
+    pulse_bus.publish(_build_event("routine"))
+    pulse_bus.publish(_build_event("warning_event", priority="warning"))
+    pulse_bus.publish(_build_event("critical_event", priority="critical"))
+
+    assert monitor.warning_events and monitor.warning_events[0]["priority"] == "warning"
+    assert monitor.critical_events and monitor.critical_events[0]["priority"] == "critical"
+    assert len(monitor.warning_events) == 1
+    assert len(monitor.critical_events) == 1
+
+    monitor.stop()
+
+
+def test_codex_self_repair_triggers_on_critical(monkeypatch, tmp_path) -> None:
+    """Codex daemon subscribes to critical events and reacts to them."""
+
+    monkeypatch.setenv("LUMOS_AUTO_APPROVE", "1")
+    codex_module = importlib.import_module("daemon.codex_daemon")
+    codex_daemon = importlib.reload(codex_module)
+
+    monkeypatch.setattr(codex_daemon, "CODEX_SESSION_FILE", tmp_path / "codex_session.json")
+    monkeypatch.setattr(codex_daemon, "CODEX_INTERVAL", 0.01)
+    monkeypatch.setattr(codex_daemon, "run_once", lambda queue: None)
+    monkeypatch.setattr(codex_daemon.pulse_bus, "replay", lambda since=None: [])
+
+    captured_priorities: List[list[str] | None] = []
+    original_subscribe = codex_daemon.pulse_bus.subscribe
+
+    def spy_subscribe(handler, priorities=None):
+        captured_priorities.append(list(priorities) if priorities is not None else None)
+        return original_subscribe(handler, priorities)
+
+    monkeypatch.setattr(codex_daemon.pulse_bus, "subscribe", spy_subscribe)
+
+    calls: List[bool] = []
+
+    def fake_self_repair(queue):
+        calls.append(True)
+
+    monkeypatch.setattr(codex_daemon, "self_repair_check", fake_self_repair)
+
+    stop = threading.Event()
+    queue = Queue()
+    thread = threading.Thread(target=codex_daemon.run_loop, args=(stop, queue))
+    thread.start()
+    try:
+        for _ in range(100):
+            if captured_priorities:
+                break
+            time.sleep(0.01)
+        assert captured_priorities and captured_priorities[0] == ["critical"]
+
+        pulse_bus.publish(_build_event("info_chatter"))
+        time.sleep(0.05)
+        assert not calls
+
+        pulse_bus.publish(
+            _build_event("resync_required", priority="critical")
+        )
+
+        for _ in range(100):
+            if calls:
+                break
+            time.sleep(0.01)
+        assert len(calls) == 1
+    finally:
+        stop.set()
+        thread.join(timeout=1)
+        codex_daemon.pulse_bus.reset()


### PR DESCRIPTION
## Summary
- add explicit priority metadata and filtering support to the pulse bus, including subscription-level selectors
- mark network and integrity daemon events with appropriate priority levels and introduce a monitoring daemon focused on high-priority pulses
- expand automated coverage for priority routing and ensure Codex only reacts to critical events

## Testing
- `pytest -q`
- `mypy --config-file mypy.ini`
- `mypy scripts/ sentientos/` *(fails: existing repository errors outside pulse changes)*
- `LUMOS_AUTO_APPROVE=1 python verify_audits.py --strict`
- `PYTHONPATH=. LUMOS_AUTO_APPROVE=1 python scripts/audit_immutability_verifier.py`


------
https://chatgpt.com/codex/tasks/task_b_68cb0e1eecd88320a6464423b1e04cd9