### PR TITLE
[codex:orchestration] integrate bounded operator-resolution feedback

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -118,6 +118,34 @@ It remains receipt-only (`ingested_operator_outcome`, `receipt_only`, `decision_
 does not self-authorize execution or bypass packetization/admission. Any follow-on action still
 requires existing trigger paths and authority surfaces.
 
+## Bounded operator-resolution feedback integration (non-executing)
+
+Operator resolutions are now also consumed as bounded feedback through a compact
+`operator_resolution_influence.v1` surface and reflected into:
+
+- packetization gating (`operator_influence`, bounded hold-relief paths)
+- next-move proposal visibility (`original_*` vs `current_*` proposal venue/posture visibility)
+- next-venue visibility (`original_next_venue_recommendation` vs `current_next_venue_recommendation`)
+
+Supported bounded effects:
+
+- `approved_continue` / `approved_with_constraints`: may relax operator-review hold to cautious packetization when other coherence requirements are already satisfied.
+- `supplied_missing_context`: may relax insufficient-context hold when context refs are present and fragmentation is not active.
+- `redirected_venue`: may change current bounded venue recommendation/proposal visibility while preserving original delegated recommendation history.
+- `declined` / `cancelled`: preserve or strengthen held/no-action posture.
+- `deferred`: preserves held posture with explicit operator-response visibility.
+
+Non-sovereign boundary invariants remain explicit on influenced surfaces:
+
+- `operator_influence_applied`
+- `does_not_imply_execution`
+- `does_not_override_admission`
+- `requires_existing_trigger_path_for_follow_on_action`
+- `historical_operator_resolution_preserved`
+
+What is still missing before any tighter delegated loop exists: no receipt-triggered execution,
+no admission bypass, no autonomous workflow sovereign, and no direct external actuation path.
+
 ## Next-move proposal review (retrospective only)
 
 `next_move_proposal_review.v1` provides a compact retrospective classifier over recent

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -259,6 +259,15 @@ _OPERATOR_BRIEF_LIFECYCLE_STATES = {
     "fragmented_unlinked_operator_resolution",
 }
 
+_OPERATOR_INFLUENCE_STATES = {
+    "no_operator_influence_yet",
+    "operator_context_applied",
+    "operator_approval_applied",
+    "operator_redirect_applied",
+    "operator_decline_preserved_hold",
+    "operator_defer_preserved_hold",
+}
+
 
 def _anti_sovereignty_payload(
     *,
@@ -2401,6 +2410,134 @@ def derive_external_feedback_gap_map(
     }
 
 
+def resolve_latest_operator_resolution_for_proposal(
+    repo_root: Path,
+    proposal_id: str,
+) -> dict[str, Any] | None:
+    """Return the latest operator resolution receipt linked to a proposal, if any."""
+
+    if not proposal_id.strip():
+        return None
+    rows = _read_jsonl(repo_root.resolve() / "glow/orchestration/operator_resolution_receipts.jsonl")
+    linked = [
+        row
+        for row in rows
+        if str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") == proposal_id
+    ]
+    latest = linked[-1] if linked else None
+    return dict(latest) if isinstance(latest, Mapping) else None
+
+
+def derive_operator_resolution_influence(
+    operator_resolution_receipt: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Derive compact bounded influence visibility from a linked operator resolution receipt."""
+
+    receipt_map = operator_resolution_receipt if isinstance(operator_resolution_receipt, Mapping) else {}
+    resolution_kind = str(receipt_map.get("resolution_kind") or "")
+    mapped_state = {
+        "approved_continue": "operator_approval_applied",
+        "approved_with_constraints": "operator_approval_applied",
+        "supplied_missing_context": "operator_context_applied",
+        "redirected_venue": "operator_redirect_applied",
+        "declined": "operator_decline_preserved_hold",
+        "cancelled": "operator_decline_preserved_hold",
+        "deferred": "operator_defer_preserved_hold",
+    }.get(resolution_kind, "no_operator_influence_yet")
+    if mapped_state not in _OPERATOR_INFLUENCE_STATES:
+        mapped_state = "no_operator_influence_yet"
+
+    redirected_venue_raw = str(receipt_map.get("redirected_venue") or "")
+    redirected_venue = (
+        redirected_venue_raw
+        if redirected_venue_raw
+        in {"internal_direct_execution", "codex_implementation", "deep_research_audit", "operator_decision_required"}
+        else None
+    )
+    context_refs = [
+        ref
+        for ref in receipt_map.get("updated_context_refs", [])
+        if isinstance(ref, str) and ref.strip()
+    ] if isinstance(receipt_map.get("updated_context_refs"), list) else []
+
+    influence = {
+        "schema_version": "operator_resolution_influence.v1",
+        "operator_influence_state": mapped_state,
+        "operator_influence_applied": mapped_state != "no_operator_influence_yet",
+        "resolution_kind": resolution_kind or None,
+        "resolution_receipt_id": str(receipt_map.get("operator_resolution_receipt_id") or "") or None,
+        "resolution_receipt_linked": bool(receipt_map),
+        "operator_context_refs_present": bool(context_refs),
+        "operator_context_refs_count": len(context_refs),
+        "operator_redirected_venue": redirected_venue,
+        "operator_redirect_applied": mapped_state == "operator_redirect_applied" and redirected_venue is not None,
+        "operator_approval_applied": mapped_state == "operator_approval_applied",
+        "operator_context_applied": mapped_state == "operator_context_applied" and bool(context_refs),
+        "operator_decline_or_cancel_preserves_hold": mapped_state == "operator_decline_preserved_hold",
+        "operator_defer_preserves_hold": mapped_state == "operator_defer_preserved_hold",
+        "compact_rationale": (
+            "operator_resolution_receipt_not_linked_to_current_proposal"
+            if not receipt_map
+            else f"operator_resolution_{resolution_kind}_is_visible_as_bounded_influence_only"
+        ),
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "does_not_imply_execution": True,
+                "does_not_override_admission": True,
+                "requires_existing_trigger_path_for_follow_on_action": True,
+                "historical_operator_resolution_preserved": True,
+            },
+        ),
+    }
+    return influence
+
+
+def derive_operator_resolution_feedback_gap_map(
+    next_move_proposal: Mapping[str, Any],
+    packetization_gate: Mapping[str, Any],
+    next_venue_recommendation: Mapping[str, Any],
+    operator_brief_lifecycle: Mapping[str, Any],
+    operator_influence: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return compact audit visibility for operator-resolution feedback integration coverage."""
+
+    influence_state = str(operator_influence.get("operator_influence_state") or "no_operator_influence_yet")
+    influence_applied = bool(operator_influence.get("operator_influence_applied"))
+    receipt_visible = bool(operator_brief_lifecycle.get("operator_resolution_received"))
+    proposal_feedback_visible = bool((next_move_proposal.get("operator_feedback") or {}).get("operator_influence_applied"))
+    gate_feedback_visible = bool((packetization_gate.get("operator_influence") or {}).get("operator_influence_applied"))
+    venue_feedback_visible = bool((next_venue_recommendation.get("operator_feedback") or {}).get("operator_influence_applied"))
+
+    return {
+        "schema_version": "orchestration_operator_feedback_gap_map.v1",
+        "next_move_proposal_visibility": {
+            "operator_resolution_visible": proposal_feedback_visible,
+            "remaining_gap": "none" if proposal_feedback_visible or not receipt_visible else "proposal_visibility_not_consuming_operator_resolution",
+        },
+        "packetization_gating": {
+            "operator_resolution_visible": gate_feedback_visible,
+            "remaining_gap": "none" if gate_feedback_visible or not receipt_visible else "packetization_gate_not_consuming_operator_resolution",
+        },
+        "next_venue_recommendation": {
+            "operator_resolution_visible": venue_feedback_visible,
+            "remaining_gap": "none" if venue_feedback_visible or not receipt_visible else "next_venue_recommendation_not_consuming_operator_resolution",
+        },
+        "operator_brief_lifecycle_visibility": {
+            "operator_resolution_received": receipt_visible,
+            "resolution_kind": operator_brief_lifecycle.get("resolution_kind"),
+            "influence_state": influence_state,
+            "remaining_gap": "none" if receipt_visible else "operator_resolution_not_yet_received",
+        },
+        "held_loop_static_after_operator_response": bool(receipt_visible and not influence_applied),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "diagnostic_only": True,
+    }
+
+
 def synthesize_next_move_proposal(
     delegated_judgment: Mapping[str, Any],
     next_venue_recommendation: Mapping[str, Any],
@@ -2543,6 +2680,96 @@ def synthesize_next_move_proposal(
     return proposal
 
 
+def derive_operator_adjusted_next_venue_recommendation(
+    next_venue_recommendation: Mapping[str, Any],
+    operator_influence: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Produce compact visibility showing operator influence on current venue recommendation."""
+
+    base = dict(next_venue_recommendation)
+    original_recommendation = str(base.get("next_venue_recommendation") or "insufficient_context")
+    original_relation = str(base.get("relation_to_delegated_judgment") or "insufficient_context")
+    redirected_venue = str(operator_influence.get("operator_redirected_venue") or "")
+    redirected_applied = bool(operator_influence.get("operator_redirect_applied"))
+    venue_to_recommendation = {
+        "internal_direct_execution": "prefer_internal_execution",
+        "codex_implementation": "prefer_codex_implementation",
+        "deep_research_audit": "prefer_deep_research_audit",
+        "operator_decision_required": "prefer_operator_decision",
+    }
+    redirected_recommendation = venue_to_recommendation.get(redirected_venue, original_recommendation)
+    current_recommendation = redirected_recommendation if redirected_applied else original_recommendation
+    current_relation = "nudging" if redirected_applied else original_relation
+    feedback = {
+        "operator_influence_state": str(operator_influence.get("operator_influence_state") or "no_operator_influence_yet"),
+        "operator_influence_applied": bool(operator_influence.get("operator_influence_applied")),
+        "resolution_kind": operator_influence.get("resolution_kind"),
+        "redirected_venue": redirected_venue or None,
+        "redirect_applied_to_next_venue_recommendation": redirected_applied,
+    }
+    return {
+        **base,
+        "operator_feedback": feedback,
+        "original_next_venue_recommendation": original_recommendation,
+        "current_next_venue_recommendation": current_recommendation,
+        "original_relation_to_delegated_judgment": original_relation,
+        "current_relation_to_delegated_judgment": current_relation,
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "does_not_imply_execution": True,
+                "does_not_override_admission": True,
+                "requires_existing_trigger_path_for_follow_on_action": True,
+                "historical_operator_resolution_preserved": True,
+            },
+        ),
+    }
+
+
+def derive_operator_adjusted_next_move_proposal_visibility(
+    next_move_proposal: Mapping[str, Any],
+    operator_influence: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Produce compact visibility showing operator influence on proposal hold/packetization posture."""
+
+    proposal = dict(next_move_proposal)
+    proposed_action = proposal.get("proposed_next_action")
+    proposed_action_map = dict(proposed_action) if isinstance(proposed_action, Mapping) else {}
+    original_venue = str(proposed_action_map.get("proposed_venue") or "insufficient_context")
+    redirected_venue = str(operator_influence.get("operator_redirected_venue") or "")
+    redirect_applied = bool(operator_influence.get("operator_redirect_applied"))
+    if redirect_applied:
+        proposed_action_map["proposed_venue"] = redirected_venue
+    feedback = {
+        "operator_influence_state": str(operator_influence.get("operator_influence_state") or "no_operator_influence_yet"),
+        "operator_influence_applied": bool(operator_influence.get("operator_influence_applied")),
+        "resolution_kind": operator_influence.get("resolution_kind"),
+        "resolution_receipt_id": operator_influence.get("resolution_receipt_id"),
+        "redirect_applied_to_proposed_venue": redirect_applied,
+        "original_proposed_venue": original_venue,
+        "current_proposed_venue": str(proposed_action_map.get("proposed_venue") or original_venue),
+    }
+    return {
+        **proposal,
+        "proposed_next_action": proposed_action_map,
+        "operator_feedback": feedback,
+        "original_proposed_next_action": proposed_action if isinstance(proposed_action, Mapping) else {},
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "does_not_imply_execution": True,
+                "does_not_override_admission": True,
+                "requires_existing_trigger_path_for_follow_on_action": True,
+                "historical_operator_resolution_preserved": True,
+            },
+        ),
+    }
+
+
 def append_next_move_proposal_ledger(repo_root: Path, proposal: Mapping[str, Any]) -> Path:
     """Append one bounded next-move proposal to the proof-visible orchestration proposal ledger."""
 
@@ -2558,6 +2785,7 @@ def derive_packetization_gate(
     next_move_proposal_review: Mapping[str, Any],
     trust_confidence_posture: Mapping[str, Any],
     operator_attention_recommendation: Mapping[str, Any],
+    operator_resolution_influence: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Derive one bounded packetization gate from existing orchestration-only signals.
@@ -2571,6 +2799,7 @@ def derive_packetization_gate(
     operator_state = operator_state_raw if isinstance(operator_state_raw, Mapping) else {}
     trust_pressure_raw = trust_confidence_posture.get("pressure_summary")
     trust_pressure = trust_pressure_raw if isinstance(trust_pressure_raw, Mapping) else {}
+    operator_influence_map = operator_resolution_influence if isinstance(operator_resolution_influence, Mapping) else {}
 
     posture = str(trust_confidence_posture.get("trust_confidence_posture") or "insufficient_history")
     proposal_review_classification = str(next_move_proposal_review.get("review_classification") or "insufficient_history")
@@ -2585,6 +2814,12 @@ def derive_packetization_gate(
     requires_operator = bool(operator_state.get("requires_operator_or_escalation"))
     escalation_classification = str(operator_state.get("escalation_classification") or "")
     trust_primary_pressure = str(trust_pressure.get("primary_pressure") or "insufficient_history")
+    influence_state = str(operator_influence_map.get("operator_influence_state") or "no_operator_influence_yet")
+    operator_approval_applied = bool(operator_influence_map.get("operator_approval_applied"))
+    operator_context_applied = bool(operator_influence_map.get("operator_context_applied"))
+    operator_decline_preserved_hold = bool(operator_influence_map.get("operator_decline_or_cancel_preserves_hold"))
+    operator_defer_preserved_hold = bool(operator_influence_map.get("operator_defer_preserves_hold"))
+    operator_influence_active = bool(operator_influence_map.get("operator_influence_applied"))
 
     hold_operator_required = (
         requires_operator
@@ -2612,19 +2847,35 @@ def derive_packetization_gate(
         and proposed_posture in {"expand", "consolidate", "audit"}
         and proposal_review_classification == "coherent_recent_proposals"
     )
+    approval_can_relieve_operator_hold = operator_approval_applied and not hold_fragmentation
+    context_can_relieve_insufficient_hold = (
+        operator_context_applied
+        and not hold_fragmentation
+        and executability != "blocked_operator_required"
+    )
+    hold_operator_required_effective = hold_operator_required and not approval_can_relieve_operator_hold
+    hold_insufficient_confidence_effective = hold_insufficient_confidence and not context_can_relieve_insufficient_hold
+    if operator_decline_preserved_hold or operator_defer_preserved_hold:
+        hold_operator_required_effective = True
 
     outcome = "packetization_hold_insufficient_confidence"
     compact_rationale = "insufficient_confidence_or_context_requires_conservative_packetization_hold"
 
-    if hold_operator_required:
+    if hold_operator_required_effective:
         outcome = "packetization_hold_operator_review"
         compact_rationale = "operator_or_escalation_requirement_is_active_so_packetization_is_held"
     elif hold_fragmentation:
         outcome = "packetization_hold_fragmentation"
         compact_rationale = "trust_posture_is_fragmented_or_unreliable_so_packetization_is_held"
-    elif hold_insufficient_confidence:
+    elif hold_insufficient_confidence_effective:
         outcome = "packetization_hold_insufficient_confidence"
         compact_rationale = "insufficient_history_or_context_prevents_confident_packetization"
+    elif operator_approval_applied and coherent_execution_ready:
+        outcome = "packetization_allowed_with_caution"
+        compact_rationale = "operator_approval_visible_with_coherent_proposal_allows_bounded_packetization_caution"
+    elif operator_context_applied and coherent_execution_ready:
+        outcome = "packetization_allowed_with_caution"
+        compact_rationale = "operator_supplied_context_relieves_insufficient_context_hold_in_bounded_form"
     elif posture == "trusted_for_bounded_use" and coherent_execution_ready:
         outcome = "packetization_allowed"
         compact_rationale = "trusted_posture_with_coherent_proposal_allows_bounded_packetization"
@@ -2681,6 +2932,20 @@ def derive_packetization_gate(
             "proposed_posture": proposed_posture,
             "requires_operator_or_escalation": requires_operator,
         },
+        "operator_influence": {
+            "operator_influence_state": influence_state,
+            "operator_influence_applied": operator_influence_active,
+            "operator_approval_applied": operator_approval_applied,
+            "operator_context_applied": operator_context_applied,
+            "operator_decline_preserved_hold": operator_decline_preserved_hold,
+            "operator_defer_preserved_hold": operator_defer_preserved_hold,
+            "applied_relief_paths": {
+                "approval_relaxed_operator_hold": approval_can_relieve_operator_hold,
+                "context_relaxed_insufficient_context_hold": context_can_relieve_insufficient_hold,
+            },
+            "resolution_kind": operator_influence_map.get("resolution_kind"),
+            "resolution_receipt_id": operator_influence_map.get("resolution_receipt_id"),
+        },
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -2690,6 +2955,10 @@ def derive_packetization_gate(
                 "packetization_stage_only": True,
                 "does_not_execute_or_route_work": True,
                 "non_authoritative": True,
+                "does_not_imply_execution": True,
+                "does_not_override_admission": True,
+                "requires_existing_trigger_path_for_follow_on_action": True,
+                "historical_operator_resolution_preserved": True,
             },
         ),
     }

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -22,6 +22,10 @@ from sentientos.orchestration_intent_fabric import (
     derive_orchestration_attention_recommendation,
     derive_packetization_gate,
     derive_external_feedback_gap_map,
+    derive_operator_resolution_feedback_gap_map,
+    derive_operator_resolution_influence,
+    derive_operator_adjusted_next_move_proposal_visibility,
+    derive_operator_adjusted_next_venue_recommendation,
     derive_orchestration_trust_confidence_posture,
     derive_next_venue_recommendation,
     derive_orchestration_outcome_review,
@@ -32,6 +36,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_codex_staged_work_order_lifecycle,
     resolve_deep_research_staged_work_order_lifecycle,
     resolve_handoff_packet_fulfillment_lifecycle,
+    resolve_latest_operator_resolution_for_proposal,
     resolve_operator_action_brief_lifecycle,
     resolve_orchestration_result,
     resolve_unified_orchestration_result,
@@ -219,6 +224,26 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         append_operator_action_brief_ledger(root, operator_action_brief) if operator_action_brief else None
     )
     operator_brief_lifecycle = resolve_operator_action_brief_lifecycle(root, operator_action_brief)
+    linked_operator_receipt = resolve_latest_operator_resolution_for_proposal(
+        root, str(next_move_proposal.get("proposal_id") or "")
+    )
+    operator_influence = derive_operator_resolution_influence(linked_operator_receipt)
+    adjusted_next_venue = derive_operator_adjusted_next_venue_recommendation(next_venue_recommendation, operator_influence)
+    adjusted_next_move_proposal = derive_operator_adjusted_next_move_proposal_visibility(next_move_proposal, operator_influence)
+    packetization_gate = derive_packetization_gate(
+        adjusted_next_move_proposal,
+        next_move_proposal_review,
+        orchestration_trust_confidence_posture,
+        orchestration_attention_recommendation,
+        operator_influence,
+    )
+    operator_feedback_gap_map = derive_operator_resolution_feedback_gap_map(
+        adjusted_next_move_proposal,
+        packetization_gate,
+        adjusted_next_venue,
+        operator_brief_lifecycle,
+        operator_influence,
+    )
     unified_result = resolve_unified_orchestration_result(root, handoff=handoff_result, handoff_packet=handoff_packet)
     unified_result_surface = resolve_unified_orchestration_result_surface(root)
     unified_result_quality_review = derive_unified_result_quality_review(root)
@@ -285,16 +310,17 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "outcome_review": orchestration_outcome_review,
             "venue_mix_review": orchestration_venue_mix_review,
             "attention_recommendation": orchestration_attention_recommendation,
-            "next_venue_recommendation": next_venue_recommendation,
+            "next_venue_recommendation": adjusted_next_venue,
             "external_fulfillment_feedback_visibility": external_feedback_gap_map,
+            "operator_resolution_feedback_gap_map": operator_feedback_gap_map,
             "next_move_proposal": {
-                **next_move_proposal,
+                **adjusted_next_move_proposal,
                 "ledger_path": str(next_move_proposal_ledger_path.relative_to(root)),
                 "current_delegated_judgment_venue": delegated_judgment.get("recommended_venue"),
-                "ready_for_internal_executable_handoff": next_move_proposal.get("executability_classification")
+                "ready_for_internal_executable_handoff": adjusted_next_move_proposal.get("executability_classification")
                 == "executable_now",
-                "staged_only": next_move_proposal.get("executability_classification") == "stageable_external_work_order",
-                "blocked_or_hold": next_move_proposal.get("executability_classification")
+                "staged_only": adjusted_next_move_proposal.get("executability_classification") == "stageable_external_work_order",
+                "blocked_or_hold": adjusted_next_move_proposal.get("executability_classification")
                 in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
             },
             "next_move_proposal_review": next_move_proposal_review,
@@ -308,6 +334,10 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "non_authoritative": True,
                     "does_not_execute_or_route_work": True,
                     "does_not_override_kernel_or_governor": True,
+                    "does_not_imply_execution": True,
+                    "does_not_override_admission": True,
+                    "requires_existing_trigger_path_for_follow_on_action": True,
+                    "historical_operator_resolution_preserved": True,
                 },
             },
             "operator_action_brief": {
@@ -346,6 +376,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "does_not_execute_or_route_work": True,
                 },
             },
+            "operator_influence": operator_influence,
             "handoff_packet": {
                 **handoff_packet,
                 "ledger_path": str(handoff_packet_ledger_path.relative_to(root)),

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -23,6 +23,10 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_external_feedback_gap_map,
+    derive_operator_adjusted_next_move_proposal_visibility,
+    derive_operator_adjusted_next_venue_recommendation,
+    derive_operator_resolution_feedback_gap_map,
+    derive_operator_resolution_influence,
     derive_packetization_gate,
     derive_next_venue_recommendation,
     derive_next_move_proposal_review,
@@ -36,6 +40,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_unified_orchestration_result,
     resolve_unified_orchestration_result_surface,
     resolve_handoff_packet_fulfillment_lifecycle,
+    resolve_latest_operator_resolution_for_proposal,
     resolve_operator_action_brief_lifecycle,
     synthesize_handoff_packet,
     synthesize_next_move_proposal,
@@ -2335,6 +2340,168 @@ def test_operator_brief_lifecycle_visibility_tracks_received_resolution() -> Non
         assert after["does_not_imply_repo_execution"] is True
 
 
+def test_operator_approved_continue_can_relieve_operator_hold_without_execution_trigger() -> None:
+    proposal = {
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "none",
+            "escalation_classification": "escalate_for_operator_priority",
+        },
+    }
+    review = {"review_classification": "coherent_recent_proposals"}
+    trust = {"trust_confidence_posture": "caution_required", "pressure_summary": {"primary_pressure": "none"}}
+    attention = {"operator_attention_recommendation": "observe"}
+    influence = derive_operator_resolution_influence(
+        {"resolution_kind": "approved_continue", "operator_resolution_receipt_id": "orr-1"}
+    )
+
+    gate = derive_packetization_gate(proposal, review, trust, attention, influence)
+    assert gate["packetization_outcome"] == "packetization_allowed_with_caution"
+    assert gate["packetization_allowed"] is True
+    assert gate["does_not_change_admission_or_execution"] is True
+    assert gate["does_not_imply_execution"] is True
+
+
+def test_operator_supplied_context_can_relieve_insufficient_context_hold_conservatively() -> None:
+    proposal = {
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": False,
+            "attention_signal": "none",
+            "escalation_classification": "no_escalation_needed",
+        },
+    }
+    review = {"review_classification": "proposal_insufficient_context_heavy"}
+    trust = {"trust_confidence_posture": "caution_required", "pressure_summary": {"primary_pressure": "none"}}
+    attention = {"operator_attention_recommendation": "insufficient_context"}
+    influence = derive_operator_resolution_influence(
+        {
+            "resolution_kind": "supplied_missing_context",
+            "updated_context_refs": ["docs/context.md#new"],
+            "operator_resolution_receipt_id": "orr-2",
+        }
+    )
+
+    gate = derive_packetization_gate(proposal, review, trust, attention, influence)
+    assert gate["packetization_outcome"] == "packetization_allowed_with_caution"
+    assert gate["operator_influence"]["operator_context_applied"] is True
+    assert gate["does_not_execute_or_route_work"] is True
+
+
+def test_operator_resolution_does_not_falsely_clear_fragmentation_hold() -> None:
+    proposal = {
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "operator_escalation_requirement_state": {"requires_operator_or_escalation": False},
+    }
+    review = {"review_classification": "coherent_recent_proposals"}
+    trust = {"trust_confidence_posture": "fragmented_or_unreliable", "pressure_summary": {"primary_pressure": "fragmentation"}}
+    attention = {"operator_attention_recommendation": "observe"}
+    influence = derive_operator_resolution_influence(
+        {"resolution_kind": "approved_continue", "operator_resolution_receipt_id": "orr-3"}
+    )
+
+    gate = derive_packetization_gate(proposal, review, trust, attention, influence)
+    assert gate["packetization_outcome"] == "packetization_hold_fragmentation"
+    assert gate["packetization_held"] is True
+
+
+def test_operator_decline_cancel_and_defer_preserve_hold() -> None:
+    proposal = {
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "executability_classification": "stageable_external_work_order",
+        "relation_posture": "affirming",
+        "operator_escalation_requirement_state": {
+            "requires_operator_or_escalation": True,
+            "attention_signal": "none",
+            "escalation_classification": "escalate_for_operator_priority",
+        },
+    }
+    review = {"review_classification": "coherent_recent_proposals"}
+    trust = {"trust_confidence_posture": "caution_required", "pressure_summary": {"primary_pressure": "none"}}
+    attention = {"operator_attention_recommendation": "observe"}
+
+    declined = derive_packetization_gate(
+        proposal,
+        review,
+        trust,
+        attention,
+        derive_operator_resolution_influence({"resolution_kind": "declined"}),
+    )
+    cancelled = derive_packetization_gate(
+        proposal,
+        review,
+        trust,
+        attention,
+        derive_operator_resolution_influence({"resolution_kind": "cancelled"}),
+    )
+    deferred = derive_packetization_gate(
+        proposal,
+        review,
+        trust,
+        attention,
+        derive_operator_resolution_influence({"resolution_kind": "deferred"}),
+    )
+    assert declined["packetization_held"] is True
+    assert cancelled["packetization_held"] is True
+    assert deferred["packetization_held"] is True
+
+
+def test_operator_redirect_updates_current_venue_visibility_without_erasing_history() -> None:
+    next_venue = {
+        "next_venue_recommendation": "prefer_codex_implementation",
+        "relation_to_delegated_judgment": "affirming",
+    }
+    proposal = {
+        "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+        "proposal_id": "proposal-redirect",
+    }
+    influence = derive_operator_resolution_influence(
+        {
+            "resolution_kind": "redirected_venue",
+            "redirected_venue": "deep_research_audit",
+            "operator_resolution_receipt_id": "orr-4",
+        }
+    )
+
+    adjusted_venue = derive_operator_adjusted_next_venue_recommendation(next_venue, influence)
+    adjusted_proposal = derive_operator_adjusted_next_move_proposal_visibility(proposal, influence)
+    assert adjusted_venue["original_next_venue_recommendation"] == "prefer_codex_implementation"
+    assert adjusted_venue["current_next_venue_recommendation"] == "prefer_deep_research_audit"
+    assert adjusted_proposal["operator_feedback"]["original_proposed_venue"] == "codex_implementation"
+    assert adjusted_proposal["operator_feedback"]["current_proposed_venue"] == "deep_research_audit"
+
+
+def test_latest_operator_resolution_for_proposal_is_resolved_from_ledger(tmp_path: Path) -> None:
+    brief = _operator_brief_for_receipt_flow()
+    append_operator_action_brief_ledger(tmp_path, brief)
+    ingest_operator_resolution_receipt(
+        tmp_path,
+        operator_action_brief_id=str(brief["operator_action_brief_id"]),
+        resolution_kind="approved_continue",
+        operator_note="continue",
+        created_at="2026-04-12T00:01:00Z",
+    )
+    redirected = ingest_operator_resolution_receipt(
+        tmp_path,
+        operator_action_brief_id=str(brief["operator_action_brief_id"]),
+        resolution_kind="redirected_venue",
+        operator_note="redirect",
+        redirected_venue="deep_research_audit",
+        created_at="2026-04-12T00:02:00Z",
+    )
+    latest = resolve_latest_operator_resolution_for_proposal(tmp_path, str(brief["source_next_move_proposal_ref"]["proposal_id"]))
+    assert latest is not None
+    assert latest["resolution_kind"] == "redirected_venue"
+    assert latest["operator_resolution_receipt_id"] == redirected["operator_resolution_receipt_id"]
+
+
 def test_handoff_packet_artifact_is_append_only_and_proof_visible(tmp_path: Path) -> None:
     delegated = synthesize_delegated_judgment(_base_evidence())
     proposal = {
@@ -2611,9 +2778,18 @@ def test_operator_resolution_end_to_end_updates_diagnostic_consumer_without_exec
     diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
     gate = diagnostic["orchestration_handoff"]["packetization_gating"]
     brief_surface = diagnostic["orchestration_handoff"]["operator_action_brief"]
+    operator_influence = diagnostic["orchestration_handoff"]["operator_influence"]
+    proposal_visibility = diagnostic["orchestration_handoff"]["next_move_proposal"]["operator_feedback"]
+    next_venue_visibility = diagnostic["orchestration_handoff"]["next_venue_recommendation"]["operator_feedback"]
     handoff = diagnostic["orchestration_handoff"]["handoff_result"]
 
-    assert gate["packetization_held"] is True
+    assert gate["packetization_outcome"] in {
+        "packetization_allowed_with_caution",
+        "packetization_hold_operator_review",
+        "packetization_hold_insufficient_confidence",
+    }
+    assert gate["operator_influence"]["operator_influence_applied"] is True
+    assert gate["operator_influence"]["resolution_kind"] == "approved_continue"
     assert brief_surface["brief_produced"] is True
     assert brief_surface["operator_resolution_received"] is True
     assert brief_surface["resolution_kind"] == "approved_continue"
@@ -2622,6 +2798,10 @@ def test_operator_resolution_end_to_end_updates_diagnostic_consumer_without_exec
     assert brief_surface["awaiting_operator_input"] is False
     assert brief_surface["non_sovereign_boundaries"]["ingested_operator_outcome"] is True
     assert brief_surface["non_sovereign_boundaries"]["explicit_clarity"] == "ingested operator outcome, not repo execution"
+    assert operator_influence["operator_influence_state"] == "operator_approval_applied"
+    assert operator_influence["does_not_imply_execution"] is True
+    assert proposal_visibility["operator_influence_applied"] is True
+    assert next_venue_visibility["operator_influence_applied"] is True
     assert handoff["handoff_outcome"] in {"blocked_by_operator_requirement", "blocked_by_insufficient_context", "staged_only", "admitted_to_execution_substrate", "blocked_by_admission"}
     assert brief_surface["non_sovereign_boundaries"]["does_not_convert_hold_to_execution"] is True
 
@@ -3569,4 +3749,46 @@ def test_external_feedback_gap_map_reports_layer_influence_coherently() -> None:
     assert gap_map["outcome_review"]["remaining_gap"] == "none"
     assert gap_map["venue_mix_review"]["remaining_gap"] == "none"
     assert gap_map["next_venue_recommendation"]["remaining_gap"] == "none"
+    assert gap_map["diagnostic_only"] is True
+
+
+def test_operator_feedback_gap_map_reports_resolution_visibility_by_layer() -> None:
+    operator_influence = derive_operator_resolution_influence(
+        {
+            "resolution_kind": "supplied_missing_context",
+            "updated_context_refs": ["docs/context.md#operator"],
+            "operator_resolution_receipt_id": "orr-gap",
+        }
+    )
+    proposal = derive_operator_adjusted_next_move_proposal_visibility(
+        {"proposed_next_action": {"proposed_venue": "codex_implementation"}},
+        operator_influence,
+    )
+    next_venue = derive_operator_adjusted_next_venue_recommendation(
+        {
+            "next_venue_recommendation": "prefer_codex_implementation",
+            "relation_to_delegated_judgment": "affirming",
+        },
+        operator_influence,
+    )
+    gate = derive_packetization_gate(
+        {
+            "proposed_next_action": {"proposed_venue": "codex_implementation", "proposed_posture": "expand"},
+            "executability_classification": "stageable_external_work_order",
+            "relation_posture": "affirming",
+            "operator_escalation_requirement_state": {"requires_operator_or_escalation": False},
+        },
+        {"review_classification": "coherent_recent_proposals"},
+        {"trust_confidence_posture": "caution_required", "pressure_summary": {"primary_pressure": "none"}},
+        {"operator_attention_recommendation": "observe"},
+        operator_influence,
+    )
+    lifecycle = {"operator_resolution_received": True, "resolution_kind": "supplied_missing_context"}
+
+    gap_map = derive_operator_resolution_feedback_gap_map(proposal, gate, next_venue, lifecycle, operator_influence)
+    assert gap_map["next_move_proposal_visibility"]["remaining_gap"] == "none"
+    assert gap_map["packetization_gating"]["remaining_gap"] == "none"
+    assert gap_map["next_venue_recommendation"]["remaining_gap"] == "none"
+    assert gap_map["operator_brief_lifecycle_visibility"]["remaining_gap"] == "none"
+    assert gap_map["held_loop_static_after_operator_response"] is False
     assert gap_map["diagnostic_only"] is True


### PR DESCRIPTION
### Motivation

- Make operator resolution receipts meaningfully influence the orchestration body so held/escalated loops can evolve after an operator responds while preserving non-sovereignty and no direct execution authority.
- Close the feedback gap for packetization gating, next-move proposal visibility, and next-venue recommendation so operator responses can unblock or reclassify holds conservatively.

### Description

- Added a compact operator influence surface and helpers: `resolve_latest_operator_resolution_for_proposal`, `derive_operator_resolution_influence`, and `derive_operator_resolution_feedback_gap_map` in `sentientos/orchestration_intent_fabric.py` to expose typed, proof-visible operator influence artifacts.
- Introduced operator-adjusted visibility helpers `derive_operator_adjusted_next_move_proposal_visibility` and `derive_operator_adjusted_next_venue_recommendation` that preserve original delegated recommendations while showing current operator-influenced visibility.
- Extended `derive_packetization_gate` to accept optional operator-resolution influence and apply conservative hold-relief semantics for `approved_continue`/`approved_with_constraints` and `supplied_missing_context`, while ensuring `declined`/`cancelled`/`deferred` preserve holds and fragmentation remains authoritative.
- Wired the new influence surfaces into the scoped diagnostic consumer (`sentientos/scoped_lifecycle_diagnostic.py`) so consumers surface `operator_influence`, operator-adjusted proposal/venue visibility, and a compact feedback-gap map; all influenced fields include explicit non-sovereign/invariant flags (e.g., `does_not_imply_execution`, `does_not_override_admission`).
- Added focused unit tests in `sentientos/tests/test_orchestration_intent_fabric.py` validating approval/context relief (bounded), redirect visibility/history preservation, decline/defer preserve holds, fragmentation is not cleared by receipts, latest-receipt resolution from ledger, feedback-gap coherence, and an end-to-end consumer visibility path.
- Updated `docs/orchestration_next_move_proposal_note.md` with a short technical section describing the bounded operator-resolution feedback semantics and the explicit non-executing boundaries.

### Testing

- Ran focused pytest for the change surface: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "operator_resolution or packetization_gate or feedback_gap_map"` and the focused tests passed.
- Ran the repository-wide test runner `python -m scripts.run_tests -q`; this run surfaced unrelated failures in the existing `tests/test_pulse_federation.py` suite (these failures pre-existed and are not caused by the operator-feedback changes).
- Ran static and audit checks: `mypy scripts/ sentientos/` reported pre-existing typing debt across the repository (not introduced by this change), `verify_audits --strict` is unavailable in the environment, and `python scripts/audit_immutability_verifier.py` completed successfully.

Notes: all changes are conservative and proof-visible; operator receipts remain receipt-only and explicitly marked as non-authoritative and non-executing, and no new venues, execution paths, or direct external actuation were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3ec4cf9c083208fde0a360f1dafa3)