### PR TITLE
[codex:orchestration] close internal handoff-to-execution result loop

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -58,6 +58,15 @@ _HANDOFF_OUTCOMES = {
     "execution_target_unavailable",
 }
 
+_EXECUTION_RESULT_STATES = {
+    "handoff_admitted_pending_result",
+    "execution_succeeded",
+    "execution_failed",
+    "execution_result_missing",
+    "execution_still_pending",
+    "handoff_not_admitted",
+}
+
 
 def _iso_utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -293,6 +302,125 @@ def append_orchestration_handoff_ledger(repo_root: Path, handoff: Mapping[str, A
     with ledger_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(handoff), sort_keys=True) + "\n")
     return ledger_path
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            rows.append(parsed)
+    return rows
+
+
+def build_handoff_execution_gap_map(repo_root: Path) -> dict[str, Any]:
+    root = repo_root.resolve()
+    return {
+        "schema_version": "orchestration_handoff_execution_gap.v1",
+        "path": [
+            "delegated_judgment",
+            "orchestration_intent",
+            "orchestration_handoff",
+            "task_admission",
+            "task_executor",
+        ],
+        "existing_downstream_result_source": {
+            "surface": "logs/task_executor.jsonl",
+            "event": "task_result",
+            "status_values": ["completed", "failed"],
+        },
+        "stable_linkage_keys": {
+            "intent_to_handoff": "intent_id",
+            "handoff_to_execution_task": "details.task_admission.task_id",
+            "execution_task_to_result": "task_id",
+        },
+        "stop_point_without_resolution": "handoff_outcome=admitted_to_execution_substrate",
+        "minimal_missing_linkage": (
+            "resolve admitted handoff task_id against task_executor task_result and classify "
+            "orchestration result state."
+        ),
+        "proof_surfaces": {
+            "intent_ledger": "glow/orchestration/orchestration_intents.jsonl",
+            "handoff_ledger": "glow/orchestration/orchestration_handoffs.jsonl",
+            "admission_log": str(task_admission._resolve_admission_log_path().relative_to(root))
+            if task_admission._resolve_admission_log_path().is_relative_to(root)
+            else str(task_admission._resolve_admission_log_path()),
+            "executor_log": str(Path(task_executor.LOG_PATH).relative_to(root))
+            if Path(task_executor.LOG_PATH).is_relative_to(root)
+            else str(Path(task_executor.LOG_PATH)),
+        },
+    }
+
+
+def resolve_orchestration_result(
+    repo_root: Path,
+    handoff: Mapping[str, Any],
+    *,
+    executor_log_path: Path | None = None,
+) -> dict[str, Any]:
+    root = repo_root.resolve()
+    handoff_outcome = str(handoff.get("handoff_outcome") or "")
+    details = handoff.get("details")
+    detail_map = details if isinstance(details, Mapping) else {}
+    task_admission_details = detail_map.get("task_admission")
+    admission_map = task_admission_details if isinstance(task_admission_details, Mapping) else {}
+    task_id = str(admission_map.get("task_id") or "")
+    log_path = executor_log_path or Path(task_executor.LOG_PATH)
+    matching_rows = [row for row in _read_jsonl(log_path) if str(row.get("task_id") or "") == task_id]
+    task_result_rows = [row for row in matching_rows if str(row.get("event") or "") == "task_result"]
+
+    state = "handoff_not_admitted"
+    execution_observed = False
+    loop_closed = False
+
+    if handoff_outcome == "admitted_to_execution_substrate":
+        if not task_id:
+            state = "execution_result_missing"
+        elif task_result_rows:
+            execution_observed = True
+            latest = task_result_rows[-1]
+            status = str(latest.get("status") or "")
+            if status == "completed":
+                state = "execution_succeeded"
+                loop_closed = True
+            elif status == "failed":
+                state = "execution_failed"
+                loop_closed = True
+            else:
+                state = "execution_result_missing"
+        elif matching_rows:
+            state = "execution_still_pending"
+        else:
+            state = "handoff_admitted_pending_result"
+
+    if state not in _EXECUTION_RESULT_STATES:
+        state = "execution_result_missing"
+
+    return {
+        "schema_version": "orchestration_result_resolution.v1",
+        "resolved_at": _iso_utc_now(),
+        "intent_ref": dict(handoff.get("intent_ref") or {}),
+        "handoff_outcome": handoff_outcome,
+        "orchestration_result_state": state,
+        "loop_closed": loop_closed,
+        "execution_observed": execution_observed,
+        "execution_task_ref": {
+            "task_id": task_id or None,
+            "executor_log_path": str(log_path.relative_to(root)) if log_path.is_relative_to(root) else str(log_path),
+        },
+        "result_evidence": {
+            "task_rows_seen": len(matching_rows),
+            "task_result_rows_seen": len(task_result_rows),
+        },
+    }
 
 
 def executable_handoff_map() -> dict[str, Any]:

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -21,6 +21,7 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
             "it does not bypass task admission, kernel, or governor decisions",
             "it can hand internal_maintenance_execution intents into task_admission for bounded admission only",
             "handoff admission is not execution completion; execution remains downstream",
+            "closed-loop orchestration result now resolves downstream task_executor task_result evidence for admitted internal handoffs",
         ],
         "internal_handoff_now_operational": {
             "intent_kind": "internal_maintenance_execution",
@@ -44,6 +45,18 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
         },
         "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
         "handoff_artifact": "glow/orchestration/orchestration_handoffs.jsonl",
+        "result_resolution": {
+            "path": "internal_maintenance_execution -> task_admission_executor -> logs/task_executor.jsonl task_result",
+            "result_states": [
+                "handoff_admitted_pending_result",
+                "execution_still_pending",
+                "execution_succeeded",
+                "execution_failed",
+                "execution_result_missing",
+                "handoff_not_admitted",
+            ],
+            "meaning": "handoff admission records substrate entry; orchestration result closure requires downstream task_result evidence.",
+        },
         "venues_still_staged_only": [
             "codex_implementation",
             "deep_research_audit",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -14,7 +14,9 @@ from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evid
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
+    build_handoff_execution_gap_map,
     executable_handoff_map,
+    resolve_orchestration_result,
     synthesize_orchestration_intent,
 )
 
@@ -86,6 +88,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     orchestration_intent = synthesize_orchestration_intent(delegated_judgment)
     orchestration_ledger_path = append_orchestration_intent_ledger(root, orchestration_intent)
     handoff_result = admit_orchestration_intent(root, orchestration_intent)
+    orchestration_result = resolve_orchestration_result(root, handoff_result)
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -96,10 +99,12 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         "slice_operator_attention_recommendation": operator_attention_recommendation,
         "delegated_judgment": delegated_judgment,
         "orchestration_handoff": {
+            "gap_map": build_handoff_execution_gap_map(root),
             "executable_handoff_map": executable_handoff_map(),
             "intent": orchestration_intent,
             "intent_ledger_path": str(orchestration_ledger_path.relative_to(root)),
             "handoff_result": handoff_result,
+            "execution_result": orchestration_result,
         },
         "actions": rows,
     }

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from importlib import reload
 import json
 from pathlib import Path
 
+import control_plane
 import task_admission
+import task_executor
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
+    build_handoff_execution_gap_map,
     executable_handoff_map,
+    resolve_orchestration_result,
     synthesize_orchestration_intent,
 )
 from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
@@ -166,6 +171,112 @@ def test_internal_executable_intent_is_admitted_to_task_admission_surface(tmp_pa
     assert handoff_row["does_not_invoke_external_tools"] is True
 
 
+def test_admitted_handoff_resolves_success_from_real_downstream_task_result(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    reload(task_executor)
+    reload(task_admission)
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    handoff = admit_orchestration_intent(tmp_path, intent)
+    assert handoff["handoff_outcome"] == "admitted_to_execution_substrate"
+
+    task = task_executor.Task(
+        task_id=handoff["details"]["task_admission"]["task_id"],
+        objective="orchestration_intent_internal_maintenance_handoff",
+        steps=(task_executor.Step(step_id=1, kind="noop", payload=task_executor.NoopPayload(note="ok")),),
+        required_privileges=("orchestration_intent_handoff",),
+    )
+    auth = control_plane.AuthorizationRecord.create(
+        request_type=control_plane.RequestType.TASK_EXECUTION,
+        requester_id="orchestration-test",
+        intent_hash="orh-success",
+        context_hash="ctx-success",
+        policy_version="v1-static",
+        decision=control_plane.Decision.ALLOW,
+        reason=control_plane.ReasonCode.OK,
+        metadata={"approved_privileges": ["orchestration_intent_handoff"]},
+    )
+    decision, result = task_admission.run_task_with_admission(
+        task=task,
+        ctx=task_admission.AdmissionContext(
+            actor="orchestration_intent_fabric",
+            mode="operator",
+            node_id="sentientos_orchestration_handoff",
+            vow_digest=None,
+            doctrine_digest=None,
+            now_utc_iso="2026-04-12T00:00:01Z",
+        ),
+        policy=task_admission.AdmissionPolicy(policy_version="orh-test.v1"),
+        authorization=auth,
+    )
+    assert decision.allowed is True
+    assert result is not None
+    assert result.status == "completed"
+    with Path(task_executor.LOG_PATH).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"task_id": result.task_id, "event": "task_result", "status": result.status}) + "\n")
+
+    resolution = resolve_orchestration_result(tmp_path, handoff, executor_log_path=Path(task_executor.LOG_PATH))
+    assert resolution["orchestration_result_state"] == "execution_succeeded"
+    assert resolution["loop_closed"] is True
+
+
+def test_admitted_handoff_resolves_failed_from_downstream_task_result(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    reload(task_executor)
+    reload(task_admission)
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    handoff = admit_orchestration_intent(tmp_path, intent)
+    task_id = handoff["details"]["task_admission"]["task_id"]
+    executor_log = Path(task_executor.LOG_PATH)
+    executor_log.parent.mkdir(parents=True, exist_ok=True)
+    executor_log.write_text(json.dumps({"task_id": task_id, "event": "task_result", "status": "failed"}) + "\n", encoding="utf-8")
+
+    resolution = resolve_orchestration_result(tmp_path, handoff, executor_log_path=Path(task_executor.LOG_PATH))
+    assert resolution["orchestration_result_state"] == "execution_failed"
+    assert resolution["loop_closed"] is True
+
+
+def test_admitted_handoff_without_downstream_result_stays_pending(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    reload(task_executor)
+    reload(task_admission)
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    handoff = admit_orchestration_intent(tmp_path, intent)
+
+    resolution = resolve_orchestration_result(tmp_path, handoff, executor_log_path=Path(task_executor.LOG_PATH))
+    assert resolution["orchestration_result_state"] == "handoff_admitted_pending_result"
+    assert resolution["loop_closed"] is False
+
+
 def test_missing_required_metadata_blocks_handoff_machine_readably(tmp_path: Path) -> None:
     handoff = admit_orchestration_intent(
         tmp_path,
@@ -214,6 +325,36 @@ def test_external_venues_remain_staged_only_without_internal_admission(tmp_path:
     assert judgment["recommended_venue"] == "codex_implementation"
     assert handoff["handoff_outcome"] == "staged_only"
     assert "task_admission" not in handoff["details"]
+    resolution = resolve_orchestration_result(tmp_path, handoff)
+    assert resolution["orchestration_result_state"] == "handoff_not_admitted"
+    assert resolution["execution_task_ref"]["task_id"] is None
+
+
+def test_blocked_handoff_does_not_fabricate_execution_attempt(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    reload(task_executor)
+    reload(task_admission)
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    denied_handoff = admit_orchestration_intent(
+        tmp_path,
+        intent,
+        admission_policy=task_admission.AdmissionPolicy(policy_version="deny.v1", max_steps=0),
+    )
+    assert denied_handoff["handoff_outcome"] == "blocked_by_admission"
+    resolution = resolve_orchestration_result(tmp_path, denied_handoff, executor_log_path=Path(task_executor.LOG_PATH))
+    assert resolution["orchestration_result_state"] == "handoff_not_admitted"
+    assert resolution["execution_task_ref"]["task_id"] == denied_handoff["details"]["task_admission"]["task_id"]
+    assert resolution["result_evidence"]["task_result_rows_seen"] == 0
 
 
 def test_scoped_lifecycle_diagnostic_surfaces_orchestration_handoff_and_ledger(monkeypatch, tmp_path: Path) -> None:
@@ -246,6 +387,8 @@ def test_scoped_lifecycle_diagnostic_surfaces_orchestration_handoff_and_ledger(m
     assert handoff["intent_ledger_path"] == "glow/orchestration/orchestration_intents.jsonl"
     assert handoff["handoff_result"]["ledger_path"] == "glow/orchestration/orchestration_handoffs.jsonl"
     assert handoff["handoff_result"]["handoff_outcome"] == "staged_only"
+    assert handoff["execution_result"]["orchestration_result_state"] == "handoff_not_admitted"
+    assert handoff["gap_map"]["stable_linkage_keys"]["execution_task_to_result"] == "task_id"
     assert handoff["intent"]["schema_version"] == "orchestration_intent.v1"
     assert handoff["executable_handoff_map"]["intent_kind_to_handoff"]["internal_maintenance_execution"]["handoff_path_status"] == "operational"
 
@@ -287,3 +430,35 @@ def test_end_to_end_judgment_to_internal_handoff_and_staged_external_only(tmp_pa
         "federation_canonical_execution",
         "external_tool_placeholder",
     ]
+
+
+def test_end_to_end_closed_loop_judgment_to_handoff_to_execution_result(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SENTIENTOS_LOG_DIR", str(tmp_path / "logs"))
+    reload(task_executor)
+    reload(task_admission)
+
+    internal_evidence = _base_evidence()
+    internal_evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(internal_evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    handoff = admit_orchestration_intent(tmp_path, intent)
+    assert handoff["handoff_outcome"] == "admitted_to_execution_substrate"
+
+    task_id = handoff["details"]["task_admission"]["task_id"]
+    executor_log = Path(task_executor.LOG_PATH)
+    executor_log.parent.mkdir(parents=True, exist_ok=True)
+    executor_log.write_text(json.dumps({"task_id": task_id, "event": "task_result", "status": "completed"}) + "\n", encoding="utf-8")
+
+    resolution = resolve_orchestration_result(tmp_path, handoff, executor_log_path=Path(task_executor.LOG_PATH))
+    assert resolution["orchestration_result_state"] == "execution_succeeded"
+    assert resolution["loop_closed"] is True
+    gap_map = build_handoff_execution_gap_map(tmp_path)
+    assert gap_map["minimal_missing_linkage"].startswith("resolve admitted handoff task_id")


### PR DESCRIPTION
### Motivation
- Orchestration handoffs targeting the internal task substrate stopped at `admitted_to_execution_substrate` and left the loop open with no machine-readable linkage to real downstream executor outcomes.
- The change aims to close that bounded loop so admitted internal intents can later resolve to explicit orchestration result states using existing task execution evidence, without expanding venues or adding new executors.

### Description
- Add a compact handoff→execution gap map via `build_handoff_execution_gap_map(repo_root)` that documents the path, stable linkage keys, and the existing downstream result surface (`logs/task_executor.jsonl` / `task_result`).
- Implement `resolve_orchestration_result(repo_root, handoff, *, executor_log_path=None)` which resolves an admitted handoff against `task_executor` `task_result` rows (linked by `details.task_admission.task_id`) and emits typed orchestration result states (`handoff_admitted_pending_result`, `execution_still_pending`, `execution_succeeded`, `execution_failed`, `execution_result_missing`, `handoff_not_admitted`).
- Add a small `_read_jsonl` helper and `_EXECUTION_RESULT_STATES` set in `sentientos/orchestration_intent_fabric.py` and expose the gap map and `execution_result` from the scoped lifecycle diagnostic consumer so observability surfaces show intent → handoff → execution resolution (no decision authority change).
- Update `sentientos/orchestration_intent_fabric_note.py` to document what result closure means and the in-scope internal path, and add focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` that prove success, failure, pending, staged-only, blocked handoffs, and an end-to-end closed-loop path from judgment → intent → handoff → downstream task_result resolution.

### Testing
- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and the test suite in that file passed (all new and existing assertions succeeded).
- New tests cover: admitted internal handoff resolving to `execution_succeeded`, resolving to `execution_failed`, admitted-but-no-result remaining pending, staged-only external handoffs not fabricating execution results, blocked handoffs not appearing as execution attempts, and an end-to-end closed-loop visibility check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc0eb018348320a715dabf62a552b5)