### PR TITLE
[codex:orchestration] add bounded next-move proposal retrospective review

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -34,3 +34,29 @@ The proposal is explicitly non-sovereign and non-authoritative:
 - `requires_operator_or_existing_handoff_path: true`
 
 It does not execute, route, or admit work by itself.
+
+## Next-move proposal review (retrospective only)
+
+`next_move_proposal_review.v1` provides a compact retrospective classifier over recent
+`orchestration_next_move_proposal.v1` records.
+
+It reads only existing proposal artifacts/fields and existing orchestration-derived proposal state:
+
+- `relation_posture`
+- `proposed_next_action.proposed_venue`
+- `executability_classification`
+- `operator_escalation_requirement_state.requires_operator_or_escalation`
+
+Bounded review classifications:
+
+- `coherent_recent_proposals`
+- `proposal_escalation_heavy`
+- `proposal_hold_heavy`
+- `proposal_insufficient_context_heavy`
+- `proposal_venue_thrash`
+- `mixed_proposal_stress`
+- `insufficient_history`
+
+The review is descriptive and diagnostic. It does **not** plan, execute, admit, route, or
+authorize work; it remains `diagnostic_only`, `non_authoritative`, `decision_power: none`,
+and `review_only`.

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -145,6 +145,16 @@ _NEXT_MOVE_EXECUTABILITY = {
     "no_action_recommended",
 }
 
+_NEXT_MOVE_PROPOSAL_REVIEW_CLASSES = {
+    "coherent_recent_proposals",
+    "proposal_escalation_heavy",
+    "proposal_hold_heavy",
+    "proposal_insufficient_context_heavy",
+    "proposal_venue_thrash",
+    "mixed_proposal_stress",
+    "insufficient_history",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -1494,6 +1504,164 @@ def append_next_move_proposal_ledger(repo_root: Path, proposal: Mapping[str, Any
     with ledger_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(proposal), sort_keys=True) + "\n")
     return ledger_path
+
+
+def derive_next_move_proposal_review(
+    repo_root: Path,
+    *,
+    window_size: int = 10,
+) -> dict[str, Any]:
+    """Derive a bounded retrospective review over recent next-move proposal behavior."""
+
+    root = repo_root.resolve()
+    proposals = _read_jsonl(root / "glow/orchestration/orchestration_next_move_proposals.jsonl")
+    recent = proposals[-max(0, window_size) :] if window_size > 0 else []
+
+    relation_counts = {posture: 0 for posture in _NEXT_VENUE_RELATIONS}
+    venue_counts = {
+        "internal_direct_execution": 0,
+        "codex_implementation": 0,
+        "deep_research_audit": 0,
+        "operator_decision_required": 0,
+        "insufficient_context": 0,
+    }
+    executability_counts = {name: 0 for name in _NEXT_MOVE_EXECUTABILITY}
+    escalation_count = 0
+    insufficient_context_count = 0
+    venue_switches = 0
+    valid_venue_transitions = 0
+    prev_venue = ""
+    unique_venues: set[str] = set()
+
+    for row in recent:
+        relation = str(row.get("relation_posture") or "insufficient_context")
+        if relation not in relation_counts:
+            relation = "insufficient_context"
+        relation_counts[relation] += 1
+
+        proposed_next_action = row.get("proposed_next_action")
+        proposed_next_action_map = proposed_next_action if isinstance(proposed_next_action, Mapping) else {}
+        venue = str(proposed_next_action_map.get("proposed_venue") or "insufficient_context")
+        if venue not in venue_counts:
+            venue = "insufficient_context"
+        venue_counts[venue] += 1
+        if venue != "insufficient_context":
+            unique_venues.add(venue)
+        if prev_venue and venue != "insufficient_context":
+            valid_venue_transitions += 1
+            if venue != prev_venue:
+                venue_switches += 1
+        if venue != "insufficient_context":
+            prev_venue = venue
+
+        executability = str(row.get("executability_classification") or "blocked_insufficient_context")
+        if executability not in executability_counts:
+            executability = "blocked_insufficient_context"
+        executability_counts[executability] += 1
+
+        operator_state = row.get("operator_escalation_requirement_state")
+        operator_state_map = operator_state if isinstance(operator_state, Mapping) else {}
+        if relation == "escalating" or bool(operator_state_map.get("requires_operator_or_escalation")):
+            escalation_count += 1
+        if relation == "insufficient_context" or executability == "blocked_insufficient_context":
+            insufficient_context_count += 1
+
+    records_considered = len(recent)
+    heavy_threshold = max(2, (records_considered + 1) // 2)
+    escalation_heavy = records_considered >= 3 and escalation_count >= heavy_threshold
+    hold_heavy = records_considered >= 3 and relation_counts["holding"] >= heavy_threshold
+    insufficient_context_heavy = records_considered >= 3 and insufficient_context_count >= heavy_threshold
+    venue_switch_ratio = (venue_switches / valid_venue_transitions) if valid_venue_transitions else 0.0
+    venue_thrash = (
+        records_considered >= 4
+        and valid_venue_transitions >= 3
+        and venue_switch_ratio >= 0.6
+        and len(unique_venues) >= 2
+    )
+    stress_flag_count = sum(1 for flag in (escalation_heavy, hold_heavy, insufficient_context_heavy, venue_thrash) if flag)
+
+    relation_supporting_coherence = relation_counts["affirming"] + relation_counts["nudging"]
+    executable_or_staged = executability_counts["executable_now"] + executability_counts["stageable_external_work_order"]
+    coherent = (
+        records_considered >= 3
+        and stress_flag_count == 0
+        and relation_supporting_coherence >= heavy_threshold
+        and executable_or_staged >= heavy_threshold
+    )
+
+    classification = "insufficient_history"
+    compact_reason = "insufficient_recent_next_move_proposal_history_for_reliable_retrospective_classification"
+    if records_considered >= 3:
+        if stress_flag_count >= 2:
+            classification = "mixed_proposal_stress"
+            compact_reason = "multiple_competing_stress_patterns_present_across_recent_next_move_proposals"
+        elif escalation_heavy:
+            classification = "proposal_escalation_heavy"
+            compact_reason = "escalation_signals_dominate_recent_next_move_proposals"
+        elif hold_heavy:
+            classification = "proposal_hold_heavy"
+            compact_reason = "holding_relation_posture_dominates_recent_next_move_proposals"
+        elif insufficient_context_heavy:
+            classification = "proposal_insufficient_context_heavy"
+            compact_reason = "insufficient_context_signals_dominate_recent_next_move_proposals"
+        elif venue_thrash:
+            classification = "proposal_venue_thrash"
+            compact_reason = "recent_next_move_proposals_switch_venues_frequently_without_stable_pattern"
+        elif coherent:
+            classification = "coherent_recent_proposals"
+            compact_reason = "recent_next_move_proposals_are_mostly_relation_consistent_and_executability_sane"
+        else:
+            classification = "mixed_proposal_stress"
+            compact_reason = "recent_next_move_proposals_are_neither_clearly_coherent_nor_singly_stressed"
+
+    if classification not in _NEXT_MOVE_PROPOSAL_REVIEW_CLASSES:
+        classification = "mixed_proposal_stress"
+        compact_reason = "unrecognized_next_move_proposal_review_classification_defaulted_to_mixed_proposal_stress"
+
+    return {
+        "schema_version": "next_move_proposal_review.v1",
+        "review_kind": "next_move_proposal_retrospective",
+        "review_classification": classification,
+        "window_size": max(0, window_size),
+        "records_considered": records_considered,
+        "recent_counts": {
+            "by_relation_posture": relation_counts,
+            "by_proposed_venue": venue_counts,
+            "by_executability_classification": executability_counts,
+            "escalation_or_operator_required": escalation_count,
+            "insufficient_context": insufficient_context_count,
+        },
+        "summary": {
+            "proposal_behavior_posture": "coherent" if classification == "coherent_recent_proposals" else "stressed_or_uncertain",
+            "compact_reason": compact_reason,
+            "diagnostic_summary": "bounded retrospective review derived from existing next-move proposal and orchestration signals only",
+        },
+        "condition_flags": {
+            "escalation_heavy": escalation_heavy,
+            "hold_heavy": hold_heavy,
+            "insufficient_context_heavy": insufficient_context_heavy,
+            "venue_thrash": venue_thrash,
+            "competing_stress_patterns": stress_flag_count >= 2,
+        },
+        "artifacts_read": {
+            "next_move_proposal_ledger": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+            "relation_posture_field": "relation_posture",
+            "proposed_next_action_field": "proposed_next_action.proposed_venue",
+            "executability_field": "executability_classification",
+            "operator_escalation_field": "operator_escalation_requirement_state.requires_operator_or_escalation",
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "decision_power": "none",
+                "non_authoritative": True,
+                "diagnostic_only": True,
+            },
+        ),
+    }
 
 
 def executable_handoff_map() -> dict[str, Any]:

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -19,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_attention_recommendation,
     derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
+    derive_next_move_proposal_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_codex_staged_work_order_lifecycle,
@@ -163,6 +164,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_attention_recommendation,
     )
     next_move_proposal_ledger_path = append_next_move_proposal_ledger(root, next_move_proposal)
+    next_move_proposal_review = derive_next_move_proposal_review(root)
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
         orchestration_intent,
@@ -219,6 +221,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "blocked_or_hold": next_move_proposal.get("executability_classification")
                 in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
             },
+            "next_move_proposal_review": next_move_proposal_review,
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,
         },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -15,6 +15,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_next_venue_recommendation,
+    derive_next_move_proposal_review,
     derive_orchestration_outcome_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
@@ -51,6 +52,27 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+
+
+def _proposal_row(
+    *,
+    relation_posture: str,
+    venue: str,
+    executability: str,
+    requires_operator: bool = False,
+) -> dict[str, object]:
+    return {
+        "schema_version": "orchestration_next_move_proposal.v1",
+        "proposal_id": f"proposal-{relation_posture}-{venue}-{executability}",
+        "relation_posture": relation_posture,
+        "proposed_next_action": {"proposed_venue": venue, "proposed_posture": "hold"},
+        "executability_classification": executability,
+        "operator_escalation_requirement_state": {"requires_operator_or_escalation": requires_operator},
+        "proposal_only": True,
+        "diagnostic_only": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+    }
 
 
 def test_deep_research_judgment_translates_to_stageable_external_work_order() -> None:
@@ -1170,6 +1192,184 @@ def test_next_move_proposal_artifact_is_append_only_and_proof_visible(tmp_path: 
     assert second["proposal_id"] == "nmp-second"
 
 
+def test_next_move_proposal_review_classifies_coherent_recent_proposals(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(
+                relation_posture="affirming",
+                venue="internal_direct_execution",
+                executability="executable_now",
+            ),
+            _proposal_row(
+                relation_posture="affirming",
+                venue="internal_direct_execution",
+                executability="executable_now",
+            ),
+            _proposal_row(
+                relation_posture="nudging",
+                venue="codex_implementation",
+                executability="stageable_external_work_order",
+            ),
+            _proposal_row(
+                relation_posture="affirming",
+                venue="codex_implementation",
+                executability="stageable_external_work_order",
+            ),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+
+    assert review["review_classification"] == "coherent_recent_proposals"
+    assert review["summary"]["proposal_behavior_posture"] == "coherent"
+    assert review["review_only"] is True
+    assert review["non_authoritative"] is True
+
+
+def test_next_move_proposal_review_classifies_escalation_heavy(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="holding",
+                venue="codex_implementation",
+                executability="stageable_external_work_order",
+            ),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "proposal_escalation_heavy"
+
+
+def test_next_move_proposal_review_classifies_hold_heavy(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(relation_posture="holding", venue="internal_direct_execution", executability="no_action_recommended"),
+            _proposal_row(relation_posture="holding", venue="internal_direct_execution", executability="no_action_recommended"),
+            _proposal_row(relation_posture="holding", venue="codex_implementation", executability="no_action_recommended"),
+            _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "proposal_hold_heavy"
+
+
+def test_next_move_proposal_review_classifies_insufficient_context_heavy(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(
+                relation_posture="insufficient_context",
+                venue="insufficient_context",
+                executability="blocked_insufficient_context",
+            ),
+            _proposal_row(
+                relation_posture="insufficient_context",
+                venue="insufficient_context",
+                executability="blocked_insufficient_context",
+            ),
+            _proposal_row(
+                relation_posture="insufficient_context",
+                venue="insufficient_context",
+                executability="blocked_insufficient_context",
+            ),
+            _proposal_row(
+                relation_posture="holding",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "proposal_insufficient_context_heavy"
+
+
+def test_next_move_proposal_review_classifies_venue_thrash(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+            _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+            _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+            _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+            _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "proposal_venue_thrash"
+
+
+def test_next_move_proposal_review_classifies_mixed_stress(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="holding",
+                venue="internal_direct_execution",
+                executability="no_action_recommended",
+            ),
+            _proposal_row(
+                relation_posture="holding",
+                venue="internal_direct_execution",
+                executability="no_action_recommended",
+            ),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "mixed_proposal_stress"
+
+
+def test_next_move_proposal_review_classifies_insufficient_history(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+            _proposal_row(relation_posture="holding", venue="codex_implementation", executability="no_action_recommended"),
+        ],
+    )
+
+    review = derive_next_move_proposal_review(tmp_path)
+    assert review["review_classification"] == "insufficient_history"
+
+
 def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_authoritative(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1349,6 +1549,84 @@ def test_next_move_proposal_flows_to_consumer_artifact_and_stays_non_authoritati
     assert persisted["proposal_id"] == proposal["proposal_id"]
 
 
+def test_next_move_proposal_review_flows_to_consumer_and_stays_non_authoritative(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        [
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="escalating",
+                venue="operator_decision_required",
+                executability="blocked_operator_required",
+                requires_operator=True,
+            ),
+            _proposal_row(
+                relation_posture="holding",
+                venue="codex_implementation",
+                executability="no_action_recommended",
+            ),
+        ],
+    )
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+        ],
+    )
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-next-move-review-consumer",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    review = diagnostic["orchestration_handoff"]["next_move_proposal_review"]
+
+    assert review["review_classification"] in {
+        "coherent_recent_proposals",
+        "proposal_escalation_heavy",
+        "proposal_hold_heavy",
+        "proposal_insufficient_context_heavy",
+        "proposal_venue_thrash",
+        "mixed_proposal_stress",
+        "insufficient_history",
+    }
+    assert review["recent_counts"]["escalation_or_operator_required"] >= 2
+    assert review["summary"]["compact_reason"]
+    assert review["diagnostic_only"] is True
+    assert review["non_authoritative"] is True
+    assert review["decision_power"] == "none"
+    assert review["review_only"] is True
+
+
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     evidence = _base_evidence()
     evidence.update(
@@ -1430,6 +1708,27 @@ def test_next_move_proposal_does_not_change_admission_or_execution_behavior(tmp_
     assert proposal["does_not_change_admission_or_execution"] is True
     assert proposal["does_not_execute_or_route_work"] is True
     assert proposal["does_not_override_delegated_judgment"] is True
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
+
+
+def test_next_move_proposal_review_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    evidence = _base_evidence()
+    judgment = synthesize_delegated_judgment(evidence)
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    outcome_review = derive_orchestration_outcome_review(tmp_path)
+    venue_mix_review = derive_orchestration_venue_mix_review(tmp_path)
+    attention = derive_orchestration_attention_recommendation(outcome_review)
+    next_venue = derive_next_venue_recommendation(judgment, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(judgment, next_venue, outcome_review, venue_mix_review, attention)
+    append_next_move_proposal_ledger(tmp_path, proposal)
+    proposal_review = derive_next_move_proposal_review(tmp_path)
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert proposal_review["does_not_change_admission_or_execution"] is True
+    assert proposal_review["review_only"] is True
     assert before["handoff_outcome"] == "blocked_by_operator_requirement"
     assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 


### PR DESCRIPTION
### Motivation

- Provide a small, conservative retrospective layer so orchestration can detect drift/stress in recent next-move proposals without adding decision or execution power. 

### Description

- Add a bounded retrospective classifier `derive_next_move_proposal_review` (returns `next_move_proposal_review.v1`) that reads only the proof-visible next-move proposal ledger and proposal fields (`relation_posture`, `proposed_next_action.proposed_venue`, `executability_classification`, `operator_escalation_requirement_state.requires_operator_or_escalation`) and computes compact classifications such as `coherent_recent_proposals`, `proposal_escalation_heavy`, `proposal_hold_heavy`, `proposal_insufficient_context_heavy`, `proposal_venue_thrash`, `mixed_proposal_stress`, and `insufficient_history` (file: `sentientos/orchestration_intent_fabric.py`).
- Extend the scoped orchestration diagnostic consumer so the derived review is surfaced at `orchestration_handoff.next_move_proposal_review` (file: `sentientos/scoped_lifecycle_diagnostic.py`).
- Keep all outputs explicitly diagnostic/non-authoritative (`review_only`, `diagnostic_only`, `non_authoritative`, `decision_power: none`) and do not add any execution/admission/venue or authority surfaces.  
- Add focused unit tests covering each required classification, consumer surfacing, and an invariant that the review does not change admission/ execution behavior (file: `sentientos/tests/test_orchestration_intent_fabric.py`).
- Update the orchestration note to document what the proposal review reads, the possible classifications, and explicit non-sovereign boundaries (file: `docs/orchestration_next_move_proposal_note.md`).

### Testing

- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and the new tests passed. ✅
- Ran the project-level test driver `python -m scripts.run_tests -q`; this run reported failures in pre-existing, unrelated federation tests under `tests/test_pulse_federation.py` (not introduced by these changes). ⚠️
- Ran `mypy scripts/ sentientos/`; the repository contains many pre-existing typing issues outside this change (no type regressions introduced by this patch were targeted). ⚠️
- `verify_audits --strict` was not available in this environment. ⚠️
- Ran `python scripts/audit_immutability_verifier.py`; the immutability audit for artifact dependencies passed. ✅

Notes: the change is intentionally conservative and diagnostic-only: it derives summaries from existing, proof-visible artifacts and explicitly does not add new venues, execution paths, or any authority surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e119aba3a883208783c3f7f049c31e)