### PR TITLE
Add Codex refiner with versioned implementation workflow

### DIFF
--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -25,6 +25,7 @@ from .meta_strategies import (
     MetaStrategyStorage,
     PatternMiningEngine,
 )
+from .refinements import Refiner, RefinementTransform
 from .governance import MetaStrategyGovernor
 from .narratives import CodexNarrator
 from .intent import (
@@ -89,6 +90,8 @@ __all__ = [
     "Implementor",
     "ImplementationBlock",
     "ImplementationRecord",
+    "Refiner",
+    "RefinementTransform",
     "ScaffoldEngine",
     "ScaffoldRecord",
     "OutcomeEntry",

--- a/codex/refinements.py
+++ b/codex/refinements.py
@@ -1,0 +1,397 @@
+"""Adaptive refinement engine for Codex implementations."""
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import json
+
+from .implementations import (
+    ImplementationBlock,
+    ImplementationRecord,
+    Implementor,
+)
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+RefinementTransform = Callable[[ImplementationBlock], ImplementationBlock | str]
+
+
+class Refiner:
+    """Iteratively improve Codex implementations based on feedback."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str = Path("."),
+        integration_root: Path | str | None = None,
+        implementor: Implementor | None = None,
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._repo_root = Path(repo_root)
+        self._integration_root = (
+            Path(integration_root)
+            if integration_root is not None
+            else self._repo_root / "integration"
+        )
+        self._integration_root.mkdir(parents=True, exist_ok=True)
+        self._log_path = self._integration_root / "refinement_log.jsonl"
+        self._now = now
+        self._implementor = implementor or Implementor(
+            repo_root=self._repo_root,
+            integration_root=self._integration_root,
+            now=now,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    def refine(
+        self,
+        spec_id: str,
+        *,
+        failure: str,
+        change_summary: str,
+        operator: str | None = None,
+        transform: RefinementTransform | None = None,
+        confidence_delta: str | None = "-0.1",
+    ) -> ImplementationRecord:
+        """Produce a refined implementation version after a failure."""
+
+        record = self._implementor.load_record(spec_id)
+        if record.final_rejected:
+            raise RuntimeError(
+                "Implementation marked as final rejected; further refinements halted."
+            )
+
+        parent_version = (
+            record.pending_version
+            or record.active_version
+            or record.version_id
+            or self._latest_version_id(record)
+        )
+        if not parent_version:
+            raise ValueError("No baseline implementation available for refinement")
+
+        parent_record = self._implementor.load_version(spec_id, parent_version)
+        version_id = self._next_version_id(record)
+        timestamp = self._now().isoformat()
+
+        new_blocks = [
+            self._build_refined_block(
+                block,
+                timestamp=timestamp,
+                failure=failure,
+                parent_version=parent_version,
+                operator=operator,
+                transform=transform,
+                confidence_delta=confidence_delta,
+            )
+            for block in parent_record.blocks
+        ]
+
+        history_entry = {
+            "timestamp": timestamp,
+            "action": "refined",
+            "failure": failure,
+            "operator": operator,
+            "version_id": version_id,
+            "parent_version": parent_version,
+            "change_summary": change_summary,
+            "confidence_delta": confidence_delta,
+        }
+
+        version_record = ImplementationRecord(
+            spec_id=spec_id,
+            title=record.title,
+            status="pending_review",
+            generated_at=timestamp,
+            blocks=new_blocks,
+            ledger_entry=record.ledger_entry,
+            history=list(parent_record.history or []) + [history_entry],
+            version_id=version_id,
+            parent_id=parent_version,
+            change_summary=change_summary,
+            confidence_delta=confidence_delta,
+        )
+        self._implementor.save_version(spec_id, version_record)
+
+        summary = self._implementor.version_summary(
+            spec_id,
+            version_id,
+            parent_id=parent_version,
+            change_summary=change_summary,
+            confidence_delta=confidence_delta,
+            status="pending_review",
+            timestamp=timestamp,
+        )
+
+        record.status = "pending_review"
+        record.pending_version = version_id
+        record.version_id = version_id
+        record.parent_id = parent_version
+        record.change_summary = change_summary
+        record.confidence_delta = confidence_delta
+        record.blocks = [replace(block, history=list(block.history)) for block in new_blocks]
+        record.history = list(record.history or []) + [history_entry]
+        record.versions = list(record.versions or []) + [summary]
+        if parent_version and parent_version != record.active_version:
+            self._implementor.update_version_entry(
+                record, parent_version, status="superseded"
+            )
+        record.final_rejected = False
+        self._implementor.save_record(record)
+
+        self._append_log(
+            "refined",
+            spec_id,
+            operator=operator,
+            metadata={
+                "failure": failure,
+                "version_id": version_id,
+                "parent_version": parent_version,
+                "change_summary": change_summary,
+                "confidence_delta": confidence_delta,
+            },
+        )
+        return version_record
+
+    def rollback(
+        self,
+        spec_id: str,
+        version_id: str,
+        *,
+        operator: str,
+        reason: str | None = None,
+    ) -> ImplementationRecord:
+        """Restore a previously generated implementation version."""
+
+        record = self._implementor.load_record(spec_id)
+        version_record = self._implementor.load_version(spec_id, version_id)
+        timestamp = self._now().isoformat()
+
+        rollback_entry = {
+            "timestamp": timestamp,
+            "action": "rollback",
+            "operator": operator,
+            "version_id": version_id,
+            "reason": reason,
+        }
+
+        if version_record.status != "approved":
+            version_record.status = "approved"
+            if not version_record.approved_at:
+                version_record.approved_at = timestamp
+            if not version_record.approved_by:
+                version_record.approved_by = operator
+        version_record.history = list(version_record.history or []) + [rollback_entry]
+        self._implementor.save_version(spec_id, version_record)
+
+        record.status = "approved"
+        record.pending_version = None
+        record.active_version = version_id
+        record.version_id = version_id
+        record.history = list(record.history or []) + [rollback_entry]
+        record.blocks = [
+            replace(block, history=list(block.history)) for block in version_record.blocks
+        ]
+        record.parent_id = version_record.parent_id
+        record.change_summary = version_record.change_summary
+        record.confidence_delta = version_record.confidence_delta
+        record.approved_at = timestamp
+        record.approved_by = operator
+        self._implementor.update_version_entry(
+            record,
+            version_id,
+            status="approved",
+            rolled_back_at=timestamp,
+            operator=operator,
+        )
+        for entry in record.versions or []:
+            if entry.get("version_id") != version_id and entry.get("status") == "approved":
+                entry["status"] = "rolled_back"
+        record.final_rejected = False
+        self._implementor.save_record(record)
+
+        self._append_log(
+            "rolled_back",
+            spec_id,
+            operator=operator,
+            metadata={
+                "version_id": version_id,
+                "reason": reason,
+            },
+        )
+        return version_record
+
+    def lock_line(
+        self,
+        spec_id: str,
+        version_id: str,
+        line_number: int,
+        *,
+        operator: str,
+        reason: str,
+    ) -> Mapping[str, Any]:
+        """Record a locked line to prevent future regressions."""
+
+        record = self._implementor.load_record(spec_id)
+        entry = {
+            "timestamp": self._now().isoformat(),
+            "version_id": version_id,
+            "line": int(line_number),
+            "operator": operator,
+            "reason": reason,
+        }
+        record.locked_lines = list(record.locked_lines or []) + [entry]
+        self._implementor.save_record(record)
+        self._append_log("locked_line", spec_id, operator=operator, metadata=entry)
+        return entry
+
+    def flag_final_rejected(
+        self,
+        spec_id: str,
+        version_id: str,
+        *,
+        operator: str,
+        reason: str,
+    ) -> ImplementationRecord:
+        """Mark a version as irrecoverable to halt further refinements."""
+
+        record = self._implementor.load_record(spec_id)
+        timestamp = self._now().isoformat()
+        entry = {
+            "timestamp": timestamp,
+            "action": "final_rejected",
+            "version_id": version_id,
+            "operator": operator,
+            "reason": reason,
+        }
+        record.final_rejected = True
+        record.status = "rejected"
+        record.pending_version = None
+        if record.active_version == version_id:
+            record.active_version = None
+        record.history = list(record.history or []) + [entry]
+        self._implementor.update_version_entry(
+            record,
+            version_id,
+            status="final_rejected",
+            operator=operator,
+            reason=reason,
+            final_rejected_at=timestamp,
+        )
+        self._implementor.save_record(record)
+        self._append_log("final_rejected", spec_id, operator=operator, metadata=entry)
+        return record
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _append_log(
+        self,
+        action: str,
+        spec_id: str,
+        *,
+        operator: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "timestamp": self._now().isoformat(),
+            "spec_id": spec_id,
+            "action": action,
+        }
+        if operator:
+            payload["operator"] = operator
+        if metadata:
+            payload["metadata"] = dict(metadata)
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    def _next_version_id(self, record: ImplementationRecord) -> str:
+        index = 0
+        for entry in record.versions or []:
+            value = self._parse_version_index(entry.get("version_id"))
+            if value is not None and value > index:
+                index = value
+        return f"v{index + 1}"
+
+    def _latest_version_id(self, record: ImplementationRecord) -> str | None:
+        versions = list(record.versions or [])
+        if versions:
+            last = versions[-1].get("version_id")
+            if isinstance(last, str):
+                return last
+        return None
+
+    def _parse_version_index(self, version_id: Any) -> int | None:
+        if not isinstance(version_id, str):
+            return None
+        if version_id.startswith("v"):
+            try:
+                return int(version_id[1:])
+            except ValueError:
+                return None
+        return None
+
+    def _build_refined_block(
+        self,
+        block: ImplementationBlock,
+        *,
+        timestamp: str,
+        failure: str,
+        parent_version: str,
+        operator: str | None,
+        transform: RefinementTransform | None,
+        confidence_delta: str | None,
+    ) -> ImplementationBlock:
+        updated = block
+        if transform:
+            result = transform(block)
+            if isinstance(result, ImplementationBlock):
+                updated = result
+            else:
+                updated = replace(block, draft=str(result))
+        history = list(updated.history)
+        history.append(
+            {
+                "timestamp": timestamp,
+                "action": "refined",
+                "failure": failure,
+                "parent_version": parent_version,
+                "operator": operator,
+            }
+        )
+        return ImplementationBlock(
+            block_id=updated.block_id,
+            component=updated.component,
+            target_path=updated.target_path,
+            function_name=updated.function_name,
+            directive=updated.directive,
+            confidence=self._adjust_confidence(updated.confidence, confidence_delta),
+            rollback_path=updated.rollback_path,
+            draft=updated.draft,
+            status="pending_review",
+            created_at=timestamp,
+            history=history,
+            pattern_key=updated.pattern_key,
+        )
+
+    def _adjust_confidence(
+        self, value: str, confidence_delta: str | None
+    ) -> str:
+        levels = ["low", "medium", "high"]
+        if value not in levels or not confidence_delta:
+            return value
+        index = levels.index(value)
+        if str(confidence_delta).startswith("-"):
+            index = max(0, index - 1)
+        elif str(confidence_delta).startswith("+"):
+            index = min(len(levels) - 1, index + 1)
+        return levels[index]
+
+
+__all__ = ["Refiner", "RefinementTransform"]

--- a/implementations_dashboard.py
+++ b/implementations_dashboard.py
@@ -1,9 +1,10 @@
 """Dashboard helpers for Codex implementation drafts."""
 from __future__ import annotations
 
-from typing import Any, Mapping
+import difflib
+from typing import Any, Iterable, Mapping
 
-from codex.implementations import Implementor
+from codex.implementations import Implementor, ImplementationRecord
 
 PANEL_TITLE = "Implementations"
 
@@ -28,6 +29,9 @@ def implementations_panel_state(
             "approved_at": record.get("approved_at"),
             "approved_by": record.get("approved_by"),
             "registry_path": record.get("registry_path"),
+            "active_version": record.get("active_version"),
+            "pending_version": record.get("pending_version"),
+            "final_rejected": record.get("final_rejected", False),
         }
         blocks_payload: list[dict[str, Any]] = []
         for block in record.get("blocks", []):
@@ -45,6 +49,46 @@ def implementations_panel_state(
                 block_entry["history"] = block.get("history", [])
             blocks_payload.append(block_entry)
         entry["blocks"] = blocks_payload
+        versions_payload: list[dict[str, Any]] = []
+        for version in record.get("versions", []) or []:
+            version_id = version.get("version_id")
+            parent_id = version.get("parent_id")
+            diff_text = ""
+            try:
+                current_version = eng.load_version(entry["spec_id"], version_id)
+            except (FileNotFoundError, TypeError, ValueError):
+                current_version = None
+            parent_version_record: ImplementationRecord | None
+            if parent_id:
+                try:
+                    parent_version_record = eng.load_version(entry["spec_id"], parent_id)
+                except (FileNotFoundError, ValueError):
+                    parent_version_record = None
+            else:
+                parent_version_record = None
+            current_text = _blocks_to_text(
+                getattr(current_version, "blocks", None)
+            )
+            parent_text = _blocks_to_text(
+                getattr(parent_version_record, "blocks", None)
+            )
+            if current_text or parent_text:
+                diff_lines = difflib.unified_diff(
+                    parent_text.splitlines(),
+                    current_text.splitlines(),
+                    fromfile=parent_id or "origin",
+                    tofile=version_id or "pending",
+                    lineterm="",
+                )
+                diff_text = "\n".join(diff_lines)
+            version_entry = dict(version)
+            if diff_text:
+                version_entry["diff"] = diff_text
+            versions_payload.append(version_entry)
+        if versions_payload:
+            entry["versions"] = versions_payload
+        if record.get("locked_lines"):
+            entry["locked_lines"] = record.get("locked_lines")
         if include_history:
             entry["history"] = record.get("history", [])
         items.append(entry)
@@ -56,6 +100,19 @@ def implementations_panel_state(
         "approved": [item for item in items if item.get("status") == "approved"],
         "rejected": [item for item in items if item.get("status") == "rejected"],
     }
+
+
+def _blocks_to_text(blocks: Iterable[Any] | None) -> str:
+    if not blocks:
+        return ""
+    contents: list[str] = []
+    for block in blocks:
+        if isinstance(block, Mapping):
+            draft = block.get("draft", "")
+        else:
+            draft = getattr(block, "draft", "")
+        contents.append(str(draft or ""))
+    return "\n".join(contents)
 
 
 __all__ = ["implementations_panel_state", "PANEL_TITLE"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_specs",
         "tests.test_codex_scaffolds",
         "tests.test_codex_implementations",
+        "tests.test_codex_refinements",
     }
     for item in items:
         if (

--- a/tests/test_codex_refinements.py
+++ b/tests/test_codex_refinements.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex.implementations import Implementor
+from codex.refinements import Refiner
+from codex.specs import SpecProposal
+from implementations_dashboard import implementations_panel_state
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.moment = datetime(2025, 3, 1, tzinfo=timezone.utc)
+
+    def now(self) -> datetime:
+        current = self.moment
+        self.moment += timedelta(seconds=1)
+        return current
+
+
+def _proposal(spec_id: str) -> SpecProposal:
+    return SpecProposal(
+        spec_id=spec_id,
+        title="Codex refinement loop",
+        objective="Exercise refiner iterations",
+        directives=["Draft initial daemon"],
+        testing_requirements=["Ensure refiner can iterate"],
+        trigger_key="anomaly::refiner",
+        trigger_context={"source": "test"},
+        status="queued",
+    )
+
+
+def _bootstrap(
+    tmp_path: Path, spec_id: str
+) -> tuple[ManualClock, Implementor, Refiner, SpecProposal]:
+    clock = ManualClock()
+    implementor = Implementor(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        now=clock.now,
+    )
+    refiner = Refiner(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        implementor=implementor,
+        now=clock.now,
+    )
+    proposal = _proposal(spec_id)
+    implementor.draft_from_scaffold(
+        proposal,
+        {
+            "paths": {
+                "daemon": "codex/daemon_module.py",
+                "test": "tests/test_daemon_module.py",
+            }
+        },
+    )
+    return clock, implementor, refiner, proposal
+
+
+def _read_log(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_refiner_generates_versions_and_dashboard(tmp_path: Path) -> None:
+    _, implementor, refiner, proposal = _bootstrap(tmp_path, "spec-refiner-1")
+
+    v1_path = tmp_path / "integration" / "implementations" / proposal.spec_id / "versions" / "v1.json"
+    assert v1_path.exists(), "Initial draft should persist as version v1"
+
+    refiner.refine(
+        proposal.spec_id,
+        failure="pytest failure",
+        change_summary="Adjust error handling",
+        operator="aurora",
+        transform=lambda block: block.draft + "\n    # refined iteration",
+    )
+
+    record = implementor.load_record(proposal.spec_id)
+    assert record.pending_version == "v2"
+    assert record.versions and record.versions[-1]["parent_id"] == "v1"
+    assert record.versions[-1]["change_summary"] == "Adjust error handling"
+
+    version_record = implementor.load_version(proposal.spec_id, "v2")
+    assert version_record.parent_id == "v1"
+    assert any(entry.get("action") == "refined" for entry in version_record.history or [])
+
+    log_path = tmp_path / "integration" / "refinement_log.jsonl"
+    entries = _read_log(log_path)
+    assert any(entry["action"] == "refined" for entry in entries)
+
+    dashboard = implementations_panel_state(implementor, include_history=True)
+    pending = next(item for item in dashboard["pending"] if item["spec_id"] == proposal.spec_id)
+    assert pending["pending_version"] == "v2"
+    latest_version = pending["versions"][-1]
+    assert "diff" in latest_version
+    assert "refined iteration" in latest_version["diff"]
+
+
+def test_refiner_gating_and_rollbacks(tmp_path: Path) -> None:
+    _clock, implementor, refiner, proposal = _bootstrap(tmp_path, "spec-refiner-2")
+
+    implementor.commit_ledger_entry(proposal.spec_id, "ledger://refiner/001")
+    implementor.approve(proposal.spec_id, operator="aurora")
+    implementor.assert_ready(proposal.spec_id)
+
+    refiner.refine(
+        proposal.spec_id,
+        failure="integration failure",
+        change_summary="Tighten validation",
+        operator="aurora",
+        transform=lambda block: block.draft + "\n    # tightened",
+    )
+
+    record = implementor.load_record(proposal.spec_id)
+    assert record.status == "pending_review"
+    with pytest.raises(RuntimeError):
+        implementor.assert_ready(proposal.spec_id)
+
+    implementor.approve(proposal.spec_id, operator="aurora", version_id="v2")
+    implementor.assert_ready(proposal.spec_id)
+    updated = implementor.load_record(proposal.spec_id)
+    assert updated.active_version == "v2"
+
+    refiner.rollback(proposal.spec_id, "v1", operator="aurora", reason="Regression")
+    rolled = implementor.load_record(proposal.spec_id)
+    assert rolled.active_version == "v1"
+    assert rolled.pending_version is None
+    implementor.assert_ready(proposal.spec_id)
+
+    log_entries = _read_log(tmp_path / "integration" / "refinement_log.jsonl")
+    actions = {entry["action"] for entry in log_entries}
+    assert {"refined", "rolled_back"}.issubset(actions)


### PR DESCRIPTION
## Summary
- introduce a Refiner component that records iterative implementation versions, logs refinements, and supports rollback, locking, and final rejection workflows
- extend the Implementor and dashboard data to track version metadata, diffs, and approval gating for each refinement
- add regression tests that exercise refinement generation, dashboard surfacing, gating behaviour, and rollbacks

## Testing
- pytest tests/test_codex_refinements.py -vv

------
https://chatgpt.com/codex/tasks/task_b_68daca4e4fcc8320bbbcbc82c0000bc5