### PR TITLE
[codex:orchestration] extract bounded orchestration venue scaffold

### DIFF
--- a/sentientos/bounded_orchestration_pattern.py
+++ b/sentientos/bounded_orchestration_pattern.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+_REQUIRED_LAYER = "required_for_new_venue"
+_OPTIONAL_LAYER = "optional_or_advanced"
+_CURRENT_INTERNAL_SPECIFIC_LAYER = "current_internal_task_admission_specific"
+
+_REQUIRED_VENUE_FIELDS = (
+    "venue_id",
+    "supported_intent_kinds",
+    "executability_classes",
+    "handoff_substrate",
+    "result_source",
+    "required_linkage_fields",
+    "review_attention_capabilities",
+    "anti_sovereignty_guarantees",
+)
+
+
+def bounded_orchestration_layers() -> list[dict[str, Any]]:
+    """Return the compact reusable layer model for bounded orchestration venues."""
+
+    return [
+        {
+            "layer": "delegated_judgment_input",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.delegated_judgment_fabric.synthesize_delegated_judgment",
+            "why": "every venue must inherit recommendation + escalation provenance before intent typing",
+        },
+        {
+            "layer": "orchestration_intent_typing",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.synthesize_orchestration_intent",
+            "why": "typed intent/work-order artifacts are the constitutional handoff unit",
+        },
+        {
+            "layer": "executability_classification",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric._translate_kind",
+            "why": "venue rollout requires explicit executable_now vs staged/blocked semantics",
+        },
+        {
+            "layer": "handoff_substrate_target",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.admit_orchestration_intent",
+            "why": "venue must declare where admitted work is staged or executed",
+        },
+        {
+            "layer": "handoff_outcome_semantics",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.admit_orchestration_intent",
+            "why": "bounded outcomes keep admission, staged-only, and blocked states machine-readable",
+        },
+        {
+            "layer": "downstream_result_resolution",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.resolve_orchestration_result",
+            "why": "handoff closure requires linking admitted execution records to result evidence",
+        },
+        {
+            "layer": "retrospective_orchestration_review",
+            "classification": _OPTIONAL_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.derive_orchestration_outcome_review",
+            "why": "recommended for diagnostics; not required for initial venue handoff viability",
+        },
+        {
+            "layer": "operator_attention_recommendation",
+            "classification": _OPTIONAL_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric.derive_orchestration_attention_recommendation",
+            "why": "bounded attention guidance is valuable but should not gate initial venue onboarding",
+        },
+        {
+            "layer": "task_admission_executor_noop_task_materialization",
+            "classification": _CURRENT_INTERNAL_SPECIFIC_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric._build_internal_maintenance_task",
+            "why": "specific to the currently operational internal task-admission substrate",
+        },
+        {
+            "layer": "task_executor_jsonl_task_result_resolution",
+            "classification": _CURRENT_INTERNAL_SPECIFIC_LAYER,
+            "implementation_anchor": "logs/task_executor.jsonl task_result linkage",
+            "why": "current venue-specific result source and linkage surface",
+        },
+        {
+            "layer": "explicit_anti_sovereignty_boundaries",
+            "classification": _REQUIRED_LAYER,
+            "implementation_anchor": "sentientos.orchestration_intent_fabric._anti_sovereignty_payload",
+            "why": "venue onboarding must preserve non-authoritative constitutional posture",
+        },
+    ]
+
+
+def bounded_orchestration_venue_scaffold() -> dict[str, Any]:
+    """Return the reusable machine-readable scaffold for bounded venue onboarding."""
+
+    return {
+        "schema_version": "bounded_orchestration_venue_scaffold.v1",
+        "pattern_scope": "bounded_orchestration_venue_expansion",
+        "current_reference_venue": {
+            "venue_id": "internal_task_admission",
+            "supported_intent_kinds": ["internal_maintenance_execution"],
+            "executability_classes": ["executable_now", "blocked_operator_required", "blocked_insufficient_context"],
+            "handoff_substrate": "task_admission_executor",
+            "result_source": {
+                "surface": "logs/task_executor.jsonl",
+                "event": "task_result",
+                "status_values": ["completed", "failed"],
+            },
+            "required_linkage_fields": {
+                "intent_to_handoff": ["intent_id"],
+                "handoff_to_admission": ["details.task_admission.task_id"],
+                "admission_to_result": ["task_id"],
+            },
+            "review_attention_capabilities": {
+                "outcome_review_enabled": True,
+                "attention_recommendation_enabled": True,
+            },
+            "anti_sovereignty_guarantees": {
+                "non_authoritative": True,
+                "decision_power": "none",
+                "does_not_invoke_external_tools": True,
+                "does_not_change_admission_or_execution": True,
+                "does_not_replace_operator_authority": True,
+            },
+        },
+        "layer_model": bounded_orchestration_layers(),
+    }
+
+
+def validate_bounded_orchestration_venue(candidate: Mapping[str, Any]) -> list[str]:
+    """Return missing required venue fields for bounded orchestration onboarding."""
+
+    missing: list[str] = []
+    for field in _REQUIRED_VENUE_FIELDS:
+        if field not in candidate:
+            missing.append(field)
+
+    linkage = candidate.get("required_linkage_fields")
+    if isinstance(linkage, Mapping):
+        for required_link in ("intent_to_handoff", "handoff_to_admission", "admission_to_result"):
+            if required_link not in linkage:
+                missing.append(f"required_linkage_fields.{required_link}")
+
+    guarantees = candidate.get("anti_sovereignty_guarantees")
+    if isinstance(guarantees, Mapping):
+        if guarantees.get("non_authoritative") is not True:
+            missing.append("anti_sovereignty_guarantees.non_authoritative")
+        if str(guarantees.get("decision_power") or "") != "none":
+            missing.append("anti_sovereignty_guarantees.decision_power")
+
+    return missing
+
+
+def next_bounded_venue_candidate_assessment() -> dict[str, Any]:
+    """Provide the grounded next venue candidate assessment without onboarding it."""
+
+    return {
+        "recommended_next_venue": "codex_implementation",
+        "why_best_next": (
+            "it already has delegated-judgment recommendation coverage and typed orchestration intent/work-order "
+            "classification, so expansion can focus on bounded handoff/result linkage without changing constitutional authority posture"
+        ),
+        "already_present_prerequisites": [
+            "delegated_judgment_fabric emits recommended_venue=codex_implementation",
+            "orchestration_intent_fabric emits intent_kind=codex_work_order",
+            "executability_classification=stageable_external_work_order keeps it non-executable in current pass",
+            "append-only intent and handoff ledgers already capture staged codex work-order artifacts",
+        ],
+        "largest_missing_prerequisite": (
+            "a bounded, append-only external handoff admission/result substrate with stable linkage keys equivalent to "
+            "the current task_admission.task_id -> task_executor.task_result closure"
+        ),
+        "relative_difficulty_vs_current_internal_venue": "harder_than_internal_task_admission",
+        "difficulty_rationale": (
+            "external venue rollout adds transport, admission parity, and downstream proof-linkage constraints absent in the current internal substrate"
+        ),
+        "not_implemented_in_this_pass": True,
+    }

--- a/sentientos/bounded_orchestration_pattern_note.py
+++ b/sentientos/bounded_orchestration_pattern_note.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def bounded_orchestration_pattern_note() -> dict[str, Any]:
+    """Compact developer/operator note for bounded orchestration venue onboarding."""
+
+    return {
+        "title": "bounded_orchestration_pattern",
+        "what_it_is": (
+            "A compact constitutional pattern: delegated judgment -> typed orchestration intent -> bounded handoff -> "
+            "result resolution -> retrospective review -> operator-attention recommendation, with explicit non-sovereign boundaries."
+        ),
+        "reusable_parts": [
+            "intent typing + executability classification",
+            "append-only intent/handoff ledgers",
+            "handoff-to-result linkage fields",
+            "bounded retrospective review and operator-attention recommendation",
+            "explicit anti-sovereignty payload fields",
+        ],
+        "onboarding_checklist": [
+            "define venue_id with supported_intent_kinds and executability_classes",
+            "declare handoff_substrate and append-only result_source",
+            "define required linkage fields from intent -> handoff -> result",
+            "preserve non_authoritative decision_power=none boundaries",
+            "add focused tests for required fields and missing-field detection",
+        ],
+        "what_not_to_do": [
+            "do not add direct external actuation by default",
+            "do not create a new sovereign or hidden orchestrator authority",
+            "do not bypass admission/result linkage proof surfaces",
+            "do not expand venue coverage without scaffold + tests",
+        ],
+    }

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -87,6 +87,29 @@ _ORCHESTRATION_ATTENTION_RECOMMENDATIONS = {
 }
 
 
+def _anti_sovereignty_payload(
+    *,
+    recommendation_only: bool,
+    diagnostic_only: bool,
+    does_not_invoke_external_tools: bool | None = None,
+    does_not_change_admission_or_execution: bool | None = None,
+    additional_fields: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "non_authoritative": True,
+        "decision_power": "none",
+        "recommendation_only": recommendation_only,
+        "diagnostic_only": diagnostic_only,
+    }
+    if does_not_invoke_external_tools is not None:
+        payload["does_not_invoke_external_tools"] = does_not_invoke_external_tools
+    if does_not_change_admission_or_execution is not None:
+        payload["does_not_change_admission_or_execution"] = does_not_change_admission_or_execution
+    if additional_fields:
+        payload.update(dict(additional_fields))
+    return payload
+
+
 def _iso_utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -224,11 +247,12 @@ def synthesize_orchestration_intent(
         "work_order": work_order,
         "requires_admission": execution_target in {"task_admission_executor", "mutation_router", "federation_canonical_execution"},
         "requires_operator_approval": requires_operator_approval,
-        "non_authoritative": True,
-        "recommendation_only": False,
-        "diagnostic_only": False,
+        **_anti_sovereignty_payload(
+            recommendation_only=False,
+            diagnostic_only=False,
+            does_not_invoke_external_tools=True,
+        ),
         "staged_handoff_only": executability != "executable_now",
-        "does_not_invoke_external_tools": True,
         "does_not_override_existing_admission": True,
         "does_not_override_kernel_or_governor": True,
         "does_not_replace_operator_authority": True,
@@ -553,12 +577,15 @@ def derive_orchestration_outcome_review(
             if (executor_log_path or Path(task_executor.LOG_PATH)).is_relative_to(root)
             else str(executor_log_path or Path(task_executor.LOG_PATH)),
         },
-        "diagnostic_only": True,
-        "non_authoritative": True,
-        "decision_power": "none",
-        "review_only": True,
-        "recommendation_only": True,
-        "does_not_change_admission_or_execution_authority": True,
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "does_not_change_admission_or_execution_authority": True,
+            },
+        ),
     }
 
 
@@ -648,11 +675,11 @@ def derive_orchestration_attention_recommendation(
                 "orchestration_outcome_review.recent_outcome_counts",
             ],
         },
-        "diagnostic_only": True,
-        "non_authoritative": True,
-        "decision_power": "none",
-        "recommendation_only": True,
-        "does_not_change_admission_or_execution": True,
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+        ),
     }
 
 
@@ -759,9 +786,12 @@ def admit_orchestration_intent(
             "intent_kind": str(intent.get("intent_kind") or ""),
         },
         "details": details,
-        "non_authoritative": True,
+        **_anti_sovereignty_payload(
+            recommendation_only=False,
+            diagnostic_only=False,
+            does_not_invoke_external_tools=True,
+        ),
         "does_not_execute_task_directly": True,
-        "does_not_invoke_external_tools": True,
     }
     handoff_ledger_path = append_orchestration_handoff_ledger(root, handoff_record)
     return {

--- a/sentientos/tests/test_bounded_orchestration_pattern.py
+++ b/sentientos/tests/test_bounded_orchestration_pattern.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from sentientos.bounded_orchestration_pattern import (
+    bounded_orchestration_layers,
+    bounded_orchestration_venue_scaffold,
+    next_bounded_venue_candidate_assessment,
+    validate_bounded_orchestration_venue,
+)
+
+
+def test_scaffold_is_coherent_and_machine_readable() -> None:
+    scaffold = bounded_orchestration_venue_scaffold()
+
+    assert scaffold["schema_version"] == "bounded_orchestration_venue_scaffold.v1"
+    assert scaffold["pattern_scope"] == "bounded_orchestration_venue_expansion"
+    reference = scaffold["current_reference_venue"]
+    assert reference["venue_id"] == "internal_task_admission"
+    assert "internal_maintenance_execution" in reference["supported_intent_kinds"]
+    assert reference["handoff_substrate"] == "task_admission_executor"
+
+
+def test_required_fields_for_candidate_venue_are_enforced() -> None:
+    candidate = {
+        "venue_id": "candidate",
+        "supported_intent_kinds": ["codex_work_order"],
+        "executability_classes": ["stageable_external_work_order"],
+        "handoff_substrate": "staged_external_handoff",
+        "result_source": {"surface": "glow/orchestration/external_results.jsonl"},
+        "required_linkage_fields": {
+            "intent_to_handoff": ["intent_id"],
+            "handoff_to_admission": ["handoff_id"],
+            "admission_to_result": ["result_id"],
+        },
+        "review_attention_capabilities": {"outcome_review_enabled": True, "attention_recommendation_enabled": True},
+        "anti_sovereignty_guarantees": {"non_authoritative": True, "decision_power": "none"},
+    }
+
+    assert validate_bounded_orchestration_venue(candidate) == []
+
+
+def test_required_vs_optional_vs_internal_specific_layers_are_distinguishable() -> None:
+    layers = bounded_orchestration_layers()
+    by_layer = {row["layer"]: row["classification"] for row in layers}
+
+    assert by_layer["delegated_judgment_input"] == "required_for_new_venue"
+    assert by_layer["retrospective_orchestration_review"] == "optional_or_advanced"
+    assert by_layer["task_admission_executor_noop_task_materialization"] == "current_internal_task_admission_specific"
+
+
+def test_missing_required_pattern_elements_are_detectable() -> None:
+    missing = validate_bounded_orchestration_venue(
+        {
+            "venue_id": "broken_candidate",
+            "supported_intent_kinds": ["codex_work_order"],
+            "anti_sovereignty_guarantees": {"non_authoritative": False, "decision_power": "full"},
+        }
+    )
+
+    assert "executability_classes" in missing
+    assert "handoff_substrate" in missing
+    assert "required_linkage_fields" in missing
+    assert "anti_sovereignty_guarantees.non_authoritative" in missing
+    assert "anti_sovereignty_guarantees.decision_power" in missing
+
+
+def test_scaffold_introduces_no_new_authority_or_execution_behavior() -> None:
+    scaffold = bounded_orchestration_venue_scaffold()
+    reference = scaffold["current_reference_venue"]
+    guarantees = reference["anti_sovereignty_guarantees"]
+
+    assert guarantees["non_authoritative"] is True
+    assert guarantees["decision_power"] == "none"
+    assert guarantees["does_not_invoke_external_tools"] is True
+    assert guarantees["does_not_change_admission_or_execution"] is True
+
+
+def test_next_candidate_assessment_is_staged_and_non_rollout() -> None:
+    assessment = next_bounded_venue_candidate_assessment()
+
+    assert assessment["recommended_next_venue"] == "codex_implementation"
+    assert assessment["not_implemented_in_this_pass"] is True
+    assert assessment["relative_difficulty_vs_current_internal_venue"] == "harder_than_internal_task_admission"


### PR DESCRIPTION
### Motivation

- Stabilize and extract the minimal reusable pattern that powered the repo's first closed judgment→handoff→result loop so future venues can be onboarded without re-architecting the core flow. 
- Make the constitutional boundaries explicit (typed intent, handoff semantics, result linkage, review, and operator-attention) and preserve non-sovereign, non-authoritative guarantees.
- Provide a small, concrete artifact set that is machine-readable and testable so next-venue work can focus on connectivity and proof-linkage rather than rediscovering the pattern.

### Description

- Added `sentientos/bounded_orchestration_pattern.py` which defines the compact layer model, a machine-readable venue scaffold (`bounded_orchestration_venue_scaffold`), a validator `validate_bounded_orchestration_venue`, and a staged `next_bounded_venue_candidate_assessment` recommending `codex_implementation` (no onboarding performed). 
- Added a short developer/operator artifact `sentientos/bounded_orchestration_pattern_note.py` summarizing the pattern, reusable parts, onboarding checklist, and anti-patterns.
- Extracted a single narrow helper `_anti_sovereignty_payload` into `sentientos/orchestration_intent_fabric.py` and used it to consolidate repeated non-authoritative / anti-sovereignty fields across intent, handoff, review, and attention payloads while preserving existing semantics. 
- Added focused tests `sentientos/tests/test_bounded_orchestration_pattern.py` that assert scaffold coherence, required vs optional vs internal-specific layer classification, required-field detection, and that the scaffold does not introduce new authority or execution behavior.
- No new execution venue, external actuation, or sovereign/authority expansion were added; the change is a refactor/extraction and small helper consolidation only.

### Testing

- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py sentientos/tests/test_bounded_orchestration_pattern.py`, and those tests passed (focused coverage for the extracted pattern and existing orchestration fabric tests).
- Ran `python scripts/audit_immutability_verifier.py`, which passed the artifact-dependent check in this environment.
- Ran `mypy scripts/ sentientos/`, which failed due to a pre-existing, repo-wide typing backlog unrelated to these changes (no new typing debt introduced by this PR beyond the small additions). 
- Ran the repo-wide test driver `python -m scripts.run_tests -q`, which surfaced unrelated existing test failures in federation/pulse tests; these are orthogonal to the bounded orchestration extraction and the included focused tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfd42afdc8832097c8d0a5d8fd6fdb)