### PR TITLE
[codex:orchestration] integrate external fulfillment receipts into outcome/venue/next-venue reviews

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -84,6 +84,7 @@ _STAGED_EXTERNAL_LIFECYCLE_STATES = {
     "fulfilled_externally_with_issues",
     "externally_declined",
     "externally_abandoned",
+    "externally_result_unusable",
     "fragmented_unlinked_work_order_state",
 }
 
@@ -918,6 +919,114 @@ def resolve_orchestration_result(
     }
 
 
+def _recent_external_fulfillment_summary(
+    repo_root: Path,
+    recent_intents: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Collect compact external fulfillment evidence linked to recent external intents."""
+
+    root = repo_root.resolve()
+    external_intents = [
+        row
+        for row in recent_intents
+        if str(row.get("intent_kind") or "") in {"codex_work_order", "deep_research_work_order"}
+    ]
+    linkage_ids = {
+        _source_judgment_linkage_id(row.get("source_delegated_judgment", {}))
+        for row in external_intents
+    }
+    linkage_ids.discard("")
+
+    packets = _read_jsonl(root / "glow/orchestration/orchestration_handoff_packets.jsonl")
+    receipts = _read_jsonl(root / "glow/orchestration/orchestration_fulfillment_receipts.jsonl")
+    recent_packets = [
+        row
+        for row in packets
+        if str((row.get("source_delegated_judgment_ref") or {}).get("source_judgment_linkage_id") or "") in linkage_ids
+        and str(row.get("target_venue") or "") in {"codex_implementation", "deep_research_audit"}
+    ]
+    packet_by_id = {
+        str(row.get("handoff_packet_id") or ""): row
+        for row in recent_packets
+        if str(row.get("handoff_packet_id") or "")
+    }
+    latest_receipt_by_packet: dict[str, dict[str, Any]] = {}
+    for row in receipts:
+        packet_id = str((row.get("source_handoff_packet_ref") or {}).get("handoff_packet_id") or "")
+        if packet_id and packet_id in packet_by_id and isinstance(row, Mapping):
+            latest_receipt_by_packet[packet_id] = dict(row)
+
+    by_kind = {
+        "fulfilled_externally": 0,
+        "fulfilled_externally_with_issues": 0,
+        "externally_declined": 0,
+        "externally_abandoned": 0,
+        "externally_result_unusable": 0,
+    }
+    by_venue = {
+        "codex_implementation": {
+            "healthy": 0,
+            "stressed": 0,
+            "blocked_or_unusable": 0,
+            "fulfilled_externally": 0,
+            "fulfilled_externally_with_issues": 0,
+            "externally_declined": 0,
+            "externally_abandoned": 0,
+            "externally_result_unusable": 0,
+        },
+        "deep_research_audit": {
+            "healthy": 0,
+            "stressed": 0,
+            "blocked_or_unusable": 0,
+            "fulfilled_externally": 0,
+            "fulfilled_externally_with_issues": 0,
+            "externally_declined": 0,
+            "externally_abandoned": 0,
+            "externally_result_unusable": 0,
+        },
+    }
+    for packet_id, receipt in latest_receipt_by_packet.items():
+        fulfillment_kind = str(receipt.get("fulfillment_kind") or "")
+        mapped_kind = {
+            "externally_completed": "fulfilled_externally",
+            "externally_completed_with_issues": "fulfilled_externally_with_issues",
+            "externally_declined": "externally_declined",
+            "externally_abandoned": "externally_abandoned",
+            "externally_result_unusable": "externally_result_unusable",
+        }.get(fulfillment_kind)
+        if not mapped_kind:
+            continue
+        by_kind[mapped_kind] += 1
+        venue = str(packet_by_id.get(packet_id, {}).get("target_venue") or "")
+        venue_bucket = by_venue.get(venue)
+        if venue_bucket is None:
+            continue
+        venue_bucket[mapped_kind] += 1
+        if mapped_kind == "fulfilled_externally":
+            venue_bucket["healthy"] += 1
+        elif mapped_kind == "fulfilled_externally_with_issues":
+            venue_bucket["stressed"] += 1
+        else:
+            venue_bucket["blocked_or_unusable"] += 1
+
+    healthy = by_kind["fulfilled_externally"]
+    stressed = by_kind["fulfilled_externally_with_issues"] + by_kind["externally_result_unusable"]
+    blocked_or_unusable = by_kind["externally_declined"] + by_kind["externally_abandoned"] + by_kind["externally_result_unusable"]
+
+    return {
+        "recent_external_intents_considered": len(external_intents),
+        "recent_external_packets_considered": len(recent_packets),
+        "receipts_linked": len(latest_receipt_by_packet),
+        "receipts_missing_for_recent_packets": max(0, len(recent_packets) - len(latest_receipt_by_packet)),
+        "by_kind": by_kind,
+        "by_venue": by_venue,
+        "healthy_receipt_count": healthy,
+        "stressed_receipt_count": stressed,
+        "blocked_or_unusable_receipt_count": blocked_or_unusable,
+        "has_external_feedback_signal": len(latest_receipt_by_packet) > 0,
+    }
+
+
 def derive_orchestration_outcome_review(
     repo_root: Path,
     *,
@@ -939,10 +1048,20 @@ def derive_orchestration_outcome_review(
             scoped_handoffs.append(handoff)
 
     recent_handoffs = scoped_handoffs[-max(0, window_size) :] if window_size > 0 else []
+    recent_intent_ids = {
+        str((row.get("intent_ref") or {}).get("intent_id") or "")
+        for row in recent_handoffs
+    }
+    recent_intents = [
+        row
+        for row in intents
+        if str(row.get("intent_id") or "") in recent_intent_ids
+    ]
     recent_resolutions = [
         resolve_orchestration_result(root, handoff, executor_log_path=executor_log_path)
         for handoff in recent_handoffs
     ]
+    external_summary = _recent_external_fulfillment_summary(root, recent_intents)
 
     outcome_counts = {
         "execution_succeeded": 0,
@@ -987,6 +1106,16 @@ def derive_orchestration_outcome_review(
     blocked_heavy = blocked_handoffs >= 2 and block_ratio >= 0.6
     failure_heavy = admitted_handoffs >= 3 and failure_count >= 2 and failure_ratio >= 0.5
     stall_heavy = admitted_handoffs >= 3 and pending_count >= 2 and pending_ratio >= 0.5
+    external_healthy = int(external_summary.get("healthy_receipt_count") or 0)
+    external_stressed = int(external_summary.get("stressed_receipt_count") or 0)
+    external_blocked_or_unusable = int(external_summary.get("blocked_or_unusable_receipt_count") or 0)
+    external_signal_present = bool(external_summary.get("has_external_feedback_signal"))
+    external_stress_heavy = external_signal_present and (external_stressed + external_blocked_or_unusable) >= 2 and (
+        external_stressed + external_blocked_or_unusable
+    ) >= external_healthy
+    external_healthy_support = external_signal_present and external_healthy >= 2 and (
+        external_stressed + external_blocked_or_unusable
+    ) == 0
 
     classification = "insufficient_history"
     if records_considered >= 3:
@@ -997,6 +1126,8 @@ def derive_orchestration_outcome_review(
         elif stall_heavy:
             classification = "pending_stall_pattern"
         elif success_count >= 2 and success_ratio >= 0.6:
+            classification = "clean_recent_orchestration"
+        elif external_healthy_support:
             classification = "clean_recent_orchestration"
         else:
             classification = "mixed_orchestration_stress"
@@ -1015,12 +1146,25 @@ def derive_orchestration_outcome_review(
             "blocked_heavy": blocked_heavy,
             "failure_heavy": failure_heavy,
             "stall_heavy": stall_heavy,
+            "external_feedback_signal_present": external_signal_present,
+            "external_stress_heavy": external_stress_heavy,
+            "external_healthy_support": external_healthy_support,
         },
+        "external_fulfillment_outcome_counts": dict(external_summary.get("by_kind") or {}),
         "summary": {
             "recent_pattern": "healthy_bounded_orchestration"
             if classification == "clean_recent_orchestration"
             else "orchestration_stress_or_uncertainty",
-            "diagnostic_summary": "bounded retrospective review derived from existing internal orchestration artifacts only",
+            "diagnostic_summary": "bounded retrospective review derived from internal orchestration artifacts plus external fulfillment receipt outcomes when linked",
+            "external_fulfillment_influence": {
+                "influenced_outcome_review": external_signal_present,
+                "influence_mode": "healthy_support"
+                if external_healthy_support
+                else ("stress_signal" if external_stress_heavy else ("present_no_strong_shift" if external_signal_present else "none")),
+                "healthy_receipt_count": external_healthy,
+                "stressed_receipt_count": external_stressed,
+                "blocked_or_unusable_receipt_count": external_blocked_or_unusable,
+            },
         },
         "artifacts_read": {
             "intent_ledger": "glow/orchestration/orchestration_intents.jsonl",
@@ -1028,6 +1172,8 @@ def derive_orchestration_outcome_review(
             "executor_log": str((executor_log_path or Path(task_executor.LOG_PATH)).relative_to(root))
             if (executor_log_path or Path(task_executor.LOG_PATH)).is_relative_to(root)
             else str(executor_log_path or Path(task_executor.LOG_PATH)),
+            "handoff_packet_ledger": "glow/orchestration/orchestration_handoff_packets.jsonl",
+            "fulfillment_receipt_ledger": "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
         },
         **_anti_sovereignty_payload(
             recommendation_only=True,
@@ -1119,6 +1265,13 @@ def derive_orchestration_venue_mix_review(
         }:
             blocked_count += 1
 
+    recent_intents = [
+        row
+        for row in intents
+        if str(row.get("intent_id") or "") in recent_intent_ids
+    ]
+    external_summary = _recent_external_fulfillment_summary(root, recent_intents)
+
     records_considered = len(recent_handoffs)
     total_primary_venue = sum(venue_counts.values())
     internal_ratio = (venue_counts["task_admission_executor"] / total_primary_venue) if total_primary_venue else 0.0
@@ -1131,6 +1284,13 @@ def derive_orchestration_venue_mix_review(
     codex_heavy = venue_counts["codex_implementation"] >= 2 and codex_ratio >= 0.6
     deep_research_heavy = venue_counts["deep_research_audit"] >= 2 and deep_ratio >= 0.6
     operator_heavy = operator_required_count >= 2 and operator_ratio >= 0.5
+    external_healthy = int(external_summary.get("healthy_receipt_count") or 0)
+    external_stressed = int(external_summary.get("stressed_receipt_count") or 0)
+    external_blocked_or_unusable = int(external_summary.get("blocked_or_unusable_receipt_count") or 0)
+    external_signal_present = bool(external_summary.get("has_external_feedback_signal"))
+    external_quality_stressed = external_signal_present and (external_stressed + external_blocked_or_unusable) >= 2 and (
+        external_stressed + external_blocked_or_unusable
+    ) > external_healthy
     dominant_flags = [internal_heavy, codex_heavy, deep_research_heavy, operator_heavy]
     heavy_pattern_count = sum(1 for flag in dominant_flags if flag)
 
@@ -1155,6 +1315,8 @@ def derive_orchestration_venue_mix_review(
         elif balanced_primary_spread and blocked_ratio < 0.4:
             classification = "balanced_recent_venue_mix"
         else:
+            classification = "mixed_venue_stress"
+        if classification in {"codex_heavy", "deep_research_heavy", "balanced_recent_venue_mix"} and external_quality_stressed:
             classification = "mixed_venue_stress"
 
     if classification not in _ORCHESTRATION_VENUE_MIX_CLASSES:
@@ -1196,6 +1358,15 @@ def derive_orchestration_venue_mix_review(
         "summary": {
             "venue_usage_balance": usage_balance,
             "diagnostic_summary": "bounded retrospective venue-mix review derived from existing orchestration artifacts only",
+            "external_fulfillment_influence": {
+                "influenced_venue_mix_review": external_signal_present,
+                "healthy_receipt_count": external_healthy,
+                "stressed_receipt_count": external_stressed,
+                "blocked_or_unusable_receipt_count": external_blocked_or_unusable,
+                "quality_signal": "stressed"
+                if external_quality_stressed
+                else ("healthy_or_mixed" if external_signal_present else "none"),
+            },
             "classification_basis": classification_basis,
         },
         "artifacts_read": {
@@ -1204,10 +1375,21 @@ def derive_orchestration_venue_mix_review(
             "codex_staged_work_order_ledger": "glow/orchestration/codex_work_orders.jsonl",
             "deep_research_staged_work_order_ledger": "glow/orchestration/deep_research_work_orders.jsonl",
             "orchestration_result_resolution_surface": "sentientos.orchestration_intent_fabric.resolve_orchestration_result",
+            "handoff_packet_ledger": "glow/orchestration/orchestration_handoff_packets.jsonl",
+            "fulfillment_receipt_ledger": "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
         },
         "evidence_counts": {
             "recent_codex_work_orders": recent_codex_work_orders,
             "recent_deep_research_work_orders": recent_deep_research_work_orders,
+        },
+        "external_fulfillment_contribution": {
+            "by_kind": dict(external_summary.get("by_kind") or {}),
+            "by_venue": dict(external_summary.get("by_venue") or {}),
+            "healthy_receipt_count": external_healthy,
+            "stressed_receipt_count": external_stressed,
+            "blocked_or_unusable_receipt_count": external_blocked_or_unusable,
+            "receipts_missing_for_recent_packets": int(external_summary.get("receipts_missing_for_recent_packets") or 0),
+            "signal_present": external_signal_present,
         },
         **_anti_sovereignty_payload(
             recommendation_only=True,
@@ -1334,6 +1516,48 @@ def derive_next_venue_recommendation(
     failure_heavy = bool((outcome_review.get("condition_flags") or {}).get("failure_heavy"))
     stall_heavy = bool((outcome_review.get("condition_flags") or {}).get("stall_heavy"))
     operator_heavy = venue_mix_classification == "operator_escalation_heavy"
+    external_contribution = venue_mix_review.get("external_fulfillment_contribution")
+    external_contribution_map = external_contribution if isinstance(external_contribution, Mapping) else {}
+    by_venue = external_contribution_map.get("by_venue")
+    by_venue_map = by_venue if isinstance(by_venue, Mapping) else {}
+
+    def _venue_external_health(venue: str) -> dict[str, int]:
+        venue_map = by_venue_map.get(venue)
+        venue_metrics = venue_map if isinstance(venue_map, Mapping) else {}
+        return {
+            "healthy": int(venue_metrics.get("healthy") or 0),
+            "stressed": int(venue_metrics.get("stressed") or 0),
+            "blocked_or_unusable": int(venue_metrics.get("blocked_or_unusable") or 0),
+            "fulfilled_externally": int(venue_metrics.get("fulfilled_externally") or 0),
+            "fulfilled_externally_with_issues": int(venue_metrics.get("fulfilled_externally_with_issues") or 0),
+            "externally_declined": int(venue_metrics.get("externally_declined") or 0),
+            "externally_abandoned": int(venue_metrics.get("externally_abandoned") or 0),
+            "externally_result_unusable": int(venue_metrics.get("externally_result_unusable") or 0),
+        }
+
+    codex_external = _venue_external_health("codex_implementation")
+    deep_external = _venue_external_health("deep_research_audit")
+    delegated_external = _venue_external_health(delegated_venue) if delegated_venue in {
+        "codex_implementation",
+        "deep_research_audit",
+    } else _venue_external_health("")
+    delegated_external_total = delegated_external["healthy"] + delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    delegated_external_healthy_strong = delegated_external["healthy"] >= 2 and (
+        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    ) == 0
+    delegated_external_stressed = delegated_external_total >= 2 and (
+        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    ) >= delegated_external["healthy"]
+    external_signal_present = bool(external_contribution_map.get("signal_present"))
+    alternative_external_healthy = (
+        deep_external["healthy"] >= 2 and (deep_external["stressed"] + deep_external["blocked_or_unusable"]) == 0
+        if delegated_venue == "codex_implementation"
+        else (
+            codex_external["healthy"] >= 2 and (codex_external["stressed"] + codex_external["blocked_or_unusable"]) == 0
+            if delegated_venue == "deep_research_audit"
+            else False
+        )
+    )
 
     delegated_to_next = {
         "internal_direct_execution": "prefer_internal_execution",
@@ -1366,6 +1590,8 @@ def derive_next_venue_recommendation(
         }
         or venue_mix_classification == "mixed_venue_stress"
     )
+    external_feedback_affirming = delegated_external_healthy_strong
+    external_feedback_stressed = delegated_external_stressed
 
     if operator_escalation_dominant:
         recommendation = "prefer_operator_decision"
@@ -1383,6 +1609,18 @@ def derive_next_venue_recommendation(
         recommendation = "prefer_deep_research_audit"
         relation = "nudging"
         rationale = "recent_stress_or_architectural_ambiguity_pattern_nudges_toward_deep_research_audit"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed and alternative_external_healthy:
+        recommendation = "prefer_deep_research_audit" if delegated_venue == "codex_implementation" else "prefer_codex_implementation"
+        relation = "nudging"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_while_alternative_external_venue_is_recently_healthy"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed:
+        recommendation = "hold_current_venue_mix"
+        relation = "holding"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_without_a_clear_healthy_external_alternative"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_affirming:
+        recommendation = delegated_next if delegated_next is not None else "insufficient_context"
+        relation = "affirming"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_healthy_and_supports_affirmation"
     elif delegated_venue == "internal_direct_execution" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
         "balanced_recent_venue_mix",
         "internal_execution_heavy",
@@ -1443,6 +1681,14 @@ def derive_next_venue_recommendation(
             "orchestration_venue_mix_review": {
                 "review_classification": venue_mix_classification,
                 "records_considered": venue_mix_records,
+                "external_fulfillment_contribution": {
+                    "signal_present": external_signal_present,
+                    "delegated_external_venue_health": delegated_external,
+                    "codex_external_health": codex_external,
+                    "deep_research_external_health": deep_external,
+                    "external_feedback_affirming": external_feedback_affirming,
+                    "external_feedback_stressed": external_feedback_stressed,
+                },
             },
             "orchestration_operator_attention_recommendation": attention_signal,
             "rationale": rationale,
@@ -1452,6 +1698,7 @@ def derive_next_venue_recommendation(
                 "orchestration_outcome_review.review_classification",
                 "orchestration_outcome_review.condition_flags",
                 "orchestration_venue_mix_review.review_classification",
+                "orchestration_venue_mix_review.external_fulfillment_contribution",
                 "orchestration_operator_attention_recommendation.operator_attention_recommendation",
             ],
         },
@@ -1464,6 +1711,52 @@ def derive_next_venue_recommendation(
                 "does_not_override_delegated_judgment": True,
             },
         ),
+    }
+
+
+def derive_external_feedback_gap_map(
+    outcome_review: Mapping[str, Any],
+    venue_mix_review: Mapping[str, Any],
+    next_venue_recommendation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return compact audit visibility for external fulfillment influence across review layers."""
+
+    outcome_influence = outcome_review.get("summary", {}).get("external_fulfillment_influence")
+    outcome_influence_map = outcome_influence if isinstance(outcome_influence, Mapping) else {}
+    venue_mix_influence = venue_mix_review.get("summary", {}).get("external_fulfillment_influence")
+    venue_mix_influence_map = venue_mix_influence if isinstance(venue_mix_influence, Mapping) else {}
+    next_basis = next_venue_recommendation.get("basis", {}).get("orchestration_venue_mix_review", {})
+    next_basis_map = next_basis if isinstance(next_basis, Mapping) else {}
+    next_external = next_basis_map.get("external_fulfillment_contribution")
+    next_external_map = next_external if isinstance(next_external, Mapping) else {}
+
+    return {
+        "schema_version": "orchestration_external_feedback_gap_map.v1",
+        "outcome_review": {
+            "external_fulfillment_influencing": bool(outcome_influence_map.get("influenced_outcome_review")),
+            "influence_mode": str(outcome_influence_map.get("influence_mode") or "none"),
+            "remaining_gap": "none"
+            if outcome_influence_map.get("influenced_outcome_review")
+            else "external_fulfillment_not_currently_visible_to_outcome_review",
+        },
+        "venue_mix_review": {
+            "external_fulfillment_influencing": bool(venue_mix_influence_map.get("influenced_venue_mix_review")),
+            "quality_signal": str(venue_mix_influence_map.get("quality_signal") or "none"),
+            "remaining_gap": "none"
+            if venue_mix_influence_map.get("influenced_venue_mix_review")
+            else "external_fulfillment_not_currently_visible_to_venue_mix_review",
+        },
+        "next_venue_recommendation": {
+            "external_fulfillment_influencing": bool(next_external_map.get("signal_present")),
+            "delegated_external_feedback_stressed": bool(next_external_map.get("external_feedback_stressed")),
+            "delegated_external_feedback_affirming": bool(next_external_map.get("external_feedback_affirming")),
+            "remaining_gap": "none"
+            if next_external_map.get("signal_present")
+            else "next_venue_recommendation_not_currently_using_external_fulfillment_history",
+        },
+        "non_authoritative": True,
+        "decision_power": "none",
+        "diagnostic_only": True,
     }
 
 
@@ -1913,7 +2206,7 @@ def resolve_handoff_packet_fulfillment_lifecycle(
             "externally_completed_with_issues": "fulfilled_externally_with_issues",
             "externally_declined": "externally_declined",
             "externally_abandoned": "externally_abandoned",
-            "externally_result_unusable": "fulfilled_externally_with_issues",
+            "externally_result_unusable": "externally_result_unusable",
         }.get(fulfillment_kind, "fragmented_unlinked_work_order_state")
 
     if lifecycle_state not in _STAGED_EXTERNAL_LIFECYCLE_STATES:

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -186,11 +186,13 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
             "meaning": "handoff admission records substrate entry; orchestration result closure requires downstream task_result evidence.",
         },
         "outcome_review": {
-            "meaning": "bounded retrospective classification over recent internal orchestration outcomes.",
+            "meaning": "bounded retrospective classification over recent internal orchestration outcomes, now with linked external fulfillment receipt influence for staged external venues.",
             "reads_existing_artifacts_only": [
                 "glow/orchestration/orchestration_intents.jsonl",
                 "glow/orchestration/orchestration_handoffs.jsonl",
                 "logs/task_executor.jsonl task_result linkage",
+                "glow/orchestration/orchestration_handoff_packets.jsonl",
+                "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
             ],
             "classifications": [
                 "clean_recent_orchestration",
@@ -206,14 +208,23 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "direct external actuation",
                 "a new execution venue",
             ],
+            "external_fulfillment_mapping": {
+                "fulfilled_externally": "healthy support signal",
+                "fulfilled_externally_with_issues": "stressed support signal",
+                "externally_declined": "blocked external pressure signal",
+                "externally_abandoned": "blocked external pressure signal",
+                "externally_result_unusable": "failure-like external quality signal",
+            },
         },
         "venue_mix_review": {
-            "meaning": "bounded retrospective check of recent venue-selection mix (internal execution vs staged Codex vs staged Deep Research vs operator-heavy escalation states).",
+            "meaning": "bounded retrospective check of recent venue-selection mix (internal execution vs staged Codex vs staged Deep Research vs operator-heavy escalation states) with compact external fulfillment quality contribution.",
             "reads_existing_artifacts_only": [
                 "glow/orchestration/orchestration_intents.jsonl",
                 "glow/orchestration/orchestration_handoffs.jsonl",
                 "glow/orchestration/codex_work_orders.jsonl",
                 "glow/orchestration/deep_research_work_orders.jsonl",
+                "glow/orchestration/orchestration_handoff_packets.jsonl",
+                "glow/orchestration/orchestration_fulfillment_receipts.jsonl",
                 "orchestration_result_resolution linkage surfaces",
             ],
             "classifications": [
@@ -230,6 +241,33 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "execution authority",
                 "a new venue",
                 "direct external actuation",
+            ],
+            "external_quality_bounding": [
+                "healthy external fulfillment contribution",
+                "stressed external fulfillment contribution",
+                "venue-heavy plus poor-fulfillment stress indicator",
+            ],
+        },
+        "next_venue_recommendation": {
+            "what_changed_in_this_pass": [
+                "uses bounded external fulfillment history from venue_mix_review.external_fulfillment_contribution",
+                "can affirm delegated Codex/Deep Research when that venue has healthy repeated external fulfillment",
+                "can nudge away or hold when delegated external venue has stressed/declined/abandoned/unusable recent outcomes",
+            ],
+            "safety_bounds": [
+                "does_not_override_delegated_judgment remains true",
+                "single bad receipt does not dominate; stress signals require repeated outcomes",
+                "staged-only packets without receipts remain explicitly distinct from fulfilled outcomes",
+            ],
+            "still_not_direct_execution": [
+                "no direct Codex/Deep Research actuation",
+                "no browser/mouse/keyboard control",
+                "no sovereign execution authority transfer",
+            ],
+            "still_missing_before_autonomous_external_delegation": [
+                "approved direct external trigger/adapter pathway",
+                "strong fulfillment attestation + verification policy with execution parity",
+                "governed autonomous retry/escalation policy that remains non-sovereign",
             ],
         },
         "operator_attention_recommendation": {

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -18,6 +18,7 @@ from sentientos.orchestration_intent_fabric import (
     append_orchestration_intent_ledger,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_external_feedback_gap_map,
     derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
     derive_next_move_proposal_review,
@@ -162,6 +163,11 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_venue_mix_review,
         orchestration_attention_recommendation,
     )
+    external_feedback_gap_map = derive_external_feedback_gap_map(
+        orchestration_outcome_review,
+        orchestration_venue_mix_review,
+        next_venue_recommendation,
+    )
     next_move_proposal = synthesize_next_move_proposal(
         delegated_judgment,
         next_venue_recommendation,
@@ -221,6 +227,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,
             "next_venue_recommendation": next_venue_recommendation,
+            "external_fulfillment_feedback_visibility": external_feedback_gap_map,
             "next_move_proposal": {
                 **next_move_proposal,
                 "ledger_path": str(next_move_proposal_ledger_path.relative_to(root)),

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from importlib import reload
 import json
 from pathlib import Path
@@ -16,6 +17,7 @@ from sentientos.orchestration_intent_fabric import (
     ingest_external_fulfillment_receipt,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_external_feedback_gap_map,
     derive_next_venue_recommendation,
     derive_next_move_proposal_review,
     derive_orchestration_outcome_review,
@@ -641,6 +643,88 @@ def _seed_venue_mix_history(
     _write_jsonl(tmp_path / "glow/orchestration/deep_research_work_orders.jsonl", deep_rows)
 
 
+def _seed_external_feedback_history(
+    tmp_path: Path,
+    *,
+    external_venues: list[str],
+    fulfillment_kinds: list[str | None],
+) -> Path:
+    intent_rows: list[dict[str, object]] = []
+    handoff_rows: list[dict[str, object]] = []
+    packet_rows: list[dict[str, object]] = []
+    receipt_rows: list[dict[str, object]] = []
+    for idx, venue in enumerate(external_venues):
+        intent_id = f"orh-ext-{idx}"
+        delegated = {
+            "work_class": "external_tool_orchestration",
+            "recommended_venue": venue,
+            "next_move_posture": "hold",
+            "consolidation_expansion_posture": "consolidate",
+            "escalation_classification": "none",
+        }
+        linkage = {
+            "work_class": str(delegated["work_class"]),
+            "recommended_venue": str(delegated["recommended_venue"]),
+            "next_move_posture": str(delegated["next_move_posture"]),
+            "consolidation_expansion_posture": str(delegated["consolidation_expansion_posture"]),
+            "escalation_classification": str(delegated["escalation_classification"]),
+            "readiness_basis": {"orchestration_substitution_readiness": {}, "basis": {}},
+        }
+        linkage_id = f"jdg-link-{hashlib.sha256(json.dumps(linkage, sort_keys=True, separators=(',', ':')).encode('utf-8')).hexdigest()[:16]}"
+        intent_kind = "codex_work_order" if venue == "codex_implementation" else "deep_research_work_order"
+        intent_rows.append(
+            {
+                "schema_version": "orchestration_intent.v1",
+                "intent_id": intent_id,
+                "intent_kind": intent_kind,
+                "source_delegated_judgment": linkage,
+                "required_authority_posture": "operator_approval_required",
+                "requires_operator_approval": True,
+            }
+        )
+        handoff_rows.append(
+            {
+                "schema_version": "orchestration_handoff.v1",
+                "handoff_outcome": "staged_only",
+                "intent_ref": {"intent_id": intent_id, "intent_kind": intent_kind},
+                "details": {"required_authority_posture": "operator_approval_required", "requires_operator_approval": True},
+            }
+        )
+        proposal_id = f"proposal-ext-{idx}"
+        packet_id = f"hpk-ext-{idx}"
+        packet_rows.append(
+            {
+                "schema_version": "orchestration_handoff_packet.v1",
+                "handoff_packet_id": packet_id,
+                "target_venue": venue,
+                "source_next_move_proposal_ref": {"proposal_id": proposal_id},
+                "source_delegated_judgment_ref": {
+                    "source_judgment_linkage_id": linkage_id
+                },
+                "packet_status": "ready_for_external_trigger",
+                "readiness": {"ready_for_external_trigger": True, "staged_only": True, "blocked": False},
+            }
+        )
+        kind = fulfillment_kinds[idx]
+        if kind:
+            receipt_rows.append(
+                {
+                    "schema_version": "orchestration_fulfillment_receipt.v1",
+                    "fulfillment_receipt_id": f"fr-ext-{idx}",
+                    "source_handoff_packet_ref": {"handoff_packet_id": packet_id},
+                    "source_venue": venue,
+                    "fulfillment_kind": kind,
+                }
+            )
+
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_intents.jsonl", intent_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoffs.jsonl", handoff_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl", packet_rows)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_fulfillment_receipts.jsonl", receipt_rows)
+    _write_jsonl(tmp_path / "logs/task_executor.jsonl", [])
+    return tmp_path / "logs/task_executor.jsonl"
+
+
 def test_outcome_review_success_dominant_classifies_clean(tmp_path: Path) -> None:
     executor_log = _seed_orchestration_history(
         tmp_path,
@@ -754,6 +838,36 @@ def test_outcome_review_insufficient_history_when_too_few_records(tmp_path: Path
     assert review["records_considered"] == 2
     attention = derive_orchestration_attention_recommendation(review)
     assert attention["operator_attention_recommendation"] == "insufficient_context"
+
+
+def test_outcome_review_uses_fulfilled_codex_receipts_as_external_healthy_support(tmp_path: Path) -> None:
+    executor_log = _seed_external_feedback_history(
+        tmp_path,
+        external_venues=["codex_implementation", "codex_implementation", "codex_implementation"],
+        fulfillment_kinds=["externally_completed", "externally_completed", "externally_completed"],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "clean_recent_orchestration"
+    assert review["condition_flags"]["external_feedback_signal_present"] is True
+    assert review["condition_flags"]["external_healthy_support"] is True
+    assert review["external_fulfillment_outcome_counts"]["fulfilled_externally"] == 3
+    assert review["summary"]["external_fulfillment_influence"]["influence_mode"] == "healthy_support"
+
+
+def test_outcome_review_marks_external_stress_for_unusable_or_declined_without_internal_failure_claim(tmp_path: Path) -> None:
+    executor_log = _seed_external_feedback_history(
+        tmp_path,
+        external_venues=["codex_implementation", "codex_implementation", "codex_implementation"],
+        fulfillment_kinds=["externally_result_unusable", "externally_declined", "externally_abandoned"],
+    )
+
+    review = derive_orchestration_outcome_review(tmp_path, executor_log_path=executor_log)
+    assert review["review_classification"] == "mixed_orchestration_stress"
+    assert review["condition_flags"]["external_feedback_signal_present"] is True
+    assert review["condition_flags"]["external_stress_heavy"] is True
+    assert review["recent_outcome_counts"]["execution_failed"] == 0
+    assert review["external_fulfillment_outcome_counts"]["externally_result_unusable"] == 1
 
 
 def test_attention_recommendation_light_block_pattern_prefers_observe(tmp_path: Path) -> None:
@@ -916,6 +1030,21 @@ def test_venue_mix_review_insufficient_history(tmp_path: Path) -> None:
     review = derive_orchestration_venue_mix_review(tmp_path)
     assert review["review_classification"] == "insufficient_history"
     assert review["records_considered"] == 2
+
+
+def test_venue_mix_review_includes_external_fulfillment_quality_contribution(tmp_path: Path) -> None:
+    _seed_external_feedback_history(
+        tmp_path,
+        external_venues=["deep_research_audit", "deep_research_audit", "deep_research_audit"],
+        fulfillment_kinds=["externally_completed", "externally_completed", "externally_completed_with_issues"],
+    )
+
+    review = derive_orchestration_venue_mix_review(tmp_path)
+    external = review["external_fulfillment_contribution"]
+    assert external["signal_present"] is True
+    assert external["by_venue"]["deep_research_audit"]["healthy"] == 2
+    assert external["by_venue"]["deep_research_audit"]["stressed"] == 1
+    assert review["summary"]["external_fulfillment_influence"]["influenced_venue_mix_review"] is True
 
 
 def test_diagnostic_consumer_surfaces_outcome_review_and_remains_non_authoritative(
@@ -1098,6 +1227,96 @@ def test_next_venue_recommendation_returns_insufficient_context_when_history_is_
 
     assert recommendation["next_venue_recommendation"] == "insufficient_context"
     assert recommendation["relation_to_delegated_judgment"] == "insufficient_context"
+
+
+def test_next_venue_recommendation_affirms_codex_when_external_fulfillment_is_healthy() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "clean_recent_orchestration",
+        "records_considered": 5,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {
+        "review_classification": "codex_heavy",
+        "records_considered": 5,
+        "external_fulfillment_contribution": {
+            "signal_present": True,
+            "by_venue": {
+                "codex_implementation": {
+                    "healthy": 2,
+                    "stressed": 0,
+                    "blocked_or_unusable": 0,
+                    "fulfilled_externally": 2,
+                    "fulfilled_externally_with_issues": 0,
+                    "externally_declined": 0,
+                    "externally_abandoned": 0,
+                    "externally_result_unusable": 0,
+                },
+                "deep_research_audit": {
+                    "healthy": 0,
+                    "stressed": 0,
+                    "blocked_or_unusable": 0,
+                    "fulfilled_externally": 0,
+                    "fulfilled_externally_with_issues": 0,
+                    "externally_declined": 0,
+                    "externally_abandoned": 0,
+                    "externally_result_unusable": 0,
+                },
+            },
+        },
+    }
+    attention = {"operator_attention_recommendation": "none"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_codex_implementation"
+    assert recommendation["relation_to_delegated_judgment"] == "affirming"
+    assert recommendation["basis"]["orchestration_venue_mix_review"]["external_fulfillment_contribution"]["external_feedback_affirming"] is True
+
+
+def test_next_venue_recommendation_nudges_from_codex_when_external_fulfillment_is_stressed_and_deep_is_healthy() -> None:
+    delegated = {"recommended_venue": "codex_implementation", "escalation_classification": "none"}
+    outcome_review = {
+        "review_classification": "mixed_orchestration_stress",
+        "records_considered": 6,
+        "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+    }
+    venue_mix_review = {
+        "review_classification": "mixed_venue_stress",
+        "records_considered": 6,
+        "external_fulfillment_contribution": {
+            "signal_present": True,
+            "by_venue": {
+                "codex_implementation": {
+                    "healthy": 0,
+                    "stressed": 1,
+                    "blocked_or_unusable": 1,
+                    "fulfilled_externally": 0,
+                    "fulfilled_externally_with_issues": 1,
+                    "externally_declined": 1,
+                    "externally_abandoned": 0,
+                    "externally_result_unusable": 0,
+                },
+                "deep_research_audit": {
+                    "healthy": 2,
+                    "stressed": 0,
+                    "blocked_or_unusable": 0,
+                    "fulfilled_externally": 2,
+                    "fulfilled_externally_with_issues": 0,
+                    "externally_declined": 0,
+                    "externally_abandoned": 0,
+                    "externally_result_unusable": 0,
+                },
+            },
+        },
+    }
+    attention = {"operator_attention_recommendation": "review_mixed_orchestration_stress"}
+
+    recommendation = derive_next_venue_recommendation(delegated, outcome_review, venue_mix_review, attention)
+
+    assert recommendation["next_venue_recommendation"] == "prefer_deep_research_audit"
+    assert recommendation["relation_to_delegated_judgment"] == "nudging"
+    assert recommendation["does_not_override_delegated_judgment"] is True
 
 
 def test_next_move_proposal_affirming_for_healthy_internal_pattern() -> None:
@@ -2104,7 +2323,7 @@ def test_external_declined_abandoned_and_unusable_states_are_visible(tmp_path: P
         created_at="2026-04-12T00:05:00Z",
     )
     unusable = resolve_handoff_packet_fulfillment_lifecycle(tmp_path, packet)
-    assert unusable["lifecycle_state"] == "fulfilled_externally_with_issues"
+    assert unusable["lifecycle_state"] == "externally_result_unusable"
 
 
 def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
@@ -2309,9 +2528,45 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     second = build_scoped_lifecycle_diagnostic(tmp_path)
     codex_diag = second["orchestration_handoff"]["codex_staged_venue"]
     assert codex_diag is not None
+    outcome_review = second["orchestration_handoff"]["outcome_review"]
+    venue_mix_review = second["orchestration_handoff"]["venue_mix_review"]
+    next_venue = second["orchestration_handoff"]["next_venue_recommendation"]
+    feedback_visibility = second["orchestration_handoff"]["external_fulfillment_feedback_visibility"]
     packet_fulfillment = codex_diag["packet_fulfillment_visibility"]
     assert packet_fulfillment["fulfillment_received"] is True
     assert packet_fulfillment["lifecycle_state"] == "fulfilled_externally"
     assert packet_fulfillment["fulfillment_kind"] == "externally_completed"
     assert packet_fulfillment["receipt_artifact_path"] == "glow/orchestration/orchestration_fulfillment_receipts.jsonl"
     assert packet_fulfillment["does_not_imply_direct_repo_execution"] is True
+    assert outcome_review["summary"]["external_fulfillment_influence"]["influenced_outcome_review"] is True
+    assert venue_mix_review["summary"]["external_fulfillment_influence"]["influenced_venue_mix_review"] is True
+    assert feedback_visibility["outcome_review"]["external_fulfillment_influencing"] is True
+    assert feedback_visibility["venue_mix_review"]["external_fulfillment_influencing"] is True
+    assert next_venue["relation_to_delegated_judgment"] == "affirming"
+    assert feedback_visibility["non_authoritative"] is True
+
+
+def test_external_feedback_gap_map_reports_layer_influence_coherently() -> None:
+    outcome_review = {
+        "summary": {"external_fulfillment_influence": {"influenced_outcome_review": True, "influence_mode": "healthy_support"}}
+    }
+    venue_mix_review = {
+        "summary": {"external_fulfillment_influence": {"influenced_venue_mix_review": True, "quality_signal": "healthy_or_mixed"}}
+    }
+    next_venue = {
+        "basis": {
+            "orchestration_venue_mix_review": {
+                "external_fulfillment_contribution": {
+                    "signal_present": True,
+                    "external_feedback_stressed": False,
+                    "external_feedback_affirming": True,
+                }
+            }
+        }
+    }
+
+    gap_map = derive_external_feedback_gap_map(outcome_review, venue_mix_review, next_venue)
+    assert gap_map["outcome_review"]["remaining_gap"] == "none"
+    assert gap_map["venue_mix_review"]["remaining_gap"] == "none"
+    assert gap_map["next_venue_recommendation"]["remaining_gap"] == "none"
+    assert gap_map["diagnostic_only"] is True


### PR DESCRIPTION
### Motivation
- Make staged external venues (Codex / Deep Research) observable by feeding externally ingested fulfillment receipts into orchestration self-review and venue-preference signals without conflating external outcomes with internal execution semantics. 
- Provide bounded, conservative feedback so the system can learn from repeated external outcomes (healthy vs stressed vs blocked/unusable) while preserving non-sovereignty and operator control.

### Description
- Add a compact external-fulfillment aggregator `_recent_external_fulfillment_summary` that links recent external intents to handoff packets and the latest receipts and classifies receipts into healthy/stressed/blocked/unusable buckets. (new helper in `orchestration_intent_fabric.py`).
- Extend `derive_orchestration_outcome_review` to incorporate linked external receipt signals (counts, flags and a compact influence descriptor such as `healthy_support` / `stress_signal`) while preserving internal execution classification logic.
- Extend `derive_orchestration_venue_mix_review` to include `external_fulfillment_contribution` (by kind and by venue), and conservatively degrade venue-heavy classifications when external fulfillment quality is stressed.
- Update `derive_next_venue_recommendation` to read bounded external-fulfillment contribution and act conservatively: affirm delegated external venues when they show repeated healthy receipts, nudge toward alternative external venue when delegated venue is repeatedly stressed and a healthier external alternative exists, or hold when stressed without clear alternative; all while keeping `does_not_override_delegated_judgment` semantics and recommendation-only payloads.
- Add `derive_external_feedback_gap_map` to produce a compact diagnostic showing which orchestration layers are influenced by external receipts and surface it through the scoped diagnostic consumer as `external_fulfillment_feedback_visibility` (no new decision surface introduced).
- Keep external lifecycle semantics explicit and honest by making `externally_result_unusable` a distinct lifecycle state and mapping it into stressed/failure-like signals; update staged-packet lifecycle resolution and note text to document mappings and limits.
- Add focused unit tests exercising: healthy Codex/Deep Research receipts influence, stressed/unusable/declined signals, next-venue affirmation/nudging behaviors, staged-only honesty, and an end-to-end staged -> receipt -> outcome/venue/next-venue -> diagnostic consumer coherence path; tests added/modified in `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Ran the targeted orchestration unit tests: `python -m pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and all new/modified tests passed (end-to-end staged->receipt->consumer path included). (PASS)
- Ran repository-wide typed checks: `mypy scripts/ sentientos/` which reported many existing repository typing issues unrelated to this change and therefore failed as a baseline-wide typing debt is present. (EXPECTED FAIL - unrelated baseline)
- Ran broader test harness: `python -m scripts.run_tests -q` which surfaced unrelated failures in the pulse federation tests in this environment; these are pre-existing integration test issues and not caused by the orchestration changes. (UNRELATED FAIL)
- Ran audit checks: `scripts/verify_audits --strict` flagged a pre-existing runtime audit-chain break requiring audit-repair (unrelated to these logic changes). (UNRELATED FAIL)
- Ran `python scripts/audit_immutability_verifier.py` which succeeded for the patch-level artifacts. (PASS)

If reviewers want, next steps are small: adjust thresholds or expand the external evidence window, and add stronger attestation/verification on receipts before treating them as high-confidence signals (kept out-of-scope for this bounded pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e13bdd8b488320b25d2b7cc1bc8314)