### PR TITLE
[codex:orchestration] add current coherence brief resolver

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -399,6 +399,19 @@ _CURRENT_ORCHESTRATION_CLOSURE_POSTURES = {
     "informational",
 }
 
+_CURRENT_ORCHESTRATION_COHERENCE_CLASSIFICATIONS = {
+    "coherent_current_picture",
+    "strained_but_coherent",
+    "fragmentation_dominant",
+    "materially_contradictory",
+    "insufficient_current_signal",
+}
+
+_CURRENT_ORCHESTRATION_COHERENCE_POSTURES = {
+    "informational_only",
+    "conservative_caution",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4576,6 +4589,32 @@ def _current_orchestration_closure_brief_id(
     return f"ocb-{digest.hexdigest()[:16]}"
 
 
+def _current_orchestration_coherence_brief_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    re_evaluation_trigger_id: str,
+    orchestration_resumption_candidate_id: str,
+    coherence_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "re_evaluation_trigger_id": re_evaluation_trigger_id,
+                "orchestration_resumption_candidate_id": orchestration_resumption_candidate_id,
+                "coherence_classification": coherence_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ocoh-{digest.hexdigest()[:16]}"
+
+
 def resolve_current_orchestration_state(
     repo_root: Path,
     *,
@@ -8238,6 +8277,345 @@ def resolve_current_orchestration_closure_brief(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_closure_brief_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_coherence_brief(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint_brief: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_re_evaluation_basis_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    proposal_packet_continuity_review: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    current_operator_facing_orchestration_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resolution_path_brief: Mapping[str, Any] | None = None,
+    current_orchestration_closure_brief: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+    operator_resolution_influence: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, observational coherence brief for the current orchestration picture."""
+
+    _ = repo_root.resolve()
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    watchpoint_brief_map = (
+        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
+    )
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
+    basis_map = current_re_evaluation_basis_brief if isinstance(current_re_evaluation_basis_brief, Mapping) else {}
+    candidate_map = (
+        current_orchestration_resumption_candidate
+        if isinstance(current_orchestration_resumption_candidate, Mapping)
+        else {}
+    )
+    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    continuity_map = (
+        proposal_packet_continuity_review if isinstance(proposal_packet_continuity_review, Mapping) else {}
+    )
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_brief_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_facing_map = (
+        current_operator_facing_orchestration_brief
+        if isinstance(current_operator_facing_orchestration_brief, Mapping)
+        else {}
+    )
+    resolution_path_map = (
+        current_orchestration_resolution_path_brief
+        if isinstance(current_orchestration_resolution_path_brief, Mapping)
+        else {}
+    )
+    closure_brief_map = (
+        current_orchestration_closure_brief if isinstance(current_orchestration_closure_brief, Mapping) else {}
+    )
+    active_packet_map = active_packet_visibility if isinstance(active_packet_visibility, Mapping) else {}
+    influence_map = operator_resolution_influence if isinstance(operator_resolution_influence, Mapping) else {}
+    unified_map = unified_result if isinstance(unified_result, Mapping) else {}
+
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+    continuity_classification = str(continuity_map.get("review_classification") or "insufficient_history")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    resolution_path_classification = str(
+        resolution_path_map.get("resolution_path_classification") or "no_current_resolution_path"
+    )
+    closure_classification = str(closure_brief_map.get("closure_classification") or "no_current_closure_posture")
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "continuity_uncertain")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "watchpoint_pending")
+    recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
+    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    basis_classification = str(basis_map.get("basis_classification") or "no_current_re_evaluation_basis")
+    operator_facing_classification = str(
+        operator_facing_map.get("operator_facing_classification") or "operator_attention_not_currently_needed"
+    )
+    operator_facing_posture = str(operator_facing_map.get("loop_posture") or "informational")
+    state_class = str(state_map.get("current_supervisory_state") or "no_active_orchestration_item")
+    operator_influence_state = str(influence_map.get("operator_influence_state") or "no_operator_influence_yet")
+    unified_result_classification = str(unified_map.get("result_classification") or "pending_or_unresolved")
+    active_packet_available = bool(active_packet_map.get("active_packet_available"))
+
+    evidence_signals = [
+        pressure_classification != "insufficient_signal",
+        continuity_classification != "insufficient_history",
+        wake_classification != "not_wake_ready",
+        next_move_classification != "no_current_next_move",
+        resolution_path_classification != "no_current_resolution_path",
+        closure_classification != "no_current_closure_posture",
+        watchpoint_class != "no_watchpoint_needed",
+        wait_kind != "no_active_watchpoint",
+        satisfaction_status != "no_active_watchpoint",
+        recommendation != "no_re_evaluation_needed",
+        active_packet_available,
+        unified_result_classification != "pending_or_unresolved",
+    ]
+    sparse_signal = sum(1 for flag in evidence_signals if flag) <= 2
+
+    fragmentation_signals = (
+        pressure_classification in {"fragmentation_pressure"}
+        or wake_classification == "wake_blocked_by_fragmentation"
+        or continuity_classification in {"fragmented_continuity", "insufficient_history"}
+        or resolution_path_classification == "fragmented_path"
+        or closure_classification == "closure_blocked_by_fragmentation"
+        or wait_kind == "continuity_uncertain"
+        or satisfaction_status in {"watchpoint_fragmented", "watchpoint_stale"}
+        or handoff_brief_map.get("handoff_packet_brief_classification") == "packet_continuity_uncertain"
+    )
+
+    contradiction_signals = (
+        (
+            closure_classification == "closure_already_satisfied"
+            and (
+                state_class
+                in {
+                    "waiting_for_operator_resolution",
+                    "waiting_for_internal_result",
+                    "waiting_for_external_fulfillment",
+                }
+                or watchpoint_class in {
+                    "await_operator_resolution",
+                    "await_internal_execution_result",
+                    "await_external_fulfillment_receipt",
+                }
+                or next_move_classification != "no_current_next_move"
+            )
+        )
+        or (
+            wake_classification in {"wake_ready", "wake_ready_with_caution"}
+            and readiness_verdict in {"hold_for_operator_review", "not_ready"}
+            and next_move_classification == "continue_current_packet_next"
+        )
+        or (
+            recommendation == "hold_for_manual_review"
+            and next_move_classification in {
+                "continue_current_packet_next",
+                "rerun_delegated_judgment_next",
+                "rerun_packetization_gate_next",
+                "rerun_packet_synthesis_next",
+            }
+        )
+        or (
+            resolution_path_classification == "completed_or_no_active_path"
+            and closure_classification
+            in {
+                "closure_pending_on_operator_resolution",
+                "closure_pending_on_internal_result",
+                "closure_pending_on_external_fulfillment",
+                "closure_pending_on_packet_continuity",
+            }
+        )
+    )
+
+    aligned = (
+        not fragmentation_signals
+        and recommendation in {"clear_wait_and_continue_current_packet", "rerun_delegated_judgment", "no_re_evaluation_needed"}
+        and next_move_classification in {"continue_current_packet_next", "rerun_delegated_judgment_next", "no_current_next_move"}
+        and closure_classification in {"closure_materially_reachable", "closure_already_satisfied", "no_current_closure_posture"}
+        and resolution_path_classification
+        in {"proposal_centered_path", "packet_centered_path", "internal_result_path", "external_fulfillment_path", "completed_or_no_active_path", "no_current_resolution_path"}
+        and wake_classification in {"wake_ready", "wake_ready_with_caution", "wake_not_applicable"}
+    )
+
+    bounded_strain = (
+        pressure_classification in {"hold_pressure", "redirect_pressure", "repacketization_pressure", "mixed_pressure"}
+        or operator_facing_classification
+        in {"operator_should_review_hold", "operator_should_review_packet_refresh_context", "operator_should_review_redirect_or_constraint_path"}
+        or operator_facing_posture == "cautionary"
+        or recommendation == "hold_for_manual_review"
+        or next_move_classification in {"hold_for_operator_review_next", "rerun_packetization_gate_next", "rerun_packet_synthesis_next"}
+        or closure_classification
+        in {
+            "closure_pending_on_operator_resolution",
+            "closure_pending_on_internal_result",
+            "closure_pending_on_external_fulfillment",
+            "closure_pending_on_packet_continuity",
+        }
+    )
+
+    if sparse_signal:
+        classification = "insufficient_current_signal"
+        rationale = "current_surfaces_are_too_sparse_to_support_an_honest_coherence_judgment"
+    elif contradiction_signals:
+        classification = "materially_contradictory"
+        rationale = "neighboring_current_surfaces_materially_disagree_about_path_wake_or_closure_posture"
+    elif fragmentation_signals:
+        classification = "fragmentation_dominant"
+        rationale = "fragmentation_or_continuity_uncertainty_signals_materially_dominate_the_current_picture"
+    elif bounded_strain and aligned:
+        classification = "strained_but_coherent"
+        rationale = "pressure_or_hold_signals_are_present_but_current_path_and_closure_surfaces_remain_aligned"
+    elif aligned:
+        classification = "coherent_current_picture"
+        rationale = "current_continuity_pressure_wake_next_move_path_and_closure_surfaces_remain_cleanly_aligned"
+    elif bounded_strain:
+        classification = "strained_but_coherent"
+        rationale = "strain_signals_are_present_without_material_cross_surface_contradiction_or_fragmentation_dominance"
+    else:
+        classification = "insufficient_current_signal"
+        rationale = "current_surfaces_do_not_support_a_stronger_honest_coherence_classification"
+
+    if classification not in _CURRENT_ORCHESTRATION_COHERENCE_CLASSIFICATIONS:
+        classification = "insufficient_current_signal"
+
+    posture = (
+        "conservative_caution"
+        if classification
+        in {
+            "strained_but_coherent",
+            "fragmentation_dominant",
+            "materially_contradictory",
+            "insufficient_current_signal",
+        }
+        else "informational_only"
+    )
+    if posture not in _CURRENT_ORCHESTRATION_COHERENCE_POSTURES:
+        posture = "conservative_caution"
+
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
+    return {
+        "schema_version": "current_orchestration_coherence_brief.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_coherence_brief_id": _current_orchestration_coherence_brief_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            coherence_classification=classification,
+        ),
+        "coherence_classification": classification,
+        "coherence_posture": posture,
+        "informational_only": posture == "informational_only",
+        "conservatively_cautionary": posture == "conservative_caution",
+        "cross_surface_alignment": {
+            "continuity_pressure_wake_next_move_path_closure_aligned": aligned,
+            "strain_present_but_bounded": bounded_strain and not fragmentation_signals and not contradiction_signals,
+            "fragmentation_materially_prevents_clean_reading": bool(fragmentation_signals),
+            "neighboring_surfaces_materially_disagree": bool(contradiction_signals),
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "current_supervisory_state": state_class,
+                "watchpoint_class": watchpoint_class,
+                "watchpoint_wait_kind": wait_kind,
+                "watchpoint_satisfaction_status": satisfaction_status,
+                "re_evaluation_recommendation": recommendation,
+                "re_evaluation_basis_classification": basis_classification,
+                "resumed_operation_readiness_verdict": readiness_verdict,
+                "wake_readiness_classification": wake_classification,
+                "pressure_classification": pressure_classification,
+                "proposal_packet_continuity_classification": continuity_classification,
+                "current_next_move_classification": next_move_classification,
+                "current_handoff_packet_brief_classification": str(
+                    handoff_brief_map.get("handoff_packet_brief_classification") or "no_current_packet_brief"
+                ),
+                "current_operator_facing_classification": operator_facing_classification,
+                "current_resolution_path_classification": resolution_path_classification,
+                "current_closure_classification": closure_classification,
+                "active_packet_available": active_packet_available,
+                "operator_influence_state": operator_influence_state,
+                "unified_result_classification": unified_result_classification,
+            },
+            "materially_supporting_surfaces": [
+                "resolve_current_orchestration_state",
+                "resolve_current_orchestration_watchpoint",
+                "resolve_current_orchestration_watchpoint_brief",
+                "resolve_watchpoint_satisfaction",
+                "resolve_re_evaluation_trigger_recommendation",
+                "resolve_current_re_evaluation_basis_brief",
+                "resolve_current_orchestration_resumption_candidate",
+                "resolve_current_resumed_operation_readiness_verdict",
+                "resolve_current_orchestration_wake_readiness_detector",
+                "resolve_current_orchestration_pressure_signal",
+                "derive_proposal_packet_continuity_review",
+                "resolve_current_orchestration_next_move_brief",
+                "resolve_current_orchestration_handoff_packet_brief",
+                "resolve_current_operator_facing_orchestration_brief",
+                "resolve_current_orchestration_resolution_path_brief",
+                "resolve_current_orchestration_closure_brief",
+                "active handoff packet visibility",
+                "operator-resolution visibility",
+                "unified result visibility",
+            ],
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_flatten_material_disagreement_into_fake_coherence": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_orchestration_coherence_brief_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -346,6 +346,32 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not imply permission to execute",
             ],
         },
+        "current_orchestration_coherence_brief": {
+            "what_it_is": "a compact observational-only resolver that classifies whether the current orchestration picture is coherent, strained-but-coherent, fragmentation-dominant, materially contradictory, or too weakly grounded",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_coherence_brief",
+            "classifications": [
+                "coherent_current_picture",
+                "strained_but_coherent",
+                "fragmentation_dominant",
+                "materially_contradictory",
+                "insufficient_current_signal",
+            ],
+            "derived_from_existing_surfaces_only": [
+                "current orchestration state/watchpoint/watchpoint brief/satisfaction",
+                "re-evaluation trigger + current re-evaluation basis brief",
+                "current resumption candidate + resumed readiness",
+                "current wake-readiness detector + pressure signal",
+                "proposal-packet continuity review",
+                "current orchestration next-move brief + handoff packet brief + operator-facing brief + resolution-path brief + closure brief",
+                "active handoff packet visibility + operator-resolution visibility + unified result visibility",
+            ],
+            "strict_boundaries": [
+                "non-sovereign, non-authoritative, non-executing",
+                "informational/coherence posture only; not a scheduler/planner/decision engine",
+                "does not create a new truth source, mutable store, or orchestration layer",
+                "does not imply permission to execute",
+            ],
+        },
         "unified_orchestration_result": {
             "what_it_is": "a bounded venue-aware resolver surface that normalizes internal execution closure and external fulfillment closure into one typed result shape",
             "machine_surface": "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -37,6 +37,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_resolution_path_brief,
     resolve_current_orchestration_closure_brief,
+    resolve_current_orchestration_coherence_brief,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
     derive_next_venue_recommendation,
@@ -517,6 +518,28 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         external_fulfillment_receipt_visibility=resolve_handoff_packet_fulfillment_lifecycle(root, effective_handoff_packet),
         unified_result=unified_result,
     )
+    current_orchestration_coherence_brief = resolve_current_orchestration_coherence_brief(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
+        watchpoint_satisfaction=current_watchpoint_satisfaction,
+        re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_re_evaluation_basis_brief=current_re_evaluation_basis_brief,
+        current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        proposal_packet_continuity_review=proposal_packet_continuity_review,
+        current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+        current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+        current_operator_facing_orchestration_brief=current_operator_facing_orchestration_brief,
+        current_orchestration_resolution_path_brief=current_orchestration_resolution_path_brief,
+        current_orchestration_closure_brief=current_orchestration_closure_brief,
+        active_packet_visibility=active_packet,
+        operator_resolution_influence=operator_influence,
+        unified_result=unified_result,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -636,6 +659,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_operator_facing_orchestration_brief": current_operator_facing_orchestration_brief,
             "current_orchestration_resolution_path_brief": current_orchestration_resolution_path_brief,
             "current_orchestration_closure_brief": current_orchestration_closure_brief,
+            "current_orchestration_coherence_brief": current_orchestration_coherence_brief,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -708,6 +732,13 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_closure_chain_reachable": current_orchestration_closure_brief.get(
                     "wake_resumption_next_move_chain_points_to_reachable_closure"
                 ),
+                "current_coherence_classification": current_orchestration_coherence_brief.get(
+                    "coherence_classification"
+                ),
+                "current_coherence_posture": current_orchestration_coherence_brief.get("coherence_posture"),
+                "current_coherence_cross_surface_aligned": (
+                    current_orchestration_coherence_brief.get("cross_surface_alignment") or {}
+                ).get("continuity_pressure_wake_next_move_path_closure_aligned"),
                 "ready_for_re_evaluation": (current_watchpoint_satisfaction.get("wake_readiness_summary") or {}).get(
                     "ready_for_re_evaluation"
                 ),
@@ -733,6 +764,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "current_operator_facing_orchestration_brief_only": True,
                     "current_orchestration_resolution_path_brief_only": True,
                     "current_orchestration_closure_brief_only": True,
+                    "current_orchestration_coherence_brief_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -53,6 +53,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_handoff_packet_brief,
     resolve_current_orchestration_resolution_path_brief,
     resolve_current_orchestration_closure_brief,
+    resolve_current_orchestration_coherence_brief,
     resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_resumption_candidate,
     resolve_current_orchestration_watchpoint_brief,
@@ -6016,6 +6017,207 @@ def test_current_orchestration_closure_brief_is_derived_only_non_authoritative_a
     assert before["handoff_outcome"] == after["handoff_outcome"]
 
 
+@pytest.mark.parametrize(
+    (
+        "pressure_classification",
+        "continuity_classification",
+        "wake_classification",
+        "next_move_classification",
+        "resolution_path_classification",
+        "closure_classification",
+        "recommendation",
+        "readiness_verdict",
+        "state_class",
+        "watchpoint_class",
+        "wait_kind",
+        "satisfaction_status",
+        "expected",
+    ),
+    [
+        (
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "wake_ready",
+            "continue_current_packet_next",
+            "packet_centered_path",
+            "closure_materially_reachable",
+            "clear_wait_and_continue_current_packet",
+            "ready_to_proceed",
+            "packet_ready_for_internal_trigger",
+            "await_internal_execution_result",
+            "awaiting_internal_result_closure",
+            "watchpoint_pending",
+            "coherent_current_picture",
+        ),
+        (
+            "hold_pressure",
+            "hold_heavy_continuity",
+            "wake_ready_with_caution",
+            "hold_for_operator_review_next",
+            "operator_resolution_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "proceed_with_caution",
+            "waiting_for_operator_resolution",
+            "await_operator_resolution",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "strained_but_coherent",
+        ),
+        (
+            "fragmentation_pressure",
+            "fragmented_continuity",
+            "wake_blocked_by_fragmentation",
+            "rerun_packet_synthesis_next",
+            "fragmented_path",
+            "closure_blocked_by_fragmentation",
+            "rerun_packet_synthesis",
+            "not_ready",
+            "held_due_to_fragmentation",
+            "await_packetization_relief",
+            "continuity_uncertain",
+            "watchpoint_fragmented",
+            "fragmentation_dominant",
+        ),
+        (
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "wake_ready",
+            "continue_current_packet_next",
+            "completed_or_no_active_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "hold_for_operator_review",
+            "waiting_for_operator_resolution",
+            "await_operator_resolution",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "materially_contradictory",
+        ),
+        (
+            "insufficient_signal",
+            "insufficient_history",
+            "not_wake_ready",
+            "no_current_next_move",
+            "no_current_resolution_path",
+            "no_current_closure_posture",
+            "no_re_evaluation_needed",
+            "not_ready",
+            "no_active_orchestration_item",
+            "no_watchpoint_needed",
+            "no_active_watchpoint",
+            "no_active_watchpoint",
+            "insufficient_current_signal",
+        ),
+    ],
+)
+def test_current_orchestration_coherence_brief_classification_cases(
+    tmp_path: Path,
+    pressure_classification: str,
+    continuity_classification: str,
+    wake_classification: str,
+    next_move_classification: str,
+    resolution_path_classification: str,
+    closure_classification: str,
+    recommendation: str,
+    readiness_verdict: str,
+    state_class: str,
+    watchpoint_class: str,
+    wait_kind: str,
+    satisfaction_status: str,
+    expected: str,
+) -> None:
+    brief = resolve_current_orchestration_coherence_brief(
+        tmp_path,
+        current_orchestration_state={
+            "current_orchestration_state_id": "cos-coherence",
+            "current_supervisory_state": state_class,
+        },
+        current_orchestration_watchpoint={
+            "orchestration_watchpoint_id": "cow-coherence",
+            "watchpoint_class": watchpoint_class,
+        },
+        current_orchestration_watchpoint_brief={"wait_kind": wait_kind},
+        watchpoint_satisfaction={
+            "watchpoint_satisfaction_id": "cws-coherence",
+            "satisfaction_status": satisfaction_status,
+        },
+        re_evaluation_trigger_recommendation={
+            "re_evaluation_trigger_id": "ret-coherence",
+            "recommendation": recommendation,
+        },
+        current_re_evaluation_basis_brief={"basis_classification": "satisfaction_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={
+            "orchestration_resumption_candidate_id": "crc-coherence",
+            "resume_ready": expected in {"coherent_current_picture", "strained_but_coherent"},
+        },
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": readiness_verdict},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        proposal_packet_continuity_review={"review_classification": continuity_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={
+            "handoff_packet_brief_classification": (
+                "packet_continuity_uncertain" if expected == "fragmentation_dominant" else "continuing_active_packet"
+            )
+        },
+        current_operator_facing_orchestration_brief={
+            "operator_facing_classification": (
+                "operator_should_review_hold" if expected == "strained_but_coherent" else "operator_attention_not_currently_needed"
+            ),
+            "loop_posture": "cautionary" if expected == "strained_but_coherent" else "informational",
+        },
+        current_orchestration_resolution_path_brief={
+            "resolution_path_classification": resolution_path_classification
+        },
+        current_orchestration_closure_brief={"closure_classification": closure_classification},
+        active_packet_visibility={"active_packet_available": expected in {"coherent_current_picture", "strained_but_coherent"}},
+        operator_resolution_influence={"operator_influence_state": "no_operator_influence_yet"},
+        unified_result={"result_classification": "pending_or_unresolved"},
+    )
+    assert brief["coherence_classification"] == expected
+
+
+def test_current_orchestration_coherence_brief_is_derived_only_non_authoritative_and_non_executing(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    brief = resolve_current_orchestration_coherence_brief(
+        tmp_path,
+        current_orchestration_state={
+            "current_orchestration_state_id": "cos-coherence-boundary",
+            "current_supervisory_state": "waiting_for_operator_resolution",
+        },
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-coherence-boundary", "watchpoint_class": "await_operator_resolution"},
+        current_orchestration_watchpoint_brief={"wait_kind": "awaiting_operator_resolution"},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-coherence-boundary", "satisfaction_status": "watchpoint_pending"},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-coherence-boundary", "recommendation": "hold_for_manual_review"},
+        current_re_evaluation_basis_brief={"basis_classification": "operator_resolution_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-coherence-boundary", "resume_ready": False},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": "hold_for_operator_review"},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": "wake_blocked_pending_operator"},
+        current_orchestration_pressure_signal={"pressure_classification": "hold_pressure"},
+        proposal_packet_continuity_review={"review_classification": "hold_heavy_continuity"},
+        current_orchestration_next_move_brief={"next_move_classification": "hold_for_operator_review_next"},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": "packetization_gate_pending"},
+        current_operator_facing_orchestration_brief={"operator_facing_classification": "operator_should_review_hold", "loop_posture": "cautionary"},
+        current_orchestration_resolution_path_brief={"resolution_path_classification": "operator_resolution_path"},
+        current_orchestration_closure_brief={"closure_classification": "closure_pending_on_operator_resolution"},
+        active_packet_visibility={"active_packet_available": False},
+        operator_resolution_influence={"operator_influence_state": "no_operator_influence_yet"},
+        unified_result={"result_classification": "pending_or_unresolved"},
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert brief["basis"]["historical_honesty"]["derived_from_existing_surfaces_only"] is True
+    assert brief["current_orchestration_coherence_brief_only"] is True
+    assert brief["boundaries"]["non_authoritative"] is True
+    assert brief["boundaries"]["non_executing"] is True
+    assert brief["does_not_execute_or_route_work"] is True
+    assert brief["decision_power"] == "none"
+    assert before["handoff_outcome"] == after["handoff_outcome"]
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -6063,6 +6265,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     current_operator_facing = diagnostic["orchestration_handoff"]["current_operator_facing_orchestration_brief"]
     current_resolution_path_brief = diagnostic["orchestration_handoff"]["current_orchestration_resolution_path_brief"]
     current_closure_brief = diagnostic["orchestration_handoff"]["current_orchestration_closure_brief"]
+    current_coherence_brief = diagnostic["orchestration_handoff"]["current_orchestration_coherence_brief"]
     current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
@@ -6245,6 +6448,17 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_closure_brief["closure_posture"] in {"blocked", "cautionary", "informational"}
     assert current_closure_brief["boundaries"]["non_authoritative"] is True
     assert current_closure_brief["does_not_execute_or_route_work"] is True
+    assert current_coherence_brief["schema_version"] == "current_orchestration_coherence_brief.v1"
+    assert current_coherence_brief["coherence_classification"] in {
+        "coherent_current_picture",
+        "strained_but_coherent",
+        "fragmentation_dominant",
+        "materially_contradictory",
+        "insufficient_current_signal",
+    }
+    assert current_coherence_brief["coherence_posture"] in {"informational_only", "conservative_caution"}
+    assert current_coherence_brief["boundaries"]["non_authoritative"] is True
+    assert current_coherence_brief["does_not_execute_or_route_work"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
     assert current_watchpoint_summary["re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
@@ -6319,6 +6533,17 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
         current_watchpoint_summary["current_closure_chain_reachable"]
         == current_closure_brief["wake_resumption_next_move_chain_points_to_reachable_closure"]
     )
+    assert (
+        current_watchpoint_summary["current_coherence_classification"]
+        == current_coherence_brief["coherence_classification"]
+    )
+    assert current_watchpoint_summary["current_coherence_posture"] == current_coherence_brief["coherence_posture"]
+    assert (
+        current_watchpoint_summary["current_coherence_cross_surface_aligned"]
+        == (current_coherence_brief["cross_surface_alignment"] or {}).get(
+            "continuity_pressure_wake_next_move_path_closure_aligned"
+        )
+    )
     assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["wake_readiness_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["re_entry_recommendation_only"] is True
@@ -6333,6 +6558,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_operator_facing_orchestration_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_resolution_path_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_closure_brief_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_coherence_brief_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True


### PR DESCRIPTION
### Motivation
- Provide a narrow, observational summary that classifies whether the current orchestration picture is coherent, strained-but-coherent, fragmented, contradictory, or under-signaled using only existing orchestration surfaces.
- Keep the surface explicitly non-sovereign, non-executing, and strictly derived from continuity/pressure/wake/next-move/closure signals so it can be consumed by diagnostics without changing behavior.

### Description
- Added a derived coherence resolver `resolve_current_orchestration_coherence_brief` with id helper `_current_orchestration_coherence_brief_id` in `sentientos/orchestration_intent_fabric.py` and compact classification vocabulary (`coherent_current_picture`, `strained_but_coherent`, `fragmentation_dominant`, `materially_contradictory`, `insufficient_current_signal`).
- Surfaced the coherence brief in `sentientos/scoped_lifecycle_diagnostic.py` under `orchestration_handoff.current_orchestration_coherence_brief` and projected compact summary fields into `current_orchestration_watchpoint_summary` while preserving non-sovereign boundaries.
- Added a short explanatory entry to `sentientos/orchestration_intent_fabric_note.py` describing the new `current_orchestration_coherence_brief`, its derivation surfaces, classifications, and strict non-authoritative boundaries.
- Extended `sentientos/tests/test_orchestration_intent_fabric.py` with focused tests: `test_current_orchestration_coherence_brief_classification_cases`, `test_current_orchestration_coherence_brief_is_derived_only_non_authoritative_and_non_executing`, and added assertions to the consumer surfacing test to ensure the diagnostic includes the coherence brief and that authority/behavior remains unchanged.
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric_note.py`, `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Ran the focused test selection with `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "coherence_brief or current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative"` and all tests passed (`.......  [100%]`).
- Test coverage includes classification cases for `coherent_current_picture`, `strained_but_coherent`, `fragmentation_dominant`, `materially_contradictory`, and `insufficient_current_signal`, plus non-authoritative/non-executing boundary checks and consumer surfacing assertions, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e824b430d08320b9bd58866559ed91)