### PR TITLE
Add Codex coverage gap analysis and dashboard

### DIFF
--- a/codex/coverage.py
+++ b/codex/coverage.py
@@ -1,0 +1,425 @@
+"""Coverage analysis and adaptive gap detection for Codex."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, MutableMapping
+
+import json
+
+from .testcycles import TestSynthesizer
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class CoverageGap:
+    """Represents a coverage gap discovered during analysis."""
+
+    module: str
+    item_type: str
+    name: str
+    reason: str
+    spec_id: str | None = None
+    scaffold: str | None = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def gap_id(self) -> str:
+        return f"{self.module}::{self.item_type}::{self.name}"
+
+    @property
+    def coverage_target(self) -> str:
+        return f"{self.item_type}:{self.module}:{self.name}"
+
+    def to_event(self, timestamp: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "timestamp": timestamp,
+            "event_type": "coverage_gap_detected",
+            "module": self.module,
+            "item_type": self.item_type,
+            "name": self.name,
+            "reason": self.reason,
+            "gap_id": self.gap_id,
+            "coverage_target": self.coverage_target,
+        }
+        if self.spec_id:
+            payload["spec_id"] = self.spec_id
+        if self.scaffold:
+            payload["scaffold_id"] = self.scaffold
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def to_dict(self, feedback: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        payload = {
+            "module": self.module,
+            "item_type": self.item_type,
+            "name": self.name,
+            "reason": self.reason,
+            "gap_id": self.gap_id,
+            "coverage_target": self.coverage_target,
+        }
+        if self.spec_id:
+            payload["spec_id"] = self.spec_id
+        if self.scaffold:
+            payload["scaffold_id"] = self.scaffold
+        if feedback:
+            payload["feedback"] = dict(feedback)
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class CoverageAnalyzer:
+    """Builds coverage maps and synthesizes remediation strategies."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str = Path("."),
+        integration_root: Path | str | None = None,
+        pulse_root: Path | str | None = None,
+        synthesizer: TestSynthesizer | None = None,
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._repo_root = Path(repo_root)
+        self._integration_root = (
+            Path(integration_root)
+            if integration_root is not None
+            else self._repo_root / "integration"
+        )
+        self._pulse_root = (
+            Path(pulse_root)
+            if pulse_root is not None
+            else self._repo_root / "pulse" / "anomalies"
+        )
+        self._coverage_map_path = self._integration_root / "coverage_map.json"
+        self._coverage_log_path = self._integration_root / "coverage_log.jsonl"
+        self._feedback_path = self._integration_root / "coverage_feedback.json"
+        self._pulse_log_path = self._pulse_root / "coverage_gaps.jsonl"
+        self._now = now
+        self._synthesizer = synthesizer or TestSynthesizer(
+            repo_root=self._repo_root,
+            integration_root=self._integration_root,
+            now=now,
+        )
+
+        self._integration_root.mkdir(parents=True, exist_ok=True)
+        self._pulse_root.mkdir(parents=True, exist_ok=True)
+        self._pulse_log_path.touch(exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    @property
+    def synthesizer(self) -> TestSynthesizer:
+        return self._synthesizer
+
+    def analyze(
+        self,
+        test_results: Mapping[str, Mapping[str, Iterable[str]]],
+        source_index: Mapping[str, Mapping[str, Iterable[str]]],
+        *,
+        link_index: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Analyze coverage and persist the resulting map."""
+
+        timestamp = self._now().isoformat()
+        previous_map = self._load_map()
+        feedback = self.feedback_summary()
+
+        modules_payload: list[dict[str, Any]] = []
+        gaps: list[CoverageGap] = []
+
+        totals = {
+            "functions": {"covered": 0, "total": 0},
+            "branches": {"covered": 0, "total": 0},
+            "integration_flows": {"covered": 0, "total": 0},
+        }
+
+        for module in sorted(source_index):
+            definitions = source_index[module]
+            functions = set(definitions.get("functions", []) or [])
+            branches = set(definitions.get("branches", []) or [])
+            flows = set(definitions.get("integration_flows", []) or [])
+
+            results = test_results.get(module, {})
+            tested_functions = set(results.get("functions", []) or []) & functions
+            tested_branches = set(results.get("branches", []) or []) & branches
+            tested_flows = set(results.get("integration_flows", []) or []) & flows
+
+            totals["functions"]["covered"] += len(tested_functions)
+            totals["functions"]["total"] += len(functions)
+            totals["branches"]["covered"] += len(tested_branches)
+            totals["branches"]["total"] += len(branches)
+            totals["integration_flows"]["covered"] += len(tested_flows)
+            totals["integration_flows"]["total"] += len(flows)
+
+            missing_functions = sorted(functions - tested_functions)
+            missing_branches = sorted(branches - tested_branches)
+            missing_flows = sorted(flows - tested_flows)
+
+            modules_payload.append(
+                {
+                    "module": module,
+                    "functions": {
+                        "tested": sorted(tested_functions),
+                        "untested": missing_functions,
+                        "coverage": self._coverage_ratio(len(tested_functions), len(functions)),
+                    },
+                    "branches": {
+                        "covered": sorted(tested_branches),
+                        "missing": missing_branches,
+                        "coverage": self._coverage_ratio(len(tested_branches), len(branches)),
+                    },
+                    "integration_flows": {
+                        "covered": sorted(tested_flows),
+                        "missing": missing_flows,
+                        "coverage": self._coverage_ratio(len(tested_flows), len(flows)),
+                    },
+                }
+            )
+
+            gaps.extend(
+                self._build_gaps(
+                    module,
+                    "function",
+                    missing_functions,
+                    link_index,
+                )
+            )
+            gaps.extend(
+                self._build_gaps(
+                    module,
+                    "branch",
+                    missing_branches,
+                    link_index,
+                )
+            )
+            gaps.extend(
+                self._build_gaps(
+                    module,
+                    "integration_flow",
+                    missing_flows,
+                    link_index,
+                )
+            )
+
+        coverage_map = {
+            "generated_at": timestamp,
+            "modules": modules_payload,
+            "overall": self._overall_summary(totals),
+            "gaps": [gap.to_dict(feedback.get(gap.gap_id)) for gap in gaps],
+        }
+
+        self._save_map(coverage_map)
+        self._log_delta(previous_map, coverage_map)
+
+        if gaps:
+            self._emit_gaps(gaps, timestamp)
+            self._propose_gap_tests(gaps)
+
+        return coverage_map
+
+    def load_map(self) -> dict[str, Any]:
+        return self._load_map()
+
+    def record_feedback(self, gap_id: str, classification: str, *, operator: str) -> dict[str, Any]:
+        """Record operator sentiment about a coverage gap."""
+
+        classification_key = classification.lower()
+        if classification_key not in {"critical", "acceptable"}:
+            raise ValueError("classification must be 'critical' or 'acceptable'")
+
+        feedback = self.feedback_summary()
+        entry = feedback.setdefault(
+            gap_id,
+            {
+                "critical": 0,
+                "acceptable": 0,
+            },
+        )
+        entry[classification_key] = entry.get(classification_key, 0) + 1
+        entry["_last_decision"] = classification_key
+        entry["_last_operator"] = operator
+        entry["_updated_at"] = self._now().isoformat()
+
+        self._feedback_path.write_text(
+            json.dumps(feedback, sort_keys=True, indent=2), encoding="utf-8"
+        )
+
+        self._append_log(
+            {
+                "timestamp": self._now().isoformat(),
+                "event": "coverage_feedback_recorded",
+                "gap_id": gap_id,
+                "classification": classification_key,
+                "operator": operator,
+            }
+        )
+        return dict(entry)
+
+    def feedback_summary(self) -> dict[str, dict[str, Any]]:
+        if not self._feedback_path.exists():
+            return {}
+        data = json.loads(self._feedback_path.read_text(encoding="utf-8"))
+        return {key: dict(value) for key, value in data.items()}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _coverage_ratio(self, covered: int, total: int) -> float:
+        if total == 0:
+            return 1.0
+        return round(covered / total, 4)
+
+    def _overall_summary(self, totals: Mapping[str, Mapping[str, int]]) -> dict[str, Any]:
+        summary: dict[str, Any] = {}
+        for key, data in totals.items():
+            summary[key] = {
+                "covered": data["covered"],
+                "total": data["total"],
+                "coverage": self._coverage_ratio(data["covered"], data["total"]),
+            }
+        return summary
+
+    def _load_map(self) -> dict[str, Any]:
+        if not self._coverage_map_path.exists():
+            return {
+                "generated_at": None,
+                "modules": [],
+                "overall": {
+                    "functions": {"covered": 0, "total": 0, "coverage": 0.0},
+                    "branches": {"covered": 0, "total": 0, "coverage": 0.0},
+                    "integration_flows": {
+                        "covered": 0,
+                        "total": 0,
+                        "coverage": 0.0,
+                    },
+                },
+                "gaps": [],
+            }
+        return json.loads(self._coverage_map_path.read_text(encoding="utf-8"))
+
+    def _save_map(self, payload: Mapping[str, Any]) -> None:
+        self._coverage_map_path.write_text(
+            json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8"
+        )
+
+    def _append_log(self, entry: Mapping[str, Any]) -> None:
+        with self._coverage_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(dict(entry), sort_keys=True) + "\n")
+
+    def _log_delta(
+        self, previous: Mapping[str, Any], current: Mapping[str, Any]
+    ) -> None:
+        prev_overall = previous.get("overall") if previous else None
+        curr_overall = current.get("overall", {})
+        delta: dict[str, Any] = {
+            "timestamp": current.get("generated_at", self._now().isoformat()),
+            "event": "coverage_delta",
+            "overall": curr_overall,
+        }
+        if prev_overall:
+            changes: dict[str, Any] = {}
+            for key in ("functions", "branches", "integration_flows"):
+                prev_cov = (
+                    prev_overall.get(key, {}).get("coverage")
+                    if isinstance(prev_overall, Mapping)
+                    else None
+                )
+                curr_cov = curr_overall.get(key, {}).get("coverage")
+                if prev_cov is not None and curr_cov is not None:
+                    changes[key] = round(curr_cov - prev_cov, 4)
+            if changes:
+                delta["delta"] = changes
+        self._append_log(delta)
+
+    def _emit_gaps(self, gaps: Iterable[CoverageGap], timestamp: str) -> None:
+        lines = [json.dumps(gap.to_event(timestamp), sort_keys=True) for gap in gaps]
+        if not lines:
+            return
+        with self._pulse_log_path.open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+    def _propose_gap_tests(self, gaps: Iterable[CoverageGap]) -> None:
+        existing_targets: set[str] = set()
+        for proposal in self._synthesizer.pending():
+            existing_targets.add(proposal.coverage_target)
+        for proposal in self._synthesizer.approved():
+            existing_targets.add(proposal.coverage_target)
+
+        for gap in gaps:
+            if gap.coverage_target in existing_targets:
+                continue
+            spec_id = gap.spec_id or gap.scaffold or f"coverage::{gap.module}"
+            proposals = self._synthesizer.propose_tests(
+                spec_id,
+                failure_context=gap.reason,
+                feedback="Coverage gap detected; operator review required.",
+                implementation_paths=[gap.module],
+                coverage_target=gap.coverage_target,
+            )
+            for proposal in proposals:
+                existing_targets.add(proposal.coverage_target)
+
+    def _build_gaps(
+        self,
+        module: str,
+        item_type: str,
+        missing: Iterable[str],
+        link_index: Mapping[str, Any] | None,
+    ) -> list[CoverageGap]:
+        gaps: list[CoverageGap] = []
+        for name in missing:
+            spec_id: str | None = None
+            scaffold: str | None = None
+            metadata: dict[str, Any] = {}
+            if link_index:
+                spec_id, scaffold, metadata = self._resolve_link(
+                    link_index, module, name
+                )
+            reason = f"Uncovered {item_type.replace('_', ' ')}"
+            gaps.append(
+                CoverageGap(
+                    module=module,
+                    item_type=item_type,
+                    name=name,
+                    reason=reason,
+                    spec_id=spec_id,
+                    scaffold=scaffold,
+                    metadata=metadata,
+                )
+            )
+        return gaps
+
+    def _resolve_link(
+        self,
+        link_index: Mapping[str, Any],
+        module: str,
+        name: str,
+    ) -> tuple[str | None, str | None, dict[str, Any]]:
+        key_variants = [f"{module}:{name}", module]
+        for key in key_variants:
+            if key not in link_index:
+                continue
+            value = link_index[key]
+            if isinstance(value, str):
+                return value, None, {}
+            if isinstance(value, Mapping):
+                metadata = {
+                    k: v
+                    for k, v in value.items()
+                    if k not in {"spec_id", "scaffold", "scaffold_id"}
+                }
+                spec_id = value.get("spec_id") or value.get("spec")
+                scaffold = value.get("scaffold") or value.get("scaffold_id")
+                return spec_id, scaffold, metadata
+        return None, None, {}
+
+
+__all__ = ["CoverageAnalyzer", "CoverageGap"]

--- a/coverage_dashboard.py
+++ b/coverage_dashboard.py
@@ -1,0 +1,82 @@
+"""Dashboard helpers for Codex coverage mapping."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from codex.coverage import CoverageAnalyzer
+from codex.testcycles import TestProposal, TestSynthesizer
+
+PANEL_TITLE = "Coverage Map"
+
+
+def _proposal_entry(proposal: TestProposal) -> dict[str, Any]:
+    payload = {
+        "proposal_id": proposal.proposal_id,
+        "spec_id": proposal.spec_id,
+        "status": proposal.status,
+        "coverage_target": proposal.coverage_target,
+        "created_at": proposal.created_at,
+        "test_path": proposal.test_path,
+        "style": proposal.style,
+    }
+    if proposal.approved_at:
+        payload["approved_at"] = proposal.approved_at
+    if proposal.approved_by:
+        payload["approved_by"] = proposal.approved_by
+    if proposal.rejected_at:
+        payload["rejected_at"] = proposal.rejected_at
+    if proposal.rejection_reason:
+        payload["rejection_reason"] = proposal.rejection_reason
+    return payload
+
+
+def coverage_panel_state(
+    analyzer: CoverageAnalyzer | None = None,
+    *,
+    synthesizer: TestSynthesizer | None = None,
+) -> Mapping[str, Any]:
+    """Return structured state for the Coverage Map dashboard."""
+
+    coverage_analyzer = analyzer or CoverageAnalyzer()
+    synth = synthesizer or coverage_analyzer.synthesizer
+    coverage_map = coverage_analyzer.load_map()
+    pending = [_proposal_entry(item) for item in synth.pending()]
+    approved = [_proposal_entry(item) for item in synth.approved()]
+    return {
+        "panel": PANEL_TITLE,
+        "coverage": coverage_map,
+        "pending_proposals": pending,
+        "approved_proposals": approved,
+        "requires_operator_approval": bool(pending),
+    }
+
+
+def approve_coverage_proposal(
+    proposal_id: str,
+    *,
+    operator: str,
+    synthesizer: TestSynthesizer | None = None,
+) -> dict[str, Any]:
+    synth = synthesizer or TestSynthesizer()
+    proposal = synth.approve(proposal_id, operator=operator)
+    return _proposal_entry(proposal)
+
+
+def reject_coverage_proposal(
+    proposal_id: str,
+    *,
+    operator: str,
+    reason: str,
+    synthesizer: TestSynthesizer | None = None,
+) -> dict[str, Any]:
+    synth = synthesizer or TestSynthesizer()
+    proposal = synth.reject(proposal_id, operator=operator, reason=reason)
+    return _proposal_entry(proposal)
+
+
+__all__ = [
+    "PANEL_TITLE",
+    "coverage_panel_state",
+    "approve_coverage_proposal",
+    "reject_coverage_proposal",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_implementations",
         "tests.test_codex_refinements",
         "tests.test_codex_testcycles",
+        "tests.test_codex_coverage",
     }
     for item in items:
         if (

--- a/tests/test_codex_coverage.py
+++ b/tests/test_codex_coverage.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex.coverage import CoverageAnalyzer
+from codex.testcycles import TestSynthesizer
+from coverage_dashboard import approve_coverage_proposal, coverage_panel_state
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.moment = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    def now(self) -> datetime:
+        current = self.moment
+        self.moment += timedelta(seconds=1)
+        return current
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_coverage_analyzer_flags_gaps(tmp_path: Path) -> None:
+    clock = ManualClock()
+    synth = TestSynthesizer(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        now=clock.now,
+    )
+    analyzer = CoverageAnalyzer(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        pulse_root=tmp_path / "pulse" / "anomalies",
+        synthesizer=synth,
+        now=clock.now,
+    )
+
+    source_index = {
+        "codex.module": {
+            "functions": ["covered_func", "missing_func"],
+            "branches": ["branch_a", "branch_b"],
+            "integration_flows": ["flow_alpha"],
+        }
+    }
+    test_results = {
+        "codex.module": {
+            "functions": ["covered_func"],
+            "branches": ["branch_a"],
+            "integration_flows": [],
+        }
+    }
+    link_index = {
+        "codex.module:missing_func": {"spec_id": "spec-coverage-1"},
+        "codex.module:branch_b": "spec-coverage-1",
+        "codex.module:flow_alpha": {"scaffold": "scaffold-alpha"},
+    }
+
+    coverage_map = analyzer.analyze(test_results, source_index, link_index=link_index)
+
+    assert coverage_map["modules"], "Module coverage should be captured"
+    module_entry = coverage_map["modules"][0]
+    assert "missing_func" in module_entry["functions"]["untested"]
+    assert module_entry["branches"]["missing"] == ["branch_b"]
+    assert module_entry["integration_flows"]["missing"] == ["flow_alpha"]
+
+    gap_ids = {gap["gap_id"] for gap in coverage_map["gaps"]}
+    assert any(gap.endswith("missing_func") for gap in gap_ids)
+    assert any(gap.endswith("branch_b") for gap in gap_ids)
+    assert any(gap.endswith("flow_alpha") for gap in gap_ids)
+
+    coverage_path = tmp_path / "integration" / "coverage_map.json"
+    assert coverage_path.exists(), "Coverage map should be written to integration root"
+    stored_map = json.loads(coverage_path.read_text(encoding="utf-8"))
+    assert stored_map["gaps"], "Stored coverage map should include gaps"
+
+    pulse_path = tmp_path / "pulse" / "anomalies" / "coverage_gaps.jsonl"
+    events = _read_jsonl(pulse_path)
+    assert events and events[0]["event_type"] == "coverage_gap_detected"
+
+    log_entries = _read_jsonl(tmp_path / "integration" / "coverage_log.jsonl")
+    assert any(entry["event"] == "coverage_delta" for entry in log_entries)
+
+    pending = synth.pending()
+    assert pending, "Coverage gaps should propose new tests"
+    targets = {proposal.coverage_target for proposal in pending}
+    assert "function:codex.module:missing_func" in targets
+
+
+def test_coverage_dashboard_surfaces_map_and_gating(tmp_path: Path) -> None:
+    clock = ManualClock()
+    synth = TestSynthesizer(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        now=clock.now,
+    )
+    analyzer = CoverageAnalyzer(
+        repo_root=tmp_path,
+        integration_root=tmp_path / "integration",
+        pulse_root=tmp_path / "pulse" / "anomalies",
+        synthesizer=synth,
+        now=clock.now,
+    )
+
+    source_index = {
+        "codex.dashboard": {
+            "functions": ["alpha", "beta"],
+            "branches": [],
+            "integration_flows": [],
+        }
+    }
+    test_results = {
+        "codex.dashboard": {
+            "functions": ["alpha"],
+            "branches": [],
+            "integration_flows": [],
+        }
+    }
+    link_index = {
+        "codex.dashboard:beta": {
+            "spec_id": "spec-dashboard",
+            "scaffold": "scaffold-beta",
+            "origin": "scaffold",
+        }
+    }
+
+    coverage_map = analyzer.analyze(test_results, source_index, link_index=link_index)
+    assert coverage_map["gaps"], "Initial run should report coverage gaps"
+
+    gap_id = coverage_map["gaps"][0]["gap_id"]
+    analyzer.record_feedback(gap_id, "critical", operator="aurora")
+
+    analyzer.analyze(test_results, source_index, link_index=link_index)
+
+    state = coverage_panel_state(analyzer, synthesizer=synth)
+    assert state["panel"] == "Coverage Map"
+    assert state["requires_operator_approval"], "Coverage remediation should be ledger gated"
+    assert state["pending_proposals"], "Pending proposals must be reviewed"
+
+    gap_feedback = state["coverage"]["gaps"][0].get("feedback", {})
+    assert gap_feedback.get("critical") == 1
+    assert gap_feedback.get("_last_operator") == "aurora"
+
+    proposal_id = state["pending_proposals"][0]["proposal_id"]
+    approve_coverage_proposal(proposal_id, operator="aurora", synthesizer=synth)
+    assert synth.approved(), "Operator approval should promote proposal to active suite"
+
+    improved_results = {
+        "codex.dashboard": {
+            "functions": ["alpha", "beta"],
+            "branches": [],
+            "integration_flows": [],
+        }
+    }
+    improved_map = analyzer.analyze(improved_results, source_index, link_index=link_index)
+    assert improved_map["overall"]["functions"]["coverage"] == pytest.approx(1.0)
+
+    log_entries = _read_jsonl(tmp_path / "integration" / "coverage_log.jsonl")
+    assert any(
+        entry.get("event") == "coverage_delta" and entry.get("overall", {}).get("functions", {}).get("coverage") == pytest.approx(1.0)
+        for entry in log_entries
+    )


### PR DESCRIPTION
## Summary
- add a CoverageAnalyzer that logs coverage maps, emits gap events, and proposes ledger-gated fixes
- surface the coverage map and proposal approvals in a dedicated dashboard helper module
- exercise the coverage workflow with targeted tests and allowlist the suite

## Testing
- pytest tests/test_codex_coverage.py

------
https://chatgpt.com/codex/tasks/task_b_68db071eda1483209b9cdf7acb529e8f