### PR TITLE
Add autogenesis loop for self-authored amendments

### DIFF
--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -7,6 +7,7 @@ from .amendments import (
     IntegrityViolation,
     SpecAmender,
 )
+from .autogenesis import GapScanner, LineageWriter, ReviewSymmetry, SelfAmender
 from .integrity_daemon import IntegrityDaemon
 from .anomalies import (
     Anomaly,
@@ -65,6 +66,10 @@ __all__ = [
     "AmendmentReviewBoard",
     "SpecAmender",
     "IntegrityViolation",
+    "GapScanner",
+    "LineageWriter",
+    "ReviewSymmetry",
+    "SelfAmender",
     "IntegrityDaemon",
     "Anomaly",
     "AnomalyCoordinator",

--- a/codex/autogenesis.py
+++ b/codex/autogenesis.py
@@ -1,0 +1,406 @@
+"""Autogenesis loop for SentientOS amendments.
+
+This module wires together the SpecAmender so it can originate its own
+amendment proposals when recurring telemetry gaps are detected.
+
+It introduces four collaborators:
+
+* :class:`GapScanner` – normalises telemetry inputs (logs, tests, covenant
+  probes) and routes them into the amendment pipeline.
+* :class:`SelfAmender` – bridges the scanner with :class:`~codex.amendments.SpecAmender`
+  and ensures every generated proposal passes through the integrity gate.
+* :class:`LineageWriter` – records provenance that clearly indicates the
+  proposal was auto-authored by SentientOS rather than an operator.
+* :class:`ReviewSymmetry` – mirrors the human review flow by ensuring the
+  AmendmentReviewBoard remains the arbiter for self-authored amendments and
+  narrates outcomes for dashboards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, MutableMapping
+
+import copy
+import json
+
+from .amendments import AmendmentProposal, AmendmentReviewBoard, SpecAmender
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class AutogenesisContext:
+    """Context payload returned when a self-authored amendment is drafted."""
+
+    proposal: AmendmentProposal
+    lineage: Mapping[str, Any]
+    metadata: Mapping[str, Any]
+
+
+class GapScanner:
+    """Monitor telemetry sources and surface recurring gaps."""
+
+    def __init__(
+        self,
+        self_amender: "SelfAmender",
+        *,
+        spec_loader: Callable[[str], Mapping[str, Any]],
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._self_amender = self_amender
+        self._spec_loader = spec_loader
+        self._now = now
+
+    # ------------------------------------------------------------------
+    # Telemetry ingestion helpers
+    def observe_log_failure(
+        self,
+        spec_id: str,
+        message: str,
+        detail: str,
+        *,
+        severity: str = "error",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AutogenesisContext | None:
+        payload = {
+            "message": message,
+            "detail": detail,
+            "severity": severity,
+            "recorded_at": self._now().isoformat(),
+        }
+        if metadata:
+            payload.update(dict(metadata))
+        return self._dispatch(
+            spec_id,
+            signal_type="log_failure",
+            channel="logs",
+            metadata=payload,
+        )
+
+    def observe_test_failure(
+        self,
+        spec_id: str,
+        test_name: str,
+        failure_reason: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AutogenesisContext | None:
+        payload = {
+            "test": test_name,
+            "reason": failure_reason,
+            "recorded_at": self._now().isoformat(),
+        }
+        if metadata:
+            payload.update(dict(metadata))
+        return self._dispatch(
+            spec_id,
+            signal_type="test_failure",
+            channel="tests",
+            metadata=payload,
+        )
+
+    def observe_covenant_probe(
+        self,
+        spec_id: str,
+        probe: str,
+        finding: str,
+        *,
+        severity: str = "alert",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AutogenesisContext | None:
+        payload = {
+            "probe": probe,
+            "finding": finding,
+            "severity": severity,
+            "recorded_at": self._now().isoformat(),
+        }
+        if metadata:
+            payload.update(dict(metadata))
+        return self._dispatch(
+            spec_id,
+            signal_type="covenant_gap",
+            channel="covenant",
+            metadata=payload,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    def _dispatch(
+        self,
+        spec_id: str,
+        *,
+        signal_type: str,
+        channel: str,
+        metadata: Mapping[str, Any],
+    ) -> AutogenesisContext | None:
+        current_spec = self._resolve_spec(spec_id)
+        result = self._self_amender.process_signal(
+            spec_id,
+            signal_type,
+            metadata,
+            current_spec=current_spec,
+            channel=channel,
+        )
+        return result
+
+    def _resolve_spec(self, spec_id: str) -> Mapping[str, Any]:
+        payload = self._spec_loader(spec_id)
+        if payload is None:
+            raise FileNotFoundError(f"Spec {spec_id} not found for autogenesis scan")
+        return copy.deepcopy(dict(payload))
+
+
+class LineageWriter:
+    """Attach provenance markers to self-authored amendments."""
+
+    def __init__(
+        self,
+        engine: SpecAmender,
+        *,
+        author: str = "sentientos.autogenesis",
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._engine = engine
+        self._author = author
+        self._now = now
+
+    def compose(
+        self,
+        *,
+        spec_id: str,
+        signal: str,
+        channel: str,
+        metadata: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "author": self._author,
+            "spec_id": spec_id,
+            "signal": signal,
+            "channel": channel,
+            "generated_at": self._now().isoformat(),
+            "metadata": dict(metadata),
+        }
+
+    def apply(
+        self,
+        proposal: AmendmentProposal,
+        *,
+        lineage: Mapping[str, Any],
+        channel: str,
+        signal: str,
+        metadata: Mapping[str, Any],
+    ) -> AmendmentProposal:
+        context_update = {
+            "autogenesis": {
+                "channel": channel,
+                "signal": signal,
+                "metadata": dict(metadata),
+            }
+        }
+        return self._engine.annotate_lineage(
+            proposal.proposal_id,
+            lineage=lineage,
+            context=context_update,
+        )
+
+
+class ReviewSymmetry:
+    """Ensure self-authored amendments share the human review lane."""
+
+    def __init__(
+        self,
+        *,
+        root: Path | str,
+        board: AmendmentReviewBoard,
+        now: Callable[[], datetime] = _default_now,
+    ) -> None:
+        self._root = Path(root)
+        self._board = board
+        self._now = now
+        self._log_path = self._root / "dashboard" / "autogenesis_log.jsonl"
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._tracked: set[str] = set()
+        self._wrap_board()
+
+    def register(
+        self,
+        proposal: AmendmentProposal,
+        *,
+        lineage: Mapping[str, Any],
+    ) -> None:
+        self._tracked.add(proposal.proposal_id)
+        self._write_event(
+            proposal,
+            stage="proposed",
+            lineage=lineage,
+            message="Autogenesis event: self-authored amendment drafted.",
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _wrap_board(self) -> None:
+        if getattr(self._board, "_autogenesis_wrapped", False):
+            return
+
+        original_approve = self._board.approve
+        original_reject = self._board.reject
+
+        def approve_wrapper(
+            proposal_id: str,
+            *,
+            operator: str,
+            ledger_entry: str | None,
+        ) -> AmendmentProposal:
+            proposal = original_approve(
+                proposal_id,
+                operator=operator,
+                ledger_entry=ledger_entry,
+            )
+            if proposal.proposal_id in self._tracked:
+                self._write_event(
+                    proposal,
+                    stage="adopted",
+                    lineage=proposal.lineage or {},
+                    message="Autogenesis event: self-authored amendment adopted.",
+                )
+            return proposal
+
+        def reject_wrapper(
+            proposal_id: str,
+            *,
+            operator: str,
+            reason: str | None = None,
+        ) -> AmendmentProposal:
+            proposal = original_reject(
+                proposal_id,
+                operator=operator,
+                reason=reason,
+            )
+            if proposal.proposal_id in self._tracked:
+                self._write_event(
+                    proposal,
+                    stage="rejected",
+                    lineage=proposal.lineage or {},
+                    message="Autogenesis event: self-authored amendment rejected.",
+                )
+            return proposal
+
+        self._board.approve = approve_wrapper  # type: ignore[assignment]
+        self._board.reject = reject_wrapper  # type: ignore[assignment]
+        setattr(self._board, "_autogenesis_wrapped", True)
+
+    def _write_event(
+        self,
+        proposal: AmendmentProposal,
+        *,
+        stage: str,
+        lineage: Mapping[str, Any],
+        message: str,
+    ) -> None:
+        payload: MutableMapping[str, Any] = {
+            "timestamp": self._now().isoformat(),
+            "proposal_id": proposal.proposal_id,
+            "spec_id": proposal.spec_id,
+            "stage": stage,
+            "message": message,
+            "lineage": dict(lineage),
+        }
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+class SelfAmender:
+    """Bridge between telemetry scans and the amendment pipeline."""
+
+    def __init__(
+        self,
+        engine: SpecAmender,
+        *,
+        lineage_writer: LineageWriter,
+        review_symmetry: ReviewSymmetry,
+    ) -> None:
+        self._engine = engine
+        self._lineage = lineage_writer
+        self._review = review_symmetry
+
+    def process_signal(
+        self,
+        spec_id: str,
+        signal_type: str,
+        metadata: Mapping[str, Any],
+        *,
+        current_spec: Mapping[str, Any],
+        channel: str,
+    ) -> AutogenesisContext | None:
+        enriched = dict(metadata)
+        enriched.setdefault("channel", channel)
+        enriched.setdefault("origin", "GapScanner")
+        proposal = self._engine.record_signal(
+            spec_id,
+            signal_type,
+            enriched,
+            current_spec=current_spec,
+        )
+        if proposal is None:
+            return None
+        lineage = self._lineage.compose(
+            spec_id=spec_id,
+            signal=signal_type,
+            channel=channel,
+            metadata=enriched,
+        )
+        proposal = self._lineage.apply(
+            proposal,
+            lineage=lineage,
+            channel=channel,
+            signal=signal_type,
+            metadata=enriched,
+        )
+        self._review.register(proposal, lineage=lineage)
+        return AutogenesisContext(proposal=proposal, lineage=lineage, metadata=enriched)
+
+    def submit_manual(
+        self,
+        spec_id: str,
+        *,
+        summary: str,
+        deltas: Mapping[str, Any],
+        context: Mapping[str, Any],
+        original_spec: Mapping[str, Any],
+        proposed_spec: Mapping[str, Any],
+        channel: str = "manual",
+        signal: str = "self_override",
+    ) -> AutogenesisContext:
+        enriched_context = dict(context)
+        enriched_context.setdefault("origin", "SelfAmender")
+        enriched_context.setdefault("channel", channel)
+        proposal = self._engine.propose_manual(
+            spec_id,
+            summary=summary,
+            deltas=deltas,
+            context=enriched_context,
+            original_spec=original_spec,
+            proposed_spec=proposed_spec,
+            kind="amendment",
+        )
+        lineage = self._lineage.compose(
+            spec_id=spec_id,
+            signal=signal,
+            channel=channel,
+            metadata=enriched_context,
+        )
+        proposal = self._lineage.apply(
+            proposal,
+            lineage=lineage,
+            channel=channel,
+            signal=signal,
+            metadata=enriched_context,
+        )
+        self._review.register(proposal, lineage=lineage)
+        return AutogenesisContext(proposal=proposal, lineage=lineage, metadata=enriched_context)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_testcycles",
         "tests.test_codex_coverage",
         "tests.test_codex_amendments",
+        "tests.test_autogenesis_loop",
     }
     for item in items:
         if (

--- a/tests/test_autogenesis_loop.py
+++ b/tests/test_autogenesis_loop.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict
+
+import json
+
+import pytest
+
+from codex.amendments import AmendmentReviewBoard, IntegrityViolation, SpecAmender
+from codex.autogenesis import GapScanner, LineageWriter, ReviewSymmetry, SelfAmender
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.moment = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    def now(self) -> datetime:
+        current = self.moment
+        self.moment += timedelta(seconds=1)
+        return current
+
+
+def _read_log(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.fixture()
+def base_spec() -> dict:
+    return {
+        "spec_id": "spec-autogenesis",
+        "title": "Autogenesis Coverage",
+        "objective": "Ensure telemetry gaps are surfaced.",
+        "directives": ["Keep telemetry watchers online."],
+        "testing_requirements": ["Replay telemetry gaps until resolved."],
+        "version": "v1",
+        "status": "active",
+    }
+
+
+@pytest.fixture()
+def autogenesis_components(tmp_path: Path, base_spec: dict):
+    clock = ManualClock()
+    root = tmp_path / "integration"
+    engine = SpecAmender(root=root, now=clock.now)
+    board = AmendmentReviewBoard(engine)
+    lineage = LineageWriter(engine, now=clock.now)
+    review = ReviewSymmetry(root=root, board=board, now=clock.now)
+    specs: Dict[str, dict] = {base_spec["spec_id"]: base_spec}
+    self_amender = SelfAmender(engine, lineage_writer=lineage, review_symmetry=review)
+    scanner = GapScanner(
+        self_amender,
+        spec_loader=lambda spec_id: specs[spec_id],
+        now=clock.now,
+    )
+    return {
+        "clock": clock,
+        "engine": engine,
+        "board": board,
+        "lineage": lineage,
+        "review": review,
+        "scanner": scanner,
+        "specs": specs,
+        "root": root,
+        "self_amender": self_amender,
+    }
+
+
+def test_gap_scanner_triggers_autogenesis(autogenesis_components: dict, base_spec: dict) -> None:
+    scanner: GapScanner = autogenesis_components["scanner"]
+    board: AmendmentReviewBoard = autogenesis_components["board"]
+    root: Path = autogenesis_components["root"]
+
+    context = None
+    for idx in range(3):
+        context = scanner.observe_log_failure(
+            base_spec["spec_id"],
+            message="runtime gap",
+            detail=f"telemetry-miss-{idx}",
+        )
+
+    assert context is not None, "Recurring log failures should trigger autogenesis"
+    proposal = context.proposal
+    assert proposal.lineage is not None
+    assert proposal.lineage["author"] == "sentientos.autogenesis"
+    assert proposal.context["autogenesis"]["signal"] == "log_failure"
+
+    board.approve(
+        proposal.proposal_id,
+        operator="aurora",
+        ledger_entry="ledger://autogenesis/001",
+    )
+
+    dashboard_log = root / "dashboard" / "autogenesis_log.jsonl"
+    entries = _read_log(dashboard_log)
+    stages = {entry["stage"] for entry in entries}
+    assert {"proposed", "adopted"}.issubset(stages)
+
+
+def test_self_authored_amendment_still_hits_integrity(autogenesis_components: dict, base_spec: dict) -> None:
+    self_amender: SelfAmender = autogenesis_components["self_amender"]
+
+    hostile_spec = dict(base_spec)
+    hostile_spec.pop("directives")
+    hostile_spec["status"] = "reboot"
+
+    with pytest.raises(IntegrityViolation):
+        self_amender.submit_manual(
+            base_spec["spec_id"],
+            summary="Strip safeguards",
+            deltas={"status": {"before": base_spec["status"], "after": "reboot"}},
+            context={"reason": "attempted bypass"},
+            original_spec={**base_spec, "lineage": {"seed": "v0"}},
+            proposed_spec=hostile_spec,
+        )
+
+
+def test_lineage_marks_self_origin(autogenesis_components: dict, base_spec: dict) -> None:
+    engine: SpecAmender = autogenesis_components["engine"]
+    scanner: GapScanner = autogenesis_components["scanner"]
+    specs: Dict[str, dict] = autogenesis_components["specs"]
+
+    manual = engine.propose_manual(
+        base_spec["spec_id"],
+        summary="Operator tune",
+        deltas={"objective": {"before": base_spec["objective"], "after": "Manual tune"}},
+        context={"origin": "operator"},
+        original_spec=base_spec,
+        proposed_spec={**base_spec, "objective": "Manual tune"},
+    )
+    assert manual.lineage is None
+
+    auto_spec = {**base_spec, "spec_id": "spec-autogenesis-tests"}
+    specs[auto_spec["spec_id"]] = auto_spec
+
+    context = None
+    for _ in range(3):
+        context = scanner.observe_test_failure(
+            auto_spec["spec_id"],
+            test_name="integration::pulse",
+            failure_reason="pulse gap persists",
+        )
+
+    assert context is not None
+    proposal = context.proposal
+    assert proposal.lineage is not None
+    assert proposal.lineage["author"] == "sentientos.autogenesis"
+    assert proposal.context["autogenesis"]["channel"] == "tests"
+


### PR DESCRIPTION
## Summary
- add an autogenesis module that lets the SpecAmender draft its own amendments from recurring telemetry gaps
- extend the amendment engine with lineage annotations and expose the new helpers from the codex package
- add regression coverage for the autogenesis loop and enable the suite in the shared conftest configuration

## Testing
- pytest tests/test_autogenesis_loop.py tests/test_codex_amendments.py

------
https://chatgpt.com/codex/tasks/task_b_68dbf76f371c8320bc4c873e0b707a38