### PR TITLE
[codex:orchestration] add bounded current-state watchpoint resolver

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -277,6 +277,29 @@ _CURRENT_ORCHESTRATION_AWAITING_ACTORS = {
     "external_actor",
 }
 
+_ORCHESTRATION_WATCHPOINT_CLASSES = {
+    "await_operator_resolution",
+    "await_internal_execution_result",
+    "await_external_fulfillment_receipt",
+    "await_packetization_relief",
+    "await_new_proposal",
+    "no_watchpoint_needed",
+}
+
+_ORCHESTRATION_WATCHPOINT_EXPECTED_ACTORS = {
+    "none",
+    "operator",
+    "internal_substrate",
+    "external_actor",
+    "orchestration_body",
+}
+
+_ORCHESTRATION_WATCHPOINT_ACTIVITY = {
+    "actively_blocked",
+    "passively_awaiting",
+    "not_waiting",
+}
+
 _HANDOFF_PACKET_STATUSES = {
     "prepared",
     "blocked_operator_required",
@@ -4041,6 +4064,28 @@ def _current_orchestration_state_id(
     return f"ocs-{digest.hexdigest()[:16]}"
 
 
+def _orchestration_watchpoint_id(
+    *,
+    current_orchestration_state_id: str,
+    watchpoint_class: str,
+    expected_actor: str,
+    expected_signal_type: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "watchpoint_class": watchpoint_class,
+                "expected_actor": expected_actor,
+                "expected_signal_type": expected_signal_type,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"owp-{digest.hexdigest()[:16]}"
+
+
 def resolve_current_orchestration_state(
     repo_root: Path,
     *,
@@ -4257,6 +4302,7 @@ def resolve_current_orchestration_state(
             "unified_result_ref": {
                 "orchestration_result_id": unified_result_id or None,
                 "resolution_path": unified_resolution_path or None,
+                "result_classification": unified_result_classification or None,
                 "unified_result_surface_path": "glow/orchestration/orchestration_unified_results.jsonl",
             },
             "packetization_gate_ref": {
@@ -4286,6 +4332,154 @@ def resolve_current_orchestration_state(
                 "does_not_execute_or_route_work": True,
                 "does_not_plan_or_create_new_goals": True,
                 "workflow_engine": False,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_watchpoint(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_proposal: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+    operator_brief_lifecycle: Mapping[str, Any] | None = None,
+    packetization_gate: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one compact, present-tense wake-condition watchpoint for bounded orchestration."""
+
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    if not state_map:
+        state_map = resolve_current_orchestration_state(
+            repo_root,
+            current_proposal=current_proposal,
+            active_packet_visibility=active_packet_visibility,
+            operator_brief_lifecycle=operator_brief_lifecycle,
+            packetization_gate=packetization_gate,
+            unified_result=unified_result,
+        )
+
+    state_class = str(state_map.get("current_supervisory_state") or "no_active_orchestration_item")
+    proposal_id = str(((state_map.get("source_linkage") or {}).get("current_proposal_ref") or {}).get("proposal_id") or "")
+    active_packet_id = str(((state_map.get("source_linkage") or {}).get("active_packet_ref") or {}).get("handoff_packet_id") or "")
+    unified_result_class = str(((state_map.get("source_linkage") or {}).get("unified_result_ref") or {}).get("result_classification") or "")
+
+    watchpoint_class = "no_watchpoint_needed"
+    expected_actor = "none"
+    expected_signal_type = "none"
+    wake_condition = "no_specific_wake_condition_required_from_current_state"
+    rationale = "current_state_does_not_indicate_a_concrete_pending_dependency"
+    loop_activity = "not_waiting"
+
+    if state_class == "waiting_for_operator_resolution":
+        watchpoint_class = "await_operator_resolution"
+        expected_actor = "operator"
+        expected_signal_type = "operator_resolution_receipt"
+        wake_condition = "ingest_operator_resolution_receipt_for_current_operator_action_brief"
+        rationale = "current_state_reports_waiting_for_operator_resolution"
+        loop_activity = "actively_blocked"
+    elif state_class == "waiting_for_internal_result":
+        watchpoint_class = "await_internal_execution_result"
+        expected_actor = "internal_substrate"
+        expected_signal_type = "internal_execution_result"
+        wake_condition = "observe_closed_internal_execution_result_for_active_handoff"
+        rationale = "current_state_reports_waiting_for_internal_result"
+        loop_activity = "actively_blocked"
+    elif state_class == "waiting_for_external_fulfillment":
+        watchpoint_class = "await_external_fulfillment_receipt"
+        expected_actor = "external_actor"
+        expected_signal_type = "external_fulfillment_receipt"
+        wake_condition = "ingest_external_fulfillment_receipt_for_active_staged_external_packet"
+        rationale = "current_state_reports_waiting_for_external_fulfillment"
+        loop_activity = "actively_blocked"
+    elif state_class in {"held_due_to_fragmentation", "held_due_to_insufficient_confidence"}:
+        watchpoint_class = "await_packetization_relief"
+        expected_actor = "orchestration_body"
+        expected_signal_type = "packetization_gate_relief_signal"
+        wake_condition = "derive_non_held_packetization_outcome_from_existing_orchestration_surfaces"
+        rationale = "current_state_reports_packetization_hold_pressure"
+        loop_activity = "actively_blocked"
+    elif state_class == "no_active_orchestration_item" and not proposal_id and not active_packet_id:
+        watchpoint_class = "await_new_proposal"
+        expected_actor = "orchestration_body"
+        expected_signal_type = "next_move_proposal"
+        wake_condition = "derive_next_move_proposal_from_existing_delegated_judgment_and_review_surfaces"
+        rationale = "current_state_reports_no_active_item_without_visible_proposal_or_packet"
+        loop_activity = "passively_awaiting"
+    elif state_class == "completed_recently_no_current_item":
+        if unified_result_class in {
+            "completed_successfully",
+            "completed_with_issues",
+            "declined_or_abandoned",
+            "failed_after_execution",
+        }:
+            watchpoint_class = "no_watchpoint_needed"
+            expected_actor = "none"
+            expected_signal_type = "none"
+            wake_condition = "recent_completion_visible_without_current_wait_dependency"
+            rationale = "current_state_reports_completed_recently_no_current_item"
+            loop_activity = "not_waiting"
+        else:
+            watchpoint_class = "await_new_proposal"
+            expected_actor = "orchestration_body"
+            expected_signal_type = "next_move_proposal"
+            wake_condition = "derive_next_move_proposal_when_loop_re-enters_active_state"
+            rationale = "completed_state_visible_without_finalized_completion_classification"
+            loop_activity = "passively_awaiting"
+
+    if watchpoint_class not in _ORCHESTRATION_WATCHPOINT_CLASSES:
+        watchpoint_class = "no_watchpoint_needed"
+    if expected_actor not in _ORCHESTRATION_WATCHPOINT_EXPECTED_ACTORS:
+        expected_actor = "none"
+    if loop_activity not in _ORCHESTRATION_WATCHPOINT_ACTIVITY:
+        loop_activity = "not_waiting"
+
+    current_state_id = str(state_map.get("current_orchestration_state_id") or "")
+    return {
+        "schema_version": "current_orchestration_watchpoint.v1",
+        "resolved_at": _iso_utc_now(),
+        "orchestration_watchpoint_id": _orchestration_watchpoint_id(
+            current_orchestration_state_id=current_state_id,
+            watchpoint_class=watchpoint_class,
+            expected_actor=expected_actor,
+            expected_signal_type=expected_signal_type,
+        ),
+        "watchpoint_class": watchpoint_class,
+        "expected_actor": expected_actor,
+        "expected_signal_type": expected_signal_type,
+        "wake_condition": wake_condition,
+        "basis": {
+            "compact_rationale": rationale,
+            "current_state_class": state_class,
+            "loop_activity": loop_activity,
+            "source_current_orchestration_state_ref": {
+                "current_orchestration_state_id": current_state_id or None,
+                "current_state_schema_version": str(state_map.get("schema_version") or "current_orchestration_state.v1"),
+                "current_state_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_state",
+            },
+        },
+        "wake_condition_summary": {
+            "current_state_class": state_class,
+            "expected_actor": expected_actor,
+            "expected_signal_type": expected_signal_type,
+            "loop_activity": loop_activity,
+            "diagnostic_only": True,
+            "non_authoritative": True,
+            "decision_power": "none",
+            "watchpoint_only": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "watchpoint_only": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+                "does_not_schedule_or_trigger_events": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
             },
         ),
     }
@@ -4951,6 +5145,11 @@ def derive_delegated_operation_readiness_verdict(
 
     active_packet_map = active_packet_visibility if isinstance(active_packet_visibility, Mapping) else {}
     current_state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    current_watchpoint_map = (
+        current_state_map.get("current_watchpoint")
+        if isinstance(current_state_map.get("current_watchpoint"), Mapping)
+        else {}
+    )
     packet_context = {
         "packetization_outcome": packetization_outcome,
         "packetization_allowed": packetization_allowed,
@@ -4992,6 +5191,12 @@ def derive_delegated_operation_readiness_verdict(
                 "current_supervisory_state": str(current_state_map.get("current_supervisory_state") or "not_supplied"),
                 "state_focus": str(current_state_map.get("state_focus") or "not_supplied"),
                 "awaiting_actor": str(current_state_map.get("awaiting_actor") or "not_supplied"),
+                "watchpoint_basis": {
+                    "watchpoint_class": str(current_watchpoint_map.get("watchpoint_class") or "not_supplied"),
+                    "expected_actor": str(current_watchpoint_map.get("expected_actor") or "not_supplied"),
+                    "expected_signal_type": str(current_watchpoint_map.get("expected_signal_type") or "not_supplied"),
+                    "basis_only": True,
+                },
                 "basis_only": True,
                 "does_not_change_verdict_logic": True,
             },

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -442,6 +442,37 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "new venue routing",
             ],
         },
+        "current_orchestration_watchpoint": {
+            "meaning": "compact present-tense wake-condition object describing the specific next condition that would let bounded orchestration advance.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_watchpoint",
+            "derived_from_current_state_surfaces_only": [
+                "resolve_current_orchestration_state",
+                "active_handoff_packet_visibility",
+                "operator_action_brief_lifecycle",
+                "packetization_gate",
+                "unified_orchestration_result",
+                "current proposal presence/absence",
+            ],
+            "watchpoint_classes": [
+                "await_operator_resolution",
+                "await_internal_execution_result",
+                "await_external_fulfillment_receipt",
+                "await_packetization_relief",
+                "await_new_proposal",
+                "no_watchpoint_needed",
+            ],
+            "how_it_differs": {
+                "from_current_orchestration_state": "current state classifies what the loop is currently doing; watchpoint classifies what concrete event/artifact would let it advance next.",
+                "from_delegated_operation_readiness": "readiness is a bounded fit verdict over retrospective + present signals; watchpoint is a narrow current-state wake dependency only.",
+            },
+            "explicitly_not": [
+                "an event engine or scheduler",
+                "execution/admission authority",
+                "new venue routing",
+                "direct external actuation",
+                "a sovereign decision layer",
+            ],
+        },
         "proposal_packet_continuity_review": {
             "meaning": "compact retrospective classifier indicating whether recent next-move proposals are converting into coherent active packet lineage or drifting through repeated holds/redirects/repacketization churn.",
             "machine_surface": "sentientos.orchestration_intent_fabric.derive_proposal_packet_continuity_review",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -42,6 +42,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_handoff_packet_history_for_proposal,
     resolve_active_handoff_packet_candidate,
     resolve_current_orchestration_state,
+    resolve_current_orchestration_watchpoint,
     resolve_latest_operator_resolution_for_proposal,
     resolve_operator_action_brief_lifecycle,
     resolve_orchestration_result,
@@ -288,6 +289,15 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         packetization_gate=packetization_gate,
         unified_result=unified_result,
     )
+    current_orchestration_watchpoint = resolve_current_orchestration_watchpoint(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_proposal=adjusted_next_move_proposal,
+        active_packet_visibility=active_packet,
+        operator_brief_lifecycle=operator_brief_lifecycle,
+        packetization_gate=packetization_gate,
+        unified_result=unified_result,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -298,7 +308,10 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         venue_mix_review=orchestration_venue_mix_review,
         next_move_proposal_review=next_move_proposal_review,
         active_packet_visibility=active_packet,
-        current_orchestration_state=current_orchestration_state,
+        current_orchestration_state={
+            **current_orchestration_state,
+            "current_watchpoint": current_orchestration_watchpoint,
+        },
     )
     unified_result_quality_review = derive_unified_result_quality_review(root)
     substitution_readiness = dict(delegated_judgment.get("orchestration_substitution_readiness") or {})
@@ -386,6 +399,21 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "trust_confidence_posture": orchestration_trust_confidence_posture,
             "delegated_operation_readiness": delegated_operation_readiness,
             "current_orchestration_state": current_orchestration_state,
+            "current_orchestration_watchpoint": current_orchestration_watchpoint,
+            "current_orchestration_watchpoint_summary": {
+                "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
+                "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
+                "expected_actor": current_orchestration_watchpoint.get("expected_actor"),
+                "expected_signal_type": current_orchestration_watchpoint.get("expected_signal_type"),
+                "compact_rationale": (current_orchestration_watchpoint.get("basis") or {}).get("compact_rationale"),
+                "non_sovereign_boundaries": {
+                    "diagnostic_only": True,
+                    "non_authoritative": True,
+                    "decision_power": "none",
+                    "watchpoint_only": True,
+                    "does_not_execute_or_route_work": True,
+                },
+            },
             "packetization_gating": {
                 **packetization_gate,
                 "packetization_allowed_or_caution": packetization_gate.get("packetization_outcome")

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -47,6 +47,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_latest_operator_resolution_for_proposal,
     resolve_active_handoff_packet_candidate,
     resolve_current_orchestration_state,
+    resolve_current_orchestration_watchpoint,
     resolve_operator_action_brief_lifecycle,
     synthesize_handoff_packet,
     synthesize_operator_refreshed_handoff_packet,
@@ -4148,6 +4149,112 @@ def test_current_orchestration_state_reports_no_active_item_when_no_evidence(tmp
     assert state["awaiting_actor"] == "none"
 
 
+def test_orchestration_watchpoint_awaits_operator_resolution_from_current_state(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-operator"},
+        packetization_gate={"packetization_outcome": "packetization_hold_operator_review", "packetization_allowed": False},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": True},
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "await_operator_resolution"
+    assert watchpoint["expected_actor"] == "operator"
+    assert watchpoint["expected_signal_type"] == "operator_resolution_receipt"
+    assert watchpoint["wake_condition_summary"]["loop_activity"] == "actively_blocked"
+
+
+def test_orchestration_watchpoint_awaits_internal_execution_result(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-internal"},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={
+            "active_packet_present": True,
+            "active_handoff_packet_id": "packet-int",
+            "active_packet_status": "ready_for_internal_trigger",
+            "active_target_venue": "internal_direct_execution",
+        },
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={"resolution_state": "handoff_admitted_pending_result", "result_classification": "pending_or_unresolved"},
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "await_internal_execution_result"
+    assert watchpoint["expected_actor"] == "internal_substrate"
+    assert watchpoint["expected_signal_type"] == "internal_execution_result"
+
+
+def test_orchestration_watchpoint_awaits_external_fulfillment_receipt(tmp_path: Path) -> None:
+    proposal_id = "proposal-ext-watchpoint"
+    _write_jsonl(
+        tmp_path / "glow/orchestration/orchestration_handoff_packets.jsonl",
+        [_packet_row(proposal_id=proposal_id, packet_id="packet-ext-watchpoint", status="prepared", venue="codex_implementation")],
+    )
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": proposal_id},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={
+            "active_packet_present": True,
+            "active_handoff_packet_id": "packet-ext-watchpoint",
+            "active_packet_status": "prepared",
+            "active_target_venue": "codex_implementation",
+        },
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={"result_classification": "pending_or_unresolved", "resolution_path": "external_fulfillment"},
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "await_external_fulfillment_receipt"
+    assert watchpoint["expected_actor"] == "external_actor"
+    assert watchpoint["expected_signal_type"] == "external_fulfillment_receipt"
+
+
+def test_orchestration_watchpoint_awaits_packetization_relief_for_held_state(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": "proposal-hold"},
+        packetization_gate={"packetization_outcome": "packetization_hold_fragmentation", "packetization_allowed": False},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "await_packetization_relief"
+    assert watchpoint["expected_actor"] == "orchestration_body"
+    assert watchpoint["wake_condition_summary"]["loop_activity"] == "actively_blocked"
+
+
+def test_orchestration_watchpoint_awaits_new_proposal_when_no_active_item(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={},
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "await_new_proposal"
+    assert watchpoint["expected_actor"] == "orchestration_body"
+    assert watchpoint["expected_signal_type"] == "next_move_proposal"
+
+
+def test_orchestration_watchpoint_reports_no_watchpoint_needed_for_completed_item(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={
+            "orchestration_result_id": "oru-complete-watchpoint",
+            "result_classification": "completed_successfully",
+            "resolution_path": "external_fulfillment",
+        },
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    assert watchpoint["watchpoint_class"] == "no_watchpoint_needed"
+    assert watchpoint["expected_actor"] == "none"
+    assert watchpoint["wake_condition_summary"]["loop_activity"] == "not_waiting"
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -4181,6 +4288,8 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
 
     diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
     current_state = diagnostic["orchestration_handoff"]["current_orchestration_state"]
+    current_watchpoint = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint"]
+    current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
     after = admit_orchestration_intent(tmp_path, before_intent)
@@ -4196,8 +4305,22 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_state["awaiting_actor"] in {"none", "operator", "internal_substrate", "external_actor"}
     assert current_state["non_authoritative"] is True
     assert current_state["does_not_execute_or_route_work"] is True
+    assert current_watchpoint["schema_version"] == "current_orchestration_watchpoint.v1"
+    assert current_watchpoint["watchpoint_class"] in {
+        "await_operator_resolution",
+        "await_internal_execution_result",
+        "await_external_fulfillment_receipt",
+        "await_packetization_relief",
+        "await_new_proposal",
+        "no_watchpoint_needed",
+    }
+    assert current_watchpoint["wake_condition_summary"]["decision_power"] == "none"
+    assert current_watchpoint["does_not_schedule_or_trigger_events"] is True
+    assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
+    assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True
     assert before["handoff_outcome"] == after["handoff_outcome"]
 
 


### PR DESCRIPTION
### Motivation
- Provide a compact, machine-readable “what am I waiting for?” watchpoint so the orchestration body can answer which concrete event/artifact would let the loop advance next without becoming a scheduler or authority surface.

### Description
- Add a small watchpoint model and stable id generator (`current_orchestration_watchpoint.v1` and `owp-...`) plus a resolver `resolve_current_orchestration_watchpoint` that is strictly derived from the existing current orchestration state and linked surfaces. 
- Introduce a compact vocabulary for watchpoint classes, expected actors, and loop activity (`await_operator_resolution`, `await_internal_execution_result`, `await_external_fulfillment_receipt`, `await_packetization_relief`, `await_new_proposal`, `no_watchpoint_needed`) and explicit anti-sovereignty metadata in the payload. 
- Surface the full watchpoint and a compact watchpoint summary in the scoped orchestration diagnostic consumer and minimally thread watchpoint visibility into the delegated-operation readiness basis as a read-only `watchpoint_basis` (basis-only, does not change verdict logic). 
- Update the orchestration note to document the watchpoint meaning, input surfaces, classes, differences from state/readiness, and explicit non-sovereign constraints. 

### Testing
- Ran focused unit tests: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "current_orchestration_state or orchestration_watchpoint"` and the added watchpoint tests passed (targeted test group successful). 
- Ran a broader subset of repository tests; unrelated federation tests failed (existing pulse_federation coverage) and therefore the full `python -m scripts.run_tests -q` run reported failures unrelated to the watchpoint changes. 
- Ran `mypy scripts/ sentientos/` which failed with repository-wide typing issues outside this change. 
- Ran `python scripts/audit_immutability_verifier.py` which passed the immutability check in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e460aea7a88320bca0e20bd4623172)