### PR TITLE
[codex:orchestration] add constitutional judgment-to-handoff intent bridge

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+_INTENT_KINDS = {
+    "internal_maintenance_execution",
+    "codex_work_order",
+    "deep_research_work_order",
+    "operator_review_request",
+    "hold_no_action",
+}
+
+_AUTHORITY_POSTURES = {
+    "no_additional_operator_approval_required",
+    "operator_approval_required",
+    "operator_priority_required",
+    "insufficient_context_blocked",
+}
+
+_EXECUTION_TARGETS = {
+    "task_admission_executor",
+    "mutation_router",
+    "federation_canonical_execution",
+    "no_execution_target_yet",
+    "external_tool_placeholder",
+}
+
+_EXECUTABILITY = {
+    "executable_now",
+    "stageable_external_work_order",
+    "blocked_operator_required",
+    "blocked_insufficient_context",
+    "no_action_recommended",
+}
+
+_ADMISSION_STATES = {
+    "admitted_for_internal_staging",
+    "deferred_operator_approval",
+    "deferred_operator_priority",
+    "deferred_insufficient_context",
+    "staged_non_executable_work_order",
+    "no_action",
+}
+
+
+def _iso_utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _intent_id(source_judgment: Mapping[str, Any], created_at: str) -> str:
+    canonical = json.dumps({"created_at": created_at, "source_judgment": source_judgment}, sort_keys=True, separators=(",", ":"))
+    return f"orh-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _classify_authority_posture(judgment: Mapping[str, Any]) -> str:
+    escalation = str(judgment.get("escalation_classification") or "")
+    venue = str(judgment.get("recommended_venue") or "")
+    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
+        return "insufficient_context_blocked"
+    if escalation == "escalate_for_operator_priority":
+        return "operator_priority_required"
+    if venue in {"codex_implementation", "deep_research_audit", "operator_decision_required"}:
+        return "operator_approval_required"
+    return "no_additional_operator_approval_required"
+
+
+def _translate_kind(judgment: Mapping[str, Any]) -> tuple[str, str, str]:
+    venue = str(judgment.get("recommended_venue") or "")
+    work_class = str(judgment.get("work_class") or "")
+    escalation = str(judgment.get("escalation_classification") or "")
+
+    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
+        return "hold_no_action", "no_execution_target_yet", "blocked_insufficient_context"
+
+    if venue == "internal_direct_execution" and work_class == "internal_runtime_maintenance":
+        return "internal_maintenance_execution", "task_admission_executor", "executable_now"
+
+    if venue == "codex_implementation":
+        return "codex_work_order", "no_execution_target_yet", "stageable_external_work_order"
+
+    if venue == "deep_research_audit":
+        return "deep_research_work_order", "no_execution_target_yet", "stageable_external_work_order"
+
+    if venue == "operator_decision_required":
+        return "operator_review_request", "no_execution_target_yet", "blocked_operator_required"
+
+    if work_class == "external_tool_orchestration":
+        return "operator_review_request", "external_tool_placeholder", "stageable_external_work_order"
+
+    return "hold_no_action", "no_execution_target_yet", "no_action_recommended"
+
+
+def _derive_admission_state(executability: str, authority_posture: str) -> str:
+    if executability == "executable_now" and authority_posture == "no_additional_operator_approval_required":
+        return "admitted_for_internal_staging"
+    if authority_posture == "operator_priority_required":
+        return "deferred_operator_priority"
+    if authority_posture == "insufficient_context_blocked":
+        return "deferred_insufficient_context"
+    if executability == "stageable_external_work_order":
+        return "staged_non_executable_work_order"
+    if executability == "blocked_operator_required":
+        return "deferred_operator_approval"
+    return "no_action"
+
+
+def _source_judgment_linkage(judgment: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "work_class": str(judgment.get("work_class") or "operator_required"),
+        "recommended_venue": str(judgment.get("recommended_venue") or "insufficient_context"),
+        "next_move_posture": str(judgment.get("next_move_posture") or "hold"),
+        "consolidation_expansion_posture": str(judgment.get("consolidation_expansion_posture") or "insufficient_context"),
+        "escalation_classification": str(judgment.get("escalation_classification") or "escalate_for_missing_context"),
+        "readiness_basis": {
+            "orchestration_substitution_readiness": judgment.get("orchestration_substitution_readiness", {}),
+            "basis": judgment.get("basis", {}),
+        },
+    }
+
+
+def _work_order_payload(intent_kind: str, source_linkage: Mapping[str, Any], executability: str, authority_posture: str) -> dict[str, Any] | None:
+    if intent_kind not in {"codex_work_order", "deep_research_work_order", "operator_review_request"}:
+        return None
+
+    venue = str(source_linkage.get("recommended_venue") or "")
+    rationale = source_linkage.get("readiness_basis", {}).get("basis", {}) if isinstance(source_linkage.get("readiness_basis"), Mapping) else {}
+    return {
+        "work_order_kind": intent_kind,
+        "intended_venue": venue,
+        "bounded_rationale": {
+            "signal_reasons": list(rationale.get("signal_reasons") or []),
+            "slice_health_status": rationale.get("slice_health_status"),
+            "slice_stability_classification": rationale.get("slice_stability_classification"),
+            "slice_review_classification": rationale.get("slice_review_classification"),
+        },
+        "authority_posture": authority_posture,
+        "executability_classification": executability,
+        "staged_only": executability != "executable_now",
+    }
+
+
+def synthesize_orchestration_intent(
+    delegated_judgment: Mapping[str, Any],
+    *,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Translate delegated judgment into a bounded, governed orchestration intent."""
+
+    source_linkage = _source_judgment_linkage(delegated_judgment)
+    authority_posture = _classify_authority_posture(delegated_judgment)
+    intent_kind, execution_target, executability = _translate_kind(delegated_judgment)
+    admission_state = _derive_admission_state(executability, authority_posture)
+    timestamp = created_at or _iso_utc_now()
+    intent_id = _intent_id(source_linkage, timestamp)
+
+    if intent_kind not in _INTENT_KINDS:
+        intent_kind = "hold_no_action"
+    if authority_posture not in _AUTHORITY_POSTURES:
+        authority_posture = "insufficient_context_blocked"
+    if execution_target not in _EXECUTION_TARGETS:
+        execution_target = "no_execution_target_yet"
+    if executability not in _EXECUTABILITY:
+        executability = "blocked_insufficient_context"
+    if admission_state not in _ADMISSION_STATES:
+        admission_state = "deferred_insufficient_context"
+
+    requires_operator_approval = authority_posture != "no_additional_operator_approval_required"
+    work_order = _work_order_payload(intent_kind, source_linkage, executability, authority_posture)
+
+    return {
+        "schema_version": "orchestration_intent.v1",
+        "intent_id": intent_id,
+        "created_at": timestamp,
+        "intent_kind": intent_kind,
+        "source_delegated_judgment": source_linkage,
+        "required_authority_posture": authority_posture,
+        "execution_target": execution_target,
+        "executability_classification": executability,
+        "handoff_admission_state": admission_state,
+        "work_order": work_order,
+        "requires_admission": execution_target in {"task_admission_executor", "mutation_router", "federation_canonical_execution"},
+        "requires_operator_approval": requires_operator_approval,
+        "non_authoritative": True,
+        "recommendation_only": False,
+        "diagnostic_only": False,
+        "staged_handoff_only": executability != "executable_now",
+        "does_not_invoke_external_tools": True,
+        "does_not_override_existing_admission": True,
+        "does_not_override_kernel_or_governor": True,
+        "does_not_replace_operator_authority": True,
+    }
+
+
+def append_orchestration_intent_ledger(repo_root: Path, intent: Mapping[str, Any]) -> Path:
+    """Append one orchestration intent to the proof-visible handoff ledger."""
+
+    ledger_path = repo_root.resolve() / "glow/orchestration/orchestration_intents.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(intent), sort_keys=True) + "\n")
+    return ledger_path

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def orchestration_intent_fabric_note() -> dict[str, Any]:
+    """Short technical note for constitutional judgment-to-execution handoff."""
+
+    return {
+        "layer": "orchestration_intent_fabric",
+        "what_it_is": [
+            "a bounded translation bridge from delegated judgment recommendations to typed orchestration intents",
+            "a governed handoff substrate that stages execution intent without claiming sovereign execution authority",
+        ],
+        "how_it_differs_from_delegated_judgment": [
+            "delegated judgment classifies and recommends; orchestration handoff emits typed intent/work-order artifacts",
+            "delegated judgment stays recommendation_only; orchestration handoff is recommendation_only=false but still non_authoritative",
+        ],
+        "how_it_differs_from_execution": [
+            "it does not execute external tools, browser, keyboard, or mouse actions",
+            "it does not bypass task admission, kernel, or governor decisions",
+            "it stages executable internal intents for admission; all execution remains downstream",
+        ],
+        "venue_to_executability": {
+            "internal_direct_execution": "executable_now via task admission staging",
+            "codex_implementation": "stageable_external_work_order",
+            "deep_research_audit": "stageable_external_work_order",
+            "operator_decision_required": "blocked_operator_required",
+            "insufficient_context": "blocked_insufficient_context",
+        },
+        "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
+        "not_in_scope_yet": [
+            "direct Codex invocation",
+            "direct Deep Research invocation",
+            "direct external adapter actuation",
+            "direct browser/mouse/keyboard tool control",
+        ],
+    }

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -11,6 +11,7 @@ from sentientos.scoped_slice_stability import derive_scoped_slice_stability
 from sentientos.scoped_slice_retrospective_integrity import derive_scoped_slice_retrospective_integrity_review
 from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice_attention_recommendation
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
+from sentientos.orchestration_intent_fabric import append_orchestration_intent_ledger, synthesize_orchestration_intent
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -77,6 +78,8 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         },
     )
     delegated_judgment = synthesize_delegated_judgment(delegated_judgment_evidence)
+    orchestration_intent = synthesize_orchestration_intent(delegated_judgment)
+    orchestration_ledger_path = append_orchestration_intent_ledger(root, orchestration_intent)
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -86,5 +89,9 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         "slice_retrospective_integrity_review": retrospective_integrity_review,
         "slice_operator_attention_recommendation": operator_attention_recommendation,
         "delegated_judgment": delegated_judgment,
+        "orchestration_handoff": {
+            "intent": orchestration_intent,
+            "ledger_path": str(orchestration_ledger_path.relative_to(root)),
+        },
         "actions": rows,
     }

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
+from sentientos.orchestration_intent_fabric import append_orchestration_intent_ledger, synthesize_orchestration_intent
+from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
+
+
+def _base_evidence() -> dict[str, object]:
+    return {
+        "contract_status_present": True,
+        "contract_drifted_domains": 0,
+        "contract_baseline_missing_domains": 0,
+        "governance_ambiguity_signal": False,
+        "slice_health_status": "healthy",
+        "slice_stability_classification": "stable",
+        "slice_review_classification": "clean_recent_history",
+        "records_considered": 6,
+        "admission_denied_ratio": 0.0,
+        "admission_sample_count": 8,
+        "executor_failure_ratio": 0.0,
+        "executor_sample_count": 6,
+        "adapter_count": 1,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+
+
+def test_deep_research_judgment_translates_to_stageable_external_work_order() -> None:
+    evidence = _base_evidence()
+    evidence["governance_ambiguity_signal"] = True
+    judgment = synthesize_delegated_judgment(evidence)
+
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+
+    assert judgment["recommended_venue"] == "deep_research_audit"
+    assert intent["intent_kind"] == "deep_research_work_order", json.dumps(intent, indent=2, sort_keys=True)
+    assert intent["executability_classification"] == "stageable_external_work_order"
+    assert intent["execution_target"] == "no_execution_target_yet"
+    assert intent["required_authority_posture"] == "operator_approval_required"
+    assert intent["work_order"]["intended_venue"] == "deep_research_audit"
+    assert intent["does_not_invoke_external_tools"] is True
+
+
+def test_internal_execution_judgment_translates_to_executable_now_via_task_admission() -> None:
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+
+    assert judgment["recommended_venue"] == "internal_direct_execution"
+    assert intent["intent_kind"] == "internal_maintenance_execution"
+    assert intent["executability_classification"] == "executable_now"
+    assert intent["execution_target"] == "task_admission_executor"
+    assert intent["requires_admission"] is True
+    assert intent["handoff_admission_state"] == "admitted_for_internal_staging"
+    assert intent["does_not_override_existing_admission"] is True
+
+
+def test_codex_work_order_is_stageable_not_falsely_executable() -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+
+    assert judgment["recommended_venue"] == "codex_implementation"
+    assert intent["intent_kind"] == "codex_work_order"
+    assert intent["executability_classification"] == "stageable_external_work_order"
+    assert intent["staged_handoff_only"] is True
+    assert intent["execution_target"] == "no_execution_target_yet"
+
+
+def test_operator_and_insufficient_context_cases_remain_blocked() -> None:
+    insufficient_context_judgment = synthesize_delegated_judgment(
+        {
+            **_base_evidence(),
+            "records_considered": 0,
+            "admission_sample_count": 0,
+            "executor_sample_count": 0,
+        }
+    )
+    insufficient_intent = synthesize_orchestration_intent(
+        insufficient_context_judgment,
+        created_at="2026-04-12T00:00:00Z",
+    )
+
+    assert insufficient_context_judgment["recommended_venue"] == "operator_decision_required"
+    assert insufficient_intent["required_authority_posture"] == "insufficient_context_blocked"
+    assert insufficient_intent["executability_classification"] == "blocked_insufficient_context"
+
+    operator_judgment = {
+        **insufficient_context_judgment,
+        "recommended_venue": "operator_decision_required",
+        "escalation_classification": "escalate_for_operator_priority",
+    }
+    operator_intent = synthesize_orchestration_intent(operator_judgment, created_at="2026-04-12T00:00:00Z")
+
+    assert operator_intent["intent_kind"] == "operator_review_request"
+    assert operator_intent["required_authority_posture"] == "operator_priority_required"
+    assert operator_intent["executability_classification"] == "blocked_operator_required"
+
+
+def test_orchestration_intent_ledger_is_append_only(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+
+    ledger_path = append_orchestration_intent_ledger(tmp_path, intent)
+    append_orchestration_intent_ledger(tmp_path, {**intent, "intent_id": "orh-second"})
+
+    lines = ledger_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+    assert first["intent_id"] == intent["intent_id"]
+    assert second["intent_id"] == "orh-second"
+
+
+def test_scoped_lifecycle_diagnostic_surfaces_orchestration_handoff_and_ledger(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+
+    def _fake_resolver(_repo_root: Path, *, action_id: str, correlation_id: str) -> dict[str, object]:
+        return {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        }
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle", _fake_resolver)
+
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-1",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+
+    handoff = diagnostic["orchestration_handoff"]
+    assert handoff["ledger_path"] == "glow/orchestration/orchestration_intents.jsonl"
+    assert handoff["intent"]["schema_version"] == "orchestration_intent.v1"
+
+    ledger = tmp_path / handoff["ledger_path"]
+    row = json.loads(ledger.read_text(encoding="utf-8").splitlines()[-1])
+    assert row["intent_id"] == handoff["intent"]["intent_id"]
+    assert row["does_not_invoke_external_tools"] is True


### PR DESCRIPTION
### Motivation
- Provide a bounded, non-sovereign bridge that converts delegated-judgment recommendations into typed orchestration intents so the system can stage governed handoff without claiming execution sovereignty.
- Make explicit what the repo can and cannot run today by classifying executability, authority posture, and execution target so internal work can be admitted while external or operator-required work is honestly staged or blocked.
- Surface handoff proof visibly and append-only so every orchestration intent is inspectable and can become the anchor for future governed adapters.

### Description
- Add `sentientos/orchestration_intent_fabric.py`, a compact typed orchestration model and translator that emits intents with `intent_kind`, `source_delegated_judgment` linkage, `required_authority_posture`, `execution_target`, `executability_classification`, `handoff_admission_state`, and anti-sovereignty flags (e.g. `does_not_invoke_external_tools`).
- Emit bounded work-order payloads for non-internal venues (`codex_work_order`, `deep_research_work_order`, `operator_review_request`) with a `bounded_rationale` and `staged_only` marker to avoid falsely claiming execution capability.
- Add append-only ledger emission via `append_orchestration_intent_ledger(...)` to `glow/orchestration/orchestration_intents.jsonl` and integrate synthesis+append into the existing consumer path by wiring `synthesize_orchestration_intent(...)` and ledger append into `build_scoped_lifecycle_diagnostic(...)` (so the handoff is proof-visible in an existing diagnostic surface).
- Add `sentientos/orchestration_intent_fabric_note.py` documenting purpose, boundaries, venue→executability mapping, and explicit non-scope (no direct Codex/Deep Research/browser actuation yet).
- Add focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` covering deep-research staging, internal executable-now mapping to `task_admission_executor`, codex staging without false executability, operator/insufficient-context blocking, ledger append-only behavior, and scoped lifecycle integration.

### Testing
- Ran `python -m pytest -q sentientos/tests/test_orchestration_intent_fabric.py sentientos/tests/test_delegated_judgment_fabric.py` and those tests passed (all assertions in the new/modified tests succeeded).
- Ran `python -m scripts.run_tests -q` which failed due to existing unrelated `tests/test_pulse_federation.py` failures in the wider test-suite and not caused by this change.
- Ran `mypy scripts/ sentientos/` which fails on repository-wide, pre-existing typing issues and is not introduced by this change.
- Ran `python scripts/audit_immutability_verifier.py` which completed successfully, and `verify_audits --strict` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dafd9c8a708320a0eb5542182e256e)