### PR TITLE
Add embodiment sensory streams to Codex

### DIFF
--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -9,6 +9,7 @@ from .anomalies import (
     ProposalPlan,
     RewriteProposalEngine,
 )
+from .embodiment import EmbodimentEvent, EmbodimentMount
 from .intent import (
     IntentCandidate,
     IntentEmitter,
@@ -31,6 +32,8 @@ __all__ = [
     "AnomalyEmitter",
     "ProposalPlan",
     "RewriteProposalEngine",
+    "EmbodimentEvent",
+    "EmbodimentMount",
     "IntentCandidate",
     "IntentEmitter",
     "IntentPrioritizer",

--- a/codex/embodiment.py
+++ b/codex/embodiment.py
@@ -1,0 +1,129 @@
+"""Embodiment hooks for bounded sensory integrations."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping
+
+import json
+
+__all__ = ["EmbodimentEvent", "EmbodimentMount"]
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class EmbodimentEvent:
+    """Normalized embodiment event recorded from physical or sensory feeds."""
+
+    channel: str
+    event_type: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=_default_now)
+
+    def to_record(self) -> Dict[str, Any]:
+        return {
+            "channel": self.channel,
+            "event_type": self.event_type,
+            "timestamp": self.timestamp.isoformat(),
+            "payload": dict(self.payload),
+            "source": self.channel,
+            "tags": ["embodiment", self.channel],
+        }
+
+
+class EmbodimentMount:
+    """Manage embodiment streams, toggles, and quarantine storage."""
+
+    _DEFAULT_CHANNELS = ("camera_feed", "audio_events", "vr_signals")
+
+    def __init__(
+        self,
+        root: Path | str = Path("/embodiment"),
+        *,
+        channels: Iterable[str] | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+        active_channels = tuple(channels) if channels is not None else self._DEFAULT_CHANNELS
+        self._channels: MutableMapping[str, bool] = {channel: True for channel in active_channels}
+        self._locked: set[str] = set()
+        self._now = now or _default_now
+        self._quarantine_root = self._root / "quarantine"
+        self._quarantine_root.mkdir(parents=True, exist_ok=True)
+        self._quarantined: list[Dict[str, Any]] = []
+
+    @property
+    def channels(self) -> Dict[str, bool]:
+        return dict(self._channels)
+
+    @property
+    def quarantined_events(self) -> list[Dict[str, Any]]:
+        return list(self._quarantined)
+
+    def is_enabled(self, channel: str) -> bool:
+        self._ensure_channel(channel)
+        return self._channels[channel] and channel not in self._locked
+
+    def toggle(self, channel: str, enabled: bool) -> None:
+        self._ensure_channel(channel)
+        self._channels[channel] = bool(enabled)
+
+    def lock(self, channel: str) -> None:
+        self._ensure_channel(channel)
+        self._locked.add(channel)
+
+    def unlock(self, channel: str) -> None:
+        self._ensure_channel(channel)
+        self._locked.discard(channel)
+
+    def ingest(
+        self,
+        channel: str,
+        payload: Mapping[str, Any],
+        *,
+        event_type: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> EmbodimentEvent:
+        self._ensure_channel(channel)
+        if not self._channels[channel]:
+            raise PermissionError(f"Channel {channel} is disabled")
+        if channel in self._locked:
+            raise PermissionError(f"Channel {channel} is locked")
+
+        event = EmbodimentEvent(
+            channel=channel,
+            event_type=event_type or str(payload.get("event") or payload.get("type") or "event"),
+            payload=dict(payload),
+            timestamp=timestamp or self._now(),
+        )
+        stream_path = self._root / f"{channel}.jsonl"
+        with stream_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.to_record(), sort_keys=True) + "\n")
+        return event
+
+    def quarantine(self, record: Mapping[str, Any], *, reason: str | None = None) -> Path:
+        entry = dict(record)
+        entry.setdefault("timestamp", self._now().isoformat())
+        if reason:
+            entry.setdefault("reason", reason)
+        tags = entry.get("tags")
+        if not isinstance(tags, list):
+            tags = [] if tags is None else [str(tags)]
+        if "embodiment" not in tags:
+            tags.append("embodiment")
+        entry["tags"] = tags
+        self._quarantined.append(entry)
+        path = self._quarantine_root / "events.jsonl"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
+        return path
+
+    def _ensure_channel(self, channel: str) -> None:
+        if channel not in self._channels:
+            raise KeyError(f"Unknown embodiment channel {channel}")
+

--- a/codex/intent.py
+++ b/codex/intent.py
@@ -34,6 +34,7 @@ _DEFAULT_SEVERITY_SCALE: SeverityScale = {
 _DEFAULT_IMPACT_SCALE: ImpactScale = {
     "system": 1.0,
     "daemon": 0.85,
+    "environment": 0.8,
     "service": 0.75,
     "module": 0.65,
     "local": 0.45,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_rewrites",
         "tests.test_codex_anomalies",
         "tests.test_codex_intent",
+        "tests.test_codex_embodiment",
         "tests.test_codex_integration",
         "tests.test_manifest_reconciliation",
         "tests.test_expand_mode",

--- a/tests/test_codex_embodiment.py
+++ b/tests/test_codex_embodiment.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import json
+import pytest
+
+from codex import (
+    Anomaly,
+    AnomalyDetector,
+    AnomalyEmitter,
+    EmbodimentMount,
+    IntentPrioritizer,
+    PriorityScoringEngine,
+)
+
+
+@dataclass
+class ManualClock:
+    moment: datetime
+
+    def now(self) -> datetime:
+        return self.moment
+
+    def tick(self, delta: timedelta) -> None:
+        self.moment += delta
+
+
+def _embodiment_anomalies(tmp_path: Path, clock: ManualClock, *, critical_noise: bool = True) -> List[Anomaly]:
+    mount = EmbodimentMount(tmp_path / "embodiment", now=clock.now)
+    motion = mount.ingest(
+        "camera_feed",
+        {"unexpected": True, "period": "night", "confidence": 0.9, "magnitude": 1.2},
+        event_type="motion",
+    )
+    noise_primary = mount.ingest(
+        "audio_events",
+        {"decibel": 87, "threshold": 60, "confidence": 0.65},
+        event_type="noise",
+    )
+    noise_events = [noise_primary]
+    if critical_noise:
+        noise_events.append(
+            mount.ingest(
+                "audio_events",
+                {"decibel": 92, "threshold": 60, "confidence": 0.7, "profanity": True},
+                event_type="noise",
+            )
+        )
+    absence = mount.ingest(
+        "camera_feed",
+        {"status": "offline", "expected": True, "confidence": 0.55},
+        event_type="status",
+    )
+
+    detector = AnomalyDetector(now=clock.now)
+    events = [event.to_record() for event in (motion, *noise_events, absence)]
+    return detector.analyze([], [], [], embodiment_events=events)
+
+
+def test_embodiment_streams_emit_anomalies(tmp_path: Path) -> None:
+    clock = ManualClock(moment=datetime(2025, 3, 1, 3, 14, tzinfo=timezone.utc))
+    anomalies = _embodiment_anomalies(tmp_path, clock)
+
+    kinds = {anomaly.kind for anomaly in anomalies}
+    assert {"embodiment_motion", "embodiment_noise", "embodiment_absence"} <= kinds
+
+    emitter = AnomalyEmitter(tmp_path / "pulse" / "anomalies")
+    for anomaly in anomalies:
+        emitter.emit(anomaly)
+
+    log_path = tmp_path / "pulse" / "anomalies" / f"{clock.now().date().isoformat()}.jsonl"
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert len(payloads) == len(anomalies)
+    for entry in payloads:
+        assert "embodiment" in entry.get("tags", [])
+        assert entry.get("impact") == "environment"
+        assert entry.get("source") in {"camera_feed", "audio_events"}
+
+
+def test_prioritizer_ranks_embodiment_against_daemon(tmp_path: Path) -> None:
+    clock = ManualClock(moment=datetime(2025, 3, 1, 3, 14, tzinfo=timezone.utc))
+    embodiment_anomalies = _embodiment_anomalies(tmp_path, clock, critical_noise=False)
+
+    daemon_anomaly = Anomaly(
+        "daemon_cooldown_breach",
+        "Daemon cooldown breach detected",
+        "high",
+        {"daemon": "CoolingDaemon", "impact": "daemon", "confidence": 0.6},
+        timestamp=clock.now(),
+    )
+
+    prioritizer = IntentPrioritizer(PriorityScoringEngine(), now=clock.now)
+    intent = prioritizer.evaluate(anomalies=[daemon_anomaly, *embodiment_anomalies])
+
+    assert intent is not None
+    assert intent.item_type == "anomaly"
+
+    candidates = {candidate.candidate_id: candidate for candidate in prioritizer.candidates}
+    absence_key = next(key for key in candidates if key.startswith("anomaly:embodiment_absence"))
+    daemon_key = "anomaly:daemon_cooldown_breach:CoolingDaemon"
+
+    assert absence_key in candidates
+    assert daemon_key in candidates
+    absence_candidate = candidates[absence_key]
+    daemon_candidate = candidates[daemon_key]
+
+    assert absence_candidate.score >= daemon_candidate.score
+    assert intent.candidate_id != daemon_key
+    assert "embodiment" in absence_candidate.payload["metadata"].get("tags", [])
+
+
+def test_operator_controls_toggle_lock_and_quarantine(tmp_path: Path) -> None:
+    mount = EmbodimentMount(tmp_path / "embodiment")
+
+    assert mount.is_enabled("audio_events")
+    mount.toggle("audio_events", False)
+    assert not mount.is_enabled("audio_events")
+    with pytest.raises(PermissionError):
+        mount.ingest("audio_events", {"decibel": 40}, event_type="noise")
+
+    mount.toggle("audio_events", True)
+    mount.lock("audio_events")
+    assert not mount.is_enabled("audio_events")
+    with pytest.raises(PermissionError):
+        mount.ingest("audio_events", {"decibel": 41}, event_type="noise")
+
+    mount.unlock("audio_events")
+    event = mount.ingest("audio_events", {"decibel": 42}, event_type="noise")
+    quarantine_path = mount.quarantine(event.to_record(), reason="review")
+    assert quarantine_path.exists()
+    assert mount.quarantined_events
+    assert mount.quarantined_events[-1]["reason"] == "review"
+    assert "embodiment" in mount.quarantined_events[-1].get("tags", [])


### PR DESCRIPTION
## Summary
- add an embodiment mount to normalize sensory feeds and support operator controls for toggles and quarantine
- extend Codex anomaly and prioritization logic to surface embodiment motion, noise, and absence events
- cover the new embodiment path with unit tests and enable the suite in pytest collection

## Testing
- pytest tests/test_codex_embodiment.py -vv

------
https://chatgpt.com/codex/tasks/task_b_68d71203a39c832087893ec40716437a