### PR TITLE
[codex:orchestration] stage bounded next-move proposal artifact

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -1,0 +1,36 @@
+# Orchestration Next-Move Proposal Note
+
+`orchestration_next_move_proposal.v1` is a bounded constitutional **proposal artifact** for "what should happen next" in orchestration.
+
+## Signals used
+
+It is derived only from existing orchestration signals:
+
+- delegated judgment
+- next-venue recommendation
+- orchestration outcome review
+- orchestration venue-mix review
+- orchestration operator-attention recommendation
+- existing escalation/operator-required state
+
+## What it is (and is not)
+
+- **Delegated judgment** states the current bounded recommendation from constitutional evidence.
+- **Next-venue recommendation** states relation-aware venue preference (`affirming`, `nudging`, `holding`, `escalating`, `insufficient_context`).
+- **Next-move proposal** fuses those signals into one machine-readable, proof-visible proposal object with:
+  - proposed venue
+  - proposed posture (`expand`, `consolidate`, `audit`, `hold`, `escalate`)
+  - executability classification
+  - operator/escalation requirement state
+
+The proposal is explicitly non-sovereign and non-authoritative:
+
+- `diagnostic_only: true`
+- `non_authoritative: true`
+- `decision_power: none`
+- `proposal_only: true`
+- `does_not_execute_or_route_work: true`
+- `does_not_override_delegated_judgment: true`
+- `requires_operator_or_existing_handoff_path: true`
+
+It does not execute, route, or admit work by itself.

--- a/glow/orchestration/orchestration_next_move_proposals.jsonl
+++ b/glow/orchestration/orchestration_next_move_proposals.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"orchestration_next_move_proposal.v1","artifact_status":"initialized","notes":"append-only proof-visible proposal ledger for bounded next-move staging","non_authoritative":true,"diagnostic_only":true,"decision_power":"none","proposal_only":true}

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -129,6 +129,22 @@ _NEXT_VENUE_RELATIONS = {
     "insufficient_context",
 }
 
+_NEXT_MOVE_PROPOSAL_POSTURES = {
+    "expand",
+    "consolidate",
+    "audit",
+    "hold",
+    "escalate",
+}
+
+_NEXT_MOVE_EXECUTABILITY = {
+    "executable_now",
+    "stageable_external_work_order",
+    "blocked_operator_required",
+    "blocked_insufficient_context",
+    "no_action_recommended",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -398,6 +414,28 @@ def _staged_work_order_id(intent: Mapping[str, Any], created_at: str, *, prefix:
 def _source_judgment_linkage_id(source_map: Mapping[str, Any]) -> str:
     canonical = json.dumps(dict(source_map), sort_keys=True, separators=(",", ":"))
     return f"jdg-link-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _next_move_proposal_id(
+    *,
+    created_at: str,
+    source_linkage_id: str,
+    relation_posture: str,
+    proposed_venue: str,
+    proposed_intent_kind: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "created_at": created_at,
+            "source_linkage_id": source_linkage_id,
+            "relation_posture": relation_posture,
+            "proposed_venue": proposed_venue,
+            "proposed_intent_kind": proposed_intent_kind,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"nmp-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
 
 
 def append_codex_work_order_ledger(repo_root: Path, work_order: Mapping[str, Any]) -> Path:
@@ -1304,6 +1342,158 @@ def derive_next_venue_recommendation(
             },
         ),
     }
+
+
+def synthesize_next_move_proposal(
+    delegated_judgment: Mapping[str, Any],
+    next_venue_recommendation: Mapping[str, Any],
+    outcome_review: Mapping[str, Any],
+    venue_mix_review: Mapping[str, Any],
+    attention_recommendation: Mapping[str, Any],
+    *,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Synthesize a bounded, non-sovereign next-move proposal from existing orchestration signals."""
+
+    source_linkage = _source_judgment_linkage(delegated_judgment)
+    source_linkage_id = _source_judgment_linkage_id(source_linkage)
+    delegated_venue = str(source_linkage.get("recommended_venue") or "insufficient_context")
+    delegated_posture = str(source_linkage.get("next_move_posture") or "hold")
+    escalation_classification = str(source_linkage.get("escalation_classification") or "escalate_for_missing_context")
+    relation_posture = str(next_venue_recommendation.get("relation_to_delegated_judgment") or "insufficient_context")
+    recommended_next_venue = str(next_venue_recommendation.get("next_venue_recommendation") or "insufficient_context")
+    attention_signal = str(attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
+    outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    venue_mix_classification = str(venue_mix_review.get("review_classification") or "insufficient_history")
+
+    recommendation_to_venue = {
+        "prefer_internal_execution": "internal_direct_execution",
+        "prefer_codex_implementation": "codex_implementation",
+        "prefer_deep_research_audit": "deep_research_audit",
+        "prefer_operator_decision": "operator_decision_required",
+        "hold_current_venue_mix": delegated_venue,
+        "insufficient_context": "insufficient_context",
+    }
+    proposed_venue = recommendation_to_venue.get(recommended_next_venue, "insufficient_context")
+    proposed_intent_kind, _, _ = _translate_kind(
+        {
+            "recommended_venue": proposed_venue,
+            "work_class": str(source_linkage.get("work_class") or ""),
+            "escalation_classification": escalation_classification,
+        }
+    )
+    proposed_posture = delegated_posture if delegated_posture in _NEXT_MOVE_PROPOSAL_POSTURES else "hold"
+    executability = "no_action_recommended"
+    if relation_posture == "escalating" or proposed_venue == "operator_decision_required":
+        proposed_posture = "escalate"
+        executability = "blocked_operator_required"
+    elif relation_posture == "holding":
+        proposed_posture = "hold"
+        executability = "no_action_recommended"
+    elif relation_posture == "insufficient_context" or proposed_venue == "insufficient_context":
+        proposed_posture = "hold"
+        executability = "blocked_insufficient_context"
+    elif proposed_venue == "internal_direct_execution":
+        executability = "executable_now"
+    elif proposed_venue in {"codex_implementation", "deep_research_audit"}:
+        executability = "stageable_external_work_order"
+
+    if executability not in _NEXT_MOVE_EXECUTABILITY:
+        executability = "blocked_insufficient_context"
+
+    if relation_posture not in _NEXT_VENUE_RELATIONS:
+        relation_posture = "insufficient_context"
+    if proposed_posture not in _NEXT_MOVE_PROPOSAL_POSTURES:
+        proposed_posture = "hold"
+    if proposed_intent_kind not in _INTENT_KINDS:
+        proposed_intent_kind = "hold_no_action"
+
+    requires_operator = (
+        escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
+        or relation_posture in {"escalating", "insufficient_context"}
+        or recommended_next_venue == "prefer_operator_decision"
+        or attention_signal in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall"}
+    )
+    timestamp = created_at or _iso_utc_now()
+    proposal = {
+        "schema_version": "orchestration_next_move_proposal.v1",
+        "proposal_id": _next_move_proposal_id(
+            created_at=timestamp,
+            source_linkage_id=source_linkage_id,
+            relation_posture=relation_posture,
+            proposed_venue=proposed_venue,
+            proposed_intent_kind=proposed_intent_kind,
+        ),
+        "recorded_at": timestamp,
+        "source_delegated_judgment": {
+            "source_judgment_linkage_id": source_linkage_id,
+            "recommended_venue": delegated_venue,
+            "next_move_posture": delegated_posture,
+            "escalation_classification": escalation_classification,
+        },
+        "current_recommended_venue": recommended_next_venue,
+        "relation_posture": relation_posture,
+        "proposed_next_action": {
+            "intent_kind": proposed_intent_kind,
+            "proposed_venue": proposed_venue,
+            "proposed_posture": proposed_posture,
+        },
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": requires_operator,
+            "attention_signal": attention_signal,
+            "escalation_classification": escalation_classification,
+        },
+        "executability_classification": executability,
+        "proposal_state": (
+            "ready_for_internal_executable_handoff"
+            if executability == "executable_now"
+            else "staged_external_or_non_executable"
+            if executability == "stageable_external_work_order"
+            else "blocked_or_hold"
+        ),
+        "basis": {
+            "orchestration_outcome_review": {
+                "review_classification": outcome_classification,
+                "records_considered": int(outcome_review.get("records_considered") or 0),
+            },
+            "orchestration_venue_mix_review": {
+                "review_classification": venue_mix_classification,
+                "records_considered": int(venue_mix_review.get("records_considered") or 0),
+            },
+            "orchestration_operator_attention_recommendation": attention_signal,
+            "next_venue_relation_posture": relation_posture,
+            "compact_rationale": str((next_venue_recommendation.get("basis") or {}).get("rationale") or ""),
+            "derived_from_existing_signals_only": [
+                "delegated_judgment",
+                "next_venue_recommendation",
+                "orchestration_outcome_review",
+                "orchestration_venue_mix_review",
+                "orchestration_operator_attention_recommendation",
+            ],
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "proposal_only": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_override_delegated_judgment": True,
+                "requires_operator_or_existing_handoff_path": True,
+            },
+        ),
+    }
+    return proposal
+
+
+def append_next_move_proposal_ledger(repo_root: Path, proposal: Mapping[str, Any]) -> Path:
+    """Append one bounded next-move proposal to the proof-visible orchestration proposal ledger."""
+
+    ledger_path = repo_root.resolve() / "glow/orchestration/orchestration_next_move_proposals.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(proposal), sort_keys=True) + "\n")
+    return ledger_path
 
 
 def executable_handoff_map() -> dict[str, Any]:

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -13,6 +13,7 @@ from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
+    append_next_move_proposal_ledger,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
@@ -23,6 +24,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_codex_staged_work_order_lifecycle,
     resolve_deep_research_staged_work_order_lifecycle,
     resolve_orchestration_result,
+    synthesize_next_move_proposal,
     synthesize_orchestration_intent,
 )
 
@@ -153,6 +155,14 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_venue_mix_review,
         orchestration_attention_recommendation,
     )
+    next_move_proposal = synthesize_next_move_proposal(
+        delegated_judgment,
+        next_venue_recommendation,
+        orchestration_outcome_review,
+        orchestration_venue_mix_review,
+        orchestration_attention_recommendation,
+    )
+    next_move_proposal_ledger_path = append_next_move_proposal_ledger(root, next_move_proposal)
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
         orchestration_intent,
@@ -199,6 +209,16 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,
             "next_venue_recommendation": next_venue_recommendation,
+            "next_move_proposal": {
+                **next_move_proposal,
+                "ledger_path": str(next_move_proposal_ledger_path.relative_to(root)),
+                "current_delegated_judgment_venue": delegated_judgment.get("recommended_venue"),
+                "ready_for_internal_executable_handoff": next_move_proposal.get("executability_classification")
+                == "executable_now",
+                "staged_only": next_move_proposal.get("executability_classification") == "stageable_external_work_order",
+                "blocked_or_hold": next_move_proposal.get("executability_classification")
+                in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
+            },
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,
         },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -10,6 +10,7 @@ import task_executor
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
+    append_next_move_proposal_ledger,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
@@ -18,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_orchestration_result,
+    synthesize_next_move_proposal,
     synthesize_orchestration_intent,
 )
 from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
@@ -1044,6 +1046,130 @@ def test_next_venue_recommendation_returns_insufficient_context_when_history_is_
     assert recommendation["relation_to_delegated_judgment"] == "insufficient_context"
 
 
+def test_next_move_proposal_affirming_for_healthy_internal_pattern() -> None:
+    delegated = {
+        "recommended_venue": "internal_direct_execution",
+        "escalation_classification": "none",
+        "work_class": "internal_runtime_maintenance",
+        "next_move_posture": "hold",
+    }
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "internal_execution_heavy", "records_considered": 6}
+    attention = {"operator_attention_recommendation": "none"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    assert proposal["relation_posture"] == "affirming"
+    assert proposal["proposed_next_action"]["proposed_venue"] == "internal_direct_execution"
+    assert proposal["executability_classification"] == "executable_now"
+    assert proposal["proposal_state"] == "ready_for_internal_executable_handoff"
+
+
+def test_next_move_proposal_nudging_or_holding_on_stressed_pattern() -> None:
+    delegated = {
+        "recommended_venue": "codex_implementation",
+        "escalation_classification": "none",
+        "work_class": "cross_slice_consolidation",
+        "next_move_posture": "consolidate",
+    }
+    outcome_review = {
+        "review_classification": "mixed_orchestration_stress",
+        "records_considered": 7,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": True, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "deep_research_heavy", "records_considered": 7}
+    attention = {"operator_attention_recommendation": "review_mixed_orchestration_stress"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    assert proposal["relation_posture"] in {"nudging", "holding"}
+    assert proposal["executability_classification"] in {"stageable_external_work_order", "no_action_recommended"}
+
+
+def test_next_move_proposal_escalates_for_operator_heavy_patterns() -> None:
+    delegated = {
+        "recommended_venue": "codex_implementation",
+        "escalation_classification": "escalate_for_operator_priority",
+        "work_class": "operator_required",
+        "next_move_posture": "escalate",
+    }
+    outcome_review = {
+        "review_classification": "handoff_block_heavy",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": True, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "operator_escalation_heavy", "records_considered": 6}
+    attention = {"operator_attention_recommendation": "inspect_handoff_blocks"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    assert proposal["relation_posture"] == "escalating"
+    assert proposal["proposed_next_action"]["proposed_posture"] == "escalate"
+    assert proposal["executability_classification"] == "blocked_operator_required"
+    assert proposal["operator_escalation_requirement_state"]["requires_operator_or_escalation"] is True
+
+
+def test_next_move_proposal_insufficient_context_when_signal_basis_is_thin() -> None:
+    delegated = {
+        "recommended_venue": "codex_implementation",
+        "escalation_classification": "none",
+        "work_class": "cross_slice_consolidation",
+        "next_move_posture": "consolidate",
+    }
+    outcome_review = {
+        "review_classification": "insufficient_history",
+        "records_considered": 2,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "insufficient_history", "records_considered": 2}
+    attention = {"operator_attention_recommendation": "insufficient_context"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    assert proposal["relation_posture"] == "insufficient_context"
+    assert proposal["executability_classification"] == "blocked_insufficient_context"
+    assert proposal["proposal_only"] is True
+    assert proposal["does_not_execute_or_route_work"] is True
+    assert proposal["does_not_override_delegated_judgment"] is True
+
+
+def test_next_move_proposal_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "balanced_recent_venue_mix", "records_considered": 6}
+    attention = {"operator_attention_recommendation": "none"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(
+        delegated,
+        next_venue,
+        outcome_review,
+        venue_mix_review,
+        attention,
+        created_at="2026-04-12T00:00:00Z",
+    )
+    ledger_path = append_next_move_proposal_ledger(tmp_path, proposal)
+    append_next_move_proposal_ledger(tmp_path, {**proposal, "proposal_id": "nmp-second"})
+
+    rows = ledger_path.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 2
+    first = json.loads(rows[0])
+    second = json.loads(rows[1])
+    assert first["proposal_id"] == proposal["proposal_id"]
+    assert second["proposal_id"] == "nmp-second"
+
+
 def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_authoritative(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1163,6 +1289,66 @@ def test_next_venue_recommendation_flows_to_consumer_and_stays_non_authoritative
     assert next_venue["does_not_override_delegated_judgment"] is True
 
 
+def test_next_move_proposal_flows_to_consumer_artifact_and_stays_non_authoritative(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+        ],
+    )
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-next-move-proposal-consumer",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    proposal = diagnostic["orchestration_handoff"]["next_move_proposal"]
+    assert proposal["relation_posture"] in {"affirming", "nudging", "holding", "escalating", "insufficient_context"}
+    assert proposal["executability_classification"] in {
+        "executable_now",
+        "stageable_external_work_order",
+        "blocked_operator_required",
+        "blocked_insufficient_context",
+        "no_action_recommended",
+    }
+    assert proposal["proposal_only"] is True
+    assert proposal["diagnostic_only"] is True
+    assert proposal["non_authoritative"] is True
+    assert proposal["decision_power"] == "none"
+    assert proposal["does_not_execute_or_route_work"] is True
+    assert proposal["requires_operator_or_existing_handoff_path"] is True
+    assert proposal["ledger_path"] == "glow/orchestration/orchestration_next_move_proposals.jsonl"
+    rows = (tmp_path / proposal["ledger_path"]).read_text(encoding="utf-8").splitlines()
+    assert rows
+    persisted = json.loads(rows[-1])
+    assert persisted["proposal_id"] == proposal["proposal_id"]
+
+
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     evidence = _base_evidence()
     evidence.update(
@@ -1223,6 +1409,27 @@ def test_next_venue_recommendation_does_not_change_admission_or_execution_behavi
     assert next_venue["does_not_change_admission_or_execution"] is True
     assert next_venue["does_not_execute_or_route_work"] is True
     assert next_venue["does_not_override_delegated_judgment"] is True
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
+
+
+def test_next_move_proposal_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    outcome_review = derive_orchestration_outcome_review(tmp_path)
+    venue_mix_review = derive_orchestration_venue_mix_review(tmp_path)
+    attention = derive_orchestration_attention_recommendation(outcome_review)
+    next_venue = derive_next_venue_recommendation(judgment, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(judgment, next_venue, outcome_review, venue_mix_review, attention)
+    append_next_move_proposal_ledger(tmp_path, proposal)
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert proposal["does_not_change_admission_or_execution"] is True
+    assert proposal["does_not_execute_or_route_work"] is True
+    assert proposal["does_not_override_delegated_judgment"] is True
     assert before["handoff_outcome"] == "blocked_by_operator_requirement"
     assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 


### PR DESCRIPTION
### Motivation
- Represent “what should happen next” as a bounded, machine-readable, proof-visible proposal object derived only from existing orchestration signals and explicitly non-sovereign.
- Make relation posture explicit (affirming, nudging, holding, escalating, insufficient_context) so consumers can programmatically see whether the proposal affirms or challenges the delegated judgment.
- Surface proposals in the existing observability consumer and persist them append-only to preserve auditability while avoiding any execution/authority changes.

### Description
- Added compact next-move vocabulary and stable ID generation (`_NEXT_MOVE_PROPOSAL_POSTURES`, `_NEXT_MOVE_EXECUTABILITY`, `_next_move_proposal_id`) to `sentientos/orchestration_intent_fabric.py`.
- Implemented `synthesize_next_move_proposal(...)` producing `orchestration_next_move_proposal.v1` that encodes source judgment linkage, current recommended venue, relation posture, proposed next action/intent_kind/venue/posture, operator/escalation requirement state, executability classification, anti-sovereignty markers, and a compact rationale/basis.
- Added append-only ledger writer `append_next_move_proposal_ledger` that writes proposals to `glow/orchestration/orchestration_next_move_proposals.jsonl` and initialized that artifact; extended the scoped lifecycle diagnostic consumer to synthesize, append, and surface the current next-move proposal (with ready/staged/blocked visibility) without changing admission or execution behavior.
- Added focused unit tests exercising affirming, nudging/holding, escalating, and insufficient-context proposals, append-only artifact behavior, consumer coherence, and that proposals remain non-authoritative; added a short note `docs/orchestration_next_move_proposal_note.md` documenting signals, semantics, and anti-sovereignty guarantees.

### Testing
- Ran the scoped orchestration unit tests `pytest -q sentientos/tests/test_orchestration_intent_fabric.py`, and they passed (new tests included).
- Ran the repository test harness `python -m scripts.run_tests -q`, which surfaced pre-existing unrelated failures in `tests/test_pulse_federation.py` and thus is not blocking this targeted change.
- Ran `mypy scripts/ sentientos/`, which reports existing repo-wide typing issues not introduced by this change.
- Ran `python scripts/audit_immutability_verifier.py` which passed the artifact-dependent immutability checks; `verify_audits --strict` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0e40c26a48320897f7dc7bfe443c5)