### PR TITLE
Improve privilege env reporting API

### DIFF
--- a/privilege_lint/env.py
+++ b/privilege_lint/env.py
@@ -24,8 +24,12 @@ def env_status() -> dict[str, dict[str, object]]:
     }
 
 
-def report() -> str:
-    return report_text()
+def report(format: str = "text") -> str:
+    if format == "text":
+        return report_text()
+    if format == "json":
+        return report_json()
+    raise ValueError(f"unsupported report format: {format}")
 
 
 def report_text() -> str:
@@ -35,6 +39,10 @@ def report_text() -> str:
         desc = caps["info"] if caps["available"] else "MISSING"
         lines.append(f"{name:<12} {check:<6} {desc}")
     return "\n".join(lines)
+
+
+def report_json() -> str:
+    return json.dumps(env_status(), indent=2)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -48,7 +56,7 @@ def main(argv: list[str] | None = None) -> None:
         parser.error("only 'report' command supported")
 
     if args.format == "json":
-        print(json.dumps(env_status(), indent=2))
+        print(report_json())
     else:
         print(report_text())
 

--- a/tests/test_env_json.py
+++ b/tests/test_env_json.py
@@ -4,9 +4,6 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from __future__ import annotations
-
-
 import json
 import subprocess
 import sys


### PR DESCRIPTION
## Summary
- add a format-aware `report` helper and shared JSON reporting function in `privilege_lint.env`
- remove the duplicated future import in the env JSON test module so it imports cleanly

## Testing
- pytest tests/test_env_json.py::test_env_json_output
- python -m privilege_lint.env report --json

------
https://chatgpt.com/codex/tasks/task_b_68de9cde3d8c8320b4da57328d3c011a