### PR TITLE
[codex:federation] add bounded operator attention recommendation for federation seed

### DIFF
--- a/sentientos/federation_mutation_control_preflight.py
+++ b/sentientos/federation_mutation_control_preflight.py
@@ -12,6 +12,7 @@ from sentientos.federation_bounded_lifecycle import (
     build_bounded_federation_trace_coherence_map,
 )
 from sentientos.federation_canonical_execution import BOUNDED_FEDERATION_CANONICAL_ACTIONS
+from sentientos.federation_seed_attention_recommendation import derive_bounded_federation_seed_attention_recommendation
 from sentientos.federation_seed_health_history import persist_bounded_federation_seed_health_history
 from sentientos.federation_seed_retrospective_integrity import derive_bounded_federation_seed_retrospective_integrity_review
 from sentientos.federation_slice_health import synthesize_bounded_federation_seed_health
@@ -140,6 +141,12 @@ def _bounded_federation_lifecycle_diagnostic(repo_root: Path | None = None) -> d
         seed_health_history["recent_history"],
         seed_stability=seed_health_history["stability"],
     )
+    attention_recommendation = derive_bounded_federation_seed_attention_recommendation(
+        seed_health=seed_health,
+        seed_health_history=seed_health_history,
+        seed_stability=seed_health_history["stability"],
+        retrospective_integrity_review=retrospective_review,
+    )
     temporal_view = {
         "current_health_status": seed_health_history["current_record"]["health_status"],
         "previous_health_status": seed_health_history["current_record"]["previous_health_status"],
@@ -148,6 +155,7 @@ def _bounded_federation_lifecycle_diagnostic(repo_root: Path | None = None) -> d
         "recent_history": seed_health_history["recent_history"],
         "stability": seed_health_history["stability"],
         "retrospective_integrity_review": retrospective_review,
+        "operator_attention_recommendation": attention_recommendation,
     }
     return {
         "bounded_federation_seed_health": seed_health,
@@ -318,11 +326,28 @@ def build_federation_mutation_control_preflight(
                     "mixed_stress_pattern",
                     "insufficient_history",
                 ],
+                "operator_attention_recommendation_meaning": "bounded operator-facing recommendation summarizes what human attention class is likely useful now, based only on existing retrospective review plus current bounded seed health/stability signals.",
+                "operator_attention_recommendation_inputs": [
+                    "bounded federation health synthesis",
+                    "bounded federation health history",
+                    "bounded federation stability/oscillation diagnostics",
+                    "bounded federation retrospective integrity review",
+                ],
+                "operator_attention_recommendation_values": [
+                    "none",
+                    "observe",
+                    "inspect_recent_failures",
+                    "inspect_fragmentation",
+                    "watch_for_oscillation",
+                    "review_mixed_stress",
+                    "insufficient_context",
+                ],
                 "does_not_do": [
                     "does not widen the federation intent slice",
                     "does not create a new governance or sovereign decision layer",
                     "does not build repo-wide history/trend governance",
                     "does not change admission, readiness verdicts, or runtime governor decisions",
+                    "does not create approval workflow, authority, or automation",
                 ],
                 "explicit_non_authority": "support-only observability signal; does not alter admission, mergeability, runtime governor behavior, or federation adjudication authority.",
             },

--- a/sentientos/federation_seed_attention_recommendation.py
+++ b/sentientos/federation_seed_attention_recommendation.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentientos.constitutional_slice_pattern import non_sovereign_diagnostic_boundaries
+
+_FEDERATION_ATTENTION_RECOMMENDATIONS = {
+    "none",
+    "observe",
+    "inspect_recent_failures",
+    "inspect_fragmentation",
+    "watch_for_oscillation",
+    "review_mixed_stress",
+    "insufficient_context",
+}
+
+
+def derive_bounded_federation_seed_attention_recommendation(
+    *,
+    seed_health: dict[str, Any],
+    seed_health_history: dict[str, Any],
+    seed_stability: dict[str, Any],
+    retrospective_integrity_review: dict[str, Any],
+) -> dict[str, Any]:
+    """Derive one bounded, operator-facing recommendation for federation seed attention."""
+
+    review_classification = str(retrospective_integrity_review.get("review_classification") or "insufficient_history")
+    stability_classification = str(seed_stability.get("classification") or "insufficient_history")
+    seed_health_status = str(seed_health.get("health_status") or "unknown")
+    records_considered = int(retrospective_integrity_review.get("records_considered") or 0)
+
+    if review_classification == "insufficient_history" or stability_classification == "insufficient_history" or records_considered < 3:
+        recommendation = "insufficient_context"
+        basis = "insufficient_recent_bounded_federation_seed_context_for_attention_guidance"
+    elif review_classification == "clean_recent_history" and seed_health_status == "healthy" and stability_classification in {"stable", "improving"}:
+        recommendation = "none"
+        basis = "clean_recent_history_with_healthy_seed_and_non_degrading_stability"
+    elif review_classification == "denial_heavy":
+        recommendation = "observe"
+        basis = "retrospective_review_denial_heavy"
+    elif review_classification == "failure_heavy":
+        recommendation = "inspect_recent_failures"
+        basis = "retrospective_review_failure_heavy"
+    elif review_classification == "fragmentation_heavy":
+        recommendation = "inspect_fragmentation"
+        basis = "retrospective_review_fragmentation_heavy"
+    elif review_classification == "oscillatory_instability":
+        recommendation = "watch_for_oscillation"
+        basis = "retrospective_review_oscillatory_instability"
+    elif review_classification == "mixed_stress_pattern":
+        recommendation = "review_mixed_stress"
+        basis = "retrospective_review_mixed_stress_pattern"
+    else:
+        recommendation = "observe"
+        basis = "unrecognized_retrospective_classification_fallback"
+
+    if recommendation not in _FEDERATION_ATTENTION_RECOMMENDATIONS:
+        recommendation = "insufficient_context"
+        basis = "recommendation_guardrail_fallback"
+
+    return {
+        "scope": "bounded_federation_seed",
+        "recommendation_kind": "operator_attention_recommendation",
+        "recommended_attention": recommendation,
+        "basis": basis,
+        "review_classification": review_classification,
+        "seed_health_status": seed_health_status,
+        "stability_classification": stability_classification,
+        "records_considered": records_considered,
+        "recommendation_only": True,
+        "does_not_change_admission_or_readiness": True,
+        "does_not_change_authority_or_execution": True,
+        "allowed_recommendations": sorted(_FEDERATION_ATTENTION_RECOMMENDATIONS),
+        "history_source": seed_health_history.get("history_path"),
+        **non_sovereign_diagnostic_boundaries(
+            derived_from=[
+                "sentientos.federation_slice_health.synthesize_bounded_federation_seed_health",
+                "sentientos.federation_seed_health_history.persist_bounded_federation_seed_health_history",
+                "sentientos.federation_seed_health_history.derive_bounded_federation_seed_stability",
+                "sentientos.federation_seed_retrospective_integrity.derive_bounded_federation_seed_retrospective_integrity_review",
+            ],
+        ),
+    }
+
+
+__all__ = ["derive_bounded_federation_seed_attention_recommendation"]

--- a/sentientos/tests/test_federation_mutation_control_preflight.py
+++ b/sentientos/tests/test_federation_mutation_control_preflight.py
@@ -128,6 +128,23 @@ def test_preflight_exposes_bounded_seed_health_summary() -> None:
     assert retrospective["decision_power"] == "none"
     assert retrospective["retrospective_support_signal_only"] is True
     assert retrospective["does_not_change_admission_or_readiness"] is True
+    recommendation = temporal_view["operator_attention_recommendation"]
+    assert recommendation["recommendation_kind"] == "operator_attention_recommendation"
+    assert recommendation["recommended_attention"] in {
+        "none",
+        "observe",
+        "inspect_recent_failures",
+        "inspect_fragmentation",
+        "watch_for_oscillation",
+        "review_mixed_stress",
+        "insufficient_context",
+    }
+    assert recommendation["diagnostic_only"] is True
+    assert recommendation["recommendation_only"] is True
+    assert recommendation["non_authoritative"] is True
+    assert recommendation["decision_power"] == "none"
+    assert recommendation["does_not_change_admission_or_readiness"] is True
+    assert recommendation["does_not_change_authority_or_execution"] is True
 
 
 def test_retrospective_review_does_not_change_readiness_or_authority_surfaces() -> None:
@@ -150,5 +167,10 @@ def test_retrospective_review_does_not_change_readiness_or_authority_surfaces() 
     assert baseline["readiness_verdict"] == "ready_for_initial_slice_onboarding"
     assert stressed["readiness_verdict"] == "ready_for_initial_slice_onboarding"
     retro = stressed["bounded_federation_lifecycle_diagnostic"]["bounded_federation_seed_temporal_view"]["retrospective_integrity_review"]
+    recommendation = stressed["bounded_federation_lifecycle_diagnostic"]["bounded_federation_seed_temporal_view"][
+        "operator_attention_recommendation"
+    ]
     assert retro["does_not_change_admission_or_readiness"] is True
     assert retro["decision_power"] == "none"
+    assert recommendation["does_not_change_admission_or_readiness"] is True
+    assert recommendation["decision_power"] == "none"

--- a/sentientos/tests/test_federation_seed_attention_recommendation.py
+++ b/sentientos/tests/test_federation_seed_attention_recommendation.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from sentientos.federation_seed_attention_recommendation import derive_bounded_federation_seed_attention_recommendation
+
+
+def _recommendation(
+    *,
+    review_classification: str,
+    stability_classification: str = "stable",
+    seed_health_status: str = "healthy",
+    records_considered: int = 4,
+) -> dict[str, object]:
+    return derive_bounded_federation_seed_attention_recommendation(
+        seed_health={"health_status": seed_health_status},
+        seed_health_history={"history_path": "glow/federation/bounded_seed_health_history.jsonl"},
+        seed_stability={"classification": stability_classification},
+        retrospective_integrity_review={
+            "review_classification": review_classification,
+            "records_considered": records_considered,
+        },
+    )
+
+
+def test_recommendation_none_for_clean_stable() -> None:
+    recommendation = _recommendation(review_classification="clean_recent_history")
+    assert recommendation["recommended_attention"] == "none"
+
+
+def test_recommendation_observe_for_denial_heavy() -> None:
+    recommendation = _recommendation(review_classification="denial_heavy")
+    assert recommendation["recommended_attention"] == "observe"
+
+
+def test_recommendation_inspect_recent_failures_for_failure_heavy() -> None:
+    recommendation = _recommendation(review_classification="failure_heavy")
+    assert recommendation["recommended_attention"] == "inspect_recent_failures"
+
+
+def test_recommendation_inspect_fragmentation_for_fragmentation_heavy() -> None:
+    recommendation = _recommendation(review_classification="fragmentation_heavy")
+    assert recommendation["recommended_attention"] == "inspect_fragmentation"
+
+
+def test_recommendation_watch_for_oscillation_for_oscillatory_instability() -> None:
+    recommendation = _recommendation(review_classification="oscillatory_instability", stability_classification="oscillating")
+    assert recommendation["recommended_attention"] == "watch_for_oscillation"
+
+
+def test_recommendation_review_mixed_stress_for_mixed_pattern() -> None:
+    recommendation = _recommendation(review_classification="mixed_stress_pattern")
+    assert recommendation["recommended_attention"] == "review_mixed_stress"
+
+
+def test_recommendation_insufficient_context_for_insufficient_history() -> None:
+    recommendation = _recommendation(review_classification="insufficient_history", records_considered=2)
+    assert recommendation["recommended_attention"] == "insufficient_context"


### PR DESCRIPTION
### Motivation

- Provide a small, conservative, machine-readable operator-facing recommendation derived only from existing bounded federation diagnostics so operators know what human attention class is likely useful now. 
- Preserve explicit non-sovereign boundaries and avoid introducing new intents, governance, authority, or automated decisioning.

### Description

- Add `derive_bounded_federation_seed_attention_recommendation` (new file `sentientos/federation_seed_attention_recommendation.py`) with a small allowed vocabulary: `none`, `observe`, `inspect_recent_failures`, `inspect_fragmentation`, `watch_for_oscillation`, `review_mixed_stress`, and `insufficient_context`.
- Derive recommendations conservatively from only existing signals: bounded seed health (`seed_health`), seed health history (`seed_health_history`), stability (`seed_stability`), and the retrospective integrity review (`retrospective_integrity_review`).
- Wire the recommendation into the bounded federation temporal diagnostic/preflight consumer as `operator_attention_recommendation` in `sentientos/federation_mutation_control_preflight.py` and document meaning, inputs, allowed values, and explicit non-authority limitations in the onboarding note.
- Add focused unit tests (`sentientos/tests/test_federation_seed_attention_recommendation.py`) and extend preflight tests to assert the consumer exposes the recommendation and that the recommendation remains diagnostic-only.

### Testing

- Ran targeted pytest for the new and updated tests with `python -m pytest -q sentientos/tests/test_federation_seed_attention_recommendation.py sentientos/tests/test_federation_mutation_control_preflight.py`, and those tests passed.
- Ran `mypy scripts/ sentientos/` which failed due to pre-existing, repository-wide typing errors unrelated to this change.
- Ran the repository test harness `python -m scripts.run_tests -q` which failed due to unrelated `tests/test_pulse_federation.py` protocol-compatibility expectations and is not caused by this patch.
- Attempted `verify_audits --strict` which is not available in this environment (`command not found`).
- Ran `python scripts/audit_immutability_verifier.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d813e466bc8320b732bf1b8948f4d0)