### PR TITLE
[codex:orchestration] restore continuity review top-level boundary compatibility

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -6490,6 +6490,7 @@ def derive_proposal_packet_continuity_review(
             diagnostic_only=True,
             does_not_change_admission_or_execution=True,
             additional_fields={
+                "does_not_execute_or_route_work": True,
                 "review_only": True,
                 "non_authoritative": True,
                 "decision_power": "none",


### PR DESCRIPTION
### Motivation
- A recent orchestration pressure-signal pass removed a top-level compatibility field expected by existing continuity-review consumers, causing `test_operator_repacketization_e2e_in_scoped_diagnostic` to fail when the scoped diagnostic no longer exposed `does_not_execute_or_route_work` at the top level.

### Description
- Reintroduce the top-level `does_not_execute_or_route_work: True` field into the `proposal_packet_continuity_review` payload by adding it to the `additional_fields` passed to `_anti_sovereignty_payload` in `derive_proposal_packet_continuity_review`.
- File changed: `sentientos/orchestration_intent_fabric.py` (single-line insertion), preserving the existing bounded/non-sovereign diagnostic shape (`diagnostic_only`, `non_authoritative`, `decision_power: "none"`) and not altering the pressure-signal architecture.
- Repair classification: code-shape restoration only (no test updates, no authority surface introduced).

### Testing
- Ran the full orchestration test module with `python -m pytest -q sentientos/tests/test_orchestration_intent_fabric.py`, which passed (all tests in that module succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e70799ab048320a8a55110aa36b2f3)