### PR TITLE
Fix privilege linter tests future import placement

### DIFF
--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,14 +1,15 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+
+from pathlib import Path
+import os
+import sys
+
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
 
-
-import os, sys
-from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import privilege_lint as pl

--- a/tests/test_import_sort.py
+++ b/tests/test_import_sort.py
@@ -1,14 +1,14 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
+
+from pathlib import Path
+import os
+import sys
+
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-
-
-import os, sys
-from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- ensure the privilege linter docstring tests import the future annotations flag before other statements
- normalise the import ordering helper tests so the module docstring and privilege checks execute before sys.path fiddling

## Testing
- pytest tests/test_docstrings.py -q
- pytest tests/test_import_sort.py -q

------
https://chatgpt.com/codex/tasks/task_b_68de9a011d7883208e9956c4a80a5052