### PR TITLE
[codex:orchestration] add derived current operator-facing orchestration brief

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -345,6 +345,15 @@ _CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS = {
     "no_current_packet_brief",
 }
 
+_CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS = {
+    "operator_attention_not_currently_needed",
+    "operator_should_review_hold",
+    "operator_should_review_fragmentation",
+    "operator_should_review_packet_refresh_context",
+    "operator_should_review_redirect_or_constraint_path",
+    "operator_should_confirm_no_current_action",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4444,6 +4453,32 @@ def _current_orchestration_handoff_packet_brief_id(
     return f"ohp-{digest.hexdigest()[:16]}"
 
 
+def _current_operator_facing_orchestration_brief_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    re_evaluation_trigger_id: str,
+    orchestration_resumption_candidate_id: str,
+    operator_facing_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "re_evaluation_trigger_id": re_evaluation_trigger_id,
+                "orchestration_resumption_candidate_id": orchestration_resumption_candidate_id,
+                "operator_facing_classification": operator_facing_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"oop-{digest.hexdigest()[:16]}"
+
+
 def resolve_current_orchestration_state(
     repo_root: Path,
     *,
@@ -7144,6 +7179,263 @@ def resolve_current_orchestration_handoff_packet_brief(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_handoff_packet_brief_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_operator_facing_orchestration_brief(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint_brief: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_re_evaluation_basis_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    operator_action_brief_visibility: Mapping[str, Any] | None = None,
+    operator_resolution_influence: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+    current_proposal: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one compact, derived operator-facing orchestration brief for current understanding only."""
+
+    _ = repo_root.resolve()
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    watchpoint_brief_map = (
+        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
+    )
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
+    basis_map = current_re_evaluation_basis_brief if isinstance(current_re_evaluation_basis_brief, Mapping) else {}
+    candidate_map = (
+        current_orchestration_resumption_candidate
+        if isinstance(current_orchestration_resumption_candidate, Mapping)
+        else {}
+    )
+    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_brief_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_brief_map = operator_action_brief_visibility if isinstance(operator_action_brief_visibility, Mapping) else {}
+    influence_map = operator_resolution_influence if isinstance(operator_resolution_influence, Mapping) else {}
+    active_packet_map = active_packet_visibility if isinstance(active_packet_visibility, Mapping) else {}
+    proposal_map = current_proposal if isinstance(current_proposal, Mapping) else {}
+    unified_result_map = unified_result if isinstance(unified_result, Mapping) else {}
+
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "watchpoint_pending")
+    recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
+    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    handoff_brief_classification = str(
+        handoff_brief_map.get("handoff_packet_brief_classification") or "no_current_packet_brief"
+    )
+    operator_influence_state = str(influence_map.get("operator_influence_state") or "no_operator_influence_yet")
+    operator_brief_state = str(operator_brief_map.get("lifecycle_state") or "brief_not_emitted")
+    basis_classification = str(basis_map.get("basis_classification") or "no_current_re_evaluation_basis")
+    resolution_path = str(unified_result_map.get("resolution_path") or str(state_map.get("current_resolution_path") or "none"))
+    result_classification = str(unified_result_map.get("result_classification") or "pending_or_unresolved")
+    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "continuity_uncertain")
+
+    operator_influence_active = operator_influence_state in {
+        "operator_resolution_applied",
+        "operator_redirect_applied",
+        "operator_constraints_applied",
+    }
+    operator_influence_needed = (
+        watchpoint_class == "await_operator_resolution"
+        or recommendation == "hold_for_manual_review"
+        or operator_brief_state == "brief_emitted"
+        or readiness_verdict == "hold_for_operator_review"
+        or wake_classification == "wake_blocked_pending_operator"
+    )
+    no_current_work = (
+        next_move_classification == "no_current_next_move"
+        and recommendation == "no_re_evaluation_needed"
+        and watchpoint_class == "no_watchpoint_needed"
+        and satisfaction_status in {"no_active_watchpoint", "watchpoint_satisfied"}
+        and handoff_brief_classification in {"no_current_packet_brief", "packet_not_currently_material"}
+    )
+    fragmentation_material = (
+        pressure_classification == "fragmentation_pressure"
+        or wake_classification == "wake_blocked_by_fragmentation"
+        or handoff_brief_classification == "packet_continuity_uncertain"
+        or satisfaction_status in {"watchpoint_fragmented", "watchpoint_stale"}
+        or wait_kind == "continuity_uncertain"
+    )
+    hold_material = (
+        recommendation == "hold_for_manual_review"
+        or next_move_classification == "hold_for_operator_review_next"
+        or readiness_verdict == "hold_for_operator_review"
+        or wake_classification == "wake_blocked_pending_operator"
+    )
+    packet_refresh_material = (
+        handoff_brief_classification in {"refreshed_packet_required", "packetization_gate_pending"}
+        or next_move_classification in {"rerun_packet_synthesis_next", "rerun_packetization_gate_next"}
+    )
+    redirect_or_constraint_material = (
+        operator_influence_state in {"operator_redirect_applied", "operator_constraints_applied"}
+        or pressure_classification == "redirect_pressure"
+        or basis_classification == "operator_resolution_driven_re_evaluation"
+    )
+
+    if no_current_work and not operator_influence_needed:
+        classification = "operator_should_confirm_no_current_action"
+        rationale = "current_watchpoint_trigger_next_move_and_packet_surfaces_show_no_meaningful_current_work"
+    elif fragmentation_material:
+        classification = "operator_should_review_fragmentation"
+        rationale = "continuity_fragmentation_or_stale_linkage_is_the_material_current_orchestration_issue"
+    elif hold_material:
+        classification = "operator_should_review_hold"
+        rationale = "current_hold_or_manual_review_signals_materially_bound_the_current_orchestration_path"
+    elif packet_refresh_material:
+        classification = "operator_should_review_packet_refresh_context"
+        rationale = "current_next_move_and_packet_posture_show_material_packet_refresh_or_gate_context"
+    elif redirect_or_constraint_material:
+        classification = "operator_should_review_redirect_or_constraint_path"
+        rationale = "operator_shaped_redirect_or_constraint_context_materially_conditions_current_path"
+    else:
+        classification = "operator_attention_not_currently_needed"
+        rationale = "current_surfaces_do_not_show_meaningful_operator_dependency_for_the_current_path"
+
+    if classification not in _CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS:
+        classification = "operator_should_review_hold"
+
+    loop_posture = "informational"
+    if classification in {"operator_should_review_hold", "operator_should_review_fragmentation"}:
+        loop_posture = "blocked"
+    elif classification in {
+        "operator_should_review_packet_refresh_context",
+        "operator_should_review_redirect_or_constraint_path",
+    }:
+        loop_posture = "cautionary"
+
+    operator_understanding_material = classification in {
+        "operator_should_review_hold",
+        "operator_should_review_fragmentation",
+        "operator_should_review_packet_refresh_context",
+        "operator_should_review_redirect_or_constraint_path",
+    }
+    informational_only = classification in {
+        "operator_attention_not_currently_needed",
+        "operator_should_confirm_no_current_action",
+    }
+
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
+    return {
+        "schema_version": "current_operator_facing_orchestration_brief.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_operator_facing_orchestration_brief_id": _current_operator_facing_orchestration_brief_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            operator_facing_classification=classification,
+        ),
+        "operator_facing_classification": classification,
+        "loop_posture": loop_posture,
+        "operator_influence_already_active": operator_influence_active,
+        "operator_influence_still_needed": operator_influence_needed and not operator_influence_active,
+        "next_move_or_packet_materially_depends_on_operator_understanding": operator_understanding_material,
+        "informational_only": informational_only,
+        "requires_conservative_attention": not informational_only,
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "watchpoint_class": watchpoint_class,
+                "watchpoint_satisfaction_status": satisfaction_status,
+                "watchpoint_wait_kind": wait_kind,
+                "re_evaluation_recommendation": recommendation,
+                "re_evaluation_basis_classification": basis_classification,
+                "resumed_operation_readiness_verdict": readiness_verdict,
+                "wake_readiness_classification": wake_classification,
+                "pressure_classification": pressure_classification,
+                "current_next_move_classification": next_move_classification,
+                "current_handoff_packet_brief_classification": handoff_brief_classification,
+                "operator_action_brief_lifecycle_state": operator_brief_state,
+                "operator_influence_state": operator_influence_state,
+                "active_packet_available": bool(active_packet_map.get("active_packet_available")),
+                "current_proposal_id": str(proposal_map.get("proposal_id") or ""),
+                "unified_result_classification": result_classification,
+                "unified_result_resolution_path": resolution_path,
+            },
+            "materially_supporting_surfaces": [
+                "resolve_current_orchestration_state",
+                "resolve_current_orchestration_watchpoint",
+                "resolve_current_orchestration_watchpoint_brief",
+                "resolve_watchpoint_satisfaction",
+                "resolve_re_evaluation_trigger_recommendation",
+                "resolve_current_re_evaluation_basis_brief",
+                "resolve_current_orchestration_resumption_candidate",
+                "resolve_current_resumed_operation_readiness_verdict",
+                "resolve_current_orchestration_wake_readiness_detector",
+                "resolve_current_orchestration_pressure_signal",
+                "resolve_current_orchestration_next_move_brief",
+                "resolve_current_orchestration_handoff_packet_brief",
+                "operator-action brief visibility",
+                "operator-resolution visibility",
+                "active handoff packet visibility",
+                "current proposal visibility",
+                "unified result visibility",
+            ],
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_fabricate_stronger_operator_need_than_visible_support": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_operator_brief_ledger": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_operator_facing_orchestration_brief_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -261,6 +261,33 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not imply permission to execute",
             ],
         },
+        "current_operator_facing_orchestration_brief": {
+            "what_it_is": "a narrow observational-only resolver that compresses the current orchestration chain into what the operator should understand right now",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_operator_facing_orchestration_brief",
+            "classifications": [
+                "operator_attention_not_currently_needed",
+                "operator_should_review_hold",
+                "operator_should_review_fragmentation",
+                "operator_should_review_packet_refresh_context",
+                "operator_should_review_redirect_or_constraint_path",
+                "operator_should_confirm_no_current_action",
+            ],
+            "derived_from_existing_surfaces_only": [
+                "current orchestration state/watchpoint/watchpoint brief/satisfaction",
+                "re-evaluation trigger + current re-evaluation basis brief",
+                "current resumption candidate + resumed readiness",
+                "current wake-readiness detector + pressure signal",
+                "current orchestration next-move brief + handoff packet brief",
+                "operator-action brief visibility + operator-resolution visibility",
+                "active handoff packet visibility + current proposal visibility + unified result visibility",
+            ],
+            "strict_boundaries": [
+                "non-sovereign, non-authoritative, non-executing",
+                "informational/conservative attention brief only; never a scheduler/planner/execution venue",
+                "does not create a new truth source or operator-brief ledger",
+                "does not imply permission to execute",
+            ],
+        },
         "unified_orchestration_result": {
             "what_it_is": "a bounded venue-aware resolver surface that normalizes internal execution closure and external fulfillment closure into one typed result shape",
             "machine_surface": "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -34,6 +34,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_re_evaluation_basis_brief,
     resolve_current_orchestration_next_move_brief,
     resolve_current_orchestration_handoff_packet_brief,
+    resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
     derive_next_venue_recommendation,
@@ -449,6 +450,26 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         operator_resolution_influence=operator_influence,
         unified_result=unified_result,
     )
+    current_operator_facing_orchestration_brief = resolve_current_operator_facing_orchestration_brief(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
+        watchpoint_satisfaction=current_watchpoint_satisfaction,
+        re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_re_evaluation_basis_brief=current_re_evaluation_basis_brief,
+        current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+        current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+        operator_action_brief_visibility=operator_brief_lifecycle,
+        operator_resolution_influence=operator_influence,
+        active_packet_visibility=active_packet,
+        current_proposal=adjusted_next_move_proposal,
+        unified_result=unified_result,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -565,6 +586,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_re_evaluation_basis_brief": current_re_evaluation_basis_brief,
             "current_orchestration_next_move_brief": current_orchestration_next_move_brief,
             "current_orchestration_handoff_packet_brief": current_orchestration_handoff_packet_brief,
+            "current_operator_facing_orchestration_brief": current_operator_facing_orchestration_brief,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -614,6 +636,13 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_handoff_packet_refreshed_packet_implied": current_orchestration_handoff_packet_brief.get(
                     "refreshed_packet_implied"
                 ),
+                "current_operator_facing_classification": current_operator_facing_orchestration_brief.get(
+                    "operator_facing_classification"
+                ),
+                "current_operator_facing_loop_posture": current_operator_facing_orchestration_brief.get("loop_posture"),
+                "current_operator_facing_informational_only": current_operator_facing_orchestration_brief.get(
+                    "informational_only"
+                ),
                 "ready_for_re_evaluation": (current_watchpoint_satisfaction.get("wake_readiness_summary") or {}).get(
                     "ready_for_re_evaluation"
                 ),
@@ -636,6 +665,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "re_evaluation_basis_brief_only": True,
                     "current_orchestration_next_move_brief_only": True,
                     "current_orchestration_handoff_packet_brief_only": True,
+                    "current_operator_facing_orchestration_brief_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -51,6 +51,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_pressure_signal,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_handoff_packet_brief,
+    resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_resumption_candidate,
     resolve_current_orchestration_watchpoint_brief,
     resolve_current_orchestration_watchpoint,
@@ -5413,6 +5414,173 @@ def test_current_orchestration_handoff_packet_brief_is_derived_only_and_non_exec
     assert brief["decision_power"] == "none"
 
 
+@pytest.mark.parametrize(
+    (
+        "next_move_classification",
+        "recommendation",
+        "watchpoint_class",
+        "satisfaction_status",
+        "wake_classification",
+        "pressure_classification",
+        "handoff_packet_brief_classification",
+        "wait_kind",
+        "operator_influence_state",
+        "operator_brief_state",
+        "expected",
+    ),
+    [
+        (
+            "continue_current_packet_next",
+            "clear_wait_and_continue_current_packet",
+            "await_external_fulfillment_receipt",
+            "watchpoint_pending",
+            "wake_ready",
+            "stable_or_low_pressure",
+            "continuing_active_packet",
+            "awaiting_external_fulfillment",
+            "no_operator_influence_yet",
+            "brief_not_emitted",
+            "operator_attention_not_currently_needed",
+        ),
+        (
+            "hold_for_operator_review_next",
+            "hold_for_manual_review",
+            "await_operator_resolution",
+            "watchpoint_pending",
+            "wake_blocked_pending_operator",
+            "hold_pressure",
+            "packetization_gate_pending",
+            "awaiting_operator_resolution",
+            "no_operator_influence_yet",
+            "brief_emitted",
+            "operator_should_review_hold",
+        ),
+        (
+            "rerun_packet_synthesis_next",
+            "rerun_packet_synthesis",
+            "await_external_fulfillment_receipt",
+            "watchpoint_fragmented",
+            "wake_blocked_by_fragmentation",
+            "fragmentation_pressure",
+            "packet_continuity_uncertain",
+            "continuity_uncertain",
+            "no_operator_influence_yet",
+            "brief_not_emitted",
+            "operator_should_review_fragmentation",
+        ),
+        (
+            "rerun_packet_synthesis_next",
+            "rerun_packet_synthesis",
+            "await_new_proposal",
+            "watchpoint_satisfied",
+            "wake_ready",
+            "stable_or_low_pressure",
+            "refreshed_packet_required",
+            "awaiting_external_fulfillment",
+            "no_operator_influence_yet",
+            "brief_not_emitted",
+            "operator_should_review_packet_refresh_context",
+        ),
+        (
+            "rerun_delegated_judgment_next",
+            "rerun_delegated_judgment",
+            "await_new_proposal",
+            "watchpoint_satisfied",
+            "wake_ready_with_caution",
+            "redirect_pressure",
+            "packet_not_currently_material",
+            "awaiting_external_fulfillment",
+            "operator_redirect_applied",
+            "operator_resolution_received",
+            "operator_should_review_redirect_or_constraint_path",
+        ),
+        (
+            "no_current_next_move",
+            "no_re_evaluation_needed",
+            "no_watchpoint_needed",
+            "no_active_watchpoint",
+            "wake_not_applicable",
+            "stable_or_low_pressure",
+            "no_current_packet_brief",
+            "no_active_watchpoint",
+            "no_operator_influence_yet",
+            "brief_not_emitted",
+            "operator_should_confirm_no_current_action",
+        ),
+    ],
+)
+def test_current_operator_facing_orchestration_brief_classification_cases(
+    tmp_path: Path,
+    next_move_classification: str,
+    recommendation: str,
+    watchpoint_class: str,
+    satisfaction_status: str,
+    wake_classification: str,
+    pressure_classification: str,
+    handoff_packet_brief_classification: str,
+    wait_kind: str,
+    operator_influence_state: str,
+    operator_brief_state: str,
+    expected: str,
+) -> None:
+    brief = resolve_current_operator_facing_orchestration_brief(
+        tmp_path,
+        current_orchestration_state={"current_orchestration_state_id": "cos-operator-facing"},
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-operator-facing", "watchpoint_class": watchpoint_class},
+        current_orchestration_watchpoint_brief={"wait_kind": wait_kind},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-operator-facing", "satisfaction_status": satisfaction_status},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-operator-facing", "recommendation": recommendation},
+        current_re_evaluation_basis_brief={"basis_classification": "satisfaction_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-operator-facing"},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": "hold_for_operator_review" if expected == "operator_should_review_hold" else "ready_to_proceed"},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": handoff_packet_brief_classification},
+        operator_action_brief_visibility={"lifecycle_state": operator_brief_state},
+        operator_resolution_influence={"operator_influence_state": operator_influence_state},
+        active_packet_visibility={"active_packet_available": True},
+        current_proposal={"proposal_id": "proposal-operator-facing"},
+        unified_result={"result_classification": "pending_or_unresolved", "resolution_path": "external_fulfillment"},
+    )
+    assert brief["operator_facing_classification"] == expected
+
+
+def test_current_operator_facing_orchestration_brief_is_derived_only_non_authoritative_and_non_executing(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    brief = resolve_current_operator_facing_orchestration_brief(
+        tmp_path,
+        current_orchestration_state={"current_orchestration_state_id": "cos-op-boundary"},
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-op-boundary", "watchpoint_class": "await_operator_resolution"},
+        current_orchestration_watchpoint_brief={"wait_kind": "awaiting_operator_resolution"},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-op-boundary", "satisfaction_status": "watchpoint_pending"},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-op-boundary", "recommendation": "hold_for_manual_review"},
+        current_re_evaluation_basis_brief={"basis_classification": "operator_resolution_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-op-boundary"},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": "hold_for_operator_review"},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": "wake_blocked_pending_operator"},
+        current_orchestration_pressure_signal={"pressure_classification": "hold_pressure"},
+        current_orchestration_next_move_brief={"next_move_classification": "hold_for_operator_review_next"},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": "packetization_gate_pending"},
+        operator_action_brief_visibility={"lifecycle_state": "brief_emitted"},
+        operator_resolution_influence={"operator_influence_state": "no_operator_influence_yet"},
+        active_packet_visibility={"active_packet_available": True},
+        current_proposal={"proposal_id": "proposal-op-boundary"},
+        unified_result={"result_classification": "pending_or_unresolved", "resolution_path": "external_fulfillment"},
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert brief["basis"]["historical_honesty"]["derived_from_existing_surfaces_only"] is True
+    assert brief["current_operator_facing_orchestration_brief_only"] is True
+    assert brief["boundaries"]["non_authoritative"] is True
+    assert brief["boundaries"]["non_executing"] is True
+    assert brief["does_not_execute_or_route_work"] is True
+    assert brief["decision_power"] == "none"
+    assert before["handoff_outcome"] == after["handoff_outcome"]
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -5457,6 +5625,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     current_re_evaluation_basis = diagnostic["orchestration_handoff"]["current_re_evaluation_basis_brief"]
     current_next_move = diagnostic["orchestration_handoff"]["current_orchestration_next_move_brief"]
     current_handoff_packet_brief = diagnostic["orchestration_handoff"]["current_orchestration_handoff_packet_brief"]
+    current_operator_facing = diagnostic["orchestration_handoff"]["current_operator_facing_orchestration_brief"]
     current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
@@ -5590,6 +5759,18 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     }
     assert current_handoff_packet_brief["boundaries"]["non_authoritative"] is True
     assert current_handoff_packet_brief["does_not_execute_or_route_work"] is True
+    assert current_operator_facing["schema_version"] == "current_operator_facing_orchestration_brief.v1"
+    assert current_operator_facing["operator_facing_classification"] in {
+        "operator_attention_not_currently_needed",
+        "operator_should_review_hold",
+        "operator_should_review_fragmentation",
+        "operator_should_review_packet_refresh_context",
+        "operator_should_review_redirect_or_constraint_path",
+        "operator_should_confirm_no_current_action",
+    }
+    assert current_operator_facing["loop_posture"] in {"blocked", "cautionary", "informational"}
+    assert current_operator_facing["boundaries"]["non_authoritative"] is True
+    assert current_operator_facing["does_not_execute_or_route_work"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
     assert current_watchpoint_summary["re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
@@ -5632,6 +5813,15 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
         current_watchpoint_summary["current_handoff_packet_refreshed_packet_implied"]
         == current_handoff_packet_brief["refreshed_packet_implied"]
     )
+    assert (
+        current_watchpoint_summary["current_operator_facing_classification"]
+        == current_operator_facing["operator_facing_classification"]
+    )
+    assert current_watchpoint_summary["current_operator_facing_loop_posture"] == current_operator_facing["loop_posture"]
+    assert (
+        current_watchpoint_summary["current_operator_facing_informational_only"]
+        == current_operator_facing["informational_only"]
+    )
     assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["wake_readiness_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["re_entry_recommendation_only"] is True
@@ -5643,6 +5833,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["non_sovereign_boundaries"]["re_evaluation_basis_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_next_move_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_handoff_packet_brief_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["current_operator_facing_orchestration_brief_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True


### PR DESCRIPTION
### Motivation

- Provide a compact, observational-only surface that communicates "what the operator should understand right now" by compressing existing orchestration/watchpoint/basis/resumption/readiness/next-move/packet surfaces. 
- Keep the new surface strictly derived, non-sovereign, non-executing, and explicitly diagnostic so it does not alter admission, execution, or create new mutable truth stores.

### Description

- Added a new resolver `resolve_current_operator_facing_orchestration_brief` (and deterministic id helper) in `sentientos/orchestration_intent_fabric.py` which classifies the operator-facing posture into a compact vocabulary and includes compact basis/evidence and materially-supporting surfaces. 
- Introduced `_CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS` and `_current_operator_facing_orchestration_brief_id` and ensured the resolver honors explicit non-sovereign/non-authoritative/non-executing boundaries and anti-sovereignty payloads. 
- Surfaced the brief in the scoped lifecycle diagnostic by calling `resolve_current_operator_facing_orchestration_brief` from `build_scoped_lifecycle_diagnostic` and adding `current_operator_facing_orchestration_brief` into the `orchestration_handoff` output and watchpoint summary fields. 
- Documented the new surface in `sentientos/orchestration_intent_fabric_note.py` and added focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` that cover the requested classifications and derivation/boundary properties without changing authority behavior.
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric_note.py`, `sentientos/tests/test_orchestration_intent_fabric.py`.
- Resolver added: `resolve_current_operator_facing_orchestration_brief` in `sentientos/orchestration_intent_fabric.py`.
- Diagnostic surface added: `current_operator_facing_orchestration_brief` under `orchestration_handoff` in the scoped lifecycle diagnostic output.
- Tests added: `test_current_operator_facing_orchestration_brief_classification_cases` and `test_current_operator_facing_orchestration_brief_is_derived_only_non_authoritative_and_non_executing` plus diagnostic-surface assertions added to the existing scoped diagnostic test.

### Testing

- Ran focused tests with `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py -k "operator_facing_orchestration_brief or current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative"` and observed the targeted tests passed (`8 passed`, others deselected). 
- Ran the full orchestration intent test module with `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py` and observed success (`223 passed`). 
- All added tests verify the brief is derived-only, non-authoritative, non-executing, is present in the scoped diagnostic, and that admission/hand-off behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7d98886f88320b7fa397a5acb8a05)