### PR TITLE
[codex:orchestration] add unified result-quality retrospective review

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -140,6 +140,15 @@ _ORCHESTRATION_VENUE_MIX_CLASSES = {
     "insufficient_history",
 }
 
+_UNIFIED_RESULT_QUALITY_REVIEW_CLASSES = {
+    "healthy_recent_results",
+    "issues_heavy",
+    "abandonment_or_decline_heavy",
+    "fragmentation_heavy",
+    "mixed_result_stress",
+    "insufficient_history",
+}
+
 _NEXT_VENUE_RECOMMENDATIONS = {
     "prefer_internal_execution",
     "prefer_codex_implementation",
@@ -1391,6 +1400,156 @@ def resolve_unified_orchestration_result_surface(
             diagnostic_only=True,
             does_not_change_admission_or_execution=True,
             additional_fields={"resolver_only": True},
+        ),
+    }
+
+
+def derive_unified_result_quality_review(
+    repo_root: Path,
+    *,
+    window_size: int = 10,
+    executor_log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Derive a compact retrospective quality classifier over recent unified orchestration results."""
+
+    unified_surface = resolve_unified_orchestration_result_surface(
+        repo_root,
+        window_size=window_size,
+        executor_log_path=executor_log_path,
+    )
+    records_considered = int(unified_surface.get("records_considered") or 0)
+    counts_raw = unified_surface.get("result_classification_counts")
+    counts_map = counts_raw if isinstance(counts_raw, Mapping) else {}
+    path_counts_raw = unified_surface.get("resolution_path_counts")
+    path_counts_map = path_counts_raw if isinstance(path_counts_raw, Mapping) else {}
+    fragmented_linkage_count = int(unified_surface.get("fragmented_linkage_count") or 0)
+
+    classification_counts = {name: int(counts_map.get(name) or 0) for name in _UNIFIED_RESULT_CLASSIFICATIONS}
+    resolution_path_counts = {name: int(path_counts_map.get(name) or 0) for name in _UNIFIED_RESULT_RESOLUTION_PATHS}
+
+    success_count = classification_counts["completed_successfully"]
+    issue_count = classification_counts["completed_with_issues"] + classification_counts["failed_after_execution"]
+    abandonment_count = classification_counts["declined_or_abandoned"]
+    fragmentation_count = classification_counts["fragmented_result_history"] + classification_counts["pending_or_unresolved"]
+    internal_count = resolution_path_counts["internal_execution"]
+    external_count = resolution_path_counts["external_fulfillment"]
+    path_total = internal_count + external_count
+
+    success_ratio = (success_count / records_considered) if records_considered else 0.0
+    issue_ratio = (issue_count / records_considered) if records_considered else 0.0
+    abandonment_ratio = (abandonment_count / records_considered) if records_considered else 0.0
+    fragmentation_ratio = (fragmentation_count / records_considered) if records_considered else 0.0
+    internal_ratio = (internal_count / path_total) if path_total else 0.0
+    external_ratio = (external_count / path_total) if path_total else 0.0
+
+    issue_heavy = issue_count >= 2 and issue_ratio >= 0.5
+    abandonment_heavy = abandonment_count >= 2 and abandonment_ratio >= 0.4
+    fragmentation_heavy = (fragmentation_count >= 2 and fragmentation_ratio >= 0.5) or (
+        fragmented_linkage_count >= 2 and fragmentation_ratio >= 0.4
+    )
+    stress_flag_count = sum(1 for flag in (issue_heavy, abandonment_heavy, fragmentation_heavy) if flag)
+    healthy_pattern = success_count >= 2 and success_ratio >= 0.6 and stress_flag_count == 0
+
+    classification = "insufficient_history"
+    if records_considered >= 3:
+        if stress_flag_count >= 2:
+            classification = "mixed_result_stress"
+        elif issue_heavy:
+            classification = "issues_heavy"
+        elif abandonment_heavy:
+            classification = "abandonment_or_decline_heavy"
+        elif fragmentation_heavy:
+            classification = "fragmentation_heavy"
+        elif healthy_pattern:
+            classification = "healthy_recent_results"
+        else:
+            classification = "mixed_result_stress"
+
+    if classification not in _UNIFIED_RESULT_QUALITY_REVIEW_CLASSES:
+        classification = "mixed_result_stress"
+
+    health_vs_stress = (
+        "healthy"
+        if classification == "healthy_recent_results"
+        else ("insufficient_evidence" if classification == "insufficient_history" else "stressed")
+    )
+
+    return {
+        "schema_version": "unified_result_quality_review.v1",
+        "review_kind": "unified_result_quality_retrospective",
+        "review_classification": classification,
+        "window_size": max(0, window_size),
+        "records_considered": records_considered,
+        "recent_unified_result_counts": classification_counts,
+        "recent_resolution_path_counts": resolution_path_counts,
+        "condition_flags": {
+            "issues_heavy": issue_heavy,
+            "abandonment_or_decline_heavy": abandonment_heavy,
+            "fragmentation_heavy": fragmentation_heavy,
+            "multiple_competing_stress_patterns": stress_flag_count >= 2,
+            "healthy_pattern": healthy_pattern,
+        },
+        "summary": {
+            "health_vs_stress": health_vs_stress,
+            "path_mix": {
+                "internal_execution_count": internal_count,
+                "external_fulfillment_count": external_count,
+                "internal_execution_ratio": round(internal_ratio, 4),
+                "external_fulfillment_ratio": round(external_ratio, 4),
+            },
+            "basis": {
+                "success_count": success_count,
+                "issue_count": issue_count,
+                "abandonment_or_decline_count": abandonment_count,
+                "fragmentation_or_unresolved_count": fragmentation_count,
+                "fragmented_linkage_count": fragmented_linkage_count,
+                "success_ratio": round(success_ratio, 4),
+                "issue_ratio": round(issue_ratio, 4),
+                "abandonment_or_decline_ratio": round(abandonment_ratio, 4),
+                "fragmentation_or_unresolved_ratio": round(fragmentation_ratio, 4),
+            },
+            "compact_reason": (
+                "recent unified results are mostly successful across available paths"
+                if classification == "healthy_recent_results"
+                else (
+                    "recent unified results show repeated issue/failure outcomes"
+                    if classification == "issues_heavy"
+                    else (
+                        "recent unified results show repeated decline/abandonment outcomes"
+                        if classification == "abandonment_or_decline_heavy"
+                        else (
+                            "recent unified results show repeated unresolved or fragmented closure"
+                            if classification == "fragmentation_heavy"
+                            else (
+                                "recent unified results show competing stress signatures"
+                                if classification == "mixed_result_stress"
+                                else "recent unified history is too small for a stable quality classification"
+                            )
+                        )
+                    )
+                )
+            ),
+            "boundaries": {
+                "review_only": True,
+                "diagnostic_only": True,
+                "decision_power": "none",
+                "non_authoritative": True,
+                "does_not_change_admission_or_execution_authority": True,
+                "does_not_add_or_invoke_any_new_venue": True,
+                "preserves_resolution_path_honesty": True,
+            },
+        },
+        "artifacts_read": {
+            "unified_result_surface": "resolve_unified_orchestration_result_surface",
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "does_not_change_admission_or_execution_authority": True,
+            },
         ),
     }
 

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -212,6 +212,36 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not create sovereign decision power",
             ],
         },
+        "unified_result_quality_review": {
+            "meaning": "bounded retrospective quality classification over recent unified orchestration results across internal and external resolution paths.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.derive_unified_result_quality_review",
+            "reads_from_unified_surface_only": [
+                "resolve_unified_orchestration_result_surface.result_classification_counts",
+                "resolve_unified_orchestration_result_surface.resolution_path_counts",
+                "resolve_unified_orchestration_result_surface.fragmented_linkage_count",
+                "unified result anti-sovereignty metadata already present in that surface",
+            ],
+            "classifications": [
+                "healthy_recent_results",
+                "issues_heavy",
+                "abandonment_or_decline_heavy",
+                "fragmentation_heavy",
+                "mixed_result_stress",
+                "insufficient_history",
+            ],
+            "preserves_internal_external_honesty": [
+                "uses one unified classification surface without forcing internal and external paths into fake equivalence",
+                "reports internal_execution vs external_fulfillment path mix directly in the summary basis",
+                "keeps external fulfillment explicitly receipt-based, not direct execution proof",
+            ],
+            "explicitly_not": [
+                "a new truth source",
+                "a new execution venue",
+                "admission or execution authority",
+                "direct external actuation",
+                "a sovereign decision layer",
+            ],
+        },
         "outcome_review": {
             "meaning": "bounded retrospective classification over recent internal orchestration outcomes, now with linked external fulfillment receipt influence for staged external venues.",
             "reads_existing_artifacts_only": [

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -22,6 +22,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_external_feedback_gap_map,
     derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
+    derive_unified_result_quality_review,
     derive_next_move_proposal_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
@@ -187,6 +188,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         handoff_packet=handoff_packet,
     )
     unified_result_surface = resolve_unified_orchestration_result_surface(root)
+    unified_result_quality_review = derive_unified_result_quality_review(root)
     next_move_proposal_review = derive_next_move_proposal_review(root)
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
@@ -235,6 +237,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "execution_result": orchestration_result,
             "unified_result": unified_result,
             "unified_result_surface": unified_result_surface,
+            "unified_result_quality_review": unified_result_quality_review,
             "outcome_review": orchestration_outcome_review,
             "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -22,6 +22,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_next_venue_recommendation,
     derive_next_move_proposal_review,
     derive_orchestration_outcome_review,
+    derive_unified_result_quality_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
     resolve_orchestration_result,
@@ -110,6 +111,39 @@ def _external_handoff_packet(
         created_at="2026-04-12T00:00:00Z",
     )
     return synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+
+
+def _mock_unified_surface(
+    monkeypatch,
+    *,
+    counts: dict[str, int],
+    path_counts: dict[str, int] | None = None,
+    records_considered: int | None = None,
+    fragmented_linkage_count: int = 0,
+) -> None:
+    base_counts = {
+        "completed_successfully": 0,
+        "completed_with_issues": 0,
+        "declined_or_abandoned": 0,
+        "failed_after_execution": 0,
+        "blocked_before_execution": 0,
+        "pending_or_unresolved": 0,
+        "fragmented_result_history": 0,
+    }
+    base_counts.update(counts)
+    base_paths = {"internal_execution": 0, "external_fulfillment": 0}
+    if path_counts:
+        base_paths.update(path_counts)
+    total = sum(base_counts.values()) if records_considered is None else records_considered
+    monkeypatch.setattr(
+        "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result_surface",
+        lambda *_args, **_kwargs: {
+            "records_considered": total,
+            "result_classification_counts": base_counts,
+            "resolution_path_counts": base_paths,
+            "fragmented_linkage_count": fragmented_linkage_count,
+        },
+    )
 
 
 def test_deep_research_judgment_translates_to_stageable_external_work_order() -> None:
@@ -2448,6 +2482,90 @@ def test_unified_result_honestly_represents_declined_and_pending_and_fragmented(
     assert fragmented["evidence_presence"]["fragmented_linkage"] is True
 
 
+def test_unified_result_quality_review_classifies_healthy_recent_results(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"completed_successfully": 4, "completed_with_issues": 1},
+        path_counts={"internal_execution": 3, "external_fulfillment": 2},
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "healthy_recent_results"
+    assert review["summary"]["health_vs_stress"] == "healthy"
+
+
+def test_unified_result_quality_review_classifies_issues_heavy(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"completed_with_issues": 2, "failed_after_execution": 2, "completed_successfully": 1},
+        path_counts={"internal_execution": 2, "external_fulfillment": 3},
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "issues_heavy"
+    assert review["condition_flags"]["issues_heavy"] is True
+
+
+def test_unified_result_quality_review_classifies_abandonment_or_decline_heavy(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"declined_or_abandoned": 3, "completed_successfully": 1},
+        path_counts={"internal_execution": 1, "external_fulfillment": 3},
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "abandonment_or_decline_heavy"
+    assert review["condition_flags"]["abandonment_or_decline_heavy"] is True
+
+
+def test_unified_result_quality_review_classifies_fragmentation_heavy(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"pending_or_unresolved": 2, "fragmented_result_history": 1, "completed_successfully": 1},
+        path_counts={"internal_execution": 2, "external_fulfillment": 2},
+        fragmented_linkage_count=2,
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "fragmentation_heavy"
+    assert review["condition_flags"]["fragmentation_heavy"] is True
+
+
+def test_unified_result_quality_review_classifies_mixed_result_stress(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"completed_with_issues": 2, "failed_after_execution": 1, "declined_or_abandoned": 2},
+        path_counts={"internal_execution": 2, "external_fulfillment": 3},
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "mixed_result_stress"
+    assert review["condition_flags"]["multiple_competing_stress_patterns"] is True
+
+
+def test_unified_result_quality_review_classifies_insufficient_history(monkeypatch, tmp_path: Path) -> None:
+    _mock_unified_surface(
+        monkeypatch,
+        counts={"completed_successfully": 1, "completed_with_issues": 1},
+        path_counts={"internal_execution": 1, "external_fulfillment": 1},
+        records_considered=2,
+    )
+    review = derive_unified_result_quality_review(tmp_path)
+    assert review["review_classification"] == "insufficient_history"
+    assert review["summary"]["health_vs_stress"] == "insufficient_evidence"
+
+
+def test_unified_result_quality_review_does_not_change_admission_behavior(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+
+    review = derive_unified_result_quality_review(tmp_path)
+
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert review["non_authoritative"] is True
+    assert review["decision_power"] == "none"
+    assert review["does_not_change_admission_or_execution"] is True
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
+
+
 def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     judgment = synthesize_delegated_judgment(_base_evidence())
     intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
@@ -2655,6 +2773,7 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert codex_diag is not None
     unified = second["orchestration_handoff"]["unified_result"]
     unified_surface = second["orchestration_handoff"]["unified_result_surface"]
+    unified_quality_review = second["orchestration_handoff"]["unified_result_quality_review"]
     outcome_review = second["orchestration_handoff"]["outcome_review"]
     venue_mix_review = second["orchestration_handoff"]["venue_mix_review"]
     next_venue = second["orchestration_handoff"]["next_venue_recommendation"]
@@ -2671,6 +2790,12 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert unified["path_honesty"]["does_not_imply_direct_repo_execution"] is True
     assert unified_surface["records_considered"] >= 1
     assert unified_surface["resolution_path_counts"]["external_fulfillment"] >= 1
+    assert unified_quality_review["review_kind"] == "unified_result_quality_retrospective"
+    assert unified_quality_review["recent_resolution_path_counts"]["external_fulfillment"] >= 1
+    assert unified_quality_review["diagnostic_only"] is True
+    assert unified_quality_review["non_authoritative"] is True
+    assert unified_quality_review["decision_power"] == "none"
+    assert unified_quality_review["summary"]["boundaries"]["preserves_resolution_path_honesty"] is True
     assert outcome_review["summary"]["external_fulfillment_influence"]["influenced_outcome_review"] is True
     assert venue_mix_review["summary"]["external_fulfillment_influence"]["influenced_venue_mix_review"] is True
     assert feedback_visibility["outcome_review"]["external_fulfillment_influencing"] is True


### PR DESCRIPTION
### Motivation

- Provide a small, bounded retrospective layer that classifies recent unified orchestration results for diagnostic hygiene across both internal and external resolution paths. 
- Keep the derivation conservative and venue-aware by using only the existing unified result surface and preserving internal/external path honesty.

### Description

- Added a compact unified result-quality classifier function `derive_unified_result_quality_review` that reads only `resolve_unified_orchestration_result_surface` outputs and returns one of: `healthy_recent_results`, `issues_heavy`, `abandonment_or_decline_heavy`, `fragmentation_heavy`, `mixed_result_stress`, or `insufficient_history`.
- Exposed a compact diagnostic `summary` with recent unified classification counts, internal vs external path counts, condition flags, a `health_vs_stress` indicator, and explicit non-sovereign/review-only boundaries in the review payload (all diagnostic-only and non-authoritative).
- Integrated the review into the scoped orchestration diagnostic consumer so `build_scoped_lifecycle_diagnostic` now returns `unified_result_quality_review` alongside existing surfaces, keeping no decision power or admission changes.
- Updated the orchestration note (`orchestration_intent_fabric_note`) with a short technical section describing the new review, the unified fields it reads, its classifications, how it preserves path honesty, and explicit non-goals.
- Added focused tests and a small test helper `_mock_unified_surface` that assert the six required classification outcomes, ensure consumer coherence (internal+external path visibility), and confirm the review remains non-authoritative.

### Testing

- Ran targeted unit tests: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "unified_result_quality_review or staged_to_external_fulfillment_receipt_to_diagnostic_visibility"` and the added tests passed. 
- Verified `python scripts/audit_immutability_verifier.py` passed (artifact-dependent check) in this environment. 
- Ran `python -m scripts.run_tests -q` which surfaced unrelated, pre-existing failures in federation tests (`tests/test_pulse_federation.py`) that are outside this change and did not originate from the additions here. 
- Ran `mypy scripts/ sentientos/` which reports pre-existing repository-wide typing errors unrelated to this patch. 

This change is diagnostic-only, preserves venue/path honesty, and does not alter admission/execution authority or add any new venues or external actuation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2c7dbeaa8832085f187f36dbecc86)