### PR TITLE
[codex:orchestration] add bounded trust confidence posture diagnostic

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -192,6 +192,25 @@ _NEXT_MOVE_PROPOSAL_REVIEW_CLASSES = {
     "insufficient_history",
 }
 
+_ORCHESTRATION_TRUST_POSTURES = {
+    "trusted_for_bounded_use",
+    "caution_required",
+    "stressed_but_usable",
+    "fragmented_or_unreliable",
+    "insufficient_history",
+}
+
+_ORCHESTRATION_TRUST_PRESSURE_KINDS = {
+    "none",
+    "proposal_stress",
+    "venue_stress",
+    "result_quality_stress",
+    "escalation_operator_dependence",
+    "fragmentation",
+    "mixed_stress",
+    "insufficient_history",
+}
+
 _HANDOFF_PACKET_STATUSES = {
     "prepared",
     "blocked_operator_required",
@@ -2927,6 +2946,196 @@ def derive_next_move_proposal_review(
                 "decision_power": "none",
                 "non_authoritative": True,
                 "diagnostic_only": True,
+            },
+        ),
+    }
+
+
+def derive_orchestration_trust_confidence_posture(
+    next_move_proposal_review: Mapping[str, Any],
+    venue_mix_review: Mapping[str, Any],
+    outcome_review: Mapping[str, Any],
+    unified_result_quality_review: Mapping[str, Any],
+    operator_attention_recommendation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Derive one compact orchestration trust/confidence posture from existing review surfaces only.
+
+    This is diagnostic-only and never grants authority, admission, or execution power.
+    """
+
+    proposal_classification = str(next_move_proposal_review.get("review_classification") or "insufficient_history")
+    venue_classification = str(venue_mix_review.get("review_classification") or "insufficient_history")
+    outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    result_quality_classification = str(unified_result_quality_review.get("review_classification") or "insufficient_history")
+    attention = str(operator_attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
+
+    records_counts = {
+        "next_move_proposal_review": int(next_move_proposal_review.get("records_considered") or 0),
+        "orchestration_venue_mix_review": int(venue_mix_review.get("records_considered") or 0),
+        "orchestration_outcome_review": int(outcome_review.get("records_considered") or 0),
+        "unified_result_quality_review": int(unified_result_quality_review.get("records_considered") or 0),
+    }
+    minimum_records = min(records_counts.values()) if records_counts else 0
+    insufficient_history = minimum_records < 3
+
+    proposal_stress = proposal_classification in {
+        "proposal_escalation_heavy",
+        "proposal_hold_heavy",
+        "proposal_insufficient_context_heavy",
+        "proposal_venue_thrash",
+        "mixed_proposal_stress",
+    }
+    proposal_coherent = proposal_classification == "coherent_recent_proposals"
+
+    venue_stress = venue_classification in {
+        "operator_escalation_heavy",
+        "mixed_venue_stress",
+    }
+    venue_balanced = venue_classification == "balanced_recent_venue_mix"
+
+    result_quality_stress = result_quality_classification in {
+        "issues_heavy",
+        "abandonment_or_decline_heavy",
+        "mixed_result_stress",
+    }
+    result_quality_healthy = result_quality_classification == "healthy_recent_results"
+
+    fragmentation_flag = (
+        result_quality_classification == "fragmentation_heavy"
+        or outcome_classification == "mixed_orchestration_stress"
+        and bool((outcome_review.get("condition_flags") or {}).get("external_stress_heavy"))
+        and bool((unified_result_quality_review.get("condition_flags") or {}).get("fragmentation_heavy"))
+    )
+    outcome_stressed = outcome_classification in {
+        "handoff_block_heavy",
+        "execution_failure_heavy",
+        "pending_stall_pattern",
+        "mixed_orchestration_stress",
+    }
+    escalation_operator_dependence = (
+        attention in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall", "insufficient_context"}
+        or proposal_classification == "proposal_escalation_heavy"
+        or venue_classification == "operator_escalation_heavy"
+    )
+
+    stress_components = {
+        "proposal_stress": proposal_stress,
+        "venue_stress": venue_stress,
+        "result_quality_stress": result_quality_stress or outcome_stressed,
+        "escalation_operator_dependence": escalation_operator_dependence,
+        "fragmentation": fragmentation_flag,
+    }
+    stress_count = sum(1 for active in stress_components.values() if active)
+    major_stress_count = sum(
+        1
+        for active in (
+            proposal_stress,
+            venue_stress,
+            result_quality_stress,
+            fragmentation_flag,
+        )
+        if active
+    )
+
+    posture = "insufficient_history"
+    compact_reason = "insufficient_recent_review_history_for_conservative_trust_posture"
+    primary_pressure = "insufficient_history"
+
+    if insufficient_history:
+        posture = "insufficient_history"
+        compact_reason = "insufficient_recent_review_history_for_conservative_trust_posture"
+        primary_pressure = "insufficient_history"
+    elif fragmentation_flag:
+        posture = "fragmented_or_unreliable"
+        compact_reason = "fragmentation_or_unreliable_linkage_signals_dominate_recent_orchestration_reviews"
+        primary_pressure = "fragmentation"
+    elif major_stress_count >= 3:
+        posture = "fragmented_or_unreliable"
+        compact_reason = "multiple_major_stress_signals_converge_across_proposal_venue_outcome_and_result_quality_reviews"
+        primary_pressure = "mixed_stress"
+    elif proposal_coherent and venue_balanced and result_quality_healthy and not escalation_operator_dependence:
+        posture = "trusted_for_bounded_use"
+        compact_reason = "recent_proposals_venues_and_unified_results_are_coherent_with_low_operator_dependence"
+        primary_pressure = "none"
+    elif stress_count >= 2:
+        posture = "stressed_but_usable"
+        compact_reason = "repeated_stress_patterns_present_but_recent_orchestration_remains_interpretable_for_bounded_use"
+        primary_pressure = "mixed_stress"
+    elif stress_count == 1 or outcome_classification in {"mixed_orchestration_stress", "handoff_block_heavy"}:
+        posture = "caution_required"
+        compact_reason = "some_stress_present_but_loop_remains_coherent_enough_for_conservative_bounded_use"
+        if proposal_stress:
+            primary_pressure = "proposal_stress"
+        elif venue_stress:
+            primary_pressure = "venue_stress"
+        elif result_quality_stress or outcome_stressed:
+            primary_pressure = "result_quality_stress"
+        elif escalation_operator_dependence:
+            primary_pressure = "escalation_operator_dependence"
+        else:
+            primary_pressure = "mixed_stress"
+    else:
+        posture = "caution_required"
+        compact_reason = "review_mix_is_non_fragmented_but_not_clean_enough_for_trusted_posture"
+        primary_pressure = "mixed_stress"
+
+    if posture not in _ORCHESTRATION_TRUST_POSTURES:
+        posture = "caution_required"
+    if primary_pressure not in _ORCHESTRATION_TRUST_PRESSURE_KINDS:
+        primary_pressure = "mixed_stress"
+
+    return {
+        "schema_version": "orchestration_trust_confidence_posture.v1",
+        "review_kind": "orchestration_trust_confidence_diagnostic",
+        "trust_confidence_posture": posture,
+        "window_considered": {
+            "records_considered_by_review": records_counts,
+            "minimum_records_considered": minimum_records,
+        },
+        "contributing_reviews": {
+            "next_move_proposal_review": {
+                "review_classification": proposal_classification,
+                "records_considered": records_counts["next_move_proposal_review"],
+            },
+            "orchestration_venue_mix_review": {
+                "review_classification": venue_classification,
+                "records_considered": records_counts["orchestration_venue_mix_review"],
+            },
+            "orchestration_outcome_review": {
+                "review_classification": outcome_classification,
+                "records_considered": records_counts["orchestration_outcome_review"],
+            },
+            "unified_result_quality_review": {
+                "review_classification": result_quality_classification,
+                "records_considered": records_counts["unified_result_quality_review"],
+            },
+            "operator_attention_recommendation": attention,
+        },
+        "pressure_summary": {
+            "primary_pressure": primary_pressure,
+            "stress_components": stress_components,
+            "compact_basis": compact_reason,
+        },
+        "summary": {
+            "diagnostic_summary": "bounded trust/confidence posture derived from existing orchestration review signals only",
+            "derived_from_existing_reviews_only": [
+                "next_move_proposal_review",
+                "orchestration_venue_mix_review",
+                "orchestration_outcome_review",
+                "unified_result_quality_review",
+                "orchestration_operator_attention_recommendation",
+            ],
+            "compact_rationale": compact_reason,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "decision_power": "none",
+                "non_authoritative": True,
             },
         ),
     }

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -350,6 +350,37 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "a sovereign decision surface",
             ],
         },
+        "orchestration_trust_confidence_posture": {
+            "meaning": "compact diagnostic posture summarizing how trustworthy recent bounded orchestration behavior is for continued delegated bounded use.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.derive_orchestration_trust_confidence_posture",
+            "derived_from_existing_review_signals_only": [
+                "next_move_proposal_review",
+                "orchestration_venue_mix_review",
+                "orchestration_outcome_review",
+                "unified_result_quality_review",
+                "orchestration_operator_attention_recommendation",
+            ],
+            "values": [
+                "trusted_for_bounded_use",
+                "caution_required",
+                "stressed_but_usable",
+                "fragmented_or_unreliable",
+                "insufficient_history",
+            ],
+            "summary_surface": [
+                "contributing review classes",
+                "primary pressure category (proposal/venue/result-quality/escalation/fragmentation)",
+                "compact rationale",
+                "diagnostic_only and non_authoritative boundaries",
+            ],
+            "explicitly_not": [
+                "admission authority",
+                "execution authority",
+                "release-readiness override",
+                "a sovereign planner",
+                "direct external actuation",
+            ],
+        },
         "venues_still_staged_only": [
             "codex_implementation",
             "deep_research_audit",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -20,6 +20,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_external_feedback_gap_map,
+    derive_orchestration_trust_confidence_posture,
     derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
     derive_unified_result_quality_review,
@@ -190,6 +191,22 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     unified_result_surface = resolve_unified_orchestration_result_surface(root)
     unified_result_quality_review = derive_unified_result_quality_review(root)
     next_move_proposal_review = derive_next_move_proposal_review(root)
+    orchestration_trust_confidence_posture = derive_orchestration_trust_confidence_posture(
+        next_move_proposal_review,
+        orchestration_venue_mix_review,
+        orchestration_outcome_review,
+        unified_result_quality_review,
+        orchestration_attention_recommendation,
+    )
+    substitution_readiness = dict(delegated_judgment.get("orchestration_substitution_readiness") or {})
+    substitution_readiness["trust_confidence_basis"] = {
+        "orchestration_trust_confidence_posture": str(
+            orchestration_trust_confidence_posture.get("trust_confidence_posture") or "insufficient_history"
+        ),
+        "diagnostic_only": True,
+        "review_only": True,
+        "does_not_change_existing_readiness_logic": True,
+    }
     codex_staged_venue = _staged_external_venue_diagnostic(
         root,
         orchestration_intent,
@@ -226,7 +243,10 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         "slice_stability": slice_stability,
         "slice_retrospective_integrity_review": retrospective_integrity_review,
         "slice_operator_attention_recommendation": operator_attention_recommendation,
-        "delegated_judgment": delegated_judgment,
+        "delegated_judgment": {
+            **delegated_judgment,
+            "orchestration_substitution_readiness": substitution_readiness,
+        },
         "orchestration_handoff": {
             "gap_map": build_handoff_execution_gap_map(root),
             "split_closure_map": build_split_closure_map(),
@@ -254,6 +274,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
             },
             "next_move_proposal_review": next_move_proposal_review,
+            "trust_confidence_posture": orchestration_trust_confidence_posture,
             "handoff_packet": {
                 **handoff_packet,
                 "ledger_path": str(handoff_packet_ledger_path.relative_to(root)),

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -22,6 +22,7 @@ from sentientos.orchestration_intent_fabric import (
     derive_next_venue_recommendation,
     derive_next_move_proposal_review,
     derive_orchestration_outcome_review,
+    derive_orchestration_trust_confidence_posture,
     derive_unified_result_quality_review,
     derive_orchestration_venue_mix_review,
     executable_handoff_map,
@@ -2566,6 +2567,70 @@ def test_unified_result_quality_review_does_not_change_admission_behavior(tmp_pa
     assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 
 
+def test_orchestration_trust_confidence_classifies_trusted_for_bounded_use() -> None:
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "coherent_recent_proposals", "records_considered": 6},
+        {"review_classification": "balanced_recent_venue_mix", "records_considered": 6},
+        {"review_classification": "clean_recent_orchestration", "records_considered": 6, "condition_flags": {}},
+        {"review_classification": "healthy_recent_results", "records_considered": 6, "condition_flags": {}},
+        {"operator_attention_recommendation": "observe"},
+    )
+    assert posture["trust_confidence_posture"] == "trusted_for_bounded_use"
+    assert posture["pressure_summary"]["primary_pressure"] == "none"
+
+
+def test_orchestration_trust_confidence_classifies_caution_required() -> None:
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "coherent_recent_proposals", "records_considered": 5},
+        {"review_classification": "balanced_recent_venue_mix", "records_considered": 5},
+        {"review_classification": "clean_recent_orchestration", "records_considered": 5, "condition_flags": {}},
+        {"review_classification": "mixed_result_stress", "records_considered": 5, "condition_flags": {}},
+        {"operator_attention_recommendation": "observe"},
+    )
+    assert posture["trust_confidence_posture"] == "caution_required"
+    assert posture["pressure_summary"]["stress_components"]["result_quality_stress"] is True
+
+
+def test_orchestration_trust_confidence_classifies_stressed_but_usable() -> None:
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "proposal_escalation_heavy", "records_considered": 6},
+        {"review_classification": "mixed_venue_stress", "records_considered": 6},
+        {"review_classification": "clean_recent_orchestration", "records_considered": 6, "condition_flags": {}},
+        {"review_classification": "healthy_recent_results", "records_considered": 6, "condition_flags": {}},
+        {"operator_attention_recommendation": "observe"},
+    )
+    assert posture["trust_confidence_posture"] == "stressed_but_usable"
+    assert posture["pressure_summary"]["primary_pressure"] == "mixed_stress"
+
+
+def test_orchestration_trust_confidence_classifies_fragmented_or_unreliable() -> None:
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "mixed_proposal_stress", "records_considered": 7},
+        {"review_classification": "mixed_venue_stress", "records_considered": 7},
+        {
+            "review_classification": "mixed_orchestration_stress",
+            "records_considered": 7,
+            "condition_flags": {"external_stress_heavy": True},
+        },
+        {"review_classification": "fragmentation_heavy", "records_considered": 7, "condition_flags": {"fragmentation_heavy": True}},
+        {"operator_attention_recommendation": "inspect_handoff_blocks"},
+    )
+    assert posture["trust_confidence_posture"] == "fragmented_or_unreliable"
+    assert posture["pressure_summary"]["primary_pressure"] == "fragmentation"
+
+
+def test_orchestration_trust_confidence_classifies_insufficient_history() -> None:
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "coherent_recent_proposals", "records_considered": 2},
+        {"review_classification": "balanced_recent_venue_mix", "records_considered": 2},
+        {"review_classification": "clean_recent_orchestration", "records_considered": 2},
+        {"review_classification": "healthy_recent_results", "records_considered": 2},
+        {"operator_attention_recommendation": "none"},
+    )
+    assert posture["trust_confidence_posture"] == "insufficient_history"
+    assert posture["pressure_summary"]["primary_pressure"] == "insufficient_history"
+
+
 def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     judgment = synthesize_delegated_judgment(_base_evidence())
     intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
@@ -2798,10 +2863,38 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert unified_quality_review["summary"]["boundaries"]["preserves_resolution_path_honesty"] is True
     assert outcome_review["summary"]["external_fulfillment_influence"]["influenced_outcome_review"] is True
     assert venue_mix_review["summary"]["external_fulfillment_influence"]["influenced_venue_mix_review"] is True
+    trust_posture = second["orchestration_handoff"]["trust_confidence_posture"]
+    assert trust_posture["schema_version"] == "orchestration_trust_confidence_posture.v1"
+    assert trust_posture["diagnostic_only"] is True
+    assert trust_posture["non_authoritative"] is True
+    assert trust_posture["decision_power"] == "none"
     assert feedback_visibility["outcome_review"]["external_fulfillment_influencing"] is True
     assert feedback_visibility["venue_mix_review"]["external_fulfillment_influencing"] is True
     assert next_venue["relation_to_delegated_judgment"] == "affirming"
     assert feedback_visibility["non_authoritative"] is True
+    readiness_basis = second["delegated_judgment"]["orchestration_substitution_readiness"]["trust_confidence_basis"]
+    assert readiness_basis["orchestration_trust_confidence_posture"] == trust_posture["trust_confidence_posture"]
+    assert readiness_basis["does_not_change_existing_readiness_logic"] is True
+
+
+def test_orchestration_trust_confidence_posture_does_not_change_admission_behavior(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    posture = derive_orchestration_trust_confidence_posture(
+        {"review_classification": "mixed_proposal_stress", "records_considered": 5},
+        {"review_classification": "mixed_venue_stress", "records_considered": 5},
+        {"review_classification": "mixed_orchestration_stress", "records_considered": 5, "condition_flags": {}},
+        {"review_classification": "mixed_result_stress", "records_considered": 5, "condition_flags": {}},
+        {"operator_attention_recommendation": "inspect_execution_failures"},
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert posture["review_only"] is True
+    assert posture["diagnostic_only"] is True
+    assert posture["decision_power"] == "none"
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 
 
 def test_external_feedback_gap_map_reports_layer_influence_coherently() -> None:


### PR DESCRIPTION
### Motivation
- Provide a compact, machine-readable diagnostic that summarizes how much the bounded orchestration loop can currently be trusted for conservative delegated use without introducing any authority or execution surface.
- Derive the posture only from existing orchestration review signals (proposal review, venue-mix review, outcome review, unified result-quality review, operator-attention recommendation) and remain explicitly non-sovereign and diagnostic-only.

### Description
- Add compact posture vocabulary and pressure kinds in `sentientos/orchestration_intent_fabric.py` and implement `derive_orchestration_trust_confidence_posture(...)` which fuses only existing review surfaces into one conservative posture classifier returning `schema_version: "orchestration_trust_confidence_posture.v1"` and a compact rationale payload.
- Integrate the posture into the scoped diagnostic consumer by surfacing `trust_confidence_posture` in the `orchestration_handoff` block and adding a minimal `orchestration_substitution_readiness.trust_confidence_basis` entry without changing existing readiness logic in `sentientos/scoped_lifecycle_diagnostic.py`.
- Update orchestration documentation note `sentientos/orchestration_intent_fabric_note.py` to briefly describe the posture meaning, inputs, allowed values, summary surface, and explicit non-goals (no admission/exec authority, no actuation, non-sovereign).
- Add focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` that assert mapping from review signals → posture for `trusted_for_bounded_use`, `caution_required`, `stressed_but_usable`, `fragmented_or_unreliable`, and `insufficient_history`, plus consumer surfacing and non-authority/non-admission regression checks.
- Preserve explicit anti-sovereignty metadata (`diagnostic_only`, `review_only`, `decision_power: none`, `non_authoritative`) and do not introduce new venues, external actuation, or authority surfaces.

### Testing
- Ran targeted tests: `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py -k "trust_confidence or end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibility"` which passed (7 tests, all passed).
- Ran full file tests: `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py` which passed (100 tests, all passed).
- Focused unit tests exercise each required posture classification and verify the posture is surfaced in the diagnostic consumer and remains non-authoritative; all added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e31e8ddd888320943b5f1b2f7be084)