### PR TITLE
[codex:orchestration] add bounded packetization trust gate

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -200,6 +200,15 @@ _ORCHESTRATION_TRUST_POSTURES = {
     "insufficient_history",
 }
 
+_PACKETIZATION_GATING_OUTCOMES = {
+    "packetization_allowed",
+    "packetization_allowed_with_caution",
+    "packetization_hold_operator_review",
+    "packetization_hold_insufficient_confidence",
+    "packetization_hold_fragmentation",
+    "packetization_hold_escalation_required",
+}
+
 _ORCHESTRATION_TRUST_PRESSURE_KINDS = {
     "none",
     "proposal_stress",
@@ -2475,15 +2484,163 @@ def append_next_move_proposal_ledger(repo_root: Path, proposal: Mapping[str, Any
     return ledger_path
 
 
+def derive_packetization_gate(
+    next_move_proposal: Mapping[str, Any],
+    next_move_proposal_review: Mapping[str, Any],
+    trust_confidence_posture: Mapping[str, Any],
+    operator_attention_recommendation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Derive one bounded packetization gate from existing orchestration-only signals.
+
+    This gate is non-sovereign and only governs whether packet preparation is ready vs held.
+    """
+
+    proposed_action = next_move_proposal.get("proposed_next_action")
+    proposed_action_map = proposed_action if isinstance(proposed_action, Mapping) else {}
+    operator_state_raw = next_move_proposal.get("operator_escalation_requirement_state")
+    operator_state = operator_state_raw if isinstance(operator_state_raw, Mapping) else {}
+    trust_pressure_raw = trust_confidence_posture.get("pressure_summary")
+    trust_pressure = trust_pressure_raw if isinstance(trust_pressure_raw, Mapping) else {}
+
+    posture = str(trust_confidence_posture.get("trust_confidence_posture") or "insufficient_history")
+    proposal_review_classification = str(next_move_proposal_review.get("review_classification") or "insufficient_history")
+    attention_signal = str(
+        operator_attention_recommendation.get("operator_attention_recommendation")
+        or operator_state.get("attention_signal")
+        or "insufficient_context"
+    )
+    executability = str(next_move_proposal.get("executability_classification") or "blocked_insufficient_context")
+    relation_posture = str(next_move_proposal.get("relation_posture") or "insufficient_context")
+    proposed_posture = str(proposed_action_map.get("proposed_posture") or "hold")
+    requires_operator = bool(operator_state.get("requires_operator_or_escalation"))
+    escalation_classification = str(operator_state.get("escalation_classification") or "")
+    trust_primary_pressure = str(trust_pressure.get("primary_pressure") or "insufficient_history")
+
+    hold_operator_required = (
+        requires_operator
+        or executability == "blocked_operator_required"
+        or escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
+        or attention_signal in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall"}
+    )
+    hold_fragmentation = posture == "fragmented_or_unreliable" or trust_primary_pressure == "fragmentation"
+    hold_insufficient_confidence = (
+        posture == "insufficient_history"
+        or executability == "blocked_insufficient_context"
+        or relation_posture == "insufficient_context"
+        or proposal_review_classification in {"proposal_insufficient_context_heavy", "insufficient_history"}
+        or attention_signal == "insufficient_context"
+    )
+    mixed_stress_signals = (
+        posture == "stressed_but_usable"
+        or proposal_review_classification in {"mixed_proposal_stress", "proposal_venue_thrash", "proposal_escalation_heavy"}
+        or attention_signal == "review_mixed_orchestration_stress"
+        or trust_primary_pressure in {"mixed_stress", "result_quality_stress", "escalation_operator_dependence"}
+    )
+    coherent_execution_ready = (
+        executability in {"executable_now", "stageable_external_work_order"}
+        and relation_posture in {"affirming", "nudging"}
+        and proposed_posture in {"expand", "consolidate", "audit"}
+        and proposal_review_classification == "coherent_recent_proposals"
+    )
+
+    outcome = "packetization_hold_insufficient_confidence"
+    compact_rationale = "insufficient_confidence_or_context_requires_conservative_packetization_hold"
+
+    if hold_operator_required:
+        outcome = "packetization_hold_operator_review"
+        compact_rationale = "operator_or_escalation_requirement_is_active_so_packetization_is_held"
+    elif hold_fragmentation:
+        outcome = "packetization_hold_fragmentation"
+        compact_rationale = "trust_posture_is_fragmented_or_unreliable_so_packetization_is_held"
+    elif hold_insufficient_confidence:
+        outcome = "packetization_hold_insufficient_confidence"
+        compact_rationale = "insufficient_history_or_context_prevents_confident_packetization"
+    elif posture == "trusted_for_bounded_use" and coherent_execution_ready:
+        outcome = "packetization_allowed"
+        compact_rationale = "trusted_posture_with_coherent_proposal_allows_bounded_packetization"
+    elif posture in {"caution_required", "stressed_but_usable"} and coherent_execution_ready and mixed_stress_signals:
+        outcome = "packetization_allowed_with_caution"
+        compact_rationale = "stress_is_present_but_coherence_is_sufficient_for_cautious_bounded_packetization"
+    elif posture == "stressed_but_usable" and mixed_stress_signals:
+        outcome = "packetization_hold_escalation_required"
+        compact_rationale = "stressed_posture_with_mixed_signals_requires_conservative_escalation_hold"
+    elif posture == "caution_required" and coherent_execution_ready:
+        outcome = "packetization_allowed_with_caution"
+        compact_rationale = "caution_posture_keeps_packetization_allowed_but_explicitly_bounded"
+    elif mixed_stress_signals:
+        outcome = "packetization_hold_escalation_required"
+        compact_rationale = "mixed_stress_signals_require_escalation_before_packetization"
+
+    if outcome not in _PACKETIZATION_GATING_OUTCOMES:
+        outcome = "packetization_hold_insufficient_confidence"
+        compact_rationale = "unrecognized_gate_outcome_defaulted_to_conservative_hold"
+
+    held = outcome.startswith("packetization_hold_")
+    return {
+        "schema_version": "orchestration_packetization_gate.v1",
+        "gate_kind": "next_move_packetization_gate",
+        "packetization_outcome": outcome,
+        "packetization_allowed": not held,
+        "packetization_held": held,
+        "summary": {
+            "compact_rationale": compact_rationale,
+            "signals_used": [
+                "orchestration_trust_confidence_posture",
+                "next_move_proposal",
+                "next_move_proposal_review",
+                "orchestration_operator_attention_recommendation",
+                "next_move_proposal.operator_escalation_requirement_state",
+            ],
+            "affects_only": [
+                "next_move_proposal_to_handoff_packet_preparation",
+                "packet_ready_vs_hold_marking",
+            ],
+            "explicitly_not": [
+                "direct_execution_authority",
+                "admission_policy_override",
+                "venue_recommendation_rewrite",
+                "sovereign_planning",
+            ],
+        },
+        "signal_snapshot": {
+            "trust_confidence_posture": posture,
+            "proposal_review_classification": proposal_review_classification,
+            "operator_attention_recommendation": attention_signal,
+            "executability_classification": executability,
+            "relation_posture": relation_posture,
+            "proposed_posture": proposed_posture,
+            "requires_operator_or_escalation": requires_operator,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "gate_only": True,
+                "packetization_stage_only": True,
+                "does_not_execute_or_route_work": True,
+                "non_authoritative": True,
+            },
+        ),
+    }
+
+
 def synthesize_handoff_packet(
     next_move_proposal: Mapping[str, Any],
     delegated_judgment: Mapping[str, Any],
+    next_move_proposal_review: Mapping[str, Any] | None = None,
+    trust_confidence_posture: Mapping[str, Any] | None = None,
+    operator_attention_recommendation: Mapping[str, Any] | None = None,
     *,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     """Derive a compact venue-specific handoff packet from existing bounded orchestration signals."""
 
     proposal_ref = next_move_proposal
+    proposal_review_map = next_move_proposal_review if isinstance(next_move_proposal_review, Mapping) else {}
+    trust_posture_map = trust_confidence_posture if isinstance(trust_confidence_posture, Mapping) else {}
+    attention_map = operator_attention_recommendation if isinstance(operator_attention_recommendation, Mapping) else {}
     proposed_action = proposal_ref.get("proposed_next_action")
     proposed_action_map = proposed_action if isinstance(proposed_action, Mapping) else {}
     operator_state_raw = proposal_ref.get("operator_escalation_requirement_state")
@@ -2524,6 +2681,74 @@ def synthesize_handoff_packet(
     if status not in _HANDOFF_PACKET_STATUSES:
         status = "blocked_insufficient_context"
         readiness["blocked"] = True
+
+    if proposal_review_map or trust_posture_map or attention_map:
+        packetization_gate = derive_packetization_gate(
+            proposal_ref,
+            proposal_review_map,
+            trust_posture_map,
+            attention_map,
+        )
+    else:
+        legacy_outcome = (
+            "packetization_hold_operator_review"
+            if status == "blocked_operator_required"
+            else "packetization_hold_insufficient_confidence"
+            if status == "blocked_insufficient_context"
+            else "packetization_allowed"
+        )
+        packetization_gate = {
+            "schema_version": "orchestration_packetization_gate.v1",
+            "gate_kind": "next_move_packetization_gate",
+            "packetization_outcome": legacy_outcome,
+            "packetization_allowed": not legacy_outcome.startswith("packetization_hold_"),
+            "packetization_held": legacy_outcome.startswith("packetization_hold_"),
+            "summary": {
+                "compact_rationale": "legacy_packetization_path_without_review_inputs_preserves_existing_status_mapping",
+                "signals_used": ["next_move_proposal.executability_classification"],
+                "affects_only": [
+                    "next_move_proposal_to_handoff_packet_preparation",
+                    "packet_ready_vs_hold_marking",
+                ],
+                "explicitly_not": [
+                    "direct_execution_authority",
+                    "admission_policy_override",
+                    "venue_recommendation_rewrite",
+                    "sovereign_planning",
+                ],
+            },
+            "signal_snapshot": {
+                "trust_confidence_posture": "unprovided",
+                "proposal_review_classification": "unprovided",
+                "operator_attention_recommendation": "unprovided",
+                "executability_classification": executability,
+                "relation_posture": str(proposal_ref.get("relation_posture") or "insufficient_context"),
+                "proposed_posture": proposed_posture,
+                "requires_operator_or_escalation": requires_operator,
+            },
+            **_anti_sovereignty_payload(
+                recommendation_only=True,
+                diagnostic_only=True,
+                does_not_change_admission_or_execution=True,
+                additional_fields={
+                    "gate_only": True,
+                    "packetization_stage_only": True,
+                    "does_not_execute_or_route_work": True,
+                    "non_authoritative": True,
+                },
+            ),
+        }
+    gate_outcome = str(packetization_gate.get("packetization_outcome") or "packetization_hold_insufficient_confidence")
+    if gate_outcome.startswith("packetization_hold_"):
+        status = (
+            "blocked_operator_required"
+            if gate_outcome in {"packetization_hold_operator_review", "packetization_hold_escalation_required"}
+            else "blocked_insufficient_context"
+        )
+        readiness["blocked"] = True
+        readiness["ready_for_internal_trigger"] = False
+        readiness["ready_for_external_trigger"] = False
+        readiness["staged_only"] = False
 
     common_payload = {
         "target_venue": target_venue,
@@ -2601,6 +2826,7 @@ def synthesize_handoff_packet(
         "artifact_references": _handoff_evidence_pointers(delegated_judgment),
         "packet_status": status,
         "readiness": readiness,
+        "packetization_gate": packetization_gate,
         "venue_payload": venue_payload,
         **_anti_sovereignty_payload(
             recommendation_only=True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -381,6 +381,40 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "direct external actuation",
             ],
         },
+        "packetization_gating": {
+            "meaning": "bounded constitutional gate deciding whether a next-move proposal can be packetized now, packetized with caution, or held for explicit reasons.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.derive_packetization_gate",
+            "applies_only_to": [
+                "next_move_proposal_to_handoff_packet_preparation",
+                "handoff_packet_ready_vs_hold_marking",
+            ],
+            "derived_from_existing_signals_only": [
+                "orchestration_trust_confidence_posture",
+                "next_move_proposal",
+                "next_move_proposal_review",
+                "orchestration_operator_attention_recommendation",
+                "next_move_proposal.operator_escalation_requirement_state",
+            ],
+            "outcomes": [
+                "packetization_allowed",
+                "packetization_allowed_with_caution",
+                "packetization_hold_operator_review",
+                "packetization_hold_insufficient_confidence",
+                "packetization_hold_fragmentation",
+                "packetization_hold_escalation_required",
+            ],
+            "how_it_differs": {
+                "from_delegated_judgment": "delegated judgment recommends venue/posture; packetization gate only constrains packet staging readiness",
+                "from_next_move_proposal": "proposal describes suggested next action; packetization gate decides if packaging that suggestion is presently permitted",
+                "from_handoff_packet": "handoff packet carries staged payload; packetization gate is the bounded readiness/hold discipline embedded into that packet",
+            },
+            "explicitly_not": [
+                "direct execution authority",
+                "admission override",
+                "venue recommendation override",
+                "a sovereign planner",
+            ],
+        },
         "venues_still_staged_only": [
             "codex_implementation",
             "deep_research_audit",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -19,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     build_split_closure_map,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_packetization_gate,
     derive_external_feedback_gap_map,
     derive_orchestration_trust_confidence_posture,
     derive_next_venue_recommendation,
@@ -181,14 +182,6 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         orchestration_attention_recommendation,
     )
     next_move_proposal_ledger_path = append_next_move_proposal_ledger(root, next_move_proposal)
-    handoff_packet = synthesize_handoff_packet(next_move_proposal, delegated_judgment)
-    handoff_packet_ledger_path = append_handoff_packet_ledger(root, handoff_packet)
-    unified_result = resolve_unified_orchestration_result(
-        root,
-        handoff=handoff_result,
-        handoff_packet=handoff_packet,
-    )
-    unified_result_surface = resolve_unified_orchestration_result_surface(root)
     unified_result_quality_review = derive_unified_result_quality_review(root)
     next_move_proposal_review = derive_next_move_proposal_review(root)
     orchestration_trust_confidence_posture = derive_orchestration_trust_confidence_posture(
@@ -198,6 +191,23 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         unified_result_quality_review,
         orchestration_attention_recommendation,
     )
+    packetization_gate = derive_packetization_gate(
+        next_move_proposal,
+        next_move_proposal_review,
+        orchestration_trust_confidence_posture,
+        orchestration_attention_recommendation,
+    )
+    handoff_packet = synthesize_handoff_packet(
+        next_move_proposal,
+        delegated_judgment,
+        next_move_proposal_review,
+        orchestration_trust_confidence_posture,
+        orchestration_attention_recommendation,
+    )
+    handoff_packet_ledger_path = append_handoff_packet_ledger(root, handoff_packet)
+    unified_result = resolve_unified_orchestration_result(root, handoff=handoff_result, handoff_packet=handoff_packet)
+    unified_result_surface = resolve_unified_orchestration_result_surface(root)
+    unified_result_quality_review = derive_unified_result_quality_review(root)
     substitution_readiness = dict(delegated_judgment.get("orchestration_substitution_readiness") or {})
     substitution_readiness["trust_confidence_basis"] = {
         "orchestration_trust_confidence_posture": str(
@@ -275,6 +285,17 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             },
             "next_move_proposal_review": next_move_proposal_review,
             "trust_confidence_posture": orchestration_trust_confidence_posture,
+            "packetization_gating": {
+                **packetization_gate,
+                "packetization_allowed_or_caution": packetization_gate.get("packetization_outcome")
+                in {"packetization_allowed", "packetization_allowed_with_caution"},
+                "packetization_held_or_escalated": bool(packetization_gate.get("packetization_held")),
+                "non_sovereign_boundaries": {
+                    "non_authoritative": True,
+                    "does_not_execute_or_route_work": True,
+                    "does_not_override_kernel_or_governor": True,
+                },
+            },
             "handoff_packet": {
                 **handoff_packet,
                 "ledger_path": str(handoff_packet_ledger_path.relative_to(root)),

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -19,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_external_feedback_gap_map,
+    derive_packetization_gate,
     derive_next_venue_recommendation,
     derive_next_move_proposal_review,
     derive_orchestration_outcome_review,
@@ -1953,6 +1954,35 @@ def test_operator_required_and_insufficient_context_packets_remain_honestly_bloc
     assert context_packet["readiness"]["blocked"] is True
 
 
+def test_packetization_gate_can_hold_otherwise_stageable_packet_without_new_authority() -> None:
+    delegated = synthesize_delegated_judgment(_base_evidence())
+    proposal = {
+        "proposal_id": "proposal-stageable-held-by-gate",
+        "relation_posture": "affirming",
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": False,
+            "attention_signal": "review_mixed_orchestration_stress",
+            "escalation_classification": "no_escalation_needed",
+        },
+        "source_delegated_judgment": {"source_judgment_linkage_id": "jdg-link-gated"},
+    }
+    packet = synthesize_handoff_packet(
+        proposal,
+        delegated,
+        {"review_classification": "mixed_proposal_stress", "records_considered": 6},
+        {"trust_confidence_posture": "stressed_but_usable", "pressure_summary": {"primary_pressure": "mixed_stress"}},
+        {"operator_attention_recommendation": "review_mixed_orchestration_stress"},
+        created_at="2026-04-12T00:00:00Z",
+    )
+    assert packet["packetization_gate"]["packetization_outcome"] == "packetization_hold_escalation_required"
+    assert packet["packet_status"] == "blocked_operator_required"
+    assert packet["readiness"]["blocked"] is True
+    assert packet["does_not_change_admission_or_execution"] is True
+    assert packet["decision_power"] == "none"
+
+
 def test_handoff_packet_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
     delegated = synthesize_delegated_judgment(_base_evidence())
     proposal = {
@@ -2631,6 +2661,103 @@ def test_orchestration_trust_confidence_classifies_insufficient_history() -> Non
     assert posture["pressure_summary"]["primary_pressure"] == "insufficient_history"
 
 
+def test_packetization_gate_allows_trusted_coherent_proposal() -> None:
+    proposal = {
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "proposed_next_action": {"proposed_posture": "expand"},
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": False,
+            "attention_signal": "observe",
+            "escalation_classification": "no_escalation_needed",
+        },
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "coherent_recent_proposals", "records_considered": 6},
+        {"trust_confidence_posture": "trusted_for_bounded_use", "pressure_summary": {"primary_pressure": "none"}},
+        {"operator_attention_recommendation": "observe"},
+    )
+    assert gate["packetization_outcome"] == "packetization_allowed"
+    assert gate["packetization_allowed"] is True
+
+
+def test_packetization_gate_allows_with_caution_for_caution_posture() -> None:
+    proposal = {
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "nudging",
+        "proposed_next_action": {"proposed_posture": "audit"},
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": False,
+            "attention_signal": "review_mixed_orchestration_stress",
+            "escalation_classification": "no_escalation_needed",
+        },
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "coherent_recent_proposals", "records_considered": 6},
+        {"trust_confidence_posture": "caution_required", "pressure_summary": {"primary_pressure": "mixed_stress"}},
+        {"operator_attention_recommendation": "review_mixed_orchestration_stress"},
+    )
+    assert gate["packetization_outcome"] == "packetization_allowed_with_caution"
+    assert gate["packetization_allowed"] is True
+
+
+def test_packetization_gate_holds_fragmented_posture() -> None:
+    proposal = {
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "proposed_next_action": {"proposed_posture": "expand"},
+        "operator_escalation_requirement_state": {"requires_operator_or_escalation": False},
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "mixed_proposal_stress", "records_considered": 6},
+        {"trust_confidence_posture": "fragmented_or_unreliable", "pressure_summary": {"primary_pressure": "fragmentation"}},
+        {"operator_attention_recommendation": "observe"},
+    )
+    assert gate["packetization_outcome"] == "packetization_hold_fragmentation"
+    assert gate["packetization_held"] is True
+
+
+def test_packetization_gate_holds_insufficient_history_or_context() -> None:
+    proposal = {
+        "executability_classification": "blocked_insufficient_context",
+        "relation_posture": "insufficient_context",
+        "proposed_next_action": {"proposed_posture": "hold"},
+        "operator_escalation_requirement_state": {"requires_operator_or_escalation": False},
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "insufficient_history", "records_considered": 1},
+        {"trust_confidence_posture": "insufficient_history", "pressure_summary": {"primary_pressure": "insufficient_history"}},
+        {"operator_attention_recommendation": "insufficient_context"},
+    )
+    assert gate["packetization_outcome"] == "packetization_hold_insufficient_confidence"
+    assert gate["packetization_held"] is True
+
+
+def test_packetization_gate_holds_operator_required_paths() -> None:
+    proposal = {
+        "executability_classification": "blocked_operator_required",
+        "relation_posture": "escalating",
+        "proposed_next_action": {"proposed_posture": "escalate"},
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "inspect_handoff_blocks",
+            "escalation_classification": "escalate_for_operator_priority",
+        },
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "proposal_escalation_heavy", "records_considered": 6},
+        {"trust_confidence_posture": "stressed_but_usable", "pressure_summary": {"primary_pressure": "mixed_stress"}},
+        {"operator_attention_recommendation": "inspect_handoff_blocks"},
+    )
+    assert gate["packetization_outcome"] == "packetization_hold_operator_review"
+    assert gate["packetization_held"] is True
+
+
 def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
     judgment = synthesize_delegated_judgment(_base_evidence())
     intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
@@ -2864,6 +2991,7 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert outcome_review["summary"]["external_fulfillment_influence"]["influenced_outcome_review"] is True
     assert venue_mix_review["summary"]["external_fulfillment_influence"]["influenced_venue_mix_review"] is True
     trust_posture = second["orchestration_handoff"]["trust_confidence_posture"]
+    packetization_gating = second["orchestration_handoff"]["packetization_gating"]
     assert trust_posture["schema_version"] == "orchestration_trust_confidence_posture.v1"
     assert trust_posture["diagnostic_only"] is True
     assert trust_posture["non_authoritative"] is True
@@ -2872,6 +3000,17 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert feedback_visibility["venue_mix_review"]["external_fulfillment_influencing"] is True
     assert next_venue["relation_to_delegated_judgment"] == "affirming"
     assert feedback_visibility["non_authoritative"] is True
+    assert packetization_gating["schema_version"] == "orchestration_packetization_gate.v1"
+    assert packetization_gating["signal_snapshot"]["trust_confidence_posture"] == trust_posture["trust_confidence_posture"]
+    assert packetization_gating["packetization_outcome"] in {
+        "packetization_allowed",
+        "packetization_allowed_with_caution",
+        "packetization_hold_operator_review",
+        "packetization_hold_insufficient_confidence",
+        "packetization_hold_fragmentation",
+        "packetization_hold_escalation_required",
+    }
+    assert packetization_gating["non_sovereign_boundaries"]["does_not_execute_or_route_work"] is True
     readiness_basis = second["delegated_judgment"]["orchestration_substitution_readiness"]["trust_confidence_basis"]
     assert readiness_basis["orchestration_trust_confidence_posture"] == trust_posture["trust_confidence_posture"]
     assert readiness_basis["does_not_change_existing_readiness_logic"] is True


### PR DESCRIPTION
### Motivation
- Introduce a small, conservative constitutional brake that uses the existing orchestration trust/confidence posture to decide whether a next-move proposal should be packetized now, packetized with caution, or held for explicit reasons.
- Keep the gate strictly non-sovereign and derived only from existing orchestration signals so it cannot change admission/execution behavior or invent new decision surfaces.

### Description
- Add a compact packetization outcomes vocabulary `_PACKETIZATION_GATING_OUTCOMES` and a derived classifier `derive_packetization_gate(...)` in `sentientos/orchestration_intent_fabric.py` that uses only `next_move_proposal`, `next_move_proposal_review`, `orchestration_trust_confidence_posture`, and `orchestration_operator_attention_recommendation` as inputs and emits a proof-visible gate artifact with compact rationale and explicit non-sovereign boundaries.
- Integrate the gate into `synthesize_handoff_packet(...)` so the gate outcome is added to the handoff packet under `packetization_gate` and the packet `packet_status` / `readiness` are marked held or allowed accordingly while preserving all `diagnostic_only` / `non_authoritative` payload semantics and not granting execution or admission power.
- Surface the gating result in the scoped orchestration diagnostic consumer (`sentientos/scoped_lifecycle_diagnostic.py`) as `orchestration_handoff.packetization_gating`, including an explicit `non_sovereign_boundaries` snapshot so consumers can inspect trust posture, proposal, gate outcome, rationale, and whether the packet is allowed/caution/held.
- Extend the orchestration note (`sentientos/orchestration_intent_fabric_note.py`) with a concise `packetization_gating` section describing meaning, inputs, outcomes, scope, and explicit non-goals, and add focused unit tests covering allow/caution/hold/fragmentation/insufficient-history/operator-review cases and an end-to-end consumer visibility test.

### Testing
- Ran focused unit tests: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` which passed for the updated suite and the packetization-focused test selection. (Passed)
- Ran a targeted selection: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "packetization_gate or trust_confidence or end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibility or handoff_packet"` which passed. (Passed)
- Ran repository-level type checks: `mypy scripts/ sentientos/` which failed due to pre-existing, repo-wide typing issues unrelated to this change (reported but not introduced by this patch). (Failed — pre-existing)
- Executed broader test harness `python -m scripts.run_tests -q` which surfaced unrelated failures in `tests/test_pulse_federation.py` from the existing baseline; these failures are external to the packetization gate changes. (Failed — unrelated)
- Ran `python scripts/audit_immutability_verifier.py` which completed successfully. (Passed)
- Note: `verify_audits --strict` was unavailable in the environment during validation (`command not found`).

This change keeps the gating conservative, proof-visible, derived from existing signals only, and limited to packet preparation readiness without adding execution authority, new venues, or sovereign planners.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3c04a06b48320abae16779ce5ba26)