### PR TITLE
Add consolidated operator dashboard

### DIFF
--- a/dashboard_ui/__init__.py
+++ b/dashboard_ui/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard UI package."""
+
+from .api import create_app
+
+__all__ = ["create_app"]

--- a/dashboard_ui/api.py
+++ b/dashboard_ui/api.py
@@ -1,0 +1,110 @@
+"""FastAPI application for the consolidated operator console."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
+
+from .event_stream import EventStream
+
+
+CATEGORIES: Dict[str, str] = {
+    "feed": "Boot Feed",
+    "oracle": "OracleCycle Log",
+    "gapseeker": "Gap Reports",
+    "commits": "CommitWatcher",
+    "research": "Deep Research",
+}
+
+
+def _format_sse(payload: Dict[str, object]) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+async def event_source(stream: EventStream):
+    subscriber_id, queue = stream.subscribe()
+    try:
+        for event in stream.get_recent():
+            yield _format_sse(event)
+        while True:
+            event = await queue.get()
+            yield _format_sse(event.as_dict())
+    finally:
+        stream.unsubscribe(subscriber_id)
+
+
+class EventIn(BaseModel):
+    category: str = Field(pattern="^(feed|oracle|gapseeker|commits|research)$")
+    module: str
+    message: str
+    metadata: Dict[str, object] = Field(default_factory=dict)
+
+
+class ArchiveResponse(BaseModel):
+    reports: Iterable[Dict[str, object]]
+
+
+def create_app(event_stream: Optional[EventStream] = None) -> FastAPI:
+    app = FastAPI(title="SentientOS Operator Console")
+
+    templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    app.state.event_stream = event_stream or EventStream(categories=CATEGORIES.keys())
+
+    def get_stream() -> EventStream:
+        return app.state.event_stream
+
+    @app.get("/dashboard", response_class=HTMLResponse)
+    def dashboard(request: Request) -> Response:
+        return templates.TemplateResponse("dashboard.html", {"request": request, "categories": CATEGORIES})
+
+    @app.get("/events")
+    async def stream_events(stream: EventStream = Depends(get_stream)) -> StreamingResponse:
+        return StreamingResponse(event_source(stream), media_type="text/event-stream")
+
+    @app.get("/feed")
+    def get_feed(stream: EventStream = Depends(get_stream), limit: int = 50):
+        return {"events": stream.get_history("feed", limit=limit)}
+
+    @app.get("/oracle")
+    def get_oracle(stream: EventStream = Depends(get_stream), limit: int = 50):
+        return {"events": stream.get_history("oracle", limit=limit)}
+
+    @app.get("/gapseeker")
+    def get_gapseeker(stream: EventStream = Depends(get_stream), limit: int = 50):
+        return {"events": stream.get_history("gapseeker", limit=limit)}
+
+    @app.get("/commits")
+    def get_commits(stream: EventStream = Depends(get_stream), limit: int = 50):
+        return {"events": stream.get_history("commits", limit=limit)}
+
+    @app.get("/research")
+    def get_research(stream: EventStream = Depends(get_stream), limit: int = 50):
+        return {"events": stream.get_history("research", limit=limit)}
+
+    @app.get("/research/archive")
+    def download_research_archive(stream: EventStream = Depends(get_stream)) -> JSONResponse:
+        return JSONResponse({"reports": stream.get_history("research")})
+
+    @app.post("/events", status_code=201)
+    def publish_event(event: EventIn, stream: EventStream = Depends(get_stream)):
+        try:
+            published = stream.publish(
+                category=event.category,
+                message=event.message,
+                module=event.module,
+                metadata=dict(event.metadata),
+            )
+        except ValueError as exc:  # pragma: no cover - validated upstream, safety net.
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return published.as_dict()
+
+    return app

--- a/dashboard_ui/event_stream.py
+++ b/dashboard_ui/event_stream.py
@@ -1,0 +1,116 @@
+"""Event stream primitives for the dashboard UI."""
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Dict, Iterable, List, MutableMapping, Optional
+
+import asyncio
+
+
+EventDict = MutableMapping[str, object]
+
+
+@dataclass(slots=True)
+class Event:
+    """Representation of a single dashboard event."""
+
+    category: str
+    message: str
+    module: str
+    metadata: Dict[str, object] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    def as_dict(self) -> EventDict:
+        """Return a JSON-serialisable dictionary."""
+        payload: EventDict = {
+            "id": self.id,
+            "category": self.category,
+            "message": self.message,
+            "module": self.module,
+            "timestamp": self.timestamp.isoformat(),
+            "metadata": self.metadata,
+        }
+        return payload
+
+
+class EventStream:
+    """In-memory pub/sub stream with bounded history."""
+
+    def __init__(self, *, categories: Iterable[str], history_limit: int = 250) -> None:
+        self._categories = set(categories)
+        self._history: Dict[str, Deque[Event]] = {
+            category: deque(maxlen=history_limit) for category in self._categories
+        }
+        self._history["__all__"] = deque(maxlen=history_limit)
+        self._subscribers: Dict[int, asyncio.Queue[Event]] = {}
+        self._lock = threading.Lock()
+        self._subscriber_index = 0
+        self._history_limit = history_limit
+
+    @property
+    def categories(self) -> Iterable[str]:
+        return tuple(sorted(self._categories))
+
+    def publish(
+        self,
+        *,
+        category: str,
+        message: str,
+        module: str,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> Event:
+        if category not in self._categories:
+            raise ValueError(f"Unknown category '{category}'")
+
+        event = Event(
+            category=category,
+            message=message,
+            module=module,
+            metadata=metadata or {},
+        )
+
+        self._history[category].appendleft(event)
+        self._history["__all__"].appendleft(event)
+
+        with self._lock:
+            stale_subscribers: List[int] = []
+            for subscriber_id, queue in self._subscribers.items():
+                try:
+                    queue.put_nowait(event)
+                except asyncio.QueueFull:
+                    stale_subscribers.append(subscriber_id)
+            for subscriber_id in stale_subscribers:
+                self._subscribers.pop(subscriber_id, None)
+
+        return event
+
+    def get_history(self, category: str, *, limit: Optional[int] = None) -> List[EventDict]:
+        if category not in self._categories:
+            raise ValueError(f"Unknown category '{category}'")
+        items = list(self._history[category])
+        if limit is not None:
+            items = items[:limit]
+        return [event.as_dict() for event in items]
+
+    def get_recent(self, *, limit: Optional[int] = None) -> List[EventDict]:
+        items = list(self._history["__all__"])
+        if limit is not None:
+            items = items[:limit]
+        return [event.as_dict() for event in items]
+
+    def subscribe(self) -> tuple[int, asyncio.Queue[Event]]:
+        queue: asyncio.Queue[Event] = asyncio.Queue()
+        with self._lock:
+            subscriber_id = self._subscriber_index
+            self._subscriber_index += 1
+            self._subscribers[subscriber_id] = queue
+        return subscriber_id, queue
+
+    def unsubscribe(self, subscriber_id: int) -> None:
+        with self._lock:
+            self._subscribers.pop(subscriber_id, None)

--- a/dashboard_ui/static/dashboard.css
+++ b/dashboard_ui/static/dashboard.css
@@ -1,0 +1,106 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #1f2a44, #0b101a);
+  color: #f8f9fb;
+}
+
+body {
+  margin: 0;
+  padding: 1.5rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.subtitle {
+  margin-top: 0.25rem;
+  color: rgba(248, 249, 251, 0.75);
+}
+
+#controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+#controls button,
+#controls select {
+  background: rgba(22, 33, 56, 0.8);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+#controls button:hover,
+#controls select:focus-visible {
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+#status-indicator {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+main {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.panel {
+  background: rgba(16, 22, 38, 0.85);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  max-height: 400px;
+}
+
+.panel h2 {
+  margin-top: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding-bottom: 0.5rem;
+}
+
+.event-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.event-item {
+  background: rgba(31, 45, 76, 0.65);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.event-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+  opacity: 0.8;
+}
+
+.event-message {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/dashboard_ui/static/dashboard.js
+++ b/dashboard_ui/static/dashboard.js
@@ -1,0 +1,172 @@
+const CATEGORY_ENDPOINTS = {
+  feed: "/feed",
+  oracle: "/oracle",
+  gapseeker: "/gapseeker",
+  commits: "/commits",
+  research: "/research",
+};
+
+const STATE = {
+  events: {
+    feed: [],
+    oracle: [],
+    gapseeker: [],
+    commits: [],
+    research: [],
+  },
+  filter24h: false,
+  moduleFilter: "",
+};
+
+const controls = {
+  last24h: document.getElementById("toggle-24h"),
+  moduleFilter: document.getElementById("module-filter"),
+  download: document.getElementById("download-archive"),
+  status: document.getElementById("status-indicator"),
+};
+
+const lists = {
+  feed: document.getElementById("feed-list"),
+  oracle: document.getElementById("oracle-list"),
+  gapseeker: document.getElementById("gapseeker-list"),
+  commits: document.getElementById("commits-list"),
+  research: document.getElementById("research-list"),
+};
+
+function cloneTemplate() {
+  const template = document.getElementById("event-template");
+  return template.content.firstElementChild.cloneNode(true);
+}
+
+function applyFilters(events) {
+  let filtered = [...events];
+  if (STATE.filter24h) {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    filtered = filtered.filter((event) => new Date(event.timestamp).getTime() >= cutoff);
+  }
+  if (STATE.moduleFilter) {
+    filtered = filtered.filter((event) => event.module === STATE.moduleFilter);
+  }
+  return filtered;
+}
+
+function renderCategory(category) {
+  const list = lists[category];
+  const fragment = document.createDocumentFragment();
+  const events = applyFilters(STATE.events[category]);
+
+  events.forEach((event) => {
+    const element = cloneTemplate();
+    element.querySelector(".event-module").textContent = event.module;
+    element.querySelector(".event-message").textContent = event.message;
+    element.querySelector(".event-timestamp").textContent = new Date(event.timestamp).toLocaleString();
+    fragment.appendChild(element);
+  });
+
+  list.innerHTML = "";
+  list.appendChild(fragment);
+}
+
+function renderAll() {
+  Object.keys(CATEGORY_ENDPOINTS).forEach(renderCategory);
+  populateModuleFilter();
+}
+
+function populateModuleFilter() {
+  const uniqueModules = new Set();
+  Object.values(STATE.events).forEach((events) => {
+    events.forEach((event) => uniqueModules.add(event.module));
+  });
+
+  const currentValue = controls.moduleFilter.value;
+  controls.moduleFilter.innerHTML = '<option value="">All</option>';
+  [...uniqueModules].sort().forEach((module) => {
+    const option = document.createElement("option");
+    option.value = module;
+    option.textContent = module;
+    controls.moduleFilter.appendChild(option);
+  });
+
+  if ([...controls.moduleFilter.options].some((option) => option.value === currentValue)) {
+    controls.moduleFilter.value = currentValue;
+  }
+}
+
+async function loadInitialData() {
+  await Promise.all(
+    Object.entries(CATEGORY_ENDPOINTS).map(async ([category, endpoint]) => {
+      const response = await fetch(endpoint);
+      if (!response.ok) return;
+      const data = await response.json();
+      STATE.events[category] = data.events || [];
+    })
+  );
+  renderAll();
+}
+
+function addEventToState(event) {
+  if (!STATE.events[event.category]) {
+    STATE.events[event.category] = [];
+  }
+  STATE.events[event.category].unshift(event);
+  renderCategory(event.category);
+  populateModuleFilter();
+}
+
+function setupControls() {
+  controls.last24h.addEventListener("click", () => {
+    STATE.filter24h = !STATE.filter24h;
+    controls.last24h.dataset.active = String(STATE.filter24h);
+    controls.last24h.textContent = STATE.filter24h ? "Showing Last 24h" : "Show Last 24h";
+    renderAll();
+  });
+
+  controls.moduleFilter.addEventListener("change", (event) => {
+    STATE.moduleFilter = event.target.value;
+    renderAll();
+  });
+
+  controls.download.addEventListener("click", async () => {
+    controls.status.textContent = "Preparing archive…";
+    try {
+      const response = await fetch("/research/archive");
+      if (!response.ok) throw new Error("Failed to fetch archive");
+      const data = await response.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `research-archive-${new Date().toISOString()}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      controls.status.textContent = "Archive downloaded";
+    } catch (error) {
+      controls.status.textContent = `Archive error: ${error.message}`;
+    }
+  });
+}
+
+function connectEventStream() {
+  const source = new EventSource("/events");
+  source.onopen = () => {
+    controls.status.textContent = "Live updates connected";
+  };
+  source.onerror = () => {
+    controls.status.textContent = "Live updates disconnected (retrying…)";
+  };
+  source.onmessage = (event) => {
+    if (!event.data) return;
+    try {
+      const payload = JSON.parse(event.data);
+      addEventToState(payload);
+    } catch (error) {
+      console.error("Failed to parse event", error);
+    }
+  };
+}
+
+setupControls();
+loadInitialData();
+connectEventStream();

--- a/dashboard_ui/templates/dashboard.html
+++ b/dashboard_ui/templates/dashboard.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SentientOS Operator Console</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='dashboard.css') }}" />
+  </head>
+  <body>
+    <header>
+      <h1>SentientOS Operator Console</h1>
+      <p class="subtitle">Unified visibility into boot ceremonies, oracle cycles, gap fixes, commits, and deep research.</p>
+    </header>
+
+    <section id="controls">
+      <button id="toggle-24h" data-active="false">Show Last 24h</button>
+      <label for="module-filter">Filter by module:</label>
+      <select id="module-filter">
+        <option value="">All</option>
+      </select>
+      <button id="download-archive">Download Research Archive</button>
+      <span id="status-indicator" aria-live="polite">Connecting…</span>
+    </section>
+
+    <main>
+      <div class="panel" data-category="feed">
+        <h2>Boot Feed</h2>
+        <ul class="event-list" id="feed-list"></ul>
+      </div>
+      <div class="panel" data-category="oracle">
+        <h2>OracleCycle Log</h2>
+        <ul class="event-list" id="oracle-list"></ul>
+      </div>
+      <div class="panel" data-category="gapseeker">
+        <h2>Gap Reports</h2>
+        <ul class="event-list" id="gapseeker-list"></ul>
+      </div>
+      <div class="panel" data-category="commits">
+        <h2>CommitWatcher</h2>
+        <ul class="event-list" id="commits-list"></ul>
+      </div>
+      <div class="panel" data-category="research">
+        <h2>Deep Research</h2>
+        <ul class="event-list" id="research-list"></ul>
+      </div>
+    </main>
+
+    <template id="event-template">
+      <li class="event-item">
+        <div class="event-header">
+          <span class="event-module"></span>
+          <time class="event-timestamp"></time>
+        </div>
+        <p class="event-message"></p>
+      </li>
+    </template>
+
+    <script src="{{ url_for('static', path='dashboard.js') }}" type="module"></script>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,8 @@ def pytest_collection_modifyitems(config, items):
         "tests.test_oracle_relay",
         "tests.test_research_timer",
         "tests.test_commit_watcher_ci",
+        "tests.test_dashboard_event_stream",
+        "tests.test_dashboard_api",
     }
     for item in items:
         if (

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+from dashboard_ui.api import create_app, event_source
+
+
+def publish_event(client: TestClient, **payload) -> None:
+    response = client.post(
+        "/events",
+        json={
+            "category": payload.get("category", "feed"),
+            "module": payload.get("module", "Daemon"),
+            "message": payload.get("message", "hello"),
+            "metadata": payload.get("metadata", {}),
+        },
+    )
+    assert response.status_code == 201
+
+
+def test_feed_endpoint_returns_history() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        publish_event(client, category="feed", module="Boot", message="Boot complete")
+        response = client.get("/feed")
+        assert response.status_code == 200
+        data = response.json()
+    assert data["events"][0]["message"] == "Boot complete"
+
+
+def test_sse_stream_receives_events() -> None:
+    app = create_app()
+    stream = app.state.event_stream
+
+    async def consume() -> dict[str, object]:
+        generator = event_source(stream)
+        event = None
+        try:
+            stream.publish(category="oracle", module="OracleCycle", message="Q1")
+            chunk = await asyncio.wait_for(generator.__anext__(), timeout=1)
+            event = json.loads(chunk.replace("data:", "", 1).strip())
+        finally:
+            await generator.aclose()
+        return event
+
+    payload = asyncio.run(consume())
+    assert payload["message"] == "Q1"
+    assert payload["category"] == "oracle"

--- a/tests/test_dashboard_event_stream.py
+++ b/tests/test_dashboard_event_stream.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from dashboard_ui.event_stream import EventStream
+
+
+@pytest.fixture()
+def event_stream() -> EventStream:
+    return EventStream(categories={"feed", "oracle", "gapseeker", "commits", "research"}, history_limit=3)
+
+
+def test_publish_and_history(event_stream: EventStream) -> None:
+    event_stream.publish(category="feed", message="Booted", module="BootDaemon")
+    history = event_stream.get_history("feed")
+    assert len(history) == 1
+    assert history[0]["message"] == "Booted"
+
+
+def test_history_limit(event_stream: EventStream) -> None:
+    for index in range(5):
+        event_stream.publish(category="feed", message=f"event-{index}", module="BootDaemon")
+    history = event_stream.get_history("feed")
+    assert len(history) == 3
+    assert history[0]["message"] == "event-4"
+    assert history[-1]["message"] == "event-2"
+
+
+def test_subscribe_receives_events(event_stream: EventStream) -> None:
+    subscriber_id, queue = event_stream.subscribe()
+    try:
+        event_stream.publish(category="oracle", message="Query", module="OracleCycle")
+        received = asyncio.run(asyncio.wait_for(queue.get(), timeout=1))
+        assert received.message == "Query"
+        assert received.category == "oracle"
+    finally:
+        event_stream.unsubscribe(subscriber_id)


### PR DESCRIPTION
## Summary
- implement an in-memory event stream to capture boot, oracle, gap, commit, and research events
- expose FastAPI endpoints with an SSE feed and ship a simple HTML/JS dashboard for live operator visibility
- cover the new components with focused unit tests and enable them in the shared test configuration

## Testing
- pytest tests/test_dashboard_event_stream.py tests/test_dashboard_api.py

------
https://chatgpt.com/codex/tasks/task_b_68dee859a3fc83209fb0359e518a891e