### PR TITLE
[codex:orchestration] add bounded re-evaluation trigger recommendation

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -316,6 +316,21 @@ _WATCHPOINT_SATISFIED_BY_ACTORS = {
     "none",
 }
 
+_RE_EVALUATION_RECOMMENDATIONS = {
+    "rerun_delegated_judgment",
+    "rerun_packetization_gate",
+    "rerun_packet_synthesis",
+    "clear_wait_and_continue_current_packet",
+    "hold_for_manual_review",
+    "no_re_evaluation_needed",
+}
+
+_RE_EVALUATION_EXPECTED_ACTORS = {
+    "orchestration_body",
+    "operator",
+    "none",
+}
+
 _HANDOFF_PACKET_STATUSES = {
     "prepared",
     "blocked_operator_required",
@@ -4126,6 +4141,30 @@ def _watchpoint_satisfaction_id(
     return f"wps-{digest.hexdigest()[:16]}"
 
 
+def _re_evaluation_trigger_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    recommendation: str,
+    expected_actor: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "recommendation": recommendation,
+                "expected_actor": expected_actor,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ret-{digest.hexdigest()[:16]}"
+
+
 def resolve_current_orchestration_state(
     repo_root: Path,
     *,
@@ -4747,6 +4786,209 @@ def resolve_watchpoint_satisfaction(
                 "wake_readiness_only": True,
                 "non_authoritative": True,
                 "decision_power": "none",
+                "does_not_schedule_or_trigger_events": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_workflow_sovereign": True,
+            },
+        ),
+    }
+
+
+def resolve_re_evaluation_trigger_recommendation(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    operator_brief_lifecycle: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+    packetization_gate: Mapping[str, Any] | None = None,
+    current_proposal: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded re-entry recommendation when wake-readiness changes."""
+
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    if not state_map:
+        state_map = resolve_current_orchestration_state(
+            repo_root,
+            current_proposal=current_proposal,
+            active_packet_visibility=active_packet_visibility,
+            operator_brief_lifecycle=operator_brief_lifecycle,
+            packetization_gate=packetization_gate,
+            unified_result=unified_result,
+        )
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    if not watchpoint_map:
+        watchpoint_map = resolve_current_orchestration_watchpoint(
+            repo_root,
+            current_orchestration_state=state_map,
+            current_proposal=current_proposal,
+            active_packet_visibility=active_packet_visibility,
+            operator_brief_lifecycle=operator_brief_lifecycle,
+            packetization_gate=packetization_gate,
+            unified_result=unified_result,
+        )
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    if not satisfaction_map:
+        satisfaction_map = resolve_watchpoint_satisfaction(
+            repo_root,
+            current_orchestration_state=state_map,
+            current_orchestration_watchpoint=watchpoint_map,
+            operator_brief_lifecycle=operator_brief_lifecycle,
+            unified_result=unified_result,
+            packetization_gate=packetization_gate,
+            current_proposal=current_proposal,
+            active_packet_visibility=active_packet_visibility,
+        )
+
+    state_class = str(state_map.get("current_supervisory_state") or "no_active_orchestration_item")
+    resolution_path = str(state_map.get("current_resolution_path") or "none")
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "watchpoint_pending")
+    active_packet_present = bool(state_map.get("has_active_packet"))
+    gate_outcome = str(((state_map.get("source_linkage") or {}).get("packetization_gate_ref") or {}).get("packetization_outcome") or "")
+    resolution_kind = str((operator_brief_lifecycle or {}).get("resolution_kind") or "")
+
+    recommendation = "no_re_evaluation_needed"
+    expected_actor = "none"
+    rationale = "no_active_or_unsatisfied_watchpoint_requires_no_re_entry_action"
+    ready_to_resume = False
+
+    if watchpoint_class == "no_watchpoint_needed" or satisfaction_status == "no_active_watchpoint":
+        recommendation = "no_re_evaluation_needed"
+        expected_actor = "none"
+        rationale = "no_active_watchpoint_visible_from_current_state"
+        ready_to_resume = True
+    elif satisfaction_status in {"watchpoint_stale", "watchpoint_fragmented"}:
+        recommendation = "hold_for_manual_review"
+        expected_actor = "operator"
+        rationale = "wake_context_is_stale_or_fragmented_and_requires_manual_review"
+        ready_to_resume = True
+    elif satisfaction_status != "watchpoint_satisfied":
+        recommendation = "no_re_evaluation_needed"
+        expected_actor = "none"
+        rationale = "watchpoint_is_not_yet_satisfied"
+        ready_to_resume = False
+    elif watchpoint_class == "await_operator_resolution":
+        if resolution_kind in {"approved_with_constraints", "supplied_missing_context", "redirected_venue"}:
+            recommendation = "rerun_packet_synthesis"
+            expected_actor = "orchestration_body"
+            rationale = "operator_resolution_updates_context_or_venue_and_requires_packet_refresh"
+        else:
+            recommendation = "rerun_packetization_gate"
+            expected_actor = "orchestration_body"
+            rationale = "operator_resolution_satisfied_watchpoint_and_packetization_should_be_rechecked"
+        ready_to_resume = True
+    elif watchpoint_class == "await_internal_execution_result":
+        if resolution_path == "internal_execution" and state_class == "completed_recently_no_current_item":
+            recommendation = "no_re_evaluation_needed"
+            expected_actor = "none"
+            rationale = "internal_execution_result_already_closed_without_active_orchestration_item"
+        else:
+            recommendation = "rerun_delegated_judgment"
+            expected_actor = "orchestration_body"
+            rationale = "internal_execution_result_satisfied_watchpoint_and_merits_bounded_judgment_refresh"
+        ready_to_resume = True
+    elif watchpoint_class == "await_external_fulfillment_receipt":
+        if resolution_path == "external_fulfillment" and state_class == "completed_recently_no_current_item":
+            recommendation = "no_re_evaluation_needed"
+            expected_actor = "none"
+            rationale = "external_fulfillment_already_closed_without_active_orchestration_item"
+        else:
+            recommendation = "rerun_delegated_judgment"
+            expected_actor = "orchestration_body"
+            rationale = "external_fulfillment_receipt_satisfied_watchpoint_and_merits_bounded_judgment_refresh"
+        ready_to_resume = True
+    elif watchpoint_class == "await_packetization_relief":
+        if gate_outcome in {"packetization_allowed", "packetization_allowed_with_caution"} and active_packet_present:
+            recommendation = "clear_wait_and_continue_current_packet"
+            expected_actor = "orchestration_body"
+            rationale = "packetization_hold_relieved_and_active_packet_remains_valid"
+        else:
+            recommendation = "rerun_packetization_gate"
+            expected_actor = "orchestration_body"
+            rationale = "packetization_relief_signal_needs_conservative_gate_recheck"
+        ready_to_resume = True
+    elif watchpoint_class == "await_new_proposal":
+        recommendation = "rerun_delegated_judgment"
+        expected_actor = "orchestration_body"
+        rationale = "new_proposal_watchpoint_satisfied_and_loop_should_re-enter_judgment_path"
+        ready_to_resume = True
+
+    if recommendation not in _RE_EVALUATION_RECOMMENDATIONS:
+        recommendation = "hold_for_manual_review"
+        expected_actor = "operator"
+        rationale = "unrecognized_re_entry_recommendation_defaulted_to_manual_review"
+    if expected_actor not in _RE_EVALUATION_EXPECTED_ACTORS:
+        expected_actor = "operator"
+    if satisfaction_status not in _WATCHPOINT_SATISFACTION_STATUSES:
+        satisfaction_status = "watchpoint_pending"
+
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+
+    return {
+        "schema_version": "orchestration_re_evaluation_trigger.v1",
+        "resolved_at": _iso_utc_now(),
+        "re_evaluation_trigger_id": _re_evaluation_trigger_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            recommendation=recommendation,
+            expected_actor=expected_actor,
+        ),
+        "source_linkage": {
+            "current_orchestration_state_ref": {
+                "current_orchestration_state_id": state_id or None,
+                "current_state_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_state",
+            },
+            "current_orchestration_watchpoint_ref": {
+                "orchestration_watchpoint_id": watchpoint_id or None,
+                "watchpoint_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_watchpoint",
+            },
+            "watchpoint_satisfaction_ref": {
+                "watchpoint_satisfaction_id": satisfaction_id or None,
+                "watchpoint_satisfaction_surface": "sentientos.orchestration_intent_fabric.resolve_watchpoint_satisfaction",
+            },
+        },
+        "recommendation": recommendation,
+        "expected_actor": expected_actor,
+        "basis": {
+            "compact_rationale": rationale,
+            "watchpoint_class": watchpoint_class,
+            "satisfaction_status": satisfaction_status,
+            "state_class": state_class,
+            "resolution_path": resolution_path,
+            "derived_from_existing_watchpoint_linked_surfaces_only": [
+                "resolve_current_orchestration_state",
+                "resolve_current_orchestration_watchpoint",
+                "resolve_watchpoint_satisfaction",
+                "operator_action_brief_lifecycle",
+                "packetization_gate",
+                "active_handoff_packet_visibility",
+            ],
+        },
+        "re_entry_summary": {
+            "watchpoint_class": watchpoint_class,
+            "satisfaction_status": satisfaction_status,
+            "recommended_re_entry_action": recommendation,
+            "expected_actor": expected_actor,
+            "ready_to_resume_bounded_evaluation": ready_to_resume,
+            "non_sovereign_boundaries": {
+                "diagnostic_only": True,
+                "non_authoritative": True,
+                "decision_power": "none",
+                "re_entry_recommendation_only": True,
+            },
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "re_entry_recommendation_only": True,
                 "does_not_schedule_or_trigger_events": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_workflow_sovereign": True,
@@ -5425,6 +5667,11 @@ def derive_delegated_operation_readiness_verdict(
         if isinstance(current_state_map.get("current_watchpoint_satisfaction"), Mapping)
         else {}
     )
+    current_re_evaluation_trigger_map = (
+        current_state_map.get("re_evaluation_trigger_recommendation")
+        if isinstance(current_state_map.get("re_evaluation_trigger_recommendation"), Mapping)
+        else {}
+    )
     packet_context = {
         "packetization_outcome": packetization_outcome,
         "packetization_allowed": packetization_allowed,
@@ -5474,6 +5721,12 @@ def derive_delegated_operation_readiness_verdict(
                         current_watchpoint_satisfaction_map.get("satisfaction_status") or "not_supplied"
                     ),
                     "basis_only": True,
+                },
+                "re_evaluation_recommendation_basis": {
+                    "recommended_re_entry_action": str(current_re_evaluation_trigger_map.get("recommendation") or "not_supplied"),
+                    "expected_actor": str(current_re_evaluation_trigger_map.get("expected_actor") or "not_supplied"),
+                    "basis_only": True,
+                    "does_not_change_verdict_logic": True,
                 },
                 "basis_only": True,
                 "does_not_change_verdict_logic": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -511,6 +511,37 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "a sovereign decision layer",
             ],
         },
+        "re_evaluation_trigger_recommendation": {
+            "meaning": "bounded re-entry recommendation that says how the loop should re-enter evaluation once watchpoint context is satisfied, stale, fragmented, or absent.",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_re_evaluation_trigger_recommendation",
+            "derived_from_existing_current_state_watchpoint_surfaces_only": [
+                "resolve_current_orchestration_state",
+                "resolve_current_orchestration_watchpoint",
+                "resolve_watchpoint_satisfaction",
+                "operator_action_brief_lifecycle",
+                "packetization_gate",
+                "active_handoff_packet_visibility",
+            ],
+            "trigger_values": [
+                "rerun_delegated_judgment",
+                "rerun_packetization_gate",
+                "rerun_packet_synthesis",
+                "clear_wait_and_continue_current_packet",
+                "hold_for_manual_review",
+                "no_re_evaluation_needed",
+            ],
+            "how_it_differs": {
+                "from_watchpoint_satisfaction": "watchpoint satisfaction says whether the wait condition is met; re-evaluation trigger recommendation says what bounded re-entry action is most conservative next.",
+                "from_current_orchestration_watchpoint": "watchpoint defines the waited-for condition; re-evaluation trigger recommendation defines post-wake re-entry posture only.",
+            },
+            "explicitly_not": [
+                "a scheduler or autonomous planner",
+                "direct execution of recommended action",
+                "admission authority",
+                "execution authority",
+                "new venue creation or routing",
+            ],
+        },
         "proposal_packet_continuity_review": {
             "meaning": "compact retrospective classifier indicating whether recent next-move proposals are converting into coherent active packet lineage or drifting through repeated holds/redirects/repacketization churn.",
             "machine_surface": "sentientos.orchestration_intent_fabric.derive_proposal_packet_continuity_review",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -43,6 +43,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_active_handoff_packet_candidate,
     resolve_current_orchestration_state,
     resolve_current_orchestration_watchpoint,
+    resolve_re_evaluation_trigger_recommendation,
     resolve_watchpoint_satisfaction,
     resolve_latest_operator_resolution_for_proposal,
     resolve_operator_action_brief_lifecycle,
@@ -309,6 +310,17 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         current_proposal=adjusted_next_move_proposal,
         active_packet_visibility=active_packet,
     )
+    re_evaluation_trigger_recommendation = resolve_re_evaluation_trigger_recommendation(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        watchpoint_satisfaction=current_watchpoint_satisfaction,
+        operator_brief_lifecycle=operator_brief_lifecycle,
+        unified_result=unified_result,
+        packetization_gate=packetization_gate,
+        current_proposal=adjusted_next_move_proposal,
+        active_packet_visibility=active_packet,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -323,6 +335,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             **current_orchestration_state,
             "current_watchpoint": current_orchestration_watchpoint,
             "current_watchpoint_satisfaction": current_watchpoint_satisfaction,
+            "re_evaluation_trigger_recommendation": re_evaluation_trigger_recommendation,
         },
     )
     unified_result_quality_review = derive_unified_result_quality_review(root)
@@ -413,25 +426,31 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_state": current_orchestration_state,
             "current_orchestration_watchpoint": current_orchestration_watchpoint,
             "current_orchestration_watchpoint_satisfaction": current_watchpoint_satisfaction,
+            "re_evaluation_trigger_recommendation": re_evaluation_trigger_recommendation,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
+                "watchpoint_satisfaction_status": current_watchpoint_satisfaction.get("satisfaction_status"),
                 "expected_actor": current_orchestration_watchpoint.get("expected_actor"),
                 "expected_signal_type": current_orchestration_watchpoint.get("expected_signal_type"),
                 "satisfaction_status": current_watchpoint_satisfaction.get("satisfaction_status"),
                 "satisfied_by_actor": current_watchpoint_satisfaction.get("satisfied_by_actor"),
                 "satisfied_by_signal_type": current_watchpoint_satisfaction.get("satisfied_by_signal_type"),
+                "re_evaluation_trigger_recommendation": re_evaluation_trigger_recommendation.get("recommendation"),
+                "re_evaluation_expected_actor": re_evaluation_trigger_recommendation.get("expected_actor"),
                 "ready_for_re_evaluation": (current_watchpoint_satisfaction.get("wake_readiness_summary") or {}).get(
                     "ready_for_re_evaluation"
                 ),
                 "compact_rationale": (current_orchestration_watchpoint.get("basis") or {}).get("compact_rationale"),
                 "satisfaction_rationale": (current_watchpoint_satisfaction.get("basis") or {}).get("compact_rationale"),
+                "re_evaluation_rationale": (re_evaluation_trigger_recommendation.get("basis") or {}).get("compact_rationale"),
                 "non_sovereign_boundaries": {
                     "diagnostic_only": True,
                     "non_authoritative": True,
                     "decision_power": "none",
                     "watchpoint_only": True,
                     "wake_readiness_only": True,
+                    "re_entry_recommendation_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -48,6 +48,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_active_handoff_packet_candidate,
     resolve_current_orchestration_state,
     resolve_current_orchestration_watchpoint,
+    resolve_re_evaluation_trigger_recommendation,
     resolve_watchpoint_satisfaction,
     resolve_operator_action_brief_lifecycle,
     synthesize_handoff_packet,
@@ -4425,6 +4426,130 @@ def test_watchpoint_satisfaction_reports_no_active_watchpoint(tmp_path: Path) ->
     assert satisfaction["satisfied_by_actor"] == "none"
 
 
+def test_re_evaluation_trigger_operator_resolution_recommends_packet_synthesis(tmp_path: Path) -> None:
+    state = {"current_orchestration_state_id": "ocs-re-eval-operator", "current_supervisory_state": "waiting_for_operator_resolution"}
+    watchpoint = {
+        "orchestration_watchpoint_id": "owp-re-eval-operator",
+        "watchpoint_class": "await_operator_resolution",
+        "expected_actor": "operator",
+        "expected_signal_type": "operator_resolution_receipt",
+    }
+    satisfaction = {
+        "watchpoint_satisfaction_id": "wps-re-eval-operator",
+        "satisfaction_status": "watchpoint_satisfied",
+    }
+    trigger = resolve_re_evaluation_trigger_recommendation(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+        watchpoint_satisfaction=satisfaction,
+        operator_brief_lifecycle={"resolution_kind": "approved_with_constraints"},
+    )
+    assert trigger["recommendation"] == "rerun_packet_synthesis"
+    assert trigger["expected_actor"] == "orchestration_body"
+
+
+def test_re_evaluation_trigger_internal_result_recommends_judgment_rerun(tmp_path: Path) -> None:
+    state = {
+        "current_orchestration_state_id": "ocs-re-eval-internal",
+        "current_supervisory_state": "waiting_for_internal_result",
+        "current_resolution_path": "internal_execution",
+    }
+    watchpoint = {
+        "orchestration_watchpoint_id": "owp-re-eval-internal",
+        "watchpoint_class": "await_internal_execution_result",
+        "expected_actor": "internal_substrate",
+        "expected_signal_type": "internal_execution_result",
+    }
+    satisfaction = {
+        "watchpoint_satisfaction_id": "wps-re-eval-internal",
+        "satisfaction_status": "watchpoint_satisfied",
+    }
+    trigger = resolve_re_evaluation_trigger_recommendation(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+        watchpoint_satisfaction=satisfaction,
+        unified_result={"resolution_path": "internal_execution"},
+    )
+    assert trigger["recommendation"] == "rerun_delegated_judgment"
+
+
+def test_re_evaluation_trigger_external_result_recommends_judgment_rerun(tmp_path: Path) -> None:
+    state = {
+        "current_orchestration_state_id": "ocs-re-eval-external",
+        "current_supervisory_state": "waiting_for_external_fulfillment",
+        "current_resolution_path": "external_fulfillment",
+    }
+    watchpoint = {
+        "orchestration_watchpoint_id": "owp-re-eval-external",
+        "watchpoint_class": "await_external_fulfillment_receipt",
+        "expected_actor": "external_actor",
+        "expected_signal_type": "external_fulfillment_receipt",
+    }
+    satisfaction = {
+        "watchpoint_satisfaction_id": "wps-re-eval-external",
+        "satisfaction_status": "watchpoint_satisfied",
+    }
+    trigger = resolve_re_evaluation_trigger_recommendation(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+        watchpoint_satisfaction=satisfaction,
+        unified_result={"resolution_path": "external_fulfillment"},
+    )
+    assert trigger["recommendation"] == "rerun_delegated_judgment"
+
+
+def test_re_evaluation_trigger_fragmented_context_holds_for_manual_review(tmp_path: Path) -> None:
+    state = {"current_orchestration_state_id": "ocs-re-eval-fragmented", "current_supervisory_state": "waiting_for_external_fulfillment"}
+    watchpoint = {
+        "orchestration_watchpoint_id": "owp-re-eval-fragmented",
+        "watchpoint_class": "await_external_fulfillment_receipt",
+        "expected_actor": "external_actor",
+        "expected_signal_type": "external_fulfillment_receipt",
+    }
+    satisfaction = {"watchpoint_satisfaction_id": "wps-re-eval-fragmented", "satisfaction_status": "watchpoint_fragmented"}
+    trigger = resolve_re_evaluation_trigger_recommendation(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+        watchpoint_satisfaction=satisfaction,
+    )
+    assert trigger["recommendation"] == "hold_for_manual_review"
+    assert trigger["expected_actor"] == "operator"
+
+
+def test_re_evaluation_trigger_no_active_watchpoint_needs_no_re_evaluation(tmp_path: Path) -> None:
+    state = resolve_current_orchestration_state(
+        tmp_path,
+        current_proposal={"proposal_id": None},
+        packetization_gate={"packetization_outcome": "packetization_allowed", "packetization_allowed": True},
+        active_packet_visibility={"active_packet_present": False},
+        operator_brief_lifecycle={"awaiting_operator_input": False},
+        unified_result={
+            "orchestration_result_id": "oru-re-eval-none",
+            "result_classification": "completed_successfully",
+            "resolution_path": "external_fulfillment",
+        },
+    )
+    watchpoint = resolve_current_orchestration_watchpoint(tmp_path, current_orchestration_state=state)
+    satisfaction = resolve_watchpoint_satisfaction(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+    )
+    trigger = resolve_re_evaluation_trigger_recommendation(
+        tmp_path,
+        current_orchestration_state=state,
+        current_orchestration_watchpoint=watchpoint,
+        watchpoint_satisfaction=satisfaction,
+    )
+    assert watchpoint["watchpoint_class"] == "no_watchpoint_needed"
+    assert trigger["recommendation"] == "no_re_evaluation_needed"
+    assert trigger["expected_actor"] == "none"
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -4460,6 +4585,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     current_state = diagnostic["orchestration_handoff"]["current_orchestration_state"]
     current_watchpoint = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint"]
     current_watchpoint_satisfaction = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_satisfaction"]
+    re_evaluation_trigger = diagnostic["orchestration_handoff"]["re_evaluation_trigger_recommendation"]
     current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
@@ -4497,10 +4623,25 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     }
     assert current_watchpoint_satisfaction["wake_readiness_summary"]["wake_readiness_only"] is True
     assert current_watchpoint_satisfaction["does_not_schedule_or_trigger_events"] is True
+    assert re_evaluation_trigger["schema_version"] == "orchestration_re_evaluation_trigger.v1"
+    assert re_evaluation_trigger["recommendation"] in {
+        "rerun_delegated_judgment",
+        "rerun_packetization_gate",
+        "rerun_packet_synthesis",
+        "clear_wait_and_continue_current_packet",
+        "hold_for_manual_review",
+        "no_re_evaluation_needed",
+    }
+    assert re_evaluation_trigger["expected_actor"] in {"orchestration_body", "operator", "none"}
+    assert re_evaluation_trigger["re_entry_summary"]["non_sovereign_boundaries"]["decision_power"] == "none"
+    assert re_evaluation_trigger["re_entry_recommendation_only"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
-    assert current_watchpoint_summary["satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
+    assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
+    assert current_watchpoint_summary["re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
+    assert current_watchpoint_summary["re_evaluation_expected_actor"] == re_evaluation_trigger["expected_actor"]
     assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["wake_readiness_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["re_entry_recommendation_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True
@@ -4512,6 +4653,12 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
         "no_active_watchpoint",
         "not_supplied",
     }
+    assert (
+        readiness["summary"]["current_orchestration_state_basis"]["re_evaluation_recommendation_basis"][
+            "does_not_change_verdict_logic"
+        ]
+        is True
+    )
     assert before["handoff_outcome"] == after["handoff_outcome"]
 
 


### PR DESCRIPTION
### Motivation

- Provide a small, bounded, machine-readable "how do I resume?" object so the orchestration loop can recommend a conservative re-entry action when a watchpoint becomes wake-ready without becoming a scheduler or executing anything.

### Description

- Add a compact re-evaluation model (`orchestration_re_evaluation_trigger.v1`) with stable id generation, source linkage to current state/watchpoint/watchpoint-satisfaction, recommendation vocabulary, expected actor set, compact rationale, and explicit anti-sovereignty markers.
- Implement `resolve_re_evaluation_trigger_recommendation`, a conservative, state-driven resolver that derives its recommendation only from existing surfaces (current orchestration state, watchpoint class, watchpoint satisfaction, active packet visibility, operator brief lifecycle, packetization gate, and unified result) and maps to one of: `rerun_delegated_judgment`, `rerun_packetization_gate`, `rerun_packet_synthesis`, `clear_wait_and_continue_current_packet`, `hold_for_manual_review`, or `no_re_evaluation_needed`.
- Surface the recommendation in the existing scoped orchestration diagnostic consumer (`build_scoped_lifecycle_diagnostic`) and include a compact `re_entry_summary` in the watchpoint summary with explicit non-sovereign boundaries; the change is basis-only for readiness and does not change verdict logic.
- Update the orchestration note with a short technical entry describing the new surface, its inputs, valid trigger values, how it differs from watchpoint satisfaction, and what it does not do.
- Add focused tests covering operator-resolution, internal execution result, external fulfillment, fragmented/stale context, and no-active-watchpoint cases, plus consumer coherence checks; tests are written to ensure the surface is diagnostic-only and non-executing.

### Testing

- Ran targeted unit tests for the new surface and integrations in the orchestration intent fabric: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "re_evaluation_trigger or current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative"` — passed.
- Ran the full orchestration intent fabric test file: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py` — passed (all new and existing assertions in that file succeeded).
- Ran repository-wide test runner `python -m scripts.run_tests -q`; test execution completed but there are pre-existing failing federation tests in `tests/test_pulse_federation.py` unrelated to this change (these failures predate and are orthogonal to the re-evaluation trigger addition).
- Ran `mypy scripts/ sentintos/` which reported many pre-existing type errors across the repository unrelated to this change (typing debt remains and was not introduced by this patch).
- Ran `python scripts/audit_immutability_verifier.py` which passed for the repository artifacts available in this environment.

Notes: the new recommendation surface is strictly diagnostic-only, non-authoritative, and does not perform any scheduling, actuation, or admission changes; it only recommends a conservative bounded re-entry action and is surfaced in diagnostics for operator and orchestration-body consumption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e50b1dd2e48320b03469296a94a446)