### PR TITLE
[codex:orchestration] add bounded operator resolution receipt ingestion

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -80,6 +80,44 @@ The operator action brief explicitly does **not**:
 - execute, route, or invoke external tools directly
 - become a workflow engine or sovereign planner
 
+## Operator-resolution receipt (ingested operator outcome only)
+
+`operator_resolution_receipt.v1` records the operator's response to a held/escalated
+`operator_action_brief.v1` as append-only constitutional history in
+`glow/orchestration/operator_resolution_receipts.jsonl`.
+
+Operator brief vs operator resolution:
+
+- **Operator action brief** = what intervention class is requested by orchestration.
+- **Operator resolution receipt** = what the operator actually decided/returned.
+
+Bounded resolution kinds:
+
+- `approved_continue`
+- `approved_with_constraints`
+- `declined`
+- `deferred`
+- `supplied_missing_context`
+- `redirected_venue`
+- `cancelled`
+
+Bounded lifecycle visibility from brief to receipt:
+
+- `brief_emitted`
+- `operator_resolution_received`
+- `operator_approved_continue`
+- `operator_approved_with_constraints`
+- `operator_declined`
+- `operator_deferred`
+- `operator_redirected`
+- `operator_supplied_missing_context`
+- `fragmented_unlinked_operator_resolution`
+
+Resolution receipt ingestion means **operator guidance was ingested**, not that execution happened.
+It remains receipt-only (`ingested_operator_outcome`, `receipt_only`, `decision_power: none`) and
+does not self-authorize execution or bypass packetization/admission. Any follow-on action still
+requires existing trigger paths and authority surfaces.
+
 ## Next-move proposal review (retrospective only)
 
 `next_move_proposal_review.v1` provides a compact retrospective classifier over recent

--- a/glow/orchestration/operator_resolution_receipts.jsonl
+++ b/glow/orchestration/operator_resolution_receipts.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"operator_resolution_receipt.v1","artifact_status":"initialized","notes":"append-only proof-visible operator resolution receipt ledger for held/escalated operator action briefs","non_authoritative":true,"diagnostic_only":true,"decision_power":"none","receipt_only":true,"ingested_operator_outcome":true,"does_not_imply_repo_self-authorization":true}

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -237,6 +237,28 @@ _OPERATOR_INTERVENTION_CLASSES = {
     "manual_external_trigger_required",
 }
 
+_OPERATOR_RESOLUTION_KINDS = {
+    "approved_continue",
+    "approved_with_constraints",
+    "declined",
+    "deferred",
+    "supplied_missing_context",
+    "redirected_venue",
+    "cancelled",
+}
+
+_OPERATOR_BRIEF_LIFECYCLE_STATES = {
+    "brief_emitted",
+    "operator_resolution_received",
+    "operator_approved_continue",
+    "operator_approved_with_constraints",
+    "operator_declined",
+    "operator_deferred",
+    "operator_redirected",
+    "operator_supplied_missing_context",
+    "fragmented_unlinked_operator_resolution",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -588,6 +610,24 @@ def _fulfillment_receipt_id(
         separators=(",", ":"),
     )
     return f"frc-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _operator_resolution_receipt_id(
+    *,
+    created_at: str,
+    operator_action_brief_id: str,
+    resolution_kind: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "created_at": created_at,
+            "operator_action_brief_id": operator_action_brief_id,
+            "resolution_kind": resolution_kind,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"orr-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
 
 
 def _compact_handoff_task_brief(next_move_proposal: Mapping[str, Any], delegated_judgment: Mapping[str, Any]) -> str:
@@ -3052,6 +3092,127 @@ def append_orchestration_fulfillment_receipt_ledger(repo_root: Path, receipt: Ma
     return ledger_path
 
 
+def append_operator_resolution_receipt_ledger(repo_root: Path, receipt: Mapping[str, Any]) -> Path:
+    """Append one bounded operator resolution receipt to the proof-visible receipt ledger."""
+
+    ledger_path = repo_root.resolve() / "glow/orchestration/operator_resolution_receipts.jsonl"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(receipt), sort_keys=True) + "\n")
+    return ledger_path
+
+
+def ingest_operator_resolution_receipt(
+    repo_root: Path,
+    *,
+    operator_action_brief_id: str,
+    resolution_kind: str,
+    operator_note: str,
+    updated_context_refs: list[str] | None = None,
+    redirected_venue: str | None = None,
+    operator_provenance: str = "human_operator",
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """
+    Ingest one bounded operator resolution outcome for a held/escalated operator brief.
+
+    This path is receipt-only and preserves operator intervention as constitutional history.
+    """
+
+    root = repo_root.resolve()
+    if not operator_action_brief_id.strip():
+        raise ValueError("operator_action_brief_id is required")
+
+    if resolution_kind not in _OPERATOR_RESOLUTION_KINDS:
+        raise ValueError(f"unrecognized resolution_kind: {resolution_kind}")
+
+    briefs = _read_jsonl(root / "glow/orchestration/operator_action_briefs.jsonl")
+    matching_briefs = [row for row in briefs if str(row.get("operator_action_brief_id") or "") == operator_action_brief_id]
+    brief = matching_briefs[-1] if matching_briefs else None
+    if not isinstance(brief, Mapping):
+        raise ValueError(f"operator action brief not found: {operator_action_brief_id}")
+
+    source_proposal_ref = brief.get("source_next_move_proposal_ref")
+    source_proposal_ref_map = source_proposal_ref if isinstance(source_proposal_ref, Mapping) else {}
+    source_gate_ref = brief.get("source_packetization_gate_ref")
+    source_gate_ref_map = source_gate_ref if isinstance(source_gate_ref, Mapping) else {}
+
+    source_proposal_id = str(source_proposal_ref_map.get("proposal_id") or "")
+    gate_outcome = str(source_gate_ref_map.get("packetization_outcome") or "")
+    gate_kind = str(source_gate_ref_map.get("gate_kind") or "")
+    if not source_proposal_id:
+        raise ValueError(f"operator action brief malformed (missing source proposal linkage): {operator_action_brief_id}")
+    if not gate_outcome or not gate_kind:
+        raise ValueError(f"operator action brief malformed (missing packetization gate linkage): {operator_action_brief_id}")
+
+    target_venue_or_posture = str(brief.get("target_venue_or_posture") or "")
+    normalized_refs = [
+        ref.strip()
+        for ref in (updated_context_refs or [])
+        if isinstance(ref, str) and ref.strip()
+    ]
+    timestamp = created_at or _iso_utc_now()
+    resolution_state = {
+        "approved_continue": "operator_approved_continue",
+        "approved_with_constraints": "operator_approved_with_constraints",
+        "declined": "operator_declined",
+        "deferred": "operator_deferred",
+        "supplied_missing_context": "operator_supplied_missing_context",
+        "redirected_venue": "operator_redirected",
+        "cancelled": "operator_declined",
+    }[resolution_kind]
+
+    receipt = {
+        "schema_version": "operator_resolution_receipt.v1",
+        "ingested_at": timestamp,
+        "operator_resolution_receipt_id": _operator_resolution_receipt_id(
+            created_at=timestamp,
+            operator_action_brief_id=operator_action_brief_id,
+            resolution_kind=resolution_kind,
+        ),
+        "source_operator_action_brief_ref": {
+            "operator_action_brief_id": operator_action_brief_id,
+            "operator_action_brief_ledger_path": "glow/orchestration/operator_action_briefs.jsonl",
+        },
+        "source_next_move_proposal_ref": {
+            "proposal_id": source_proposal_id,
+            "proposal_ledger_path": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+            "source_judgment_linkage_id": source_proposal_ref_map.get("source_judgment_linkage_id"),
+        },
+        "source_packetization_gate_ref": {
+            "gate_kind": gate_kind,
+            "packetization_outcome": gate_outcome,
+            "gate_schema_version": source_gate_ref_map.get("gate_schema_version"),
+        },
+        "resolution_kind": resolution_kind,
+        "resolution_lifecycle_state": resolution_state,
+        "operator_note": operator_note.strip() or "operator_resolution_ingested_without_additional_note",
+        "updated_context_refs": normalized_refs,
+        "redirected_venue": redirected_venue.strip() if isinstance(redirected_venue, str) and redirected_venue.strip() else None,
+        "target_venue_or_posture_hint": target_venue_or_posture or None,
+        "trust_confidence_posture": brief.get("trust_confidence_posture"),
+        "operator_provenance": operator_provenance.strip() or "human_operator",
+        "ingested_operator_outcome": True,
+        "explicit_clarity": "ingested operator outcome, not repo execution",
+        **_anti_sovereignty_payload(
+            recommendation_only=False,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "does_not_imply_repo_self-authorization": True,
+                "does_not_imply_repo_self_authorization": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+                "receipt_only": True,
+                "requires_existing_trigger_path_for_any_follow-on_action": True,
+                "requires_existing_trigger_path_for_any_follow_on_action": True,
+            },
+        ),
+    }
+    ledger_path = append_operator_resolution_receipt_ledger(root, receipt)
+    return {**receipt, "ledger_path": str(ledger_path.relative_to(root))}
+
+
 def ingest_external_fulfillment_receipt(
     repo_root: Path,
     *,
@@ -3205,6 +3366,67 @@ def resolve_handoff_packet_fulfillment_lifecycle(
         "decision_power": "none",
         "receipt_only": True,
         "requires_external_actor_or_operator": True,
+    }
+
+
+def resolve_operator_action_brief_lifecycle(
+    repo_root: Path,
+    operator_action_brief: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve bounded lifecycle visibility for one operator action brief."""
+
+    root = repo_root.resolve()
+    brief_map = operator_action_brief if isinstance(operator_action_brief, Mapping) else {}
+    brief_id = str(brief_map.get("operator_action_brief_id") or "")
+    receipts = _read_jsonl(root / "glow/orchestration/operator_resolution_receipts.jsonl")
+    linked = [
+        row
+        for row in receipts
+        if str((row.get("source_operator_action_brief_ref") or {}).get("operator_action_brief_id") or "") == brief_id
+    ]
+    latest = linked[-1] if linked else None
+
+    lifecycle_state = "fragmented_unlinked_operator_resolution"
+    resolution_received = False
+    resolution_kind = None
+    receipt_id = None
+    if brief_id:
+        lifecycle_state = "brief_emitted"
+        if isinstance(latest, Mapping):
+            resolution_kind_value = str(latest.get("resolution_kind") or "")
+            lifecycle_state = {
+                "approved_continue": "operator_approved_continue",
+                "approved_with_constraints": "operator_approved_with_constraints",
+                "declined": "operator_declined",
+                "deferred": "operator_deferred",
+                "supplied_missing_context": "operator_supplied_missing_context",
+                "redirected_venue": "operator_redirected",
+                "cancelled": "operator_declined",
+            }.get(resolution_kind_value, "fragmented_unlinked_operator_resolution")
+            resolution_received = lifecycle_state != "fragmented_unlinked_operator_resolution"
+            resolution_kind = resolution_kind_value or None
+            receipt_id = str(latest.get("operator_resolution_receipt_id") or "") or None
+
+    if lifecycle_state not in _OPERATOR_BRIEF_LIFECYCLE_STATES:
+        lifecycle_state = "fragmented_unlinked_operator_resolution"
+
+    return {
+        "schema_version": "operator_action_brief_lifecycle.v1",
+        "operator_action_brief_id": brief_id or None,
+        "lifecycle_state": lifecycle_state,
+        "operator_resolution_received": resolution_received,
+        "resolution_kind": resolution_kind,
+        "operator_resolution_receipt_id": receipt_id,
+        "receipt_artifact_path": "glow/orchestration/operator_resolution_receipts.jsonl",
+        "ingested_operator_outcome": bool((latest or {}).get("ingested_operator_outcome")) if isinstance(latest, Mapping) else False,
+        "awaiting_operator_input": bool(brief_id) and not resolution_received,
+        "has_operator_guidance": resolution_received,
+        "operator_intervention_human_mediated": True,
+        "does_not_imply_repo_execution": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "receipt_only": True,
+        "requires_existing_trigger_path_for_any_follow-on_action": True,
     }
 
 

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -32,6 +32,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_codex_staged_work_order_lifecycle,
     resolve_deep_research_staged_work_order_lifecycle,
     resolve_handoff_packet_fulfillment_lifecycle,
+    resolve_operator_action_brief_lifecycle,
     resolve_orchestration_result,
     resolve_unified_orchestration_result,
     resolve_unified_orchestration_result_surface,
@@ -217,6 +218,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     operator_action_brief_ledger_path = (
         append_operator_action_brief_ledger(root, operator_action_brief) if operator_action_brief else None
     )
+    operator_brief_lifecycle = resolve_operator_action_brief_lifecycle(root, operator_action_brief)
     unified_result = resolve_unified_orchestration_result(root, handoff=handoff_result, handoff_packet=handoff_packet)
     unified_result_surface = resolve_unified_orchestration_result_surface(root)
     unified_result_quality_review = derive_unified_result_quality_review(root)
@@ -310,11 +312,21 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             },
             "operator_action_brief": {
                 "brief_produced": operator_action_brief is not None,
-                "loop_held_pending_operator_intervention": bool(packetization_gate.get("packetization_held")),
+                "loop_held_pending_operator_intervention": bool(packetization_gate.get("packetization_held"))
+                and bool(operator_brief_lifecycle.get("awaiting_operator_input")),
                 "intervention_class": None if operator_action_brief is None else operator_action_brief.get("intervention_class"),
                 "target_venue_or_posture": None
                 if operator_action_brief is None
                 else operator_action_brief.get("target_venue_or_posture"),
+                "lifecycle_visibility": operator_brief_lifecycle,
+                "operator_resolution_received": bool(operator_brief_lifecycle.get("operator_resolution_received")),
+                "resolution_kind": operator_brief_lifecycle.get("resolution_kind"),
+                "resolution_receipt_artifact_linkage": {
+                    "ledger_path": operator_brief_lifecycle.get("receipt_artifact_path"),
+                    "operator_resolution_receipt_id": operator_brief_lifecycle.get("operator_resolution_receipt_id"),
+                },
+                "awaiting_operator_input": bool(operator_brief_lifecycle.get("awaiting_operator_input")),
+                "has_operator_guidance": bool(operator_brief_lifecycle.get("has_operator_guidance")),
                 "brief_artifact_linkage": None
                 if operator_action_brief_ledger_path is None
                 else {
@@ -327,6 +339,8 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "non_sovereign_boundaries": {
                     "non_authoritative": True,
                     "operator_guidance_only": True,
+                    "ingested_operator_outcome": bool(operator_brief_lifecycle.get("ingested_operator_outcome")),
+                    "explicit_clarity": "ingested operator outcome, not repo execution",
                     "does_not_override_packetization_gate": True,
                     "does_not_convert_hold_to_execution": True,
                     "does_not_execute_or_route_work": True,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -4,8 +4,10 @@ import hashlib
 from importlib import reload
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import control_plane
+import pytest
 import task_admission
 import task_executor
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
@@ -17,6 +19,7 @@ from sentientos.orchestration_intent_fabric import (
     append_orchestration_intent_ledger,
     build_split_closure_map,
     ingest_external_fulfillment_receipt,
+    ingest_operator_resolution_receipt,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_external_feedback_gap_map,
@@ -33,6 +36,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_unified_orchestration_result,
     resolve_unified_orchestration_result_surface,
     resolve_handoff_packet_fulfillment_lifecycle,
+    resolve_operator_action_brief_lifecycle,
     synthesize_handoff_packet,
     synthesize_next_move_proposal,
     synthesize_orchestration_intent,
@@ -115,6 +119,37 @@ def _external_handoff_packet(
         created_at="2026-04-12T00:00:00Z",
     )
     return synthesize_handoff_packet(proposal, delegated, created_at="2026-04-12T00:00:00Z")
+
+
+def _operator_brief_for_receipt_flow() -> dict[str, object]:
+    proposal = {
+        "proposal_id": "proposal-operator-receipt-flow",
+        "relation_posture": "escalating",
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "escalate"},
+        "executability_classification": "stageable_external_work_order",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "inspect_handoff_blocks",
+            "escalation_classification": "escalate_for_operator_priority",
+        },
+        "source_delegated_judgment": {"source_judgment_linkage_id": "jdg-link-receipt-flow"},
+    }
+    gate = derive_packetization_gate(
+        proposal,
+        {"review_classification": "proposal_escalation_heavy", "records_considered": 5},
+        {"trust_confidence_posture": "stressed_but_usable", "pressure_summary": {"primary_pressure": "mixed_stress"}},
+        {"operator_attention_recommendation": "inspect_handoff_blocks"},
+    )
+    brief = synthesize_operator_action_brief(
+        proposal,
+        gate,
+        {"trust_confidence_posture": "stressed_but_usable", "pressure_summary": {"primary_pressure": "mixed_stress"}},
+        {"operator_attention_recommendation": "inspect_handoff_blocks"},
+        next_move_proposal_review={"review_classification": "proposal_escalation_heavy"},
+        created_at="2026-04-12T00:00:00Z",
+    )
+    assert brief is not None
+    return brief
 
 
 def _mock_unified_surface(
@@ -2181,6 +2216,125 @@ def test_operator_action_brief_artifact_is_append_only_and_proof_visible(tmp_pat
     assert ledger_path == tmp_path / "glow/orchestration/operator_action_briefs.jsonl"
 
 
+def test_operator_resolution_receipt_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
+    brief = _operator_brief_for_receipt_flow()
+    append_operator_action_brief_ledger(tmp_path, brief)
+    receipt_one = ingest_operator_resolution_receipt(
+        tmp_path,
+        operator_action_brief_id=str(brief["operator_action_brief_id"]),
+        resolution_kind="approved_continue",
+        operator_note="approved after review",
+        updated_context_refs=["glow/orchestration/operator_action_briefs.jsonl#1"],
+        created_at="2026-04-12T00:01:00Z",
+    )
+    receipt_two = ingest_operator_resolution_receipt(
+        tmp_path,
+        operator_action_brief_id=str(brief["operator_action_brief_id"]),
+        resolution_kind="declined",
+        operator_note="declined in later pass",
+        created_at="2026-04-12T00:02:00Z",
+    )
+
+    ledger_path = tmp_path / "glow/orchestration/operator_resolution_receipts.jsonl"
+    rows = ledger_path.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 2
+    first = json.loads(rows[0])
+    second = json.loads(rows[1])
+    assert first["operator_resolution_receipt_id"] == receipt_one["operator_resolution_receipt_id"]
+    assert first["resolution_kind"] == "approved_continue"
+    assert second["operator_resolution_receipt_id"] == receipt_two["operator_resolution_receipt_id"]
+    assert second["resolution_kind"] == "declined"
+
+
+def test_operator_resolution_ingestion_supports_multiple_resolution_kinds() -> None:
+    with TemporaryDirectory() as tmp_dir:
+        repo_root = Path(tmp_dir)
+        brief = _operator_brief_for_receipt_flow()
+        append_operator_action_brief_ledger(repo_root, brief)
+
+        supplied = ingest_operator_resolution_receipt(
+            repo_root,
+            operator_action_brief_id=str(brief["operator_action_brief_id"]),
+            resolution_kind="supplied_missing_context",
+            operator_note="added missing context",
+            updated_context_refs=["docs/context.md#section"],
+            created_at="2026-04-12T00:01:00Z",
+        )
+        declined = ingest_operator_resolution_receipt(
+            repo_root,
+            operator_action_brief_id=str(brief["operator_action_brief_id"]),
+            resolution_kind="declined",
+            operator_note="not approved",
+            created_at="2026-04-12T00:02:00Z",
+        )
+        redirected = ingest_operator_resolution_receipt(
+            repo_root,
+            operator_action_brief_id=str(brief["operator_action_brief_id"]),
+            resolution_kind="redirected_venue",
+            operator_note="use deep research instead",
+            redirected_venue="deep_research_audit",
+            created_at="2026-04-12T00:03:00Z",
+        )
+
+        assert supplied["resolution_kind"] == "supplied_missing_context"
+        assert supplied["resolution_lifecycle_state"] == "operator_supplied_missing_context"
+        assert supplied["ingested_operator_outcome"] is True
+        assert supplied["does_not_imply_repo_self-authorization"] is True
+        assert supplied["requires_existing_trigger_path_for_any_follow-on_action"] is True
+        assert declined["resolution_lifecycle_state"] == "operator_declined"
+        assert redirected["resolution_lifecycle_state"] == "operator_redirected"
+        assert redirected["redirected_venue"] == "deep_research_audit"
+
+
+def test_operator_resolution_ingestion_fails_closed_when_brief_missing_or_malformed(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="operator action brief not found"):
+        ingest_operator_resolution_receipt(
+            tmp_path,
+            operator_action_brief_id="oab-missing",
+            resolution_kind="approved_continue",
+            operator_note="missing",
+        )
+
+    malformed = {
+        "schema_version": "operator_action_brief.v1",
+        "operator_action_brief_id": "oab-malformed",
+        "source_next_move_proposal_ref": {},
+        "source_packetization_gate_ref": {},
+    }
+    append_operator_action_brief_ledger(tmp_path, malformed)
+    with pytest.raises(ValueError, match="malformed"):
+        ingest_operator_resolution_receipt(
+            tmp_path,
+            operator_action_brief_id="oab-malformed",
+            resolution_kind="approved_continue",
+            operator_note="should fail",
+        )
+
+
+def test_operator_brief_lifecycle_visibility_tracks_received_resolution() -> None:
+    with TemporaryDirectory() as tmp_dir:
+        repo_root = Path(tmp_dir)
+        brief = _operator_brief_for_receipt_flow()
+        append_operator_action_brief_ledger(repo_root, brief)
+        before = resolve_operator_action_brief_lifecycle(repo_root, brief)
+        ingest_operator_resolution_receipt(
+            repo_root,
+            operator_action_brief_id=str(brief["operator_action_brief_id"]),
+            resolution_kind="approved_continue",
+            operator_note="continue",
+            created_at="2026-04-12T00:01:00Z",
+        )
+        after = resolve_operator_action_brief_lifecycle(repo_root, brief)
+
+        assert before["lifecycle_state"] == "brief_emitted"
+        assert before["operator_resolution_received"] is False
+        assert before["awaiting_operator_input"] is True
+        assert after["lifecycle_state"] == "operator_approved_continue"
+        assert after["operator_resolution_received"] is True
+        assert after["has_operator_guidance"] is True
+        assert after["does_not_imply_repo_execution"] is True
+
+
 def test_handoff_packet_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
     delegated = synthesize_delegated_judgment(_base_evidence())
     proposal = {
@@ -2340,8 +2494,12 @@ def test_handoff_packet_flows_to_diagnostic_consumer_and_stays_non_authoritative
     assert packet["requires_operator_or_existing_trigger_path"] is True
     assert "brief_produced" in operator_brief_surface
     assert "loop_held_pending_operator_intervention" in operator_brief_surface
+    assert "lifecycle_visibility" in operator_brief_surface
+    assert "operator_resolution_received" in operator_brief_surface
+    assert operator_brief_surface["resolution_receipt_artifact_linkage"]["ledger_path"] == "glow/orchestration/operator_resolution_receipts.jsonl"
     assert operator_brief_surface["non_sovereign_boundaries"]["does_not_override_packetization_gate"] is True
     assert operator_brief_surface["non_sovereign_boundaries"]["does_not_convert_hold_to_execution"] is True
+    assert operator_brief_surface["non_sovereign_boundaries"]["explicit_clarity"] == "ingested operator outcome, not repo execution"
 
 
 def test_operator_brief_end_to_end_from_hold_to_diagnostic_surface(monkeypatch, tmp_path: Path) -> None:
@@ -2398,6 +2556,74 @@ def test_operator_brief_end_to_end_from_hold_to_diagnostic_surface(monkeypatch, 
     assert brief_surface["brief"]["does_not_override_packetization_gate"] is True
     assert brief_surface["brief"]["does_not_create_execution_path"] is True
     assert brief_surface["brief"]["non_authoritative"] is True
+    assert brief_surface["awaiting_operator_input"] is True
+    assert brief_surface["operator_resolution_received"] is False
+    assert brief_surface["lifecycle_visibility"]["lifecycle_state"] == "brief_emitted"
+
+
+def test_operator_resolution_end_to_end_updates_diagnostic_consumer_without_execution(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle",
+        lambda _repo_root, *, action_id, correlation_id: {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(
+            {
+                **_base_evidence(),
+                "governance_ambiguity_signal": True,
+                "admission_denied_ratio": 0.9,
+                "executor_failure_ratio": 0.5,
+            }
+        ),
+    )
+    original_append = append_operator_action_brief_ledger
+
+    def _append_and_ingest(repo_root: Path, brief: dict[str, object]) -> Path:
+        ledger_path = original_append(repo_root, brief)
+        ingest_operator_resolution_receipt(
+            repo_root,
+            operator_action_brief_id=str(brief["operator_action_brief_id"]),
+            resolution_kind="approved_continue",
+            operator_note="operator approved continue",
+            created_at="2026-04-12T00:01:00Z",
+        )
+        return ledger_path
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.append_operator_action_brief_ledger", _append_and_ingest)
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-operator-resolution-e2e",
+            }
+        ],
+    )
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    gate = diagnostic["orchestration_handoff"]["packetization_gating"]
+    brief_surface = diagnostic["orchestration_handoff"]["operator_action_brief"]
+    handoff = diagnostic["orchestration_handoff"]["handoff_result"]
+
+    assert gate["packetization_held"] is True
+    assert brief_surface["brief_produced"] is True
+    assert brief_surface["operator_resolution_received"] is True
+    assert brief_surface["resolution_kind"] == "approved_continue"
+    assert brief_surface["lifecycle_visibility"]["lifecycle_state"] == "operator_approved_continue"
+    assert brief_surface["has_operator_guidance"] is True
+    assert brief_surface["awaiting_operator_input"] is False
+    assert brief_surface["non_sovereign_boundaries"]["ingested_operator_outcome"] is True
+    assert brief_surface["non_sovereign_boundaries"]["explicit_clarity"] == "ingested operator outcome, not repo execution"
+    assert handoff["handoff_outcome"] in {"blocked_by_operator_requirement", "blocked_by_insufficient_context", "staged_only", "admitted_to_execution_substrate", "blocked_by_admission"}
+    assert brief_surface["non_sovereign_boundaries"]["does_not_convert_hold_to_execution"] is True
 
 
 def test_attention_recommendation_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
@@ -3046,6 +3272,31 @@ def test_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_p
 
     split_map = build_split_closure_map()
     assert split_map["schema_version"] == "orchestration_split_closure_map.v1"
+
+
+def test_operator_resolution_receipt_ingestion_does_not_change_admission_or_execution_behavior(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+
+    brief = _operator_brief_for_receipt_flow()
+    append_operator_action_brief_ledger(tmp_path, brief)
+    receipt = ingest_operator_resolution_receipt(
+        tmp_path,
+        operator_action_brief_id=str(brief["operator_action_brief_id"]),
+        resolution_kind="approved_continue",
+        operator_note="approved bounded continuation",
+        created_at="2026-04-12T00:01:00Z",
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+
+    assert receipt["ingested_operator_outcome"] is True
+    assert receipt["does_not_change_admission_or_execution"] is True
+    assert receipt["decision_power"] == "none"
+    assert receipt["receipt_only"] is True
+    assert before["handoff_outcome"] == "blocked_by_operator_requirement"
+    assert after["handoff_outcome"] == "blocked_by_operator_requirement"
 
 
 def test_codex_missing_metadata_yields_blocked_insufficient_and_lifecycle_fragment_visibility(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Record operator responses to held/escalated operator action briefs as typed, append-only constitutional history instead of leaving them out-of-band.
- Provide a small, typed receipt model and ingestion path that preserves source brief/proposal/gate linkage and fails closed on missing/malformed briefs.
- Make operator guidance visible to diagnostics while preserving explicit anti-sovereignty semantics (no implied repo execution or authorization).

### Description

- Add compact resolution vocabulary and lifecycle states via `_OPERATOR_RESOLUTION_KINDS` and `_OPERATOR_BRIEF_LIFECYCLE_STATES` in `sentientos/orchestration_intent_fabric.py`.
- Implement deterministic receipt id generation `_operator_resolution_receipt_id`, append-only ledger writer `append_operator_resolution_receipt_ledger`, and receipt ingestion API `ingest_operator_resolution_receipt` which validates brief linkage, preserves proposal/gate references, normalizes context refs, and injects explicit anti-sovereignty markers (e.g. `ingested_operator_outcome`, `receipt_only`, `decision_power: none`).
- Add brief lifecycle resolver `resolve_operator_action_brief_lifecycle` to expose brief→receipt visibility and states such as `brief_emitted`, `operator_approved_continue`, `operator_supplied_missing_context`, and `fragmented_unlinked_operator_resolution`.
- Surface operator-resolution state in the scoped orchestration diagnostic consumer (`sentientos/scoped_lifecycle_diagnostic.py`) including `lifecycle_visibility`, `operator_resolution_received`, `resolution_kind`, receipt artifact linkage, `awaiting_operator_input`, and clear non-sovereign language (`ingested operator outcome, not repo execution`).
- Add append-only proof-visible artifact template `glow/orchestration/operator_resolution_receipts.jsonl` and update docs `docs/orchestration_next_move_proposal_note.md` with a concise explanation of operator-resolution receipts and their semantics.
- Add focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` covering successful ingestion for `approved_continue`, `supplied_missing_context`, `declined`, and `redirected_venue`, fail-closed behavior for missing/malformed briefs, lifecycle visibility progression, and an end-to-end diagnostic consumer flow that verifies ingestion does not imply execution.

### Testing

- Ran the focused pytest selection: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "operator_resolution or operator_brief_end_to_diagnostic_surface or handoff_packet_flows_to_diagnostic_consumer"`, which completed successfully (tests passed).
- Added unit tests exercising `ingest_operator_resolution_receipt` for multiple resolution kinds and negative cases, and they passed under the repository test run.
- Performed an end-to-end diagnostic consumer test that synthesizes a held packet → operator brief → ingests a resolution receipt and asserts the diagnostic surface updated while admission/execution behavior remained unchanged, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3e3a137408320b1ce00fff42fc59b)