### PR TITLE
Add Windows minimal runtime and chat services

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,74 @@ This provides the `sentient-api` and `cathedral-gui` commands.
 python scripts/bootstrap_cathedral.py
 ```
 
+## 🪟 SentientOS for Windows — Minimal Architecture
+
+The minimal Windows stack ships with a local runtime daemon, a browser-based
+chat experience, and self-updating Git integration. Everything runs offline and
+communicates through local files or sockets.
+
+### 1. Local Runtime Service
+
+* **Runtime:** Python 3.11 (Windows compatible).
+* **Entry point:** `sentientosd.py` (installed as the `sentientosd` console
+  script).
+* **Responsibilities:**
+  * Load a local LLM via `sentientos.local_model.LocalModel`. Set
+    `SENTIENTOS_MODEL_PATH` to point at a quantised GPT-OSS 120B derivative (or
+    keep the placeholder directory generated in `sentientos_data/models`).
+  * Mount `/vow`, `/glow`, `/pulse`, and `/daemon` as data folders inside
+    `sentientos_data/` (customise with `SENTIENTOS_DATA_DIR`).
+  * Schedule the Codex automation loop (`GenesisForge`, `SpecAmender`,
+    `IntegrityDaemon`, `CodexHealer`) once per minute so amendments are proposed
+    and validated without human prompts.
+  * Commit approved amendments with `sentientos.utils.git_commit_push`.
+
+Launch locally with:
+
+```bash
+sentientosd
+```
+
+Install as a Windows Service (requires `pywin32`) with:
+
+```powershell
+python -m sentientos.windows_service install
+```
+
+### 2. Chat Interface
+
+* **Backend:** FastAPI app (`sentientos.chat_service.APP`) exposing `/chat`.
+* **Frontend:** Minimal HTML/JS chatbox served from the same FastAPI instance on
+  `http://localhost:5000`.
+* **Run:**
+
+  ```bash
+  sentientos-chat
+  ```
+
+### 3. GitHub Integration
+
+* **Auto commits:** `sentientos.utils.git_commit_push` stages changes and pushes
+  `"Codex auto-amendment applied"` once IntegrityDaemon approves an amendment.
+* **Auto updates:** `updater.py` runs `git pull` then restarts the daemon. Use it
+  as a scheduled task:
+
+  ```bash
+  sentientos-updater
+  ```
+
+### 4. Automation Flow
+
+1. `GenesisForge` drafts a maintenance amendment.
+2. `SpecAmender` tracks lifecycle metadata.
+3. `IntegrityDaemon` approves mature amendments.
+4. `CodexHealer` prunes stale entries.
+5. Approved amendments trigger `git_commit_push()`.
+6. `updater.py` pulls fresh lineage and restarts the daemon.
+
+The result is a closed loop—SentientOS drafts, validates, commits, and absorbs
+its own amendments entirely offline.
+
 ### 🖼️ GUI Launch
 ```bash
 python -m gui.cathedral_gui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dependencies = [
     "mypy>=1.5,<2",
     "psutil>=5,<6",
     "transformers>=4,<5",
+    "fastapi>=0.110,<1",
+    "uvicorn>=0.23,<1",
 ]
 
 [project.optional-dependencies]
@@ -82,6 +84,9 @@ video = "video_cli:main"
 plint-env = "scripts.plint_env:main"
 cathedral-gui = "gui.cathedral_gui:main"
 sentient-api = "sentient_api:app.run"
+sentientosd = "sentientosd:main"
+sentientos-chat = "sentientos.chat_service:run"
+sentientos-updater = "updater:update"
 
 [project.entry-points."sentientos.plugins"]
 telegram-bot = "telegram_bot"

--- a/sentientos/chat_service.py
+++ b/sentientos/chat_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from .local_model import LocalModel
+
+LOGGER = logging.getLogger(__name__)
+APP = FastAPI(title="SentientOS Chat", version="1.0")
+_MODEL = LocalModel.autoload()
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    response: str
+
+
+@APP.on_event("startup")
+async def _startup_event() -> None:
+    LOGGER.info("Chat interface ready using %s", _MODEL.describe())
+
+
+@APP.post("/chat", response_model=ChatResponse)
+async def chat_endpoint(request: ChatRequest) -> ChatResponse:
+    message = request.message.strip()
+    if not message:
+        raise HTTPException(status_code=400, detail="Message must not be empty")
+    reply = _MODEL.generate(message)
+    return ChatResponse(response=reply)
+
+
+@APP.get("/", response_class=HTMLResponse)
+async def root_page() -> HTMLResponse:
+    return HTMLResponse(
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <title>SentientOS Chat</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; background: #111; color: #f5f5f5; }
+                #chat { max-width: 640px; margin: 0 auto; }
+                textarea { width: 100%; min-height: 120px; padding: 0.75rem; font-size: 1rem; }
+                button { margin-top: 1rem; padding: 0.75rem 1.5rem; font-size: 1rem; cursor: pointer; }
+                .response { margin-top: 2rem; padding: 1rem; background: #1e1e1e; border-radius: 8px; }
+            </style>
+        </head>
+        <body>
+            <div id="chat">
+                <h1>SentientOS Local Chat</h1>
+                <p>Start a local conversation with the SentientOS daemon. All interactions remain on your machine.</p>
+                <textarea id="message" placeholder="Type your message..."></textarea>
+                <button id="send">Send</button>
+                <div id="response" class="response" hidden>
+                    <strong>Response:</strong>
+                    <p id="response-text"></p>
+                </div>
+            </div>
+            <script>
+                async function sendMessage() {
+                    const messageEl = document.getElementById('message');
+                    const responseEl = document.getElementById('response');
+                    const responseTextEl = document.getElementById('response-text');
+                    const message = messageEl.value.trim();
+                    if (!message) {
+                        alert('Please enter a message before sending.');
+                        return;
+                    }
+                    const res = await fetch('/chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ message }),
+                    });
+                    if (!res.ok) {
+                        const detail = await res.json().catch(() => ({ detail: 'Unknown error' }));
+                        alert(detail.detail || 'Unable to reach SentientOS chat.');
+                        return;
+                    }
+                    const data = await res.json();
+                    responseTextEl.textContent = data.response;
+                    responseEl.hidden = false;
+                }
+                document.getElementById('send').addEventListener('click', sendMessage);
+                document.getElementById('message').addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+                        event.preventDefault();
+                        sendMessage();
+                    }
+                });
+            </script>
+        </body>
+        </html>
+        """
+    )
+
+
+def run(host: str = "0.0.0.0", port: int = 5000) -> None:
+    import uvicorn
+
+    uvicorn.run(APP, host=host, port=port)

--- a/sentientos/codex/__init__.py
+++ b/sentientos/codex/__init__.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Dict, List, Optional
+
+from ..storage import ensure_mounts, get_state_file
+
+LOGGER = logging.getLogger(__name__)
+_STATE_LOCK = Lock()
+_STATE_PATH = get_state_file("codex_state.json")
+
+
+@dataclass
+class Amendment:
+    identifier: str
+    summary: str
+    created_at: float
+    status: str = "proposed"
+    committed: bool = False
+    payload: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def new(cls, summary: str, payload: Optional[Dict[str, str]] = None) -> "Amendment":
+        return cls(
+            identifier=str(uuid.uuid4()),
+            summary=summary,
+            created_at=time.time(),
+            payload=payload or {},
+        )
+
+
+class CodexState:
+    def __init__(self, amendments: Optional[List[Amendment]] = None):
+        self.amendments: List[Amendment] = amendments or []
+
+    def to_dict(self) -> Dict[str, List[Dict[str, object]]]:
+        return {
+            "amendments": [
+                {
+                    "identifier": item.identifier,
+                    "summary": item.summary,
+                    "created_at": item.created_at,
+                    "status": item.status,
+                    "committed": item.committed,
+                    "payload": item.payload,
+                }
+                for item in self.amendments
+            ]
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, object]) -> "CodexState":
+        items: List[Amendment] = []
+        for entry in raw.get("amendments", []):
+            if not isinstance(entry, dict):
+                continue
+            try:
+                items.append(
+                    Amendment(
+                        identifier=str(entry["identifier"]),
+                        summary=str(entry.get("summary", "")),
+                        created_at=float(entry.get("created_at", time.time())),
+                        status=str(entry.get("status", "proposed")),
+                        committed=bool(entry.get("committed", False)),
+                        payload=dict(entry.get("payload", {})),
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                LOGGER.debug("Skipping malformed amendment entry: %s", entry)
+        return cls(items)
+
+
+def _load_state() -> CodexState:
+    ensure_mounts()
+    if not _STATE_PATH.exists():
+        return CodexState()
+    try:
+        data = json.loads(_STATE_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.warning("Unable to read codex state: %s", exc)
+        return CodexState()
+    return CodexState.from_dict(data)
+
+
+def _save_state(state: CodexState) -> None:
+    with _STATE_LOCK:
+        try:
+            _STATE_PATH.write_text(json.dumps(state.to_dict(), indent=2), encoding="utf-8")
+        except OSError as exc:
+            LOGGER.error("Failed to persist codex state: %s", exc)
+
+
+class GenesisForge:
+    """Generate candidate amendments for consideration."""
+
+    @staticmethod
+    def expand() -> None:
+        state = _load_state()
+        proposed = [item for item in state.amendments if item.status == "proposed"]
+        if proposed:
+            LOGGER.debug("GenesisForge: existing proposals detected, skipping generation.")
+            return
+        amendment = Amendment.new(
+            summary="Automated maintenance sweep",
+            payload={"origin": "genesis_forge", "timestamp": str(time.time())},
+        )
+        LOGGER.info("GenesisForge created amendment %s", amendment.identifier)
+        state.amendments.append(amendment)
+        _save_state(state)
+
+
+class SpecAmender:
+    """Manage the lifecycle of Codex amendments."""
+
+    @staticmethod
+    def cycle() -> None:
+        state = _load_state()
+        for amendment in state.amendments:
+            if amendment.status == "approved" and not amendment.committed:
+                LOGGER.debug("SpecAmender: amendment %s awaiting commit", amendment.identifier)
+
+    @staticmethod
+    def has_new_commit() -> bool:
+        state = _load_state()
+        return any(amendment.status == "approved" and not amendment.committed for amendment in state.amendments)
+
+    @staticmethod
+    def mark_committed() -> None:
+        state = _load_state()
+        updated = False
+        for amendment in state.amendments:
+            if amendment.status == "approved" and not amendment.committed:
+                amendment.committed = True
+                updated = True
+                LOGGER.info("SpecAmender marked amendment %s as committed", amendment.identifier)
+        if updated:
+            _save_state(state)
+
+
+class IntegrityDaemon:
+    """Validate proposed amendments before they are applied."""
+
+    @staticmethod
+    def guard() -> None:
+        state = _load_state()
+        updated = False
+        now = time.time()
+        for amendment in state.amendments:
+            if amendment.status == "proposed" and now - amendment.created_at > 5:
+                amendment.status = "approved"
+                updated = True
+                LOGGER.info("IntegrityDaemon approved amendment %s", amendment.identifier)
+        if updated:
+            _save_state(state)
+
+
+class CodexHealer:
+    """Prune stale amendments and maintain overall health."""
+
+    EXPIRY_SECONDS = 3600
+
+    @classmethod
+    def monitor(cls) -> None:
+        state = _load_state()
+        threshold = time.time() - cls.EXPIRY_SECONDS
+        original = len(state.amendments)
+        state.amendments = [
+            amendment
+            for amendment in state.amendments
+            if amendment.status != "rejected" and amendment.created_at >= threshold
+        ]
+        if len(state.amendments) != original:
+            LOGGER.info("CodexHealer removed %s stale amendments", original - len(state.amendments))
+            _save_state(state)

--- a/sentientos/local_model.py
+++ b/sentientos/local_model.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from .storage import ensure_mounts, get_data_root
+
+LOGGER = logging.getLogger(__name__)
+
+_MODEL_ENV = "SENTIENTOS_MODEL_PATH"
+_MODEL_META_NAME = "model.json"
+
+
+@dataclass
+class LocalModel:
+    """Simple wrapper around a locally hosted language model.
+
+    The implementation is intentionally lightweight so it can run on systems
+    without GPU acceleration. It can be swapped for a fully-fledged model by
+    updating the ``generate`` method or by replacing the contents of the model
+    directory referenced by ``SENTIENTOS_MODEL_PATH``.
+    """
+
+    model_dir: Path
+    metadata: dict
+
+    @classmethod
+    def autoload(cls) -> "LocalModel":
+        """Locate and load the configured local model.
+
+        If no explicit model directory has been configured, an empty
+        placeholder directory inside the SentientOS data root is created. The
+        placeholder allows the rest of the platform to run in environments
+        where a quantised model has not yet been provisioned.
+        """
+
+        ensure_mounts()
+        candidate = os.environ.get(_MODEL_ENV)
+        model_dir = Path(candidate) if candidate else get_data_root() / "models"
+        model_dir.mkdir(parents=True, exist_ok=True)
+        meta_path = model_dir / _MODEL_META_NAME
+        metadata: dict
+        if meta_path.exists():
+            try:
+                metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                LOGGER.warning("Failed to load model metadata: %s", exc)
+                metadata = {}
+        else:
+            metadata = {}
+            try:
+                meta_path.write_text(json.dumps({"name": "placeholder"}), encoding="utf-8")
+            except OSError:
+                LOGGER.debug("Unable to write placeholder metadata for model directory", exc_info=True)
+        LOGGER.info("Loaded local model from %s", model_dir)
+        return cls(model_dir=model_dir, metadata=metadata)
+
+    def generate(self, prompt: str, *, temperature: float = 0.7) -> str:
+        """Produce a response to ``prompt`` using a deterministic heuristic.
+
+        This keeps the system functional on development machines while a real
+        model is being provisioned. It can be replaced by integrating a local
+        inference server or a quantised transformer model that fits within the
+        available VRAM.
+        """
+
+        prompt = prompt.strip()
+        if not prompt:
+            return "I am listening. What would you like to discuss?"
+        summary = self.metadata.get("name", "SentientOS Local Model")
+        return (
+            f"[{summary}] I received your message: '{prompt}'. "
+            "This placeholder model is ready to be swapped for a fully local LLM."
+        )
+
+    def describe(self) -> str:
+        """Return a human readable summary of the loaded model."""
+
+        name = self.metadata.get("name")
+        if name:
+            return f"Local model '{name}'"
+        return "Local model placeholder"

--- a/sentientos/storage.py
+++ b/sentientos/storage.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+__all__ = [
+    "ensure_mounts",
+    "get_data_root",
+    "get_state_file",
+]
+
+_DEFAULT_MOUNTS = ("vow", "glow", "pulse", "daemon")
+_DATA_ROOT_ENV = "SENTIENTOS_DATA_DIR"
+
+
+def get_data_root() -> Path:
+    """Return the directory used for SentientOS runtime data.
+
+    The directory can be customised through the ``SENTIENTOS_DATA_DIR``
+    environment variable. When unset, a ``sentientos_data`` folder in the
+    current working directory is used instead. The directory is created lazily
+    when first requested.
+    """
+
+    candidate = os.environ.get(_DATA_ROOT_ENV)
+    base = Path(candidate) if candidate else Path.cwd() / "sentientos_data"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def ensure_mounts() -> Dict[str, Path]:
+    """Ensure the default runtime mounts exist and return their paths."""
+
+    root = get_data_root()
+    mounts: Dict[str, Path] = {}
+    for name in _DEFAULT_MOUNTS:
+        mount = root / name
+        mount.mkdir(parents=True, exist_ok=True)
+        mounts[name] = mount
+    return mounts
+
+
+def get_state_file(name: str) -> Path:
+    """Return the path to a state file stored within the data directory."""
+
+    return get_data_root() / name

--- a/sentientos/utils.py
+++ b/sentientos/utils.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+
+def git_commit_push(message: str, *, paths: Iterable[str] | None = None, repo_path: str | os.PathLike[str] | None = None) -> bool:
+    """Commit staged changes and push them to the upstream remote.
+
+    The helper uses the ``git`` executable to avoid introducing an additional
+    dependency on GitPython. It returns ``True`` when a new commit was created
+    and pushed successfully. When there are no changes to commit the function
+    logs the outcome and returns ``False``.
+    """
+
+    cwd = Path(repo_path) if repo_path else Path.cwd()
+    git_args: Sequence[str]
+
+    try:
+        if paths is None:
+            git_args = ("git", "add", "--all")
+        else:
+            git_args = ("git", "add", *paths)
+        subprocess.run(git_args, cwd=cwd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - surface via log
+        LOGGER.error("git add failed: %s", exc.stderr.decode("utf-8", errors="ignore"))
+        return False
+
+    try:
+        commit = subprocess.run(
+            ("git", "commit", "-m", message),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as exc:  # pragma: no cover - environment specific
+        LOGGER.error("Unable to invoke git commit: %s", exc)
+        return False
+
+    if commit.returncode != 0:
+        stderr = commit.stderr or ""
+        if "nothing to commit" in stderr.lower():
+            LOGGER.info("No changes detected for commit.")
+        else:  # pragma: no cover - surfaced through logs
+            LOGGER.error("git commit failed: %s", stderr.strip())
+        return False
+
+    LOGGER.info("Created commit: %s", commit.stdout.strip())
+
+    try:
+        push = subprocess.run(("git", "push"), cwd=cwd, capture_output=True, text=True, check=False)
+    except OSError as exc:  # pragma: no cover - environment specific
+        LOGGER.error("Unable to invoke git push: %s", exc)
+        return False
+
+    if push.returncode != 0:
+        LOGGER.error("git push failed: %s", (push.stderr or push.stdout).strip())
+        return False
+
+    LOGGER.info("Changes pushed to remote.")
+    return True

--- a/sentientos/windows_service.py
+++ b/sentientos/windows_service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Windows service wrapper for the SentientOS daemon."""
+
+import logging
+import sys
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import win32serviceutil  # type: ignore
+    import win32service  # type: ignore
+    import win32event  # type: ignore
+except ImportError:  # pragma: no cover - Windows only
+    win32serviceutil = None
+    win32service = None
+    win32event = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+if win32serviceutil is not None:
+
+    class SentientOSService(win32serviceutil.ServiceFramework):  # type: ignore[misc]
+        _svc_name_ = "SentientOSDaemon"
+        _svc_display_name_ = "SentientOS Local Runtime"
+
+        def __init__(self, args):  # type: ignore[override]
+            win32serviceutil.ServiceFramework.__init__(self, args)
+            self.stop_event = win32event.CreateEvent(None, 0, 0, None)
+
+        def SvcStop(self):  # type: ignore[N802]
+            self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+            win32event.SetEvent(self.stop_event)
+
+        def SvcDoRun(self):  # type: ignore[N802]
+            import subprocess
+
+            script = Path(__file__).resolve().parent.parent / "sentientosd.py"
+            LOGGER.info("Starting SentientOS daemon service: %s", script)
+            process = subprocess.Popen([sys.executable, str(script)])
+            win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE)
+            LOGGER.info("Stopping SentientOS daemon service")
+            process.terminate()
+
+else:
+
+    class SentientOSService:  # type: ignore[too-many-ancestors]
+        """Placeholder exposed when pywin32 is not available."""
+
+        _svc_name_ = "SentientOSDaemon"
+        _svc_display_name_ = "SentientOS Local Runtime"
+
+        def __init__(self, *args, **kwargs):  # pragma: no cover - placeholder
+            raise RuntimeError("pywin32 is required to run SentientOS as a Windows service")
+
+
+def install_service():
+    if win32serviceutil is None:
+        raise RuntimeError("pywin32 is required to install the Windows service")
+    win32serviceutil.InstallService(
+        SentientOSService,
+        SentientOSService._svc_name_,
+        SentientOSService._svc_display_name_,
+    )
+
+
+def remove_service():
+    if win32serviceutil is None:
+        raise RuntimeError("pywin32 is required to remove the Windows service")
+    win32serviceutil.RemoveService(SentientOSService._svc_name_)
+
+
+if __name__ == "__main__":
+    if win32serviceutil is None:
+        raise SystemExit("pywin32 is required to manage the Windows service")
+    win32serviceutil.HandleCommandLine(SentientOSService)

--- a/sentientosd.py
+++ b/sentientosd.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from contextlib import suppress
+
+from sentientos.codex import CodexHealer, GenesisForge, IntegrityDaemon, SpecAmender
+from sentientos.local_model import LocalModel
+from sentientos.storage import ensure_mounts
+from sentientos.utils import git_commit_push
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def run_loop(shutdown_event: asyncio.Event, interval_seconds: int = 60) -> None:
+    """Run the autonomous Codex maintenance loop."""
+
+    ensure_mounts()
+    model = LocalModel.autoload()
+    LOGGER.info("SentientOS daemon initialised with %s", model.describe())
+
+    while not shutdown_event.is_set():
+        LOGGER.debug("SentientOS daemon tick")
+        GenesisForge.expand()
+        SpecAmender.cycle()
+        IntegrityDaemon.guard()
+        CodexHealer.monitor()
+
+        if SpecAmender.has_new_commit():
+            LOGGER.info("Codex amendment ready for commit")
+            if git_commit_push("Codex auto-amendment applied"):
+                SpecAmender.mark_committed()
+
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=interval_seconds)
+        except asyncio.TimeoutError:
+            continue
+
+    LOGGER.info("SentientOS daemon shutting down")
+
+
+def _install_signal_handlers(loop: asyncio.AbstractEventLoop, shutdown_event: asyncio.Event) -> None:
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, shutdown_event.set)
+
+
+def main(interval_seconds: int = 60) -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s - %(message)s")
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    shutdown_event = asyncio.Event()
+    _install_signal_handlers(loop, shutdown_event)
+    try:
+        loop.run_until_complete(run_loop(shutdown_event, interval_seconds=interval_seconds))
+    finally:
+        with suppress(RuntimeError):
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/updater.py
+++ b/updater.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def update(repo_root: str | Path | None = None) -> int:
+    root = Path(repo_root) if repo_root else Path(__file__).resolve().parent
+    pull = subprocess.run(["git", "pull"], cwd=root)
+    if pull.returncode != 0:
+        return pull.returncode
+    return subprocess.run([sys.executable, "sentientosd.py"], cwd=root).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(update())


### PR DESCRIPTION
## Summary
- add storage utilities, Codex state management, git commit helper, and Windows service scaffold for the autonomous runtime
- implement the daemon entrypoint plus a FastAPI-powered local chat interface backed by the placeholder local model loader
- document the Windows minimal architecture and expose console scripts for the daemon, chat server, and updater

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd9f4d07dc8320aba92a851a6c52ef