### PR TITLE
Add anomaly-driven Codex rewrite proposals

### DIFF
--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,6 +1,14 @@
 """Codex helpers for SentientOS."""
 from __future__ import annotations
 
+from .anomalies import (
+    Anomaly,
+    AnomalyCoordinator,
+    AnomalyDetector,
+    AnomalyEmitter,
+    ProposalPlan,
+    RewriteProposalEngine,
+)
 from .rewrites import (
     LedgerInterface,
     PatchStorage,
@@ -10,6 +18,12 @@ from .rewrites import (
 )
 
 __all__ = [
+    "Anomaly",
+    "AnomalyCoordinator",
+    "AnomalyDetector",
+    "AnomalyEmitter",
+    "ProposalPlan",
+    "RewriteProposalEngine",
     "LedgerInterface",
     "PatchStorage",
     "RewriteDashboard",

--- a/codex/anomalies.py
+++ b/codex/anomalies.py
@@ -1,0 +1,285 @@
+"""Anomaly detection and proposal helpers for Codex."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+import json
+
+from .rewrites import RewritePatch, ScopedRewriteEngine
+
+Severity = str
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    """Representation of a detected daemon anomaly."""
+
+    kind: str
+    description: str
+    severity: Severity
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=_default_now)
+
+    def to_event(self) -> Dict[str, Any]:
+        payload = dict(self.metadata)
+        payload.update(
+            {
+                "kind": self.kind,
+                "description": self.description,
+                "severity": self.severity,
+                "timestamp": self.timestamp.isoformat(),
+            }
+        )
+        return payload
+
+
+class AnomalyEmitter:
+    """Persist anomaly events and optionally forward them to the pulse bus."""
+
+    def __init__(
+        self,
+        root: Path | str = Path("/pulse/anomalies"),
+        *,
+        bus: Any | None = None,
+    ) -> None:
+        self._root = Path(root)
+        self._bus = bus
+
+    def emit(self, anomaly: Anomaly, *, patch_id: str | None = None) -> Path:
+        event = anomaly.to_event()
+        if patch_id:
+            event["patch_id"] = patch_id
+
+        self._root.mkdir(parents=True, exist_ok=True)
+        day_path = self._root / f"{anomaly.timestamp.date().isoformat()}.jsonl"
+        with day_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+        if self._bus is not None:
+            priority = "critical" if anomaly.severity == "critical" else "warning"
+            payload = dict(event)
+            payload.setdefault("severity", anomaly.severity)
+            self._bus.publish(
+                {
+                    "timestamp": anomaly.timestamp.isoformat(),
+                    "source_daemon": "CodexDaemon",
+                    "event_type": "anomaly_detected",
+                    "priority": priority,
+                    "payload": payload,
+                }
+            )
+
+        return day_path
+
+
+class AnomalyDetector:
+    """Detect key anomaly classes from daemon telemetry samples."""
+
+    def __init__(
+        self,
+        *,
+        crash_threshold: int = 3,
+        latency_threshold_ms: float = 1_000.0,
+        backlog_threshold: int = 10,
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._crash_threshold = max(1, crash_threshold)
+        self._latency_threshold_ms = float(latency_threshold_ms)
+        self._backlog_threshold = max(1, backlog_threshold)
+        self._now = now
+
+    def analyze(
+        self,
+        logs: Iterable[Mapping[str, Any]],
+        pulses: Iterable[Mapping[str, Any]],
+        backlog: Iterable[Mapping[str, Any]],
+    ) -> List[Anomaly]:
+        anomalies: List[Anomaly] = []
+        observed = self._now()
+
+        crash_counts: MutableMapping[str, int] = {}
+        for entry in logs:
+            if not isinstance(entry, Mapping):
+                continue
+            if not (entry.get("crash_loop") or entry.get("event") == "crash"):
+                continue
+            daemon = str(entry.get("daemon") or entry.get("name") or "unknown")
+            crash_counts[daemon] = crash_counts.get(daemon, 0) + 1
+        for daemon, count in crash_counts.items():
+            if count >= self._crash_threshold:
+                anomalies.append(
+                    Anomaly(
+                        "crash_loop",
+                        f"Daemon {daemon} crash loop detected {count}×",
+                        "critical",
+                        {"daemon": daemon, "count": count},
+                        timestamp=observed,
+                    )
+                )
+
+        for sample in pulses:
+            if not isinstance(sample, Mapping):
+                continue
+            latency = sample.get("latency_ms") or sample.get("latency")
+            if latency is None:
+                continue
+            try:
+                latency_value = float(latency)
+            except (TypeError, ValueError):
+                continue
+            threshold = sample.get("latency_threshold_ms") or sample.get("expected_latency_ms")
+            threshold_value = float(threshold) if threshold is not None else self._latency_threshold_ms
+            if latency_value > threshold_value:
+                daemon = str(sample.get("daemon") or sample.get("source") or "unknown")
+                anomalies.append(
+                    Anomaly(
+                        "latency_spike",
+                        f"Daemon {daemon} latency spike: {latency_value:.0f}ms > {threshold_value:.0f}ms",
+                        "warning",
+                        {
+                            "daemon": daemon,
+                            "latency_ms": latency_value,
+                            "threshold_ms": threshold_value,
+                        },
+                        timestamp=observed,
+                    )
+                )
+
+        backlog_entries = list(backlog)
+        for entry in backlog_entries:
+            if not isinstance(entry, Mapping):
+                continue
+            if entry.get("ledger_mismatch") or entry.get("ledger_status") == "diverged":
+                daemon = str(entry.get("daemon") or entry.get("owner") or "unknown")
+                anomalies.append(
+                    Anomaly(
+                        "ledger_mismatch",
+                        f"Daemon {daemon} ledger mismatch detected",
+                        "warning",
+                        {"daemon": daemon, "task_id": entry.get("task_id")},
+                        timestamp=observed,
+                    )
+                )
+                break
+
+        orphaned_tasks = [entry for entry in backlog_entries if _is_orphan(entry)]
+        if orphaned_tasks:
+            daemon = str(orphaned_tasks[0].get("daemon") or orphaned_tasks[0].get("owner") or "unknown")
+            metadata = {
+                "daemon": daemon,
+                "orphaned_tasks": [entry.get("task_id") for entry in orphaned_tasks],
+                "count": len(orphaned_tasks),
+            }
+            anomalies.append(
+                Anomaly(
+                    "orphaned_tasks",
+                    f"{len(orphaned_tasks)} orphaned tasks detected for {daemon}",
+                    "warning",
+                    metadata,
+                    timestamp=observed,
+                )
+            )
+
+        if len(backlog_entries) >= self._backlog_threshold:
+            daemon = str(backlog_entries[0].get("daemon") or backlog_entries[0].get("owner") or "unknown")
+            anomalies.append(
+                Anomaly(
+                    "backlog_drift",
+                    f"{daemon} backlog drifted to {len(backlog_entries)} entries",
+                    "warning",
+                    {"daemon": daemon, "backlog_size": len(backlog_entries)},
+                    timestamp=observed,
+                )
+            )
+
+        return anomalies
+
+
+def _is_orphan(entry: Mapping[str, Any]) -> bool:
+    status = entry.get("status") or entry.get("state")
+    return bool(entry.get("orphaned")) or status == "orphaned"
+
+
+ProposalBuilder = Callable[[Path, Anomaly], str]
+
+
+@dataclass
+class ProposalPlan:
+    """Defines how to respond to a detected anomaly with a rewrite proposal."""
+
+    daemon: str
+    target_path: Path
+    builder: ProposalBuilder
+    reason: str
+    confidence: float
+    urgency: str = "medium"
+    metadata: Optional[Mapping[str, Any]] = None
+
+
+class RewriteProposalEngine:
+    """Bridge anomaly detections into Codex rewrite proposals."""
+
+    def __init__(self, engine: ScopedRewriteEngine, *, emitter: AnomalyEmitter | None = None) -> None:
+        self._engine = engine
+        self._emitter = emitter
+
+    def propose(
+        self,
+        plan: ProposalPlan,
+        anomaly: Anomaly,
+    ) -> RewritePatch:
+        new_content = plan.builder(plan.target_path, anomaly)
+        metadata = {
+            "anomaly": anomaly.to_event(),
+            "reason": plan.reason,
+            "confidence": float(plan.confidence),
+        }
+        if plan.metadata:
+            metadata.update(plan.metadata)
+
+        patch = self._engine.request_rewrite(
+            plan.daemon,
+            plan.target_path,
+            new_content,
+            reason=plan.reason,
+            confidence=plan.confidence,
+            urgency=plan.urgency,
+            metadata=metadata,
+        )
+
+        if self._emitter is not None:
+            self._emitter.emit(anomaly, patch_id=patch.patch_id)
+
+        return patch
+
+
+class AnomalyCoordinator:
+    """Coordinate anomaly detection and proposal generation."""
+
+    def __init__(self, detector: AnomalyDetector, proposal_engine: RewriteProposalEngine) -> None:
+        self._detector = detector
+        self._proposal_engine = proposal_engine
+
+    def evaluate(
+        self,
+        logs: Iterable[Mapping[str, Any]],
+        pulses: Iterable[Mapping[str, Any]],
+        backlog: Iterable[Mapping[str, Any]],
+        plans: Mapping[str, ProposalPlan],
+    ) -> List[RewritePatch]:
+        patches: List[RewritePatch] = []
+        for anomaly in self._detector.analyze(logs, pulses, backlog):
+            plan = plans.get(anomaly.kind)
+            if plan is None:
+                continue
+            patch = self._proposal_engine.propose(plan, anomaly)
+            patches.append(patch)
+        return patches
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_veil",
         "tests.test_codex_iterations",
         "tests.test_codex_rewrites",
+        "tests.test_codex_anomalies",
         "tests.test_manifest_reconciliation",
         "tests.test_expand_mode",
         "tests.test_architect_integration",

--- a/tests/test_codex_anomalies.py
+++ b/tests/test_codex_anomalies.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex import (
+    AnomalyCoordinator,
+    AnomalyDetector,
+    AnomalyEmitter,
+    LedgerInterface,
+    PatchStorage,
+    ProposalPlan,
+    RewriteDashboard,
+    RewriteProposalEngine,
+    ScopedRewriteEngine,
+)
+
+
+class DummyLedger(LedgerInterface):
+    def __init__(self, verdicts: list[bool]) -> None:
+        self._verdicts = deque(verdicts)
+
+    def verify_patch(self, patch):  # type: ignore[override]
+        if not self._verdicts:
+            return False
+        return self._verdicts.popleft()
+
+
+@dataclass
+class ManualClock:
+    moment: datetime
+
+    def tick(self, delta: timedelta) -> None:
+        self.moment += delta
+
+    def now(self) -> datetime:
+        return self.moment
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_anomaly_pipeline_generates_guarded_proposals(tmp_path: Path) -> None:
+    crash_path = _write(tmp_path / "daemons" / "healer.py", "cooldown = 1\n")
+    latency_path = _write(tmp_path / "daemons" / "pulse.py", "LATENCY_BUDGET = 200\n")
+    ledger_path = _write(tmp_path / "daemons" / "ledger.py", "SYNC_REQUIRED = False\n")
+    orphan_path = _write(tmp_path / "daemons" / "tasks.py", "ORPHAN_GUARD = False\n")
+
+    logs = [
+        {"daemon": "HealingDaemon", "event": "crash"},
+        {"daemon": "HealingDaemon", "event": "crash"},
+        {"daemon": "HealingDaemon", "event": "crash"},
+    ]
+    pulses = [
+        {"daemon": "PulseDaemon", "latency_ms": 1_500, "expected_latency_ms": 400},
+    ]
+    backlog = [
+        {"daemon": "LedgerDaemon", "ledger_mismatch": True, "task_id": "ledger-1"},
+        {"daemon": "TaskDaemon", "status": "orphaned", "task_id": "task-77"},
+    ]
+
+    clock = ManualClock(moment=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    ledger = DummyLedger([False, False, False, False])
+    storage = PatchStorage(tmp_path / "glow" / "proposals", tmp_path / "daemon" / "quarantine")
+    engine = ScopedRewriteEngine(ledger, storage=storage, cooldown=timedelta(seconds=0), now=clock.now)
+
+    published_events: list[dict[str, object]] = []
+    emitter = AnomalyEmitter(
+        tmp_path / "pulse" / "anomalies",
+        bus=SimpleNamespace(publish=lambda event: published_events.append(event)),
+    )
+    detector = AnomalyDetector(
+        crash_threshold=3,
+        latency_threshold_ms=800,
+        backlog_threshold=5,
+        now=clock.now,
+    )
+    proposal_engine = RewriteProposalEngine(engine, emitter=emitter)
+
+    plans = {
+        "crash_loop": ProposalPlan(
+            daemon="HealingDaemon",
+            target_path=crash_path,
+            builder=lambda path, anomaly: path.read_text(encoding="utf-8").replace("cooldown = 1", "cooldown = 3"),
+            reason="Increase cooldown to break crash loop",
+            confidence=0.8,
+            urgency="high",
+        ),
+        "latency_spike": ProposalPlan(
+            daemon="PulseDaemon",
+            target_path=latency_path,
+            builder=lambda path, anomaly: path.read_text(encoding="utf-8").replace("200", "400"),
+            reason="Expand latency budget",
+            confidence=0.6,
+        ),
+        "ledger_mismatch": ProposalPlan(
+            daemon="LedgerDaemon",
+            target_path=ledger_path,
+            builder=lambda path, anomaly: path.read_text(encoding="utf-8").replace("False", "True"),
+            reason="Force ledger resynchronization",
+            confidence=0.7,
+        ),
+        "orphaned_tasks": ProposalPlan(
+            daemon="TaskDaemon",
+            target_path=orphan_path,
+            builder=lambda path, anomaly: path.read_text(encoding="utf-8").replace("False", "True"),
+            reason="Reclaim orphaned tasks",
+            confidence=0.65,
+        ),
+    }
+
+    coordinator = AnomalyCoordinator(detector, proposal_engine)
+    patches = coordinator.evaluate(logs, pulses, backlog, plans)
+
+    assert len(patches) == 4
+    assert all(patch.status == "pending" for patch in patches)
+
+    # Suggestions should not mutate source files.
+    assert crash_path.read_text(encoding="utf-8") == "cooldown = 1\n"
+    assert latency_path.read_text(encoding="utf-8") == "LATENCY_BUDGET = 200\n"
+    assert ledger_path.read_text(encoding="utf-8") == "SYNC_REQUIRED = False\n"
+    assert orphan_path.read_text(encoding="utf-8") == "ORPHAN_GUARD = False\n"
+
+    # Proposals are persisted under /glow/proposals.
+    for patch in patches:
+        proposal_dir = storage.base_dir / patch.patch_id  # type: ignore[attr-defined]
+        assert (proposal_dir / "patch.json").exists()
+
+    dashboard = RewriteDashboard(storage)
+    rows = {row["patch_id"]: row for row in dashboard.rows()}
+    assert set(rows) == {patch.patch_id for patch in patches}
+    for patch in patches:
+        entry = rows[patch.patch_id]
+        assert entry["anomaly_description"]
+        assert entry["confidence"] == pytest.approx(patch.confidence)
+        assert entry["actions"]["approve"] is True
+
+    log_path = tmp_path / "pulse" / "anomalies" / f"{clock.now().date().isoformat()}.jsonl"
+    assert log_path.exists(), "Anomaly emitter should persist events"
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").strip().splitlines()]
+    assert len(payloads) == 4
+    assert {entry["patch_id"] for entry in payloads} == set(rows)
+
+    assert len(published_events) == 4
+    assert all(event["event_type"] == "anomaly_detected" for event in published_events)
+
+    # Ledger gating denies auto-application and sends proposals to quarantine.
+    engine.process_pending()
+    assert crash_path.read_text(encoding="utf-8") == "cooldown = 1\n"
+    assert latency_path.read_text(encoding="utf-8") == "LATENCY_BUDGET = 200\n"
+    quarantine_root = tmp_path / "daemon" / "quarantine"
+    assert quarantine_root.exists()
+    quarantined_ids = {entry.name for entry in quarantine_root.iterdir()}
+    assert quarantined_ids == {patch.patch_id for patch in patches}


### PR DESCRIPTION
## Summary
- add a Codex anomaly detection and proposal module that logs events to /pulse/anomalies and pushes guarded rewrite requests into the ledger flow
- extend the rewrite dashboard metadata to surface anomaly context and updated guardrail actions
- enable and cover the anomaly workflow with focused tests

## Testing
- pytest tests/test_codex_anomalies.py -vv
- pytest tests/test_codex_rewrites.py


------
https://chatgpt.com/codex/tasks/task_b_68d6cb9e74c08320bf0d746dee59c5df