### PR TITLE
[codex:orchestration] add bounded external fulfillment receipt ingestion

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -80,7 +80,19 @@ _STAGED_EXTERNAL_LIFECYCLE_STATES = {
     "staged_cleanly",
     "blocked_operator_required",
     "blocked_insufficient_context",
+    "fulfilled_externally",
+    "fulfilled_externally_with_issues",
+    "externally_declined",
+    "externally_abandoned",
     "fragmented_unlinked_work_order_state",
+}
+
+_FULFILLMENT_KINDS = {
+    "externally_completed",
+    "externally_completed_with_issues",
+    "externally_declined",
+    "externally_abandoned",
+    "externally_result_unusable",
 }
 
 _ORCHESTRATION_REVIEW_CLASSES = {
@@ -476,6 +488,26 @@ def _handoff_packet_id(
     return f"hpk-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
 
 
+def _fulfillment_receipt_id(
+    *,
+    created_at: str,
+    handoff_packet_id: str,
+    venue: str,
+    fulfillment_kind: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "created_at": created_at,
+            "handoff_packet_id": handoff_packet_id,
+            "venue": venue,
+            "fulfillment_kind": fulfillment_kind,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"frc-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
 def _compact_handoff_task_brief(next_move_proposal: Mapping[str, Any], delegated_judgment: Mapping[str, Any]) -> str:
     proposed = next_move_proposal.get("proposed_next_action")
     proposed_map = proposed if isinstance(proposed, Mapping) else {}
@@ -667,6 +699,8 @@ def _resolve_staged_external_work_order_lifecycle(
         lifecycle_state = "blocked_insufficient_context"
     elif str(latest.get("status") or "") == "staged":
         lifecycle_state = "staged_cleanly"
+    elif str(latest.get("status") or "") == "fulfilled_externally_unverified":
+        lifecycle_state = "fulfilled_externally_with_issues"
     else:
         lifecycle_state = "fragmented_unlinked_work_order_state"
 
@@ -1735,6 +1769,172 @@ def append_handoff_packet_ledger(repo_root: Path, packet: Mapping[str, Any]) -> 
     with ledger_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(packet), sort_keys=True) + "\n")
     return ledger_path
+
+
+def append_orchestration_fulfillment_receipt_ledger(repo_root: Path, receipt: Mapping[str, Any]) -> Path:
+    """Append one bounded fulfillment receipt to the proof-visible receipt ledger."""
+
+    ledger_path = repo_root.resolve() / "glow/orchestration/orchestration_fulfillment_receipts.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(receipt), sort_keys=True) + "\n")
+    return ledger_path
+
+
+def ingest_external_fulfillment_receipt(
+    repo_root: Path,
+    *,
+    handoff_packet_id: str,
+    fulfillment_kind: str,
+    operator_or_adapter: str,
+    summary_notes: str,
+    evidence_refs: list[str] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """
+    Ingest one externally supplied fulfillment outcome for a staged handoff packet.
+
+    This path is receipt-only and never executes external work directly.
+    """
+
+    root = repo_root.resolve()
+    packets = _read_jsonl(root / "glow/orchestration/orchestration_handoff_packets.jsonl")
+    matching_packets = [row for row in packets if str(row.get("handoff_packet_id") or "") == handoff_packet_id]
+    packet = matching_packets[-1] if matching_packets else None
+    if not isinstance(packet, Mapping):
+        raise ValueError(f"handoff packet not found: {handoff_packet_id}")
+
+    venue = str(packet.get("target_venue") or "")
+    if venue not in {"codex_implementation", "deep_research_audit"}:
+        raise ValueError(f"handoff packet is not a staged external venue packet: {handoff_packet_id}")
+
+    proposal_ref = packet.get("source_next_move_proposal_ref")
+    proposal_ref_map = proposal_ref if isinstance(proposal_ref, Mapping) else {}
+    proposal_id = str(proposal_ref_map.get("proposal_id") or "")
+    if not proposal_id:
+        raise ValueError(f"handoff packet missing source next_move proposal linkage: {handoff_packet_id}")
+
+    if fulfillment_kind not in _FULFILLMENT_KINDS:
+        raise ValueError(f"unrecognized fulfillment_kind: {fulfillment_kind}")
+
+    timestamp = created_at or _iso_utc_now()
+    compact_refs = [
+        ref.strip()
+        for ref in (evidence_refs or [])
+        if isinstance(ref, str) and ref.strip()
+    ]
+    operator_state = packet.get("operator_escalation_requirement_state")
+    operator_state_map = operator_state if isinstance(operator_state, Mapping) else {}
+    source_judgment_ref = packet.get("source_delegated_judgment_ref")
+    source_judgment_ref_map = source_judgment_ref if isinstance(source_judgment_ref, Mapping) else {}
+
+    receipt = {
+        "schema_version": "orchestration_fulfillment_receipt.v1",
+        "ingested_at": timestamp,
+        "fulfillment_receipt_id": _fulfillment_receipt_id(
+            created_at=timestamp,
+            handoff_packet_id=handoff_packet_id,
+            venue=venue,
+            fulfillment_kind=fulfillment_kind,
+        ),
+        "source_handoff_packet_ref": {
+            "handoff_packet_id": handoff_packet_id,
+            "handoff_packet_ledger_path": "glow/orchestration/orchestration_handoff_packets.jsonl",
+        },
+        "source_next_move_proposal_ref": {
+            "proposal_id": proposal_id,
+            "proposal_ledger_path": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        },
+        "source_venue": venue,
+        "fulfillment_kind": fulfillment_kind,
+        "operator_or_adapter_provenance": operator_or_adapter.strip() or "unspecified_external_actor",
+        "summary_notes": summary_notes.strip() or "external_fulfillment_ingested_without_additional_summary",
+        "evidence_refs": compact_refs,
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": bool(operator_state_map.get("requires_operator_or_escalation")),
+            "attention_signal": str(operator_state_map.get("attention_signal") or ""),
+            "escalation_classification": str(operator_state_map.get("escalation_classification") or ""),
+        },
+        "source_delegated_judgment_ref": {
+            "source_judgment_linkage_id": str(source_judgment_ref_map.get("source_judgment_linkage_id") or ""),
+            "recommended_venue": str(source_judgment_ref_map.get("recommended_venue") or ""),
+        },
+        "ingested_external_outcome": True,
+        "explicit_clarity": "ingested external outcome, not direct repo execution",
+        **_anti_sovereignty_payload(
+            recommendation_only=False,
+            diagnostic_only=True,
+            does_not_invoke_external_tools=True,
+            additional_fields={
+                "does_not_imply_direct_repo_execution": True,
+                "receipt_only": True,
+                "requires_external_actor_or_operator": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+            },
+        ),
+    }
+    ledger_path = append_orchestration_fulfillment_receipt_ledger(root, receipt)
+    return {**receipt, "ledger_path": str(ledger_path.relative_to(root))}
+
+
+def resolve_handoff_packet_fulfillment_lifecycle(
+    repo_root: Path,
+    handoff_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve staged/fulfilled visibility for one external handoff packet."""
+
+    root = repo_root.resolve()
+    venue = str(handoff_packet.get("target_venue") or "")
+    packet_id = str(handoff_packet.get("handoff_packet_id") or "")
+    receipts = _read_jsonl(root / "glow/orchestration/orchestration_fulfillment_receipts.jsonl")
+    linked = [
+        row
+        for row in receipts
+        if str((row.get("source_handoff_packet_ref") or {}).get("handoff_packet_id") or "") == packet_id
+    ]
+    latest = linked[-1] if linked else None
+
+    readiness = handoff_packet.get("readiness")
+    readiness_map = readiness if isinstance(readiness, Mapping) else {}
+    packet_status = str(handoff_packet.get("packet_status") or "")
+    lifecycle_state = "fragmented_unlinked_work_order_state"
+    if latest is None:
+        if packet_status == "blocked_operator_required":
+            lifecycle_state = "blocked_operator_required"
+        elif packet_status == "blocked_insufficient_context":
+            lifecycle_state = "blocked_insufficient_context"
+        elif bool(readiness_map.get("ready_for_external_trigger")):
+            lifecycle_state = "staged_cleanly"
+    else:
+        fulfillment_kind = str(latest.get("fulfillment_kind") or "")
+        lifecycle_state = {
+            "externally_completed": "fulfilled_externally",
+            "externally_completed_with_issues": "fulfilled_externally_with_issues",
+            "externally_declined": "externally_declined",
+            "externally_abandoned": "externally_abandoned",
+            "externally_result_unusable": "fulfilled_externally_with_issues",
+        }.get(fulfillment_kind, "fragmented_unlinked_work_order_state")
+
+    if lifecycle_state not in _STAGED_EXTERNAL_LIFECYCLE_STATES:
+        lifecycle_state = "fragmented_unlinked_work_order_state"
+
+    return {
+        "schema_version": "external_handoff_packet_fulfillment_lifecycle.v1",
+        "target_venue": venue,
+        "handoff_packet_id": packet_id or None,
+        "lifecycle_state": lifecycle_state,
+        "fulfillment_received": latest is not None,
+        "fulfillment_kind": str(latest.get("fulfillment_kind") or "") if isinstance(latest, Mapping) else None,
+        "fulfillment_receipt_id": str(latest.get("fulfillment_receipt_id") or "") if isinstance(latest, Mapping) else None,
+        "receipt_artifact_path": "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
+        "ingested_external_outcome": bool((latest or {}).get("ingested_external_outcome")) if isinstance(latest, Mapping) else False,
+        "does_not_imply_direct_repo_execution": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "receipt_only": True,
+        "requires_external_actor_or_operator": True,
+    }
 
 
 def derive_next_move_proposal_review(

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -46,6 +46,7 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
         "proof_visible_artifact": "glow/orchestration/orchestration_intents.jsonl",
         "handoff_artifact": "glow/orchestration/orchestration_handoffs.jsonl",
         "handoff_packet_artifact": "glow/orchestration/orchestration_handoff_packets.jsonl",
+        "fulfillment_receipt_artifact": "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
         "codex_staged_work_order_artifact": "glow/orchestration/codex_work_orders.jsonl",
         "deep_research_staged_work_order_artifact": "glow/orchestration/deep_research_work_orders.jsonl",
         "handoff_packet_substrate": {
@@ -73,6 +74,27 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "automatic routing/execution without existing admission and operator pathways",
             ],
         },
+        "fulfillment_receipt_substrate": {
+            "what_it_is": "a compact typed ingestion record for externally reported outcomes of staged handoff packets",
+            "how_it_differs_from_handoff_packet": "handoff packet stages work intent; fulfillment receipt records externally supplied outcome evidence after staging",
+            "fulfillment_kinds": [
+                "externally_completed",
+                "externally_completed_with_issues",
+                "externally_declined",
+                "externally_abandoned",
+                "externally_result_unusable",
+            ],
+            "fulfilled_externally_means": "an external actor/operator reported an outcome and the receipt was appended to the proof-visible ledger",
+            "fulfilled_externally_does_not_mean": [
+                "direct in-repo Codex/Deep Research execution occurred",
+                "automatic correctness approval of the external result",
+                "sovereign authority transfer into this repository",
+            ],
+            "still_missing_before_direct_external_delegation": [
+                "approved direct adapter invocation path",
+                "strong external attestation/verification policy beyond receipt ingestion",
+            ],
+        },
         "codex_staged_venue_onboarding": {
             "status": "first_class_bounded_staged_venue",
             "venue": "codex_implementation",
@@ -92,6 +114,10 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "staged_cleanly",
                 "blocked_operator_required",
                 "blocked_insufficient_context",
+                "fulfilled_externally",
+                "fulfilled_externally_with_issues",
+                "externally_declined",
+                "externally_abandoned",
                 "fragmented_unlinked_work_order_state",
             ],
             "still_missing_before_any_direct_codex_delegation": [
@@ -124,6 +150,10 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "staged_cleanly",
                 "blocked_operator_required",
                 "blocked_insufficient_context",
+                "fulfilled_externally",
+                "fulfilled_externally_with_issues",
+                "externally_declined",
+                "externally_abandoned",
                 "fragmented_unlinked_work_order_state",
             ],
             "still_missing_before_any_direct_deep_research_delegation": [

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -25,6 +25,7 @@ from sentientos.orchestration_intent_fabric import (
     executable_handoff_map,
     resolve_codex_staged_work_order_lifecycle,
     resolve_deep_research_staged_work_order_lifecycle,
+    resolve_handoff_packet_fulfillment_lifecycle,
     resolve_orchestration_result,
     synthesize_next_move_proposal,
     synthesize_handoff_packet,
@@ -54,6 +55,7 @@ def _staged_external_venue_diagnostic(
     orchestration_intent: dict[str, Any],
     handoff_result: dict[str, Any],
     orchestration_result: dict[str, Any],
+    handoff_packet: dict[str, Any],
     *,
     venue: str,
     lifecycle_key: str,
@@ -69,6 +71,7 @@ def _staged_external_venue_diagnostic(
 
     lifecycle = orchestration_result.get(lifecycle_key)
     lifecycle_map = lifecycle if isinstance(lifecycle, dict) else resolve_lifecycle(repo_root, orchestration_intent, handoff_result)
+    packet_fulfillment = resolve_handoff_packet_fulfillment_lifecycle(repo_root, handoff_packet)
     work_order_ref = handoff_result.get("details", {}).get(handoff_ref_key, {})
     ref_map = work_order_ref if isinstance(work_order_ref, dict) else {}
     executability_visibility = {
@@ -93,6 +96,7 @@ def _staged_external_venue_diagnostic(
             "escalation_classification": str(orchestration_intent.get("source_delegated_judgment", {}).get("escalation_classification") or ""),
         },
         "lifecycle_visibility": lifecycle_map,
+        "packet_fulfillment_visibility": packet_fulfillment,
         "executability_visibility": executability_visibility,
         "observability_only": True,
     }
@@ -174,6 +178,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_intent,
         handoff_result,
         orchestration_result,
+        handoff_packet,
         venue="codex_implementation",
         lifecycle_key="codex_staged_lifecycle",
         handoff_ref_key="codex_work_order_ref",
@@ -187,6 +192,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_intent,
         handoff_result,
         orchestration_result,
+        handoff_packet,
         venue="deep_research_audit",
         lifecycle_key="deep_research_staged_lifecycle",
         handoff_ref_key="deep_research_work_order_ref",
@@ -233,6 +239,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "blocked": bool((handoff_packet.get("readiness") or {}).get("blocked")),
                 "ready_for_internal_trigger": bool((handoff_packet.get("readiness") or {}).get("ready_for_internal_trigger")),
                 "ready_for_external_trigger": bool((handoff_packet.get("readiness") or {}).get("ready_for_external_trigger")),
+                "fulfillment_visibility": resolve_handoff_packet_fulfillment_lifecycle(root, handoff_packet),
             },
             "codex_staged_venue": codex_staged_venue,
             "deep_research_staged_venue": deep_research_staged_venue,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -13,6 +13,7 @@ from sentientos.orchestration_intent_fabric import (
     append_handoff_packet_ledger,
     append_next_move_proposal_ledger,
     append_orchestration_intent_ledger,
+    ingest_external_fulfillment_receipt,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_next_venue_recommendation,
@@ -21,6 +22,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_orchestration_result,
+    resolve_handoff_packet_fulfillment_lifecycle,
     synthesize_handoff_packet,
     synthesize_next_move_proposal,
     synthesize_orchestration_intent,
@@ -75,6 +77,34 @@ def _proposal_row(
         "non_authoritative": True,
         "decision_power": "none",
     }
+
+
+def _external_handoff_packet(
+    delegated: dict[str, object],
+    *,
+    venue_recommendation: str,
+    outcome_classification: str,
+    venue_mix_classification: str,
+    attention_signal: str,
+) -> dict[str, object]:
+    next_venue = derive_next_venue_recommendation(
+        delegated,
+        {"review_classification": outcome_classification, "records_considered": 4, "condition_flags": {}},
+        {"review_classification": venue_mix_classification, "records_considered": 4},
+        {"operator_attention_recommendation": attention_signal},
+    )
+    next_venue["next_venue_recommendation"] = venue_recommendation
+    if venue_recommendation in {"prefer_codex_implementation", "prefer_deep_research_audit"}:
+        next_venue["relation_to_delegated_judgment"] = "affirming"
+    proposal = synthesize_next_move_proposal(
+        delegated,
+        next_venue,
+        {"review_classification": outcome_classification, "records_considered": 4},
+        {"review_classification": venue_mix_classification, "records_considered": 4},
+        {"operator_attention_recommendation": attention_signal},
+        created_at="2026-04-12T00:00:00Z",
+    )
+    return synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
 
 
 def test_deep_research_judgment_translates_to_stageable_external_work_order() -> None:
@@ -1962,6 +1992,149 @@ def test_deep_research_staged_work_order_artifact_is_append_only_and_proof_visib
     assert work_order["requires_external_tool_or_operator_trigger"] is True
 
 
+def test_staged_codex_packet_can_ingest_externally_completed_receipt(tmp_path: Path) -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    packet = _external_handoff_packet(
+        delegated,
+        venue_recommendation="prefer_codex_implementation",
+        outcome_classification="clean_recent_orchestration",
+        venue_mix_classification="balanced_recent_venue_mix",
+        attention_signal="observe",
+    )
+    append_handoff_packet_ledger(tmp_path, packet)
+
+    receipt = ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_completed",
+        operator_or_adapter="operator:unit-test",
+        summary_notes="implemented in external codex session",
+        evidence_refs=["artifacts/codex_patch.diff"],
+        created_at="2026-04-12T00:05:00Z",
+    )
+
+    assert receipt["source_venue"] == "codex_implementation"
+    assert receipt["fulfillment_kind"] == "externally_completed"
+    assert receipt["ingested_external_outcome"] is True
+    assert receipt["does_not_imply_direct_repo_execution"] is True
+    assert receipt["requires_external_actor_or_operator"] is True
+
+
+def test_staged_deep_research_packet_can_ingest_externally_completed_receipt(tmp_path: Path) -> None:
+    delegated = synthesize_delegated_judgment({**_base_evidence(), "governance_ambiguity_signal": True})
+    packet = _external_handoff_packet(
+        delegated,
+        venue_recommendation="prefer_deep_research_audit",
+        outcome_classification="mixed_orchestration_stress",
+        venue_mix_classification="deep_research_heavy",
+        attention_signal="review_mixed_orchestration_stress",
+    )
+    append_handoff_packet_ledger(tmp_path, packet)
+
+    receipt = ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_completed",
+        operator_or_adapter="adapter:research-broker",
+        summary_notes="research summary returned from external process",
+        evidence_refs=["reports/deep_research.md"],
+        created_at="2026-04-12T00:05:00Z",
+    )
+
+    assert receipt["source_venue"] == "deep_research_audit"
+    assert receipt["fulfillment_kind"] == "externally_completed"
+    assert receipt["ingested_external_outcome"] is True
+    assert receipt["does_not_imply_direct_repo_execution"] is True
+
+
+def test_fulfillment_ingestion_fails_closed_when_packet_linkage_missing(tmp_path: Path) -> None:
+    try:
+        ingest_external_fulfillment_receipt(
+            tmp_path,
+            handoff_packet_id="hpk-missing",
+            fulfillment_kind="externally_completed",
+            operator_or_adapter="operator:test",
+            summary_notes="should fail",
+        )
+    except ValueError as exc:
+        assert "handoff packet not found" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing handoff packet linkage")
+
+
+def test_external_declined_abandoned_and_unusable_states_are_visible(tmp_path: Path) -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    packet = _external_handoff_packet(
+        delegated,
+        venue_recommendation="prefer_codex_implementation",
+        outcome_classification="clean_recent_orchestration",
+        venue_mix_classification="balanced_recent_venue_mix",
+        attention_signal="observe",
+    )
+    append_handoff_packet_ledger(tmp_path, packet)
+
+    ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_declined",
+        operator_or_adapter="operator:test",
+        summary_notes="declined by external actor",
+        created_at="2026-04-12T00:03:00Z",
+    )
+    declined = resolve_handoff_packet_fulfillment_lifecycle(tmp_path, packet)
+    assert declined["lifecycle_state"] == "externally_declined"
+
+    ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_abandoned",
+        operator_or_adapter="operator:test",
+        summary_notes="abandoned externally",
+        created_at="2026-04-12T00:04:00Z",
+    )
+    abandoned = resolve_handoff_packet_fulfillment_lifecycle(tmp_path, packet)
+    assert abandoned["lifecycle_state"] == "externally_abandoned"
+
+    ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_result_unusable",
+        operator_or_adapter="operator:test",
+        summary_notes="result unusable",
+        created_at="2026-04-12T00:05:00Z",
+    )
+    unusable = resolve_handoff_packet_fulfillment_lifecycle(tmp_path, packet)
+    assert unusable["lifecycle_state"] == "fulfilled_externally_with_issues"
+
+
+def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    packet = _external_handoff_packet(
+        delegated,
+        venue_recommendation="prefer_codex_implementation",
+        outcome_classification="clean_recent_orchestration",
+        venue_mix_classification="balanced_recent_venue_mix",
+        attention_signal="observe",
+    )
+    append_handoff_packet_ledger(tmp_path, packet)
+    ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(packet["handoff_packet_id"]),
+        fulfillment_kind="externally_completed_with_issues",
+        operator_or_adapter="operator:test",
+        summary_notes="external completion with caveats",
+    )
+
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
+
+
 def test_codex_missing_metadata_yields_blocked_insufficient_and_lifecycle_fragment_visibility(tmp_path: Path) -> None:
     handoff = admit_orchestration_intent(
         tmp_path,
@@ -2032,7 +2205,9 @@ def test_end_to_end_codex_staged_venue_visibility_is_honest(monkeypatch, tmp_pat
     assert codex_diag is not None
     assert codex_diag["proof_artifact"]["ledger_path"] == "glow/orchestration/codex_work_orders.jsonl"
     assert codex_diag["lifecycle_visibility"]["lifecycle_state"] == "blocked_operator_required"
+    assert codex_diag["packet_fulfillment_visibility"]["fulfillment_received"] is False
     assert codex_diag["executability_visibility"]["not_directly_executable_here"] is True
+    assert handoff["handoff_packet"]["fulfillment_visibility"]["does_not_imply_direct_repo_execution"] is True
 
 
 def test_end_to_end_deep_research_staged_venue_visibility_is_honest(monkeypatch, tmp_path: Path) -> None:
@@ -2073,4 +2248,70 @@ def test_end_to_end_deep_research_staged_venue_visibility_is_honest(monkeypatch,
     assert deep_research_diag is not None
     assert deep_research_diag["proof_artifact"]["ledger_path"] == "glow/orchestration/deep_research_work_orders.jsonl"
     assert deep_research_diag["lifecycle_visibility"]["lifecycle_state"] == "blocked_operator_required"
+    assert deep_research_diag["packet_fulfillment_visibility"]["fulfillment_received"] is False
     assert deep_research_diag["executability_visibility"]["not_directly_executable_here"] is True
+
+
+def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibility(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+
+    def _fake_resolver(_repo_root: Path, *, action_id: str, correlation_id: str) -> dict[str, object]:
+        return {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        }
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle", _fake_resolver)
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.derive_next_venue_recommendation",
+        lambda *_args, **_kwargs: {
+            "next_venue_recommendation": "prefer_codex_implementation",
+            "relation_to_delegated_judgment": "affirming",
+            "basis": {},
+        },
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-codex-fulfilled-e2e",
+            }
+        ],
+    )
+
+    first = build_scoped_lifecycle_diagnostic(tmp_path)
+    handoff_packet = first["orchestration_handoff"]["handoff_packet"]
+    assert handoff_packet["target_venue"] == "codex_implementation"
+    receipt = ingest_external_fulfillment_receipt(
+        tmp_path,
+        handoff_packet_id=str(handoff_packet["handoff_packet_id"]),
+        fulfillment_kind="externally_completed",
+        operator_or_adapter="operator:e2e-test",
+        summary_notes="external codex completion reported",
+        evidence_refs=["artifacts/e2e.patch"],
+        created_at="2026-04-12T00:10:00Z",
+    )
+    receipt_rows = (tmp_path / "glow/orchestration/orchestration_fulfillment_receipts.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(receipt_rows) == 1
+    assert receipt["ingested_external_outcome"] is True
+    assert receipt["non_authoritative"] is True
+    assert receipt["receipt_only"] is True
+    assert receipt["does_not_imply_direct_repo_execution"] is True
+
+    second = build_scoped_lifecycle_diagnostic(tmp_path)
+    codex_diag = second["orchestration_handoff"]["codex_staged_venue"]
+    assert codex_diag is not None
+    packet_fulfillment = codex_diag["packet_fulfillment_visibility"]
+    assert packet_fulfillment["fulfillment_received"] is True
+    assert packet_fulfillment["lifecycle_state"] == "fulfilled_externally"
+    assert packet_fulfillment["fulfillment_kind"] == "externally_completed"
+    assert packet_fulfillment["receipt_artifact_path"] == "glow/orchestration/orchestration_fulfillment_receipts.jsonl"
+    assert packet_fulfillment["does_not_imply_direct_repo_execution"] is True


### PR DESCRIPTION
### Motivation
- Staged external handoff packets (Codex/Deep Research) lacked a bounded, proof-visible way to record externally performed outcomes so downstream history remained fragmented.
- The system must record externally supplied fulfillment evidence without implying in-repo execution or transferring sovereign decision authority.
- Keep the model compact, typed, venue-bounded (`codex_implementation`, `deep_research_audit`) and fail-closed on missing linkage.

### Description
- Introduced a compact fulfillment model and vocabulary: `_FULFILLMENT_KINDS` and new staged lifecycle states (`fulfilled_externally`, `fulfilled_externally_with_issues`, `externally_declined`, `externally_abandoned`) in `sentientos/orchestration_intent_fabric.py`.
- Added stable receipt ID builder `_fulfillment_receipt_id`, an append-only receipt ledger writer `append_orchestration_fulfillment_receipt_ledger(...)`, and a bounded ingestion API `ingest_external_fulfillment_receipt(...)` that validates source `handoff_packet_id`, enforces venue limits, preserves proposal/operator context, accepts `evidence_refs`, and encodes explicit anti-sovereignty markers (`ingested_external_outcome`, `does_not_imply_direct_repo_execution`, `receipt_only`, `decision_power: none`).
- Added `resolve_handoff_packet_fulfillment_lifecycle(...)` to derive per-packet fulfillment visibility and wire lifecycle_state mapping from receipt `fulfillment_kind` to the staged lifecycle.
- Updated the scoped diagnostic consumer to surface `packet_fulfillment_visibility` and `fulfillment_visibility` on the handoff packet so consumers can see whether a fulfillment receipt has been ingested and what kind it was (`sentientos/scoped_lifecycle_diagnostic.py`).
- Documented the new artifact and semantics in the orchestration note at `sentientos/orchestration_intent_fabric_note.py` and added tests that exercise ingestion flows and boundary guarantees.

### Testing
- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` which passed and covers: staged Codex and Deep Research receipt ingestion, missing-packet fail-closed behavior, `externally_declined` / `externally_abandoned` / `externally_result_unusable` visibility, diagnostic consumer surfacing of fulfillment state, non-authoritative/non-execution semantics, and an end-to-end staged→receipt→diagnostic flow.
- Attempted `python -m scripts.run_tests -q` but the full dependency/bootstrap install started and did not complete within this run; focused unit tests above were used for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1250980688320a313077bb83e5fac)