### PR TITLE
[codex:orchestration] add bounded proposal→packet continuity review

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -192,6 +192,15 @@ _NEXT_MOVE_PROPOSAL_REVIEW_CLASSES = {
     "insufficient_history",
 }
 
+_PROPOSAL_PACKET_CONTINUITY_CLASSES = {
+    "coherent_proposal_packet_continuity",
+    "hold_heavy_continuity",
+    "redirect_heavy_continuity",
+    "repacketization_churn",
+    "fragmented_continuity",
+    "insufficient_history",
+}
+
 _ORCHESTRATION_TRUST_POSTURES = {
     "trusted_for_bounded_use",
     "caution_required",
@@ -4116,12 +4125,194 @@ def derive_next_move_proposal_review(
     }
 
 
+def derive_proposal_packet_continuity_review(
+    repo_root: Path,
+    *,
+    window_size: int = 10,
+) -> dict[str, Any]:
+    """Derive a bounded retrospective continuity classifier from proposal->packet lineage artifacts only."""
+
+    root = repo_root.resolve()
+    proposals = _read_jsonl(root / "glow/orchestration/orchestration_next_move_proposals.jsonl")
+    packets = _read_jsonl(root / "glow/orchestration/orchestration_handoff_packets.jsonl")
+    briefs = _read_jsonl(root / "glow/orchestration/operator_action_briefs.jsonl")
+    operator_receipts = _read_jsonl(root / "glow/orchestration/operator_resolution_receipts.jsonl")
+    recent = proposals[-max(0, window_size) :] if window_size > 0 else []
+    recent_proposal_ids = [str(row.get("proposal_id") or "") for row in recent if str(row.get("proposal_id") or "")]
+    proposal_id_set = set(recent_proposal_ids)
+    records_considered = len(recent_proposal_ids)
+
+    linked_packets = [
+        row
+        for row in packets
+        if str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") in proposal_id_set
+    ]
+    linked_briefs = [
+        row
+        for row in briefs
+        if str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") in proposal_id_set
+    ]
+    linked_receipts = [
+        row
+        for row in operator_receipts
+        if str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") in proposal_id_set
+    ]
+
+    hold_related_count = 0
+    for row in linked_packets + linked_briefs:
+        packetization_outcome = str((row.get("source_packetization_gate_ref") or {}).get("packetization_outcome") or "")
+        if packetization_outcome.startswith("packetization_hold_"):
+            hold_related_count += 1
+
+    redirect_receipt_count = sum(1 for row in linked_receipts if str(row.get("resolution_kind") or "") == "redirected_venue")
+    redirect_refresh_count = 0
+    repacketization_count = 0
+    broken_lineage_count = 0
+    stable_active_packet_count = 0
+    for proposal_id in recent_proposal_ids:
+        proposal_packets = [
+            row
+            for row in linked_packets
+            if str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") == proposal_id
+        ]
+        packet_ids = {str(row.get("handoff_packet_id") or "") for row in proposal_packets if str(row.get("handoff_packet_id") or "")}
+        current_candidates = 0
+        for row in proposal_packets:
+            lineage_map = row.get("packet_lineage") if isinstance(row.get("packet_lineage"), Mapping) else {}
+            supersedes_id = str(lineage_map.get("supersedes_handoff_packet_id") or "")
+            if supersedes_id:
+                repacketization_count += 1
+                if supersedes_id not in packet_ids:
+                    broken_lineage_count += 1
+            if bool(row.get("repacketized_from_operator_feedback")):
+                repacketization_count += 1
+            refresh_reason = str(lineage_map.get("refresh_reason") or "")
+            if refresh_reason == "operator_redirected_venue_refresh":
+                redirect_refresh_count += 1
+            if bool(lineage_map.get("current_packet_candidate", True)):
+                current_candidates += 1
+        if current_candidates > 1:
+            broken_lineage_count += 1
+
+        active = resolve_active_handoff_packet_candidate(root, proposal_id)
+        active_present = bool(active.get("active_packet_present"))
+        active_id = str(active.get("active_handoff_packet_id") or "")
+        if proposal_packets and (not active_present or not active_id):
+            broken_lineage_count += 1
+        if active_present and active.get("current_packet_candidate") and active_id:
+            stable_active_packet_count += 1
+
+    redirect_related_count = redirect_receipt_count + redirect_refresh_count
+    recent_packet_count = len(linked_packets)
+    proposals_with_packets = sum(
+        1
+        for proposal_id in recent_proposal_ids
+        if any(str((row.get("source_next_move_proposal_ref") or {}).get("proposal_id") or "") == proposal_id for row in linked_packets)
+    )
+    stable_emergence_ratio = (stable_active_packet_count / proposals_with_packets) if proposals_with_packets else 0.0
+    stable_active_packet_usually_emerges = proposals_with_packets > 0 and stable_emergence_ratio >= 0.67
+
+    hold_heavy = hold_related_count >= max(2, (records_considered + 1) // 2)
+    redirect_heavy = redirect_related_count >= max(2, (records_considered + 1) // 2)
+    churn_heavy = repacketization_count >= max(3, records_considered) and not stable_active_packet_usually_emerges
+    fragmented = broken_lineage_count > 0 or (
+        records_considered >= 3 and recent_packet_count > 0 and not stable_active_packet_usually_emerges
+    )
+    coherent = (
+        records_considered >= 3
+        and recent_packet_count >= 2
+        and hold_related_count <= 1
+        and redirect_related_count <= 1
+        and repacketization_count <= max(1, records_considered // 2)
+        and broken_lineage_count == 0
+        and stable_active_packet_usually_emerges
+    )
+
+    classification = "insufficient_history"
+    compact_reason = "insufficient_recent_proposal_packet_history_for_reliable_continuity_review"
+    if records_considered >= 3:
+        if churn_heavy:
+            classification = "repacketization_churn"
+            compact_reason = "repeated_repacketization_without_consistent_stable_active_packet_emergence"
+        elif fragmented:
+            classification = "fragmented_continuity"
+            compact_reason = "proposal_packet_linkage_or_active_candidate_resolution_is_fragmented"
+        elif hold_heavy:
+            classification = "hold_heavy_continuity"
+            compact_reason = "packetization_hold_outcomes_repeat_across_recent_proposal_to_packet_flow"
+        elif redirect_heavy:
+            classification = "redirect_heavy_continuity"
+            compact_reason = "redirect_linked_operator_or_lineage_signals_repeat_across_recent_packets"
+        elif coherent:
+            classification = "coherent_proposal_packet_continuity"
+            compact_reason = "recent_proposals_usually_resolve_to_stable_active_packets_with_low_hold_redirect_churn"
+        else:
+            classification = "fragmented_continuity"
+            compact_reason = "proposal_to_packet_continuity_is_not_yet_coherently_stable"
+
+    if classification not in _PROPOSAL_PACKET_CONTINUITY_CLASSES:
+        classification = "fragmented_continuity"
+        compact_reason = "unrecognized_continuity_classification_defaulted_to_fragmented_continuity"
+
+    return {
+        "schema_version": "proposal_packet_continuity_review.v1",
+        "review_kind": "proposal_packet_continuity_retrospective",
+        "review_classification": classification,
+        "window_size": max(0, window_size),
+        "records_considered": records_considered,
+        "continuity_counts": {
+            "recent_proposal_count": records_considered,
+            "recent_packet_count": recent_packet_count,
+            "repacketization_count": repacketization_count,
+            "redirect_related_count": redirect_related_count,
+            "hold_related_count": hold_related_count,
+            "broken_lineage_count": broken_lineage_count,
+            "stable_active_packet_count": stable_active_packet_count,
+            "proposals_with_packets": proposals_with_packets,
+        },
+        "summary": {
+            "stable_active_packet_usually_emerges": stable_active_packet_usually_emerges,
+            "stable_active_packet_emergence_ratio": round(stable_emergence_ratio, 4),
+            "compact_reason": compact_reason,
+            "diagnostic_summary": "bounded retrospective continuity review derived from existing proposal/packet/operator lineage artifacts only",
+            "boundaries": {
+                "diagnostic_only": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+                "review_only": True,
+            },
+        },
+        "artifacts_read": {
+            "next_move_proposal_ledger": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+            "handoff_packet_ledger": "glow/orchestration/orchestration_handoff_packets.jsonl",
+            "operator_action_brief_ledger": "glow/orchestration/operator_action_briefs.jsonl",
+            "operator_resolution_receipt_ledger": "glow/orchestration/operator_resolution_receipts.jsonl",
+            "packetization_gate_outcomes_from": [
+                "handoff_packet.source_packetization_gate_ref.packetization_outcome",
+                "operator_action_brief.source_packetization_gate_ref.packetization_outcome",
+            ],
+            "active_packet_candidate_resolver": "resolve_active_handoff_packet_candidate",
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "review_only": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+            },
+        ),
+    }
+
+
 def derive_orchestration_trust_confidence_posture(
     next_move_proposal_review: Mapping[str, Any],
     venue_mix_review: Mapping[str, Any],
     outcome_review: Mapping[str, Any],
     unified_result_quality_review: Mapping[str, Any],
     operator_attention_recommendation: Mapping[str, Any],
+    proposal_packet_continuity_review: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Derive one compact orchestration trust/confidence posture from existing review surfaces only.
@@ -4134,6 +4325,8 @@ def derive_orchestration_trust_confidence_posture(
     outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
     result_quality_classification = str(unified_result_quality_review.get("review_classification") or "insufficient_history")
     attention = str(operator_attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
+    continuity_map = proposal_packet_continuity_review if isinstance(proposal_packet_continuity_review, Mapping) else {}
+    continuity_classification = str(continuity_map.get("review_classification") or "insufficient_history")
 
     records_counts = {
         "next_move_proposal_review": int(next_move_proposal_review.get("records_considered") or 0),
@@ -4276,6 +4469,11 @@ def derive_orchestration_trust_confidence_posture(
                 "records_considered": records_counts["unified_result_quality_review"],
             },
             "operator_attention_recommendation": attention,
+            "proposal_packet_continuity_review": {
+                "review_classification": continuity_classification,
+                "records_considered": int(continuity_map.get("records_considered") or 0),
+                "bounded_basis_only": True,
+            },
         },
         "pressure_summary": {
             "primary_pressure": primary_pressure,
@@ -4290,6 +4488,7 @@ def derive_orchestration_trust_confidence_posture(
                 "orchestration_outcome_review",
                 "unified_result_quality_review",
                 "orchestration_operator_attention_recommendation",
+                "proposal_packet_continuity_review",
             ],
             "compact_rationale": compact_reason,
         },

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -409,6 +409,43 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "direct external actuation",
             ],
         },
+        "proposal_packet_continuity_review": {
+            "meaning": "compact retrospective classifier indicating whether recent next-move proposals are converting into coherent active packet lineage or drifting through repeated holds/redirects/repacketization churn.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.derive_proposal_packet_continuity_review",
+            "derived_from_existing_artifacts_only": [
+                "orchestration_next_move_proposals.jsonl",
+                "orchestration_handoff_packets.jsonl",
+                "operator_action_briefs.jsonl",
+                "operator_resolution_receipts.jsonl",
+                "resolve_active_handoff_packet_candidate",
+            ],
+            "reads_fields": [
+                "source_next_move_proposal_ref.proposal_id",
+                "source_packetization_gate_ref.packetization_outcome",
+                "packet_lineage.supersedes_handoff_packet_id",
+                "packet_lineage.current_packet_candidate",
+                "packet_lineage.refresh_reason",
+                "resolution_kind",
+            ],
+            "values": [
+                "coherent_proposal_packet_continuity",
+                "hold_heavy_continuity",
+                "redirect_heavy_continuity",
+                "repacketization_churn",
+                "fragmented_continuity",
+                "insufficient_history",
+            ],
+            "how_it_differs": {
+                "from_unified_result_quality_review": "continuity review diagnoses proposal->packet lineage coherence before/alongside execution or fulfillment quality outcomes",
+                "from_trust_confidence_posture": "trust posture synthesizes multiple review surfaces; continuity review is one bounded lineage-specific retrospective signal",
+            },
+            "explicitly_not": [
+                "planner authority",
+                "packetization gate override",
+                "admission or execution control",
+                "new venue routing or actuation",
+            ],
+        },
         "packetization_gating": {
             "meaning": "bounded constitutional gate deciding whether a next-move proposal can be packetized now, packetized with caution, or held for explicit reasons.",
             "machine_surface": "sentientos.orchestration_intent_fabric.derive_packetization_gate",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -21,6 +21,7 @@ from sentientos.orchestration_intent_fabric import (
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
     derive_packetization_gate,
+    derive_proposal_packet_continuity_review,
     derive_external_feedback_gap_map,
     derive_repacketization_gap_map,
     derive_operator_resolution_feedback_gap_map,
@@ -196,12 +197,14 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     next_move_proposal_ledger_path = append_next_move_proposal_ledger(root, next_move_proposal)
     unified_result_quality_review = derive_unified_result_quality_review(root)
     next_move_proposal_review = derive_next_move_proposal_review(root)
+    proposal_packet_continuity_review = derive_proposal_packet_continuity_review(root)
     orchestration_trust_confidence_posture = derive_orchestration_trust_confidence_posture(
         next_move_proposal_review,
         orchestration_venue_mix_review,
         orchestration_outcome_review,
         unified_result_quality_review,
         orchestration_attention_recommendation,
+        proposal_packet_continuity_review,
     )
     packetization_gate = derive_packetization_gate(
         next_move_proposal,
@@ -354,6 +357,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 in {"blocked_operator_required", "blocked_insufficient_context", "no_action_recommended"},
             },
             "next_move_proposal_review": next_move_proposal_review,
+            "proposal_packet_continuity_review": proposal_packet_continuity_review,
             "trust_confidence_posture": orchestration_trust_confidence_posture,
             "packetization_gating": {
                 **packetization_gate,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -22,6 +22,7 @@ from sentientos.orchestration_intent_fabric import (
     ingest_operator_resolution_receipt,
     build_handoff_execution_gap_map,
     derive_orchestration_attention_recommendation,
+    derive_proposal_packet_continuity_review,
     derive_external_feedback_gap_map,
     derive_operator_adjusted_next_move_proposal_visibility,
     derive_operator_adjusted_next_venue_recommendation,
@@ -99,6 +100,39 @@ def _proposal_row(
         "diagnostic_only": True,
         "non_authoritative": True,
         "decision_power": "none",
+    }
+
+
+def _packet_row(
+    *,
+    proposal_id: str,
+    packet_id: str,
+    status: str = "ready_for_external_trigger",
+    venue: str = "codex_implementation",
+    gate_outcome: str = "packetization_allowed",
+    supersedes: str | None = None,
+    refresh_reason: str | None = None,
+    current_candidate: bool = True,
+    repacketized: bool = False,
+) -> dict[str, object]:
+    return {
+        "schema_version": "orchestration_handoff_packet.v1",
+        "handoff_packet_id": packet_id,
+        "recorded_at": "2026-04-12T00:00:00Z",
+        "packet_status": status,
+        "target_venue": venue,
+        "source_next_move_proposal_ref": {"proposal_id": proposal_id},
+        "source_packetization_gate_ref": {"packetization_outcome": gate_outcome},
+        "packet_lineage": {
+            "supersedes_handoff_packet_id": supersedes,
+            "refresh_reason": refresh_reason,
+            "source_operator_resolution_receipt_id": None,
+            "current_packet_candidate": current_candidate,
+        },
+        "repacketized_from_operator_feedback": repacketized,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "diagnostic_only": True,
     }
 
 
@@ -1704,6 +1738,155 @@ def test_next_move_proposal_review_classifies_insufficient_history(tmp_path: Pat
 
     review = derive_next_move_proposal_review(tmp_path)
     assert review["review_classification"] == "insufficient_history"
+
+
+def test_proposal_packet_continuity_classifies_coherent(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="nudging", venue="deep_research_audit", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+    ]
+    packets = [
+        _packet_row(proposal_id=str(proposals[0]["proposal_id"]), packet_id="packet-coherent-1"),
+        _packet_row(proposal_id=str(proposals[1]["proposal_id"]), packet_id="packet-coherent-2", venue="deep_research_audit"),
+        _packet_row(proposal_id=str(proposals[2]["proposal_id"]), packet_id="packet-coherent-3", venue="internal_direct_execution"),
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl", packets)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "coherent_proposal_packet_continuity"
+    assert review["summary"]["stable_active_packet_usually_emerges"] is True
+
+
+def test_proposal_packet_continuity_classifies_hold_heavy(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="holding", venue="operator_decision_required", executability="blocked_operator_required"),
+        _proposal_row(relation_posture="holding", venue="operator_decision_required", executability="blocked_operator_required"),
+        _proposal_row(relation_posture="holding", venue="operator_decision_required", executability="blocked_operator_required"),
+    ]
+    briefs = [
+        {
+            "source_next_move_proposal_ref": {"proposal_id": str(proposals[0]["proposal_id"])},
+            "source_packetization_gate_ref": {"packetization_outcome": "packetization_hold_operator_review"},
+        },
+        {
+            "source_next_move_proposal_ref": {"proposal_id": str(proposals[1]["proposal_id"])},
+            "source_packetization_gate_ref": {"packetization_outcome": "packetization_hold_insufficient_confidence"},
+        },
+        {
+            "source_next_move_proposal_ref": {"proposal_id": str(proposals[2]["proposal_id"])},
+            "source_packetization_gate_ref": {"packetization_outcome": "packetization_hold_fragmentation"},
+        },
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+    _write_jsonl(tmp_path / "glow/orchestration/operator_action_briefs.jsonl", briefs)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "hold_heavy_continuity"
+    assert review["continuity_counts"]["hold_related_count"] >= 3
+
+
+def test_proposal_packet_continuity_classifies_redirect_heavy(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="escalating", venue="codex_implementation", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="escalating", venue="deep_research_audit", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="escalating", venue="internal_direct_execution", executability="executable_now"),
+    ]
+    packets = [
+        _packet_row(
+            proposal_id=str(proposals[0]["proposal_id"]),
+            packet_id="packet-redirect-1",
+            refresh_reason="operator_redirected_venue_refresh",
+        ),
+        _packet_row(
+            proposal_id=str(proposals[1]["proposal_id"]),
+            packet_id="packet-redirect-2",
+            refresh_reason="operator_redirected_venue_refresh",
+        ),
+        _packet_row(proposal_id=str(proposals[2]["proposal_id"]), packet_id="packet-redirect-3"),
+    ]
+    receipts = [
+        {"source_next_move_proposal_ref": {"proposal_id": str(proposals[0]["proposal_id"])}, "resolution_kind": "redirected_venue"},
+        {"source_next_move_proposal_ref": {"proposal_id": str(proposals[1]["proposal_id"])}, "resolution_kind": "redirected_venue"},
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl", packets)
+    _write_jsonl(tmp_path / "glow/orchestration/operator_resolution_receipts.jsonl", receipts)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "redirect_heavy_continuity"
+    assert review["continuity_counts"]["redirect_related_count"] >= 2
+
+
+def test_proposal_packet_continuity_classifies_repacketization_churn(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="affirming", venue="deep_research_audit", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+    ]
+    packets = [
+        _packet_row(
+            proposal_id=str(proposals[0]["proposal_id"]),
+            packet_id="packet-churn-1",
+            supersedes="packet-churn-0",
+            repacketized=True,
+            current_candidate=False,
+        ),
+        _packet_row(
+            proposal_id=str(proposals[1]["proposal_id"]),
+            packet_id="packet-churn-2",
+            supersedes="packet-churn-1",
+            repacketized=True,
+            current_candidate=False,
+        ),
+        _packet_row(
+            proposal_id=str(proposals[2]["proposal_id"]),
+            packet_id="packet-churn-3",
+            supersedes="packet-churn-2",
+            repacketized=True,
+            current_candidate=False,
+        ),
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl", packets)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "repacketization_churn"
+    assert review["summary"]["stable_active_packet_usually_emerges"] is False
+
+
+def test_proposal_packet_continuity_classifies_fragmented(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="nudging", venue="deep_research_audit", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="affirming", venue="internal_direct_execution", executability="executable_now"),
+    ]
+    packets = [
+        _packet_row(
+            proposal_id=str(proposals[0]["proposal_id"]),
+            packet_id="packet-frag-1",
+            supersedes="missing-parent-packet",
+        ),
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl", packets)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "fragmented_continuity"
+    assert review["continuity_counts"]["broken_lineage_count"] >= 1
+
+
+def test_proposal_packet_continuity_classifies_insufficient_history(tmp_path: Path) -> None:
+    proposals = [
+        _proposal_row(relation_posture="affirming", venue="codex_implementation", executability="stageable_external_work_order"),
+        _proposal_row(relation_posture="affirming", venue="deep_research_audit", executability="stageable_external_work_order"),
+    ]
+    _write_jsonl(tmp_path / "glow/orchestration/orchestration_next_move_proposals.jsonl", proposals)
+
+    review = derive_proposal_packet_continuity_review(tmp_path)
+    assert review["review_classification"] == "insufficient_history"
+    assert review["summary"]["boundaries"]["non_authoritative"] is True
 
 
 def test_multi_venue_history_flows_to_consumer_venue_mix_review_and_stays_non_authoritative(
@@ -3996,6 +4179,7 @@ def test_operator_repacketization_e2e_in_scoped_diagnostic(monkeypatch, tmp_path
     active = handoff_packet["active_packet_candidate"]
     history = handoff_packet["lineage_history"]
     gap = diagnostic["orchestration_handoff"]["repacketization_gap_map"]
+    continuity = diagnostic["orchestration_handoff"]["proposal_packet_continuity_review"]
 
     assert handoff_packet["repacketized_from_operator_feedback"] is True
     assert handoff_packet["historical_packet_state_preserved"] is True
@@ -4006,3 +4190,13 @@ def test_operator_repacketization_e2e_in_scoped_diagnostic(monkeypatch, tmp_path
     assert gap["history"]["manual_reconstruction_required"] is False
     assert handoff_packet["does_not_execute_or_route_work"] is True
     assert gap["diagnostic_only"] is True
+    assert continuity["review_classification"] in {
+        "coherent_proposal_packet_continuity",
+        "hold_heavy_continuity",
+        "redirect_heavy_continuity",
+        "repacketization_churn",
+        "fragmented_continuity",
+        "insufficient_history",
+    }
+    assert continuity["summary"]["boundaries"]["decision_power"] == "none"
+    assert continuity["summary"]["boundaries"]["non_authoritative"] is True


### PR DESCRIPTION
### Motivation

- Provide a small, conservative retrospective classifier so the orchestration body can detect whether next-move proposals reliably become stable handoff packets or whether the loop is drifting through holds, redirects, or repeated repacketization churn. 
- Keep the model diagnostic-only, non-sovereign, and derived only from existing proposal/packet/operator artifacts.

### Description

- Add a bounded continuity classifier `derive_proposal_packet_continuity_review(repo_root, *, window_size=10)` that reads existing ledgers (`glow/orchestration/orchestration_next_move_proposals.jsonl`, `glow/orchestration/orchestration_handoff_packets.jsonl`, `glow/orchestration/operator_action_briefs.jsonl`, `glow/orchestration/operator_resolution_receipts.jsonl`) and `resolve_active_handoff_packet_candidate`, and emits one of six compact classes: `coherent_proposal_packet_continuity`, `hold_heavy_continuity`, `redirect_heavy_continuity`, `repacketization_churn`, `fragmented_continuity`, or `insufficient_history` along with compact continuity counts and a short diagnostic summary. (file: `sentientos/orchestration_intent_fabric.py`) 
- Add continuity vocabulary constant `_PROPOSAL_PACKET_CONTINUITY_CLASSES` and wire conservative heuristics (hold/redirect/repacketize/broken-lineage/stable-active-packet checks) into the classifier. (file: `sentientos/orchestration_intent_fabric.py`) 
- Surface the review in the scoped orchestration diagnostic consumer so the continuity review appears alongside existing handoff diagnostics, and pass it into `derive_orchestration_trust_confidence_posture` as a bounded visibility field only (no change to admission/execution authority). (files: `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric.py`) 
- Add a short technical note describing what the continuity review means, which fields it reads, expected values, and explicit non-sovereign boundaries. (file: `sentientos/orchestration_intent_fabric_note.py`) 
- Add focused tests that exercise each continuity class, the consumer surfacing, and an end-to-end repacketization operator-flow where refreshed packet lineage and the continuity review are produced and remain non-authoritative. (file: `sentientos/tests/test_orchestration_intent_fabric.py`) 

### Testing

- Ran the focused unit tests for the new continuity functionality: `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py -k "proposal_packet_continuity or operator_repacketization_e2e_in_scoped_diagnostic"`, and the targeted suite passed: `7 passed`.
- Ran the repository `mypy scripts/ sentientos/` which exposes many pre-existing repo-wide typing issues; failures are unrelated to this change and remain as before (repository-wide typing errors). 
- Ran the full test harness `python -m scripts.run_tests -q`; this surfaced unrelated failures in pulse federation tests in the broader suite (these failures pre-exist and are not caused by the continuity review). 
- Ran `python scripts/audit_immutability_verifier.py` which passed in this environment. 

All continuity outputs are explicitly diagnostic-only and declared `non_authoritative` / `decision_power: none`; no new venues, execution paths, or sovereign authorities were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e402c0c4c88320941c16fff3f1e8aa)