### PR TITLE
[codex:federation] onboard bounded replay-receipt increment via scaffold

### DIFF
--- a/sentientos/daemons/pulse_federation.py
+++ b/sentientos/daemons/pulse_federation.py
@@ -603,6 +603,50 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
         )
         raise ValueError(f"Federated protocol incompatible for {peer_name}")
     if replay_classification in {"incompatible_replay_policy", "peer_too_stale_for_replay_horizon"}:
+        typed_replay_gate = resolve_federation_typed_action_id(replay_classification=replay_classification)
+        try:
+            replay_gate_result = get_federation_canonical_execution_router().execute(
+                typed_action_id=str(typed_replay_gate or ""),
+                peer_name=peer_name,
+                action_kind="federated_control",
+                target_subsystem=f"{peer_name}:replay",
+                correlation_id=correlation_id,
+                metadata={
+                    "correlation_id": correlation_id,
+                    "subject": f"{peer_name}:replay",
+                    "scope": "federated",
+                    "event_type": str(payload.get("event_type", "")),
+                    "replay_horizon_classification": replay_classification,
+                    "replay_horizon_detail": dict(replay_detail),
+                    "protocol_compatibility": protocol_compatibility,
+                },
+                handler=lambda: {"gate": "ingest_replay_admission_gate", "classification": replay_classification},
+            )
+        except ValueError as exc:
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_replay_admission_gate",
+                decision="deny",
+                reason=str(exc),
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+            )
+            raise ValueError(f"Federated replay admission gate failed closed for {peer_name}: {exc}") from exc
+        if replay_gate_result.canonical_outcome != "admitted_succeeded":
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="denied_replay_horizon",
+                decision="deny",
+                reason=f"replay:{replay_classification}",
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+                canonical_outcome=replay_gate_result.canonical_outcome,
+                admission_decision_ref=replay_gate_result.admission_decision_ref,
+                canonical_handler=replay_gate_result.canonical_handler,
+            )
+            raise ValueError(f"Federated replay policy/horizon denied for {peer_name}: {replay_classification}")
         _record_federation_ingest(
             peer_name=peer_name,
             event=payload,
@@ -610,9 +654,57 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
             decision="deny",
             reason=f"replay:{replay_classification}",
             correlation_id=correlation_id,
+            typed_action_id=typed_replay_gate,
+            canonical_outcome=replay_gate_result.canonical_outcome,
+            admission_decision_ref=replay_gate_result.admission_decision_ref,
+            canonical_handler=replay_gate_result.canonical_handler,
         )
         raise ValueError(f"Federated replay policy/horizon denied for {peer_name}: {replay_classification}")
     if replay_classification == "peer_outside_accepted_replay_horizon":
+        typed_replay_gate = resolve_federation_typed_action_id(replay_classification=replay_classification)
+        try:
+            replay_gate_result = get_federation_canonical_execution_router().execute(
+                typed_action_id=str(typed_replay_gate or ""),
+                peer_name=peer_name,
+                action_kind="federated_control",
+                target_subsystem=f"{peer_name}:replay",
+                correlation_id=correlation_id,
+                metadata={
+                    "correlation_id": correlation_id,
+                    "subject": f"{peer_name}:replay",
+                    "scope": "federated",
+                    "event_type": str(payload.get("event_type", "")),
+                    "replay_horizon_classification": replay_classification,
+                    "replay_horizon_detail": dict(replay_detail),
+                    "protocol_compatibility": protocol_compatibility,
+                },
+                handler=lambda: {"gate": "ingest_replay_admission_gate", "classification": replay_classification},
+            )
+        except ValueError as exc:
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_replay_admission_gate",
+                decision="deny",
+                reason=str(exc),
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+            )
+            raise ValueError(f"Federated replay admission gate failed closed for {peer_name}: {exc}") from exc
+        if replay_gate_result.canonical_outcome != "admitted_succeeded":
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_replay_admission_gate",
+                decision="deny",
+                reason=f"replay:{replay_classification}",
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+                canonical_outcome=replay_gate_result.canonical_outcome,
+                admission_decision_ref=replay_gate_result.admission_decision_ref,
+                canonical_handler=replay_gate_result.canonical_handler,
+            )
+            raise ValueError(f"Federated replay admission gate failed closed for {peer_name}: {replay_classification}")
         _record_federation_ingest(
             peer_name=peer_name,
             event=payload,
@@ -620,6 +712,10 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
             decision="drop",
             reason="signed_but_outside_control_horizon",
             correlation_id=correlation_id,
+            typed_action_id=typed_replay_gate,
+            canonical_outcome=replay_gate_result.canonical_outcome,
+            admission_decision_ref=replay_gate_result.admission_decision_ref,
+            canonical_handler=replay_gate_result.canonical_handler,
         )
         return payload
     if equivocation_classification in {
@@ -627,6 +723,57 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
         "protocol_claim_conflict",
         "replay_claim_conflict",
     }:
+        typed_receipt_gate = resolve_federation_typed_action_id(
+            receipt_consistency_classification=equivocation_classification
+        )
+        try:
+            consistency_gate_result = get_federation_canonical_execution_router().execute(
+                typed_action_id=str(typed_receipt_gate or ""),
+                peer_name=peer_name,
+                action_kind="federated_control",
+                target_subsystem=f"{peer_name}:receipt",
+                correlation_id=correlation_id,
+                metadata={
+                    "correlation_id": correlation_id,
+                    "subject": f"{peer_name}:receipt",
+                    "scope": "federated",
+                    "event_type": str(payload.get("event_type", "")),
+                    "equivocation_classification": equivocation_classification,
+                    "evidence_count": len(equivocation_rows),
+                    "protocol_compatibility": protocol_compatibility,
+                    "replay_horizon_classification": replay_classification,
+                },
+                handler=lambda: (
+                    {"gate": "replay_or_receipt_consistency_gate", "classification": equivocation_classification}
+                    if equivocation_classification != "confirmed_equivocation"
+                    else (_ for _ in ()).throw(ValueError(f"receipt_consistency:{equivocation_classification}"))
+                ),
+            )
+        except ValueError as exc:
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_receipt_consistency",
+                decision="deny",
+                reason=str(exc),
+                correlation_id=correlation_id,
+                typed_action_id=typed_receipt_gate,
+            )
+            raise ValueError(f"Federated receipt consistency gate failed closed for {peer_name}: {exc}") from exc
+        if consistency_gate_result.canonical_outcome != "admitted_succeeded":
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="denied_equivocation",
+                decision="deny",
+                reason=f"equivocation:{equivocation_classification}",
+                correlation_id=correlation_id,
+                typed_action_id=typed_receipt_gate,
+                canonical_outcome=consistency_gate_result.canonical_outcome,
+                admission_decision_ref=consistency_gate_result.admission_decision_ref,
+                canonical_handler=consistency_gate_result.canonical_handler,
+            )
+            raise ValueError(f"Federated equivocation denied for {peer_name}: {equivocation_classification}")
         _record_federation_ingest(
             peer_name=peer_name,
             event=payload,
@@ -634,6 +781,10 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
             decision="deny",
             reason=f"equivocation:{equivocation_classification}",
             correlation_id=correlation_id,
+            typed_action_id=typed_receipt_gate,
+            canonical_outcome=consistency_gate_result.canonical_outcome,
+            admission_decision_ref=consistency_gate_result.admission_decision_ref,
+            canonical_handler=consistency_gate_result.canonical_handler,
         )
         get_trust_ledger().record_control_attempt(
             peer_name,
@@ -729,6 +880,50 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
     correlation_id = str(payload.get("correlation_id") or candidate_hash)
     if _is_duplicate_event_hash(candidate_hash):
         logger.info("Suppressed duplicate federated pulse event hash=%s peer=%s", candidate_hash, peer_name)
+        typed_replay_gate = resolve_federation_typed_action_id(replay_classification="duplicate_event_hash")
+        try:
+            replay_gate_result = get_federation_canonical_execution_router().execute(
+                typed_action_id=str(typed_replay_gate or ""),
+                peer_name=peer_name,
+                action_kind="federated_control",
+                target_subsystem=f"{peer_name}:replay",
+                correlation_id=correlation_id,
+                metadata={
+                    "correlation_id": correlation_id,
+                    "subject": f"{peer_name}:replay",
+                    "scope": "federated",
+                    "event_type": str(payload.get("event_type", "")),
+                    "replay_horizon_classification": "duplicate_event_hash",
+                    "event_hash": candidate_hash,
+                    "protocol_compatibility": protocol_compatibility,
+                },
+                handler=lambda: {"gate": "ingest_replay_admission_gate", "classification": "duplicate_event_hash"},
+            )
+        except ValueError as exc:
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_replay_admission_gate",
+                decision="deny",
+                reason=str(exc),
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+            )
+            raise ValueError(f"Federated replay admission gate failed closed for {peer_name}: {exc}") from exc
+        if replay_gate_result.canonical_outcome != "admitted_succeeded":
+            _record_federation_ingest(
+                peer_name=peer_name,
+                event=payload,
+                classification="failed_closed_replay_admission_gate",
+                decision="deny",
+                reason="duplicate_event_hash",
+                correlation_id=correlation_id,
+                typed_action_id=typed_replay_gate,
+                canonical_outcome=replay_gate_result.canonical_outcome,
+                admission_decision_ref=replay_gate_result.admission_decision_ref,
+                canonical_handler=replay_gate_result.canonical_handler,
+            )
+            raise ValueError(f"Federated replay admission gate denied duplicate from {peer_name}")
         trust_ledger.record_replay_signal(peer_name, actor="pulse_federation_ingest", event_hash=candidate_hash)
         _record_federation_ingest(
             peer_name=peer_name,
@@ -737,7 +932,10 @@ def ingest_remote_event(event: pulse_bus.PulseEvent, peer_name: str) -> pulse_bu
             decision="drop",
             reason="duplicate_event_hash",
             correlation_id=correlation_id,
-            typed_action_id=typed_from_payload,
+            typed_action_id=typed_replay_gate,
+            canonical_outcome=replay_gate_result.canonical_outcome,
+            admission_decision_ref=replay_gate_result.admission_decision_ref,
+            canonical_handler=replay_gate_result.canonical_handler,
         )
         return payload
     if isinstance(event_payload, dict):

--- a/sentientos/federation_canonical_execution.py
+++ b/sentientos/federation_canonical_execution.py
@@ -19,6 +19,8 @@ BOUNDED_FEDERATION_CANONICAL_ACTIONS: tuple[str, ...] = (
     "sentientos.federation.restart_daemon_request",
     "sentientos.federation.governance_digest_or_quorum_denial_gate",
     "sentientos.federation.epoch_or_trust_posture_gate",
+    "sentientos.federation.replay_or_receipt_consistency_gate",
+    "sentientos.federation.ingest_replay_admission_gate",
 )
 
 
@@ -26,6 +28,8 @@ _CANONICAL_HANDLER_REGISTRY: dict[str, str] = {
     "sentientos.federation.restart_daemon_request": "sentientos.daemons.pulse_federation._canonical_restart_daemon_handler.v1",
     "sentientos.federation.governance_digest_or_quorum_denial_gate": "sentientos.daemons.pulse_federation._canonical_governance_gate_handler.v1",
     "sentientos.federation.epoch_or_trust_posture_gate": "sentientos.daemons.pulse_federation._canonical_epoch_trust_gate_handler.v1",
+    "sentientos.federation.replay_or_receipt_consistency_gate": "sentientos.daemons.pulse_federation._canonical_replay_receipt_consistency_gate_handler.v1",
+    "sentientos.federation.ingest_replay_admission_gate": "sentientos.daemons.pulse_federation._canonical_ingest_replay_admission_gate_handler.v1",
 }
 
 

--- a/sentientos/federation_mutation_control_preflight.py
+++ b/sentientos/federation_mutation_control_preflight.py
@@ -295,7 +295,7 @@ def build_federation_mutation_control_preflight(
             "cleared_prerequisite": "canonical_execution_seed_for_bounded_federation_intents",
             "next_prerequisite_unlocked": "next bounded federation expansion can reuse canonical proof-visible admission/outcome linkage and lifecycle resolution checks",
             "bounded_seed_health_note": {
-                "meaning": "bounded federation seed health is a diagnostic synthesis over latest resolved lifecycle outcomes for the three in-scope typed federation intents.",
+                "meaning": "bounded federation seed health is a diagnostic synthesis over latest resolved lifecycle outcomes for the current in-scope typed federation intents.",
                 "history_meaning": "bounded temporal history records the current health snapshot with previous status and one conservative transition classification per evaluation.",
                 "stability_meaning": "bounded stability is a derived, windowed diagnostic over recent seed-health history transitions and existing fragmentation/admitted-failure markers.",
                 "stability_window": "latest six bounded history records",

--- a/sentientos/federation_slice_pattern.py
+++ b/sentientos/federation_slice_pattern.py
@@ -26,6 +26,8 @@ CURRENT_SEED_SPECIFIC_FEDERATION_PATTERN_LAYERS: tuple[str, ...] = (
     "restart_daemon_request_intent",
     "governance_digest_or_quorum_denial_gate_intent",
     "epoch_or_trust_posture_gate_intent",
+    "replay_or_receipt_consistency_gate_intent",
+    "ingest_replay_admission_gate_intent",
 )
 
 
@@ -85,6 +87,8 @@ def build_bounded_federation_seed_scaffold() -> FederationSliceScaffold:
         "sentientos.federation.restart_daemon_request",
         "sentientos.federation.governance_digest_or_quorum_denial_gate",
         "sentientos.federation.epoch_or_trust_posture_gate",
+        "sentientos.federation.replay_or_receipt_consistency_gate",
+        "sentientos.federation.ingest_replay_admission_gate",
     )
     return FederationSliceScaffold(
         slice_id="bounded_federation_seed",
@@ -92,6 +96,8 @@ def build_bounded_federation_seed_scaffold() -> FederationSliceScaffold:
             "federation.restart_daemon_request",
             "federation.governance_digest_or_quorum_denial_gate",
             "federation.epoch_or_trust_posture_gate",
+            "federation.replay_or_receipt_consistency_gate",
+            "federation.ingest_replay_admission_gate",
         ),
         typed_action_ids=typed_action_ids,
         canonical_ingress_surfaces=(
@@ -102,6 +108,8 @@ def build_bounded_federation_seed_scaffold() -> FederationSliceScaffold:
             "sentientos.federation.restart_daemon_request": "sentientos.daemons.pulse_federation._canonical_restart_daemon_handler.v1",
             "sentientos.federation.governance_digest_or_quorum_denial_gate": "sentientos.daemons.pulse_federation._canonical_governance_gate_handler.v1",
             "sentientos.federation.epoch_or_trust_posture_gate": "sentientos.daemons.pulse_federation._canonical_epoch_trust_gate_handler.v1",
+            "sentientos.federation.replay_or_receipt_consistency_gate": "sentientos.daemons.pulse_federation._canonical_replay_receipt_consistency_gate_handler.v1",
+            "sentientos.federation.ingest_replay_admission_gate": "sentientos.daemons.pulse_federation._canonical_ingest_replay_admission_gate_handler.v1",
         },
         proof_visible_artifact_boundaries={
             "sentientos.federation.restart_daemon_request": (
@@ -114,6 +122,14 @@ def build_bounded_federation_seed_scaffold() -> FederationSliceScaffold:
             ),
             "sentientos.federation.epoch_or_trust_posture_gate": (
                 "glow/control_plane/kernel_decisions.jsonl:reason_codes+delegated_outcomes.federation_context",
+                "glow/federation/canonical_execution.jsonl:canonical_handler+admission_decision_ref",
+            ),
+            "sentientos.federation.replay_or_receipt_consistency_gate": (
+                "glow/federation/ingest_classifications.jsonl:event_type+typed_action_id",
+                "glow/federation/canonical_execution.jsonl:canonical_handler+admission_decision_ref",
+            ),
+            "sentientos.federation.ingest_replay_admission_gate": (
+                "glow/federation/ingest_classifications.jsonl:event_type+typed_action_id",
                 "glow/federation/canonical_execution.jsonl:canonical_handler+admission_decision_ref",
             ),
         },
@@ -307,6 +323,27 @@ def bounded_federation_slice_onboarding_note() -> dict[str, Any]:
                 "explicit proof-visible boundary declarations for replay/receipt artifacts",
             ],
             "relative_difficulty": "slightly_harder_than_current_seed_due_to_multi_artifact_replay_coherence_checks",
+        },
+        "onboarded_increment": {
+            "intent_set": [
+                "federation.replay_or_receipt_consistency_gate",
+                "federation.ingest_replay_admission_gate",
+            ],
+            "status": "implemented_bounded_increment_v1",
+            "scaffold_requirements_satisfied": [
+                "typed_federation_action_identity",
+                "bounded_canonical_execution_path",
+                "explicit_success_denial_admitted_failure_semantics",
+                "proof_visible_execution_history",
+                "bounded_lifecycle_resolution",
+                "bounded_health_synthesis",
+            ],
+            "next_after_this_increment": "promote replay receipt artifact redundancy checks as optional hardening only",
+            "still_out_of_scope": [
+                "whole-federation intent onboarding",
+                "new sovereignty or governance layer introduction",
+                "auto-execution framework expansion",
+            ],
         },
     }
 

--- a/sentientos/federation_typed_actions.py
+++ b/sentientos/federation_typed_actions.py
@@ -54,6 +54,24 @@ FEDERATION_TYPED_ACTIONS: tuple[FederationTypedAction, ...] = (
         canonical_entry_surface="sentientos.control_plane_kernel.ControlPlaneKernel.admit(authority_class=FEDERATED_CONTROL)",
         proof_visible_boundary="glow/control_plane/kernel_decisions.jsonl:reason_codes+delegated_outcomes.federation_context",
     ),
+    FederationTypedAction(
+        action_id="sentientos.federation.replay_or_receipt_consistency_gate",
+        intent="federation.replay_or_receipt_consistency_gate",
+        mutation_control_domain="federation_mutation_control_slice",
+        authority_class="federated_control",
+        lifecycle_context="runtime.replay_receipt_consistency_gate",
+        canonical_entry_surface="sentientos.control_plane_kernel.ControlPlaneKernel.admit(authority_class=FEDERATED_CONTROL)",
+        proof_visible_boundary="glow/federation/canonical_execution.jsonl:canonical_handler+admission_decision_ref",
+    ),
+    FederationTypedAction(
+        action_id="sentientos.federation.ingest_replay_admission_gate",
+        intent="federation.ingest_replay_admission_gate",
+        mutation_control_domain="federation_mutation_control_slice",
+        authority_class="federated_control",
+        lifecycle_context="runtime.ingest_replay_admission_gate",
+        canonical_entry_surface="sentientos.daemons.pulse_federation.ingest_remote_event",
+        proof_visible_boundary="glow/federation/ingest_classifications.jsonl:event_type+typed_action_id",
+    ),
 )
 
 FEDERATION_TYPED_ACTION_REGISTRY: dict[str, FederationTypedAction] = {
@@ -78,6 +96,8 @@ def resolve_federation_typed_action_id(
     payload_action: str = "",
     denial_cause: str = "",
     trust_epoch_classification: str = "",
+    replay_classification: str = "",
+    receipt_consistency_classification: str = "",
 ) -> str | None:
     action = payload_action.strip().lower()
     if action == "restart_daemon":
@@ -88,6 +108,21 @@ def resolve_federation_typed_action_id(
     trust = trust_epoch_classification.strip().lower()
     if trust and trust not in {"trusted", "ok", "allow"}:
         return "sentientos.federation.epoch_or_trust_posture_gate"
+    replay = replay_classification.strip().lower()
+    if replay in {
+        "incompatible_replay_policy",
+        "peer_too_stale_for_replay_horizon",
+        "peer_outside_accepted_replay_horizon",
+        "duplicate_event_hash",
+    }:
+        return "sentientos.federation.ingest_replay_admission_gate"
+    receipt = receipt_consistency_classification.strip().lower()
+    if receipt in {
+        "confirmed_equivocation",
+        "protocol_claim_conflict",
+        "replay_claim_conflict",
+    }:
+        return "sentientos.federation.replay_or_receipt_consistency_gate"
     return None
 
 
@@ -107,7 +142,12 @@ def federation_typed_action_diagnostic() -> dict[str, Any]:
                 "emits_action_ids": [
                     "sentientos.federation.governance_digest_or_quorum_denial_gate",
                     "sentientos.federation.epoch_or_trust_posture_gate",
+                    "sentientos.federation.replay_or_receipt_consistency_gate",
                 ],
+            },
+            {
+                "surface": "sentientos.daemons.pulse_federation.ingest_remote_event(replay/duplicate gate)",
+                "emits_action_ids": ["sentientos.federation.ingest_replay_admission_gate"],
             },
         ],
         "untyped_out_of_scope_intents": [

--- a/sentientos/tests/test_federation_bounded_lifecycle.py
+++ b/sentientos/tests/test_federation_bounded_lifecycle.py
@@ -18,6 +18,7 @@ from sentientos.federation_bounded_lifecycle import (
     build_bounded_federation_trace_coherence_map,
     resolve_bounded_federation_lifecycle,
 )
+from sentientos.federation_slice_health import synthesize_bounded_federation_seed_health
 
 
 @dataclass(frozen=True)
@@ -304,3 +305,28 @@ def test_latest_lifecycle_rows_use_latest_observed_correlation(tmp_path: Path) -
     restart_row = next(row for row in latest_rows if row["typed_action_identity"] == "sentientos.federation.restart_daemon_request")
     assert restart_row["correlation_id"] == "corr-new"
     assert restart_row["outcome_class"] == "denied"
+
+
+def test_replay_gate_e2e_lifecycle_and_health_inclusion(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(pulse_federation, "get_trust_epoch_manager", lambda: type("M", (), {"classify_epoch": lambda *a, **k: _Trust(True)})())
+    monkeypatch.setattr(pulse_federation, "get_federated_governance_controller", lambda: _Governance(_Evaluation("none", "observe")))
+    monkeypatch.setattr(
+        pulse_federation,
+        "_classify_replay_horizon",
+        lambda event, claim: ("incompatible_replay_policy", {"age_seconds": 7200}),
+    )
+
+    with pytest.raises(ValueError):
+        pulse_federation.ingest_remote_event(_event("corr-replay-health"), "peer-a")
+
+    lifecycle = resolve_bounded_federation_lifecycle(
+        tmp_path,
+        typed_action_id="sentientos.federation.ingest_replay_admission_gate",
+        correlation_id="corr-replay-health",
+    )
+    assert lifecycle["outcome_class"] == "success"
+    assert lifecycle["proof_linkage"] == "present"
+    latest = build_bounded_federation_latest_lifecycle_rows(tmp_path)
+    assert any(row["typed_action_identity"] == "sentientos.federation.ingest_replay_admission_gate" for row in latest)
+    health = synthesize_bounded_federation_seed_health(latest)
+    assert "sentientos.federation.ingest_replay_admission_gate" in health["per_intent_latest_outcome"]

--- a/sentientos/tests/test_federation_canonical_ingress.py
+++ b/sentientos/tests/test_federation_canonical_ingress.py
@@ -160,3 +160,57 @@ def test_governance_denial_emits_canonical_denied_semantics(monkeypatch, tmp_pat
     rows = [json.loads(line) for line in (tmp_path / "glow/federation/canonical_execution.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
     assert rows[-1]["typed_action_id"] == "sentientos.federation.governance_digest_or_quorum_denial_gate"
     assert rows[-1]["canonical_outcome"] == "denied_pre_execution"
+
+
+def test_replay_admission_gate_is_canonical_and_proof_visible(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(pulse_federation, "get_trust_epoch_manager", lambda: type("M", (), {"classify_epoch": lambda *a, **k: _Trust(True)})())
+    monkeypatch.setattr(pulse_federation, "get_federated_governance_controller", lambda: _Governance(_Evaluation("none", "observe")))
+    monkeypatch.setattr(
+        pulse_federation,
+        "_classify_replay_horizon",
+        lambda event, claim: ("incompatible_replay_policy", {"age_seconds": 9999}),
+    )
+
+    event = {
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "event_type": "restart_request",
+        "correlation_id": "corr-replay-gate",
+        "payload": {"action": "restart_daemon", "daemon_name": "alpha", "scope": "federated"},
+        "pulse_protocol": {"schema_family": "pulse", "protocol_version": "2.2.0", "protocol_fingerprint": "x", "replay_policy": {"policy_version": "federation_replay_v1", "window_seconds": 1200, "tolerance_seconds": 120}},
+    }
+
+    with pytest.raises(ValueError, match="Federated replay policy/horizon denied"):
+        pulse_federation.ingest_remote_event(event, "peer-a")
+
+    rows = [json.loads(line) for line in (tmp_path / "glow/federation/canonical_execution.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert rows[-1]["typed_action_id"] == "sentientos.federation.ingest_replay_admission_gate"
+    assert rows[-1]["canonical_outcome"] == "admitted_succeeded"
+    ingest_rows = [json.loads(line) for line in (tmp_path / "glow/federation/ingest_classifications.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert ingest_rows[-1]["typed_action_id"] == "sentientos.federation.ingest_replay_admission_gate"
+    assert ingest_rows[-1]["canonical_linkage_present"] is True
+
+
+def test_receipt_consistency_confirmed_equivocation_is_machine_readable_failure(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(pulse_federation, "get_trust_epoch_manager", lambda: type("M", (), {"classify_epoch": lambda *a, **k: _Trust(True)})())
+    monkeypatch.setattr(pulse_federation, "get_federated_governance_controller", lambda: _Governance(_Evaluation("none", "observe")))
+    monkeypatch.setattr(
+        pulse_federation,
+        "_classify_equivocation",
+        lambda **kwargs: ("confirmed_equivocation", [{"kind": "double_send"}]),
+    )
+
+    event = {
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "event_type": "restart_request",
+        "correlation_id": "corr-receipt-fail",
+        "payload": {"action": "restart_daemon", "daemon_name": "alpha", "scope": "federated"},
+        "pulse_protocol": {"schema_family": "pulse", "protocol_version": "2.2.0", "protocol_fingerprint": "x", "replay_policy": {"policy_version": "federation_replay_v1", "window_seconds": 1200, "tolerance_seconds": 120}},
+    }
+
+    with pytest.raises(ValueError, match="Federated equivocation denied"):
+        pulse_federation.ingest_remote_event(event, "peer-a")
+
+    rows = [json.loads(line) for line in (tmp_path / "glow/federation/canonical_execution.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert rows[-1]["typed_action_id"] == "sentientos.federation.replay_or_receipt_consistency_gate"
+    assert rows[-1]["canonical_outcome"] == "admitted_failed"
+    assert rows[-1]["failure"]["exception_type"] == "ValueError"

--- a/sentientos/tests/test_federation_mutation_control_preflight.py
+++ b/sentientos/tests/test_federation_mutation_control_preflight.py
@@ -99,7 +99,7 @@ def test_preflight_exposes_bounded_seed_health_summary() -> None:
     seed_health = lifecycle_diag["bounded_federation_seed_health"]
     latest = lifecycle_diag["latest_lifecycle_by_intent"]
 
-    assert len(latest) == 3
+    assert len(latest) == 5
     assert set(seed_health["outcome_counts"]) == {
         "success",
         "denied",

--- a/sentientos/tests/test_federation_slice_health.py
+++ b/sentientos/tests/test_federation_slice_health.py
@@ -20,11 +20,13 @@ def test_all_success_latest_lifecycles_report_healthy() -> None:
                 "sentientos.federation.restart_daemon_request": "success",
                 "sentientos.federation.governance_digest_or_quorum_denial_gate": "success",
                 "sentientos.federation.epoch_or_trust_posture_gate": "success",
+                "sentientos.federation.replay_or_receipt_consistency_gate": "success",
+                "sentientos.federation.ingest_replay_admission_gate": "success",
             }
         )
     )
     assert health["health_status"] == "healthy"
-    assert health["outcome_counts"]["success"] == 3
+    assert health["outcome_counts"]["success"] == 5
     assert health["has_fragmentation"] is False
     assert health["has_admitted_failure"] is False
 
@@ -36,6 +38,8 @@ def test_admitted_failure_presence_reports_degraded() -> None:
                 "sentientos.federation.restart_daemon_request": "success",
                 "sentientos.federation.governance_digest_or_quorum_denial_gate": "failed_after_admission",
                 "sentientos.federation.epoch_or_trust_posture_gate": "denied",
+                "sentientos.federation.replay_or_receipt_consistency_gate": "success",
+                "sentientos.federation.ingest_replay_admission_gate": "denied",
             }
         )
     )
@@ -51,6 +55,8 @@ def test_fragmentation_presence_reports_fragmented() -> None:
                 "sentientos.federation.restart_daemon_request": "success",
                 "sentientos.federation.governance_digest_or_quorum_denial_gate": "fragmented_unresolved",
                 "sentientos.federation.epoch_or_trust_posture_gate": "success",
+                "sentientos.federation.replay_or_receipt_consistency_gate": "success",
+                "sentientos.federation.ingest_replay_admission_gate": "success",
             }
         )
     )
@@ -66,11 +72,13 @@ def test_denied_only_stays_healthy_in_bounded_model() -> None:
                 "sentientos.federation.restart_daemon_request": "denied",
                 "sentientos.federation.governance_digest_or_quorum_denial_gate": "denied",
                 "sentientos.federation.epoch_or_trust_posture_gate": "denied",
+                "sentientos.federation.replay_or_receipt_consistency_gate": "denied",
+                "sentientos.federation.ingest_replay_admission_gate": "denied",
             }
         )
     )
     assert health["health_status"] == "healthy"
-    assert health["outcome_counts"]["denied"] == 3
+    assert health["outcome_counts"]["denied"] == 5
 
 
 def test_health_signal_is_explicitly_non_sovereign() -> None:

--- a/sentientos/tests/test_federation_slice_pattern.py
+++ b/sentientos/tests/test_federation_slice_pattern.py
@@ -69,3 +69,4 @@ def test_note_captures_reusable_pattern_and_next_candidate_without_rollout() -> 
 
     candidate = note["recommended_next_bounded_candidate"]
     assert candidate["relative_difficulty"].startswith("slightly_harder")
+    assert note["onboarded_increment"]["status"] == "implemented_bounded_increment_v1"

--- a/sentientos/tests/test_federation_typed_actions.py
+++ b/sentientos/tests/test_federation_typed_actions.py
@@ -49,6 +49,8 @@ def test_bounded_federation_actions_have_stable_ids() -> None:
         "sentientos.federation.restart_daemon_request",
         "sentientos.federation.governance_digest_or_quorum_denial_gate",
         "sentientos.federation.epoch_or_trust_posture_gate",
+        "sentientos.federation.replay_or_receipt_consistency_gate",
+        "sentientos.federation.ingest_replay_admission_gate",
     }
 
 
@@ -64,6 +66,14 @@ def test_entry_surface_resolution_emits_expected_typed_action_ids() -> None:
     assert (
         resolve_federation_typed_action_id(trust_epoch_classification="revoked_epoch")
         == "sentientos.federation.epoch_or_trust_posture_gate"
+    )
+    assert (
+        resolve_federation_typed_action_id(replay_classification="incompatible_replay_policy")
+        == "sentientos.federation.ingest_replay_admission_gate"
+    )
+    assert (
+        resolve_federation_typed_action_id(receipt_consistency_classification="protocol_claim_conflict")
+        == "sentientos.federation.replay_or_receipt_consistency_gate"
     )
 
 
@@ -122,5 +132,5 @@ def test_typed_identity_does_not_change_admission_behavior(tmp_path) -> None:
 def test_diagnostic_surfaces_chosen_and_out_of_scope_sets() -> None:
     diagnostic = federation_typed_action_diagnostic()
     assert diagnostic["typed_identity_status"] == "bounded_initial_registration"
-    assert len(diagnostic["chosen_intents"]) == 3
+    assert len(diagnostic["chosen_intents"]) == 5
     assert diagnostic["untyped_out_of_scope_intents"]


### PR DESCRIPTION
### Motivation
- Expand the existing bounded federation seed by onboarding the next recommended increment (replay/receipt consistency + ingest replay admission) using the extracted federation slice scaffold without introducing new authority, sovereignty, or broad federation widening.
- Preserve the canonical admission/execution path and proof-visible lifecycle model so the new increment participates in kernel/governor mediation and bounded diagnostics.

### Description
- Added two typed federation actions: `sentientos.federation.replay_or_receipt_consistency_gate` and `sentientos.federation.ingest_replay_admission_gate` and wired them into the resolver (`resolve_federation_typed_action_id`) and typed action registry. (`sentientos/federation_typed_actions.py`)
- Extended the bounded canonical execution registry and handler map to include the two new typed actions so they use the existing `FederationCanonicalExecutionRouter` semantics and required metadata checks. (`sentientos/federation_canonical_execution.py`)
- Integrated canonical execution for replay/admission and receipt-consistency mediation into `pulse_federation.ingest_remote_event`, routing replay-horizon denials, duplicate suppression and equivocation checks through the canonical router with fail-closed handling and proof-linkage fields. (`sentientos/daemons/pulse_federation.py`)
- Updated the scaffold/onboarding note and seed scaffold to declare the new in-scope intents, proof-visible artifact boundaries, and record the increment as implemented while explicitly documenting what remains out-of-scope. (`sentientos/federation_slice_pattern.py`)
- Added focused tests that validate typed identity resolution, canonical execution outcomes (denied/admitted_succeeded/admitted_failed), lifecycle resolution and inclusion in bounded health/diagnostics, and updated expectations where the in-scope intent count increased. (tests under `sentientos/tests/`)

### Testing
- Ran the focused pytest suite `pytest -q sentientos/tests/test_federation_typed_actions.py sentientos/tests/test_federation_canonical_execution.py sentientos/tests/test_federation_canonical_ingress.py sentientos/tests/test_federation_bounded_lifecycle.py sentientos/tests/test_federation_slice_health.py sentientos/tests/test_federation_slice_pattern.py sentientos/tests/test_federation_mutation_control_preflight.py`, and the tests passed. 
- Ran `mypy scripts/ sentientos/` which failed due to existing, repository-wide typing issues unrelated to this incremental change. 
- `verify_audits --strict` was not available in the environment so it could not be executed here. 
- Ran `python scripts/audit_immutability_verifier.py` which completed and reported the expected artifact-dependent result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d974b589008320a99c4ae12f0ec111)