### PR TITLE
Add pulse federation support

### DIFF
--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -11,4 +11,6 @@ network_policies:
   block_ports: []
   max_bandwidth_percent: 90
   mode: monitor_only  # monitor_only | active_enforce
+federation_enabled: false
+federation_peers: []
 federation_peer_ip: null

--- a/profiles/template/config.yaml
+++ b/profiles/template/config.yaml
@@ -11,4 +11,6 @@ network_policies:
   block_ports: []
   max_bandwidth_percent: 90
   mode: monitor_only  # monitor_only | active_enforce
+federation_enabled: false
+federation_peers: []
 federation_peer_ip: null

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,7 @@ testpaths =
     tests/test_emotion_pump.py
     tests/test_audit_immutability.py
     tests/test_network_daemon.py
+    tests/test_pulse_bus.py
+    tests/test_pulse_persistence.py
+    tests/test_pulse_priority.py
+    tests/test_pulse_federation.py

--- a/sentientos/daemons/__init__.py
+++ b/sentientos/daemons/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import monitoring_daemon, pulse_bus
+from . import monitoring_daemon, pulse_bus, pulse_federation
 
-__all__ = ["pulse_bus", "monitoring_daemon"]
+__all__ = ["pulse_bus", "pulse_federation", "monitoring_daemon"]

--- a/sentientos/daemons/pulse_federation.py
+++ b/sentientos/daemons/pulse_federation.py
@@ -1,0 +1,292 @@
+"""Federated propagation and ingestion for the pulse bus."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import copy
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import requests
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
+
+from . import pulse_bus
+
+logger = logging.getLogger(__name__)
+
+_KEYS_DIR_ENV = "PULSE_FEDERATION_KEYS_DIR"
+_DEFAULT_KEYS_DIR = Path("/glow/federation_keys")
+_REQUEST_TIMEOUT_SECONDS = 5
+_FEDERATION_ENDPOINT = "/pulse/federation"
+
+
+@dataclass(frozen=True)
+class _Peer:
+    name: str
+    endpoint: str
+
+    def api_base(self) -> str:
+        base = self.endpoint.strip()
+        if not base:
+            return ""
+        if "://" not in base:
+            base = f"http://{base}"
+        return base.rstrip("/")
+
+
+_ENABLED = False
+_PEER_MAP: dict[str, _Peer] = {}
+_PEER_KEYS: dict[str, VerifyKey] = {}
+_SUBSCRIPTION: pulse_bus.PulseSubscription | None = None
+
+
+def _keys_dir() -> Path:
+    override = os.getenv(_KEYS_DIR_ENV)
+    if override:
+        return Path(override)
+    return _DEFAULT_KEYS_DIR
+
+
+def _sanitize_name(value: str) -> str:
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "_", value.strip())
+    return sanitized or "peer"
+
+
+def _normalize_peer(entry: object) -> _Peer | None:
+    if isinstance(entry, str):
+        endpoint = entry.strip()
+        if not endpoint:
+            return None
+        name = _sanitize_name(endpoint)
+        return _Peer(name=name, endpoint=endpoint)
+    if isinstance(entry, dict):
+        raw_name = entry.get("name") or entry.get("id") or entry.get("peer")
+        raw_endpoint = (
+            entry.get("url")
+            or entry.get("endpoint")
+            or entry.get("address")
+            or entry.get("host")
+        )
+        endpoint = str(raw_endpoint or "").strip()
+        if not endpoint:
+            return None
+        name_value = str(raw_name or endpoint)
+        name = _sanitize_name(name_value)
+        return _Peer(name=name, endpoint=endpoint)
+    return None
+
+
+def configure(*, enabled: bool, peers: Iterable[object] | None = None) -> None:
+    """Configure federation state and subscriptions for the pulse bus."""
+
+    global _ENABLED, _PEER_MAP
+
+    _ENABLED = bool(enabled)
+    normalized: dict[str, _Peer] = {}
+    if peers is not None:
+        for entry in peers:
+            peer = _normalize_peer(entry)
+            if peer is None:
+                continue
+            normalized[peer.name] = peer
+    _PEER_MAP = normalized
+    _load_peer_keys()
+    _update_subscription()
+
+
+def reset() -> None:
+    """Disable federation support and drop cached peer state."""
+
+    global _ENABLED, _PEER_MAP, _PEER_KEYS, _SUBSCRIPTION
+
+    _ENABLED = False
+    _PEER_MAP = {}
+    _PEER_KEYS = {}
+    if _SUBSCRIPTION is not None and _SUBSCRIPTION.active:
+        _SUBSCRIPTION.unsubscribe()
+    _SUBSCRIPTION = None
+
+
+def is_enabled() -> bool:
+    """Return whether federation support is currently enabled."""
+
+    return _ENABLED and bool(_PEER_MAP)
+
+
+def peers() -> Sequence[str]:
+    """Return the configured federation peer names."""
+
+    return tuple(_PEER_MAP.keys())
+
+
+def verify_remote_signature(event: pulse_bus.PulseEvent, peer_name: str) -> bool:
+    """Return ``True`` when ``event`` is signed by ``peer_name``."""
+
+    key = _PEER_KEYS.get(peer_name)
+    if key is None:
+        return False
+    signature = event.get("signature")
+    if not isinstance(signature, str) or not signature:
+        return False
+    try:
+        payload = pulse_bus._serialize_for_signature(event)
+        key.verify(payload, base64.b64decode(signature))
+        return True
+    except (BadSignatureError, binascii.Error, ValueError):
+        return False
+
+
+def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bus.PulseEvent:
+    """Validate and ingest ``event`` from ``peer_name`` into the local bus."""
+
+    if not _ENABLED:
+        raise RuntimeError("Pulse federation is disabled")
+    peer = _PEER_MAP.get(peer_name)
+    if peer is None:
+        raise ValueError(f"Unknown federation peer: {peer_name}")
+    if not verify_remote_signature(event, peer_name):
+        raise ValueError(f"Invalid signature from federation peer: {peer_name}")
+    payload = copy.deepcopy(event)
+    payload["source_peer"] = peer_name
+    return pulse_bus.ingest(payload, source_peer=peer_name)
+
+
+def request_recent_events(minutes: int) -> List[pulse_bus.PulseEvent]:
+    """Request recent pulse history from all peers and ingest new events."""
+
+    if not is_enabled():
+        return []
+    collected: List[pulse_bus.PulseEvent] = []
+    for peer in _PEER_MAP.values():
+        endpoint = peer.api_base()
+        if not endpoint:
+            continue
+        try:
+            response = _http_get(
+                f"{endpoint}{_FEDERATION_ENDPOINT}",
+                params={"minutes": minutes},
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+        except Exception:  # pragma: no cover - network failures best-effort
+            logger.warning("Failed to request pulse replay from peer %s", peer.name, exc_info=True)
+            continue
+        for event in _extract_events(response):
+            try:
+                ingested = ingest_remote_event(event, peer.name)
+            except ValueError:
+                logger.warning(
+                    "Rejected invalid federated event from peer %s", peer.name, exc_info=True
+                )
+                continue
+            collected.append(ingested)
+    return collected
+
+
+def _load_peer_keys() -> None:
+    global _PEER_KEYS
+
+    directory = _keys_dir()
+    _PEER_KEYS = {}
+    if not directory.exists():
+        return
+    for peer in _PEER_MAP.values():
+        key_path = directory / f"{peer.name}.pub"
+        try:
+            key_bytes = key_path.read_bytes()
+        except FileNotFoundError:
+            logger.warning("Federation verify key missing for peer %s at %s", peer.name, key_path)
+            continue
+        try:
+            _PEER_KEYS[peer.name] = VerifyKey(key_bytes)
+        except Exception as exc:
+            logger.warning("Unable to load federation key for %s: %s", peer.name, exc)
+
+
+def _update_subscription() -> None:
+    global _SUBSCRIPTION
+
+    if not is_enabled():
+        if _SUBSCRIPTION is not None and _SUBSCRIPTION.active:
+            _SUBSCRIPTION.unsubscribe()
+        _SUBSCRIPTION = None
+        return
+    if _SUBSCRIPTION is not None and _SUBSCRIPTION.active:
+        return
+    _SUBSCRIPTION = pulse_bus.subscribe(_handle_local_publish)
+
+
+def _handle_local_publish(event: pulse_bus.PulseEvent) -> None:
+    if not _ENABLED or not _PEER_MAP:
+        return
+    if str(event.get("source_peer", "local")) != "local":
+        return
+    if not _payload_is_safe(event):
+        logger.warning("Skipping privileged pulse event; payload not federated")
+        return
+    for peer in _PEER_MAP.values():
+        endpoint = peer.api_base()
+        if not endpoint:
+            continue
+        try:
+            _http_post(
+                f"{endpoint}{_FEDERATION_ENDPOINT}",
+                json=event,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+        except Exception:  # pragma: no cover - network failures best-effort
+            logger.warning("Failed to forward pulse event to peer %s", peer.name, exc_info=True)
+
+
+def _payload_is_safe(event: pulse_bus.PulseEvent) -> bool:
+    try:
+        payload = json.dumps(event, sort_keys=True)
+    except (TypeError, ValueError):
+        return False
+    lowered = payload.lower()
+    return "/vow" not in lowered and "newlegacy" not in lowered
+
+
+def _extract_events(response: object) -> List[pulse_bus.PulseEvent]:
+    if response is None:
+        return []
+    if isinstance(response, list):
+        raw = response
+    elif hasattr(response, "json") and callable(response.json):
+        try:
+            raw = response.json()
+        except Exception:
+            logger.warning("Failed to decode federated replay payload", exc_info=True)
+            return []
+    else:
+        return []
+    events: List[pulse_bus.PulseEvent] = []
+    for item in raw:
+        if isinstance(item, dict):
+            events.append(copy.deepcopy(item))
+    return events
+
+
+def _http_post(url: str, *, json: pulse_bus.PulseEvent, timeout: int) -> None:
+    requests.post(url, json=json, timeout=timeout)
+
+
+def _http_get(url: str, *, params: dict[str, object], timeout: int):
+    return requests.get(url, params=params, timeout=timeout)
+
+
+__all__ = [
+    "configure",
+    "reset",
+    "is_enabled",
+    "peers",
+    "verify_remote_signature",
+    "ingest_remote_event",
+    "request_recent_events",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_network_daemon",
         "tests.test_pulse_persistence",
         "tests.test_pulse_priority",
+        "tests.test_pulse_federation",
         "tests.test_daemon_manager",
     }
     for item in items:

--- a/tests/test_network_daemon.py
+++ b/tests/test_network_daemon.py
@@ -59,7 +59,8 @@ def base_config(tmp_path):
                 {"bandwidth": 1000, "action": "throttle"},
             ],
         },
-        "federation_peer_ip": "192.0.2.10",
+        "federation_enabled": True,
+        "federation_peers": ["192.0.2.10"],
         "log_dir": tmp_path,
     }
 
@@ -114,6 +115,7 @@ def test_federation_resync_trigger(daemon):
         evt["event_type"] == "resync_required" and evt["priority"] == "critical"
         for evt in events
     )
+    assert all(evt.get("source_peer") == "local" for evt in events)
 
 
 def test_no_uptime_event_below_threshold(daemon):
@@ -170,6 +172,8 @@ def test_policy_violation_generates_ledger_entry(make_daemon):
     assert port_events[0]["payload"]["policy"].startswith("port=23")
     assert all(evt["priority"] == "critical" for evt in enforcement_events)
     assert all(evt["priority"] == "info" for evt in port_events)
+    assert all(evt.get("source_peer") == "local" for evt in enforcement_events)
+    assert all(evt.get("source_peer") == "local" for evt in port_events)
 
 
 def test_enforcement_mode_toggle_suppresses_ledger(make_daemon):

--- a/tests/test_pulse_bus.py
+++ b/tests/test_pulse_bus.py
@@ -38,7 +38,8 @@ def base_config(tmp_path):
                 {"bandwidth": 1000, "action": "throttle"},
             ],
         },
-        "federation_peer_ip": "192.0.2.10",
+        "federation_enabled": True,
+        "federation_peers": ["192.0.2.10"],
         "log_dir": tmp_path,
     }
 
@@ -62,8 +63,10 @@ def test_multiple_subscribers_receive_events():
 
     assert direct_events and direct_events[0]["event_type"] == "heartbeat"
     assert direct_events[0]["priority"] == "info"
+    assert direct_events[0]["source_peer"] == "local"
     assert integrity.received_events and integrity.received_events[0]["event_type"] == "heartbeat"
     assert integrity.received_events[0]["priority"] == "info"
+    assert integrity.received_events[0]["source_peer"] == "local"
     integrity.stop()
 
 
@@ -74,6 +77,7 @@ def test_events_persist_until_consumed():
     pending = pulse_bus.pending_events()
     assert pending and pending[0]["event_type"] == "persist_test"
     assert pending[0]["priority"] == "info"
+    assert pending[0]["source_peer"] == "local"
 
     consumed = pulse_bus.consume_events()
     assert consumed == pending
@@ -101,5 +105,7 @@ def test_network_daemon_publishes_to_pulse(base_config):
     assert enforcement_events[0]["payload"] == ledger_entries[0]
     assert "port=23" in enforcement_events[0]["payload"]["policy"]
     assert enforcement_events[0]["priority"] == "critical"
+    assert enforcement_events[0]["source_peer"] == "local"
     assert port_events[0]["payload"]["policy"].startswith("port=23")
     assert port_events[0]["priority"] == "info"
+    assert port_events[0]["source_peer"] == "local"

--- a/tests/test_pulse_federation.py
+++ b/tests/test_pulse_federation.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import base64
+import copy
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+from nacl.signing import SigningKey
+
+from sentientos.daemons import pulse_bus, pulse_federation
+
+
+@pytest.fixture(autouse=True)
+def reset_state(tmp_path, monkeypatch):
+    pulse_bus.reset()
+    pulse_federation.reset()
+    key_dir = tmp_path / "federation_keys"
+    key_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("PULSE_FEDERATION_KEYS_DIR", str(key_dir))
+    yield
+    pulse_bus.reset()
+    pulse_federation.reset()
+
+
+def _sign_event(signing_key: SigningKey, event: dict) -> dict:
+    payload = copy.deepcopy(event)
+    payload.setdefault("priority", "info")
+    signature = signing_key.sign(pulse_bus._serialize_for_signature(payload)).signature
+    payload["signature"] = base64.b64encode(signature).decode("ascii")
+    return payload
+
+
+def test_local_publish_forwarded_with_signature(monkeypatch):
+    captured: List[tuple[str, dict]] = []
+
+    def fake_post(url: str, *, json: dict, timeout: int) -> None:  # noqa: A002 - matching signature
+        captured.append((url, json))
+
+    monkeypatch.setattr(pulse_federation, "_http_post", fake_post)
+
+    pulse_federation.configure(enabled=True, peers=["peer-alpha"])
+
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source_daemon": "network",
+        "event_type": "status",
+        "payload": {"ok": True},
+    }
+    published = pulse_bus.publish(event)
+
+    assert published["source_peer"] == "local"
+    assert captured, "Publishing should forward the event to peers"
+    url, payload = captured[0]
+    assert url == "http://peer-alpha/pulse/federation"
+    assert payload["signature"]
+    assert payload["source_peer"] == "local"
+    assert pulse_bus.verify(payload) is True
+
+
+def test_tampered_signature_rejected():
+    key_dir = Path(os.environ["PULSE_FEDERATION_KEYS_DIR"])
+    signing_key = SigningKey.generate()
+    (key_dir / "peer-alpha.pub").write_bytes(signing_key.verify_key.encode())
+
+    pulse_federation.configure(enabled=True, peers=["peer-alpha"])
+
+    base_event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source_daemon": "remote",
+        "event_type": "metric",
+        "payload": {"value": 1},
+    }
+    signed = _sign_event(signing_key, base_event)
+    ingested = pulse_federation.ingest_remote_event(copy.deepcopy(signed), "peer-alpha")
+    assert ingested["source_peer"] == "peer-alpha"
+    assert pulse_bus.verify(ingested) is True
+
+    tampered = copy.deepcopy(signed)
+    tampered["payload"]["value"] = 999
+
+    with pytest.raises(ValueError):
+        pulse_federation.ingest_remote_event(tampered, "peer-alpha")
+
+
+def test_remote_replay_ingests_events(monkeypatch):
+    key_dir = Path(os.environ["PULSE_FEDERATION_KEYS_DIR"])
+    signing_key = SigningKey.generate()
+    (key_dir / "peer-alpha.pub").write_bytes(signing_key.verify_key.encode())
+
+    pulse_federation.configure(enabled=True, peers=["peer-alpha"])
+
+    replay_event = _sign_event(
+        signing_key,
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "source_daemon": "remote",
+            "event_type": "heartbeat",
+            "payload": {"note": "synced"},
+        },
+    )
+
+    def fake_get(url: str, *, params: dict, timeout: int):  # noqa: ANN001 - params shape defined by caller
+        assert params.get("minutes") == 15
+        return [copy.deepcopy(replay_event)]
+
+    monkeypatch.setattr(pulse_federation, "_http_get", fake_get)
+
+    ingested = pulse_federation.request_recent_events(15)
+    assert ingested and ingested[0]["source_peer"] == "peer-alpha"
+    events = pulse_bus.pending_events()
+    assert events and events[0]["event_type"] == "heartbeat"
+    assert events[0]["source_peer"] == "peer-alpha"
+    assert pulse_bus.verify(events[0]) is True
+
+
+def test_remote_events_do_not_echo(monkeypatch):
+    key_dir = Path(os.environ["PULSE_FEDERATION_KEYS_DIR"])
+    signing_key = SigningKey.generate()
+    (key_dir / "peer-alpha.pub").write_bytes(signing_key.verify_key.encode())
+
+    pulse_federation.configure(enabled=True, peers=["peer-alpha"])
+
+    captured: List[tuple[str, dict]] = []
+
+    def fake_post(url: str, *, json: dict, timeout: int) -> None:  # noqa: A002
+        captured.append((url, json))
+
+    monkeypatch.setattr(pulse_federation, "_http_post", fake_post)
+
+    remote_event = _sign_event(
+        signing_key,
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "source_daemon": "remote",
+            "event_type": "alert",
+            "payload": {"detail": "peer"},
+        },
+    )
+
+    ingested = pulse_federation.ingest_remote_event(remote_event, "peer-alpha")
+    assert ingested["source_peer"] == "peer-alpha"
+    assert captured == []
+    pending = pulse_bus.pending_events()
+    assert pending and pending[0]["event_type"] == "alert"
+    assert pending[0]["source_peer"] == "peer-alpha"

--- a/tests/test_pulse_persistence.py
+++ b/tests/test_pulse_persistence.py
@@ -48,6 +48,7 @@ def test_event_persisted_with_signature() -> None:
     stored = entries[0]
     assert stored["signature"] == published["signature"]
     assert stored["priority"] == "info"
+    assert stored["source_peer"] == "local"
     assert pulse_bus.verify(stored) is True
 
 
@@ -75,6 +76,7 @@ def test_replay_returns_events_in_chronological_order() -> None:
 
     replayed = list(pulse_bus.replay())
     assert [evt["event_type"] for evt in replayed] == ["first", "second", "third"]
+    assert all(evt.get("source_peer") == "local" for evt in replayed)
     assert all(pulse_bus.verify(evt) for evt in replayed)
 
 
@@ -88,6 +90,7 @@ def test_replay_since_filters_events() -> None:
     replayed = list(pulse_bus.replay(since=since))
 
     assert [evt["event_type"] for evt in replayed] == ["late", "next"]
+    assert all(evt.get("source_peer") == "local" for evt in replayed)
 
 
 def test_history_survives_reset() -> None:
@@ -98,3 +101,4 @@ def test_history_survives_reset() -> None:
 
     replayed = list(pulse_bus.replay())
     assert replayed and replayed[0]["event_type"] == "survive"
+    assert replayed[0]["source_peer"] == "local"


### PR DESCRIPTION
## Summary
- extend the pulse bus with source peer metadata and an ingest helper for federated events
- add a pulse_federation module that forwards local pulses, validates remote signatures, and replays recent history from peers
- wire federation configuration through the codex and network daemons and update defaults and tests to cover the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb3328644c83208dc05bde9a34d3af