### PR TITLE
[codex:first-boot] implement first boot wizard

### DIFF
--- a/sentientos/first_boot.py
+++ b/sentientos/first_boot.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+import yaml
+
+from log_utils import append_json
+from sentientos.daemons import pulse_bus
+from sentientos.daemons.driver_manager import DriverManager
+from sentientos.privilege import require_lumos_approval
+
+__all__ = [
+    "FirstBootPanel",
+    "WizardDecisions",
+    "FirstBootWizard",
+]
+
+
+@dataclass(frozen=True)
+class FirstBootPanel:
+    """Lightweight description of a wizard panel shown in SentientShell."""
+
+    title: str
+    description: str
+    buttons: tuple[str, ...] = ()
+
+
+@dataclass
+class WizardDecisions:
+    """Scripted responses for automating the first-boot flow in tests."""
+
+    bless: bool = True
+    driver_choices: dict[str, bool] = field(default_factory=dict)
+    codex_mode: str | None = None
+    codex_interval: int | None = None
+    codex_max_iterations: int | None = None
+    federation_peer_name: str | None = None
+    federation_addresses: Sequence[str] | None = None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_sequence(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    result: List[str] = []
+    for value in values:
+        normalized = str(value).strip()
+        if not normalized:
+            continue
+        lowered = normalized.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        result.append(normalized)
+    return result
+
+
+class FirstBootWizard:
+    """Guided configuration flow for first-boot covenant setup."""
+
+    def __init__(
+        self,
+        *,
+        driver_manager: DriverManager | None = None,
+        ledger_path: Path | None = None,
+        config_path: Path | None = None,
+        completion_path: Path | None = None,
+        pulse_source: str = "FirstBootWizard",
+        ledger_writer: Callable[[Path, Mapping[str, object]], None] | None = None,
+        pulse_publisher: Callable[[dict[str, object]], dict[str, object]] | None = None,
+        blessing_hook: Callable[[], None] = require_lumos_approval,
+        connectivity_tester: Callable[[str, str], bool] | None = None,
+        clock: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        vow_root = Path(os.getenv("SENTIENTOS_VOW_DIR", "/vow"))
+        if config_path is None:
+            config_path = vow_root / "config.yaml"
+        if completion_path is None:
+            completion_path = vow_root / "first_boot_complete"
+        if ledger_path is None:
+            ledger_default = os.getenv("SENTIENTOS_LEDGER_FILE", "/daemon/logs/ledger.jsonl")
+            ledger_path = Path(ledger_default)
+        self._driver_manager = driver_manager
+        self._ledger_path = ledger_path
+        self._config_path = config_path
+        self._completion_path = completion_path
+        self._pulse_source = pulse_source
+        self._ledger_writer = ledger_writer or append_json
+        self._pulse_publisher = pulse_publisher or pulse_bus.publish
+        self._blessing_hook = blessing_hook
+        self._clock = clock
+        self._connectivity_tester = connectivity_tester or self._default_connectivity_tester
+        self._panels: List[FirstBootPanel] = []
+        self._last_summary: dict[str, object] | None = None
+
+    @property
+    def panels(self) -> List[FirstBootPanel]:
+        return list(self._panels)
+
+    @property
+    def last_summary(self) -> dict[str, object] | None:
+        return None if self._last_summary is None else dict(self._last_summary)
+
+    def should_run(self) -> bool:
+        return not self._completion_path.exists()
+
+    def reset(self) -> None:
+        if self._completion_path.exists():
+            self._completion_path.unlink()
+        self._last_summary = None
+
+    def run(
+        self,
+        decisions: WizardDecisions | None = None,
+        *,
+        force: bool = False,
+    ) -> dict[str, object]:
+        if not force and not self.should_run():
+            summary = {"status": "skipped", "reason": "first_boot_complete"}
+            self._last_summary = summary
+            return dict(summary)
+
+        decisions = decisions or WizardDecisions()
+        self._panels = []
+        config = self._load_config()
+        summary: dict[str, object] = {
+            "status": "completed",
+            "drivers": [],
+            "codex": {},
+            "federation": {},
+            "panels": [],
+        }
+
+        self._record_step("welcome", {"force": force})
+        self._panels.append(
+            FirstBootPanel(
+                title="Welcome to SentientOS",
+                description=(
+                    "Review the covenant vows and receive Lumos' blessing before accessing the desktop."
+                ),
+                buttons=("Receive Blessing",),
+            )
+        )
+        if not decisions.bless:
+            raise PermissionError("Lumos blessing is required to continue the first-boot wizard.")
+        try:
+            self._blessing_hook()
+        except SystemExit as exc:  # pragma: no cover - surfaced when blessing denied interactively
+            raise PermissionError("Lumos did not grant the blessing.") from exc
+        self._record_step("blessing", {"status": "approved"})
+        self._log_event("first_boot_blessed", {"status": "approved"})
+
+        driver_results = self._handle_driver_step(decisions)
+        summary["drivers"] = driver_results
+
+        codex_payload = self._handle_codex_step(decisions, config)
+        summary["codex"] = codex_payload
+
+        federation_payload = self._handle_federation_step(decisions, config)
+        summary["federation"] = federation_payload
+
+        self._panels.append(
+            FirstBootPanel(
+                title="Summary",
+                description="Review your selections and confirm to complete first-boot setup.",
+                buttons=("Finish",),
+            )
+        )
+        summary["panels"] = [
+            {"title": panel.title, "buttons": list(panel.buttons)} for panel in self._panels
+        ]
+        summary_payload = {
+            "codex_mode": codex_payload.get("mode"),
+            "driver_installs": len([result for result in driver_results if result.get("status") == "success" or result.get("requires_veil")]),
+            "federation_peers": len(federation_payload.get("addresses", [])),
+        }
+        self._record_step("summary", summary_payload)
+        self._write_completion_flag()
+        completion_payload = {
+            "codex_mode": codex_payload.get("mode"),
+            "drivers": driver_results,
+            "federation": federation_payload,
+        }
+        self._log_event("first_boot_complete", completion_payload)
+        self._last_summary = summary
+        return dict(summary)
+
+    # Internal helpers -------------------------------------------------
+    def _handle_driver_step(self, decisions: WizardDecisions) -> List[dict[str, object]]:
+        devices: List[Mapping[str, object]] = []
+        results: List[dict[str, object]] = []
+        if self._driver_manager is not None:
+            snapshot = self._driver_manager.refresh()
+            raw_devices = snapshot.get("devices", []) if isinstance(snapshot, Mapping) else []
+            for entry in raw_devices:
+                if isinstance(entry, Mapping):
+                    devices.append(entry)
+        needs_install: List[Mapping[str, object]] = []
+        for device in devices:
+            status = str(device.get("status", "")).lower()
+            if bool(device.get("needs_driver")) or status in {"missing", "unknown"}:
+                if device.get("recommended_driver"):
+                    needs_install.append(device)
+        buttons = []
+        for device in needs_install:
+            name = str(device.get("name", device.get("id", "device")))
+            driver_name = str(device.get("recommended_driver", "driver"))
+            buttons.append(f"Install {driver_name} for {name}")
+        self._panels.append(
+            FirstBootPanel(
+                title="Driver Check",
+                description="Review detected hardware and install any recommended covenant drivers.",
+                buttons=tuple(buttons) if buttons else ("Continue",),
+            )
+        )
+        for device in needs_install:
+            device_id = str(device.get("id") or device.get("device_id") or "")
+            if not device_id:
+                continue
+            should_install = decisions.driver_choices.get(device_id, False)
+            if not should_install:
+                continue
+            if self._driver_manager is None:
+                continue
+            try:
+                result = self._driver_manager.install_driver(device_id)
+            except Exception as exc:  # pragma: no cover - defensive logging, exercised in tests
+                result = {
+                    "device_id": device_id,
+                    "status": "error",
+                    "error": str(exc),
+                }
+            results.append(dict(result))
+        payload = {
+            "devices": len(devices),
+            "recommended": len(needs_install),
+            "installs": [result.get("device_id") for result in results],
+        }
+        self._record_step("drivers", payload)
+        return results
+
+    def _handle_codex_step(
+        self,
+        decisions: WizardDecisions,
+        config: MutableMapping[str, object],
+    ) -> dict[str, object]:
+        self._panels.append(
+            FirstBootPanel(
+                title="Codex Configuration",
+                description="Select Codex operating mode and reasoning cadence for the covenant.",
+                buttons=("Save Codex Settings",),
+            )
+        )
+        mode = str(
+            (decisions.codex_mode or config.get("codex_mode", "observe")).strip().lower()
+        )
+        if mode not in {"observe", "repair", "full", "expand"}:
+            raise ValueError("codex_mode must be one of: observe, repair, full, expand")
+        interval = int(decisions.codex_interval or config.get("codex_interval", 3600))
+        max_iterations = int(decisions.codex_max_iterations or config.get("codex_max_iterations", 1))
+        config["codex_mode"] = mode
+        config["codex_interval"] = interval
+        config["codex_max_iterations"] = max_iterations
+        self._save_config(config)
+        payload = {"mode": mode, "interval": interval, "max_iterations": max_iterations}
+        self._record_step("codex", payload)
+        self._log_event("first_boot_codex_configured", payload, pulse=False)
+        return payload
+
+    def _handle_federation_step(
+        self,
+        decisions: WizardDecisions,
+        config: MutableMapping[str, object],
+    ) -> dict[str, object]:
+        self._panels.append(
+            FirstBootPanel(
+                title="Federation Setup",
+                description="Name your presence and connect to covenant peers for pulse federation.",
+                buttons=("Save Federation Settings",),
+            )
+        )
+        peer_name = str(
+            (decisions.federation_peer_name or config.get("federation_peer_name", "")).strip()
+        )
+        addresses: Sequence[str] | None = decisions.federation_addresses
+        if addresses is None:
+            existing = config.get("federation_peers") or config.get("federation_addresses")
+            if isinstance(existing, Iterable) and not isinstance(existing, (str, bytes)):
+                addresses = [str(item) for item in existing]
+            else:
+                addresses = []
+        normalized_addresses = _normalize_sequence(addresses)
+        config["federation_peer_name"] = peer_name
+        config["federation_peers"] = normalized_addresses
+        self._save_config(config)
+        connectivity: Dict[str, bool] = {}
+        for address in normalized_addresses:
+            try:
+                connectivity[address] = bool(self._connectivity_tester(peer_name, address))
+            except Exception:  # pragma: no cover - connectivity failure recorded as False
+                connectivity[address] = False
+        payload = {
+            "peer_name": peer_name,
+            "addresses": normalized_addresses,
+            "connectivity": connectivity,
+        }
+        self._record_step("federation", payload)
+        self._log_event("first_boot_federation_configured", payload, pulse=False)
+        return payload
+
+    def _load_config(self) -> MutableMapping[str, object]:
+        if not self._config_path.exists():
+            return {}
+        try:
+            data = yaml.safe_load(self._config_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        if isinstance(data, Mapping):
+            return dict(data)
+        return {}
+
+    def _save_config(self, config: Mapping[str, object]) -> None:
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._config_path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(dict(config), handle, sort_keys=True)
+
+    def _write_completion_flag(self) -> None:
+        self._completion_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = self._clock().isoformat()
+        self._completion_path.write_text(f"completed {timestamp}\n", encoding="utf-8")
+
+    def _record_step(self, step: str, payload: Mapping[str, object]) -> None:
+        normalized_payload = dict(payload)
+        normalized_payload["step"] = step
+        self._log_event("first_boot_step", normalized_payload)
+
+    def _log_event(
+        self,
+        event_type: str,
+        payload: Mapping[str, object],
+        *,
+        pulse: bool = True,
+        ledger: bool = True,
+        priority: str = "info",
+    ) -> None:
+        timestamp = self._clock().isoformat()
+        normalized_payload = {
+            key: (list(value) if isinstance(value, tuple) else value)
+            for key, value in payload.items()
+        }
+        if ledger:
+            ledger_entry = {
+                "timestamp": timestamp,
+                "source": self._pulse_source,
+                "event": event_type,
+                "payload": normalized_payload,
+            }
+            self._ledger_writer(self._ledger_path, ledger_entry)
+        if pulse:
+            event = {
+                "timestamp": timestamp,
+                "source_daemon": self._pulse_source,
+                "event_type": event_type,
+                "priority": priority,
+                "payload": normalized_payload,
+            }
+            self._pulse_publisher(event)
+
+    def _default_connectivity_tester(self, peer_name: str, address: str) -> bool:
+        payload = {"peer": peer_name, "address": address}
+        self._log_event(
+            "first_boot_federation_ping",
+            payload,
+            ledger=False,
+        )
+        return True

--- a/tests/test_driver_manager.py
+++ b/tests/test_driver_manager.py
@@ -10,6 +10,21 @@ from sentientos.daemons.driver_manager import DriverManager
 from sentientos.shell import SentientShell, ShellConfig, ShellEventLogger
 
 
+class StubFirstBootWizard:
+    def should_run(self) -> bool:
+        return False
+
+    def run(self, decisions=None, force: bool = False) -> dict[str, object]:
+        return {"status": "skipped"}
+
+    def reset(self) -> None:
+        return None
+
+    @property
+    def last_summary(self) -> dict[str, object] | None:
+        return None
+
+
 def _make_clock() -> Callable[[], datetime]:
     base = datetime(2024, 1, 1, tzinfo=timezone.utc)
     counter = {"value": 0}
@@ -161,6 +176,7 @@ def test_shell_dashboard_driver_panel(tmp_path: Path, monkeypatch: pytest.Monkey
         pulse_publisher=shell_publisher,
         home_root=tmp_path / "home" / "tester",
         driver_manager=manager,
+        first_boot_wizard=StubFirstBootWizard(),
     )
 
     snapshot = shell.open_lumos_dashboard()

--- a/tests/test_first_boot.py
+++ b/tests/test_first_boot.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+import yaml
+
+from sentientos.first_boot import FirstBootWizard, WizardDecisions
+from sentientos.shell import SentientShell, ShellConfig, ShellEventLogger
+
+
+class DummyDriverManager:
+    def __init__(self) -> None:
+        self.refresh_calls = 0
+        self.installs: List[str] = []
+
+    def refresh(self) -> dict[str, object]:
+        self.refresh_calls += 1
+        return {
+            "devices": [
+                {
+                    "id": "gpu-1",
+                    "name": "NVIDIA RTX 4090",
+                    "status": "missing",
+                    "needs_driver": True,
+                    "recommended_driver": "nvidia-driver",
+                }
+            ]
+        }
+
+    def install_driver(self, device_id: str) -> dict[str, object]:
+        self.installs.append(device_id)
+        return {
+            "device_id": device_id,
+            "device": "NVIDIA RTX 4090",
+            "driver": "nvidia-driver",
+            "status": "veil_pending",
+            "requires_veil": True,
+        }
+
+
+class RecordingWizard:
+    def __init__(self) -> None:
+        self.run_calls: List[Dict[str, object]] = []
+        self.reset_calls = 0
+        self._summary: dict[str, object] = {
+            "status": "completed",
+            "drivers": [],
+            "codex": {},
+            "federation": {},
+        }
+        self._should_run = True
+
+    def should_run(self) -> bool:
+        return self._should_run
+
+    def run(self, decisions=None, force: bool = False) -> dict[str, object]:
+        self.run_calls.append({"decisions": decisions, "force": force})
+        self._should_run = False
+        return dict(self._summary)
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+        self._should_run = True
+
+    @property
+    def last_summary(self) -> dict[str, object]:
+        return dict(self._summary)
+
+
+def test_wizard_requires_blessing(tmp_path: Path) -> None:
+    ledger_entries: List[dict[str, object]] = []
+    pulses: List[dict[str, object]] = []
+
+    def ledger_writer(path: Path, entry: dict[str, object]) -> None:
+        ledger_entries.append({"path": path, "entry": dict(entry)})
+
+    def pulse(event: dict[str, object]) -> dict[str, object]:
+        pulses.append(dict(event))
+        return event
+
+    wizard = FirstBootWizard(
+        driver_manager=None,
+        ledger_path=tmp_path / "daemon/logs/ledger.jsonl",
+        config_path=tmp_path / "vow/config.yaml",
+        completion_path=tmp_path / "vow/first_boot_complete",
+        ledger_writer=ledger_writer,
+        pulse_publisher=pulse,
+        blessing_hook=lambda: None,
+    )
+
+    with pytest.raises(PermissionError):
+        wizard.run(decisions=WizardDecisions(bless=False), force=True)
+
+    assert any(item["entry"]["event"] == "first_boot_step" for item in ledger_entries)
+    assert all(event["event_type"] == "first_boot_step" for event in pulses)
+
+
+def test_wizard_configures_codex_and_federation(tmp_path: Path) -> None:
+    driver_manager = DummyDriverManager()
+    ledger_entries: List[dict[str, object]] = []
+    pulses: List[dict[str, object]] = []
+    blessing_calls: List[str] = []
+    connectivity_checks: List[tuple[str, str]] = []
+
+    def ledger_writer(path: Path, entry: dict[str, object]) -> None:
+        ledger_entries.append({"path": path, "entry": dict(entry)})
+
+    def pulse(event: dict[str, object]) -> dict[str, object]:
+        pulses.append(dict(event))
+        return event
+
+    wizard = FirstBootWizard(
+        driver_manager=driver_manager,
+        ledger_path=tmp_path / "daemon/logs/ledger.jsonl",
+        config_path=tmp_path / "vow/config.yaml",
+        completion_path=tmp_path / "vow/first_boot_complete",
+        ledger_writer=ledger_writer,
+        pulse_publisher=pulse,
+        blessing_hook=lambda: blessing_calls.append("called"),
+        connectivity_tester=lambda peer, address: (connectivity_checks.append((peer, address)) or True),
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    decisions = WizardDecisions(
+        bless=True,
+        driver_choices={"gpu-1": True},
+        codex_mode="expand",
+        codex_interval=7200,
+        codex_max_iterations=5,
+        federation_peer_name="Aurora",
+        federation_addresses=("tcp://aurora:7777",),
+    )
+
+    summary = wizard.run(decisions=decisions, force=True)
+
+    assert blessing_calls == ["called"]
+    assert driver_manager.installs == ["gpu-1"]
+    assert (tmp_path / "vow/first_boot_complete").exists()
+
+    config = yaml.safe_load((tmp_path / "vow/config.yaml").read_text(encoding="utf-8"))
+    assert config["codex_mode"] == "expand"
+    assert config["codex_interval"] == 7200
+    assert config["codex_max_iterations"] == 5
+    assert config["federation_peer_name"] == "Aurora"
+    assert config["federation_peers"] == ["tcp://aurora:7777"]
+
+    events = [item["entry"]["event"] for item in ledger_entries]
+    assert "first_boot_blessed" in events
+    assert "first_boot_codex_configured" in events
+    assert "first_boot_federation_configured" in events
+    assert any(event["event_type"] == "first_boot_complete" for event in pulses)
+
+    assert summary["codex"]["mode"] == "expand"
+    assert summary["drivers"][0]["requires_veil"] is True
+    assert summary["federation"]["connectivity"]["tcp://aurora:7777"] is True
+    assert connectivity_checks == [("Aurora", "tcp://aurora:7777")]
+    assert len(wizard.panels) >= 4
+    assert wizard.last_summary == summary
+
+
+def test_wizard_skip_when_completed(tmp_path: Path) -> None:
+    ledger_entries: List[dict[str, object]] = []
+    blessing_calls: List[str] = []
+
+    def ledger_writer(path: Path, entry: dict[str, object]) -> None:
+        ledger_entries.append(dict(entry))
+
+    wizard = FirstBootWizard(
+        driver_manager=None,
+        ledger_path=tmp_path / "daemon/logs/ledger.jsonl",
+        config_path=tmp_path / "vow/config.yaml",
+        completion_path=tmp_path / "vow/first_boot_complete",
+        ledger_writer=ledger_writer,
+        pulse_publisher=lambda event: event,
+        blessing_hook=lambda: blessing_calls.append("blessed"),
+    )
+
+    wizard.run(decisions=WizardDecisions(), force=True)
+    initial_ledger_count = len(ledger_entries)
+    assert blessing_calls == ["blessed"]
+
+    result = wizard.run()
+    assert result == {"status": "skipped", "reason": "first_boot_complete"}
+    assert len(ledger_entries) == initial_ledger_count
+    assert blessing_calls == ["blessed"]
+
+
+def test_shell_integration_invokes_wizard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    pulses: List[dict[str, object]] = []
+
+    def pulse(event: dict[str, object]) -> dict[str, object]:
+        pulses.append(dict(event))
+        return event
+
+    logger = ShellEventLogger(
+        ledger_path=tmp_path / "logs" / "shell.jsonl",
+        pulse_publisher=pulse,
+    )
+    wizard = RecordingWizard()
+
+    shell = SentientShell(
+        user="tester",
+        logger=logger,
+        config=ShellConfig(path=tmp_path / "shell_config.json"),
+        request_dir=tmp_path / "requests",
+        trace_dir=tmp_path / "traces",
+        codex_module=None,
+        ci_runner=lambda: True,
+        pulse_publisher=pulse,
+        home_root=tmp_path / "home" / "tester",
+        first_boot_wizard=wizard,
+    )
+
+    assert wizard.run_calls == [{"decisions": None, "force": False}]
+    assert shell.first_boot_summary == wizard.last_summary
+
+    search_results = shell.search("first-boot")
+    assert "re-run first-boot wizard" in search_results["settings"]
+
+    rerun_summary = shell.start_menu.open_setting("Re-run First-Boot Wizard")
+    assert rerun_summary == wizard.last_summary
+    assert wizard.reset_calls == 1
+    assert wizard.run_calls[-1]["force"] is True
+    assert shell.first_boot_summary == wizard.last_summary


### PR DESCRIPTION
## Summary
- add a SentientShell first-boot wizard module with blessing, driver, Codex, federation, and summary steps
- auto-run the wizard on first launch, expose a re-run option, and extend shell tests with stubs
- add targeted first boot wizard unit tests covering configuration, federation, and rerun behavior

## Testing
- pytest -q
- mypy scripts/ sentientos/ *(fails: repository contains existing typing errors outside the change scope)*
- LUMOS_AUTO_APPROVE=1 python verify_audits.py --strict
- LUMOS_AUTO_APPROVE=1 PYTHONPATH=. python scripts/audit_immutability_verifier.py *(fails: manifest hash mismatch in repository baseline)*

------
https://chatgpt.com/codex/tasks/task_b_68d1f46ef1288320a956dff7cab4f42f