### PR TITLE
Implement updater rollback workflow with health checks

### DIFF
--- a/tests/test_oracle_cycle.py
+++ b/tests/test_oracle_cycle.py
@@ -13,10 +13,15 @@ from sentientos.oracle_cycle import (
     CodexExecutor,
     CommitObservation,
     CommitWatcher,
+    HealthCheck,
+    LedgerLink,
+    NarratorLink,
     OracleClient,
     OracleCycle,
     OracleQuery,
     ResearchTimer,
+    RollbackHandler,
+    SnapshotManager,
     UpdateResult,
     WorkspaceSubmission,
     Updater,
@@ -83,6 +88,26 @@ class RecordingReload:
     def __call__(self) -> bool:
         self.invocations += 1
         return self.succeed
+
+
+class FakeRepo:
+    def __init__(self, head: str) -> None:
+        self.head = head
+        self.pull_args: list[str] = []
+        self.reset_calls: list[str] = []
+
+    def read_head(self) -> str:
+        return self.head
+
+    def pull(self, commit_sha: str) -> bool:
+        self.pull_args.append(commit_sha)
+        self.head = commit_sha
+        return True
+
+    def reset(self, commit_sha: str) -> bool:
+        self.reset_calls.append(commit_sha)
+        self.head = commit_sha
+        return True
 
 
 class RecordingIntegrityDaemon(IntegrityDaemon):
@@ -210,6 +235,110 @@ def test_research_timer_runs_on_schedule(tmp_path: Path, ledger: RecoveryLedger)
     assert workspace.instructions[-1][0].startswith("Commit the latest deep research report")
     assert client.questions[-1].startswith("Summarize SentientOS GitHub progress")
     assert ledger.entries[-1]["status"] == "deep_research_recorded"
+
+
+def test_updater_records_successful_update(tmp_path: Path, ledger: RecoveryLedger) -> None:
+    repo = FakeRepo("a" * 40)
+    snapshot_path = tmp_path / "state" / "last_good"
+    snapshot = SnapshotManager(read_current=repo.read_head, storage_path=snapshot_path)
+    health = HealthCheck({"IntegrityDaemon": lambda: True})
+    updater = Updater(
+        repo.pull,
+        reload_strategy=lambda: True,
+        snapshot_manager=snapshot,
+        health_check=health,
+        ledger=LedgerLink(ledger),
+    )
+
+    new_commit = "b" * 40
+    result = updater.apply(new_commit)
+
+    assert repo.head == new_commit
+    assert result.commit_sha == new_commit
+    assert result.last_known_good == new_commit
+    assert result.ledger_entry is not None
+    assert result.ledger_entry["status"] == "Update applied"
+    assert result.health_report is not None and result.health_report.healthy
+    assert snapshot_path.read_text(encoding="utf-8").strip() == new_commit
+
+
+def test_updater_rolls_back_on_failed_health(tmp_path: Path, ledger: RecoveryLedger) -> None:
+    repo = FakeRepo("c" * 40)
+    snapshot = SnapshotManager(
+        read_current=repo.read_head,
+        storage_path=tmp_path / "state" / "rollback_last_good",
+    )
+    events: list[dict[str, object]] = []
+    narrator = NarratorLink(
+        on_announce=lambda message, payload: events.append({"message": message, **payload})
+    )
+    health = HealthCheck(
+        {"IntegrityDaemon": lambda: False},
+        timeout=0.0,
+        interval=0.0,
+        sleep=lambda _: None,
+    )
+    rollback = RollbackHandler(repo.reset)
+    updater = Updater(
+        repo.pull,
+        reload_strategy=lambda: True,
+        snapshot_manager=snapshot,
+        health_check=health,
+        rollback_handler=rollback,
+        ledger=LedgerLink(ledger),
+        narrator=narrator,
+    )
+
+    failed_commit = "d" * 40
+    result = updater.apply(failed_commit)
+
+    assert result.failure_reason == "health_check_failed"
+    assert result.rolled_back
+    assert result.rollback_commit == "c" * 40
+    assert repo.head == "c" * 40
+    assert ledger.entries[-1]["status"] == "Rolled back to last stable commit"
+    assert events, "Narrator should announce the rollback"
+    assert "restored commit" in events[-1]["message"]
+
+
+def test_updater_logs_missing_snapshot(tmp_path: Path, ledger: RecoveryLedger) -> None:
+    repo = FakeRepo("e" * 40)
+
+    def read_missing() -> str | None:
+        return None
+
+    snapshot = SnapshotManager(
+        read_current=read_missing,
+        storage_path=tmp_path / "state" / "missing_last_good",
+    )
+    events: list[dict[str, object]] = []
+    narrator = NarratorLink(
+        on_announce=lambda message, payload: events.append({"message": message, **payload})
+    )
+    health = HealthCheck(
+        {"IntegrityDaemon": lambda: False},
+        timeout=0.0,
+        interval=0.0,
+        sleep=lambda _: None,
+    )
+    rollback = RollbackHandler(repo.reset)
+    updater = Updater(
+        repo.pull,
+        reload_strategy=lambda: True,
+        snapshot_manager=snapshot,
+        health_check=health,
+        rollback_handler=rollback,
+        ledger=LedgerLink(ledger),
+        narrator=narrator,
+    )
+
+    result = updater.apply("f" * 40)
+
+    assert result.failure_reason == "health_check_failed"
+    assert not result.rolled_back
+    assert result.ledger_entry is not None
+    assert result.ledger_entry["status"] == "Rollback snapshot missing"
+    assert events and events[-1]["restored_commit"] is None
 
 
 def test_oracle_query_remains_integrity_gated(tmp_path: Path, ledger: RecoveryLedger) -> None:

--- a/updater.py
+++ b/updater.py
@@ -3,14 +3,110 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+from typing import Callable
+
+from sentientos.codex_healer import RecoveryLedger
+from sentientos.oracle_cycle import (
+    HealthCheck,
+    LedgerLink,
+    NarratorLink,
+    RollbackHandler,
+    SnapshotManager,
+    Updater,
+)
+
+
+def _rev_parse_head(root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _git_pull(root: Path) -> bool:
+    return subprocess.run(["git", "pull"], cwd=root).returncode == 0
+
+
+def _git_reset(root: Path, commit_sha: str) -> bool:
+    return (
+        subprocess.run(["git", "reset", "--hard", commit_sha], cwd=root).returncode
+        == 0
+    )
+
+
+def _reload_daemons(root: Path) -> bool:
+    return (
+        subprocess.run([sys.executable, "sentientosd.py"], cwd=root).returncode == 0
+    )
+
+
+def _build_health_probes() -> dict[str, Callable[[], bool]]:
+    def check_integrity() -> bool:
+        from sentientos.codex import IntegrityDaemon
+
+        IntegrityDaemon.guard()
+        return True
+
+    def check_codex_healer() -> bool:
+        from sentientos.codex import CodexHealer
+
+        CodexHealer.monitor()
+        return True
+
+    def check_oracle_cycle() -> bool:
+        from sentientos.oracle_cycle import OracleCycle
+
+        return OracleCycle is not None
+
+    return {
+        "IntegrityDaemon": check_integrity,
+        "CodexHealer": check_codex_healer,
+        "OracleCycle": check_oracle_cycle,
+    }
 
 
 def update(repo_root: str | Path | None = None) -> int:
     root = Path(repo_root) if repo_root else Path(__file__).resolve().parent
-    pull = subprocess.run(["git", "pull"], cwd=root)
-    if pull.returncode != 0:
-        return pull.returncode
-    return subprocess.run([sys.executable, "sentientosd.py"], cwd=root).returncode
+    snapshot = SnapshotManager(
+        read_current=lambda: _rev_parse_head(root),
+        storage_path=root / ".sentientos" / "last_known_good",
+    )
+    ledger_path = root / "logs" / "recovery_ledger.jsonl"
+    ledger = LedgerLink(RecoveryLedger(ledger_path))
+    narrator = NarratorLink(on_announce=lambda message, _: print(f"[Narrator] {message}"))
+    health = HealthCheck(_build_health_probes(), timeout=10.0, interval=1.0)
+    rollback = RollbackHandler(
+        lambda commit: _git_reset(root, commit),
+        restart=lambda: _reload_daemons(root),
+    )
+    updater = Updater(
+        lambda commit: _git_pull(root),
+        reload_strategy=lambda: _reload_daemons(root),
+        snapshot_manager=snapshot,
+        health_check=health,
+        rollback_handler=rollback,
+        ledger=ledger,
+        narrator=narrator,
+    )
+    target_commit = snapshot.current_commit() or "HEAD"
+    result = updater.apply(target_commit)
+    if result.failure_reason is None:
+        print(f"[Updater] Update applied at {result.commit_sha}")
+        return 0
+    if result.rolled_back and result.rollback_commit:
+        print(
+            "[Updater] Update failed; restored last-known-good commit "
+            f"{result.rollback_commit}"
+        )
+        return 1
+    print("[Updater] Update failed and rollback was unavailable.")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add snapshot management, health verification, ledger logging, and rollback support to the updater flow
- extend the external gap seeker narrative to capture rollback metadata
- enhance the updater CLI to use the new safeguards and add regression tests for rollback scenarios

## Testing
- pytest tests/test_oracle_cycle.py tests/test_external_gap_seeker.py

------
https://chatgpt.com/codex/tasks/task_b_68deaf06592c8320a8104410bc4c2aac