### PR TITLE
[codex:federation] audit post-expansion bounded slice coherence

### DIFF
--- a/sentientos/federation_mutation_control_preflight.py
+++ b/sentientos/federation_mutation_control_preflight.py
@@ -188,7 +188,7 @@ def build_federation_mutation_control_preflight(
             "capability": "mutation_and_control",
             "candidate_action_intents": [
                 "federation.restart_daemon_request",
-                "federation.governance_digest_or_quorum_denial",
+                "federation.governance_digest_or_quorum_denial_gate",
                 "federation.epoch_or_trust_posture_gate",
             ],
             "candidate_canonical_entry_surfaces": [

--- a/sentientos/federation_slice_pattern.py
+++ b/sentientos/federation_slice_pattern.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from sentientos.constitutional_slice_pattern import non_sovereign_diagnostic_boundaries
+from sentientos.federation_typed_actions import FEDERATION_TYPED_ACTION_REGISTRY
 
 REQUIRED_FEDERATION_PATTERN_LAYERS: tuple[str, ...] = (
     "typed_federation_action_identity",
@@ -345,6 +347,108 @@ def bounded_federation_slice_onboarding_note() -> dict[str, Any]:
                 "auto-execution framework expansion",
             ],
         },
+        "post_expansion_coherence": {
+            "current_in_scope_intent_ids": list(build_bounded_federation_seed_scaffold().in_scope_intent_ids),
+            "slice_coherence_assessment": "remains_one_bounded_constitutional_subsystem",
+            "single_biggest_remaining_gap": (
+                "health and temporal diagnostics include every in-scope intent uniformly by outcome class, "
+                "but do not yet preserve intent-specific semantic richness for stress attribution."
+            ),
+            "next_move_recommendation": "consolidation_first_before_next_increment",
+        },
+    }
+
+
+def build_post_expansion_bounded_federation_coherence_artifact() -> dict[str, Any]:
+    """Return a compact post-expansion coherence snapshot for the bounded federation slice."""
+
+    scaffold = build_bounded_federation_seed_scaffold()
+    in_scope = list(scaffold.in_scope_intent_ids)
+    typed_ids = list(scaffold.typed_action_ids)
+
+    maturity: list[dict[str, Any]] = []
+    maturity_labels: dict[str, int] = {"fully_integrated": 0, "mostly_integrated": 0, "partially_integrated": 0, "uneven_or_special_cased": 0}
+    for intent_id, typed_action_id in zip(in_scope, typed_ids, strict=True):
+        typed_entry = FEDERATION_TYPED_ACTION_REGISTRY.get(typed_action_id)
+        checks = {
+            "typed_identity": typed_entry is not None and typed_entry.intent == intent_id,
+            "canonical_execution": typed_action_id in scaffold.canonical_handlers,
+            "explicit_outcome_semantics": all(
+                bucket in scaffold.success_denial_admitted_failure_expectations for bucket in ("success", "denial", "admitted_failure")
+            ),
+            "proof_visible_linkage": typed_action_id in scaffold.proof_visible_artifact_boundaries,
+            "lifecycle_resolution": bool(scaffold.lifecycle_trace_requirements.get("bounded_lifecycle_resolver")),
+            "bounded_health_synthesis": bool(scaffold.diagnostic_capabilities_enabled.get("bounded_health_synthesis")),
+            "temporal_stability_retrospective_attention": all(
+                bool(scaffold.diagnostic_capabilities_enabled.get(flag))
+                for flag in (
+                    "bounded_temporal_health_history",
+                    "bounded_stability_oscillation_diagnostics",
+                    "bounded_retrospective_integrity_review",
+                    "bounded_operator_attention_recommendation",
+                )
+            ),
+        }
+        score = sum(1 for value in checks.values() if value)
+        if score == len(checks):
+            classification = "fully_integrated"
+        elif score >= len(checks) - 1:
+            classification = "mostly_integrated"
+        elif score >= 4:
+            classification = "partially_integrated"
+        else:
+            classification = "uneven_or_special_cased"
+        maturity_labels[classification] += 1
+        maturity.append(
+            {
+                "intent_id": intent_id,
+                "typed_action_id": typed_action_id,
+                "classification": classification,
+                "integration_checks": checks,
+                "canonical_ingress_surface": typed_entry.canonical_entry_surface if typed_entry is not None else "missing",
+                "canonical_execution_handler": scaffold.canonical_handlers.get(typed_action_id, "missing"),
+                "proof_visible_boundaries": list(scaffold.proof_visible_artifact_boundaries.get(typed_action_id, ())),
+                "authority_of_judgment_or_reconciliation_semantics": (
+                    "control_plane_kernel_admission_authoritative_for_federated_control"
+                    if "control_plane_kernel" in (typed_entry.canonical_entry_surface if typed_entry is not None else "")
+                    else "ingest_classification_and_canonical_router_linkage_authoritative_for_trace_resolution"
+                ),
+            }
+        )
+
+    coherent = all(row["classification"] == "fully_integrated" for row in maturity)
+    return {
+        "artifact_kind": "bounded_federation_post_expansion_coherence_audit",
+        "slice_id": scaffold.slice_id,
+        "in_scope_intent_count": len(in_scope),
+        "in_scope_intent_ids": in_scope,
+        "per_intent_maturity": maturity,
+        "maturity_counts": maturity_labels,
+        "coherence_verdict": (
+            "coherent_bounded_constitutional_subsystem"
+            if coherent
+            else "fragmenting_or_uneven_sub_slices_detected"
+        ),
+        "single_biggest_remaining_gap": {
+            "gap_id": "diagnostic_semantic_richness_parity",
+            "statement": (
+                "All in-scope intents are included in health/temporal/stability/retrospective/attention layers, "
+                "but those layers currently aggregate by outcome class only and lose intent-specific stress semantics."
+            ),
+            "impact": "can hide uneven stress semantics across intents while still reporting aggregate bounded health.",
+            "fix_scope": "consolidation_before_next_increment",
+        },
+        **non_sovereign_diagnostic_boundaries(
+            derived_from=[
+                "sentientos.federation_slice_pattern.build_bounded_federation_seed_scaffold",
+                "sentientos.federation_typed_actions.FEDERATION_TYPED_ACTION_REGISTRY",
+            ],
+            extra={
+                "support_signal_only": True,
+                "acts_as_federation_adjudicator": False,
+                "does_not_create_new_authority": True,
+            },
+        ),
     }
 
 
@@ -354,6 +458,7 @@ __all__ = [
     "REQUIRED_FEDERATION_PATTERN_LAYERS",
     "FederationSliceScaffold",
     "bounded_federation_slice_onboarding_note",
+    "build_post_expansion_bounded_federation_coherence_artifact",
     "build_bounded_diagnostic_capability_flags",
     "build_bounded_federation_seed_scaffold",
     "validate_federation_slice_scaffold",

--- a/sentientos/federation_typed_actions.py
+++ b/sentientos/federation_typed_actions.py
@@ -38,7 +38,7 @@ FEDERATION_TYPED_ACTIONS: tuple[FederationTypedAction, ...] = (
     ),
     FederationTypedAction(
         action_id="sentientos.federation.governance_digest_or_quorum_denial_gate",
-        intent="federation.governance_digest_or_quorum_denial",
+        intent="federation.governance_digest_or_quorum_denial_gate",
         mutation_control_domain="federation_mutation_control_slice",
         authority_class="federated_control",
         lifecycle_context="runtime.control_mediation",

--- a/sentientos/tests/test_federation_mutation_control_preflight.py
+++ b/sentientos/tests/test_federation_mutation_control_preflight.py
@@ -21,6 +21,7 @@ def test_preflight_reports_required_layer_presence_and_absence() -> None:
     assert set(REQUIRED_READINESS_LAYERS).issubset(required.keys())
     assert required["typed_action_model"] == "present"
     assert required["trace_requirements"] == "present"
+    assert "federation.governance_digest_or_quorum_denial_gate" in report["candidate_slice_boundary"]["candidate_action_intents"]
 
 
 def test_preflight_detects_single_critical_missing_prerequisite() -> None:

--- a/sentientos/tests/test_federation_slice_pattern.py
+++ b/sentientos/tests/test_federation_slice_pattern.py
@@ -6,6 +6,7 @@ from sentientos.federation_slice_pattern import (
     OPTIONAL_ADVANCED_FEDERATION_PATTERN_LAYERS,
     REQUIRED_FEDERATION_PATTERN_LAYERS,
     bounded_federation_slice_onboarding_note,
+    build_post_expansion_bounded_federation_coherence_artifact,
     build_bounded_federation_seed_scaffold,
     validate_federation_slice_scaffold,
 )
@@ -70,3 +71,47 @@ def test_note_captures_reusable_pattern_and_next_candidate_without_rollout() -> 
     candidate = note["recommended_next_bounded_candidate"]
     assert candidate["relative_difficulty"].startswith("slightly_harder")
     assert note["onboarded_increment"]["status"] == "implemented_bounded_increment_v1"
+    post_expansion = note["post_expansion_coherence"]
+    assert "federation.replay_or_receipt_consistency_gate" in post_expansion["current_in_scope_intent_ids"]
+    assert post_expansion["slice_coherence_assessment"] == "remains_one_bounded_constitutional_subsystem"
+    assert post_expansion["next_move_recommendation"] == "consolidation_first_before_next_increment"
+
+
+def test_post_expansion_coherence_artifact_reports_bounded_in_scope_and_non_authority() -> None:
+    artifact = build_post_expansion_bounded_federation_coherence_artifact()
+    assert artifact["artifact_kind"] == "bounded_federation_post_expansion_coherence_audit"
+    assert artifact["in_scope_intent_count"] == 5
+    assert artifact["coherence_verdict"] == "coherent_bounded_constitutional_subsystem"
+    assert artifact["maturity_counts"]["fully_integrated"] == 5
+    assert artifact["diagnostic_only"] is True
+    assert artifact["non_authoritative"] is True
+    assert artifact["decision_power"] == "none"
+    assert artifact["does_not_create_new_authority"] is True
+    assert artifact["acts_as_federation_adjudicator"] is False
+
+
+def test_post_expansion_coherence_artifact_detects_uneven_integration_when_typed_identity_drifts(monkeypatch) -> None:
+    from sentientos import federation_slice_pattern as fsp
+
+    registry = dict(fsp.FEDERATION_TYPED_ACTION_REGISTRY)
+    drifted = registry["sentientos.federation.governance_digest_or_quorum_denial_gate"]
+    monkeypatch.setattr(
+        fsp,
+        "FEDERATION_TYPED_ACTION_REGISTRY",
+        {
+            **registry,
+            "sentientos.federation.governance_digest_or_quorum_denial_gate": drifted.__class__(  # type: ignore[misc]
+                action_id=drifted.action_id,
+                intent="federation.governance_digest_or_quorum_denial",
+                mutation_control_domain=drifted.mutation_control_domain,
+                authority_class=drifted.authority_class,
+                lifecycle_context=drifted.lifecycle_context,
+                canonical_entry_surface=drifted.canonical_entry_surface,
+                proof_visible_boundary=drifted.proof_visible_boundary,
+            ),
+        },
+    )
+
+    artifact = build_post_expansion_bounded_federation_coherence_artifact()
+    assert artifact["coherence_verdict"] == "fragmenting_or_uneven_sub_slices_detected"
+    assert artifact["maturity_counts"]["mostly_integrated"] == 1


### PR DESCRIPTION
### Motivation
- After the first scaffold-driven expansion (replay/receipt admission), we need a compact, machine-readable coherence snapshot that shows whether the enlarged bounded federation slice still behaves as one coherent bounded constitutional subsystem. 
- The change must remain diagnostic-only, avoid adding new intents/authority/sovereignty, and make any uneven maturity explicit and testable.

### Description
- Add `build_post_expansion_bounded_federation_coherence_artifact()` in `sentientos/federation_slice_pattern.py` which rebuilds the post-expansion slice map, enumerates in-scope intents, reports canonical ingress/handlers/proof boundaries, computes per-intent maturity classifications, emits a coherence verdict, and records one highest-value remaining gap while preserving non-sovereign diagnostic boundaries. 
- Extend `bounded_federation_slice_onboarding_note()` to include a concise `post_expansion_coherence` block listing current in-scope intent IDs, a coherence assessment, the single biggest remaining gap, and a recommendation to consolidate before further increments. 
- Apply one narrow normalization fix: unify the governance intent identifier to `federation.governance_digest_or_quorum_denial_gate` in `sentientos/federation_typed_actions.py` and the preflight candidate list in `sentientos/federation_mutation_control_preflight.py` to remove a naming asymmetry that would hide unevenness. 
- Add focused tests in `sentientos/tests/test_federation_slice_pattern.py` and a small assertion in `sentientos/tests/test_federation_mutation_control_preflight.py` that validate the artifact shape, non-authoritative diagnostics, in-scope representation after expansion, and detection of uneven integration when typed identity drifts. 

### Testing
- Ran `pytest -q sentientos/tests/test_federation_slice_pattern.py sentientos/tests/test_federation_mutation_control_preflight.py` and the targeted test set passed. 
- Ran `mypy scripts/ sentientos/` which failed due to existing, repository-wide type-check debt not introduced by this change. 
- Ran the broader test harness with `python -m scripts.run_tests -q` which surfaced unrelated repository-wide failures in `tests/test_pulse_federation.py` and therefore did not pass end-to-end. 
- `verify_audits --strict` was unavailable in the environment (`command not found`). 
- `python scripts/audit_immutability_verifier.py` completed successfully for artifact checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9ca671b5c832094bbe9566c159a9e)