### PR TITLE
[codex:architect] link first boot wizard to architect daemon

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_iterations",
         "tests.test_manifest_reconciliation",
         "tests.test_expand_mode",
+        "tests.test_architect_integration",
     }
     for item in items:
         if (

--- a/tests/test_architect_daemon.py
+++ b/tests/test_architect_daemon.py
@@ -29,12 +29,32 @@ def test_monitor_anomaly_generates_request(tmp_path: Path, monkeypatch: pytest.M
     ledger_events: list[dict[str, object]] = []
     published: list[dict[str, object]] = []
 
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "codex_mode: expand",
+                "codex_interval: 3600",
+                "codex_max_iterations: 1",
+                "architect_autonomy: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completion_path.parent.mkdir(parents=True, exist_ok=True)
+    completion_path.write_text("completed\n", encoding="utf-8")
+
     monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "ETHICS")
 
     daemon = architect_daemon.ArchitectDaemon(
         request_dir=request_dir,
         session_file=session_file,
         ledger_path=ledger_path,
+        config_path=config_path,
+        completion_path=completion_path,
         ledger_sink=ledger_events.append,
         pulse_publisher=lambda event: (published.append(event) or event),
         clock=_fixed_clock,
@@ -71,6 +91,24 @@ def test_codex_success_records_success(tmp_path: Path, monkeypatch: pytest.Monke
     published: list[dict[str, object]] = []
     commands: list[list[str]] = []
 
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "codex_mode: expand",
+                "codex_interval: 3600",
+                "codex_max_iterations: 1",
+                "architect_autonomy: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completion_path.parent.mkdir(parents=True, exist_ok=True)
+    completion_path.write_text("completed\n", encoding="utf-8")
+
     def fake_run(cmd: list[str], capture_output: bool = False, text: bool = False, **_: object) -> _Result:
         commands.append(list(cmd))
         return _Result(returncode=0, stdout="", stderr="")
@@ -82,6 +120,8 @@ def test_codex_success_records_success(tmp_path: Path, monkeypatch: pytest.Monke
         request_dir=tmp_path / "requests",
         session_file=tmp_path / "session.json",
         ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
         ledger_sink=ledger_events.append,
         pulse_publisher=lambda event: (published.append(event) or event),
         clock=_fixed_clock,
@@ -116,10 +156,30 @@ def test_failed_attempts_retries_capped(tmp_path: Path, monkeypatch: pytest.Monk
     ledger_events: list[dict[str, object]] = []
     monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
 
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "codex_mode: expand",
+                "codex_interval: 3600",
+                "codex_max_iterations: 2",
+                "architect_autonomy: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completion_path.parent.mkdir(parents=True, exist_ok=True)
+    completion_path.write_text("completed\n", encoding="utf-8")
+
     daemon = architect_daemon.ArchitectDaemon(
         request_dir=tmp_path / "requests",
         session_file=tmp_path / "session.json",
         ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
         ledger_sink=ledger_events.append,
         pulse_publisher=lambda event: event,
         clock=_fixed_clock,
@@ -164,10 +224,30 @@ def test_veil_pending_publishes_pulse(tmp_path: Path, monkeypatch: pytest.Monkey
     published: list[dict[str, object]] = []
     monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
 
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "codex_mode: expand",
+                "codex_interval: 3600",
+                "codex_max_iterations: 1",
+                "architect_autonomy: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completion_path.parent.mkdir(parents=True, exist_ok=True)
+    completion_path.write_text("completed\n", encoding="utf-8")
+
     daemon = architect_daemon.ArchitectDaemon(
         request_dir=tmp_path / "requests",
         session_file=tmp_path / "session.json",
         ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
         ledger_sink=ledger_events.append,
         pulse_publisher=lambda event: (published.append(event) or event),
         clock=_fixed_clock,
@@ -197,6 +277,24 @@ def test_branch_merge_failure_logged(tmp_path: Path, monkeypatch: pytest.MonkeyP
     ledger_events: list[dict[str, object]] = []
     commands: list[list[str]] = []
 
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "codex_mode: expand",
+                "codex_interval: 3600",
+                "codex_max_iterations: 1",
+                "architect_autonomy: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completion_path.parent.mkdir(parents=True, exist_ok=True)
+    completion_path.write_text("completed\n", encoding="utf-8")
+
     def fake_run(cmd: list[str], capture_output: bool = False, text: bool = False, **_: object) -> _Result:
         commands.append(list(cmd))
         if cmd and cmd[0] == "pytest":
@@ -210,6 +308,8 @@ def test_branch_merge_failure_logged(tmp_path: Path, monkeypatch: pytest.MonkeyP
         request_dir=tmp_path / "requests",
         session_file=tmp_path / "session.json",
         ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
         ledger_sink=ledger_events.append,
         pulse_publisher=lambda event: event,
         clock=_fixed_clock,

--- a/tests/test_architect_integration.py
+++ b/tests/test_architect_integration.py
@@ -1,0 +1,237 @@
+"""Integration tests covering ArchitectDaemon and FirstBootWizard coupling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+import architect_daemon
+from sentientos.daemons import pulse_bus
+from sentientos.first_boot import FirstBootWizard, WizardDecisions
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def _write_config(path: Path, *, autonomy: bool = False) -> None:
+    payload = {
+        "codex_mode": "observe",
+        "codex_interval": 3600,
+        "codex_max_iterations": 1,
+        "architect_autonomy": autonomy,
+        "federation_peer_name": "",
+        "federation_peers": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_pulse_bus() -> None:
+    pulse_bus.reset()
+    yield
+    pulse_bus.reset()
+
+
+def test_daemon_inactive_until_first_boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request_dir = tmp_path / "requests"
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    _write_config(config_path)
+    ledger_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
+
+    daemon = architect_daemon.ArchitectDaemon(
+        request_dir=request_dir,
+        session_file=tmp_path / "session.json",
+        ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_sink=ledger_events.append,
+        pulse_publisher=pulse_bus.publish,
+        clock=_fixed_clock,
+        ci_commands=[["true"]],
+        immutability_command=["true"],
+    )
+
+    daemon.start()
+    assert daemon.active is False
+
+    with pytest.raises(RuntimeError):
+        daemon.request_expand("pre_blessing", None)
+
+    pulse_bus.publish(
+        {
+            "timestamp": _fixed_clock().isoformat(),
+            "source_daemon": "MonitoringDaemon",
+            "event_type": "monitor_alert",
+            "priority": "critical",
+            "payload": {"detail": "cpu"},
+        }
+    )
+
+    assert not any(request_dir.glob("architect_*.txt"))
+    assert not ledger_events
+
+
+def test_wizard_completion_activates_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request_dir = tmp_path / "requests"
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    ledger_events: list[dict[str, object]] = []
+    pulse_bus.reset()
+
+    monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
+
+    daemon = architect_daemon.ArchitectDaemon(
+        request_dir=request_dir,
+        session_file=tmp_path / "session.json",
+        ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_sink=ledger_events.append,
+        pulse_publisher=pulse_bus.publish,
+        clock=_fixed_clock,
+        ci_commands=[["true"]],
+        immutability_command=["true"],
+    )
+    daemon.start()
+    assert daemon.active is False
+
+    wizard = FirstBootWizard(
+        driver_manager=None,
+        ledger_path=tmp_path / "daemon" / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_writer=lambda path, entry: None,
+        pulse_publisher=pulse_bus.publish,
+        blessing_hook=lambda: None,
+        clock=_fixed_clock,
+    )
+
+    wizard.run(decisions=WizardDecisions(codex_mode="repair", codex_interval=1800), force=True)
+
+    assert daemon.active is True
+    enabled_events = [entry for entry in ledger_events if entry.get("event") == "architect_enabled"]
+    assert enabled_events
+    summary = enabled_events[0]["summary"]
+    assert summary["codex_mode"] == "repair"
+    assert summary["codex_interval"] == 1800
+
+    published = pulse_bus.consume_events()
+    assert any(event["event_type"] == "architect_enabled" for event in published)
+
+
+def test_config_change_emits_update(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request_dir = tmp_path / "requests"
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    ledger_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
+
+    daemon = architect_daemon.ArchitectDaemon(
+        request_dir=request_dir,
+        session_file=tmp_path / "session.json",
+        ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_sink=ledger_events.append,
+        pulse_publisher=pulse_bus.publish,
+        clock=_fixed_clock,
+        ci_commands=[["true"]],
+        immutability_command=["true"],
+    )
+    daemon.start()
+
+    wizard = FirstBootWizard(
+        driver_manager=None,
+        ledger_path=tmp_path / "daemon" / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_writer=lambda path, entry: None,
+        pulse_publisher=pulse_bus.publish,
+        blessing_hook=lambda: None,
+        clock=_fixed_clock,
+    )
+    wizard.run(decisions=WizardDecisions(codex_mode="expand", codex_interval=1800), force=True)
+
+    pulse_bus.consume_events()
+    ledger_events.clear()
+
+    wizard.run(
+        decisions=WizardDecisions(codex_mode="full", codex_interval=600, architect_autonomy=True),
+        force=True,
+    )
+
+    assert pytest.approx(daemon.interval) == 600
+    assert daemon.active is True
+    config_updates = [entry for entry in ledger_events if entry.get("event") == "architect_config_update"]
+    assert config_updates
+    changes = config_updates[0]["changes"]
+    assert "codex_mode" in changes
+    assert changes["architect_autonomy"]["current"] is True
+
+
+def test_autonomy_toggle_controls_submission(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request_dir = tmp_path / "requests"
+    config_path = tmp_path / "vow" / "config.yaml"
+    completion_path = tmp_path / "vow" / "first_boot_complete"
+    ledger_events: list[dict[str, object]] = []
+
+    monkeypatch.setattr(architect_daemon.codex_daemon, "load_ethics", lambda: "")
+
+    daemon = architect_daemon.ArchitectDaemon(
+        request_dir=request_dir,
+        session_file=tmp_path / "session.json",
+        ledger_path=tmp_path / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_sink=ledger_events.append,
+        pulse_publisher=pulse_bus.publish,
+        clock=_fixed_clock,
+        ci_commands=[["true"]],
+        immutability_command=["true"],
+    )
+    daemon.start()
+
+    wizard = FirstBootWizard(
+        driver_manager=None,
+        ledger_path=tmp_path / "daemon" / "ledger.jsonl",
+        config_path=config_path,
+        completion_path=completion_path,
+        ledger_writer=lambda path, entry: None,
+        pulse_publisher=pulse_bus.publish,
+        blessing_hook=lambda: None,
+        clock=_fixed_clock,
+    )
+    wizard.run(
+        decisions=WizardDecisions(codex_mode="repair", architect_autonomy=False),
+        force=True,
+    )
+    pulse_bus.consume_events()
+    ledger_events.clear()
+
+    request = daemon.request_expand("improvement", None)
+    pending_events = [entry for entry in ledger_events if entry.get("event") == "architect_prompt_pending"]
+    submitted_events = [entry for entry in ledger_events if entry.get("event") == "architect_prompt_submitted"]
+    assert pending_events
+    assert not submitted_events
+    assert daemon.active is True
+
+    wizard.run(
+        decisions=WizardDecisions(codex_mode="repair", architect_autonomy=True),
+        force=True,
+    )
+    pulse_bus.consume_events()
+    ledger_events.clear()
+
+    daemon.request_expand("autonomous", None)
+    submitted_events = [entry for entry in ledger_events if entry.get("event") == "architect_prompt_submitted"]
+    assert submitted_events
+    assert daemon.active is True

--- a/tests/test_first_boot.py
+++ b/tests/test_first_boot.py
@@ -144,6 +144,7 @@ def test_wizard_configures_codex_and_federation(tmp_path: Path) -> None:
     assert config["codex_mode"] == "expand"
     assert config["codex_interval"] == 7200
     assert config["codex_max_iterations"] == 5
+    assert config["architect_autonomy"] is False
     assert config["federation_peer_name"] == "Aurora"
     assert config["federation_peers"] == ["tcp://aurora:7777"]
 
@@ -154,6 +155,7 @@ def test_wizard_configures_codex_and_federation(tmp_path: Path) -> None:
     assert any(event["event_type"] == "first_boot_complete" for event in pulses)
 
     assert summary["codex"]["mode"] == "expand"
+    assert summary["codex"]["autonomy_enabled"] is False
     assert summary["drivers"][0]["requires_veil"] is True
     assert summary["federation"]["connectivity"]["tcp://aurora:7777"] is True
     assert connectivity_checks == [("Aurora", "tcp://aurora:7777")]


### PR DESCRIPTION
## Summary
- gate ArchitectDaemon activation until first boot completes, sync configuration changes, and emit new prompt lifecycle events tied to the autonomy toggle
- extend FirstBootWizard with the architect_autonomy toggle and surface the choice in wizard summaries and completion payloads
- add integration coverage for the handoff plus adjust existing tests to exercise the new gating semantics

## Testing
- pytest -q
- mypy scripts/ sentientos/ *(fails: repository already has extensive type errors)*
- python verify_audits.py --strict
- PYTHONPATH=. python scripts/audit_immutability_verifier.py *(fails: missing /vow/immutable_manifest.json)*

------
https://chatgpt.com/codex/tasks/task_b_68d2e9f64f648320a0115d9267670cf4