### PR TITLE
[codex:orchestration] onboard deep_research_audit staged venue substrate

### DIFF
--- a/sentientos/bounded_orchestration_pattern.py
+++ b/sentientos/bounded_orchestration_pattern.py
@@ -195,20 +195,64 @@ def codex_implementation_bounded_venue() -> dict[str, Any]:
         },
     }
 
+
+def deep_research_audit_bounded_venue() -> dict[str, Any]:
+    """Return the onboarded bounded venue scaffold payload for deep-research staged work orders."""
+
+    return {
+        "venue_id": "deep_research_audit",
+        "supported_intent_kinds": ["deep_research_work_order"],
+        "executability_classes": [
+            "stageable_external_work_order",
+            "blocked_operator_required",
+            "blocked_insufficient_context",
+        ],
+        "handoff_substrate": "glow/orchestration/deep_research_work_orders.jsonl",
+        "result_source": {
+            "surface": "glow/orchestration/deep_research_work_orders.jsonl",
+            "event": "deep_research_staged_work_order",
+            "status_values": [
+                "staged",
+                "blocked_operator_required",
+                "blocked_insufficient_context",
+                "cancelled",
+            ],
+        },
+        "required_linkage_fields": {
+            "intent_to_handoff": ["intent_id", "source_intent_id"],
+            "handoff_to_admission": ["details.deep_research_work_order_ref.work_order_id", "work_order_id"],
+            "admission_to_result": ["work_order_id", "source_intent_id"],
+        },
+        "review_attention_capabilities": {
+            "outcome_review_enabled": True,
+            "attention_recommendation_enabled": True,
+            "staged_lifecycle_visibility_enabled": True,
+        },
+        "anti_sovereignty_guarantees": {
+            "non_authoritative": True,
+            "decision_power": "none",
+            "staged_only": True,
+            "does_not_invoke_deep_research_directly": True,
+            "requires_external_tool_or_operator_trigger": True,
+            "does_not_replace_operator_authority": True,
+        },
+    }
+
+
 def next_bounded_venue_candidate_assessment() -> dict[str, Any]:
     """Provide the grounded next venue candidate assessment without onboarding it."""
 
     return {
-        "recommended_next_venue": "codex_implementation",
+        "recommended_next_venue": "deep_research_audit",
         "why_best_next": (
-            "it already has delegated-judgment recommendation coverage and typed orchestration intent/work-order "
+            "it now has delegated-judgment recommendation coverage and typed orchestration intent/work-order "
             "classification, so expansion can focus on bounded handoff/result linkage without changing constitutional authority posture"
         ),
         "already_present_prerequisites": [
-            "delegated_judgment_fabric emits recommended_venue=codex_implementation",
-            "orchestration_intent_fabric emits intent_kind=codex_work_order",
+            "delegated_judgment_fabric emits recommended_venue=deep_research_audit",
+            "orchestration_intent_fabric emits intent_kind=deep_research_work_order",
             "executability_classification=stageable_external_work_order keeps it non-executable in current pass",
-            "append-only intent and handoff ledgers already capture staged codex work-order artifacts",
+            "append-only intent and handoff ledgers now capture staged deep-research work-order artifacts",
         ],
         "largest_missing_prerequisite": (
             "a bounded, append-only external handoff admission/result substrate with stable linkage keys equivalent to "

--- a/sentientos/bounded_orchestration_pattern_note.py
+++ b/sentientos/bounded_orchestration_pattern_note.py
@@ -32,4 +32,8 @@ def bounded_orchestration_pattern_note() -> dict[str, Any]:
             "do not bypass admission/result linkage proof surfaces",
             "do not expand venue coverage without scaffold + tests",
         ],
+        "current_staged_external_venues": [
+            "codex_implementation",
+            "deep_research_audit",
+        ],
     }

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -68,7 +68,7 @@ _EXECUTION_RESULT_STATES = {
 }
 
 
-_CODEX_WORK_ORDER_STATUSES = {
+_STAGED_EXTERNAL_WORK_ORDER_STATUSES = {
     "staged",
     "blocked_operator_required",
     "blocked_insufficient_context",
@@ -76,7 +76,7 @@ _CODEX_WORK_ORDER_STATUSES = {
     "fulfilled_externally_unverified",
 }
 
-_CODEX_STAGED_LIFECYCLE_STATES = {
+_STAGED_EXTERNAL_LIFECYCLE_STATES = {
     "staged_cleanly",
     "blocked_operator_required",
     "blocked_insufficient_context",
@@ -355,7 +355,7 @@ def _default_admission_policy() -> task_admission.AdmissionPolicy:
     return task_admission.AdmissionPolicy(policy_version="orchestration_intent_handoff.v1")
 
 
-def _codex_work_order_id(intent: Mapping[str, Any], created_at: str) -> str:
+def _staged_work_order_id(intent: Mapping[str, Any], created_at: str, *, prefix: str) -> str:
     canonical = json.dumps(
         {
             "created_at": created_at,
@@ -365,7 +365,12 @@ def _codex_work_order_id(intent: Mapping[str, Any], created_at: str) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
-    return f"codex-wo-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+    return f"{prefix}-wo-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _source_judgment_linkage_id(source_map: Mapping[str, Any]) -> str:
+    canonical = json.dumps(dict(source_map), sort_keys=True, separators=(",", ":"))
+    return f"jdg-link-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
 
 
 def append_codex_work_order_ledger(repo_root: Path, work_order: Mapping[str, Any]) -> Path:
@@ -376,11 +381,23 @@ def append_codex_work_order_ledger(repo_root: Path, work_order: Mapping[str, Any
     return ledger_path
 
 
-def build_codex_staged_work_order(
+def append_deep_research_work_order_ledger(repo_root: Path, work_order: Mapping[str, Any]) -> Path:
+    ledger_path = repo_root.resolve() / "glow/orchestration/deep_research_work_orders.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(work_order), sort_keys=True) + "\n")
+    return ledger_path
+
+
+def _build_staged_external_work_order(
     intent: Mapping[str, Any],
     *,
     handoff_outcome: str,
     created_at: str | None = None,
+    venue: str,
+    schema_version: str,
+    work_order_prefix: str,
+    direct_invocation_boundary_key: str,
 ) -> dict[str, Any]:
     timestamp = created_at or _iso_utc_now()
     source = intent.get("source_delegated_judgment")
@@ -393,17 +410,18 @@ def build_codex_staged_work_order(
     else:
         status = "staged"
 
-    if status not in _CODEX_WORK_ORDER_STATUSES:
+    if status not in _STAGED_EXTERNAL_WORK_ORDER_STATUSES:
         status = "blocked_insufficient_context"
 
-    return {
-        "schema_version": "codex_staged_work_order.v1",
+    work_order = {
+        "schema_version": schema_version,
         "recorded_at": timestamp,
-        "venue": "codex_implementation",
-        "work_order_id": _codex_work_order_id(intent, timestamp),
+        "venue": venue,
+        "work_order_id": _staged_work_order_id(intent, timestamp, prefix=work_order_prefix),
         "source_intent_id": str(intent.get("intent_id") or ""),
         "source_intent_kind": str(intent.get("intent_kind") or ""),
         "source_judgment_linkage": {
+            "source_judgment_linkage_id": _source_judgment_linkage_id(source_map),
             "recommended_venue": str(source_map.get("recommended_venue") or ""),
             "judgment_kind": "execution_venue_recommendation",
             "escalation_classification": str(source_map.get("escalation_classification") or ""),
@@ -420,7 +438,6 @@ def build_codex_staged_work_order(
         "readiness_basis": dict(source_map.get("readiness_basis") or {}),
         "status": status,
         "staged_only": True,
-        "does_not_invoke_codex_directly": True,
         "requires_external_tool_or_operator_trigger": True,
         **_anti_sovereignty_payload(
             recommendation_only=False,
@@ -432,16 +449,57 @@ def build_codex_staged_work_order(
             },
         ),
     }
+    work_order[direct_invocation_boundary_key] = True
+    return work_order
 
 
-def resolve_codex_staged_work_order_lifecycle(
+def build_codex_staged_work_order(
+    intent: Mapping[str, Any],
+    *,
+    handoff_outcome: str,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    return _build_staged_external_work_order(
+        intent,
+        handoff_outcome=handoff_outcome,
+        created_at=created_at,
+        venue="codex_implementation",
+        schema_version="codex_staged_work_order.v1",
+        work_order_prefix="codex",
+        direct_invocation_boundary_key="does_not_invoke_codex_directly",
+    )
+
+
+def build_deep_research_staged_work_order(
+    intent: Mapping[str, Any],
+    *,
+    handoff_outcome: str,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    return _build_staged_external_work_order(
+        intent,
+        handoff_outcome=handoff_outcome,
+        created_at=created_at,
+        venue="deep_research_audit",
+        schema_version="deep_research_staged_work_order.v1",
+        work_order_prefix="deep-research",
+        direct_invocation_boundary_key="does_not_invoke_deep_research_directly",
+    )
+
+
+def _resolve_staged_external_work_order_lifecycle(
     repo_root: Path,
     intent: Mapping[str, Any],
     handoff: Mapping[str, Any],
+    *,
+    venue: str,
+    ledger_relative_path: str,
+    schema_version: str,
+    direct_invocation_boundary_key: str,
 ) -> dict[str, Any]:
     root = repo_root.resolve()
     intent_id = str(intent.get("intent_id") or "")
-    ledger_path = root / "glow/orchestration/codex_work_orders.jsonl"
+    ledger_path = root / ledger_relative_path
     records = _read_jsonl(ledger_path)
     linked = [row for row in records if str(row.get("source_intent_id") or "") == intent_id]
     latest = linked[-1] if linked else None
@@ -458,21 +516,20 @@ def resolve_codex_staged_work_order_lifecycle(
     else:
         lifecycle_state = "fragmented_unlinked_work_order_state"
 
-    if lifecycle_state not in _CODEX_STAGED_LIFECYCLE_STATES:
+    if lifecycle_state not in _STAGED_EXTERNAL_LIFECYCLE_STATES:
         lifecycle_state = "fragmented_unlinked_work_order_state"
 
-    return {
-        "schema_version": "codex_staged_lifecycle.v1",
+    lifecycle = {
+        "schema_version": schema_version,
         "intent_id": intent_id,
-        "venue": "codex_implementation",
+        "venue": venue,
         "lifecycle_state": lifecycle_state,
         "work_order_present": latest is not None,
         "work_order_id": str(latest.get("work_order_id") or "") if isinstance(latest, Mapping) else None,
         "work_order_status": str(latest.get("status") or "") if isinstance(latest, Mapping) else None,
-        "proof_artifact_path": "glow/orchestration/codex_work_orders.jsonl",
+        "proof_artifact_path": ledger_relative_path,
         "not_directly_executable_here": True,
         "staged_only": True,
-        "does_not_invoke_codex_directly": True,
         "requires_external_tool_or_operator_trigger": True,
         "operator_requirement_state": {
             "requires_operator_approval": bool(intent.get("requires_operator_approval")),
@@ -484,6 +541,40 @@ def resolve_codex_staged_work_order_lifecycle(
             does_not_change_admission_or_execution=True,
         ),
     }
+    lifecycle[direct_invocation_boundary_key] = True
+    return lifecycle
+
+
+def resolve_codex_staged_work_order_lifecycle(
+    repo_root: Path,
+    intent: Mapping[str, Any],
+    handoff: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _resolve_staged_external_work_order_lifecycle(
+        repo_root,
+        intent,
+        handoff,
+        venue="codex_implementation",
+        ledger_relative_path="glow/orchestration/codex_work_orders.jsonl",
+        schema_version="codex_staged_lifecycle.v1",
+        direct_invocation_boundary_key="does_not_invoke_codex_directly",
+    )
+
+
+def resolve_deep_research_staged_work_order_lifecycle(
+    repo_root: Path,
+    intent: Mapping[str, Any],
+    handoff: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _resolve_staged_external_work_order_lifecycle(
+        repo_root,
+        intent,
+        handoff,
+        venue="deep_research_audit",
+        ledger_relative_path="glow/orchestration/deep_research_work_orders.jsonl",
+        schema_version="deep_research_staged_lifecycle.v1",
+        direct_invocation_boundary_key="does_not_invoke_deep_research_directly",
+    )
 
 
 def append_orchestration_handoff_ledger(repo_root: Path, handoff: Mapping[str, Any]) -> Path:
@@ -596,8 +687,19 @@ def resolve_orchestration_result(
 
     intent_ref = dict(handoff.get("intent_ref") or {})
     codex_staged_lifecycle = None
+    deep_research_staged_lifecycle = None
     if str(intent_ref.get("intent_kind") or "") == "codex_work_order":
         codex_staged_lifecycle = resolve_codex_staged_work_order_lifecycle(
+            root,
+            {
+                "intent_id": str(intent_ref.get("intent_id") or ""),
+                "required_authority_posture": str(detail_map.get("required_authority_posture") or ""),
+                "requires_operator_approval": bool(detail_map.get("requires_operator_approval")),
+            },
+            handoff,
+        )
+    if str(intent_ref.get("intent_kind") or "") == "deep_research_work_order":
+        deep_research_staged_lifecycle = resolve_deep_research_staged_work_order_lifecycle(
             root,
             {
                 "intent_id": str(intent_ref.get("intent_id") or ""),
@@ -624,6 +726,7 @@ def resolve_orchestration_result(
             "task_result_rows_seen": len(task_result_rows),
         },
         "codex_staged_lifecycle": codex_staged_lifecycle,
+        "deep_research_staged_lifecycle": deep_research_staged_lifecycle,
     }
 
 
@@ -951,6 +1054,17 @@ def admit_orchestration_intent(
             "status": codex_work_order_record["status"],
             "staged_only": True,
             "does_not_invoke_codex_directly": True,
+            "requires_external_tool_or_operator_trigger": True,
+        }
+    if str(intent.get("intent_kind") or "") == "deep_research_work_order":
+        deep_research_work_order_record = build_deep_research_staged_work_order(intent, handoff_outcome=outcome)
+        deep_research_path = append_deep_research_work_order_ledger(root, deep_research_work_order_record)
+        details["deep_research_work_order_ref"] = {
+            "work_order_id": deep_research_work_order_record["work_order_id"],
+            "ledger_path": str(deep_research_path.relative_to(root)),
+            "status": deep_research_work_order_record["status"],
+            "staged_only": True,
+            "does_not_invoke_deep_research_directly": True,
             "requires_external_tool_or_operator_trigger": True,
         }
 

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -46,6 +46,7 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
         "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
         "handoff_artifact": "glow/orchestration/orchestration_handoffs.jsonl",
         "codex_staged_work_order_artifact": "glow/orchestration/codex_work_orders.jsonl",
+        "deep_research_staged_work_order_artifact": "glow/orchestration/deep_research_work_orders.jsonl",
         "codex_staged_venue_onboarding": {
             "status": "first_class_bounded_staged_venue",
             "venue": "codex_implementation",
@@ -74,6 +75,44 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
             ],
             "still_out_of_scope": [
                 "direct Codex invocation from this repository",
+                "browser or desktop automation",
+                "automatic completion claims without proof-visible external evidence",
+            ],
+        },
+        "deep_research_staged_venue_onboarding": {
+            "status": "first_class_bounded_staged_venue",
+            "venue": "deep_research_audit",
+            "constitutional_fields": [
+                "work_order_id",
+                "source_intent_id",
+                "source_judgment_linkage",
+                "operator_requirements",
+                "executability_classification",
+                "staged_only",
+                "does_not_invoke_deep_research_directly",
+                "requires_external_tool_or_operator_trigger",
+                "non_authoritative",
+                "decision_power=none",
+            ],
+            "lifecycle_states": [
+                "staged_cleanly",
+                "blocked_operator_required",
+                "blocked_insufficient_context",
+                "fragmented_unlinked_work_order_state",
+            ],
+            "still_missing_before_any_direct_deep_research_delegation": [
+                "an approved external transport/trigger path",
+                "admission parity for external execution",
+                "result attestation proving fulfillment beyond staged state",
+            ],
+            "comparison_to_codex_staged_venue": [
+                "both venues are stageable_external_work_order only in this pass",
+                "both venues carry stable work_order_id + source intent/judgment linkage",
+                "both venues expose append-only proof artifacts and staged lifecycle visibility",
+                "both venues remain non-sovereign and non-executable here",
+            ],
+            "still_out_of_scope": [
+                "direct Deep Research invocation from this repository",
                 "browser or desktop automation",
                 "automatic completion claims without proof-visible external evidence",
             ],

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -19,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_outcome_review,
     executable_handoff_map,
     resolve_codex_staged_work_order_lifecycle,
+    resolve_deep_research_staged_work_order_lifecycle,
     resolve_orchestration_result,
     synthesize_orchestration_intent,
 )
@@ -41,29 +42,43 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def _codex_staged_venue_diagnostic(
+def _staged_external_venue_diagnostic(
     repo_root: Path,
     orchestration_intent: dict[str, Any],
     handoff_result: dict[str, Any],
     orchestration_result: dict[str, Any],
+    *,
+    venue: str,
+    lifecycle_key: str,
+    handoff_ref_key: str,
+    default_ledger_path: str,
+    direct_boundary_key: str,
+    resolve_lifecycle: Any,
+    schema_version: str,
 ) -> dict[str, Any] | None:
-    venue = str(orchestration_intent.get("source_delegated_judgment", {}).get("recommended_venue") or "")
-    if venue != "codex_implementation":
+    recommended_venue = str(orchestration_intent.get("source_delegated_judgment", {}).get("recommended_venue") or "")
+    if recommended_venue != venue:
         return None
 
-    lifecycle = orchestration_result.get("codex_staged_lifecycle")
-    lifecycle_map = lifecycle if isinstance(lifecycle, dict) else resolve_codex_staged_work_order_lifecycle(repo_root, orchestration_intent, handoff_result)
-    codex_ref = handoff_result.get("details", {}).get("codex_work_order_ref", {})
-    codex_ref_map = codex_ref if isinstance(codex_ref, dict) else {}
+    lifecycle = orchestration_result.get(lifecycle_key)
+    lifecycle_map = lifecycle if isinstance(lifecycle, dict) else resolve_lifecycle(repo_root, orchestration_intent, handoff_result)
+    work_order_ref = handoff_result.get("details", {}).get(handoff_ref_key, {})
+    ref_map = work_order_ref if isinstance(work_order_ref, dict) else {}
+    executability_visibility = {
+        "executability_classification": str(orchestration_intent.get("executability_classification") or ""),
+        "not_directly_executable_here": True,
+        "staged_only": True,
+    }
+    executability_visibility[direct_boundary_key] = True
 
     return {
-        "schema_version": "codex_staged_venue_diagnostic.v1",
-        "venue": "codex_implementation",
-        "staged_work_order_present": bool(codex_ref_map),
-        "staged_work_order_id": codex_ref_map.get("work_order_id"),
+        "schema_version": schema_version,
+        "venue": venue,
+        "staged_work_order_present": bool(ref_map),
+        "staged_work_order_id": ref_map.get("work_order_id"),
         "proof_artifact": {
-            "ledger_path": codex_ref_map.get("ledger_path", "glow/orchestration/codex_work_orders.jsonl"),
-            "status": codex_ref_map.get("status"),
+            "ledger_path": ref_map.get("ledger_path", default_ledger_path),
+            "status": ref_map.get("status"),
         },
         "operator_requirement_state": {
             "required_authority_posture": str(orchestration_intent.get("required_authority_posture") or ""),
@@ -71,12 +86,7 @@ def _codex_staged_venue_diagnostic(
             "escalation_classification": str(orchestration_intent.get("source_delegated_judgment", {}).get("escalation_classification") or ""),
         },
         "lifecycle_visibility": lifecycle_map,
-        "executability_visibility": {
-            "executability_classification": str(orchestration_intent.get("executability_classification") or ""),
-            "not_directly_executable_here": True,
-            "staged_only": True,
-            "does_not_invoke_codex_directly": True,
-        },
+        "executability_visibility": executability_visibility,
         "observability_only": True,
     }
 
@@ -134,7 +144,32 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     orchestration_result = resolve_orchestration_result(root, handoff_result)
     orchestration_outcome_review = derive_orchestration_outcome_review(root)
     orchestration_attention_recommendation = derive_orchestration_attention_recommendation(orchestration_outcome_review)
-    codex_staged_venue = _codex_staged_venue_diagnostic(root, orchestration_intent, handoff_result, orchestration_result)
+    codex_staged_venue = _staged_external_venue_diagnostic(
+        root,
+        orchestration_intent,
+        handoff_result,
+        orchestration_result,
+        venue="codex_implementation",
+        lifecycle_key="codex_staged_lifecycle",
+        handoff_ref_key="codex_work_order_ref",
+        default_ledger_path="glow/orchestration/codex_work_orders.jsonl",
+        direct_boundary_key="does_not_invoke_codex_directly",
+        resolve_lifecycle=resolve_codex_staged_work_order_lifecycle,
+        schema_version="codex_staged_venue_diagnostic.v1",
+    )
+    deep_research_staged_venue = _staged_external_venue_diagnostic(
+        root,
+        orchestration_intent,
+        handoff_result,
+        orchestration_result,
+        venue="deep_research_audit",
+        lifecycle_key="deep_research_staged_lifecycle",
+        handoff_ref_key="deep_research_work_order_ref",
+        default_ledger_path="glow/orchestration/deep_research_work_orders.jsonl",
+        direct_boundary_key="does_not_invoke_deep_research_directly",
+        resolve_lifecycle=resolve_deep_research_staged_work_order_lifecycle,
+        schema_version="deep_research_staged_venue_diagnostic.v1",
+    )
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -154,6 +189,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "outcome_review": orchestration_outcome_review,
             "attention_recommendation": orchestration_attention_recommendation,
             "codex_staged_venue": codex_staged_venue,
+            "deep_research_staged_venue": deep_research_staged_venue,
         },
         "actions": rows,
     }

--- a/sentientos/tests/test_bounded_orchestration_pattern.py
+++ b/sentientos/tests/test_bounded_orchestration_pattern.py
@@ -4,6 +4,7 @@ from sentientos.bounded_orchestration_pattern import (
     bounded_orchestration_layers,
     bounded_orchestration_venue_scaffold,
     codex_implementation_bounded_venue,
+    deep_research_audit_bounded_venue,
     next_bounded_venue_candidate_assessment,
     validate_bounded_orchestration_venue,
 )
@@ -78,7 +79,7 @@ def test_scaffold_introduces_no_new_authority_or_execution_behavior() -> None:
 def test_next_candidate_assessment_tracks_codex_as_onboarded_next_venue() -> None:
     assessment = next_bounded_venue_candidate_assessment()
 
-    assert assessment["recommended_next_venue"] == "codex_implementation"
+    assert assessment["recommended_next_venue"] == "deep_research_audit"
     assert assessment["not_implemented_in_this_pass"] is False
     assert assessment["relative_difficulty_vs_current_internal_venue"] == "harder_than_internal_task_admission"
 
@@ -88,5 +89,14 @@ def test_codex_onboarded_venue_payload_passes_scaffold_validation() -> None:
 
     assert candidate["venue_id"] == "codex_implementation"
     assert "codex_work_order" in candidate["supported_intent_kinds"]
+    assert "stageable_external_work_order" in candidate["executability_classes"]
+    assert validate_bounded_orchestration_venue(candidate) == []
+
+
+def test_deep_research_onboarded_venue_payload_passes_scaffold_validation() -> None:
+    candidate = deep_research_audit_bounded_venue()
+
+    assert candidate["venue_id"] == "deep_research_audit"
+    assert "deep_research_work_order" in candidate["supported_intent_kinds"]
     assert "stageable_external_work_order" in candidate["executability_classes"]
     assert validate_bounded_orchestration_venue(candidate) == []

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -320,18 +320,31 @@ def test_internal_handoff_honors_admission_denial(tmp_path: Path) -> None:
 
 
 def test_external_venues_remain_staged_only_without_internal_admission(tmp_path: Path) -> None:
-    judgment = synthesize_delegated_judgment(_base_evidence())
-    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
-    handoff = admit_orchestration_intent(tmp_path, intent)
+    codex_judgment = synthesize_delegated_judgment(_base_evidence())
+    codex_intent = synthesize_orchestration_intent(codex_judgment, created_at="2026-04-12T00:00:00Z")
+    codex_handoff = admit_orchestration_intent(tmp_path, codex_intent)
 
-    assert judgment["recommended_venue"] == "codex_implementation"
-    assert handoff["handoff_outcome"] == "blocked_by_operator_requirement"
-    assert "task_admission" not in handoff["details"]
-    assert handoff["details"]["codex_work_order_ref"]["staged_only"] is True
-    resolution = resolve_orchestration_result(tmp_path, handoff)
-    assert resolution["orchestration_result_state"] == "handoff_not_admitted"
-    assert resolution["execution_task_ref"]["task_id"] is None
-    assert resolution["codex_staged_lifecycle"]["lifecycle_state"] == "blocked_operator_required"
+    assert codex_judgment["recommended_venue"] == "codex_implementation"
+    assert codex_handoff["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert "task_admission" not in codex_handoff["details"]
+    assert codex_handoff["details"]["codex_work_order_ref"]["staged_only"] is True
+    codex_resolution = resolve_orchestration_result(tmp_path, codex_handoff)
+    assert codex_resolution["orchestration_result_state"] == "handoff_not_admitted"
+    assert codex_resolution["execution_task_ref"]["task_id"] is None
+    assert codex_resolution["codex_staged_lifecycle"]["lifecycle_state"] == "blocked_operator_required"
+
+    deep_research_judgment = synthesize_delegated_judgment({**_base_evidence(), "governance_ambiguity_signal": True})
+    deep_research_intent = synthesize_orchestration_intent(deep_research_judgment, created_at="2026-04-12T00:01:00Z")
+    deep_research_handoff = admit_orchestration_intent(tmp_path, deep_research_intent)
+
+    assert deep_research_judgment["recommended_venue"] == "deep_research_audit"
+    assert deep_research_handoff["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert "task_admission" not in deep_research_handoff["details"]
+    assert deep_research_handoff["details"]["deep_research_work_order_ref"]["staged_only"] is True
+    deep_research_resolution = resolve_orchestration_result(tmp_path, deep_research_handoff)
+    assert deep_research_resolution["orchestration_result_state"] == "handoff_not_admitted"
+    assert deep_research_resolution["execution_task_ref"]["task_id"] is None
+    assert deep_research_resolution["deep_research_staged_lifecycle"]["lifecycle_state"] == "blocked_operator_required"
 
 
 def test_blocked_handoff_does_not_fabricate_execution_attempt(monkeypatch, tmp_path: Path) -> None:
@@ -759,6 +772,22 @@ def test_codex_staged_work_order_artifact_is_append_only_and_proof_visible(tmp_p
     assert work_order["requires_external_tool_or_operator_trigger"] is True
 
 
+def test_deep_research_staged_work_order_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment({**_base_evidence(), "governance_ambiguity_signal": True})
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    handoff = admit_orchestration_intent(tmp_path, intent)
+
+    assert handoff["details"]["deep_research_work_order_ref"]["ledger_path"] == "glow/orchestration/deep_research_work_orders.jsonl"
+    rows = (tmp_path / "glow/orchestration/deep_research_work_orders.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+    work_order = json.loads(rows[0])
+    assert work_order["venue"] == "deep_research_audit"
+    assert work_order["source_intent_id"] == intent["intent_id"]
+    assert work_order["status"] == "blocked_operator_required"
+    assert work_order["does_not_invoke_deep_research_directly"] is True
+    assert work_order["requires_external_tool_or_operator_trigger"] is True
+
+
 def test_codex_missing_metadata_yields_blocked_insufficient_and_lifecycle_fragment_visibility(tmp_path: Path) -> None:
     handoff = admit_orchestration_intent(
         tmp_path,
@@ -773,6 +802,22 @@ def test_codex_missing_metadata_yields_blocked_insufficient_and_lifecycle_fragme
     assert "codex_work_order_ref" in handoff["details"]
     resolution = resolve_orchestration_result(tmp_path, handoff)
     assert resolution["codex_staged_lifecycle"]["lifecycle_state"] == "blocked_insufficient_context"
+
+
+def test_deep_research_missing_metadata_yields_blocked_insufficient_and_lifecycle_fragment_visibility(tmp_path: Path) -> None:
+    handoff = admit_orchestration_intent(
+        tmp_path,
+        {
+            "intent_kind": "deep_research_work_order",
+            "execution_target": "no_execution_target_yet",
+            "executability_classification": "stageable_external_work_order",
+        },
+    )
+
+    assert handoff["handoff_outcome"] == "blocked_by_insufficient_context"
+    assert "deep_research_work_order_ref" in handoff["details"]
+    resolution = resolve_orchestration_result(tmp_path, handoff)
+    assert resolution["deep_research_staged_lifecycle"]["lifecycle_state"] == "blocked_insufficient_context"
 
 
 def test_end_to_end_codex_staged_venue_visibility_is_honest(monkeypatch, tmp_path: Path) -> None:
@@ -814,3 +859,44 @@ def test_end_to_end_codex_staged_venue_visibility_is_honest(monkeypatch, tmp_pat
     assert codex_diag["proof_artifact"]["ledger_path"] == "glow/orchestration/codex_work_orders.jsonl"
     assert codex_diag["lifecycle_visibility"]["lifecycle_state"] == "blocked_operator_required"
     assert codex_diag["executability_visibility"]["not_directly_executable_here"] is True
+
+
+def test_end_to_end_deep_research_staged_venue_visibility_is_honest(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+
+    def _fake_resolver(_repo_root: Path, *, action_id: str, correlation_id: str) -> dict[str, object]:
+        return {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        }
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle", _fake_resolver)
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment({**_base_evidence(), "governance_ambiguity_signal": True}),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-deep-research-e2e",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+
+    assert diagnostic["delegated_judgment"]["recommended_venue"] == "deep_research_audit"
+    handoff = diagnostic["orchestration_handoff"]
+    assert handoff["intent"]["intent_kind"] == "deep_research_work_order"
+    assert handoff["handoff_result"]["handoff_outcome"] in {"blocked_by_operator_requirement", "blocked_by_insufficient_context", "staged_only"}
+    assert handoff["execution_result"]["orchestration_result_state"] == "handoff_not_admitted"
+    deep_research_diag = handoff["deep_research_staged_venue"]
+    assert deep_research_diag is not None
+    assert deep_research_diag["proof_artifact"]["ledger_path"] == "glow/orchestration/deep_research_work_orders.jsonl"
+    assert deep_research_diag["lifecycle_visibility"]["lifecycle_state"] == "blocked_operator_required"
+    assert deep_research_diag["executability_visibility"]["not_directly_executable_here"] is True


### PR DESCRIPTION
### Motivation
- Constitutionalize `deep_research_audit` as the next first-class staged external venue so the orchestration substrate can proof-visibly stage Deep Research work orders without claiming direct execution authority.
- Preserve anti-sovereignty and non-execution boundaries (no browser/keyboard automation, no direct tool invocation, operator-in-the-loop required) while enabling stable IDs, intent/judgment linkage, and append-only proof artifacts.

### Description
- Add a small, typed staged work-order model and ledger for Deep Research at `glow/orchestration/deep_research_work_orders.jsonl` with stable `work_order_id`, `source_intent_id`, `source_judgment_linkage`, `operator_requirements`, `executability_classification`, and explicit boundary flags like `staged_only`, `does_not_invoke_deep_research_directly`, `requires_external_tool_or_operator_trigger`, `non_authoritative`, and `decision_power: none` (implemented in `sentientos/orchestration_intent_fabric.py`).
- Normalize shared staged-venue pieces by extracting a small `_build_staged_external_work_order` and `_resolve_staged_external_work_order_lifecycle` used by both Codex and Deep Research, and add ledger appenders and ID helpers (`_staged_work_order_id`, `_source_judgment_linkage_id`).
- Extend orchestration admission/result flow to emit deep-research staged work-order refs from `admit_orchestration_intent` and to resolve a parallel staged lifecycle (`staged_cleanly`, `blocked_operator_required`, `blocked_insufficient_context`, `fragmented_unlinked_work_order_state`) surfaced in `resolve_orchestration_result`.
- Add an observability-only diagnostic consumer extension that surfaces staged-venue diagnostics for Codex and Deep Research (work-order presence, proof artifact linkage, operator requirement state, lifecycle visibility, and explicit non-executable posture) in `sentientos/scoped_lifecycle_diagnostic.py`.
- Update the bounded-orchestration scaffold and short notes to include `deep_research_audit` as a constitutional staged venue and add focused tests covering typing, artifact emission, blocked/missing metadata behavior, lifecycle visibility, and diagnostic surfacing.

### Testing
- Ran targeted unit tests: `pytest -q sentientos/tests/test_bounded_orchestration_pattern.py sentientos/tests/test_orchestration_intent_fabric.py` and they passed (subset validating staged-venue semantics and Deep Research workflows).
- Ran repository type checks: `mypy scripts/ sentientos/` which failed due to pre-existing, repository-wide typing debt unrelated to this change.
- Ran full test harness: `python -m scripts.run_tests -q` which surfaced unrelated failures in existing pulse federation tests (external to the staged-venue onboarding work), showing no regressions in the focused tests added here.
- Ran audit verification: `python scripts/audit_immutability_verifier.py` passed; `verify_audits` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e04cb2c44083209d7490b40cbb1214)