### PR TITLE
Add privilege lint report router and review board gating

### DIFF
--- a/privilege_lint.py
+++ b/privilege_lint.py
@@ -6,17 +6,38 @@ require_admin_banner()
 require_lumos_approval()
 
 import argparse
+import sys
+
 from privilege_lint_cli import main as pl_main
 
-def cli() -> None:
+
+def _run_report(argv: list[str]) -> int:
+    from privilege_lint.reporting.report_router import create_default_router
+
+    ap = argparse.ArgumentParser(prog="privilege_lint report", description="Generate privilege lint report")
+    ap.add_argument("--format", default="json", help="Report format (json|yaml|markdown)")
+    ap.add_argument("paths", nargs="*", help="Optional paths to lint")
+    args = ap.parse_args(argv)
+    router = create_default_router()
+    report, rendered, _, _ = router.generate(args.format, paths=args.paths or None)
+    print(rendered)
+    return 0 if report.passed else 1
+
+
+def cli(argv: list[str] | None = None) -> None:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    if argv and argv[0] == "report":
+        rc = _run_report(argv[1:])
+        raise SystemExit(rc)
+
     ap = argparse.ArgumentParser(description="Run privilege linter")
     ap.add_argument("--mode", choices=["fix", "lint"], default="lint")
     ap.add_argument("paths", nargs="*")
-    args = ap.parse_args()
-    argv = args.paths
+    args = ap.parse_args(argv)
+    cli_args = args.paths
     if args.mode == "fix":
-        argv = ["--fix"] + argv
-    rc = pl_main(argv)
+        cli_args = ["--fix"] + cli_args
+    rc = pl_main(cli_args)
     raise SystemExit(rc)
 
 if __name__ == "__main__":

--- a/privilege_lint/reporting/__init__.py
+++ b/privilege_lint/reporting/__init__.py
@@ -1,0 +1,19 @@
+from .models import LintExecution, PrivilegeReport
+from .format_engines import JSONFormatEngine, MarkdownFormatEngine, YAMLFormatEngine
+from .report_router import ReportRouter, create_default_router
+from .error_handler import ErrorHandler
+from .narrator import NarratorLink
+from .review_board import ReviewBoardHook
+
+__all__ = [
+    "LintExecution",
+    "PrivilegeReport",
+    "JSONFormatEngine",
+    "MarkdownFormatEngine",
+    "YAMLFormatEngine",
+    "ReportRouter",
+    "create_default_router",
+    "ErrorHandler",
+    "NarratorLink",
+    "ReviewBoardHook",
+]

--- a/privilege_lint/reporting/error_handler.py
+++ b/privilege_lint/reporting/error_handler.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+
+class ErrorHandler:
+    """Resolve requested report formats with graceful fallbacks."""
+
+    def __init__(self, default_format: str = "json", logger: logging.Logger | None = None) -> None:
+        self.default_format = default_format
+        self._logger = logger or logging.getLogger(__name__)
+
+    def resolve(self, requested: str | None, available: Iterable[str]) -> str:
+        if requested:
+            fmt = requested.lower()
+        else:
+            fmt = self.default_format
+        available_set = {name.lower() for name in available}
+        if fmt in available_set:
+            return fmt
+        if requested:
+            self._logger.warning(
+                "Unsupported privilege lint report format '%s'; defaulting to '%s'.",
+                requested,
+                self.default_format,
+            )
+        return self.default_format

--- a/privilege_lint/reporting/format_engines.py
+++ b/privilege_lint/reporting/format_engines.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+import yaml
+
+from .models import PrivilegeReport
+
+
+class FormatEngine(Protocol):
+    format_name: str
+    extension: str
+
+    def render(self, report: PrivilegeReport) -> str:
+        ...
+
+
+@dataclass
+class JSONFormatEngine:
+    format_name: str = "json"
+    extension: str = "json"
+
+    def render(self, report: PrivilegeReport) -> str:
+        payload = {
+            "status": report.status,
+            "summary": report.summary(),
+            "timestamp": report.timestamp.isoformat(),
+            "issues": report.issues,
+            "metrics": report.metrics,
+            "checked_files": report.checked_files,
+        }
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+
+@dataclass
+class YAMLFormatEngine:
+    format_name: str = "yaml"
+    extension: str = "yaml"
+
+    def render(self, report: PrivilegeReport) -> str:
+        payload = {
+            "status": report.status,
+            "summary": report.summary(),
+            "timestamp": report.timestamp.isoformat(),
+            "issues": report.issues,
+            "metrics": report.metrics,
+            "checked_files": report.checked_files,
+        }
+        return yaml.safe_dump(payload, sort_keys=True)
+
+
+@dataclass
+class MarkdownFormatEngine:
+    format_name: str = "markdown"
+    extension: str = "md"
+
+    def render(self, report: PrivilegeReport) -> str:
+        status_icon = "✅" if report.passed else "❌"
+        lines = [
+            f"# Sanctuary Privilege Report — {report.timestamp.isoformat()}",
+            "",
+            f"* **Status:** {status_icon} {'Clean' if report.passed else 'Violation detected'}",
+            f"* **Summary:** {report.summary()}",
+            f"* **Files Checked:** {len(report.checked_files)}",
+            f"* **Issues:** {report.issue_count}",
+            f"* **Runtime:** {report.metrics.get('runtime', 0)}s",
+            "",
+        ]
+        if report.issues:
+            lines.append("## Findings")
+            for entry in report.issues:
+                lines.append(f"- {entry}")
+        else:
+            lines.append("All sanctuaries honour the privilege covenant. No issues detected.")
+        return "\n".join(lines)

--- a/privilege_lint/reporting/models.py
+++ b/privilege_lint/reporting/models.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from privilege_lint.metrics import MetricsCollector
+
+
+@dataclass
+class PrivilegeReport:
+    """Normalized privilege lint result for downstream consumers."""
+
+    status: str
+    timestamp: datetime
+    issues: List[str]
+    metrics: dict[str, object]
+    checked_files: List[str]
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "clean"
+
+    @property
+    def issue_count(self) -> int:
+        return len(self.issues)
+
+    def summary(self) -> str:
+        if self.passed:
+            return "Sanctuary Privilege: intact"
+        suffix = "issue" if self.issue_count == 1 else "issues"
+        return f"Sanctuary Privilege: compromised ({self.issue_count} {suffix})"
+
+
+@dataclass
+class LintExecution:
+    """Raw lint execution details captured from privilege_lint_cli."""
+
+    metrics: MetricsCollector
+    issues: List[str]
+    timestamp: datetime
+    checked_files: List[Path]
+    project_root: Path
+    config_hash: str
+    report_json_enabled: bool
+    sarif_enabled: bool
+    fixed_count: int = 0
+
+    def to_privilege_report(self) -> PrivilegeReport:
+        timestamp = self.timestamp
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        checked: List[str] = []
+        for path in self.checked_files:
+            try:
+                checked.append(str(path.relative_to(self.project_root)))
+            except ValueError:
+                checked.append(str(path))
+        payload = PrivilegeReport(
+            status="clean" if not self.issues else "violation",
+            timestamp=timestamp,
+            issues=sorted(self.issues),
+            metrics=self.metrics.to_dict(),
+            checked_files=sorted(checked),
+        )
+        return payload

--- a/privilege_lint/reporting/narrator.py
+++ b/privilege_lint/reporting/narrator.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from .models import PrivilegeReport
+
+
+Emitter = Callable[[str], None]
+
+
+class NarratorLink:
+    """Narrate privilege lint outcomes for ceremony and amendment flows."""
+
+    def __init__(self, emitter: Emitter | None = None) -> None:
+        self._logger = logging.getLogger(__name__)
+        self._emitter = emitter or self._logger.info
+
+    def announce_boot(self, report: PrivilegeReport, *, archive_path: Path | None = None) -> None:
+        message = report.summary()
+        if archive_path:
+            message = f"{message} (archive: {archive_path})"
+        self._emit(message)
+
+    def narrate_amendment(
+        self,
+        report: PrivilegeReport,
+        *,
+        spec_id: str,
+        proposal_id: str,
+        archive_path: Path | None = None,
+    ) -> None:
+        prefix = f"Amendment privilege check for {spec_id} ({proposal_id})"
+        if report.passed:
+            message = f"{prefix}: sanctuary privilege intact."
+        else:
+            suffix = "issue" if report.issue_count == 1 else "issues"
+            message = (
+                f"{prefix}: sanctuary privilege compromised ({report.issue_count} {suffix})."
+            )
+        if archive_path:
+            message = f"{message} Archive: {archive_path}"
+        self._emit(message)
+
+    def _emit(self, message: str) -> None:
+        try:
+            self._emitter(message)
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Failed to narrate privilege status: %s", message)

--- a/privilege_lint/reporting/report_router.py
+++ b/privilege_lint/reporting/report_router.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Sequence
+
+from .error_handler import ErrorHandler
+from .format_engines import FormatEngine, JSONFormatEngine, MarkdownFormatEngine, YAMLFormatEngine
+from .models import LintExecution, PrivilegeReport
+
+
+Runner = Callable[..., LintExecution]
+
+
+@dataclass
+class ReportRouter:
+    """Route privilege lint execution results to the requested formatter."""
+
+    engines: dict[str, FormatEngine]
+    runner: Runner
+    error_handler: ErrorHandler
+    archive_root: Path
+    default_paths: Sequence[str]
+    logger: logging.Logger
+
+    def generate(
+        self,
+        requested_format: str | None = None,
+        *,
+        paths: Sequence[str] | None = None,
+        max_workers: int | None = None,
+        mypy: bool = False,
+    ) -> tuple[PrivilegeReport, str, Path, str]:
+        execution = self.runner(
+            list(paths or self.default_paths),
+            fix=False,
+            quiet=True,
+            max_workers=max_workers,
+            show_hints=False,
+            no_cache=False,
+            mypy=mypy,
+        )
+        report = execution.to_privilege_report()
+        fmt = self.error_handler.resolve(requested_format, self.engines.keys())
+        engine = self.engines[fmt]
+        rendered = engine.render(report)
+        archive_path = self._write_archive(report.timestamp, engine.extension, rendered)
+        self.logger.info(
+            "Privilege lint report archived at %s (%s)", archive_path, fmt
+        )
+        return report, rendered, archive_path, fmt
+
+    def _write_archive(self, timestamp: datetime, extension: str, payload: str) -> Path:
+        archive_dir = self.archive_root
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{timestamp.strftime('%Y-%m-%d')}.{extension}"
+        archive_path = archive_dir / filename
+        archive_path.write_text(payload, encoding="utf-8")
+        return archive_path
+
+
+def create_default_router(logger: logging.Logger | None = None) -> ReportRouter:
+    from privilege_lint_cli import run_lint
+
+    engines = [JSONFormatEngine(), YAMLFormatEngine(), MarkdownFormatEngine()]
+    default_paths = [str(Path(__file__).resolve().parents[2])]
+    archive_root = Path(os.getenv("PRIVILEGE_REPORT_ARCHIVE", "/glow/privilege"))
+    return ReportRouter(
+        engines={engine.format_name: engine for engine in engines},
+        runner=run_lint,
+        error_handler=ErrorHandler(),
+        archive_root=archive_root,
+        default_paths=default_paths,
+        logger=logger or logging.getLogger(__name__),
+    )

--- a/privilege_lint/reporting/review_board.py
+++ b/privilege_lint/reporting/review_board.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from .narrator import NarratorLink
+from .report_router import ReportRouter
+from .models import PrivilegeReport
+
+
+@dataclass
+class ReviewBoardHook:
+    """Bridge privilege lint results into the amendment review board."""
+
+    router: ReportRouter
+    narrator: NarratorLink | None = None
+    logger: logging.Logger = logging.getLogger(__name__)
+
+    def enforce(
+        self,
+        *,
+        spec_id: str,
+        proposal_id: str,
+        requested_format: str | None = None,
+        paths: Sequence[str] | None = None,
+    ) -> PrivilegeReport:
+        report, _, archive_path, fmt = self.router.generate(
+            requested_format, paths=paths
+        )
+        self.logger.debug(
+            "ReviewBoardHook processed privilege report for %s/%s in %s format.",
+            spec_id,
+            proposal_id,
+            fmt,
+        )
+        if self.narrator:
+            self.narrator.narrate_amendment(
+                report,
+                spec_id=spec_id,
+                proposal_id=proposal_id,
+                archive_path=archive_path,
+            )
+        return report

--- a/tests/test_privilege_reporting.py
+++ b/tests/test_privilege_reporting.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from privilege_lint.metrics import MetricsCollector
+from privilege_lint.reporting import (
+    ErrorHandler,
+    JSONFormatEngine,
+    LintExecution,
+    MarkdownFormatEngine,
+    NarratorLink,
+    PrivilegeReport,
+    ReportRouter,
+    ReviewBoardHook,
+    YAMLFormatEngine,
+)
+import privilege_lint
+
+
+def _stub_execution(issues: list[str]) -> LintExecution:
+    metrics = MetricsCollector()
+    metrics.finish()
+    return LintExecution(
+        metrics=metrics,
+        issues=issues,
+        timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checked_files=[Path("/repo/app.py")],
+        project_root=Path("/repo"),
+        config_hash="abc123",
+        report_json_enabled=True,
+        sarif_enabled=False,
+    )
+
+
+class StubRunner:
+    def __init__(self, issues: list[str]) -> None:
+        self.issues = issues
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, paths, **kwargs) -> LintExecution:  # type: ignore[override]
+        self.calls.append((list(paths), kwargs))
+        return _stub_execution(self.issues)
+
+
+def _make_router(tmp_path: Path, issues: list[str]) -> ReportRouter:
+    runner = StubRunner(issues)
+    engines = [JSONFormatEngine(), YAMLFormatEngine(), MarkdownFormatEngine()]
+    return ReportRouter(
+        engines={engine.format_name: engine for engine in engines},
+        runner=runner,
+        error_handler=ErrorHandler(),
+        archive_root=tmp_path,
+        default_paths=["/repo"],
+        logger=logging.getLogger("privilege-test"),
+    )
+
+
+def test_report_router_generates_requested_format(tmp_path: Path) -> None:
+    router = _make_router(tmp_path, ["app.py:1: missing banner"])
+    report, rendered, archive_path, fmt = router.generate("yaml")
+    assert fmt == "yaml"
+    assert report.status == "violation"
+    assert "missing banner" in rendered
+    assert archive_path.suffix == ".yaml"
+    assert archive_path.read_text(encoding="utf-8") == rendered
+
+
+def test_report_router_falls_back_to_default_on_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    router = _make_router(tmp_path, [])
+    report, _, archive_path, fmt = router.generate("xml")
+    assert fmt == "json"
+    assert report.passed
+    assert archive_path.suffix == ".json"
+    assert any("defaulting" in record.message for record in caplog.records)
+
+
+def test_narrator_link_announces_states(tmp_path: Path) -> None:
+    messages: list[str] = []
+    link = NarratorLink(messages.append)
+    clean_report = PrivilegeReport(
+        status="clean",
+        timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        issues=[],
+        metrics={"files": 1, "cache_hits": 0, "runtime": 0, "rules": {}},
+        checked_files=["app.py"],
+    )
+    link.announce_boot(clean_report, archive_path=tmp_path / "clean.json")
+    link.narrate_amendment(clean_report, spec_id="spec-1", proposal_id="amend-1")
+    assert any("Sanctuary Privilege: intact" in msg for msg in messages)
+    assert any("privilege intact" in msg.lower() for msg in messages)
+
+
+def test_review_board_hook_invokes_narrator(tmp_path: Path) -> None:
+    reports: list[str] = []
+    runner = StubRunner([])
+    engines = [JSONFormatEngine(), YAMLFormatEngine(), MarkdownFormatEngine()]
+    router = ReportRouter(
+        engines={engine.format_name: engine for engine in engines},
+        runner=runner,
+        error_handler=ErrorHandler(),
+        archive_root=tmp_path,
+        default_paths=["/repo"],
+        logger=logging.getLogger("privilege-test"),
+    )
+    narrator = NarratorLink(reports.append)
+    hook = ReviewBoardHook(router, narrator=narrator)
+    report = hook.enforce(spec_id="spec-1", proposal_id="amend-1")
+    assert report.passed
+    assert reports, "Narrator should emit amendment status"
+
+
+def test_privilege_lint_report_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    stub_report = PrivilegeReport(
+        status="clean",
+        timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        issues=[],
+        metrics={"files": 0, "cache_hits": 0, "runtime": 0, "rules": {}},
+        checked_files=[],
+    )
+
+    class StubRouter:
+        def generate(self, fmt: str | None = None, *, paths=None, max_workers=None, mypy: bool = False):
+            path = tmp_path / "report.json"
+            payload = "{\n  \"status\": \"clean\"\n}"
+            path.write_text(payload, encoding="utf-8")
+            return stub_report, payload, path, fmt or "json"
+
+    monkeypatch.setattr(
+        "privilege_lint.reporting.report_router.create_default_router",
+        lambda logger=None: StubRouter(),
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        privilege_lint.cli(["report", "--format", "json"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "\"status\": \"clean\"" in captured.out


### PR DESCRIPTION
## Summary
- add a reporting subsystem with JSON, YAML, and Markdown engines plus a router CLI entrypoint
- integrate privilege lint gating with the amendment review board and narrate status during boot and amendments
- cover reporting, narration, and governance hooks with targeted pytest suites

## Testing
- pytest tests/test_privilege_reporting.py tests/test_codex_amendments.py

------
https://chatgpt.com/codex/tasks/task_b_68deed8c85448320b0e3410525b33d2d