### PR TITLE
[codex:orchestration] add bounded next-venue recommendation diagnostics

### DIFF
--- a/sentientos/bounded_orchestration_pattern_note.py
+++ b/sentientos/bounded_orchestration_pattern_note.py
@@ -10,15 +10,43 @@ def bounded_orchestration_pattern_note() -> dict[str, Any]:
         "title": "bounded_orchestration_pattern",
         "what_it_is": (
             "A compact constitutional pattern: delegated judgment -> typed orchestration intent -> bounded handoff -> "
-            "result resolution -> retrospective review -> operator-attention recommendation, with explicit non-sovereign boundaries."
+            "result resolution -> retrospective review -> operator-attention recommendation -> bounded next-venue recommendation, "
+            "with explicit non-sovereign boundaries."
         ),
         "reusable_parts": [
             "intent typing + executability classification",
             "append-only intent/handoff ledgers",
             "handoff-to-result linkage fields",
             "bounded retrospective review and operator-attention recommendation",
+            "bounded next-venue recommendation derived from delegated judgment + retrospective signals",
             "explicit anti-sovereignty payload fields",
         ],
+        "next_venue_recommendation": {
+            "what_it_means": "A bounded recommendation for which existing venue is likely preferable next, not a planner or router.",
+            "derived_from": [
+                "delegated_judgment.recommended_venue and escalation_classification",
+                "orchestration_outcome_review",
+                "orchestration_venue_mix_review",
+                "orchestration_operator_attention_recommendation",
+            ],
+            "return_values": [
+                "prefer_internal_execution",
+                "prefer_codex_implementation",
+                "prefer_deep_research_audit",
+                "prefer_operator_decision",
+                "hold_current_venue_mix",
+                "insufficient_context",
+            ],
+            "difference_from_delegated_judgment": (
+                "delegated_judgment proposes venue from current slice evidence; next-venue recommendation applies conservative "
+                "self-correction using recent orchestration outcome and venue-mix behavior."
+            ),
+            "explicitly_does_not_do": [
+                "does_not_execute_or_route_work",
+                "does_not_override_delegated_judgment",
+                "does_not_add_new_venues_or_authority_surface",
+            ],
+        },
         "onboarding_checklist": [
             "define venue_id with supported_intent_kinds and executability_classes",
             "declare handoff_substrate and append-only result_source",

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -112,6 +112,23 @@ _ORCHESTRATION_VENUE_MIX_CLASSES = {
     "insufficient_history",
 }
 
+_NEXT_VENUE_RECOMMENDATIONS = {
+    "prefer_internal_execution",
+    "prefer_codex_implementation",
+    "prefer_deep_research_audit",
+    "prefer_operator_decision",
+    "hold_current_venue_mix",
+    "insufficient_context",
+}
+
+_NEXT_VENUE_RELATIONS = {
+    "affirming",
+    "nudging",
+    "holding",
+    "escalating",
+    "insufficient_context",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -1133,6 +1150,158 @@ def derive_orchestration_attention_recommendation(
             recommendation_only=True,
             diagnostic_only=True,
             does_not_change_admission_or_execution=True,
+        ),
+    }
+
+
+def derive_next_venue_recommendation(
+    delegated_judgment: Mapping[str, Any],
+    outcome_review: Mapping[str, Any],
+    venue_mix_review: Mapping[str, Any],
+    attention_recommendation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive a bounded next-venue recommendation from existing orchestration signals only."""
+
+    delegated_venue = str(delegated_judgment.get("recommended_venue") or "insufficient_context")
+    escalation_classification = str(delegated_judgment.get("escalation_classification") or "")
+    outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    venue_mix_classification = str(venue_mix_review.get("review_classification") or "insufficient_history")
+    attention_signal = str(attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
+    outcome_records = int(outcome_review.get("records_considered") or 0)
+    venue_mix_records = int(venue_mix_review.get("records_considered") or 0)
+    blocked_heavy = bool((outcome_review.get("condition_flags") or {}).get("blocked_heavy"))
+    failure_heavy = bool((outcome_review.get("condition_flags") or {}).get("failure_heavy"))
+    stall_heavy = bool((outcome_review.get("condition_flags") or {}).get("stall_heavy"))
+    operator_heavy = venue_mix_classification == "operator_escalation_heavy"
+
+    delegated_to_next = {
+        "internal_direct_execution": "prefer_internal_execution",
+        "codex_implementation": "prefer_codex_implementation",
+        "deep_research_audit": "prefer_deep_research_audit",
+        "operator_decision_required": "prefer_operator_decision",
+    }
+    delegated_next = delegated_to_next.get(delegated_venue)
+
+    recommendation = "insufficient_context"
+    relation = "insufficient_context"
+    rationale = "insufficient_or_conflicting_recent_signal_basis_for_next_venue"
+
+    operator_escalation_dominant = (
+        delegated_venue == "operator_decision_required"
+        or escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
+        or operator_heavy
+        or (
+            attention_signal in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall"}
+            and (blocked_heavy or failure_heavy or stall_heavy)
+        )
+    )
+    has_minimum_history = outcome_records >= 3 and venue_mix_records >= 3
+    stress_signals_present = (
+        outcome_classification in {
+            "handoff_block_heavy",
+            "execution_failure_heavy",
+            "pending_stall_pattern",
+            "mixed_orchestration_stress",
+        }
+        or venue_mix_classification == "mixed_venue_stress"
+    )
+
+    if operator_escalation_dominant:
+        recommendation = "prefer_operator_decision"
+        relation = "escalating"
+        rationale = "operator_required_or_escalation_signals_dominate_recent_orchestration_pattern"
+    elif not has_minimum_history or delegated_next is None:
+        recommendation = "insufficient_context"
+        relation = "insufficient_context"
+        rationale = "insufficient_recent_orchestration_history_or_delegated_judgment_venue_unavailable"
+    elif (
+        delegated_venue in {"internal_direct_execution", "codex_implementation"}
+        and venue_mix_classification in {"mixed_venue_stress", "deep_research_heavy"}
+        and outcome_classification in {"mixed_orchestration_stress", "execution_failure_heavy"}
+    ):
+        recommendation = "prefer_deep_research_audit"
+        relation = "nudging"
+        rationale = "recent_stress_or_architectural_ambiguity_pattern_nudges_toward_deep_research_audit"
+    elif delegated_venue == "internal_direct_execution" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "internal_execution_heavy",
+    }:
+        recommendation = "prefer_internal_execution"
+        relation = "affirming"
+        rationale = "clean_recent_internal_outcomes_and_compatible_venue_mix_affirm_internal_execution"
+    elif delegated_venue == "codex_implementation" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "codex_heavy",
+    }:
+        recommendation = "prefer_codex_implementation"
+        relation = "affirming"
+        rationale = "clean_recent_outcomes_and_compatible_codex_usage_affirm_codex_implementation"
+    elif delegated_venue == "deep_research_audit" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "deep_research_heavy",
+    } and outcome_classification in {"clean_recent_orchestration", "mixed_orchestration_stress", "execution_failure_heavy"}:
+        recommendation = "prefer_deep_research_audit"
+        relation = "affirming"
+        rationale = "delegated_judgment_and_recent_venue_patterns_support_deep_research_audit"
+    elif stress_signals_present:
+        recommendation = "hold_current_venue_mix"
+        relation = "holding"
+        rationale = "recent_venue_behavior_is_stressed_or_unstable_without_clear_safe_correction_target"
+    elif delegated_next is not None:
+        recommendation = delegated_next
+        relation = "affirming"
+        rationale = "delegated_judgment_is_compatible_with_recent_orchestration_signals"
+
+    if recommendation not in _NEXT_VENUE_RECOMMENDATIONS:
+        recommendation = "insufficient_context"
+        relation = "insufficient_context"
+        rationale = "unrecognized_next_venue_recommendation_defaulted_to_insufficient_context"
+    if relation not in _NEXT_VENUE_RELATIONS:
+        relation = "insufficient_context"
+
+    return {
+        "schema_version": "next_venue_recommendation.v1",
+        "source": "delegated_judgment_plus_orchestration_reviews",
+        "current_delegated_judgment_venue": delegated_venue,
+        "next_venue_recommendation": recommendation,
+        "relation_to_delegated_judgment": relation,
+        "basis": {
+            "delegated_judgment": {
+                "recommended_venue": delegated_venue,
+                "escalation_classification": escalation_classification,
+            },
+            "orchestration_outcome_review": {
+                "review_classification": outcome_classification,
+                "records_considered": outcome_records,
+                "condition_flags": {
+                    "blocked_heavy": blocked_heavy,
+                    "failure_heavy": failure_heavy,
+                    "stall_heavy": stall_heavy,
+                },
+            },
+            "orchestration_venue_mix_review": {
+                "review_classification": venue_mix_classification,
+                "records_considered": venue_mix_records,
+            },
+            "orchestration_operator_attention_recommendation": attention_signal,
+            "rationale": rationale,
+            "derived_from_existing_signals_only": [
+                "delegated_judgment.recommended_venue",
+                "delegated_judgment.escalation_classification",
+                "orchestration_outcome_review.review_classification",
+                "orchestration_outcome_review.condition_flags",
+                "orchestration_venue_mix_review.review_classification",
+                "orchestration_operator_attention_recommendation.operator_attention_recommendation",
+            ],
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "does_not_execute_or_route_work": True,
+                "does_not_override_delegated_judgment": True,
+            },
         ),
     }
 

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -16,6 +16,7 @@ from sentientos.orchestration_intent_fabric import (
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
@@ -146,6 +147,12 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     orchestration_outcome_review = derive_orchestration_outcome_review(root)
     orchestration_venue_mix_review = derive_orchestration_venue_mix_review(root)
     orchestration_attention_recommendation = derive_orchestration_attention_recommendation(orchestration_outcome_review)
+    next_venue_recommendation = derive_next_venue_recommendation(
+        delegated_judgment,
+        orchestration_outcome_review,
+        orchestration_venue_mix_review,
+        orchestration_attention_recommendation,
+    )
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
         orchestration_intent,
@@ -191,6 +198,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "outcome_review": orchestration_outcome_review,
             "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,
+            "next_venue_recommendation": next_venue_recommendation,
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,
         },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -13,6 +13,7 @@ from sentientos.orchestration_intent_fabric import (
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
@@ -947,6 +948,102 @@ def test_recent_history_review_to_attention_to_consumer_stays_non_authoritative(
     assert attention["does_not_change_admission_or_execution"] is True
 
 
+def test_next_venue_recommendation_prefers_internal_for_healthy_internal_pattern() -> None:
+    delegated = {"recommended_venue": "internal_direct_execution", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "internal_execution_heavy", "records_considered": 6}
+    attention = {"operator_attention_recommendation": "none"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_internal_execution"
+    assert recommendation["relation_to_delegated_judgment"] == "affirming"
+
+
+def test_next_venue_recommendation_prefers_codex_for_healthy_codex_pattern() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 5,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "balanced_recent_venue_mix", "records_considered": 5}
+    attention = {"operator_attention_recommendation": "none"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_codex_implementation"
+    assert recommendation["relation_to_delegated_judgment"] == "affirming"
+
+
+def test_next_venue_recommendation_prefers_deep_research_for_architecture_stress() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "mixed_orchestration_stress",
+        "records_considered": 7,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": True, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "deep_research_heavy", "records_considered": 7}
+    attention = {"operator_attention_recommendation": "review_mixed_orchestration_stress"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_deep_research_audit"
+    assert recommendation["relation_to_delegated_judgment"] == "nudging"
+
+
+def test_next_venue_recommendation_prefers_operator_decision_for_escalation_dominant_pattern() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "escalate_for_operator_priority"}
+    outcome_review = {
+        "review_classification": "handoff_block_heavy",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": True, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "operator_escalation_heavy", "records_considered": 6}
+    attention = {"operator_attention_recommendation": "inspect_handoff_blocks"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_operator_decision"
+    assert recommendation["relation_to_delegated_judgment"] == "escalating"
+
+
+def test_next_venue_recommendation_holds_for_stressed_mix_without_clear_correction_target() -> None:
+    delegated = {"recommended_venue": "deep_research_audit", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "mixed_orchestration_stress",
+        "records_considered": 5,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "mixed_venue_stress", "records_considered": 5}
+    attention = {"operator_attention_recommendation": "observe"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "hold_current_venue_mix"
+    assert recommendation["relation_to_delegated_judgment"] == "holding"
+
+
+def test_next_venue_recommendation_returns_insufficient_context_when_history_is_thin() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "insufficient_history",
+        "records_considered": 2,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "insufficient_history", "records_considered": 2}
+    attention = {"operator_attention_recommendation": "insufficient_context"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "insufficient_context"
+    assert recommendation["relation_to_delegated_judgment"] == "insufficient_context"
+
+
 def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_authoritative(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1001,6 +1098,71 @@ def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_au
     assert venue_mix_review["review_only"] is True
 
 
+def test_next_venue_recommendation_flows_to_consumer_and_stays_non_authoritative(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+        ],
+    )
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-next-venue-consumer",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    next_venue = diagnostic["orchestration_handoff"]["next_venue_recommendation"]
+    delegated_venue = diagnostic["delegated_judgment"]["recommended_venue"]
+
+    assert next_venue["current_delegated_judgment_venue"] == delegated_venue
+    assert next_venue["next_venue_recommendation"] in {
+        "prefer_internal_execution",
+        "prefer_codex_implementation",
+        "prefer_deep_research_audit",
+        "prefer_operator_decision",
+        "hold_current_venue_mix",
+        "insufficient_context",
+    }
+    assert next_venue["relation_to_delegated_judgment"] in {
+        "affirming",
+        "nudging",
+        "holding",
+        "escalating",
+        "insufficient_context",
+    }
+    assert next_venue["diagnostic_only"] is True
+    assert next_venue["non_authoritative"] is True
+    assert next_venue["decision_power"] == "none"
+    assert next_venue["recommendation_only"] is True
+    assert next_venue["does_not_execute_or_route_work"] is True
+    assert next_venue["does_not_override_delegated_judgment"] is True
+
+
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     evidence = _base_evidence()
     evidence.update(
@@ -1044,6 +1206,25 @@ def test_venue_mix_review_does_not_change_admission_or_execution_behavior(tmp_pa
     assert review["does_not_change_admission_or_execution"] is True
     assert before["handoff_outcome"] == "admitted_to_execution_substrate"
     assert after["handoff_outcome"] == "admitted_to_execution_substrate"
+
+
+def test_next_venue_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    outcome_review = derive_orchestration_outcome_review(tmp_path)
+    venue_mix_review = derive_orchestration_venue_mix_review(tmp_path)
+    attention = derive_orchestration_attention_recommendation(outcome_review)
+    next_venue = derive_next_venue_recommendation(judgment, outcome_review, venue_mix_review, attention)
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert next_venue["does_not_change_admission_or_execution"] is True
+    assert next_venue["does_not_execute_or_route_work"] is True
+    assert next_venue["does_not_override_delegated_judgment"] is True
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 
 
 def test_codex_staged_work_order_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide a small, machine-readable, self-correcting recommendation layer that suggests which existing venue should likely be preferred next without becoming an authority or planner. 
- Derive recommendations conservatively only from existing orchestration signals: delegated judgment, orchestration outcome review, venue-mix review, and operator-attention recommendation. 
- Preserve explicit anti-sovereignty boundaries so the recommendation is diagnostic-only and cannot execute, route, or override delegated judgment. 

### Description
- Added a compact next-venue vocabulary and relation set in `sentientos/orchestration_intent_fabric.py` (`_NEXT_VENUE_RECOMMENDATIONS`, `_NEXT_VENUE_RELATIONS`).
- Implemented `derive_next_venue_recommendation(...)` in `sentientos/orchestration_intent_fabric.py`, which returns a `next_venue_recommendation.v1` payload that includes `next_venue_recommendation`, `relation_to_delegated_judgment`, a machine-readable `basis`/`rationale`, and explicit anti-sovereignty fields such as `diagnostic_only`, `non_authoritative`, and `decision_power: none`.
- Surfaces the recommendation in the existing orchestration diagnostic consumer by adding `next_venue_recommendation` to `sentientos/scoped_lifecycle_diagnostic.build_scoped_lifecycle_diagnostic` under `orchestration_handoff`, and updated the bounded orchestration note in `sentientos/bounded_orchestration_pattern_note.py` to document meaning, inputs, return values and explicit non-actions.
- Added focused unit tests in `sentientos/tests/test_orchestration_intent_fabric.py` that assert behavior for: `prefer_internal_execution`, `prefer_codex_implementation`, `prefer_deep_research_audit`, `prefer_operator_decision`, `hold_current_venue_mix`, `insufficient_context`, consumer coherence, and that the recommendation does not change admission/execution behavior.

### Testing
- Ran the focused test module with `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and it passed (all tests green).
- Ran combined checks `pytest -q sentientos/tests/test_bounded_orchestration_pattern.py sentientos/tests/test_orchestration_intent_fabric.py` and they passed (all tests green).
- Added tests verify that the recommendation is surfaced in the scoped diagnostic consumer and that it remains non-authoritative and does not change admission or execution outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0587169208320ae65244392e904b1)