### PR TITLE
[codex:orchestration] add bounded next-move handoff packet substrate

### DIFF
--- a/glow/orchestration/orchestration_handoff_packets.jsonl
+++ b/glow/orchestration/orchestration_handoff_packets.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"orchestration_handoff_packet.v1","artifact_status":"initialized","notes":"append-only proof-visible handoff packet ledger for bounded next-move packet staging","non_authoritative":true,"diagnostic_only":true,"decision_power":"none","packet_only":true}

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -155,6 +155,14 @@ _NEXT_MOVE_PROPOSAL_REVIEW_CLASSES = {
     "insufficient_history",
 }
 
+_HANDOFF_PACKET_STATUSES = {
+    "prepared",
+    "blocked_operator_required",
+    "blocked_insufficient_context",
+    "ready_for_external_trigger",
+    "ready_for_internal_trigger",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -446,6 +454,77 @@ def _next_move_proposal_id(
         separators=(",", ":"),
     )
     return f"nmp-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _handoff_packet_id(
+    *,
+    created_at: str,
+    source_proposal_id: str,
+    source_judgment_linkage_id: str,
+    target_venue: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "created_at": created_at,
+            "source_proposal_id": source_proposal_id,
+            "source_judgment_linkage_id": source_judgment_linkage_id,
+            "target_venue": target_venue,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"hpk-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _compact_handoff_task_brief(next_move_proposal: Mapping[str, Any], delegated_judgment: Mapping[str, Any]) -> str:
+    proposed = next_move_proposal.get("proposed_next_action")
+    proposed_map = proposed if isinstance(proposed, Mapping) else {}
+    work_class = str(delegated_judgment.get("work_class") or "operator_required")
+    venue = str(proposed_map.get("proposed_venue") or "insufficient_context")
+    posture = str(proposed_map.get("proposed_posture") or "hold")
+    executability = str(next_move_proposal.get("executability_classification") or "blocked_insufficient_context")
+    return f"{work_class}:{venue}:{posture}:{executability}"
+
+
+def _compact_handoff_rationale(
+    next_move_proposal: Mapping[str, Any],
+    delegated_judgment: Mapping[str, Any],
+) -> str:
+    proposal_basis = next_move_proposal.get("basis")
+    basis_map = proposal_basis if isinstance(proposal_basis, Mapping) else {}
+    compact_rationale = str(basis_map.get("compact_rationale") or "").strip()
+    if compact_rationale:
+        return compact_rationale
+    delegated_basis = delegated_judgment.get("basis")
+    delegated_basis_map = delegated_basis if isinstance(delegated_basis, Mapping) else {}
+    reasons = delegated_basis_map.get("signal_reasons")
+    if isinstance(reasons, list) and reasons:
+        return str(reasons[0])
+    return "bounded_handoff_packet_derived_from_existing_orchestration_signals"
+
+
+def _handoff_evidence_pointers(
+    delegated_judgment: Mapping[str, Any],
+) -> list[str]:
+    delegated_basis = delegated_judgment.get("basis")
+    delegated_basis_map = delegated_basis if isinstance(delegated_basis, Mapping) else {}
+    pointers = [
+        "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        "glow/orchestration/orchestration_handoffs.jsonl",
+        "glow/orchestration/orchestration_intents.jsonl",
+    ]
+    artifacts = delegated_basis_map.get("artifacts_read")
+    if isinstance(artifacts, Mapping):
+        for value in artifacts.values():
+            if isinstance(value, str) and value:
+                pointers.append(value)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for pointer in pointers:
+        if pointer not in seen:
+            ordered.append(pointer)
+            seen.add(pointer)
+    return ordered
 
 
 def append_codex_work_order_ledger(repo_root: Path, work_order: Mapping[str, Any]) -> Path:
@@ -1503,6 +1582,158 @@ def append_next_move_proposal_ledger(repo_root: Path, proposal: Mapping[str, Any
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
     with ledger_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(proposal), sort_keys=True) + "\n")
+    return ledger_path
+
+
+def synthesize_handoff_packet(
+    next_move_proposal: Mapping[str, Any],
+    delegated_judgment: Mapping[str, Any],
+    *,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Derive a compact venue-specific handoff packet from existing bounded orchestration signals."""
+
+    proposal_ref = next_move_proposal
+    proposed_action = proposal_ref.get("proposed_next_action")
+    proposed_action_map = proposed_action if isinstance(proposed_action, Mapping) else {}
+    operator_state_raw = proposal_ref.get("operator_escalation_requirement_state")
+    operator_state = operator_state_raw if isinstance(operator_state_raw, Mapping) else {}
+    source_judgment = proposal_ref.get("source_delegated_judgment")
+    source_judgment_map = source_judgment if isinstance(source_judgment, Mapping) else {}
+    target_venue = str(proposed_action_map.get("proposed_venue") or "insufficient_context")
+    proposed_posture = str(proposed_action_map.get("proposed_posture") or "hold")
+    executability = str(proposal_ref.get("executability_classification") or "blocked_insufficient_context")
+    requires_operator = bool(operator_state.get("requires_operator_or_escalation"))
+    escalation = str(operator_state.get("escalation_classification") or delegated_judgment.get("escalation_classification") or "")
+    source_judgment_linkage_id = str(source_judgment_map.get("source_judgment_linkage_id") or "")
+    recorded_at = created_at or _iso_utc_now()
+    proposal_id = str(proposal_ref.get("proposal_id") or "")
+
+    status = "prepared"
+    readiness = {
+        "staged_only": False,
+        "blocked": False,
+        "ready_for_internal_trigger": False,
+        "ready_for_external_trigger": False,
+    }
+    if executability == "blocked_insufficient_context":
+        status = "blocked_insufficient_context"
+        readiness["blocked"] = True
+    elif executability == "blocked_operator_required" or requires_operator:
+        status = "blocked_operator_required"
+        readiness["blocked"] = True
+    elif executability == "executable_now" and target_venue == "internal_direct_execution":
+        status = "ready_for_internal_trigger"
+        readiness["ready_for_internal_trigger"] = True
+    elif executability == "stageable_external_work_order" and target_venue in {"codex_implementation", "deep_research_audit"}:
+        status = "ready_for_external_trigger"
+        readiness["ready_for_external_trigger"] = True
+        readiness["staged_only"] = True
+    elif executability in {"no_action_recommended"}:
+        status = "prepared"
+    if status not in _HANDOFF_PACKET_STATUSES:
+        status = "blocked_insufficient_context"
+        readiness["blocked"] = True
+
+    common_payload = {
+        "target_venue": target_venue,
+        "expected_venue_class": "staged_external_work_order"
+        if target_venue in {"codex_implementation", "deep_research_audit"}
+        else "internal_task_admission_handoff"
+        if target_venue == "internal_direct_execution"
+        else "operator_or_context_hold",
+        "source_links": {
+            "next_move_proposal_id": proposal_id,
+            "source_judgment_linkage_id": source_judgment_linkage_id,
+        },
+        "operator_requirement_state": {
+            "requires_operator_or_escalation": requires_operator,
+            "attention_signal": str(operator_state.get("attention_signal") or ""),
+            "escalation_classification": escalation,
+        },
+    }
+
+    venue_payload: dict[str, Any]
+    if target_venue == "codex_implementation":
+        venue_payload = {
+            **common_payload,
+            "implementation_objective": _compact_handoff_task_brief(next_move_proposal, delegated_judgment),
+            "scope_constraints": [
+                "bounded_orchestration_body_only",
+                "no_direct_external_actuation",
+                "no_browser_mouse_keyboard_control",
+            ],
+            "staged_only_not_directly_invoked_here": True,
+        }
+    elif target_venue == "deep_research_audit":
+        venue_payload = {
+            **common_payload,
+            "audit_objective": _compact_handoff_task_brief(next_move_proposal, delegated_judgment),
+            "ambiguity_or_stress_basis": _compact_handoff_rationale(next_move_proposal, delegated_judgment),
+            "research_question_class": str(delegated_judgment.get("work_class") or "architectural_audit"),
+            "staged_only_not_directly_invoked_here": True,
+        }
+    elif target_venue == "internal_direct_execution":
+        venue_payload = {
+            **common_payload,
+            "internal_execution_brief": _compact_handoff_task_brief(next_move_proposal, delegated_judgment),
+            "executable_now_classification": executability == "executable_now",
+            "target_substrate": "task_admission_executor",
+            "required_admission_handoff_posture": "admit_before_execute",
+        }
+    else:
+        venue_payload = common_payload
+
+    packet = {
+        "schema_version": "orchestration_handoff_packet.v1",
+        "recorded_at": recorded_at,
+        "handoff_packet_id": _handoff_packet_id(
+            created_at=recorded_at,
+            source_proposal_id=proposal_id,
+            source_judgment_linkage_id=source_judgment_linkage_id,
+            target_venue=target_venue,
+        ),
+        "source_next_move_proposal_ref": {
+            "proposal_id": proposal_id,
+            "proposal_ledger_path": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        },
+        "source_delegated_judgment_ref": {
+            "source_judgment_linkage_id": source_judgment_linkage_id,
+            "recommended_venue": str(delegated_judgment.get("recommended_venue") or ""),
+            "judgment_kind": str(delegated_judgment.get("recommendation_kind") or ""),
+        },
+        "target_venue": target_venue,
+        "proposed_posture": proposed_posture,
+        "executability_classification": executability,
+        "operator_escalation_requirement_state": dict(operator_state),
+        "compact_task_brief": _compact_handoff_task_brief(next_move_proposal, delegated_judgment),
+        "compact_rationale": _compact_handoff_rationale(next_move_proposal, delegated_judgment),
+        "artifact_references": _handoff_evidence_pointers(delegated_judgment),
+        "packet_status": status,
+        "readiness": readiness,
+        "venue_payload": venue_payload,
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "packet_only": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_invoke_external_tools": True,
+                "requires_operator_or_existing_trigger_path": True,
+            },
+        ),
+    }
+    return packet
+
+
+def append_handoff_packet_ledger(repo_root: Path, packet: Mapping[str, Any]) -> Path:
+    """Append one bounded handoff packet to the proof-visible packet ledger."""
+
+    ledger_path = repo_root.resolve() / "glow/orchestration/orchestration_handoff_packets.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(packet), sort_keys=True) + "\n")
     return ledger_path
 
 

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -45,8 +45,34 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
         },
         "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
         "handoff_artifact": "glow/orchestration/orchestration_handoffs.jsonl",
+        "handoff_packet_artifact": "glow/orchestration/orchestration_handoff_packets.jsonl",
         "codex_staged_work_order_artifact": "glow/orchestration/codex_work_orders.jsonl",
         "deep_research_staged_work_order_artifact": "glow/orchestration/deep_research_work_orders.jsonl",
+        "handoff_packet_substrate": {
+            "what_it_is": "a compact typed packet derived from next_move_proposal + delegated_judgment for operator/future-adapter pickup",
+            "how_it_differs": {
+                "from_delegated_judgment": "delegated judgment recommends venue/posture; packet binds that recommendation to a concrete venue-targeted handoff bundle",
+                "from_next_venue_recommendation": "next-venue recommendation is directional; packet is a proof-visible, venue-specific actionable handoff object",
+                "from_next_move_proposal": "next-move proposal frames posture/executability; packet packages compact brief, rationale, status, and evidence pointers",
+            },
+            "packetized_venues": [
+                "task_admission_executor (internal_direct_execution path)",
+                "codex_implementation",
+                "deep_research_audit",
+            ],
+            "packet_status_meaning": {
+                "prepared": "packet built but not trigger-ready",
+                "blocked_operator_required": "operator/escalation gate blocks trigger",
+                "blocked_insufficient_context": "context gap blocks honest trigger-readiness",
+                "ready_for_external_trigger": "staged external packet ready for explicit operator/adapter trigger only",
+                "ready_for_internal_trigger": "internal packet ready for existing admission trigger path only",
+            },
+            "explicitly_not": [
+                "direct Codex/Deep Research invocation",
+                "new execution or sovereign decision surface",
+                "automatic routing/execution without existing admission and operator pathways",
+            ],
+        },
         "codex_staged_venue_onboarding": {
             "status": "first_class_bounded_staged_venue",
             "venue": "codex_implementation",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -13,6 +13,7 @@ from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
+    append_handoff_packet_ledger,
     append_next_move_proposal_ledger,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
@@ -26,6 +27,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_deep_research_staged_work_order_lifecycle,
     resolve_orchestration_result,
     synthesize_next_move_proposal,
+    synthesize_handoff_packet,
     synthesize_orchestration_intent,
 )
 
@@ -164,6 +166,8 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_attention_recommendation,
     )
     next_move_proposal_ledger_path = append_next_move_proposal_ledger(root, next_move_proposal)
+    handoff_packet = synthesize_handoff_packet(next_move_proposal, delegated_judgment)
+    handoff_packet_ledger_path = append_handoff_packet_ledger(root, handoff_packet)
     next_move_proposal_review = derive_next_move_proposal_review(root)
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
@@ -222,6 +226,14 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
             },
             "next_move_proposal_review": next_move_proposal_review,
+            "handoff_packet": {
+                **handoff_packet,
+                "ledger_path": str(handoff_packet_ledger_path.relative_to(root)),
+                "staged_only": bool((handoff_packet.get("readiness") or {}).get("staged_only")),
+                "blocked": bool((handoff_packet.get("readiness") or {}).get("blocked")),
+                "ready_for_internal_trigger": bool((handoff_packet.get("readiness") or {}).get("ready_for_internal_trigger")),
+                "ready_for_external_trigger": bool((handoff_packet.get("readiness") or {}).get("ready_for_external_trigger")),
+            },
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,
         },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -10,6 +10,7 @@ import task_executor
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
+    append_handoff_packet_ledger,
     append_next_move_proposal_ledger,
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
@@ -20,6 +21,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_orchestration_result,
+    synthesize_handoff_packet,
     synthesize_next_move_proposal,
     synthesize_orchestration_intent,
 )
@@ -1549,6 +1551,147 @@ def test_next_move_proposal_flows_to_consumer_artifact_and_stays_non_authoritati
     assert persisted["proposal_id"] == proposal["proposal_id"]
 
 
+def test_codex_next_move_proposal_becomes_typed_staged_handoff_packet() -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 4,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "balanced_recent_venue_mix", "records_considered": 4}
+    attention = {"operator_attention_recommendation": "none"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    packet = synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+
+    assert packet["target_venue"] == "codex_implementation"
+    assert packet["packet_status"] == "ready_for_external_trigger"
+    assert packet["venue_payload"]["staged_only_not_directly_invoked_here"] is True
+    assert packet["readiness"]["staged_only"] is True
+    assert packet["does_not_execute_or_route_work"] is True
+
+
+def test_deep_research_next_move_proposal_becomes_typed_staged_handoff_packet() -> None:
+    delegated = synthesize_delegated_judgment({**_base_evidence(), "governance_ambiguity_signal": True})
+    outcome_review = {
+        "review_classification": "mixed_orchestration_stress",
+        "records_considered": 4,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": True, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "deep_research_heavy", "records_considered": 4}
+    attention = {"operator_attention_recommendation": "review_mixed_orchestration_stress"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    packet = synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+
+    assert packet["target_venue"] == "deep_research_audit"
+    assert packet["packet_status"] == "ready_for_external_trigger"
+    assert packet["venue_payload"]["staged_only_not_directly_invoked_here"] is True
+    assert packet["readiness"]["ready_for_external_trigger"] is True
+    assert packet["does_not_invoke_external_tools"] is True
+
+
+def test_internal_execution_next_move_proposal_becomes_internal_handoff_packet_with_honest_readiness() -> None:
+    delegated = synthesize_delegated_judgment(
+        {
+            **_base_evidence(),
+            "admission_denied_ratio": 0.75,
+            "admission_sample_count": 8,
+            "executor_failure_ratio": 0.4,
+            "executor_sample_count": 8,
+        }
+    )
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 4,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {"review_classification": "internal_execution_heavy", "records_considered": 4}
+    attention = {"operator_attention_recommendation": "none"}
+    next_venue = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+    proposal = synthesize_next_move_proposal(delegated, next_venue, outcome_review, venue_mix_review, attention)
+
+    packet = synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+
+    assert packet["target_venue"] == "internal_direct_execution"
+    assert packet["packet_status"] == "ready_for_internal_trigger"
+    assert packet["venue_payload"]["target_substrate"] == "task_admission_executor"
+    assert packet["readiness"]["ready_for_internal_trigger"] is True
+    assert packet["readiness"]["staged_only"] is False
+
+
+def test_operator_required_and_insufficient_context_packets_remain_honestly_blocked() -> None:
+    delegated_operator = synthesize_delegated_judgment(_base_evidence())
+    blocked_operator_proposal = {
+        "proposal_id": "proposal-blocked-operator",
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "escalate"},
+        "executability_classification": "blocked_operator_required",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "inspect_handoff_blocks",
+            "escalation_classification": "escalate_for_operator_priority",
+        },
+        "source_delegated_judgment": {"source_judgment_linkage_id": "jdg-link-1"},
+    }
+    operator_packet = synthesize_handoff_packet(
+        blocked_operator_proposal,
+        delegated_operator,
+        created_at="2026-04-12T00:00:00Z",
+    )
+    assert operator_packet["packet_status"] == "blocked_operator_required"
+    assert operator_packet["readiness"]["blocked"] is True
+
+    delegated_missing = synthesize_delegated_judgment(
+        {**_base_evidence(), "records_considered": 0, "admission_sample_count": 0, "executor_sample_count": 0}
+    )
+    blocked_context_proposal = {
+        "proposal_id": "proposal-blocked-context",
+        "proposed_next_action": {"proposed_venue": "insufficient_context", "proposed_posture": "hold"},
+        "executability_classification": "blocked_insufficient_context",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "insufficient_context",
+            "escalation_classification": "escalate_for_missing_context",
+        },
+        "source_delegated_judgment": {"source_judgment_linkage_id": "jdg-link-2"},
+    }
+    context_packet = synthesize_handoff_packet(
+        blocked_context_proposal,
+        delegated_missing,
+        created_at="2026-04-12T00:00:00Z",
+    )
+    assert context_packet["packet_status"] == "blocked_insufficient_context"
+    assert context_packet["readiness"]["blocked"] is True
+
+
+def test_handoff_packet_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    proposal = {
+        "proposal_id": "proposal-codex-packet-artifact",
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": False,
+            "attention_signal": "none",
+            "escalation_classification": "no_escalation_needed",
+        },
+        "source_delegated_judgment": {"source_judgment_linkage_id": "jdg-link-artifact"},
+    }
+    packet = synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+    ledger_path = append_handoff_packet_ledger(tmp_path, packet)
+    append_handoff_packet_ledger(tmp_path, {**packet, "handoff_packet_id": "hpk-second"})
+
+    rows = ledger_path.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 2
+    first = json.loads(rows[0])
+    second = json.loads(rows[1])
+    assert first["packet_status"] == "ready_for_external_trigger"
+    assert first["target_venue"] == "codex_implementation"
+    assert second["handoff_packet_id"] == "hpk-second"
+
+
 def test_next_move_proposal_review_flows_to_consumer_and_stays_non_authoritative(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1625,6 +1768,60 @@ def test_next_move_proposal_review_flows_to_consumer_and_stays_non_authoritative
     assert review["non_authoritative"] is True
     assert review["decision_power"] == "none"
     assert review["review_only"] is True
+
+
+def test_handoff_packet_flows_to_diagnostic_consumer_and_stays_non_authoritative(monkeypatch, tmp_path: Path) -> None:
+    _seed_venue_mix_history(
+        tmp_path,
+        records=[
+            {"intent_kind": "codex_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+            {"intent_kind": "internal_maintenance_execution", "handoff_outcome": "admitted_to_execution_substrate"},
+            {"intent_kind": "deep_research_work_order", "handoff_outcome": "staged_only", "required_authority_posture": "operator_approval_required"},
+        ],
+    )
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-handoff-packet-consumer",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    packet = diagnostic["orchestration_handoff"]["handoff_packet"]
+
+    assert packet["target_venue"] in {"internal_direct_execution", "codex_implementation", "deep_research_audit", "operator_decision_required", "insufficient_context"}
+    assert packet["packet_status"] in {
+        "prepared",
+        "blocked_operator_required",
+        "blocked_insufficient_context",
+        "ready_for_external_trigger",
+        "ready_for_internal_trigger",
+    }
+    assert packet["ledger_path"] == "glow/orchestration/orchestration_handoff_packets.jsonl"
+    assert packet["packet_only"] is True
+    assert packet["diagnostic_only"] is True
+    assert packet["non_authoritative"] is True
+    assert packet["decision_power"] == "none"
+    assert packet["does_not_execute_or_route_work"] is True
+    assert packet["requires_operator_or_existing_trigger_path"] is True
 
 
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Package “what should happen next” into a compact, proof-visible, venue-specific handoff packet so operators and future adapters can pick up context without reconstructing it manually.
- Retain explicit anti-sovereignty boundaries so the packet layer remains diagnostic/non-authoritative and does not perform direct execution or external actuation.
- Support current venues (`codex_implementation`, `deep_research_audit`, `task_admission_executor`) with a small, typed payload surface tailored to each target class.

### Description
- Added a compact handoff-packet model `orchestration_handoff_packet.v1` with stable `handoff_packet_id`, source proposal/judgment linkage, `packet_status`, `readiness` flags, compact brief/rationale helpers, evidence pointers, and explicit anti-sovereignty markers in `sentientos/orchestration_intent_fabric.py`.
- Implemented `synthesize_handoff_packet` and `append_handoff_packet_ledger` that produce and append packets to the new append-only artifact `glow/orchestration/orchestration_handoff_packets.jsonl`.
- Created minimal venue-specific payloads for `codex_implementation` (implementation brief, constraints, staged-only marker), `deep_research_audit` (audit brief, ambiguity basis, research class), and `internal_direct_execution` (internal execution brief, `task_admission_executor` substrate and admission posture).
- Updated the scoped diagnostic consumer to synthesize/append the packet and surface `next_move_proposal`, current `handoff_packet`, `target_venue`, packet `status/readiness` booleans, and ledger path in the diagnostic output (`sentientos/scoped_lifecycle_diagnostic.py`).
- Added compact helpers for task briefs, rationale, and evidence pointer extraction, and extended the orchestration technical note to document what a handoff packet is, how it differs from other signals, which venues are packetized, packet status semantics, and explicit non-execution boundaries (`sentientos/orchestration_intent_fabric_note.py`).
- Added focused tests that validate codex/deep-research/internal packet synthesis, honest blocked states for operator/insufficient-context conditions, append-only proof-visible ledger behavior, and that the diagnostic consumer surfaces the packet without changing admission/execution behavior (`sentientos/tests/test_orchestration_intent_fabric.py`).

### Testing
- Ran the targeted test module with `pytest -q sentientos/tests/test_orchestration_intent_fabric.py`, and all tests in that file passed successfully.
- Tests verify: packet synthesis for `codex_implementation`, `deep_research_audit`, and `internal_direct_execution`; blocked-state honesty for operator/insufficient-context; append-only packet ledger semantics; and diagnostic consumer visibility while preserving non-authoritative, non-executing behavior.
- No changes were made to admission or execution semantics beyond adding the packet synthesis and read-only evidence surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e11f580ba48320893e4f2c9d7710fd)