### PR TITLE
[codex:orchestration] add bounded retrospective outcome review for internal handoffs

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -67,6 +67,15 @@ _EXECUTION_RESULT_STATES = {
     "handoff_not_admitted",
 }
 
+_ORCHESTRATION_REVIEW_CLASSES = {
+    "clean_recent_orchestration",
+    "handoff_block_heavy",
+    "execution_failure_heavy",
+    "pending_stall_pattern",
+    "mixed_orchestration_stress",
+    "insufficient_history",
+}
+
 
 def _iso_utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -420,6 +429,126 @@ def resolve_orchestration_result(
             "task_rows_seen": len(matching_rows),
             "task_result_rows_seen": len(task_result_rows),
         },
+    }
+
+
+def derive_orchestration_outcome_review(
+    repo_root: Path,
+    *,
+    window_size: int = 10,
+    executor_log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Derive a bounded retrospective review over recent orchestration outcomes."""
+
+    root = repo_root.resolve()
+    intents = _read_jsonl(root / "glow/orchestration/orchestration_intents.jsonl")
+    handoffs = _read_jsonl(root / "glow/orchestration/orchestration_handoffs.jsonl")
+    intent_ids = {str(row.get("intent_id") or "") for row in intents}
+    scoped_handoffs: list[dict[str, Any]] = []
+    for handoff in handoffs:
+        intent_ref = handoff.get("intent_ref")
+        intent_ref_map = intent_ref if isinstance(intent_ref, Mapping) else {}
+        intent_id = str(intent_ref_map.get("intent_id") or "")
+        if intent_id and intent_id in intent_ids:
+            scoped_handoffs.append(handoff)
+
+    recent_handoffs = scoped_handoffs[-max(0, window_size) :] if window_size > 0 else []
+    recent_resolutions = [
+        resolve_orchestration_result(root, handoff, executor_log_path=executor_log_path)
+        for handoff in recent_handoffs
+    ]
+
+    outcome_counts = {
+        "execution_succeeded": 0,
+        "execution_failed": 0,
+        "handoff_admitted_pending_result": 0,
+        "execution_still_pending": 0,
+        "execution_result_missing": 0,
+        "handoff_not_admitted": 0,
+    }
+    blocked_handoffs = 0
+    admitted_handoffs = 0
+    for idx, resolution in enumerate(recent_resolutions):
+        state = str(resolution.get("orchestration_result_state") or "execution_result_missing")
+        if state not in outcome_counts:
+            state = "execution_result_missing"
+        outcome_counts[state] += 1
+
+        handoff_outcome = str(recent_handoffs[idx].get("handoff_outcome") or "")
+        if handoff_outcome in {
+            "blocked_by_admission",
+            "blocked_by_operator_requirement",
+            "blocked_by_insufficient_context",
+            "execution_target_unavailable",
+        }:
+            blocked_handoffs += 1
+        if handoff_outcome == "admitted_to_execution_substrate":
+            admitted_handoffs += 1
+
+    records_considered = len(recent_resolutions)
+    success_count = outcome_counts["execution_succeeded"]
+    failure_count = outcome_counts["execution_failed"]
+    pending_count = (
+        outcome_counts["handoff_admitted_pending_result"]
+        + outcome_counts["execution_still_pending"]
+        + outcome_counts["execution_result_missing"]
+    )
+    block_ratio = (blocked_handoffs / records_considered) if records_considered else 0.0
+    success_ratio = (success_count / records_considered) if records_considered else 0.0
+    failure_ratio = (failure_count / admitted_handoffs) if admitted_handoffs else 0.0
+    pending_ratio = (pending_count / admitted_handoffs) if admitted_handoffs else 0.0
+
+    blocked_heavy = blocked_handoffs >= 2 and block_ratio >= 0.6
+    failure_heavy = admitted_handoffs >= 3 and failure_count >= 2 and failure_ratio >= 0.5
+    stall_heavy = admitted_handoffs >= 3 and pending_count >= 2 and pending_ratio >= 0.5
+
+    classification = "insufficient_history"
+    if records_considered >= 3:
+        if blocked_heavy:
+            classification = "handoff_block_heavy"
+        elif failure_heavy:
+            classification = "execution_failure_heavy"
+        elif stall_heavy:
+            classification = "pending_stall_pattern"
+        elif success_count >= 2 and success_ratio >= 0.6:
+            classification = "clean_recent_orchestration"
+        else:
+            classification = "mixed_orchestration_stress"
+
+    if classification not in _ORCHESTRATION_REVIEW_CLASSES:
+        classification = "mixed_orchestration_stress"
+
+    return {
+        "schema_version": "orchestration_outcome_review.v1",
+        "review_kind": "orchestration_outcome_retrospective",
+        "review_classification": classification,
+        "window_size": max(0, window_size),
+        "records_considered": records_considered,
+        "recent_outcome_counts": outcome_counts,
+        "condition_flags": {
+            "blocked_heavy": blocked_heavy,
+            "failure_heavy": failure_heavy,
+            "stall_heavy": stall_heavy,
+        },
+        "summary": {
+            "recent_pattern": "healthy_bounded_orchestration"
+            if classification == "clean_recent_orchestration"
+            else "orchestration_stress_or_uncertainty",
+            "diagnostic_summary": "bounded retrospective review derived from existing internal orchestration artifacts only",
+        },
+        "artifacts_read": {
+            "intent_ledger": "glow/orchestration/orchestration_intents.jsonl",
+            "handoff_ledger": "glow/orchestration/orchestration_handoffs.jsonl",
+            "executor_log": str((executor_log_path or Path(task_executor.LOG_PATH)).relative_to(root))
+            if (executor_log_path or Path(task_executor.LOG_PATH)).is_relative_to(root)
+            else str(executor_log_path or Path(task_executor.LOG_PATH)),
+        },
+        "diagnostic_only": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "review_only": True,
+        "recommendation_only": True,
+        "does_not_change_admission_or_execution_authority": True,
     }
 
 

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -57,6 +57,28 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
             ],
             "meaning": "handoff admission records substrate entry; orchestration result closure requires downstream task_result evidence.",
         },
+        "outcome_review": {
+            "meaning": "bounded retrospective classification over recent internal orchestration outcomes.",
+            "reads_existing_artifacts_only": [
+                "glow/orchestration/orchestration_intents.jsonl",
+                "glow/orchestration/orchestration_handoffs.jsonl",
+                "logs/task_executor.jsonl task_result linkage",
+            ],
+            "classifications": [
+                "clean_recent_orchestration",
+                "handoff_block_heavy",
+                "execution_failure_heavy",
+                "pending_stall_pattern",
+                "mixed_orchestration_stress",
+                "insufficient_history",
+            ],
+            "explicitly_not": [
+                "a new admission authority",
+                "a governor/kernel override",
+                "direct external actuation",
+                "a new execution venue",
+            ],
+        },
         "venues_still_staged_only": [
             "codex_implementation",
             "deep_research_audit",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -15,6 +15,7 @@ from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
+    derive_orchestration_outcome_review,
     executable_handoff_map,
     resolve_orchestration_result,
     synthesize_orchestration_intent,
@@ -89,6 +90,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     orchestration_ledger_path = append_orchestration_intent_ledger(root, orchestration_intent)
     handoff_result = admit_orchestration_intent(root, orchestration_intent)
     orchestration_result = resolve_orchestration_result(root, handoff_result)
+    orchestration_outcome_review = derive_orchestration_outcome_review(root)
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -105,6 +107,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "intent_ledger_path": str(orchestration_ledger_path.relative_to(root)),
             "handoff_result": handoff_result,
             "execution_result": orchestration_result,
+            "outcome_review": orchestration_outcome_review,
         },
         "actions": rows,
     }

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -12,6 +12,7 @@ from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
+    derive_orchestration_outcome_review,
     executable_handoff_map,
     resolve_orchestration_result,
     synthesize_orchestration_intent,
@@ -462,3 +463,181 @@ def test_end_to_end_closed_loop_judgment_to_handoff_to_execution_result(monkeypa
     assert resolution["loop_closed"] is True
     gap_map = build_handoff_execution_gap_map(tmp_path)
     assert gap_map["minimal_missing_linkage"].startswith("resolve admitted handoff task_id")
+
+
+def _seed_orchestration_history(
+    tmp_path: Path,
+    *,
+    outcomes: list[str],
+    executor_statuses: list[str | None],
+) -> Path:
+    intent_rows: list[dict[str, object]] = []
+    handoff_rows: list[dict[str, object]] = []
+    executor_rows: list[dict[str, object]] = []
+    for idx, handoff_outcome in enumerate(outcomes):
+        intent_id = f"orh-seed-{idx}"
+        intent_rows.append(
+            {
+                "schema_version": "orchestration_intent.v1",
+                "intent_id": intent_id,
+            }
+        )
+        details: dict[str, object] = {}
+        status = executor_statuses[idx]
+        if handoff_outcome == "admitted_to_execution_substrate":
+            task_id = f"task-{idx}"
+            details["task_admission"] = {"task_id": task_id}
+            if status is not None:
+                executor_rows.append({"task_id": task_id, "event": "task_result", "status": status})
+        handoff_rows.append(
+            {
+                "schema_version": "orchestration_handoff.v1",
+                "handoff_outcome": handoff_outcome,
+                "intent_ref": {"intent_id": intent_id, "intent_kind": "internal_maintenance_execution"},
+                "details": details,
+            }
+        )
+
+    intent_path = tmp_path / "glow/orchestration/orchestration_intents.jsonl"
+    handoff_path = tmp_path / "glow/orchestration/orchestration_handoffs.jsonl"
+    executor_path = tmp_path / "logs/task_executor.jsonl"
+    _write_jsonl(intent_path, intent_rows)
+    _write_jsonl(handoff_path, handoff_rows)
+    _write_jsonl(executor_path, executor_rows)
+    return executor_path
+
+
+def test_outcome_review_success_dominant_classifies_clean(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "blocked_by_admission",
+            "admitted_to_execution_substrate",
+        ],
+        executor_statuses=["completed", "completed", "completed", None, "failed"],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "clean_recent_orchestration"
+    assert review["summary"]["recent_pattern"] == "healthy_bounded_orchestration"
+
+
+def test_outcome_review_block_heavy_classifies_blocked_pattern(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "blocked_by_admission",
+            "blocked_by_admission",
+            "blocked_by_operator_requirement",
+            "admitted_to_execution_substrate",
+            "staged_only",
+        ],
+        executor_statuses=[None, None, None, "completed", None],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "handoff_block_heavy"
+    assert review["condition_flags"]["blocked_heavy"] is True
+
+
+def test_outcome_review_failure_heavy_classifies_execution_failure_pattern(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+        ],
+        executor_statuses=["failed", "failed", "completed", "failed"],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "execution_failure_heavy"
+    assert review["condition_flags"]["failure_heavy"] is True
+
+
+def test_outcome_review_pending_heavy_classifies_stall_pattern(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+        ],
+        executor_statuses=[None, None, "completed", None],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "pending_stall_pattern"
+    assert review["condition_flags"]["stall_heavy"] is True
+
+
+def test_outcome_review_mixed_classifies_stress_pattern(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "blocked_by_admission",
+            "staged_only",
+            "admitted_to_execution_substrate",
+        ],
+        executor_statuses=["completed", "failed", None, None, None],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "mixed_orchestration_stress"
+    assert review["summary"]["recent_pattern"] == "orchestration_stress_or_uncertainty"
+
+
+def test_outcome_review_insufficient_history_when_too_few_records(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=["admitted_to_execution_substrate", "blocked_by_admission"],
+        executor_statuses=["completed", None],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "insufficient_history"
+    assert review["records_considered"] == 2
+
+
+def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritative(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+
+    def _fake_resolver(_repo_root: Path, *, action_id: str, correlation_id: str) -> dict[str, object]:
+        return {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        }
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle", _fake_resolver)
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-orh-review",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    review = diagnostic["orchestration_handoff"]["outcome_review"]
+
+    assert "review_classification" in review
+    assert "recent_outcome_counts" in review
+    assert review["diagnostic_only"] is True
+    assert review["non_authoritative"] is True
+    assert review["decision_power"] == "none"
+    assert review["does_not_change_admission_or_execution_authority"] is True


### PR DESCRIPTION
### Motivation
- Provide a small, conservative, machine-readable retrospective review so the closed-loop orchestration path can report whether recent delegated judgment → handoff → execution patterns look healthy or stressed.  
- Keep the review strictly diagnostic and non-sovereign, derived only from existing proof-visible artifacts (intents, handoffs, downstream task results) and not changing any admission or execution authority.  

### Description
- Add a bounded outcome reviewer `derive_orchestration_outcome_review(...)` in `sentientos/orchestration_intent_fabric.py` that reads `glow/orchestration/orchestration_intents.jsonl`, `glow/orchestration/orchestration_handoffs.jsonl`, and the task executor log to produce a compact classification vocabulary: `clean_recent_orchestration`, `handoff_block_heavy`, `execution_failure_heavy`, `pending_stall_pattern`, `mixed_orchestration_stress`, and `insufficient_history`, plus recent outcome counts, stress flags, and a short summary; the review is explicitly `diagnostic_only`, `non_authoritative`, and `decision_power: none`.  
- Surface the review from the existing scoped diagnostic consumer by exposing `orchestration_handoff.outcome_review` in `sentientos/scoped_lifecycle_diagnostic.py` so existing diagnostic consumers can access the retrospective hint without adding a new decision surface.  
- Extend `sentientos/orchestration_intent_fabric_note.py` with a short technical section describing what the outcome review means, which artifacts it reads, the possible classifications, and what it explicitly does not do.  
- Add focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` that seed proof-visible intent/handoff/executor artifacts and assert each requested classification and that the diagnostic consumer surfaces the review while remaining non-authoritative.  

### Testing
- Ran the focused unit tests `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and they passed.  
- Ran the repository test harness `python -m scripts.run_tests -q`; this run surfaced unrelated failures in the pulse federation tests (6 failing tests in `tests/test_pulse_federation.py`) that pre-exist the orchestration changes and are orthogonal to this diagnostic-only feature.  
- Ran `mypy scripts/ sentientos/` which reports repository-wide typing issues unrelated to these changes (pre-existing typing noise).  
- Ran `python scripts/audit_immutability_verifier.py` which passed locally; `verify_audits --strict` is not present in this environment.  

Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric_note.py`, and `sentientos/tests/test_orchestration_intent_fabric.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69deee6e7a348320ad81e34e413dbe6d)