### PR TITLE
Add boot retrospective narration and coverage

### DIFF
--- a/sentientos/boot_chronicler.py
+++ b/sentientos/boot_chronicler.py
@@ -1,0 +1,168 @@
+"""Boot retrospective narration for SentientOS awakenings.
+
+This module links the existing change narration utilities with the boot
+ceremony so that every awakening can include a short retrospective about what
+changed since the previous cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+from .change_narrator import ChangeCollector, ChangeSet, DiffSummarizer, ScopeFilter
+from .storage import get_state_file
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ChangeRecall:
+    """Retrieve change data that has not yet been narrated during boot."""
+
+    collector: ChangeCollector
+
+    def gather(self, *, now: datetime | None = None) -> Tuple[ScopeFilter, ChangeSet]:
+        """Return the unreported change set and scope used for collection."""
+
+        scope = ScopeFilter(since=None, modules=set(), change_types=set(), requested=True)
+        change_set = self.collector.collect(scope, now=now)
+        return scope, change_set
+
+
+class Chronicler:
+    """Compose a single narrative passage summarising the collected changes."""
+
+    def __init__(self, summarizer: DiffSummarizer | None = None) -> None:
+        self._summarizer = summarizer or DiffSummarizer()
+
+    def compose(self, change_set: ChangeSet) -> str | None:
+        sentences = self._summarizer.summarize(change_set)
+        if not sentences:
+            return None
+
+        lead = f"Since my last awakening, {sentences[0].strip()}"
+        additions: list[str] = []
+        for sentence in sentences[1:]:
+            fragment = sentence.strip()
+            if not fragment:
+                continue
+            additions.append(f"Additionally, {fragment}")
+
+        narrative = " ".join([lead, *additions]).strip()
+        if narrative and not narrative.endswith(('.', '!', '?')):
+            narrative += '.'
+        return narrative
+
+
+@dataclass(slots=True)
+class MemoryMark:
+    """Persist which changes have been narrated so they are not repeated."""
+
+    collector: ChangeCollector
+
+    def record(
+        self,
+        change_set: ChangeSet,
+        *,
+        scope: ScopeFilter,
+        response: str,
+        timestamp: datetime | None = None,
+    ) -> None:
+        self.collector.mark_reported(
+            change_set,
+            scope=scope,
+            response=response,
+            timestamp=timestamp or change_set.collected_at,
+        )
+
+
+class CeremonyLink:
+    """Inject the retrospective into the boot ceremony output."""
+
+    def __init__(
+        self,
+        emitter,
+        change_recall: ChangeRecall,
+        chronicler: Chronicler,
+        memory_mark: MemoryMark,
+        *,
+        salutation: str = "Allen",
+    ) -> None:
+        self._emitter = emitter
+        self._change_recall = change_recall
+        self._chronicler = chronicler
+        self._memory_mark = memory_mark
+        self._salutation = salutation.strip()
+
+    def narrate(self, *, now: datetime | None = None) -> None:
+        try:
+            scope, change_set = self._change_recall.gather(now=now)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("Unable to recall boot retrospective changes: %s", exc)
+            return
+
+        if not change_set.commits and not change_set.ledger_entries:
+            return
+
+        try:
+            narrative = self._chronicler.compose(change_set)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("Unable to compose boot retrospective: %s", exc)
+            return
+
+        if not narrative:
+            return
+
+        narrative = narrative.strip()
+        if self._salutation:
+            message = f"{self._salutation}, {narrative}"
+        else:
+            message = narrative
+
+        try:
+            self._emitter.emit(message, level="info")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("Unable to emit boot retrospective: %s", exc)
+
+        try:
+            self._memory_mark.record(
+                change_set,
+                scope=scope,
+                response=message,
+                timestamp=change_set.collected_at,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("Unable to persist boot retrospective memory: %s", exc)
+
+
+def build_boot_ceremony_link(emitter, *, collector: ChangeCollector | None = None) -> CeremonyLink:
+    """Factory returning a :class:`CeremonyLink` configured for runtime use."""
+
+    if collector is None:
+        repo_path = Path(os.getenv("SENTIENTOS_REPO_PATH", Path.cwd()))
+        ledger_path_env = os.getenv("CODEX_LEDGER_PATH")
+        ledger_path = Path(ledger_path_env) if ledger_path_env else None
+        collector = ChangeCollector(
+            repo_path=repo_path,
+            state_path=get_state_file("boot_chronicler_state.json"),
+            ledger_path=ledger_path,
+        )
+
+    change_recall = ChangeRecall(collector)
+    chronicler = Chronicler()
+    memory_mark = MemoryMark(collector)
+    return CeremonyLink(emitter, change_recall, chronicler, memory_mark)
+
+
+__all__ = [
+    "ChangeRecall",
+    "Chronicler",
+    "CeremonyLink",
+    "MemoryMark",
+    "build_boot_ceremony_link",
+]

--- a/sentientosd.py
+++ b/sentientosd.py
@@ -12,6 +12,7 @@ from sentientos.boot_ceremony import (
     EventEmitter,
     FirstContact,
 )
+from sentientos.boot_chronicler import build_boot_ceremony_link
 from sentientos.codex import CodexHealer, GenesisForge, IntegrityDaemon, SpecAmender
 from sentientos.local_model import LocalModel
 from sentientos.utils import git_commit_push
@@ -33,6 +34,7 @@ async def run_loop(shutdown_event: asyncio.Event, interval_seconds: int = 60) ->
     first_contact = FirstContact(emitter)
     first_contact.affirm_integrity()
     first_contact.invite_conversation()
+    build_boot_ceremony_link(emitter).narrate()
     model = LocalModel.autoload()
     LOGGER.info("SentientOS daemon initialised with %s", model.describe())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,7 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_codex_narratives",
         "tests.test_codex_healer",
         "tests.test_change_narrator",
+        "tests.test_boot_chronicler",
         "tests.test_codex_specs",
         "tests.test_codex_scaffolds",
         "tests.test_codex_implementations",

--- a/tests/test_boot_chronicler.py
+++ b/tests/test_boot_chronicler.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sentientos.boot_chronicler import ChangeRecall, CeremonyLink, Chronicler, MemoryMark
+from sentientos.change_narrator import ChangeCollector
+from sentientos.codex_healer import Anomaly, RecoveryLedger
+
+
+class DummyEmitter:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def emit(self, message: str, *, level: str = "info") -> None:
+        self.messages.append((level, message))
+
+
+@pytest.fixture()
+def collector(tmp_path):
+    ledger = RecoveryLedger()
+    state_path = tmp_path / "boot_state.json"
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    collector = ChangeCollector(ledger=ledger, repo_path=repo_path, state_path=state_path)
+    return collector, ledger
+
+
+def _build_link(collector: ChangeCollector) -> tuple[CeremonyLink, DummyEmitter]:
+    emitter = DummyEmitter()
+    recall = ChangeRecall(collector)
+    chronicler = Chronicler()
+    memory = MemoryMark(collector)
+    link = CeremonyLink(emitter, recall, chronicler, memory)
+    return link, emitter
+
+
+def test_boot_retrospective_skips_when_no_changes(collector: tuple[ChangeCollector, RecoveryLedger]) -> None:
+    collector_obj, ledger = collector
+    link, emitter = _build_link(collector_obj)
+    link.narrate(now=datetime.now(timezone.utc))
+    assert emitter.messages == []
+
+
+def test_boot_retrospective_composes_single_passage(collector: tuple[ChangeCollector, RecoveryLedger]) -> None:
+    collector_obj, ledger = collector
+    link, emitter = _build_link(collector_obj)
+    ledger.log("Rebuilt LocalModel wrapper", anomaly=Anomaly(kind="codex", subject="LocalModel"))
+    ledger.log(
+        "Forged IntegrityDaemon check",
+        anomaly=Anomaly(kind="integrity", subject="IntegrityDaemon"),
+    )
+
+    moment = datetime.now(timezone.utc) + timedelta(seconds=1)
+    link.narrate(now=moment)
+
+    assert len(emitter.messages) == 1
+    level, message = emitter.messages[0]
+    assert level == "info"
+    assert message.lower().startswith("allen, since my last awakening")
+    assert "\n" not in message
+    assert "•" not in message
+
+
+def test_boot_retrospective_does_not_repeat_changes(collector: tuple[ChangeCollector, RecoveryLedger]) -> None:
+    collector_obj, ledger = collector
+    link, emitter = _build_link(collector_obj)
+    ledger.log("Calibrated ceremony", anomaly=Anomaly(kind="ritual", subject="Boot"))
+
+    first_moment = datetime.now(timezone.utc) + timedelta(seconds=1)
+    link.narrate(now=first_moment)
+    assert len(emitter.messages) == 1
+
+    second_moment = first_moment + timedelta(seconds=1)
+    link.narrate(now=second_moment)
+    assert len(emitter.messages) == 1
+
+
+def test_boot_retrospective_ignores_recall_failures(collector: tuple[ChangeCollector, RecoveryLedger]) -> None:
+    collector_obj, ledger = collector
+    emitter = DummyEmitter()
+
+    class ExplodingRecall:
+        def gather(self, *, now=None):  # type: ignore[no-untyped-def]
+            raise RuntimeError("ledger offline")
+
+    memory = MemoryMark(collector_obj)
+    link = CeremonyLink(emitter, ExplodingRecall(), Chronicler(), memory)
+
+    link.narrate(now=datetime.now(timezone.utc))
+
+    assert emitter.messages == []


### PR DESCRIPTION
## Summary
- add a boot chronicler module that recalls untold RecoveryLedger entries and formats a single retrospective passage
- hook the chronicler into the daemon boot sequence and persist narrated changes so they are not repeated
- add targeted tests for the boot retrospective flow and enable them in the collection whitelist

## Testing
- pytest tests/test_boot_chronicler.py

------
https://chatgpt.com/codex/tasks/task_b_68de881278708320a0ccbbb691b19c40