### PR TITLE
[codex:orchestration] operationalize internal intent handoff into task admission

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -6,6 +6,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
+import task_admission
+import task_executor
+
 _INTENT_KINDS = {
     "internal_maintenance_execution",
     "codex_work_order",
@@ -44,6 +47,15 @@ _ADMISSION_STATES = {
     "deferred_insufficient_context",
     "staged_non_executable_work_order",
     "no_action",
+}
+
+_HANDOFF_OUTCOMES = {
+    "staged_only",
+    "admitted_to_execution_substrate",
+    "blocked_by_admission",
+    "blocked_by_operator_requirement",
+    "blocked_by_insufficient_context",
+    "execution_target_unavailable",
 }
 
 
@@ -203,3 +215,195 @@ def append_orchestration_intent_ledger(repo_root: Path, intent: Mapping[str, Any
     with ledger_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(intent), sort_keys=True) + "\n")
     return ledger_path
+
+
+def _validate_handoff_minimum_fields(intent: Mapping[str, Any]) -> list[str]:
+    missing: list[str] = []
+    if not str(intent.get("intent_id") or "").strip():
+        missing.append("intent_id")
+    if not str(intent.get("intent_kind") or "").strip():
+        missing.append("intent_kind")
+    if not str(intent.get("execution_target") or "").strip():
+        missing.append("execution_target")
+    if not str(intent.get("executability_classification") or "").strip():
+        missing.append("executability_classification")
+    source = intent.get("source_delegated_judgment")
+    if not isinstance(source, Mapping):
+        missing.append("source_delegated_judgment")
+        return missing
+    if not str(source.get("recommended_venue") or "").strip():
+        missing.append("source_delegated_judgment.recommended_venue")
+    if not str(source.get("work_class") or "").strip():
+        missing.append("source_delegated_judgment.work_class")
+    if not str(source.get("escalation_classification") or "").strip():
+        missing.append("source_delegated_judgment.escalation_classification")
+    return missing
+
+
+def _build_internal_maintenance_task(intent: Mapping[str, Any]) -> task_executor.Task:
+    source = intent.get("source_delegated_judgment")
+    source_mapping = source if isinstance(source, Mapping) else {}
+    return task_executor.Task(
+        task_id=f"orh-{str(intent.get('intent_id') or 'missing')}",
+        objective="orchestration_intent_internal_maintenance_handoff",
+        constraints=(
+            "bounded_orchestration_handoff_only",
+            "no_external_tool_direct_invocation",
+            "admission_required_before_execution",
+        ),
+        steps=(
+            task_executor.Step(
+                step_id=1,
+                kind="noop",
+                payload=task_executor.NoopPayload(
+                    note=json.dumps(
+                        {
+                            "intent_kind": intent.get("intent_kind"),
+                            "recommended_venue": source_mapping.get("recommended_venue"),
+                            "executability_classification": intent.get("executability_classification"),
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            ),
+        ),
+        allow_epr=False,
+        required_privileges=("orchestration_intent_handoff",),
+    )
+
+
+def _default_admission_context() -> task_admission.AdmissionContext:
+    return task_admission.AdmissionContext(
+        actor="orchestration_intent_fabric",
+        mode="autonomous",
+        node_id="sentientos_orchestration_handoff",
+        vow_digest=None,
+        doctrine_digest=None,
+        now_utc_iso=_iso_utc_now(),
+    )
+
+
+def _default_admission_policy() -> task_admission.AdmissionPolicy:
+    return task_admission.AdmissionPolicy(policy_version="orchestration_intent_handoff.v1")
+
+
+def append_orchestration_handoff_ledger(repo_root: Path, handoff: Mapping[str, Any]) -> Path:
+    ledger_path = repo_root.resolve() / "glow/orchestration/orchestration_handoffs.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(handoff), sort_keys=True) + "\n")
+    return ledger_path
+
+
+def executable_handoff_map() -> dict[str, Any]:
+    return {
+        "intent_kind_to_handoff": {
+            "internal_maintenance_execution": {
+                "execution_target": "task_admission_executor",
+                "executability_classification": "executable_now",
+                "admission_surface": "task_admission.admit",
+                "handoff_path_status": "operational",
+            },
+            "codex_work_order": {
+                "execution_target": "no_execution_target_yet",
+                "executability_classification": "stageable_external_work_order",
+                "admission_surface": "none",
+                "handoff_path_status": "staged_only",
+            },
+            "deep_research_work_order": {
+                "execution_target": "no_execution_target_yet",
+                "executability_classification": "stageable_external_work_order",
+                "admission_surface": "none",
+                "handoff_path_status": "staged_only",
+            },
+            "operator_review_request": {
+                "execution_target": "no_execution_target_yet",
+                "executability_classification": "blocked_operator_required",
+                "admission_surface": "operator-only",
+                "handoff_path_status": "blocked_or_staged",
+            },
+            "hold_no_action": {
+                "execution_target": "no_execution_target_yet",
+                "executability_classification": "no_action_recommended",
+                "admission_surface": "none",
+                "handoff_path_status": "not_applicable",
+            },
+        },
+        "known_named_targets_without_handoff_path": [
+            "mutation_router",
+            "federation_canonical_execution",
+            "external_tool_placeholder",
+        ],
+    }
+
+
+def admit_orchestration_intent(
+    repo_root: Path,
+    intent: Mapping[str, Any],
+    *,
+    admission_context: task_admission.AdmissionContext | None = None,
+    admission_policy: task_admission.AdmissionPolicy | None = None,
+) -> dict[str, Any]:
+    root = repo_root.resolve()
+    missing_fields = _validate_handoff_minimum_fields(intent)
+    execution_target = str(intent.get("execution_target") or "")
+    executability = str(intent.get("executability_classification") or "")
+    authority_posture = str(intent.get("required_authority_posture") or "")
+
+    outcome = "staged_only"
+    details: dict[str, Any] = {
+        "intent_id": str(intent.get("intent_id") or ""),
+        "intent_kind": str(intent.get("intent_kind") or ""),
+        "execution_target": execution_target,
+        "executability_classification": executability,
+    }
+
+    if missing_fields:
+        outcome = "blocked_by_insufficient_context"
+        details["missing_required_fields"] = missing_fields
+    elif executability != "executable_now":
+        outcome = "staged_only"
+    elif authority_posture != "no_additional_operator_approval_required":
+        outcome = "blocked_by_operator_requirement"
+        details["required_authority_posture"] = authority_posture
+    elif execution_target != "task_admission_executor":
+        outcome = "execution_target_unavailable"
+    else:
+        ctx = admission_context or _default_admission_context()
+        policy = admission_policy or _default_admission_policy()
+        task = _build_internal_maintenance_task(intent)
+        decision = task_admission.admit(task, ctx, policy)
+        task_admission._log_admission_event(decision, task, ctx, policy)
+        details["task_admission"] = {
+            "task_id": task.task_id,
+            "allowed": decision.allowed,
+            "reason": decision.reason,
+            "policy_version": decision.policy_version,
+            "constraints": decision.constraints,
+            "log_path": str(task_admission._resolve_admission_log_path().relative_to(root))
+            if task_admission._resolve_admission_log_path().is_relative_to(root)
+            else str(task_admission._resolve_admission_log_path()),
+        }
+        outcome = "admitted_to_execution_substrate" if decision.allowed else "blocked_by_admission"
+
+    if outcome not in _HANDOFF_OUTCOMES:
+        outcome = "blocked_by_insufficient_context"
+
+    handoff_record = {
+        "schema_version": "orchestration_handoff.v1",
+        "recorded_at": _iso_utc_now(),
+        "handoff_outcome": outcome,
+        "intent_ref": {
+            "intent_id": str(intent.get("intent_id") or ""),
+            "intent_kind": str(intent.get("intent_kind") or ""),
+        },
+        "details": details,
+        "non_authoritative": True,
+        "does_not_execute_task_directly": True,
+        "does_not_invoke_external_tools": True,
+    }
+    handoff_ledger_path = append_orchestration_handoff_ledger(root, handoff_record)
+    return {
+        **handoff_record,
+        "ledger_path": str(handoff_ledger_path.relative_to(root)),
+    }

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -19,8 +19,22 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
         "how_it_differs_from_execution": [
             "it does not execute external tools, browser, keyboard, or mouse actions",
             "it does not bypass task admission, kernel, or governor decisions",
-            "it stages executable internal intents for admission; all execution remains downstream",
+            "it can hand internal_maintenance_execution intents into task_admission for bounded admission only",
+            "handoff admission is not execution completion; execution remains downstream",
         ],
+        "internal_handoff_now_operational": {
+            "intent_kind": "internal_maintenance_execution",
+            "execution_target": "task_admission_executor",
+            "admission_surface": "task_admission.admit",
+            "handoff_outcomes": [
+                "admitted_to_execution_substrate",
+                "blocked_by_admission",
+                "blocked_by_operator_requirement",
+                "blocked_by_insufficient_context",
+                "execution_target_unavailable",
+                "staged_only",
+            ],
+        },
         "venue_to_executability": {
             "internal_direct_execution": "executable_now via task admission staging",
             "codex_implementation": "stageable_external_work_order",
@@ -29,10 +43,17 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
             "insufficient_context": "blocked_insufficient_context",
         },
         "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
+        "handoff_artifact": "glow/orchestration/orchestration_handoffs.jsonl",
+        "venues_still_staged_only": [
+            "codex_implementation",
+            "deep_research_audit",
+            "operator_decision_required",
+        ],
         "not_in_scope_yet": [
             "direct Codex invocation",
             "direct Deep Research invocation",
             "direct external adapter actuation",
             "direct browser/mouse/keyboard tool control",
+            "external tool delegation with real execution authority",
         ],
     }

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -11,7 +11,12 @@ from sentientos.scoped_slice_stability import derive_scoped_slice_stability
 from sentientos.scoped_slice_retrospective_integrity import derive_scoped_slice_retrospective_integrity_review
 from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice_attention_recommendation
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
-from sentientos.orchestration_intent_fabric import append_orchestration_intent_ledger, synthesize_orchestration_intent
+from sentientos.orchestration_intent_fabric import (
+    admit_orchestration_intent,
+    append_orchestration_intent_ledger,
+    executable_handoff_map,
+    synthesize_orchestration_intent,
+)
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -80,6 +85,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     delegated_judgment = synthesize_delegated_judgment(delegated_judgment_evidence)
     orchestration_intent = synthesize_orchestration_intent(delegated_judgment)
     orchestration_ledger_path = append_orchestration_intent_ledger(root, orchestration_intent)
+    handoff_result = admit_orchestration_intent(root, orchestration_intent)
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -90,8 +96,10 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         "slice_operator_attention_recommendation": operator_attention_recommendation,
         "delegated_judgment": delegated_judgment,
         "orchestration_handoff": {
+            "executable_handoff_map": executable_handoff_map(),
             "intent": orchestration_intent,
-            "ledger_path": str(orchestration_ledger_path.relative_to(root)),
+            "intent_ledger_path": str(orchestration_ledger_path.relative_to(root)),
+            "handoff_result": handoff_result,
         },
         "actions": rows,
     }

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import task_admission
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
-from sentientos.orchestration_intent_fabric import append_orchestration_intent_ledger, synthesize_orchestration_intent
+from sentientos.orchestration_intent_fabric import (
+    admit_orchestration_intent,
+    append_orchestration_intent_ledger,
+    executable_handoff_map,
+    synthesize_orchestration_intent,
+)
 from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
 
 
@@ -132,6 +138,84 @@ def test_orchestration_intent_ledger_is_append_only(tmp_path: Path) -> None:
     assert second["intent_id"] == "orh-second"
 
 
+def test_internal_executable_intent_is_admitted_to_task_admission_surface(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+
+    handoff = admit_orchestration_intent(tmp_path, intent)
+
+    assert handoff["handoff_outcome"] == "admitted_to_execution_substrate"
+    assert handoff["details"]["task_admission"]["allowed"] is True
+    assert handoff["details"]["task_admission"]["reason"] == "OK"
+    assert handoff["ledger_path"] == "glow/orchestration/orchestration_handoffs.jsonl"
+
+    handoff_rows = (tmp_path / handoff["ledger_path"]).read_text(encoding="utf-8").splitlines()
+    assert len(handoff_rows) == 1
+    handoff_row = json.loads(handoff_rows[-1])
+    assert handoff_row["intent_ref"]["intent_id"] == intent["intent_id"]
+    assert handoff_row["does_not_invoke_external_tools"] is True
+
+
+def test_missing_required_metadata_blocks_handoff_machine_readably(tmp_path: Path) -> None:
+    handoff = admit_orchestration_intent(
+        tmp_path,
+        {
+            "intent_kind": "internal_maintenance_execution",
+            "execution_target": "task_admission_executor",
+            "executability_classification": "executable_now",
+        },
+    )
+    assert handoff["handoff_outcome"] == "blocked_by_insufficient_context"
+    assert "intent_id" in handoff["details"]["missing_required_fields"]
+
+
+def test_internal_handoff_honors_admission_denial(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+
+    denied_handoff = admit_orchestration_intent(
+        tmp_path,
+        intent,
+        admission_policy=task_admission.AdmissionPolicy(
+            policy_version="orchestration_intent_handoff.denied.v1",
+            max_steps=0,
+        ),
+    )
+
+    assert denied_handoff["handoff_outcome"] == "blocked_by_admission"
+    assert denied_handoff["details"]["task_admission"]["allowed"] is False
+    assert denied_handoff["details"]["task_admission"]["reason"] == "TOO_MANY_STEPS"
+
+
+def test_external_venues_remain_staged_only_without_internal_admission(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    handoff = admit_orchestration_intent(tmp_path, intent)
+
+    assert judgment["recommended_venue"] == "codex_implementation"
+    assert handoff["handoff_outcome"] == "staged_only"
+    assert "task_admission" not in handoff["details"]
+
+
 def test_scoped_lifecycle_diagnostic_surfaces_orchestration_handoff_and_ledger(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -159,10 +243,47 @@ def test_scoped_lifecycle_diagnostic_surfaces_orchestration_handoff_and_ledger(m
     diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
 
     handoff = diagnostic["orchestration_handoff"]
-    assert handoff["ledger_path"] == "glow/orchestration/orchestration_intents.jsonl"
+    assert handoff["intent_ledger_path"] == "glow/orchestration/orchestration_intents.jsonl"
+    assert handoff["handoff_result"]["ledger_path"] == "glow/orchestration/orchestration_handoffs.jsonl"
+    assert handoff["handoff_result"]["handoff_outcome"] == "staged_only"
     assert handoff["intent"]["schema_version"] == "orchestration_intent.v1"
+    assert handoff["executable_handoff_map"]["intent_kind_to_handoff"]["internal_maintenance_execution"]["handoff_path_status"] == "operational"
 
-    ledger = tmp_path / handoff["ledger_path"]
+    ledger = tmp_path / handoff["intent_ledger_path"]
     row = json.loads(ledger.read_text(encoding="utf-8").splitlines()[-1])
     assert row["intent_id"] == handoff["intent"]["intent_id"]
     assert row["does_not_invoke_external_tools"] is True
+
+
+def test_end_to_end_judgment_to_internal_handoff_and_staged_external_only(tmp_path: Path) -> None:
+    internal_evidence = _base_evidence()
+    internal_evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    internal_judgment = synthesize_delegated_judgment(internal_evidence)
+    internal_intent = synthesize_orchestration_intent(internal_judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, internal_intent)
+    internal_handoff = admit_orchestration_intent(tmp_path, internal_intent)
+
+    assert internal_judgment["recommended_venue"] == "internal_direct_execution"
+    assert internal_intent["executability_classification"] == "executable_now"
+    assert internal_handoff["handoff_outcome"] == "admitted_to_execution_substrate"
+
+    external_judgment = synthesize_delegated_judgment(_base_evidence())
+    external_intent = synthesize_orchestration_intent(external_judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, external_intent)
+    external_handoff = admit_orchestration_intent(tmp_path, external_intent)
+
+    assert external_judgment["recommended_venue"] == "codex_implementation"
+    assert external_handoff["handoff_outcome"] == "staged_only"
+    assert "task_admission" not in external_handoff["details"]
+    assert executable_handoff_map()["known_named_targets_without_handoff_path"] == [
+        "mutation_router",
+        "federation_canonical_execution",
+        "external_tool_placeholder",
+    ]


### PR DESCRIPTION
### Motivation
- Make the orchestration handoff fabric do more than append-only recording by admitting truly `executable_now` internal intents into an existing repo-native admission substrate while preserving constitutional admission boundaries. 
- Keep external/staged venues (`codex_implementation`, `deep_research_audit`, `operator_decision_required`) unchanged and avoid any direct external actuation or new sovereigns. 

### Description
- Added a bounded internal handoff function `admit_orchestration_intent` that validates minimal intent fields, translates `internal_maintenance_execution` intents into a bounded `task_executor.Task`, and calls the existing `task_admission.admit` admission surface to decide admit/deny, then logs the admission decision. 
- Introduced explicit, compact handoff outcome semantics (`staged_only`, `admitted_to_execution_substrate`, `blocked_by_admission`, `blocked_by_operator_requirement`, `blocked_by_insufficient_context`, `execution_target_unavailable`) and a small `_validate_handoff_minimum_fields` check to keep block/defer behavior machine-readable. 
- Added append-only handoff ledger at `glow/orchestration/orchestration_handoffs.jsonl` via `append_orchestration_handoff_ledger` while preserving the original intent ledger `glow/orchestration/orchestration_intents.jsonl`. 
- Exposed a compact `executable_handoff_map()` that documents which intent kinds/targets are operational today and which are named-but-unwired, and surfaced it in the scoped lifecycle diagnostic (`build_scoped_lifecycle_diagnostic`) as `orchestration_handoff.executable_handoff_map` plus `handoff_result`. 
- Updated the orchestration note (`orchestration_intent_fabric_note`) to document the now-operational internal handoff scope, staged-only external venues, and the distinction between admission/handoff and execution completion. 
- Added focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` covering admitted internal handoff, missing-metadata blocking, admission denial honesty, staged-only external behavior, diagnostic visibility, and an end-to-end internal-vs-external path. 

### Testing
- Ran the focused test module with `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and all tests in that file passed. 
- New tests verify: an `internal_direct_execution` judgment produces an `executable_now` intent that is admitted to the `task_admission.admit` surface; missing intent metadata yields a machine-readable block; admission denial is recorded and reported; external/staged venues remain `staged_only`; and the diagnostic surface shows both intent ledger and handoff outcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc0564a1548320b0d4af6c9f9694a2)