### PR TITLE
Implement multi-cycle Codex strategy arcs

### DIFF
--- a/codex/strategy.py
+++ b/codex/strategy.py
@@ -14,14 +14,20 @@ from integration_memory import integration_memory
 from .intent import PriorityWeights
 
 __all__ = [
+    "CodexStrategy",
     "OutcomeEntry",
     "StrategyAdjustmentEngine",
+    "StrategyBranch",
+    "StrategyLedger",
+    "StrategyPlan",
+    "StrategyStorage",
     "strategy_engine",
     "configure_strategy_root",
 ]
 
 
 _DEFAULT_OUTCOME_STATUS = {"success", "failure", "rollback", "override"}
+_DEFAULT_STRATEGY_STATUS = {"proposed", "active", "checkpoint", "completed", "rolled_back"}
 
 
 def _now() -> datetime:
@@ -119,7 +125,7 @@ class _OutcomeLogger:
     def __init__(self, base_dir: Path) -> None:
         self._base_dir = base_dir
         self._base_dir.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def log(self, entry: OutcomeEntry) -> Path:
         path = self._base_dir / f"{entry.plan_id}.jsonl"
@@ -130,16 +136,234 @@ class _OutcomeLogger:
         return path
 
 
+@dataclass
+class StrategyBranch:
+    """Conditional branch mapping for a strategy checkpoint."""
+
+    condition: str
+    next_plan: str | None
+    label: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "condition": self.condition,
+            "next_plan": self.next_plan,
+            "label": self.label,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "StrategyBranch":
+        return cls(
+            condition=str(payload.get("condition", "default")),
+            next_plan=payload.get("next_plan"),
+            label=payload.get("label"),
+            metadata=dict(payload.get("metadata", {})),
+        )
+
+
+@dataclass
+class StrategyPlan:
+    """Plan segment within a multi-cycle Codex strategy."""
+
+    plan_id: str
+    title: str
+    checkpoint: bool = True
+    branches: list[StrategyBranch] = field(default_factory=list)
+    status: str = "pending"
+    ledger_confirmed: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            "title": self.title,
+            "checkpoint": self.checkpoint,
+            "branches": [branch.to_dict() for branch in self.branches],
+            "status": self.status,
+            "ledger_confirmed": self.ledger_confirmed,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "StrategyPlan":
+        return cls(
+            plan_id=str(payload.get("plan_id")),
+            title=str(payload.get("title", "")),
+            checkpoint=bool(payload.get("checkpoint", True)),
+            branches=[StrategyBranch.from_dict(branch) for branch in payload.get("branches", [])],
+            status=str(payload.get("status", "pending")),
+            ledger_confirmed=bool(payload.get("ledger_confirmed", False)),
+        )
+
+
+@dataclass
+class CodexStrategy:
+    """Structured, multi-cycle strategy arc with conditional branching."""
+
+    strategy_id: str
+    goal: str
+    plan_chain: list[StrategyPlan]
+    conditions: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    status: str = "proposed"
+    current_plan_index: int = 0
+    history: list[Dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.status not in _DEFAULT_STRATEGY_STATUS:
+            self.status = "proposed"
+        if not self.plan_chain:
+            raise ValueError("CodexStrategy requires at least one plan in the chain")
+        self.current_plan_index = max(0, min(self.current_plan_index, len(self.plan_chain) - 1))
+
+    @property
+    def current_plan(self) -> StrategyPlan:
+        return self.plan_chain[self.current_plan_index]
+
+    def add_history(self, action: str, operator: str | None, details: Mapping[str, Any] | None = None) -> None:
+        entry = {
+            "timestamp": _serialize_timestamp(),
+            "action": action,
+            "operator": operator,
+            "status": self.status,
+        }
+        if details:
+            entry.update({"details": dict(details)})
+        self.history.append(entry)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "goal": self.goal,
+            "plan_chain": [plan.to_dict() for plan in self.plan_chain],
+            "conditions": dict(self.conditions),
+            "metadata": dict(self.metadata),
+            "status": self.status,
+            "current_plan_index": self.current_plan_index,
+            "history": list(self.history),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CodexStrategy":
+        return cls(
+            strategy_id=str(payload.get("strategy_id")),
+            goal=str(payload.get("goal", "")),
+            plan_chain=[StrategyPlan.from_dict(item) for item in payload.get("plan_chain", [])],
+            conditions=dict(payload.get("conditions", {})),
+            metadata=dict(payload.get("metadata", {})),
+            status=str(payload.get("status", "proposed")),
+            current_plan_index=int(payload.get("current_plan_index", 0)),
+            history=list(payload.get("history", [])),
+        )
+
+    def activate(self, operator: str | None = None) -> None:
+        if self.status != "proposed":
+            return
+        self.status = "active"
+        self.current_plan.status = "active"
+        self.add_history("activated", operator)
+
+    def mark_checkpoint(self, operator: str | None = None) -> None:
+        self.status = "checkpoint"
+        self.current_plan.status = "completed"
+        self.add_history("checkpoint", operator)
+
+    def pause(self, operator: str | None = None) -> None:
+        self.metadata["paused"] = True
+        self.add_history("paused", operator)
+
+    def resume(self, operator: str | None = None) -> None:
+        if self.metadata.pop("paused", False):
+            self.add_history("resumed", operator)
+
+    def set_ledger_confirmed(self) -> None:
+        self.current_plan.ledger_confirmed = True
+
+    def complete(self, operator: str | None = None) -> None:
+        self.status = "completed"
+        self.add_history("completed", operator)
+
+    def rollback(self, operator: str | None = None) -> None:
+        self.status = "rolled_back"
+        self.add_history("rolled_back", operator)
+
+    def advance_to_plan(self, plan_id: str, operator: str | None = None) -> None:
+        for index, plan in enumerate(self.plan_chain):
+            if plan.plan_id == plan_id:
+                self.current_plan_index = index
+                plan.status = "active"
+                self.status = "active"
+                self.add_history("advanced", operator, {"plan_id": plan_id})
+                return
+        raise KeyError(f"Plan {plan_id} not found in strategy {self.strategy_id}")
+
+
+class StrategyLedger:
+    """Ledger gate for strategy checkpoints and branches."""
+
+    def confirm_checkpoint(self, strategy: CodexStrategy, plan: StrategyPlan) -> bool:  # pragma: no cover - interface default
+        return True
+
+    def confirm_branch(
+        self,
+        strategy: CodexStrategy,
+        plan: StrategyPlan,
+        branch: StrategyBranch,
+    ) -> bool:  # pragma: no cover - interface default
+        return True
+
+
+class StrategyStorage:
+    """Persist Codex strategies to /integration/strategies."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    def path_for(self, strategy_id: str) -> Path:
+        return self._root / f"{strategy_id}.json"
+
+    def save(self, strategy: CodexStrategy) -> Path:
+        data = json.dumps(strategy.to_dict(), indent=2, sort_keys=True)
+        path = self.path_for(strategy.strategy_id)
+        with self._lock:
+            path.write_text(data, encoding="utf-8")
+        return path
+
+    def load(self, strategy_id: str) -> CodexStrategy:
+        path = self.path_for(strategy_id)
+        if not path.exists():
+            raise KeyError(f"Strategy {strategy_id} is not stored")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return CodexStrategy.from_dict(payload)
+
+    def list_all(self) -> Dict[str, CodexStrategy]:
+        strategies: Dict[str, CodexStrategy] = {}
+        for file in self._root.glob("*.json"):
+            try:
+                payload = json.loads(file.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+            try:
+                strategy = CodexStrategy.from_dict(payload)
+            except (ValueError, KeyError):
+                continue
+            strategies[strategy.strategy_id] = strategy
+        return strategies
+
+
 class StrategyAdjustmentEngine:
     """Manage adaptive strategy adjustments based on plan outcomes."""
 
     def __init__(self, root: Path | str = Path("integration"), *, override_threshold: int = 3) -> None:
         self._root = Path(root)
         self._override_threshold = max(1, int(override_threshold))
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._logger = _OutcomeLogger(self._root / "outcomes")
         self._strategy_log_path = self._root / "strategy_log.jsonl"
         self._state_path = self._root / "strategy_state.json"
+        self._strategy_storage = StrategyStorage(self._root / "strategies")
         self._weights = PriorityWeights().normalized()
         self._version = 1
         self._locked = False
@@ -148,6 +372,9 @@ class StrategyAdjustmentEngine:
         self._action_rollbacks: Counter[str] = Counter()
         self._sequence_counts: Counter[tuple[str, str]] = Counter()
         self._preferred_sequences: Dict[tuple[str, str], int] = {}
+        self._strategies: Dict[str, CodexStrategy] = self._strategy_storage.list_all()
+        self._branch_usage: Counter[str] = Counter()
+        self._strategy_ledger: StrategyLedger = StrategyLedger()
         self._load_state()
 
     # ------------------------------------------------------------------
@@ -176,6 +403,137 @@ class StrategyAdjustmentEngine:
             "confidence": self._weights.confidence,
         }
 
+    def set_strategy_ledger(self, ledger: StrategyLedger) -> None:
+        with self._lock:
+            self._strategy_ledger = ledger
+
+    # ------------------------------------------------------------------
+    # Strategy arc management
+    def list_strategies(self) -> Sequence[CodexStrategy]:
+        with self._lock:
+            return list(self._strategies.values())
+
+    def register_strategy(self, strategy: CodexStrategy, *, operator: str | None = None) -> CodexStrategy:
+        with self._lock:
+            self._strategies[strategy.strategy_id] = strategy
+            self._strategy_storage.save(strategy)
+            payload = {"goal": strategy.goal, "horizon": strategy.metadata.get("horizon")}
+        self._log_strategy_event("strategy_registered", strategy, operator, payload)
+        return strategy
+
+    def load_strategy(self, strategy_id: str) -> CodexStrategy:
+        with self._lock:
+            if strategy_id not in self._strategies:
+                strategy = self._strategy_storage.load(strategy_id)
+                self._strategies[strategy.strategy_id] = strategy
+            return self._strategies[strategy_id]
+
+    def activate_strategy(self, strategy_id: str, *, operator: str | None = None) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            strategy.activate(operator)
+            self._strategy_storage.save(strategy)
+            payload = {"plan": strategy.current_plan.plan_id}
+        self._log_strategy_event("strategy_activated", strategy, operator, payload)
+        return strategy
+
+    def checkpoint_strategy(self, strategy_id: str, *, operator: str | None = None) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            plan = strategy.current_plan
+            if not plan.checkpoint:
+                return strategy
+            if not self._strategy_ledger.confirm_checkpoint(strategy, plan):
+                raise PermissionError("Strategy checkpoint not confirmed by ledger")
+            strategy.mark_checkpoint(operator)
+            strategy.set_ledger_confirmed()
+            self._strategy_storage.save(strategy)
+            payload = {"plan": plan.plan_id, "title": plan.title}
+        self._log_strategy_event("strategy_checkpoint", strategy, operator, payload)
+        return strategy
+
+    def advance_strategy(
+        self,
+        strategy_id: str,
+        condition_key: str,
+        *,
+        operator: str | None = None,
+        condition_payload: Mapping[str, Any] | None = None,
+    ) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            if strategy.status != "checkpoint":
+                raise RuntimeError("Strategy must be at a checkpoint before advancing")
+            plan = strategy.current_plan
+            matched_branch: StrategyBranch | None = None
+            for branch in plan.branches:
+                if branch.condition == condition_key:
+                    matched_branch = branch
+                    break
+            if matched_branch is None:
+                for branch in plan.branches:
+                    if branch.condition in {"default", "*"}:
+                        matched_branch = branch
+                        break
+            if matched_branch is None:
+                raise KeyError(f"No branch matching condition {condition_key}")
+            if not self._strategy_ledger.confirm_branch(strategy, plan, matched_branch):
+                raise PermissionError("Strategy branch not confirmed by ledger")
+            self._branch_usage[matched_branch.condition] += 1
+            next_plan = matched_branch.next_plan
+            if next_plan:
+                strategy.advance_to_plan(next_plan, operator)
+            else:
+                strategy.complete(operator)
+            strategy.metadata.setdefault("last_condition", condition_key)
+            if condition_payload:
+                strategy.metadata.setdefault("condition_log", []).append(dict(condition_payload))
+            adjust = self._maybe_adjust_strategy_horizon(strategy, matched_branch.condition)
+            self._strategy_storage.save(strategy)
+            payload = {
+                "from_plan": plan.plan_id,
+                "branch": matched_branch.condition,
+                "next_plan": next_plan,
+            }
+        self._log_strategy_event("strategy_advanced", strategy, operator, payload)
+        if adjust is not None:
+            self._log_strategy_event("strategy_horizon_adjusted", strategy, operator=None, extra=adjust)
+        return strategy
+
+    def pause_strategy(self, strategy_id: str, *, operator: str | None = None) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            strategy.pause(operator)
+            self._strategy_storage.save(strategy)
+        self._log_strategy_event("strategy_paused", strategy, operator, {})
+        return strategy
+
+    def resume_strategy(self, strategy_id: str, *, operator: str | None = None) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            strategy.resume(operator)
+            self._strategy_storage.save(strategy)
+        self._log_strategy_event("strategy_resumed", strategy, operator, {})
+        return strategy
+
+    def terminate_strategy(
+        self,
+        strategy_id: str,
+        *,
+        operator: str | None = None,
+        rolled_back: bool = True,
+    ) -> CodexStrategy:
+        with self._lock:
+            strategy = self.load_strategy(strategy_id)
+            if rolled_back:
+                strategy.rollback(operator)
+            else:
+                strategy.complete(operator)
+            self._strategy_storage.save(strategy)
+            payload = {"rolled_back": rolled_back}
+        self._log_strategy_event("strategy_terminated", strategy, operator, payload)
+        return strategy
+
     # ------------------------------------------------------------------
     def reconfigure(self, root: Path | str) -> None:
         with self._lock:
@@ -183,6 +541,7 @@ class StrategyAdjustmentEngine:
             self._logger = _OutcomeLogger(self._root / "outcomes")
             self._strategy_log_path = self._root / "strategy_log.jsonl"
             self._state_path = self._root / "strategy_state.json"
+            self._strategy_storage = StrategyStorage(self._root / "strategies")
             self._version = 1
             self._locked = False
             self._metrics = defaultdict(float)
@@ -190,6 +549,9 @@ class StrategyAdjustmentEngine:
             self._action_rollbacks = Counter()
             self._sequence_counts = Counter()
             self._preferred_sequences = {}
+            self._strategies = self._strategy_storage.list_all()
+            self._branch_usage = Counter()
+            self._strategy_ledger = StrategyLedger()
             self._weights = PriorityWeights().normalized()
             self._load_state()
 
@@ -299,6 +661,7 @@ class StrategyAdjustmentEngine:
         self._metrics = defaultdict(float, payload.get("metrics", {}))
         self._action_success = Counter(payload.get("action_success", {}))
         self._action_rollbacks = Counter(payload.get("action_rollbacks", {}))
+        self._branch_usage = Counter(payload.get("branch_usage", {}))
         raw_sequences = payload.get("sequence_counts", {})
         parsed_sequences: Counter[tuple[str, str]] = Counter()
         for key, count in raw_sequences.items():
@@ -321,6 +684,7 @@ class StrategyAdjustmentEngine:
             "metrics": dict(self._metrics),
             "action_success": dict(self._action_success),
             "action_rollbacks": dict(self._action_rollbacks),
+            "branch_usage": dict(self._branch_usage),
             "sequence_counts": {
                 f"{start}→{follow}": count for (start, follow), count in self._sequence_counts.items()
             },
@@ -341,6 +705,33 @@ class StrategyAdjustmentEngine:
         self._strategy_log_path.parent.mkdir(parents=True, exist_ok=True)
         with self._strategy_log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    def _log_strategy_event(
+        self,
+        action: str,
+        strategy: CodexStrategy,
+        operator: str | None,
+        extra: Mapping[str, Any],
+    ) -> None:
+        payload = {
+            "strategy_id": strategy.strategy_id,
+            "goal": strategy.goal,
+            "status": strategy.status,
+            "operator": operator,
+            "horizon": strategy.metadata.get("horizon"),
+            "confidence": strategy.metadata.get("confidence"),
+            "current_plan": strategy.current_plan.plan_id if strategy.plan_chain else None,
+        }
+        payload.update(dict(extra))
+        self._append_strategy_log(action, payload)
+        impact = "failed" if strategy.status == "rolled_back" else "baseline"
+        integration_memory.record_event(
+            "strategy.event",
+            source=strategy.strategy_id,
+            impact=impact,
+            confidence=float(strategy.metadata.get("confidence", 0.6) or 0.6),
+            payload=payload,
+        )
 
     def _update_metrics(self, entry: OutcomeEntry) -> None:
         action = entry.step_action
@@ -398,6 +789,24 @@ class StrategyAdjustmentEngine:
                     "rollback_ratio": rollback_ratio,
                 },
             )
+
+    def _maybe_adjust_strategy_horizon(
+        self, strategy: CodexStrategy, condition: str
+    ) -> Mapping[str, Any] | None:
+        horizon_value = strategy.metadata.get("horizon")
+        if horizon_value is None:
+            return None
+        try:
+            horizon = int(horizon_value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+        usage = self._branch_usage.get(condition, 0)
+        if usage >= 2 and horizon > 1:
+            new_horizon = max(1, horizon - 1)
+            if new_horizon != horizon:
+                strategy.metadata["horizon"] = new_horizon
+                return {"condition": condition, "previous": horizon, "updated": new_horizon}
+        return None
 
 
 strategy_engine = StrategyAdjustmentEngine()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_architect_trajectory",
         "tests.test_codex_plans",
         "tests.test_codex_strategy",
+        "tests.test_codex_strategies",
     }
     for item in items:
         if (

--- a/tests/test_codex_strategies.py
+++ b/tests/test_codex_strategies.py
@@ -1,0 +1,201 @@
+"""Tests for multi-cycle Codex strategy arcs with conditional branches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex.strategy import (
+    CodexStrategy,
+    StrategyBranch,
+    StrategyLedger,
+    StrategyPlan,
+    configure_strategy_root,
+    strategy_engine,
+)
+from integration_memory import configure_integration_root
+
+
+class _LedgerSpy(StrategyLedger):
+    def __init__(self) -> None:
+        self.checkpoints: list[tuple[str, StrategyPlan]] = []
+        self.branches: list[tuple[str, StrategyPlan, StrategyBranch]] = []
+
+    def confirm_checkpoint(self, strategy: CodexStrategy, plan: StrategyPlan) -> bool:
+        self.checkpoints.append((strategy.strategy_id, plan))
+        return True
+
+    def confirm_branch(self, strategy: CodexStrategy, plan: StrategyPlan, branch: StrategyBranch) -> bool:
+        self.branches.append((strategy.strategy_id, plan, branch))
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _reset_strategy_engine(tmp_path: Path) -> None:
+    integration_root = tmp_path / "integration"
+    configure_integration_root(integration_root)
+    configure_strategy_root(integration_root)
+    strategy_engine.set_strategy_ledger(StrategyLedger())
+
+
+def test_strategy_branching_and_horizon_persistence(tmp_path: Path) -> None:
+    integration_root = tmp_path / "integration"
+    configure_integration_root(integration_root)
+    configure_strategy_root(integration_root)
+
+    ledger = _LedgerSpy()
+    strategy_engine.set_strategy_ledger(ledger)
+
+    strategy = CodexStrategy(
+        strategy_id="overnight-feed",
+        goal="Maintain stable embodiment feeds overnight",
+        plan_chain=[
+            StrategyPlan(
+                plan_id="stabilize",
+                title="Stabilize feed",
+                branches=[
+                    StrategyBranch("anomaly_persists", "escalate", "Escalate if unresolved"),
+                    StrategyBranch("resolved", "verify", "Verify when resolved"),
+                ],
+            ),
+            StrategyPlan(
+                plan_id="escalate",
+                title="Escalate response",
+                branches=[
+                    StrategyBranch("anomaly_persists", "verify", "Escalation follow up"),
+                    StrategyBranch("default", "verify", "Default verification"),
+                ],
+            ),
+            StrategyPlan(
+                plan_id="verify",
+                title="Verify recovery",
+                checkpoint=False,
+                branches=[],
+            ),
+        ],
+        conditions={
+            "anomaly_persists": "If anomaly persists",
+            "resolved": "If anomaly resolved early",
+        },
+        metadata={"horizon": 6, "confidence": 0.7, "rollback_path": "rollbacks/feed"},
+    )
+
+    strategy_engine.register_strategy(strategy, operator="warden")
+    strategy_engine.activate_strategy(strategy.strategy_id, operator="warden")
+
+    strategy_engine.checkpoint_strategy(strategy.strategy_id, operator="warden")
+    assert ledger.checkpoints[0][1].plan_id == "stabilize"
+
+    strategy_engine.advance_strategy(
+        strategy.strategy_id,
+        "anomaly_persists",
+        operator="warden",
+        condition_payload={"cycle": 1, "anomaly": "camera drift"},
+    )
+
+    after_first_branch = strategy_engine.load_strategy(strategy.strategy_id)
+    assert after_first_branch.current_plan.plan_id == "escalate"
+    assert after_first_branch.metadata["last_condition"] == "anomaly_persists"
+    assert after_first_branch.plan_chain[0].ledger_confirmed is True
+
+    strategy_engine.checkpoint_strategy(strategy.strategy_id, operator="warden")
+    assert ledger.checkpoints[-1][1].plan_id == "escalate"
+
+    strategy_engine.advance_strategy(
+        strategy.strategy_id,
+        "anomaly_persists",
+        operator="warden",
+        condition_payload={"cycle": 2, "anomaly": "sensor noise"},
+    )
+
+    after_second_branch = strategy_engine.load_strategy(strategy.strategy_id)
+    assert after_second_branch.current_plan.plan_id == "verify"
+    assert after_second_branch.metadata["horizon"] == 5
+    assert after_second_branch.plan_chain[1].ledger_confirmed is True
+
+    strategy_engine.terminate_strategy(strategy.strategy_id, operator="warden", rolled_back=False)
+    final_strategy = strategy_engine.load_strategy(strategy.strategy_id)
+    assert final_strategy.status == "completed"
+
+    strategy_log = integration_root / "strategy_log.jsonl"
+    assert strategy_log.exists()
+    entries = [json.loads(line) for line in strategy_log.read_text(encoding="utf-8").splitlines() if line]
+    actions = [entry["action"] for entry in entries]
+    assert "strategy_advanced" in actions
+    assert "strategy_horizon_adjusted" in actions
+
+    stored_strategy = json.loads((integration_root / "strategies" / "overnight-feed.json").read_text())
+    assert stored_strategy["metadata"]["horizon"] == 5
+
+
+def test_operator_controls_and_branch_override(tmp_path: Path) -> None:
+    integration_root = tmp_path / "integration"
+    configure_integration_root(integration_root)
+    configure_strategy_root(integration_root)
+
+    class _BlockingLedger(StrategyLedger):
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def confirm_checkpoint(self, strategy: CodexStrategy, plan: StrategyPlan) -> bool:
+            self.calls.append(f"checkpoint:{plan.plan_id}")
+            return True
+
+        def confirm_branch(self, strategy: CodexStrategy, plan: StrategyPlan, branch: StrategyBranch) -> bool:
+            self.calls.append(f"branch:{branch.condition}")
+            return branch.condition != "blocked"
+
+    ledger = _BlockingLedger()
+    strategy_engine.set_strategy_ledger(ledger)
+
+    strategy = CodexStrategy(
+        strategy_id="conditional-arc",
+        goal="Route anomaly mitigation",
+        plan_chain=[
+            StrategyPlan(
+                plan_id="mitigate",
+                title="Mitigate anomaly",
+                branches=[
+                    StrategyBranch("blocked", "escalate", "Escalate when blocked"),
+                    StrategyBranch("clear", "verify", "Verify when clear"),
+                ],
+            ),
+            StrategyPlan(
+                plan_id="escalate",
+                title="Escalate",
+                branches=[StrategyBranch("default", None, "End escalation")],
+            ),
+            StrategyPlan(
+                plan_id="verify",
+                title="Verify closure",
+                checkpoint=False,
+                branches=[],
+            ),
+        ],
+        metadata={"horizon": 4, "confidence": 0.8, "rollback_path": "rollback://mitigate"},
+    )
+
+    strategy_engine.register_strategy(strategy, operator="guide")
+    strategy_engine.activate_strategy(strategy.strategy_id, operator="guide")
+
+    checkpointed = strategy_engine.checkpoint_strategy(strategy.strategy_id, operator="guide")
+    assert checkpointed.status == "checkpoint"
+    assert ledger.calls[0] == "checkpoint:mitigate"
+
+    paused = strategy_engine.pause_strategy(strategy.strategy_id, operator="guide")
+    assert paused.metadata["paused"] is True
+
+    resumed = strategy_engine.resume_strategy(strategy.strategy_id, operator="guide")
+    assert "paused" not in resumed.metadata
+
+    with pytest.raises(PermissionError):
+        strategy_engine.advance_strategy(strategy.strategy_id, "blocked", operator="guide")
+
+    progressed = strategy_engine.advance_strategy(strategy.strategy_id, "clear", operator="guide")
+    assert progressed.current_plan.plan_id == "verify"
+
+    terminated = strategy_engine.terminate_strategy(strategy.strategy_id, operator="guide", rolled_back=True)
+    assert terminated.status == "rolled_back"
+    assert any(call.startswith("branch:") for call in ledger.calls)


### PR DESCRIPTION
## Summary
- add CodexStrategy, StrategyPlan, and StrategyBranch models with persistence, ledger gating, and adaptive horizon tracking
- extend StrategyAdjustmentEngine with strategy arc lifecycle controls and structured logging
- cover multi-cycle branching behaviour and operator controls with new tests

## Testing
- pytest tests/test_codex_strategy.py tests/test_codex_strategies.py

------
https://chatgpt.com/codex/tasks/task_b_68d9a7344e888320a82ffcbf7e8d44c3