### PR TITLE
Add configurable local model loader with fallback support

### DIFF
--- a/sentientos/config.py
+++ b/sentientos/config.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .storage import get_data_root
+
+LOGGER = logging.getLogger(__name__)
+
+_MODEL_CONFIG_ENV = "SENTIENTOS_MODEL_CONFIG"
+_MODEL_PATH_ENV = "SENTIENTOS_MODEL_PATH"
+_MODEL_FALLBACKS_ENV = "SENTIENTOS_MODEL_FALLBACKS"
+_MODEL_ENGINE_ENV = "SENTIENTOS_MODEL_ENGINE"
+_MODEL_CTX_ENV = "SENTIENTOS_MODEL_CTX"
+_MODEL_MAX_NEW_TOKENS_ENV = "SENTIENTOS_MODEL_MAX_NEW_TOKENS"
+_MODEL_TEMPERATURE_ENV = "SENTIENTOS_MODEL_TEMPERATURE"
+_MODEL_TOP_P_ENV = "SENTIENTOS_MODEL_TOP_P"
+_MODEL_TOP_K_ENV = "SENTIENTOS_MODEL_TOP_K"
+_MODEL_REPETITION_ENV = "SENTIENTOS_MODEL_REPETITION_PENALTY"
+
+
+@dataclass
+class GenerationConfig:
+    """Default sampling parameters for local generation."""
+
+    max_new_tokens: int = 512
+    temperature: float = 0.7
+    top_p: float = 0.95
+    top_k: Optional[int] = None
+    repetition_penalty: Optional[float] = None
+
+    def as_kwargs(self, **overrides: Any) -> Dict[str, Any]:
+        """Return a merged dictionary of sampling parameters."""
+
+        params: Dict[str, Any] = {
+            "max_new_tokens": self.max_new_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "repetition_penalty": self.repetition_penalty,
+        }
+        for key, value in overrides.items():
+            if value is None:
+                continue
+            params[key] = value
+        return params
+
+
+@dataclass
+class ModelCandidate:
+    """A concrete local model candidate that can be loaded."""
+
+    path: Optional[Path]
+    engine: str = "auto"
+    name: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    def display_name(self) -> str:
+        if self.name:
+            return self.name
+        if self.path is not None:
+            return str(self.path)
+        return self.engine
+
+
+@dataclass
+class ModelConfig:
+    """Runtime configuration describing available local language models."""
+
+    candidates: List[ModelCandidate]
+    default_engine: str = "auto"
+    max_context_tokens: int = 4096
+    generation: GenerationConfig = field(default_factory=GenerationConfig)
+
+
+def load_model_config() -> ModelConfig:
+    """Load the runtime model configuration from disk or environment."""
+
+    config_path = os.environ.get(_MODEL_CONFIG_ENV)
+    data_root = get_data_root()
+    if config_path:
+        config_file = Path(config_path)
+        if config_file.exists():
+            try:
+                raw = json.loads(config_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                LOGGER.warning("Invalid model configuration file %s: %s", config_file, exc)
+            else:
+                return _parse_config_mapping(raw, data_root)
+        else:
+            LOGGER.warning("Model configuration file %s does not exist", config_file)
+    return _default_config(data_root)
+
+
+def _parse_config_mapping(mapping: Dict[str, Any], data_root: Path) -> ModelConfig:
+    candidates = [
+        _parse_candidate(candidate, data_root)
+        for candidate in mapping.get("candidates", [])
+        if isinstance(candidate, dict)
+    ]
+    if not candidates:
+        candidates = _default_candidates(data_root)
+
+    default_engine = str(mapping.get("default_engine", "auto"))
+    max_context_tokens = int(mapping.get("max_context_tokens", 4096))
+    generation = _parse_generation(mapping.get("generation", {}))
+
+    return ModelConfig(
+        candidates=candidates,
+        default_engine=default_engine,
+        max_context_tokens=max_context_tokens,
+        generation=generation,
+    )
+
+
+def _parse_candidate(candidate: Dict[str, Any], data_root: Path) -> ModelCandidate:
+    path_value = candidate.get("path")
+    path: Optional[Path]
+    if path_value is None:
+        path = None
+    else:
+        resolved = Path(path_value)
+        if not resolved.is_absolute():
+            resolved = data_root / resolved
+        path = resolved
+    engine = str(candidate.get("engine", "auto"))
+    name = candidate.get("name")
+    options = candidate.get("options")
+    if not isinstance(options, dict):
+        options = {}
+    return ModelCandidate(path=path, engine=engine, name=name, options=options)
+
+
+def _parse_generation(mapping: Dict[str, Any]) -> GenerationConfig:
+    generation = GenerationConfig()
+    if "max_new_tokens" in mapping:
+        generation.max_new_tokens = int(mapping["max_new_tokens"])
+    if "temperature" in mapping:
+        generation.temperature = float(mapping["temperature"])
+    if "top_p" in mapping:
+        generation.top_p = float(mapping["top_p"])
+    if "top_k" in mapping:
+        value = mapping["top_k"]
+        generation.top_k = None if value is None else int(value)
+    if "repetition_penalty" in mapping:
+        value = mapping["repetition_penalty"]
+        generation.repetition_penalty = None if value is None else float(value)
+    return generation
+
+
+def _default_config(data_root: Path) -> ModelConfig:
+    candidates = _default_candidates(data_root)
+    default_engine = os.environ.get(_MODEL_ENGINE_ENV, "auto")
+    max_context_tokens = _env_int(_MODEL_CTX_ENV, 4096)
+    generation = GenerationConfig(
+        max_new_tokens=_env_int(_MODEL_MAX_NEW_TOKENS_ENV, 512),
+        temperature=_env_float(_MODEL_TEMPERATURE_ENV, 0.7),
+        top_p=_env_float(_MODEL_TOP_P_ENV, 0.95),
+        top_k=_env_optional_int(_MODEL_TOP_K_ENV),
+        repetition_penalty=_env_optional_float(_MODEL_REPETITION_ENV),
+    )
+    return ModelConfig(
+        candidates=candidates,
+        default_engine=default_engine,
+        max_context_tokens=max_context_tokens,
+        generation=generation,
+    )
+
+
+def _default_candidates(data_root: Path) -> List[ModelCandidate]:
+    candidates: List[ModelCandidate] = []
+    default_path = os.environ.get(_MODEL_PATH_ENV)
+    if default_path:
+        base_path = Path(default_path)
+        if not base_path.is_absolute():
+            base_path = data_root / base_path
+    else:
+        base_path = data_root / "models" / "gpt-oss-120b"
+    candidates.append(
+        ModelCandidate(
+            path=base_path,
+            engine=os.environ.get(_MODEL_ENGINE_ENV, "auto"),
+            name="gpt-oss-120b",
+        )
+    )
+
+    fallback_env = os.environ.get(_MODEL_FALLBACKS_ENV)
+    if fallback_env:
+        for entry in fallback_env.split(os.pathsep):
+            entry = entry.strip()
+            if not entry:
+                continue
+            fallback_path = Path(entry)
+            if not fallback_path.is_absolute():
+                fallback_path = data_root / fallback_path
+            candidates.append(
+                ModelCandidate(
+                    path=fallback_path,
+                    engine="auto",
+                )
+            )
+
+    default_fallback = data_root / "models" / "gpt-oss-13b"
+    if all(candidate.path != default_fallback for candidate in candidates):
+        candidates.append(ModelCandidate(path=default_fallback, engine="auto", name="gpt-oss-13b"))
+    return candidates
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        LOGGER.warning("Invalid integer for %s: %s", name, value)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        LOGGER.warning("Invalid float for %s: %s", name, value)
+        return default
+
+
+def _env_optional_int(name: str) -> Optional[int]:
+    value = os.environ.get(name)
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        LOGGER.warning("Invalid integer for %s: %s", name, value)
+        return None
+
+
+def _env_optional_float(name: str) -> Optional[float]:
+    value = os.environ.get(name)
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        LOGGER.warning("Invalid float for %s: %s", name, value)
+        return None

--- a/sentientos/local_model.py
+++ b/sentientos/local_model.py
@@ -1,85 +1,361 @@
 from __future__ import annotations
 
-import json
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
+from .config import GenerationConfig, ModelCandidate, ModelConfig, load_model_config
 from .storage import ensure_mounts, get_data_root
 
 LOGGER = logging.getLogger(__name__)
 
-_MODEL_ENV = "SENTIENTOS_MODEL_PATH"
 _MODEL_META_NAME = "model.json"
+
+__all__ = ["LocalModel"]
+
+
+class ModelLoadError(RuntimeError):
+    """Raised when a model backend cannot be instantiated."""
+
+
+class _ModelBackend:
+    """Abstract backend interface."""
+
+    engine: str = "unknown"
+
+    def __init__(self, candidate: ModelCandidate, metadata: Dict[str, Any]) -> None:
+        self._candidate = candidate
+        self._metadata = dict(metadata)
+        self._metadata.setdefault("engine", self.engine)
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return dict(self._metadata)
+
+    def describe(self) -> str:
+        location: str
+        if self._candidate.path is not None:
+            location = str(self._candidate.path)
+        else:
+            location = "<unspecified>"
+        return f"{self.engine} backend ({location})"
+
+    def generate(
+        self,
+        prompt: str,
+        history: Sequence[str],
+        generation: Dict[str, Any],
+    ) -> str:
+        raise NotImplementedError
+
+
+class _NullBackend(_ModelBackend):
+    engine = "null"
+
+    def generate(
+        self,
+        prompt: str,
+        history: Sequence[str],
+        generation: Dict[str, Any],
+    ) -> str:
+        summary = self._metadata.get("name", "SentientOS Placeholder")
+        if prompt.strip():
+            return (
+                f"[{summary}] Received: '{prompt}'. "
+                "This placeholder backend is waiting for local weights to be provisioned."
+            )
+        return f"[{summary}] I am online and ready once a local language model is installed."
+
+
+class _EchoBackend(_ModelBackend):
+    engine = "echo"
+
+    def generate(
+        self,
+        prompt: str,
+        history: Sequence[str],
+        generation: Dict[str, Any],
+    ) -> str:
+        name = self._metadata.get("name", "Echo Model")
+        history_text = " | ".join(history)
+        if history_text:
+            return f"[{name}] {history_text} => {prompt}"
+        return f"[{name}] {prompt}"
+
+
+class _TransformersBackend(_ModelBackend):
+    engine = "transformers"
+
+    def __init__(
+        self,
+        candidate: ModelCandidate,
+        metadata: Dict[str, Any],
+        generation: GenerationConfig,
+        max_context_tokens: int,
+    ) -> None:
+        super().__init__(candidate, metadata)
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ModelLoadError("transformers is not installed") from exc
+
+        model_location = self._resolve_model_location(candidate)
+        if candidate.path is not None and not Path(model_location).exists():
+            raise ModelLoadError(f"Model path {model_location} does not exist")
+
+        self._torch = torch
+        self._tokenizer = AutoTokenizer.from_pretrained(model_location, trust_remote_code=True, local_files_only=True)
+        device_map: Optional[str]
+        torch_dtype: Optional[torch.dtype]
+        if torch.cuda.is_available():
+            device_map = "auto"
+            torch_dtype = torch.float16
+        else:
+            device_map = None
+            torch_dtype = torch.float32
+        self._model = AutoModelForCausalLM.from_pretrained(
+            model_location,
+            device_map=device_map,
+            torch_dtype=torch_dtype,
+            trust_remote_code=True,
+            local_files_only=True,
+        )
+        self._generation = generation
+        self._max_context_tokens = max_context_tokens
+
+    def _resolve_model_location(self, candidate: ModelCandidate) -> str:
+        model_id = candidate.options.get("model_id")
+        if model_id:
+            return str(model_id)
+        if candidate.path is None:
+            raise ModelLoadError("No path provided for transformers backend")
+        return str(candidate.path)
+
+    def generate(
+        self,
+        prompt: str,
+        history: Sequence[str],
+        generation: Dict[str, Any],
+    ) -> str:
+        params = self._generation.as_kwargs(**generation)
+        tokenizer_inputs = self._tokenizer(
+            prompt,
+            return_tensors="pt",
+            truncation=True,
+            max_length=self._max_context_tokens,
+        )
+        tokenizer_inputs = {key: value.to(self._model.device) for key, value in tokenizer_inputs.items()}
+        try:
+            output = self._model.generate(**tokenizer_inputs, **params)
+        except Exception as exc:  # pragma: no cover - runtime safety net
+            raise ModelLoadError(f"transformers generation failed: {exc}") from exc
+        decoded = self._tokenizer.decode(output[0], skip_special_tokens=True)
+        if decoded.startswith(prompt):
+            decoded = decoded[len(prompt) :]
+        return decoded.strip() or ""
+
+
+class _LlamaCppBackend(_ModelBackend):
+    engine = "llama_cpp"
+
+    def __init__(
+        self,
+        candidate: ModelCandidate,
+        metadata: Dict[str, Any],
+        generation: GenerationConfig,
+        max_context_tokens: int,
+    ) -> None:
+        super().__init__(candidate, metadata)
+        try:
+            from llama_cpp import Llama
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ModelLoadError("llama_cpp is not installed") from exc
+
+        if candidate.path is None:
+            raise ModelLoadError("No GGUF path provided for llama.cpp backend")
+        model_path = candidate.path
+        if not model_path.exists():
+            raise ModelLoadError(f"Quantized model {model_path} does not exist")
+
+        gpu_layers = candidate.options.get("gpu_layers")
+        if gpu_layers is None:
+            gpu_layers = -1 if _cuda_available() else 0
+
+        self._llama = Llama(
+            model_path=str(model_path),
+            n_ctx=max_context_tokens,
+            n_gpu_layers=gpu_layers,
+            logits_all=False,
+        )
+        self._generation = generation
+
+    def generate(
+        self,
+        prompt: str,
+        history: Sequence[str],
+        generation: Dict[str, Any],
+    ) -> str:
+        params = self._generation.as_kwargs(**generation)
+        response = self._llama(
+            prompt,
+            max_tokens=params.get("max_new_tokens"),
+            temperature=params.get("temperature"),
+            top_p=params.get("top_p"),
+            top_k=params.get("top_k"),
+            repeat_penalty=params.get("repetition_penalty"),
+        )
+        output = response.get("choices", [{}])[0].get("text", "")
+        return str(output).strip()
+
+
+def _cuda_available() -> bool:
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - optional dependency
+        return False
+    return bool(torch.cuda.is_available())
 
 
 @dataclass
 class LocalModel:
-    """Simple wrapper around a locally hosted language model.
+    """Wrapper around the configured local language model backend."""
 
-    The implementation is intentionally lightweight so it can run on systems
-    without GPU acceleration. It can be swapped for a fully-fledged model by
-    updating the ``generate`` method or by replacing the contents of the model
-    directory referenced by ``SENTIENTOS_MODEL_PATH``.
-    """
-
-    model_dir: Path
-    metadata: dict
+    backend: _ModelBackend
+    metadata: Dict[str, Any]
+    config: ModelConfig
+    _fallback_backend: _ModelBackend
 
     @classmethod
     def autoload(cls) -> "LocalModel":
-        """Locate and load the configured local model.
-
-        If no explicit model directory has been configured, an empty
-        placeholder directory inside the SentientOS data root is created. The
-        placeholder allows the rest of the platform to run in environments
-        where a quantised model has not yet been provisioned.
-        """
-
         ensure_mounts()
-        candidate = os.environ.get(_MODEL_ENV)
-        model_dir = Path(candidate) if candidate else get_data_root() / "models"
-        model_dir.mkdir(parents=True, exist_ok=True)
-        meta_path = model_dir / _MODEL_META_NAME
-        metadata: dict
-        if meta_path.exists():
+        config = load_model_config()
+        errors: List[str] = []
+        for candidate in config.candidates:
             try:
-                metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError) as exc:
-                LOGGER.warning("Failed to load model metadata: %s", exc)
-                metadata = {}
-        else:
-            metadata = {}
+                backend, metadata = cls._initialise_backend(candidate, config)
+            except ModelLoadError as exc:
+                errors.append(f"{candidate.display_name()}: {exc}")
+                LOGGER.warning("Failed to load model candidate %s: %s", candidate.display_name(), exc)
+                continue
+            LOGGER.info(
+                "Loaded local model '%s' using %s",
+                metadata.get("name", candidate.display_name()),
+                backend.describe(),
+            )
+            safe_backend = _NullBackend(candidate, metadata)
+            return cls(backend=backend, metadata=backend.metadata, config=config, _fallback_backend=safe_backend)
+
+        placeholder_metadata = {
+            "name": "SentientOS Placeholder Model",
+            "engine": "null",
+            "errors": errors,
+        }
+        placeholder_dir = get_data_root() / "models"
+        placeholder_dir.mkdir(parents=True, exist_ok=True)
+        meta_path = placeholder_dir / _MODEL_META_NAME
+        if not meta_path.exists():
             try:
-                meta_path.write_text(json.dumps({"name": "placeholder"}), encoding="utf-8")
+                meta_path.write_text("{\"name\": \"placeholder\"}", encoding="utf-8")
             except OSError:
-                LOGGER.debug("Unable to write placeholder metadata for model directory", exc_info=True)
-        LOGGER.info("Loaded local model from %s", model_dir)
-        return cls(model_dir=model_dir, metadata=metadata)
+                LOGGER.debug("Unable to write placeholder metadata", exc_info=True)
+        backend = _NullBackend(ModelCandidate(path=placeholder_dir, engine="null"), placeholder_metadata)
+        LOGGER.warning("Using placeholder language model backend")
+        return cls(backend=backend, metadata=backend.metadata, config=config, _fallback_backend=backend)
 
-    def generate(self, prompt: str, *, temperature: float = 0.7) -> str:
-        """Produce a response to ``prompt`` using a deterministic heuristic.
+    @classmethod
+    def _initialise_backend(
+        cls,
+        candidate: ModelCandidate,
+        config: ModelConfig,
+    ) -> tuple[_ModelBackend, Dict[str, Any]]:
+        if candidate.path is not None and not candidate.path.exists():
+            raise ModelLoadError(f"Model path {candidate.path} not found")
+        metadata = cls._load_metadata(candidate)
+        if candidate.name and "name" not in metadata:
+            metadata["name"] = candidate.name
+        engine = candidate.engine or config.default_engine
+        if engine == "auto":
+            engine = cls._guess_engine(candidate)
+        if engine == "echo":
+            backend: _ModelBackend = _EchoBackend(candidate, metadata)
+        elif engine == "llama_cpp":
+            backend = _LlamaCppBackend(candidate, metadata, config.generation, config.max_context_tokens)
+        elif engine == "transformers":
+            backend = _TransformersBackend(candidate, metadata, config.generation, config.max_context_tokens)
+        else:
+            raise ModelLoadError(f"Unknown backend engine '{engine}'")
+        metadata.setdefault("engine", engine)
+        return backend, backend.metadata
 
-        This keeps the system functional on development machines while a real
-        model is being provisioned. It can be replaced by integrating a local
-        inference server or a quantised transformer model that fits within the
-        available VRAM.
-        """
+    @classmethod
+    def _load_metadata(cls, candidate: ModelCandidate) -> Dict[str, Any]:
+        if candidate.path is None:
+            return {}
+        meta_path = cls._candidate_meta_path(candidate.path)
+        if not meta_path.exists():
+            return {}
+        try:
+            import json
 
-        prompt = prompt.strip()
-        if not prompt:
-            return "I am listening. What would you like to discuss?"
-        summary = self.metadata.get("name", "SentientOS Local Model")
-        return (
-            f"[{summary}] I received your message: '{prompt}'. "
-            "This placeholder model is ready to be swapped for a fully local LLM."
-        )
+            return json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            LOGGER.warning("Failed to read metadata for %s", candidate.display_name(), exc_info=True)
+            return {}
+
+    @staticmethod
+    def _candidate_meta_path(path: Path) -> Path:
+        if path.is_dir():
+            return path / _MODEL_META_NAME
+        return path.with_suffix(".json")
+
+    @staticmethod
+    def _guess_engine(candidate: ModelCandidate) -> str:
+        if candidate.path is None:
+            return "transformers"
+        suffix = candidate.path.suffix.lower()
+        if suffix in {".gguf", ".ggml"}:
+            return "llama_cpp"
+        return "transformers"
+
+    def generate(
+        self,
+        prompt: Optional[str],
+        history: Optional[Iterable[Any]] = None,
+        **overrides: Any,
+    ) -> str:
+        safe_prompt = "" if prompt is None else str(prompt)
+        safe_prompt = safe_prompt.strip()
+        history_list: List[str] = []
+        if isinstance(history, str):
+            history_list = [history]
+        elif history is not None:
+            try:
+                for entry in history:
+                    if entry is None:
+                        continue
+                    history_list.append(str(entry).strip())
+            except TypeError:
+                history_list = [str(history)]
+        history_list = [item for item in history_list if item]
+        generation_params = dict(overrides)
+        if not safe_prompt and not history_list:
+            return self._fallback_backend.generate("", history_list, generation_params)
+
+        combined_prompt = "\n".join(history_list + ([safe_prompt] if safe_prompt else []))
+        try:
+            response = self.backend.generate(combined_prompt, history_list, generation_params)
+        except Exception:  # pragma: no cover - runtime guard
+            LOGGER.exception("Local model backend crashed; returning fallback response")
+            response = self._fallback_backend.generate(combined_prompt, history_list, generation_params)
+        if not isinstance(response, str) or not response.strip():
+            response = self._fallback_backend.generate(combined_prompt, history_list, generation_params)
+        return response
 
     def describe(self) -> str:
-        """Return a human readable summary of the loaded model."""
-
         name = self.metadata.get("name")
+        engine = self.metadata.get("engine", getattr(self.backend, "engine", "unknown"))
         if name:
-            return f"Local model '{name}'"
-        return "Local model placeholder"
+            return f"Local model '{name}' via {engine}"
+        return f"Local model via {engine}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_amendments",
         "tests.test_autogenesis_loop",
         "tests.test_genesis_forge",
+        "tests.test_local_model",
     }
     for item in items:
         if (

--- a/tests/test_local_model.py
+++ b/tests/test_local_model.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sentientos.local_model import LocalModel
+
+
+def _write_config(tmp_path: Path, data: dict) -> Path:
+    config_path = tmp_path / "model_config.json"
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+    return config_path
+
+
+def _prepare_candidate(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / name
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "model.json").write_text(json.dumps({"description": name}), encoding="utf-8")
+    return path
+
+
+def test_local_model_smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    primary_dir = _prepare_candidate(tmp_path, "primary")
+    config = {
+        "candidates": [
+            {
+                "path": str(primary_dir),
+                "engine": "echo",
+                "name": "Echo Primary",
+            }
+        ]
+    }
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+
+    model = LocalModel.autoload()
+
+    description = model.describe()
+    assert "Echo Primary" in description
+
+
+def test_local_model_inference(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    primary_dir = _prepare_candidate(tmp_path, "primary")
+    config = {
+        "generation": {"temperature": 0.5, "max_new_tokens": 32},
+        "candidates": [
+            {
+                "path": str(primary_dir),
+                "engine": "echo",
+                "name": "Echo Primary",
+            }
+        ],
+    }
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+
+    model = LocalModel.autoload()
+
+    response = model.generate("Hello world", history=["previous message"])
+    assert isinstance(response, str)
+    assert response
+
+
+def test_local_model_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    fallback_dir = _prepare_candidate(tmp_path, "fallback")
+    config = {
+        "candidates": [
+            {
+                "path": str(tmp_path / "missing"),
+                "engine": "echo",
+                "name": "Missing Primary",
+            },
+            {
+                "path": str(fallback_dir),
+                "engine": "echo",
+                "name": "Echo Fallback",
+            },
+        ]
+    }
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+
+    model = LocalModel.autoload()
+
+    assert model.metadata.get("name") == "Echo Fallback"
+
+
+def test_local_model_generate_resilient(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    primary_dir = _prepare_candidate(tmp_path, "primary")
+    config = {
+        "candidates": [
+            {
+                "path": str(primary_dir),
+                "engine": "echo",
+                "name": "Echo Primary",
+            }
+        ]
+    }
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+
+    model = LocalModel.autoload()
+
+    response_empty = model.generate(None, history=None)
+    assert isinstance(response_empty, str)
+    assert response_empty
+
+    response_malformed = model.generate("", history=["", None, 42])
+    assert isinstance(response_malformed, str)
+    assert response_malformed


### PR DESCRIPTION
## Summary
- add configuration helpers for discovering local model candidates and generation settings
- extend the LocalModel wrapper to load transformers or llama.cpp backends with graceful fallbacks
- cover the loader with smoke, inference, fallback, and resiliency tests

## Testing
- pytest tests/test_local_model.py

------
https://chatgpt.com/codex/tasks/task_b_68ddefcd292483209721f41351c00dd6