### PR TITLE
[codex:federation] add bounded seed retrospective integrity review

### DIFF
--- a/sentientos/federation_mutation_control_preflight.py
+++ b/sentientos/federation_mutation_control_preflight.py
@@ -13,6 +13,7 @@ from sentientos.federation_bounded_lifecycle import (
 )
 from sentientos.federation_canonical_execution import BOUNDED_FEDERATION_CANONICAL_ACTIONS
 from sentientos.federation_seed_health_history import persist_bounded_federation_seed_health_history
+from sentientos.federation_seed_retrospective_integrity import derive_bounded_federation_seed_retrospective_integrity_review
 from sentientos.federation_slice_health import synthesize_bounded_federation_seed_health
 from sentientos.federation_typed_actions import federation_typed_action_diagnostic
 
@@ -135,6 +136,10 @@ def _bounded_federation_lifecycle_diagnostic(repo_root: Path | None = None) -> d
         for intent in coherence.get("trace_coherence_map", [])
         if isinstance(intent, Mapping)
     )
+    retrospective_review = derive_bounded_federation_seed_retrospective_integrity_review(
+        seed_health_history["recent_history"],
+        seed_stability=seed_health_history["stability"],
+    )
     temporal_view = {
         "current_health_status": seed_health_history["current_record"]["health_status"],
         "previous_health_status": seed_health_history["current_record"]["previous_health_status"],
@@ -142,6 +147,7 @@ def _bounded_federation_lifecycle_diagnostic(repo_root: Path | None = None) -> d
         "history_path": seed_health_history["history_path"],
         "recent_history": seed_health_history["recent_history"],
         "stability": seed_health_history["stability"],
+        "retrospective_integrity_review": retrospective_review,
     }
     return {
         "bounded_federation_seed_health": seed_health,
@@ -296,6 +302,22 @@ def build_federation_mutation_control_preflight(
                     "recovered_from_failure",
                 ],
                 "stability_classes": ["stable", "improving", "degrading", "oscillating", "insufficient_history"],
+                "retrospective_integrity_review_meaning": "bounded retrospective integrity review summarizes the dominant recent constitutional stress pattern from existing bounded lifecycle/health/stability signals.",
+                "retrospective_inputs": [
+                    "bounded federation lifecycle resolution",
+                    "bounded federation health synthesis",
+                    "bounded federation health history",
+                    "bounded federation stability/oscillation diagnostics",
+                ],
+                "retrospective_classes": [
+                    "clean_recent_history",
+                    "denial_heavy",
+                    "failure_heavy",
+                    "fragmentation_heavy",
+                    "oscillatory_instability",
+                    "mixed_stress_pattern",
+                    "insufficient_history",
+                ],
                 "does_not_do": [
                     "does not widen the federation intent slice",
                     "does not create a new governance or sovereign decision layer",

--- a/sentientos/federation_seed_retrospective_integrity.py
+++ b/sentientos/federation_seed_retrospective_integrity.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentientos.constitutional_slice_pattern import non_sovereign_diagnostic_boundaries
+
+_RETROSPECTIVE_WINDOW = 6
+_MIN_HISTORY_FOR_REVIEW = 3
+_DOMINANCE_RATIO = 0.6
+
+
+def _sum_outcome(records: list[dict[str, Any]], key: str) -> int:
+    total = 0
+    for record in records:
+        outcome_counts = record.get("outcome_counts")
+        if not isinstance(outcome_counts, dict):
+            continue
+        value = outcome_counts.get(key)
+        if isinstance(value, int):
+            total += value
+    return total
+
+
+def derive_bounded_federation_seed_retrospective_integrity_review(
+    history_records: list[dict[str, Any]],
+    *,
+    seed_stability: dict[str, Any] | None,
+    window_size: int = _RETROSPECTIVE_WINDOW,
+) -> dict[str, Any]:
+    bounded_window_size = max(1, int(window_size))
+    recent_history = history_records[-bounded_window_size:]
+    stability_classification = str((seed_stability or {}).get("classification") or "insufficient_history")
+
+    if len(recent_history) < _MIN_HISTORY_FOR_REVIEW:
+        classification = "insufficient_history"
+        basis = "need_at_least_three_recent_records"
+    else:
+        statuses = [str(record.get("health_status") or "unknown") for record in recent_history]
+        denied_total = _sum_outcome(recent_history, "denied")
+        failure_total = _sum_outcome(recent_history, "failed_after_admission")
+        fragmentation_total = _sum_outcome(recent_history, "fragmented_unresolved")
+        stress_total = denied_total + failure_total + fragmentation_total
+
+        if (
+            stability_classification == "oscillating"
+            and "healthy" in statuses
+            and any(status in {"degraded", "fragmented"} for status in statuses)
+        ):
+            classification = "oscillatory_instability"
+            basis = "stability_is_oscillating_with_mixed_recent_health_states"
+        elif stress_total == 0 and all(status == "healthy" for status in statuses):
+            classification = "clean_recent_history"
+            basis = "no_recent_denial_failure_or_fragmentation_pressure"
+        else:
+            by_class = {
+                "denial_heavy": denied_total,
+                "failure_heavy": failure_total,
+                "fragmentation_heavy": fragmentation_total,
+            }
+            dominant_label = max(by_class.items(), key=lambda item: item[1])[0]
+            dominant_total = by_class[dominant_label]
+
+            if stress_total > 0 and dominant_total >= 2 and (dominant_total / stress_total) >= _DOMINANCE_RATIO:
+                classification = dominant_label
+                basis = f"dominant_recent_stress_signal={dominant_label}"
+            elif stress_total > 0:
+                classification = "mixed_stress_pattern"
+                basis = "multiple_recent_stress_signals_without_single_dominant_class"
+            else:
+                classification = "insufficient_history"
+                basis = "insufficient_stress_evidence_for_classification"
+
+    return {
+        "scope": "bounded_federation_seed",
+        "review_kind": "retrospective_integrity_review",
+        "review_classification": classification,
+        "basis": basis,
+        "window_size": bounded_window_size,
+        "records_considered": len(recent_history),
+        "stability_classification": stability_classification,
+        "retrospective_support_signal_only": True,
+        "does_not_change_admission_or_readiness": True,
+        **non_sovereign_diagnostic_boundaries(
+            derived_from=[
+                "sentientos.federation_bounded_lifecycle.resolve_bounded_federation_lifecycle",
+                "sentientos.federation_slice_health.synthesize_bounded_federation_seed_health",
+                "sentientos.federation_seed_health_history.persist_bounded_federation_seed_health_history",
+                "sentientos.federation_seed_health_history.derive_bounded_federation_seed_stability",
+            ],
+        ),
+    }
+
+
+__all__ = ["derive_bounded_federation_seed_retrospective_integrity_review"]

--- a/sentientos/tests/test_federation_mutation_control_preflight.py
+++ b/sentientos/tests/test_federation_mutation_control_preflight.py
@@ -112,3 +112,43 @@ def test_preflight_exposes_bounded_seed_health_summary() -> None:
     temporal_view = lifecycle_diag["bounded_federation_seed_temporal_view"]
     assert temporal_view["history_path"].endswith("bounded_seed_health_history.jsonl")
     assert temporal_view["current_health_status"] in {"healthy", "degraded", "fragmented"}
+    retrospective = temporal_view["retrospective_integrity_review"]
+    assert retrospective["review_kind"] == "retrospective_integrity_review"
+    assert retrospective["review_classification"] in {
+        "clean_recent_history",
+        "denial_heavy",
+        "failure_heavy",
+        "fragmentation_heavy",
+        "oscillatory_instability",
+        "mixed_stress_pattern",
+        "insufficient_history",
+    }
+    assert retrospective["diagnostic_only"] is True
+    assert retrospective["non_authoritative"] is True
+    assert retrospective["decision_power"] == "none"
+    assert retrospective["retrospective_support_signal_only"] is True
+    assert retrospective["does_not_change_admission_or_readiness"] is True
+
+
+def test_retrospective_review_does_not_change_readiness_or_authority_surfaces() -> None:
+    baseline = build_federation_mutation_control_preflight()
+    stressed = build_federation_mutation_control_preflight(
+        {
+            "required_layer_classification": {
+                "typed_action_model": "present",
+                "canonical_router_handler_viability": "present",
+                "success_denial_admitted_failure_clarity": "present",
+                "proof_visible_artifact_boundaries": "present",
+                "trace_requirements": "present",
+                "diagnostic_layer_prerequisites": "present",
+                "authority_of_judgment_clarity": "present",
+                "non_sovereign_boundary_compatibility": "present",
+            }
+        }
+    )
+
+    assert baseline["readiness_verdict"] == "ready_for_initial_slice_onboarding"
+    assert stressed["readiness_verdict"] == "ready_for_initial_slice_onboarding"
+    retro = stressed["bounded_federation_lifecycle_diagnostic"]["bounded_federation_seed_temporal_view"]["retrospective_integrity_review"]
+    assert retro["does_not_change_admission_or_readiness"] is True
+    assert retro["decision_power"] == "none"

--- a/sentientos/tests/test_federation_seed_retrospective_integrity.py
+++ b/sentientos/tests/test_federation_seed_retrospective_integrity.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+
+from sentientos.federation_seed_retrospective_integrity import derive_bounded_federation_seed_retrospective_integrity_review
+
+
+def _record(*, health_status: str, denied: int = 0, failed: int = 0, fragmented: int = 0, transition: str = "unchanged") -> dict[str, object]:
+    return {
+        "health_status": health_status,
+        "transition_classification": transition,
+        "outcome_counts": {
+            "success": 3 - min(3, denied + failed + fragmented),
+            "denied": denied,
+            "failed_after_admission": failed,
+            "fragmented_unresolved": fragmented,
+        },
+    }
+
+
+def _review(history: list[dict[str, object]], *, stability: str = "stable") -> dict[str, object]:
+    return derive_bounded_federation_seed_retrospective_integrity_review(
+        history,
+        seed_stability={"classification": stability},
+    )
+
+
+def test_classifies_clean_recent_history() -> None:
+    review = _review([_record(health_status="healthy"), _record(health_status="healthy"), _record(health_status="healthy")])
+    assert review["review_classification"] == "clean_recent_history", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_denial_heavy() -> None:
+    review = _review(
+        [
+            _record(health_status="healthy", denied=3),
+            _record(health_status="healthy", denied=2),
+            _record(health_status="healthy", denied=3),
+            _record(health_status="healthy"),
+        ]
+    )
+    assert review["review_classification"] == "denial_heavy", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_failure_heavy() -> None:
+    review = _review(
+        [
+            _record(health_status="degraded", failed=1),
+            _record(health_status="degraded", failed=2),
+            _record(health_status="degraded", failed=2),
+            _record(health_status="healthy"),
+        ]
+    )
+    assert review["review_classification"] == "failure_heavy", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_fragmentation_heavy() -> None:
+    review = _review(
+        [
+            _record(health_status="fragmented", fragmented=2),
+            _record(health_status="fragmented", fragmented=3),
+            _record(health_status="fragmented", fragmented=2),
+            _record(health_status="healthy"),
+        ]
+    )
+    assert review["review_classification"] == "fragmentation_heavy", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_oscillatory_instability() -> None:
+    review = _review(
+        [
+            _record(health_status="healthy", denied=1),
+            _record(health_status="degraded", failed=1),
+            _record(health_status="healthy", denied=1),
+            _record(health_status="degraded", failed=1),
+        ],
+        stability="oscillating",
+    )
+    assert review["review_classification"] == "oscillatory_instability", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_mixed_stress_pattern() -> None:
+    review = _review(
+        [
+            _record(health_status="healthy", denied=1),
+            _record(health_status="degraded", failed=1),
+            _record(health_status="fragmented", fragmented=1),
+        ]
+    )
+    assert review["review_classification"] == "mixed_stress_pattern", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_classifies_insufficient_history() -> None:
+    review = _review([_record(health_status="healthy"), _record(health_status="healthy")])
+    assert review["review_classification"] == "insufficient_history", json.dumps(review, indent=2, sort_keys=True)
+
+
+def test_retrospective_is_explicitly_non_sovereign() -> None:
+    review = _review([_record(health_status="healthy"), _record(health_status="healthy"), _record(health_status="healthy")])
+    assert review["diagnostic_only"] is True
+    assert review["non_authoritative"] is True
+    assert review["decision_power"] == "none"
+    assert review["retrospective_support_signal_only"] is True
+    assert review["does_not_change_admission_or_readiness"] is True


### PR DESCRIPTION
### Motivation
- Provide a small, conservative, machine-readable retrospective integrity review for the bounded federation canonical seed so the repo can summarize dominant recent constitutional stress patterns without introducing any new authority surfaces. 
- Keep the review diagnostic-only, derived strictly from existing bounded signals (lifecycle → health → history → stability), and preserve explicit non-sovereign boundaries so it cannot affect admission or runtime behavior. 

### Description
- Add `sentientos/federation_seed_retrospective_integrity.py` with `derive_bounded_federation_seed_retrospective_integrity_review`, a bounded classifier that returns one of: `clean_recent_history`, `denial_heavy`, `failure_heavy`, `fragmentation_heavy`, `oscillatory_instability`, `mixed_stress_pattern`, `insufficient_history`. 
- Wire the derived retrospective into the existing consumer by attaching it as `bounded_federation_seed_temporal_view["retrospective_integrity_review"]` inside `build_federation_mutation_control_preflight` without changing readiness or admission semantics. 
- Extend the federation onboarding note to describe inputs, allowed retrospective classes, and explicit limits (diagnostic-only, `decision_power: none`, `retrospective_support_signal_only`, `does_not_change_admission_or_readiness`). 
- Add focused tests in `sentientos/tests/test_federation_seed_retrospective_integrity.py` and extend `sentientos/tests/test_federation_mutation_control_preflight.py` to assert classification behavior, consumer exposure, and preserved non-sovereign guarantees. 

### Testing
- Ran targeted unit tests `pytest -q sentientos/tests/test_federation_seed_retrospective_integrity.py sentientos/tests/test_federation_mutation_control_preflight.py sentientos/tests/test_federation_seed_health_history.py` and they passed. 
- Re-ran the two-file smoke check `pytest -q sentientos/tests/test_federation_seed_retrospective_integrity.py sentientos/tests/test_federation_mutation_control_preflight.py` and it passed. 
- Ran `python scripts/audit_immutability_verifier.py` which completed successfully, and attempted `verify_audits --strict` which is unavailable in this environment. 
- Repository-wide checks show pre-existing issues: `mypy scripts/ sentientos/` reports multiple unrelated type errors, and `python -m scripts.run_tests -q` fails on unrelated `pulse_federation` tests; these failures are outside the scope of this change and do not affect the new retrospective classifier or its narrow consumer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7d9311f9483208f820603f98f973c)