### PR TITLE
[codex:orchestration] add bounded current orchestration state resolver

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -171,3 +171,43 @@ Bounded review classifications:
 The review is descriptive and diagnostic. It does **not** plan, execute, admit, route, or
 authorize work; it remains `diagnostic_only`, `non_authoritative`, `decision_power: none`,
 and `review_only`.
+
+## Current orchestration state (bounded present-tense resolver)
+
+`current_orchestration_state.v1` is a compact, machine-readable **current-state** surface that
+collapses existing orchestration artifacts into one present-tense answer for:
+
+- current active orchestration item linkage
+- current wait condition / awaiting actor
+- current bounded supervisory state
+
+It is derived only from already-existing surfaces:
+
+- next-move proposal visibility
+- packetization gate outcome
+- active handoff packet candidate + packet fulfillment lifecycle
+- operator action brief lifecycle
+- unified orchestration result linkage
+
+Bounded supervisory values:
+
+- `ready_to_packetize`
+- `packet_ready_for_internal_trigger`
+- `packet_ready_for_external_trigger`
+- `waiting_for_operator_resolution`
+- `waiting_for_external_fulfillment`
+- `waiting_for_internal_result`
+- `held_due_to_fragmentation`
+- `held_due_to_insufficient_confidence`
+- `no_active_orchestration_item`
+- `completed_recently_no_current_item`
+
+This differs from trust/readiness layers:
+
+- **trust posture** = retrospective confidence pressure classification
+- **readiness verdict** = bounded readiness posture over recent reviews
+- **current orchestration state** = present-tense legibility of what loop state is active now
+
+It does **not** add authority, execution, planning, new goals, new venues, or workflow sovereignty.
+It remains explicit current-state visibility only (`non_authoritative`, `diagnostic_only`,
+`decision_power: none`, `does_not_execute_or_route_work`).

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -248,6 +248,35 @@ _DELEGATED_OPERATION_PRESSURE_SOURCES = {
     "insufficient_history",
 }
 
+_CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
+    "ready_to_packetize",
+    "packet_ready_for_internal_trigger",
+    "packet_ready_for_external_trigger",
+    "waiting_for_operator_resolution",
+    "waiting_for_external_fulfillment",
+    "waiting_for_internal_result",
+    "held_due_to_fragmentation",
+    "held_due_to_insufficient_confidence",
+    "no_active_orchestration_item",
+    "completed_recently_no_current_item",
+}
+
+_CURRENT_ORCHESTRATION_STATE_FOCUS = {
+    "proposal",
+    "packet",
+    "operator_brief",
+    "internal_execution",
+    "external_fulfillment",
+    "completed_or_idle",
+}
+
+_CURRENT_ORCHESTRATION_AWAITING_ACTORS = {
+    "none",
+    "operator",
+    "internal_substrate",
+    "external_actor",
+}
+
 _HANDOFF_PACKET_STATUSES = {
     "prepared",
     "blocked_operator_required",
@@ -3986,6 +4015,282 @@ def resolve_operator_action_brief_lifecycle(
     }
 
 
+def _current_orchestration_state_id(
+    *,
+    supervisory_state: str,
+    proposal_id: str,
+    handoff_packet_id: str,
+    operator_action_brief_id: str,
+    operator_resolution_receipt_id: str,
+    orchestration_result_id: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "supervisory_state": supervisory_state,
+                "proposal_id": proposal_id,
+                "handoff_packet_id": handoff_packet_id,
+                "operator_action_brief_id": operator_action_brief_id,
+                "operator_resolution_receipt_id": operator_resolution_receipt_id,
+                "orchestration_result_id": orchestration_result_id,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ocs-{digest.hexdigest()[:16]}"
+
+
+def resolve_current_orchestration_state(
+    repo_root: Path,
+    *,
+    current_proposal: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+    operator_brief_lifecycle: Mapping[str, Any] | None = None,
+    packetization_gate: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, inspectable current-state surface for orchestration."""
+
+    root = repo_root.resolve()
+    proposal_map = current_proposal if isinstance(current_proposal, Mapping) else {}
+    gate_map = packetization_gate if isinstance(packetization_gate, Mapping) else {}
+    brief_map = operator_brief_lifecycle if isinstance(operator_brief_lifecycle, Mapping) else {}
+    active_packet_map = active_packet_visibility if isinstance(active_packet_visibility, Mapping) else {}
+    unified_map = unified_result if isinstance(unified_result, Mapping) else {}
+
+    if not proposal_map:
+        proposals = _read_jsonl(root / "glow/orchestration/orchestration_next_move_proposals.jsonl")
+        proposal_map = proposals[-1] if proposals else {}
+    if not active_packet_map:
+        proposal_id_for_active = str(proposal_map.get("proposal_id") or "")
+        active_packet_map = (
+            resolve_active_handoff_packet_candidate(root, proposal_id_for_active)
+            if proposal_id_for_active
+            else {}
+        )
+    if not brief_map:
+        briefs = _read_jsonl(root / "glow/orchestration/operator_action_briefs.jsonl")
+        brief_row = briefs[-1] if briefs else {}
+        brief_map = resolve_operator_action_brief_lifecycle(root, brief_row)
+    if not gate_map:
+        gates = _read_jsonl(root / "glow/orchestration/orchestration_packetization_gates.jsonl")
+        gate_map = gates[-1] if gates else {}
+
+    packet_status = str(active_packet_map.get("active_packet_status") or "")
+    active_target_venue = str(active_packet_map.get("active_target_venue") or "")
+    packet_present = bool(active_packet_map.get("active_packet_present"))
+    handoff_packet_id = str(active_packet_map.get("active_handoff_packet_id") or "")
+
+    packet_row: Mapping[str, Any] | None = None
+    if packet_present and handoff_packet_id:
+        packet_rows = _read_jsonl(root / "glow/orchestration/orchestration_handoff_packets.jsonl")
+        packet_row = next(
+            (row for row in reversed(packet_rows) if str(row.get("handoff_packet_id") or "") == handoff_packet_id),
+            None,
+        )
+
+    fulfillment = (
+        resolve_handoff_packet_fulfillment_lifecycle(root, packet_row)
+        if isinstance(packet_row, Mapping)
+        else {}
+    )
+    if not unified_map and isinstance(packet_row, Mapping):
+        handoffs = _read_jsonl(root / "glow/orchestration/orchestration_handoffs.jsonl")
+        handoff_row = handoffs[-1] if handoffs else {}
+        unified_map = resolve_unified_orchestration_result(root, handoff=handoff_row, handoff_packet=packet_row)
+
+    proposal_id = str(proposal_map.get("proposal_id") or "")
+    brief_id = str(brief_map.get("operator_action_brief_id") or "")
+    brief_waiting = bool(brief_map.get("awaiting_operator_input"))
+    operator_receipt_id = str(brief_map.get("operator_resolution_receipt_id") or "")
+    packetization_outcome = str(gate_map.get("packetization_outcome") or "")
+    packetization_allowed = bool(gate_map.get("packetization_allowed"))
+    unified_result_id = str(unified_map.get("orchestration_result_id") or "")
+    unified_result_classification = str(unified_map.get("result_classification") or "")
+    unified_resolution_path = str(unified_map.get("resolution_path") or "none")
+    unified_resolution_state = str(unified_map.get("resolution_state") or "")
+    fulfillment_received = bool(fulfillment.get("fulfillment_received"))
+    has_pending_external_fulfillment = bool(
+        packet_present
+        and active_target_venue in {"codex_implementation", "deep_research_audit"}
+        and not fulfillment_received
+    )
+
+    supervisory_state = "no_active_orchestration_item"
+    state_focus = "completed_or_idle"
+    current_resolution_path = "none"
+    awaiting_actor = "none"
+    rationale = "no_current_proposal_packet_or_wait_condition_visible"
+    wait_condition = "none"
+
+    if brief_waiting:
+        supervisory_state = "waiting_for_operator_resolution"
+        state_focus = "operator_brief"
+        current_resolution_path = "operator_resolution"
+        awaiting_actor = "operator"
+        rationale = "operator_action_brief_is_emitted_and_resolution_receipt_is_not_yet_ingested"
+        wait_condition = "operator_resolution_receipt_pending"
+    elif packetization_outcome == "packetization_hold_fragmentation":
+        supervisory_state = "held_due_to_fragmentation"
+        state_focus = "proposal"
+        current_resolution_path = "packetization"
+        awaiting_actor = "operator"
+        rationale = "packetization_gate_reports_fragmentation_hold"
+        wait_condition = "fragmentation_hold"
+    elif packetization_outcome in {
+        "packetization_hold_insufficient_confidence",
+        "packetization_hold_operator_review",
+        "packetization_hold_escalation_required",
+    }:
+        supervisory_state = "held_due_to_insufficient_confidence"
+        state_focus = "proposal"
+        current_resolution_path = "packetization"
+        awaiting_actor = "operator"
+        rationale = "packetization_gate_reports_hold_due_to_low_confidence_or_required_review"
+        wait_condition = "packetization_hold"
+    elif packet_present and active_target_venue in {"codex_implementation", "deep_research_audit"}:
+        if fulfillment_received:
+            supervisory_state = "completed_recently_no_current_item"
+            state_focus = "completed_or_idle"
+            current_resolution_path = "external_fulfillment"
+            awaiting_actor = "none"
+            rationale = "active_external_packet_has_fulfillment_receipt"
+            wait_condition = "none"
+        elif packet_status == "ready_for_external_trigger":
+            supervisory_state = "packet_ready_for_external_trigger"
+            state_focus = "packet"
+            current_resolution_path = "external_fulfillment"
+            awaiting_actor = "external_actor"
+            rationale = "active_external_packet_is_ready_for_external_trigger_and_has_no_fulfillment_receipt"
+            wait_condition = "external_trigger_pending"
+        else:
+            supervisory_state = "waiting_for_external_fulfillment"
+            state_focus = "external_fulfillment"
+            current_resolution_path = "external_fulfillment"
+            awaiting_actor = "external_actor"
+            rationale = "active_external_packet_is_staged_without_fulfillment_receipt"
+            wait_condition = "external_fulfillment_receipt_pending"
+    elif packet_present and packet_status == "ready_for_internal_trigger":
+        pending_internal_state = unified_resolution_state in {
+            "handoff_admitted_pending_result",
+            "execution_still_pending",
+            "execution_result_missing",
+        }
+        if pending_internal_state:
+            supervisory_state = "waiting_for_internal_result"
+            state_focus = "internal_execution"
+            current_resolution_path = "internal_execution"
+            awaiting_actor = "internal_substrate"
+            rationale = "internal_handoff_is_admitted_or_observed_without_closed_result_state"
+            wait_condition = "internal_result_pending"
+        else:
+            supervisory_state = "packet_ready_for_internal_trigger"
+            state_focus = "packet"
+            current_resolution_path = "internal_execution"
+            awaiting_actor = "internal_substrate"
+            rationale = "active_internal_packet_is_ready_for_internal_trigger"
+            wait_condition = "internal_trigger_pending"
+    elif proposal_id and packetization_allowed and not packet_present:
+        supervisory_state = "ready_to_packetize"
+        state_focus = "proposal"
+        current_resolution_path = "packetization"
+        awaiting_actor = "none"
+        rationale = "proposal_exists_and_packetization_is_allowed_without_active_packet"
+        wait_condition = "packetization_step_pending"
+    elif not proposal_id and not packet_present and unified_result_classification in {
+        "completed_successfully",
+        "completed_with_issues",
+        "declined_or_abandoned",
+        "failed_after_execution",
+    }:
+        supervisory_state = "completed_recently_no_current_item"
+        state_focus = "completed_or_idle"
+        current_resolution_path = unified_resolution_path if unified_resolution_path else "none"
+        awaiting_actor = "none"
+        rationale = "recent_unified_result_is_completed_and_no_current_proposal_or_packet_is_visible"
+        wait_condition = "none"
+
+    if supervisory_state not in _CURRENT_ORCHESTRATION_SUPERVISORY_STATES:
+        supervisory_state = "no_active_orchestration_item"
+    if state_focus not in _CURRENT_ORCHESTRATION_STATE_FOCUS:
+        state_focus = "completed_or_idle"
+    if awaiting_actor not in _CURRENT_ORCHESTRATION_AWAITING_ACTORS:
+        awaiting_actor = "none"
+
+    return {
+        "schema_version": "current_orchestration_state.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_state_id": _current_orchestration_state_id(
+            supervisory_state=supervisory_state,
+            proposal_id=proposal_id,
+            handoff_packet_id=handoff_packet_id,
+            operator_action_brief_id=brief_id,
+            operator_resolution_receipt_id=operator_receipt_id,
+            orchestration_result_id=unified_result_id,
+        ),
+        "current_supervisory_state": supervisory_state,
+        "state_focus": state_focus,
+        "current_resolution_path": current_resolution_path,
+        "awaiting_actor": awaiting_actor,
+        "wait_condition": wait_condition,
+        "has_active_packet": packet_present,
+        "has_pending_operator_brief": brief_waiting,
+        "has_pending_external_fulfillment": has_pending_external_fulfillment,
+        "source_linkage": {
+            "current_proposal_ref": {
+                "proposal_id": proposal_id or None,
+                "proposal_ledger_path": "glow/orchestration/orchestration_next_move_proposals.jsonl",
+            },
+            "active_packet_ref": {
+                "handoff_packet_id": handoff_packet_id or None,
+                "handoff_packet_ledger_path": "glow/orchestration/orchestration_handoff_packets.jsonl",
+                "target_venue": active_target_venue or None,
+                "packet_status": packet_status or None,
+            },
+            "operator_brief_ref": {
+                "operator_action_brief_id": brief_id or None,
+                "operator_resolution_receipt_id": operator_receipt_id or None,
+                "operator_brief_ledger_path": "glow/orchestration/operator_action_briefs.jsonl",
+                "operator_receipt_ledger_path": "glow/orchestration/operator_resolution_receipts.jsonl",
+            },
+            "unified_result_ref": {
+                "orchestration_result_id": unified_result_id or None,
+                "resolution_path": unified_resolution_path or None,
+                "unified_result_surface_path": "glow/orchestration/orchestration_unified_results.jsonl",
+            },
+            "packetization_gate_ref": {
+                "packetization_outcome": packetization_outcome or None,
+                "packetization_allowed": packetization_allowed,
+                "packetization_gate_ledger_path": "glow/orchestration/orchestration_packetization_gates.jsonl",
+            },
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "derived_from_existing_surfaces_only": [
+                "orchestration_next_move_proposals",
+                "orchestration_packetization_gates",
+                "orchestration_handoff_packets",
+                "operator_action_briefs",
+                "operator_resolution_receipts",
+                "orchestration_fulfillment_receipts",
+                "orchestration_unified_results",
+            ],
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "non_sovereign_current_state_only": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_plan_or_create_new_goals": True,
+                "workflow_engine": False,
+            },
+        ),
+    }
+
+
 def derive_next_move_proposal_review(
     repo_root: Path,
     *,
@@ -4535,6 +4840,7 @@ def derive_delegated_operation_readiness_verdict(
     venue_mix_review: Mapping[str, Any] | None = None,
     next_move_proposal_review: Mapping[str, Any] | None = None,
     active_packet_visibility: Mapping[str, Any] | None = None,
+    current_orchestration_state: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Derive a compact bounded readiness verdict for supervised delegated operation.
@@ -4644,6 +4950,7 @@ def derive_delegated_operation_readiness_verdict(
         dominant_pressure = "insufficient_history"
 
     active_packet_map = active_packet_visibility if isinstance(active_packet_visibility, Mapping) else {}
+    current_state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
     packet_context = {
         "packetization_outcome": packetization_outcome,
         "packetization_allowed": packetization_allowed,
@@ -4681,6 +4988,13 @@ def derive_delegated_operation_readiness_verdict(
                 "operator_dependence": operator_dependence,
             },
             "packetization_posture_context": packet_context,
+            "current_orchestration_state_basis": {
+                "current_supervisory_state": str(current_state_map.get("current_supervisory_state") or "not_supplied"),
+                "state_focus": str(current_state_map.get("state_focus") or "not_supplied"),
+                "awaiting_actor": str(current_state_map.get("awaiting_actor") or "not_supplied"),
+                "basis_only": True,
+                "does_not_change_verdict_logic": True,
+            },
             "conservative_readiness_only": True,
             "boundaries": {
                 "diagnostic_only": True,

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -41,6 +41,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_handoff_packet_fulfillment_lifecycle,
     resolve_handoff_packet_history_for_proposal,
     resolve_active_handoff_packet_candidate,
+    resolve_current_orchestration_state,
     resolve_latest_operator_resolution_for_proposal,
     resolve_operator_action_brief_lifecycle,
     resolve_orchestration_result,
@@ -264,17 +265,6 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         str(next_move_proposal.get("proposal_id") or ""),
         operator_influence=operator_influence,
     )
-    delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
-        orchestration_trust_confidence_posture,
-        proposal_packet_continuity_review,
-        unified_result_quality_review,
-        packetization_gate,
-        orchestration_attention_recommendation,
-        outcome_review=orchestration_outcome_review,
-        venue_mix_review=orchestration_venue_mix_review,
-        next_move_proposal_review=next_move_proposal_review,
-        active_packet_visibility=active_packet,
-    )
     repacketization_gap_map = derive_repacketization_gap_map(
         operator_brief_lifecycle,
         operator_influence,
@@ -290,6 +280,26 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     )
     unified_result = resolve_unified_orchestration_result(root, handoff=handoff_result, handoff_packet=effective_handoff_packet)
     unified_result_surface = resolve_unified_orchestration_result_surface(root)
+    current_orchestration_state = resolve_current_orchestration_state(
+        root,
+        current_proposal=adjusted_next_move_proposal,
+        active_packet_visibility=active_packet,
+        operator_brief_lifecycle=operator_brief_lifecycle,
+        packetization_gate=packetization_gate,
+        unified_result=unified_result,
+    )
+    delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
+        orchestration_trust_confidence_posture,
+        proposal_packet_continuity_review,
+        unified_result_quality_review,
+        packetization_gate,
+        orchestration_attention_recommendation,
+        outcome_review=orchestration_outcome_review,
+        venue_mix_review=orchestration_venue_mix_review,
+        next_move_proposal_review=next_move_proposal_review,
+        active_packet_visibility=active_packet,
+        current_orchestration_state=current_orchestration_state,
+    )
     unified_result_quality_review = derive_unified_result_quality_review(root)
     substitution_readiness = dict(delegated_judgment.get("orchestration_substitution_readiness") or {})
     substitution_readiness["trust_confidence_basis"] = {
@@ -375,6 +385,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "proposal_packet_continuity_review": proposal_packet_continuity_review,
             "trust_confidence_posture": orchestration_trust_confidence_posture,
             "delegated_operation_readiness": delegated_operation_readiness,
+            "current_orchestration_state": current_orchestration_state,
             "packetization_gating": {
                 **packetization_gate,
                 "packetization_allowed_or_caution": packetization_gate.get("packetization_outcome")

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -46,6 +46,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_handoff_packet_history_for_proposal,
     resolve_latest_operator_resolution_for_proposal,
     resolve_active_handoff_packet_candidate,
+    resolve_current_orchestration_state,
     resolve_operator_action_brief_lifecycle,
     synthesize_handoff_packet,
     synthesize_operator_refreshed_handoff_packet,
@@ -4010,6 +4011,194 @@ def test_end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibil
     assert readiness["summary"]["boundaries"]["diagnostic_only"] is True
     assert readiness["summary"]["boundaries"]["decision_power"] == "none"
     assert readiness["does_not_execute_or_route_work"] is True
+
+
+def test_current_orchestration_state_ready_to_packetize_when_allowed_without_packet(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-ready"},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={"result_classification": "pending_or_unresolved", "resolution_path": "internal_execution"},
+    )
+    assert state["current_supervisory_state"] == "ready_to_packetize"
+    assert state["state_focus"] == "proposal"
+    assert state["awaiting_actor"] == "none"
+
+
+def test_current_orchestration_state_waiting_for_internal_result_with_pending_internal_packet(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-internal"},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={
+            "active_packet_present": True,
+            "active_handoff_packet_id": "packet-int",
+            "active_packet_status": "ready_for_internal_trigger",
+            "active_target_venue": "internal_direct_execution",
+        },
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={
+            "orchestration_result_id": "oru-pending",
+            "resolution_path": "internal_execution",
+            "resolution_state": "handoff_admitted_pending_result",
+            "result_classification": "pending_or_unresolved",
+        },
+    )
+    assert state["current_supervisory_state"] == "waiting_for_internal_result"
+    assert state["state_focus"] == "internal_execution"
+    assert state["awaiting_actor"] == "internal_substrate"
+
+
+def test_current_orchestration_state_waiting_for_external_fulfillment_when_staged_packet_unfulfilled(tmp_path: Path) -> None:
+    proposal_id = "proposal-ext"
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl",
+        [
+            _packet_row(
+                proposal_id=proposal_id,
+                packet_id="packet-ext",
+                status="prepared",
+                venue="codex_implementation",
+                gate_outcome="packetization_allowed",
+            )
+        ],
+    )
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": proposal_id},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={
+            "active_packet_present": True,
+            "active_handoff_packet_id": "packet-ext",
+            "active_packet_status": "prepared",
+            "active_target_venue": "codex_implementation",
+        },
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={"result_classification": "pending_or_unresolved", "resolution_path": "external_fulfillment"},
+    )
+    assert state["current_supervisory_state"] == "waiting_for_external_fulfillment"
+    assert state["state_focus"] == "external_fulfillment"
+    assert state["awaiting_actor"] == "external_actor"
+
+
+def test_current_orchestration_state_waiting_for_operator_resolution_when_brief_unresolved(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-operator"},
+        packetization_gate={
+            "packetization_outcome": "packetization_hold_operator_review",
+            "packetization_allowed": False,
+        },
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={
+            "operator_action_brief_id": "brief-1",
+            "awaiting_operator_input": True,
+            "operator_resolution_received": False,
+        },
+    )
+    assert state["current_supervisory_state"] == "waiting_for_operator_resolution"
+    assert state["state_focus"] == "operator_brief"
+    assert state["awaiting_actor"] == "operator"
+
+
+def test_current_orchestration_state_reports_fragmentation_hold(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-hold"},
+        packetization_gate={
+            "packetization_outcome": "packetization_hold_fragmentation",
+            "packetization_allowed": False,
+        },
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+    )
+    assert state["current_supervisory_state"] == "held_due_to_fragmentation"
+    assert state["state_focus"] == "proposal"
+
+
+def test_current_orchestration_state_reports_completed_without_active_item(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={
+            "orchestration_result_id": "oru-complete",
+            "result_classification": "completed_successfully",
+            "resolution_path": "external_fulfillment",
+        },
+    )
+    assert state["current_supervisory_state"] == "completed_recently_no_current_item"
+    assert state["state_focus"] == "completed_or_idle"
+    assert state["awaiting_actor"] == "none"
+
+
+def test_current_orchestration_state_reports_no_active_item_when_no_evidence(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={},
+    )
+    assert state["current_supervisory_state"] == "no_active_orchestration_item"
+    assert state["state_focus"] == "completed_or_idle"
+    assert state["awaiting_actor"] == "none"
+
+
+def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
+
+    def _fake_resolver(_repo_root: Path, *, action_id: str, correlation_id: str) -> dict[str, object]:
+        return {
+            "typed_action_identity": action_id,
+            "correlation_id": correlation_id,
+            "outcome_class": "success",
+        }
+
+    monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.resolve_scoped_mutation_lifecycle", _fake_resolver)
+    monkeypatch.setattr(
+        "sentientos.scoped_lifecycle_diagnostic.synthesize_delegated_judgment",
+        lambda _evidence: synthesize_delegated_judgment(_base_evidence()),
+    )
+    _write_json(tmp_path / "glow/contracts/contract_status.json", {"contracts": []})
+    _write_jsonl(
+        tmp_path / "pulse/forge_events.jsonl",
+        [
+            {
+                "event": "constitutional_mutation_router_execution",
+                "typed_action_id": "sentientos.manifest.generate",
+                "correlation_id": "cid-current-state-consumer",
+            }
+        ],
+    )
+
+    before_intent = synthesize_orchestration_intent(synthesize_delegated_judgment(_base_evidence()), created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, before_intent)
+    before = admit_orchestration_intent(tmp_path, before_intent)
+
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    current_state = diagnostic["orchestration_handoff"]["current_orchestration_state"]
+    readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
+
+    after = admit_orchestration_intent(tmp_path, before_intent)
+    assert current_state["schema_version"] == "current_orchestration_state.v1"
+    assert current_state["state_focus"] in {
+        "proposal",
+        "packet",
+        "operator_brief",
+        "internal_execution",
+        "external_fulfillment",
+        "completed_or_idle",
+    }
+    assert current_state["awaiting_actor"] in {"none", "operator", "internal_substrate", "external_actor"}
+    assert current_state["non_authoritative"] is True
+    assert current_state["does_not_execute_or_route_work"] is True
+    assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
+    assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
+    assert before["handoff_outcome"] == after["handoff_outcome"]
 
 
 def test_orchestration_trust_confidence_posture_does_not_change_admission_behavior(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide one compact, machine-readable current-state surface so operators can answer "what is the loop actively doing or waiting for now" without inventing execution authority or a workflow sovereign. 
- Keep the surface conservative and historically honest by deriving it only from existing proposal/packet/brief/readiness/unified-result artifacts and exposing explicit anti-sovereignty markers.

### Description
- Add a bounded current-state model and resolver `resolve_current_orchestration_state(...)` that emits `current_orchestration_state.v1` with `current_orchestration_state_id`, `current_supervisory_state`, `state_focus`, `current_resolution_path`, `awaiting_actor`, active/pending flags, compact rationale, and source linkage refs; the resolver is purely diagnostic and anti-sovereign. (changes in `sentientos/orchestration_intent_fabric.py`).
- Introduce compact supervised-state vocabularies and awaiting-actor enums for clarity (`ready_to_packetize`, `packet_ready_for_internal_trigger`, `packet_ready_for_external_trigger`, `waiting_for_operator_resolution`, `waiting_for_external_fulfillment`, `waiting_for_internal_result`, `held_due_to_fragmentation`, `held_due_to_insufficient_confidence`, `no_active_orchestration_item`, `completed_recently_no_current_item`).
- Surface the resolver in the scoped consumer (`build_scoped_lifecycle_diagnostic`) so the diagnostic payload now includes `orchestration_handoff.current_orchestration_state` and pass the current-state into readiness as a basis-only input. (changes in `sentientos/scoped_lifecycle_diagnostic.py`).
- Integrate minimally with readiness by adding a `current_orchestration_state_basis` field to `derive_delegated_operation_readiness_verdict(...)` that is explicitly labeled `basis_only` and `does_not_change_verdict_logic`. (changes in `sentientos/orchestration_intent_fabric.py`).
- Add focused tests exercising the required classifications and end-to-end consumer visibility and non-authoritative invariants, and update the orchestration note to document inputs, meaning, values, and anti-sovereign boundaries. (tests in `sentientos/tests/test_orchestration_intent_fabric.py`, doc update in `docs/orchestration_next_move_proposal_note.md`).

### Testing
- Ran targeted unit tests for the orchestration intent fabric additions and consumer integration with `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` and specific focused test subsets; the new current-state tests and the full orchestration intent fabric test module passed.  
- Executed the repository test harness `python -m scripts.run_tests -q`; this run exercised broader suites and revealed unrelated pre-existing failures in `tests/test_pulse_federation.py` (6 failing tests) that are not caused by this change.  
- Ran type checks with `mypy scripts/ sentientos/`; the repository has many pre-existing typing issues outside this change set and the invocation reports those unrelated typing failures.  
- Ran `python scripts/audit_immutability_verifier.py`; the audit immutability verification passed in this environment.  

All changes are diagnostic-only and preserve the repository invariants: no new venues, no new execution paths, no direct external actuation, and explicit non-sovereign markers on all outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e42ae8975c832083cbb9fccc7a9e20)