### PR TITLE
Implement GenesisForge capability expansion pipeline

### DIFF
--- a/sentientos/genesis_forge.py
+++ b/sentientos/genesis_forge.py
@@ -1,0 +1,572 @@
+"""GenesisForge — Autonomous capability expansion pipeline.
+
+This module implements the GenesisForge flow described by the cathedral
+charter.  When the existing SentientOS daemons are unable to honour a vow or
+handle a new telemetry stream, GenesisForge can draft the scaffolding for a new
+daemon, probe it for covenant violations, execute sandbox trials, and finally
+bind the daemon into the covenant lineage if the review board approves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+from codex.integrity_daemon import IntegrityDaemon, IntegrityViolation
+from sentientos.codex_healer import Anomaly, RecoveryLedger, RepairAction
+
+
+# ---------------------------------------------------------------------------
+# Shared dataclasses
+
+
+@dataclass(slots=True, frozen=True)
+class TelemetryStream:
+    """Description of an incoming telemetry stream."""
+
+    name: str
+    capability: str
+    description: str
+    handled_by: frozenset[str] = field(default_factory=frozenset)
+    sample_payload: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True, frozen=True)
+class CovenantVow:
+    """Represents a covenant requirement that must be honoured."""
+
+    capability: str
+    description: str
+
+
+@dataclass(slots=True, frozen=True)
+class DaemonManifest:
+    """Known daemon with its declared capabilities."""
+
+    name: str
+    capabilities: frozenset[str]
+    telemetry_streams: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(slots=True)
+class GenesisNeed:
+    """A capability gap identified by :class:`NeedSeer`."""
+
+    capability: str
+    description: str
+    source: str
+    telemetry: TelemetryStream | None = None
+    vow: CovenantVow | None = None
+
+
+@dataclass(slots=True)
+class TestCase:
+    """Single sandbox expectation executed during :class:`TrialRun`."""
+
+    name: str
+    input_payload: Mapping[str, object]
+    validator: Callable[[Mapping[str, object], Mapping[str, object]], bool]
+    failure_message: str
+
+
+@dataclass(slots=True)
+class DaemonBlueprint:
+    """Scaffolding for the daemon produced by :class:`ForgeEngine`."""
+
+    name: str
+    objective: str
+    directives: list[str]
+    testing_requirements: list[str]
+    handler: Callable[[Mapping[str, object]], Mapping[str, object]]
+    test_cases: list[TestCase]
+
+
+@dataclass(slots=True)
+class ForgeProposal:
+    """Proposal submitted to the IntegrityDaemon."""
+
+    proposal_id: str
+    spec_id: str
+    summary: str
+    need: GenesisNeed
+    blueprint: DaemonBlueprint
+    original_spec: Mapping[str, object]
+    proposed_spec: Mapping[str, object]
+    deltas: Mapping[str, object]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "proposal_id": self.proposal_id,
+            "spec_id": self.spec_id,
+            "summary": self.summary,
+            "need": {
+                "capability": self.need.capability,
+                "description": self.need.description,
+                "source": self.need.source,
+            },
+            "original_spec": dict(self.original_spec),
+            "proposed_spec": dict(self.proposed_spec),
+            "deltas": dict(self.deltas),
+        }
+
+
+@dataclass(slots=True)
+class TrialReport:
+    """Result of sandbox simulation executed by :class:`TrialRun`."""
+
+    passed: bool
+    results: list[dict[str, object]]
+    failures: list[str]
+
+
+@dataclass(slots=True)
+class GenesisOutcome:
+    """Narrates the result for a single :class:`GenesisNeed`."""
+
+    need: GenesisNeed
+    status: str
+    details: Mapping[str, object]
+
+
+class GenesisForgeError(RuntimeError):
+    """Raised when GenesisForge cannot complete a stage."""
+
+
+# ---------------------------------------------------------------------------
+# NeedSeer
+
+
+class NeedSeer:
+    """Scans telemetry, amendments, and covenant gaps for missing coverage."""
+
+    def __init__(self, *, daemons: Sequence[DaemonManifest] | None = None) -> None:
+        self._daemons: dict[str, DaemonManifest] = {}
+        if daemons:
+            for manifest in daemons:
+                self._daemons[manifest.name] = manifest
+
+    def register_daemon(self, manifest: DaemonManifest) -> None:
+        self._daemons[manifest.name] = manifest
+
+    def scan(
+        self,
+        telemetry_streams: Sequence[TelemetryStream],
+        vows: Sequence[CovenantVow],
+    ) -> list[GenesisNeed]:
+        """Return unmet covenant needs based on telemetry + vows."""
+
+        existing_capabilities = {
+            capability
+            for manifest in self._daemons.values()
+            for capability in manifest.capabilities
+        }
+        handled_streams = {
+            stream
+            for manifest in self._daemons.values()
+            for stream in manifest.telemetry_streams
+        }
+
+        needs: list[GenesisNeed] = []
+        seen_capabilities: set[str] = set()
+
+        for vow in vows:
+            if vow.capability not in existing_capabilities:
+                needs.append(
+                    GenesisNeed(
+                        capability=vow.capability,
+                        description=vow.description,
+                        source="vow",
+                        vow=vow,
+                    )
+                )
+                seen_capabilities.add(vow.capability)
+
+        for stream in telemetry_streams:
+            already_handled = stream.name in handled_streams or any(
+                daemon_name in stream.handled_by for daemon_name in self._daemons
+            )
+            capability_claimed = stream.capability in existing_capabilities
+            if already_handled and capability_claimed:
+                continue
+            if stream.capability in seen_capabilities:
+                # Already covered by a missing vow entry.
+                continue
+            needs.append(
+                GenesisNeed(
+                    capability=stream.capability,
+                    description=stream.description,
+                    source="telemetry",
+                    telemetry=stream,
+                )
+            )
+            seen_capabilities.add(stream.capability)
+
+        return needs
+
+
+# ---------------------------------------------------------------------------
+# ForgeEngine
+
+
+class ForgeEngine:
+    """Drafts scaffolding for a new daemon aligned with covenant law."""
+
+    def __init__(self, *, existing_daemons: Sequence[DaemonManifest] | None = None) -> None:
+        self._existing_names = {manifest.name for manifest in existing_daemons or ()}
+
+    def _canonical_name(self, capability: str) -> str:
+        words = re.findall(r"[A-Za-z0-9]+", capability)
+        if not words:
+            words = ["Genesis"]
+        name = "".join(word.title() for word in words)
+        candidate = f"{name}GenesisDaemon"
+        counter = 1
+        while candidate in self._existing_names:
+            counter += 1
+            candidate = f"{name}GenesisDaemon{counter}"
+        self._existing_names.add(candidate)
+        return candidate
+
+    def _build_handler(self, need: GenesisNeed) -> Callable[[Mapping[str, object]], Mapping[str, object]]:
+        def handler(payload: Mapping[str, object]) -> Mapping[str, object]:
+            now = datetime.now(timezone.utc).isoformat()
+            envelope: dict[str, object] = {
+                "status": "ok",
+                "capability": need.capability,
+                "provenance": "GenesisForge",
+                "received_at": now,
+                "payload": dict(payload),
+            }
+            if need.telemetry is not None:
+                envelope["telemetry_stream"] = need.telemetry.name
+            if need.vow is not None:
+                envelope["vow"] = need.vow.description
+            return envelope
+
+        return handler
+
+    def _build_test_cases(self, need: GenesisNeed) -> list[TestCase]:
+        sample_payload: Mapping[str, object]
+        if need.telemetry is not None and need.telemetry.sample_payload:
+            sample_payload = need.telemetry.sample_payload
+        elif need.telemetry is not None:
+            sample_payload = {"stream": need.telemetry.name, "signal": need.capability}
+        else:
+            sample_payload = {"signal": need.capability}
+
+        def validator(_: Mapping[str, object], output: Mapping[str, object]) -> bool:
+            if output.get("status") != "ok":
+                return False
+            if output.get("capability") != need.capability:
+                return False
+            if output.get("provenance") != "GenesisForge":
+                return False
+            return True
+
+        return [
+            TestCase(
+                name="capability_ack",
+                input_payload=sample_payload,
+                validator=validator,
+                failure_message="Daemon did not acknowledge capability or status",
+            )
+        ]
+
+    def draft(self, need: GenesisNeed) -> ForgeProposal:
+        name = self._canonical_name(need.capability)
+        handler = self._build_handler(need)
+        test_cases = self._build_test_cases(need)
+        objective = f"Honor {need.capability} inputs discovered via {need.source}."
+        directives = [
+            "inherit_vows",
+            "preserve_lineage",
+            f"ingest_{need.capability}_telemetry",
+        ]
+        testing_requirements = [
+            "acknowledge_capability",
+            "emit_success_status",
+            "record_provenance_GenesisForge",
+        ]
+
+        proposed_spec: MutableMapping[str, object] = {
+            "name": name,
+            "objective": objective,
+            "directives": directives,
+            "testing_requirements": testing_requirements,
+            "lineage": {
+                "provenance": "GenesisForge",
+                "born_from": need.source,
+                "capability": need.capability,
+            },
+            "ledger_required": True,
+        }
+        if need.telemetry is not None:
+            proposed_spec["telemetry_stream"] = need.telemetry.name
+
+        blueprint = DaemonBlueprint(
+            name=name,
+            objective=objective,
+            directives=list(directives),
+            testing_requirements=list(testing_requirements),
+            handler=handler,
+            test_cases=test_cases,
+        )
+
+        proposal = ForgeProposal(
+            proposal_id=f"GF-{uuid.uuid4().hex}",
+            spec_id=name,
+            summary=f"GenesisForge scaffolding for {name}",
+            need=need,
+            blueprint=blueprint,
+            original_spec={},
+            proposed_spec=dict(proposed_spec),
+            deltas={"added": [name], "capability": need.capability},
+        )
+        return proposal
+
+
+# ---------------------------------------------------------------------------
+# TrialRun
+
+
+class TrialRun:
+    """Sandbox executor that validates blueprint behaviour."""
+
+    def execute(self, blueprint: DaemonBlueprint) -> TrialReport:
+        results: list[dict[str, object]] = []
+        failures: list[str] = []
+        for case in blueprint.test_cases:
+            try:
+                output = blueprint.handler(case.input_payload)
+            except Exception as exc:  # pragma: no cover - defensive
+                failures.append(f"{case.name}: handler raised {exc!r}")
+                continue
+            passed = case.validator(case.input_payload, output)
+            results.append({
+                "case": case.name,
+                "input": dict(case.input_payload),
+                "output": dict(output),
+                "passed": passed,
+            })
+            if not passed:
+                failures.append(f"{case.name}: {case.failure_message}")
+        return TrialReport(passed=not failures, results=results, failures=failures)
+
+
+# ---------------------------------------------------------------------------
+# SpecBinder
+
+
+class SpecBinder:
+    """Integrates the daemon into covenant lineage mounts."""
+
+    def __init__(self, *, lineage_root: Path, covenant_root: Path) -> None:
+        self._lineage_root = Path(lineage_root)
+        self._covenant_root = Path(covenant_root)
+        self._lineage_root.mkdir(parents=True, exist_ok=True)
+        self._covenant_root.mkdir(parents=True, exist_ok=True)
+        self._daemon_dir = self._covenant_root / "daemons"
+        self._daemon_dir.mkdir(parents=True, exist_ok=True)
+        self._lineage_log = self._lineage_root / "lineage.jsonl"
+
+    def integrate(self, proposal: ForgeProposal) -> Mapping[str, object]:
+        spec_path = self._daemon_dir / f"{proposal.blueprint.name}.json"
+        if spec_path.exists():
+            raise GenesisForgeError(
+                f"Daemon '{proposal.blueprint.name}' already exists; refusing to overwrite"
+            )
+        spec_payload = {
+            "name": proposal.blueprint.name,
+            "objective": proposal.blueprint.objective,
+            "directives": proposal.blueprint.directives,
+            "testing_requirements": proposal.blueprint.testing_requirements,
+            "lineage": proposal.proposed_spec.get("lineage", {}),
+        }
+        spec_path.write_text(json.dumps(spec_payload, indent=2, sort_keys=True), encoding="utf-8")
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "provenance": "GenesisForge",
+            "proposal_id": proposal.proposal_id,
+            "spec_id": proposal.spec_id,
+            "capability": proposal.need.capability,
+        }
+        with self._lineage_log.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
+        return entry
+
+
+# ---------------------------------------------------------------------------
+# AdoptionRite
+
+
+class AdoptionRite:
+    """Final promotion into the live mount once governance approves."""
+
+    def __init__(
+        self,
+        *,
+        live_mount: Path,
+        codex_index: Path,
+        review_board: Callable[[ForgeProposal, TrialReport], bool],
+    ) -> None:
+        self._live_mount = Path(live_mount)
+        self._live_mount.mkdir(parents=True, exist_ok=True)
+        self._codex_index = Path(codex_index)
+        self._review_board = review_board
+
+    def promote(
+        self,
+        proposal: ForgeProposal,
+        report: TrialReport,
+        lineage_entry: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        if not report.passed:
+            raise GenesisForgeError("Cannot promote daemon with failing sandbox trials")
+        approved = self._review_board(proposal, report)
+        if not approved:
+            return {"status": "rejected", "reason": "review_board"}
+
+        live_path = self._live_mount / f"{proposal.blueprint.name}.json"
+        if live_path.exists():
+            raise GenesisForgeError(
+                f"Live mount already contains '{proposal.blueprint.name}'"
+            )
+        live_payload = {
+            "name": proposal.blueprint.name,
+            "lineage": dict(lineage_entry),
+            "objective": proposal.blueprint.objective,
+        }
+        live_path.write_text(json.dumps(live_payload, indent=2, sort_keys=True), encoding="utf-8")
+
+        index_payload: list[dict[str, object]] = []
+        if self._codex_index.exists():
+            try:
+                index_payload = json.loads(self._codex_index.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                index_payload = []
+        if any(entry.get("spec_id") == proposal.spec_id for entry in index_payload):
+            raise GenesisForgeError(
+                f"Codex index already tracks daemon '{proposal.spec_id}'"
+            )
+        index_payload.append(
+            {
+                "spec_id": proposal.spec_id,
+                "proposal_id": proposal.proposal_id,
+                "capability": proposal.need.capability,
+                "provenance": "GenesisForge",
+            }
+        )
+        self._codex_index.write_text(json.dumps(index_payload, indent=2, sort_keys=True), encoding="utf-8")
+        return {"status": "adopted", "path": str(live_path)}
+
+
+# ---------------------------------------------------------------------------
+# GenesisForge orchestrator
+
+
+class GenesisForge:
+    """Coordinates capability expansion across all GenesisForge modules."""
+
+    def __init__(
+        self,
+        *,
+        need_seer: NeedSeer,
+        forge_engine: ForgeEngine,
+        integrity_daemon: IntegrityDaemon,
+        trial_run: TrialRun,
+        spec_binder: SpecBinder,
+        adoption_rite: AdoptionRite,
+        ledger: RecoveryLedger,
+    ) -> None:
+        self._need_seer = need_seer
+        self._forge_engine = forge_engine
+        self._integrity_daemon = integrity_daemon
+        self._trial_run = trial_run
+        self._spec_binder = spec_binder
+        self._adoption_rite = adoption_rite
+        self._ledger = ledger
+
+    def expand(
+        self,
+        telemetry_streams: Sequence[TelemetryStream],
+        vows: Sequence[CovenantVow],
+    ) -> list[GenesisOutcome]:
+        outcomes: list[GenesisOutcome] = []
+        needs = self._need_seer.scan(telemetry_streams, vows)
+        for need in needs:
+            anomaly = Anomaly(kind="genesis_need", subject=need.capability)
+            try:
+                proposal = self._forge_engine.draft(need)
+                self._integrity_daemon.evaluate(proposal)
+                report = self._trial_run.execute(proposal.blueprint)
+                if not report.passed:
+                    raise GenesisForgeError(
+                        "Sandbox validation failed",
+                    )
+                lineage_entry = self._spec_binder.integrate(proposal)
+                adoption = self._adoption_rite.promote(proposal, report, lineage_entry)
+                if adoption.get("status") != "adopted":
+                    raise GenesisForgeError(
+                        f"Review board rejected daemon ({adoption.get('reason', 'unknown')})"
+                    )
+                outcome = GenesisOutcome(
+                    need=need,
+                    status="adopted",
+                    details={
+                        "proposal_id": proposal.proposal_id,
+                        "spec_id": proposal.spec_id,
+                        "lineage": lineage_entry,
+                        "adoption": adoption,
+                    },
+                )
+                self._ledger.log(
+                    "GenesisForge event",
+                    anomaly=anomaly,
+                    action=RepairAction(
+                        kind="genesis_birth",
+                        subject=proposal.spec_id,
+                        description="GenesisForge promoted new daemon",
+                        execute=lambda: True,
+                    ),
+                    details=outcome.details,
+                )
+                outcomes.append(outcome)
+            except IntegrityViolation as exc:
+                self._ledger.log(
+                    "GenesisForge rejected",
+                    anomaly=anomaly,
+                    details={
+                        "reason_codes": list(exc.reason_codes),
+                        "spec_id": exc.spec_id,
+                    },
+                    quarantined=True,
+                )
+                outcomes.append(
+                    GenesisOutcome(
+                        need=need,
+                        status="rejected",
+                        details={"reason": "integrity_violation", "codes": list(exc.reason_codes)},
+                    )
+                )
+            except GenesisForgeError as exc:
+                self._ledger.log(
+                    "GenesisForge integration_failed",
+                    anomaly=anomaly,
+                    details={"error": str(exc)},
+                    quarantined=True,
+                )
+                outcomes.append(
+                    GenesisOutcome(
+                        need=need,
+                        status="failed",
+                        details={"error": str(exc)},
+                    )
+                )
+        return outcomes
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_coverage",
         "tests.test_codex_amendments",
         "tests.test_autogenesis_loop",
+        "tests.test_genesis_forge",
     }
     for item in items:
         if (

--- a/tests/test_genesis_forge.py
+++ b/tests/test_genesis_forge.py
@@ -1,0 +1,168 @@
+"""Tests for the GenesisForge autonomous capability expansion pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex.integrity_daemon import IntegrityDaemon
+from sentientos.codex_healer import RecoveryLedger
+from sentientos.genesis_forge import (
+    AdoptionRite,
+    CovenantVow,
+    DaemonManifest,
+    ForgeEngine,
+    GenesisForge,
+    NeedSeer,
+    SpecBinder,
+    TelemetryStream,
+    TrialRun,
+)
+
+
+def _review_board(_: object, __: object) -> bool:
+    return True
+
+
+def test_needseer_detects_unhandled_stream(tmp_path: Path) -> None:
+    telemetries = [
+        TelemetryStream(
+            name="vision_bus",
+            capability="vision_input",
+            description="Camera frames from sanctuary sensors",
+            handled_by=frozenset(),
+            sample_payload={"frames": 1},
+        )
+    ]
+    vows = [
+        CovenantVow(
+            capability="vision_input",
+            description="Every camera input must be witnessed",
+        )
+    ]
+    seer = NeedSeer(daemons=[DaemonManifest("audio_daemon", frozenset({"audio_input"}))])
+    needs = seer.scan(telemetries, vows)
+    assert [need.capability for need in needs] == ["vision_input"]
+
+    engine = ForgeEngine(existing_daemons=[DaemonManifest("audio_daemon", frozenset({"audio_input"}))])
+    proposal = engine.draft(needs[0])
+    assert proposal.proposed_spec["lineage"]["provenance"] == "GenesisForge"
+    assert proposal.blueprint.testing_requirements == [
+        "acknowledge_capability",
+        "emit_success_status",
+        "record_provenance_GenesisForge",
+    ]
+
+
+def test_trialrun_detects_malformed_handler() -> None:
+    need = NeedSeer().scan(
+        [TelemetryStream("vision", "vision_input", "camera", frozenset(), {"frames": 3})],
+        [CovenantVow("vision_input", "camera vow")],
+    )[0]
+    engine = ForgeEngine()
+    proposal = engine.draft(need)
+
+    # Replace handler with malformed implementation.
+    def bad_handler(_: object) -> dict[str, object]:
+        return {"status": "error"}
+
+    proposal.blueprint.handler = bad_handler
+    report = TrialRun().execute(proposal.blueprint)
+    assert not report.passed
+    assert "capability" in report.failures[0]
+
+
+def test_lineage_records_provenance(tmp_path: Path) -> None:
+    telemetry = [
+        TelemetryStream(
+            name="vision_stream",
+            capability="vision_input",
+            description="Camera frames",
+            handled_by=frozenset(),
+            sample_payload={"frames": 5},
+        )
+    ]
+    vows = [CovenantVow("vision_input", "Cameras must be witnessed")]
+
+    lineage_root = tmp_path / "lineage"
+    covenant_root = tmp_path / "covenant"
+    live_mount = tmp_path / "live"
+    codex_index = tmp_path / "codex.json"
+    ledger_path = tmp_path / "ledger.jsonl"
+
+    seer = NeedSeer()
+    engine = ForgeEngine()
+    integrity = IntegrityDaemon(tmp_path)
+    trial = TrialRun()
+    binder = SpecBinder(lineage_root=lineage_root, covenant_root=covenant_root)
+    adoption = AdoptionRite(
+        live_mount=live_mount,
+        codex_index=codex_index,
+        review_board=_review_board,
+    )
+    ledger = RecoveryLedger(ledger_path)
+    forge = GenesisForge(
+        need_seer=seer,
+        forge_engine=engine,
+        integrity_daemon=integrity,
+        trial_run=trial,
+        spec_binder=binder,
+        adoption_rite=adoption,
+        ledger=ledger,
+    )
+
+    outcomes = forge.expand(telemetry, vows)
+    assert outcomes and outcomes[0].status == "adopted"
+
+    lineage_entries = [json.loads(line) for line in (lineage_root / "lineage.jsonl").read_text().splitlines()]
+    assert lineage_entries[0]["provenance"] == "GenesisForge"
+
+    ledger_lines = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+    assert any(entry["status"] == "GenesisForge event" for entry in ledger_lines)
+
+    codex_payload = json.loads(codex_index.read_text())
+    assert codex_payload[0]["provenance"] == "GenesisForge"
+
+
+def test_prevents_overwriting_existing_daemon(tmp_path: Path) -> None:
+    telemetry = [
+        TelemetryStream(
+            name="vision_stream",
+            capability="vision_input",
+            description="Camera frames",
+            handled_by=frozenset(),
+        )
+    ]
+    vows = [CovenantVow("vision_input", "camera vow")]
+
+    lineage_root = tmp_path / "lineage"
+    covenant_root = tmp_path / "covenant"
+    live_mount = tmp_path / "live"
+    codex_index = tmp_path / "codex.json"
+    ledger_path = tmp_path / "ledger.jsonl"
+
+    binder = SpecBinder(lineage_root=lineage_root, covenant_root=covenant_root)
+    # Pre-create a daemon file to force an overwrite attempt.
+    existing = covenant_root / "daemons" / "VisionInputGenesisDaemon.json"
+    existing.write_text("{}", encoding="utf-8")
+
+    forge = GenesisForge(
+        need_seer=NeedSeer(),
+        forge_engine=ForgeEngine(),
+        integrity_daemon=IntegrityDaemon(tmp_path),
+        trial_run=TrialRun(),
+        spec_binder=binder,
+        adoption_rite=AdoptionRite(
+            live_mount=live_mount,
+            codex_index=codex_index,
+            review_board=_review_board,
+        ),
+        ledger=RecoveryLedger(ledger_path),
+    )
+
+    outcomes = forge.expand(telemetry, vows)
+    assert outcomes[0].status == "failed"
+    assert isinstance(outcomes[0].details["error"], str)
+    # Original file remains untouched.
+    assert existing.read_text(encoding="utf-8") == "{}"
+


### PR DESCRIPTION
## Summary
- add the GenesisForge module that detects unmet vows, drafts new daemon scaffolding, runs covenant trials, and logs outcomes in the recovery ledger
- cover the new expansion flow with dedicated unit tests and allow the suite to execute under the repository’s test gatekeeper

## Testing
- pytest tests/test_genesis_forge.py

------
https://chatgpt.com/codex/tasks/task_b_68dd2b9a0d0c8320ba9ff7434bd51559