### PR TITLE
[codex:orchestration] add bounded operator-attention recommendation layer

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -76,6 +76,16 @@ _ORCHESTRATION_REVIEW_CLASSES = {
     "insufficient_history",
 }
 
+_ORCHESTRATION_ATTENTION_RECOMMENDATIONS = {
+    "none",
+    "observe",
+    "inspect_handoff_blocks",
+    "inspect_execution_failures",
+    "inspect_pending_stall",
+    "review_mixed_orchestration_stress",
+    "insufficient_context",
+}
+
 
 def _iso_utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -549,6 +559,100 @@ def derive_orchestration_outcome_review(
         "review_only": True,
         "recommendation_only": True,
         "does_not_change_admission_or_execution_authority": True,
+    }
+
+
+def derive_orchestration_attention_recommendation(
+    outcome_review: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive bounded operator-attention recommendation from orchestration outcome review only."""
+
+    review_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    records_considered = int(outcome_review.get("records_considered") or 0)
+    condition_flags_raw = outcome_review.get("condition_flags")
+    condition_flags = condition_flags_raw if isinstance(condition_flags_raw, Mapping) else {}
+    blocked_heavy = bool(condition_flags.get("blocked_heavy"))
+    failure_heavy = bool(condition_flags.get("failure_heavy"))
+    stall_heavy = bool(condition_flags.get("stall_heavy"))
+    recent_counts_raw = outcome_review.get("recent_outcome_counts")
+    recent_outcome_counts = recent_counts_raw if isinstance(recent_counts_raw, Mapping) else {}
+    handoff_not_admitted = int(recent_outcome_counts.get("handoff_not_admitted") or 0)
+    light_block_pattern = handoff_not_admitted >= 1 and not blocked_heavy
+
+    recommendation = "insufficient_context"
+    rationale = "insufficient_orchestration_history_for_confident_attention_guidance"
+
+    if review_classification == "clean_recent_orchestration":
+        recommendation = "none"
+        rationale = "recent_internal_orchestration_outcomes_are_clean_and_loop_closure_is_healthy"
+    elif review_classification == "handoff_block_heavy" or blocked_heavy:
+        recommendation = "inspect_handoff_blocks"
+        rationale = "recent_history_shows_block_heavy_internal_handoff_behavior"
+    elif review_classification == "execution_failure_heavy" or failure_heavy:
+        recommendation = "inspect_execution_failures"
+        rationale = "recent_history_shows_execution_failure_heavy_pattern_after_admission"
+    elif review_classification == "pending_stall_pattern" or stall_heavy:
+        recommendation = "inspect_pending_stall"
+        rationale = "recent_history_shows_pending_or_missing_result_stall_pattern"
+    elif review_classification == "mixed_orchestration_stress":
+        recommendation = "review_mixed_orchestration_stress"
+        rationale = "recent_history_shows_mixed_orchestration_stress_needing_human_interpretation"
+    elif review_classification == "insufficient_history":
+        recommendation = "insufficient_context"
+        rationale = "insufficient_recent_orchestration_history_for_specific_attention_recommendation"
+    elif light_block_pattern and records_considered >= 3 and review_classification not in {"clean_recent_orchestration"}:
+        recommendation = "observe"
+        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
+
+    if (
+        light_block_pattern
+        and review_classification == "mixed_orchestration_stress"
+        and recommendation == "review_mixed_orchestration_stress"
+    ):
+        recommendation = "observe"
+        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
+
+    if recommendation not in _ORCHESTRATION_ATTENTION_RECOMMENDATIONS:
+        recommendation = "insufficient_context"
+        rationale = "unrecognized_review_pattern_defaulted_to_insufficient_context"
+
+    return {
+        "schema_version": "orchestration_attention_recommendation.v1",
+        "source": "orchestration_outcome_review",
+        "review_ref": {
+            "schema_version": str(outcome_review.get("schema_version") or ""),
+            "review_kind": str(outcome_review.get("review_kind") or ""),
+            "review_classification": review_classification,
+        },
+        "operator_attention_recommendation": recommendation,
+        "basis": {
+            "records_considered": records_considered,
+            "condition_flags": {
+                "blocked_heavy": blocked_heavy,
+                "failure_heavy": failure_heavy,
+                "stall_heavy": stall_heavy,
+                "light_block_pattern": light_block_pattern,
+            },
+            "recent_outcome_counts": {
+                "execution_succeeded": int(recent_outcome_counts.get("execution_succeeded") or 0),
+                "execution_failed": int(recent_outcome_counts.get("execution_failed") or 0),
+                "handoff_admitted_pending_result": int(recent_outcome_counts.get("handoff_admitted_pending_result") or 0),
+                "execution_still_pending": int(recent_outcome_counts.get("execution_still_pending") or 0),
+                "execution_result_missing": int(recent_outcome_counts.get("execution_result_missing") or 0),
+                "handoff_not_admitted": handoff_not_admitted,
+            },
+            "rationale": rationale,
+            "derived_from_existing_signals_only": [
+                "orchestration_outcome_review.review_classification",
+                "orchestration_outcome_review.condition_flags",
+                "orchestration_outcome_review.recent_outcome_counts",
+            ],
+        },
+        "diagnostic_only": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "recommendation_only": True,
+        "does_not_change_admission_or_execution": True,
     }
 
 

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -79,6 +79,29 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "a new execution venue",
             ],
         },
+        "operator_attention_recommendation": {
+            "meaning": "bounded diagnostic recommendation about what operator attention internal orchestration behavior likely needs.",
+            "derived_from": [
+                "orchestration_outcome_review.review_classification",
+                "orchestration_outcome_review.condition_flags",
+                "orchestration_outcome_review.recent_outcome_counts",
+            ],
+            "values": [
+                "none",
+                "observe",
+                "inspect_handoff_blocks",
+                "inspect_execution_failures",
+                "inspect_pending_stall",
+                "review_mixed_orchestration_stress",
+                "insufficient_context",
+            ],
+            "explicitly_not": [
+                "workflow automation authority",
+                "admission policy mutation",
+                "execution control",
+                "a sovereign decision surface",
+            ],
+        },
         "venues_still_staged_only": [
             "codex_implementation",
             "deep_research_audit",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -15,6 +15,7 @@ from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
+    derive_orchestration_attention_recommendation,
     derive_orchestration_outcome_review,
     executable_handoff_map,
     resolve_orchestration_result,
@@ -91,6 +92,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     handoff_result = admit_orchestration_intent(root, orchestration_intent)
     orchestration_result = resolve_orchestration_result(root, handoff_result)
     orchestration_outcome_review = derive_orchestration_outcome_review(root)
+    orchestration_attention_recommendation = derive_orchestration_attention_recommendation(orchestration_outcome_review)
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -108,6 +110,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "handoff_result": handoff_result,
             "execution_result": orchestration_result,
             "outcome_review": orchestration_outcome_review,
+            "attention_recommendation": orchestration_attention_recommendation,
         },
         "actions": rows,
     }

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -12,6 +12,7 @@ from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
+    derive_orchestration_attention_recommendation,
     derive_orchestration_outcome_review,
     executable_handoff_map,
     resolve_orchestration_result,
@@ -523,6 +524,8 @@ def test_outcome_review_success_dominant_classifies_clean(tmp_path: Path) -> Non
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "clean_recent_orchestration"
     assert review["summary"]["recent_pattern"] == "healthy_bounded_orchestration"
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] == "none"
 
 
 def test_outcome_review_block_heavy_classifies_blocked_pattern(tmp_path: Path) -> None:
@@ -541,6 +544,8 @@ def test_outcome_review_block_heavy_classifies_blocked_pattern(tmp_path: Path) -
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "handoff_block_heavy"
     assert review["condition_flags"]["blocked_heavy"] is True
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] == "inspect_handoff_blocks"
 
 
 def test_outcome_review_failure_heavy_classifies_execution_failure_pattern(tmp_path: Path) -> None:
@@ -558,6 +563,8 @@ def test_outcome_review_failure_heavy_classifies_execution_failure_pattern(tmp_p
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "execution_failure_heavy"
     assert review["condition_flags"]["failure_heavy"] is True
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] == "inspect_execution_failures"
 
 
 def test_outcome_review_pending_heavy_classifies_stall_pattern(tmp_path: Path) -> None:
@@ -575,6 +582,8 @@ def test_outcome_review_pending_heavy_classifies_stall_pattern(tmp_path: Path) -
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "pending_stall_pattern"
     assert review["condition_flags"]["stall_heavy"] is True
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] == "inspect_pending_stall"
 
 
 def test_outcome_review_mixed_classifies_stress_pattern(tmp_path: Path) -> None:
@@ -593,6 +602,11 @@ def test_outcome_review_mixed_classifies_stress_pattern(tmp_path: Path) -> None:
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "mixed_orchestration_stress"
     assert review["summary"]["recent_pattern"] == "orchestration_stress_or_uncertainty"
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] in {
+        "review_mixed_orchestration_stress",
+        "observe",
+    }
 
 
 def test_outcome_review_insufficient_history_when_too_few_records(tmp_path: Path) -> None:
@@ -605,6 +619,27 @@ def test_outcome_review_insufficient_history_when_too_few_records(tmp_path: Path
     review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
     assert review["review_classification"] == "insufficient_history"
     assert review["records_considered"] == 2
+    attention = derive_orchestration_attention_recommendation(review)
+    assert attention["operator_attention_recommendation"] == "insufficient_context"
+
+
+def test_attention_recommendation_light_block_pattern_prefers_observe(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "blocked_by_admission",
+            "admitted_to_execution_substrate",
+            "staged_only",
+        ],
+        executor_statuses=["completed", "completed", None, "completed", None],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    attention = derive_orchestration_attention_recommendation(review)
+    assert review["review_classification"] in {"clean_recent_orchestration", "mixed_orchestration_stress"}
+    assert attention["operator_attention_recommendation"] in {"none", "observe"}
 
 
 def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritative(
@@ -634,6 +669,7 @@ def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritati
 
     diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
     review = diagnostic["orchestration_handoff"]["outcome_review"]
+    attention = diagnostic["orchestration_handoff"]["attention_recommendation"]
 
     assert "review_classification" in review
     assert "recent_outcome_counts" in review
@@ -641,3 +677,62 @@ def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritati
     assert review["non_authoritative"] is True
     assert review["decision_power"] == "none"
     assert review["does_not_change_admission_or_execution_authority"] is True
+    assert attention["operator_attention_recommendation"] in {
+        "none",
+        "observe",
+        "inspect_handoff_blocks",
+        "inspect_execution_failures",
+        "inspect_pending_stall",
+        "review_mixed_orchestration_stress",
+        "insufficient_context",
+    }
+    assert attention["diagnostic_only"] is True
+    assert attention["non_authoritative"] is True
+    assert attention["decision_power"] == "none"
+    assert attention["recommendation_only"] is True
+    assert attention["does_not_change_admission_or_execution"] is True
+
+
+def test_recent_history_review_to_attention_to_consumer_stays_non_authoritative(tmp_path: Path) -> None:
+    executor_log = _seed_orchestration_history(
+        tmp_path,
+        outcomes=[
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+            "admitted_to_execution_substrate",
+        ],
+        executor_statuses=["failed", "failed", "completed", "failed"],
+    )
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    attention = derive_orchestration_attention_recommendation(review)
+
+    assert review["review_classification"] == "execution_failure_heavy"
+    assert attention["operator_attention_recommendation"] == "inspect_execution_failures"
+    assert attention["review_ref"]["review_classification"] == review["review_classification"]
+    assert attention["non_authoritative"] is True
+    assert attention["decision_power"] == "none"
+    assert attention["does_not_change_admission_or_execution"] is True
+
+
+def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    review = derive_orchestration_outcome_review(tmp_path)
+    attention = derive_orchestration_attention_recommendation(review)
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert attention["does_not_change_admission_or_execution"] is True
+    assert before["handoff_outcome"] == "admitted_to_execution_substrate"
+    assert after["handoff_outcome"] == "admitted_to_execution_substrate"


### PR DESCRIPTION
### Motivation
- Provide a small, conservative, machine-readable layer that recommends the kind of human attention internal orchestration handoffs may need, derived only from existing orchestration outcome review signals. 
- Keep the layer strictly diagnostic and non-sovereign so it cannot alter admission or execution behavior. 

### Description
- Added a compact attention vocabulary and classifier: `derive_orchestration_attention_recommendation` with values `none`, `observe`, `inspect_handoff_blocks`, `inspect_execution_failures`, `inspect_pending_stall`, `review_mixed_orchestration_stress`, `insufficient_context`. 
- Classifier only reads `orchestration_outcome_review` fields (`review_classification`, `condition_flags`, `recent_outcome_counts`, `records_considered`) and returns a typed, proof-visible recommendation artifact including `diagnostic_only`, `non_authoritative`, `decision_power: none`, and `does_not_change_admission_or_execution`. 
- Exposed the recommendation in the scoped diagnostic consumer at `orchestration_handoff.attention_recommendation` without changing any handoff/admission/execution code paths. 
- Updated `orchestration_intent_fabric` note to document meaning, inputs, allowed values, and explicit non-authoritative boundaries; added focused tests exercising the mapping rules and non-authority guarantees. 

### Testing
- Ran focused unit tests: `python -m pytest -q sentientos/tests/test_orchestration_intent_fabric.py` — passed (new recommendation tests included). 
- Verified artifact immutability check: `python scripts/audit_immutability_verifier.py` — passed. 
- Repository-wide static checks and full test suite show pre-existing failures: `mypy scripts/ sentientos/` — failed due to repository-wide typing issues unrelated to this change; `python -m scripts.run_tests -q` — failed due to unrelated test failures (notably `tests/test_pulse_federation.py`); `verify_audits --strict` is not available in this environment. 
- Added tests proving: clean → `none`; light block → `observe`/`none` (bounded); block-heavy → `inspect_handoff_blocks`; failure-heavy → `inspect_execution_failures`; pending-stall → `inspect_pending_stall`; mixed → `review_mixed_orchestration_stress`; insufficient history → `insufficient_context`; and that the diagnostic consumer surfaces the recommendation and that the recommendation does not change admission/execution behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69def92d24e88320a1052d3702066ddd)