### PR TITLE
[codex:orchestration] add bounded venue-mix retrospective review

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -102,6 +102,16 @@ _ORCHESTRATION_ATTENTION_RECOMMENDATIONS = {
     "insufficient_context",
 }
 
+_ORCHESTRATION_VENUE_MIX_CLASSES = {
+    "balanced_recent_venue_mix",
+    "internal_execution_heavy",
+    "codex_heavy",
+    "deep_research_heavy",
+    "operator_escalation_heavy",
+    "mixed_venue_stress",
+    "insufficient_history",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -840,6 +850,186 @@ def derive_orchestration_outcome_review(
             "executor_log": str((executor_log_path or Path(task_executor.LOG_PATH)).relative_to(root))
             if (executor_log_path or Path(task_executor.LOG_PATH)).is_relative_to(root)
             else str(executor_log_path or Path(task_executor.LOG_PATH)),
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "does_not_change_admission_or_execution_authority": True,
+            },
+        ),
+    }
+
+
+def derive_orchestration_venue_mix_review(
+    repo_root: Path,
+    *,
+    window_size: int = 10,
+) -> dict[str, Any]:
+    """Derive a bounded retrospective classifier over recent orchestration venue mix."""
+
+    root = repo_root.resolve()
+    intents = _read_jsonl(root / "glow/orchestration/orchestration_intents.jsonl")
+    handoffs = _read_jsonl(root / "glow/orchestration/orchestration_handoffs.jsonl")
+    codex_work_orders = _read_jsonl(root / "glow/orchestration/codex_work_orders.jsonl")
+    deep_research_work_orders = _read_jsonl(root / "glow/orchestration/deep_research_work_orders.jsonl")
+
+    intent_map: dict[str, dict[str, Any]] = {}
+    for row in intents:
+        intent_id = str(row.get("intent_id") or "")
+        if intent_id:
+            intent_map[intent_id] = row
+
+    scoped_handoffs: list[dict[str, Any]] = []
+    for handoff in handoffs:
+        intent_ref = handoff.get("intent_ref")
+        intent_ref_map = intent_ref if isinstance(intent_ref, Mapping) else {}
+        intent_id = str(intent_ref_map.get("intent_id") or "")
+        if intent_id and intent_id in intent_map:
+            scoped_handoffs.append(handoff)
+
+    recent_handoffs = scoped_handoffs[-max(0, window_size) :] if window_size > 0 else []
+    recent_intent_ids: set[str] = set()
+    venue_counts = {
+        "task_admission_executor": 0,
+        "codex_implementation": 0,
+        "deep_research_audit": 0,
+    }
+    operator_required_count = 0
+    blocked_count = 0
+
+    for handoff in recent_handoffs:
+        intent_ref = handoff.get("intent_ref")
+        intent_ref_map = intent_ref if isinstance(intent_ref, Mapping) else {}
+        details = handoff.get("details")
+        details_map = details if isinstance(details, Mapping) else {}
+        intent_id = str(intent_ref_map.get("intent_id") or "")
+        intent_kind = str(intent_ref_map.get("intent_kind") or "")
+        intent = intent_map.get(intent_id, {})
+        recent_intent_ids.add(intent_id)
+
+        if intent_kind == "internal_maintenance_execution":
+            venue_counts["task_admission_executor"] += 1
+        elif intent_kind == "codex_work_order":
+            venue_counts["codex_implementation"] += 1
+        elif intent_kind == "deep_research_work_order":
+            venue_counts["deep_research_audit"] += 1
+
+        handoff_outcome = str(handoff.get("handoff_outcome") or "")
+        required_authority_posture = str(details_map.get("required_authority_posture") or intent.get("required_authority_posture") or "")
+        escalation_classification = str(
+            intent.get("source_delegated_judgment", {}).get("escalation_classification")
+            if isinstance(intent.get("source_delegated_judgment"), Mapping)
+            else ""
+        )
+
+        if (
+            required_authority_posture in {"operator_priority_required", "insufficient_context_blocked"}
+            or handoff_outcome in {"blocked_by_operator_requirement", "blocked_by_insufficient_context"}
+            or intent_kind == "operator_review_request"
+            or escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
+        ):
+            operator_required_count += 1
+
+        if handoff_outcome in {
+            "blocked_by_admission",
+            "blocked_by_operator_requirement",
+            "blocked_by_insufficient_context",
+            "execution_target_unavailable",
+        }:
+            blocked_count += 1
+
+    records_considered = len(recent_handoffs)
+    total_primary_venue = sum(venue_counts.values())
+    internal_ratio = (venue_counts["task_admission_executor"] / total_primary_venue) if total_primary_venue else 0.0
+    codex_ratio = (venue_counts["codex_implementation"] / total_primary_venue) if total_primary_venue else 0.0
+    deep_ratio = (venue_counts["deep_research_audit"] / total_primary_venue) if total_primary_venue else 0.0
+    operator_ratio = (operator_required_count / records_considered) if records_considered else 0.0
+    blocked_ratio = (blocked_count / records_considered) if records_considered else 0.0
+
+    internal_heavy = venue_counts["task_admission_executor"] >= 2 and internal_ratio >= 0.6
+    codex_heavy = venue_counts["codex_implementation"] >= 2 and codex_ratio >= 0.6
+    deep_research_heavy = venue_counts["deep_research_audit"] >= 2 and deep_ratio >= 0.6
+    operator_heavy = operator_required_count >= 2 and operator_ratio >= 0.5
+    dominant_flags = [internal_heavy, codex_heavy, deep_research_heavy, operator_heavy]
+    heavy_pattern_count = sum(1 for flag in dominant_flags if flag)
+
+    classification = "insufficient_history"
+    if records_considered >= 3:
+        active_primary_venues = sum(1 for count in venue_counts.values() if count > 0)
+        balanced_primary_spread = (
+            active_primary_venues >= 2
+            and max(venue_counts.values()) - min(venue_counts.values()) <= 2
+            and not operator_heavy
+        )
+        if heavy_pattern_count >= 2:
+            classification = "mixed_venue_stress"
+        elif operator_heavy:
+            classification = "operator_escalation_heavy"
+        elif internal_heavy:
+            classification = "internal_execution_heavy"
+        elif codex_heavy:
+            classification = "codex_heavy"
+        elif deep_research_heavy:
+            classification = "deep_research_heavy"
+        elif balanced_primary_spread and blocked_ratio < 0.4:
+            classification = "balanced_recent_venue_mix"
+        else:
+            classification = "mixed_venue_stress"
+
+    if classification not in _ORCHESTRATION_VENUE_MIX_CLASSES:
+        classification = "mixed_venue_stress"
+
+    recent_codex_work_orders = sum(1 for row in codex_work_orders if str(row.get("source_intent_id") or "") in recent_intent_ids)
+    recent_deep_research_work_orders = sum(
+        1 for row in deep_research_work_orders if str(row.get("source_intent_id") or "") in recent_intent_ids
+    )
+    usage_balance = "balanced" if classification == "balanced_recent_venue_mix" else "skewed_or_stressed"
+    classification_basis = {
+        "heavy_flags": {
+            "internal_execution_heavy": internal_heavy,
+            "codex_heavy": codex_heavy,
+            "deep_research_heavy": deep_research_heavy,
+            "operator_escalation_heavy": operator_heavy,
+            "conflicting_heavy_patterns": heavy_pattern_count >= 2,
+        },
+        "ratios": {
+            "internal_ratio": round(internal_ratio, 4),
+            "codex_ratio": round(codex_ratio, 4),
+            "deep_research_ratio": round(deep_ratio, 4),
+            "operator_ratio": round(operator_ratio, 4),
+            "blocked_ratio": round(blocked_ratio, 4),
+        },
+    }
+
+    return {
+        "schema_version": "orchestration_venue_mix_review.v1",
+        "review_kind": "orchestration_venue_mix_retrospective",
+        "review_classification": classification,
+        "window_size": max(0, window_size),
+        "records_considered": records_considered,
+        "recent_venue_counts": venue_counts,
+        "recent_operator_and_blocked_counts": {
+            "operator_required_or_escalated": operator_required_count,
+            "blocked_handoffs": blocked_count,
+        },
+        "summary": {
+            "venue_usage_balance": usage_balance,
+            "diagnostic_summary": "bounded retrospective venue-mix review derived from existing orchestration artifacts only",
+            "classification_basis": classification_basis,
+        },
+        "artifacts_read": {
+            "intent_ledger": "glow/orchestration/orchestration_intents.jsonl",
+            "handoff_ledger": "glow/orchestration/orchestration_handoffs.jsonl",
+            "codex_staged_work_order_ledger": "glow/orchestration/codex_work_orders.jsonl",
+            "deep_research_staged_work_order_ledger": "glow/orchestration/deep_research_work_orders.jsonl",
+            "orchestration_result_resolution_surface": "sentientos.orchestration_intent_fabric.resolve_orchestration_result",
+        },
+        "evidence_counts": {
+            "recent_codex_work_orders": recent_codex_work_orders,
+            "recent_deep_research_work_orders": recent_deep_research_work_orders,
         },
         **_anti_sovereignty_payload(
             recommendation_only=True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -151,6 +151,31 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "a new execution venue",
             ],
         },
+        "venue_mix_review": {
+            "meaning": "bounded retrospective check of recent venue-selection mix (internal execution vs staged Codex vs staged Deep Research vs operator-heavy escalation states).",
+            "reads_existing_artifacts_only": [
+                "glow/orchestration/orchestration_intents.jsonl",
+                "glow/orchestration/orchestration_handoffs.jsonl",
+                "glow/orchestration/codex_work_orders.jsonl",
+                "glow/orchestration/deep_research_work_orders.jsonl",
+                "orchestration_result_resolution linkage surfaces",
+            ],
+            "classifications": [
+                "balanced_recent_venue_mix",
+                "internal_execution_heavy",
+                "codex_heavy",
+                "deep_research_heavy",
+                "operator_escalation_heavy",
+                "mixed_venue_stress",
+                "insufficient_history",
+            ],
+            "explicitly_not": [
+                "admission authority",
+                "execution authority",
+                "a new venue",
+                "direct external actuation",
+            ],
+        },
         "operator_attention_recommendation": {
             "meaning": "bounded diagnostic recommendation about what operator attention internal orchestration behavior likely needs.",
             "derived_from": [

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -17,6 +17,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_orchestration_outcome_review,
+    derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_codex_staged_work_order_lifecycle,
     resolve_deep_research_staged_work_order_lifecycle,
@@ -143,6 +144,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     handoff_result = admit_orchestration_intent(root, orchestration_intent)
     orchestration_result = resolve_orchestration_result(root, handoff_result)
     orchestration_outcome_review = derive_orchestration_outcome_review(root)
+    orchestration_venue_mix_review = derive_orchestration_venue_mix_review(root)
     orchestration_attention_recommendation = derive_orchestration_attention_recommendation(orchestration_outcome_review)
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
@@ -187,6 +189,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "handoff_result": handoff_result,
             "execution_result": orchestration_result,
             "outcome_review": orchestration_outcome_review,
+            "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -14,6 +14,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_orchestration_outcome_review,
+    derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_orchestration_result,
     synthesize_orchestration_intent,
@@ -522,6 +523,67 @@ def _seed_orchestration_history(
     return executor_path
 
 
+def _seed_venue_mix_history(
+    tmp_path: Path,
+    *,
+    records: list[dict[str, object]],
+) -> None:
+    intent_rows: list[dict[str, object]] = []
+    handoff_rows: list[dict[str, object]] = []
+    codex_rows: list[dict[str, object]] = []
+    deep_rows: list[dict[str, object]] = []
+
+    for idx, record in enumerate(records):
+        intent_id = f"orh-venue-{idx}"
+        intent_kind = str(record.get("intent_kind") or "internal_maintenance_execution")
+        authority = str(record.get("required_authority_posture") or "no_additional_operator_approval_required")
+        requires_operator = bool(record.get("requires_operator_approval", authority != "no_additional_operator_approval_required"))
+        escalation = str(record.get("escalation_classification") or "")
+        handoff_outcome = str(record.get("handoff_outcome") or "staged_only")
+        intent_rows.append(
+            {
+                "schema_version": "orchestration_intent.v1",
+                "intent_id": intent_id,
+                "intent_kind": intent_kind,
+                "required_authority_posture": authority,
+                "requires_operator_approval": requires_operator,
+                "source_delegated_judgment": {"escalation_classification": escalation},
+            }
+        )
+        handoff_rows.append(
+            {
+                "schema_version": "orchestration_handoff.v1",
+                "handoff_outcome": handoff_outcome,
+                "intent_ref": {"intent_id": intent_id, "intent_kind": intent_kind},
+                "details": {
+                    "required_authority_posture": authority,
+                    "requires_operator_approval": requires_operator,
+                },
+            }
+        )
+        if intent_kind == "codex_work_order":
+            codex_rows.append(
+                {
+                    "schema_version": "codex_staged_work_order.v1",
+                    "source_intent_id": intent_id,
+                    "venue": "codex_implementation",
+                }
+            )
+        if intent_kind == "deep_research_work_order":
+            deep_rows.append(
+                {
+                    "schema_version": "deep_research_staged_work_order.v1",
+                    "source_intent_id": intent_id,
+                    "venue": "deep_research_audit",
+                }
+            )
+
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_intents.jsonl", intent_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoffs.jsonl", handoff_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/codex_work_orders.jsonl", codex_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/deep_research_work_orders.jsonl", deep_rows)
+
+
 def test_outcome_review_success_dominant_classifies_clean(tmp_path: Path) -> None:
     executor_log = _seed_orchestration_history(
         tmp_path,
@@ -656,6 +718,149 @@ def test_attention_recommendation_light_block_pattern_prefers_observe(tmp_path: 
     assert attention["operator_attention_recommendation"] in {"none", "observe"}
 
 
+def test_venue_mix_review_balanced_recent_use_classifies_balanced(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "balanced_recent_venue_mix"
+    assert review["recent_venue_counts"]["task_admission_executor"] == 2
+    assert review["recent_venue_counts"]["codex_implementation"] == 1
+    assert review["recent_venue_counts"]["deep_research_audit"] == 1
+
+
+def test_venue_mix_review_internal_heavy_classification(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "internal_execution_heavy"
+
+
+def test_venue_mix_review_codex_heavy_classification(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "codex_heavy"
+    assert review["evidence_counts"]["recent_codex_work_orders"] == 3
+
+
+def test_venue_mix_review_deep_research_heavy_classification(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "deep_research_heavy"
+    assert review["evidence_counts"]["recent_deep_research_work_orders"] == 3
+
+
+def test_venue_mix_review_operator_escalation_heavy_classification(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {
+                "intent_kind": "internal_maintenance_execution",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_approval_required",
+            },
+            {
+                "intent_kind": "operator_review_request",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_priority_required",
+                "escalation_classification": "escalate_for_operator_priority",
+            },
+            {
+                "intent_kind": "codex_work_order",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_approval_required",
+            },
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "operator_escalation_heavy"
+    assert review["recent_operator_and_blocked_counts"]["operator_required_or_escalated"] >= 3
+
+
+def test_venue_mix_review_conflicting_stress_classifies_mixed_stress(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {
+                "intent_kind": "internal_maintenance_execution",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_approval_required",
+            },
+            {
+                "intent_kind": "internal_maintenance_execution",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_approval_required",
+            },
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {
+                "intent_kind": "operator_review_request",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_priority_required",
+                "escalation_classification": "escalate_for_operator_priority",
+            },
+            {
+                "intent_kind": "operator_review_request",
+                "handoff_outcome": "blocked_by_operator_requirement",
+                "required_authority_posture": "operator_priority_required",
+                "escalation_classification": "escalate_for_operator_priority",
+            },
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "mixed_venue_stress"
+    assert review["summary"]["classification_basis"]["heavy_flags"]["conflicting_heavy_patterns"] is True
+
+
+def test_venue_mix_review_insufficient_history(tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only"},
+        ],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    assert review["review_classification"] == "insufficient_history"
+    assert review["records_considered"] == 2
+
+
 def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritative(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -687,6 +892,7 @@ def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritati
 
     diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
     review = diagnostic["orchestration_handoff"]["outcome_review"]
+    venue_mix_review = diagnostic["orchestration_handoff"]["venue_mix_review"]
     attention = diagnostic["orchestration_handoff"]["attention_recommendation"]
 
     assert "review_classification" in review
@@ -695,6 +901,14 @@ def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritati
     assert review["non_authoritative"] is True
     assert review["decision_power"] == "none"
     assert review["does_not_change_admission_or_execution_authority"] is True
+    assert "review_classification" in venue_mix_review
+    assert "recent_venue_counts" in venue_mix_review
+    assert "recent_operator_and_blocked_counts" in venue_mix_review
+    assert venue_mix_review["diagnostic_only"] is True
+    assert venue_mix_review["non_authoritative"] is True
+    assert venue_mix_review["decision_power"] == "none"
+    assert venue_mix_review["review_only"] is True
+    assert venue_mix_review["does_not_change_admission_or_execution"] is True
     assert attention["operator_attention_recommendation"] in {
         "none",
         "observe",
@@ -733,6 +947,60 @@ def test_recent_history_review_to_attention_to_consumer_stays_non_authoritative(
     assert attention["does_not_change_admission_or_execution"] is True
 
 
+def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_authoritative(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+        ],
+    )
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-venue-mix-consumer",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    venue_mix_review = diagnostic["orchestration_handoff"]["venue_mix_review"]
+    assert venue_mix_review["review_classification"] in {
+        "balanced_recent_venue_mix",
+        "internal_execution_heavy",
+        "codex_heavy",
+        "deep_research_heavy",
+        "operator_escalation_heavy",
+        "mixed_venue_stress",
+        "insufficient_history",
+    }
+    assert venue_mix_review["non_authoritative"] is True
+    assert venue_mix_review["diagnostic_only"] is True
+    assert venue_mix_review["decision_power"] == "none"
+    assert venue_mix_review["review_only"] is True
+
+
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     evidence = _base_evidence()
     evidence.update(
@@ -752,6 +1020,28 @@ def test_attention_recommendation_does_not_change_admission_or_execution_behavio
     after = admit_orchestration_intent(tmp_path, intent)
 
     assert attention["does_not_change_admission_or_execution"] is True
+    assert before["handoff_outcome"] == "admitted_to_execution_substrate"
+    assert after["handoff_outcome"] == "admitted_to_execution_substrate"
+
+
+def test_venue_mix_review_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    evidence.update(
+        {
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert review["does_not_change_admission_or_execution"] is True
     assert before["handoff_outcome"] == "admitted_to_execution_substrate"
     assert after["handoff_outcome"] == "admitted_to_execution_substrate"
 


### PR DESCRIPTION
### Motivation
- Provide a small, bounded retrospective diagnostic so the orchestration body can detect venue-choice drift (internal execution vs Codex vs Deep Research vs operator escalation) without adding authority or new venues.
- Keep the review conservative, proof-visible, and derived only from existing orchestration artifacts and operator/escalation signals.

### Description
- Add a typed venue-mix classifier `derive_orchestration_venue_mix_review` that reads `glow/orchestration/orchestration_intents.jsonl`, `glow/orchestration/orchestration_handoffs.jsonl`, `glow/orchestration/codex_work_orders.jsonl`, and `glow/orchestration/deep_research_work_orders.jsonl` and returns one of: `balanced_recent_venue_mix`, `internal_execution_heavy`, `codex_heavy`, `deep_research_heavy`, `operator_escalation_heavy`, `mixed_venue_stress`, or `insufficient_history` plus compact counts, ratios, and a conservative classification basis; it is diagnostic-only and explicitly non-authoritative (`decision_power: none`).
- Surface the venue-mix review in the existing diagnostic consumer (`build_scoped_lifecycle_diagnostic`) under `orchestration_handoff.venue_mix_review` without creating any admission/execution side effects or new decision surfaces.
- Update the orchestration intent fabric note to document what the venue-mix review means, which artifacts it reads, the allowed classifications, and explicit non-goals.
- Add focused tests exercising balanced, internal-heavy, codex-heavy, deep-research-heavy, operator-escalation-heavy, mixed-stress, and insufficient-history cases plus consumer coherence and a test proving the review does not change admission/execution behavior; changes are in `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric_note.py`, and `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and the entire modified test set passed (all added venue-mix tests succeeded). 
- Ran `mypy scripts/ sentientos/` which failed due to large pre-existing repository typing debt unrelated to this change. 
- Ran the project test runner `python -m scripts.run_tests -q` which hit unrelated failures in the pulse federation integration tests in this environment and are not caused by the venue-mix review.
- Ran `python scripts/audit_immutability_verifier.py` which passed (artifact-dependent check); `verify_audits --strict` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e051a7a0988320be80b095b17dd39d)