### PR TITLE
[codex:orchestration] add bounded current orchestration digest surface

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -412,6 +412,27 @@ _CURRENT_ORCHESTRATION_COHERENCE_POSTURES = {
     "conservative_caution",
 }
 
+_CURRENT_ORCHESTRATION_DIGEST_CLASSIFICATIONS = {
+    "mature_current_picture",
+    "cautionary_current_picture",
+    "fragmented_current_picture",
+    "contradictory_current_picture",
+    "minimal_current_picture",
+}
+
+_CURRENT_ORCHESTRATION_DIGEST_ALIGNMENT = {
+    "aligned",
+    "cautionary",
+    "fragmented",
+    "contradictory",
+}
+
+_CURRENT_ORCHESTRATION_DIGEST_RESUMED_MOTION = {
+    "plausible",
+    "blocked",
+    "not_applicable",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4615,6 +4636,32 @@ def _current_orchestration_coherence_brief_id(
     return f"ocoh-{digest.hexdigest()[:16]}"
 
 
+def _current_orchestration_digest_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    re_evaluation_trigger_id: str,
+    orchestration_resumption_candidate_id: str,
+    digest_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "re_evaluation_trigger_id": re_evaluation_trigger_id,
+                "orchestration_resumption_candidate_id": orchestration_resumption_candidate_id,
+                "digest_classification": digest_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ocd-{digest.hexdigest()[:16]}"
+
+
 def resolve_current_orchestration_state(
     repo_root: Path,
     *,
@@ -8616,6 +8663,319 @@ def resolve_current_orchestration_coherence_brief(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_coherence_brief_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_digest(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint_brief: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_re_evaluation_basis_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    proposal_packet_continuity_review: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    current_operator_facing_orchestration_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resolution_path_brief: Mapping[str, Any] | None = None,
+    current_orchestration_closure_brief: Mapping[str, Any] | None = None,
+    current_orchestration_coherence_brief: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, observational digest for the current orchestration picture."""
+
+    _ = repo_root.resolve()
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    watchpoint_brief_map = (
+        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
+    )
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
+    basis_map = current_re_evaluation_basis_brief if isinstance(current_re_evaluation_basis_brief, Mapping) else {}
+    candidate_map = (
+        current_orchestration_resumption_candidate
+        if isinstance(current_orchestration_resumption_candidate, Mapping)
+        else {}
+    )
+    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    continuity_map = (
+        proposal_packet_continuity_review if isinstance(proposal_packet_continuity_review, Mapping) else {}
+    )
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_brief_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_map = (
+        current_operator_facing_orchestration_brief
+        if isinstance(current_operator_facing_orchestration_brief, Mapping)
+        else {}
+    )
+    path_map = (
+        current_orchestration_resolution_path_brief
+        if isinstance(current_orchestration_resolution_path_brief, Mapping)
+        else {}
+    )
+    closure_map = (
+        current_orchestration_closure_brief if isinstance(current_orchestration_closure_brief, Mapping) else {}
+    )
+    coherence_map = (
+        current_orchestration_coherence_brief if isinstance(current_orchestration_coherence_brief, Mapping) else {}
+    )
+
+    state_class = str(state_map.get("current_supervisory_state") or "no_active_orchestration_item")
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "no_active_watchpoint")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "no_active_watchpoint")
+    recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
+    basis_classification = str(basis_map.get("basis_classification") or "no_current_re_evaluation_basis")
+    resume_mode = str(candidate_map.get("bounded_resume_mode") or "no_re_evaluation_needed")
+    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    continuity_classification = str(continuity_map.get("review_classification") or "insufficient_history")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    handoff_classification = str(
+        handoff_brief_map.get("handoff_packet_brief_classification") or "no_current_packet_brief"
+    )
+    operator_classification = str(
+        operator_map.get("operator_facing_classification") or "operator_attention_not_currently_needed"
+    )
+    operator_loop_posture = str(operator_map.get("loop_posture") or "informational")
+    path_classification = str(path_map.get("resolution_path_classification") or "no_current_resolution_path")
+    closure_classification = str(closure_map.get("closure_classification") or "no_current_closure_posture")
+    coherence_classification = str(coherence_map.get("coherence_classification") or "insufficient_current_signal")
+
+    evidence_count = sum(
+        1
+        for present in (
+            state_class != "no_active_orchestration_item",
+            watchpoint_class != "no_watchpoint_needed",
+            satisfaction_status != "no_active_watchpoint",
+            recommendation != "no_re_evaluation_needed",
+            wake_classification != "not_wake_ready",
+            pressure_classification != "insufficient_signal",
+            continuity_classification != "insufficient_history",
+            next_move_classification != "no_current_next_move",
+            path_classification != "no_current_resolution_path",
+            closure_classification != "no_current_closure_posture",
+            coherence_classification != "insufficient_current_signal",
+        )
+        if present
+    )
+
+    contradictory = (
+        coherence_classification == "materially_contradictory"
+        or (
+            path_classification == "completed_or_no_active_path"
+            and closure_classification
+            in {
+                "closure_pending_on_operator_resolution",
+                "closure_pending_on_internal_result",
+                "closure_pending_on_external_fulfillment",
+                "closure_pending_on_packet_continuity",
+            }
+        )
+        or (
+            closure_classification == "closure_already_satisfied"
+            and next_move_classification != "no_current_next_move"
+        )
+    )
+    fragmented = (
+        coherence_classification == "fragmentation_dominant"
+        or pressure_classification == "fragmentation_pressure"
+        or continuity_classification in {"fragmented_continuity", "insufficient_history"}
+        or path_classification == "fragmented_path"
+        or closure_classification == "closure_blocked_by_fragmentation"
+        or satisfaction_status in {"watchpoint_fragmented", "watchpoint_stale"}
+        or wait_kind == "continuity_uncertain"
+        or handoff_classification == "packet_continuity_uncertain"
+    )
+    cautionary = (
+        recommendation == "hold_for_manual_review"
+        or readiness_verdict in {"hold_for_operator_review", "not_ready"}
+        or wake_classification in {"wake_ready_with_caution", "wake_blocked_pending_operator"}
+        or pressure_classification in {"hold_pressure", "redirect_pressure", "repacketization_pressure", "mixed_pressure"}
+        or operator_loop_posture == "cautionary"
+        or next_move_classification in {"hold_for_operator_review_next", "rerun_packetization_gate_next", "rerun_packet_synthesis_next"}
+        or closure_classification
+        in {
+            "closure_pending_on_operator_resolution",
+            "closure_pending_on_internal_result",
+            "closure_pending_on_external_fulfillment",
+            "closure_pending_on_packet_continuity",
+        }
+        or coherence_classification == "strained_but_coherent"
+    )
+    aligned = (
+        coherence_classification == "coherent_current_picture"
+        and not cautionary
+        and not fragmented
+        and not contradictory
+        and recommendation in {"clear_wait_and_continue_current_packet", "rerun_delegated_judgment", "no_re_evaluation_needed"}
+        and next_move_classification in {"continue_current_packet_next", "rerun_delegated_judgment_next", "no_current_next_move"}
+    )
+
+    if contradictory:
+        classification = "contradictory_current_picture"
+        picture_posture = "contradictory"
+        rationale = "neighboring_current_surfaces_materially_disagree_and_should_not_be_flattened"
+    elif fragmented:
+        classification = "fragmented_current_picture"
+        picture_posture = "fragmented"
+        rationale = "fragmentation_or_continuity_uncertainty_materially_dominates_the_current_picture"
+    elif evidence_count <= 3:
+        classification = "minimal_current_picture"
+        picture_posture = "cautionary"
+        rationale = "current_evidence_is_sparse_so_only_a_minimal_honest_picture_is_supported"
+    elif aligned and evidence_count >= 8:
+        classification = "mature_current_picture"
+        picture_posture = "aligned"
+        rationale = "neighboring_current_surfaces_are_rich_and_cleanly_aligned"
+    else:
+        classification = "cautionary_current_picture"
+        picture_posture = "cautionary"
+        rationale = "current_picture_is_mostly_aligned_but_material_caution_signals_remain"
+
+    if classification not in _CURRENT_ORCHESTRATION_DIGEST_CLASSIFICATIONS:
+        classification = "minimal_current_picture"
+    if picture_posture not in _CURRENT_ORCHESTRATION_DIGEST_ALIGNMENT:
+        picture_posture = "cautionary"
+
+    resumed_bounded_motion = "not_applicable"
+    if wake_classification in {"wake_not_applicable"} and recommendation == "no_re_evaluation_needed":
+        resumed_bounded_motion = "not_applicable"
+    elif (
+        wake_classification in {"wake_ready", "wake_ready_with_caution"}
+        and readiness_verdict in {"ready_to_proceed", "proceed_with_caution"}
+        and recommendation in {"clear_wait_and_continue_current_packet", "rerun_delegated_judgment"}
+    ):
+        resumed_bounded_motion = "plausible"
+    else:
+        resumed_bounded_motion = "blocked"
+    if resumed_bounded_motion not in _CURRENT_ORCHESTRATION_DIGEST_RESUMED_MOTION:
+        resumed_bounded_motion = "blocked"
+
+    digest_posture = (
+        "informational_only" if classification == "mature_current_picture" else "conservative_caution"
+    )
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
+    return {
+        "schema_version": "current_orchestration_digest.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_digest_id": _current_orchestration_digest_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            digest_classification=classification,
+        ),
+        "digest_classification": classification,
+        "overall_picture_posture": picture_posture,
+        "resumed_bounded_motion": resumed_bounded_motion,
+        "digest_posture": digest_posture,
+        "informational_only": digest_posture == "informational_only",
+        "conservatively_cautionary": digest_posture == "conservative_caution",
+        "bounded_summary": {
+            "current_path": path_classification,
+            "current_next_move": next_move_classification,
+            "current_closure_posture": closure_classification,
+            "current_coherence_posture": coherence_classification,
+            "current_operator_facing_posture": operator_classification,
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "current_supervisory_state": state_class,
+                "watchpoint_class": watchpoint_class,
+                "watchpoint_wait_kind": wait_kind,
+                "watchpoint_satisfaction_status": satisfaction_status,
+                "re_evaluation_recommendation": recommendation,
+                "re_evaluation_basis_classification": basis_classification,
+                "resumption_mode": resume_mode,
+                "resumed_operation_readiness_verdict": readiness_verdict,
+                "wake_readiness_classification": wake_classification,
+                "pressure_classification": pressure_classification,
+                "proposal_packet_continuity_classification": continuity_classification,
+                "current_next_move_classification": next_move_classification,
+                "current_handoff_packet_brief_classification": handoff_classification,
+                "current_operator_facing_classification": operator_classification,
+                "current_resolution_path_classification": path_classification,
+                "current_closure_classification": closure_classification,
+                "current_coherence_classification": coherence_classification,
+                "evidence_count": evidence_count,
+            },
+            "surface_linkage": {
+                "current_orchestration_state_surface": "resolve_current_orchestration_state",
+                "current_orchestration_watchpoint_surface": "resolve_current_orchestration_watchpoint",
+                "current_orchestration_watchpoint_brief_surface": "resolve_current_orchestration_watchpoint_brief",
+                "watchpoint_satisfaction_surface": "resolve_watchpoint_satisfaction",
+                "re_evaluation_trigger_surface": "resolve_re_evaluation_trigger_recommendation",
+                "current_re_evaluation_basis_brief_surface": "resolve_current_re_evaluation_basis_brief",
+                "current_orchestration_resumption_candidate_surface": "resolve_current_orchestration_resumption_candidate",
+                "current_resumed_operation_readiness_surface": "resolve_current_resumed_operation_readiness_verdict",
+                "current_orchestration_wake_readiness_detector_surface": "resolve_current_orchestration_wake_readiness_detector",
+                "current_orchestration_pressure_signal_surface": "resolve_current_orchestration_pressure_signal",
+                "proposal_packet_continuity_review_surface": "derive_proposal_packet_continuity_review",
+                "current_orchestration_next_move_brief_surface": "resolve_current_orchestration_next_move_brief",
+                "current_orchestration_handoff_packet_brief_surface": "resolve_current_orchestration_handoff_packet_brief",
+                "current_operator_facing_orchestration_brief_surface": "resolve_current_operator_facing_orchestration_brief",
+                "current_orchestration_resolution_path_brief_surface": "resolve_current_orchestration_resolution_path_brief",
+                "current_orchestration_closure_brief_surface": "resolve_current_orchestration_closure_brief",
+                "current_orchestration_coherence_brief_surface": "resolve_current_orchestration_coherence_brief",
+            },
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_flatten_material_ambiguity_into_fake_clarity": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_orchestration_digest_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -372,6 +372,31 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not imply permission to execute",
             ],
         },
+        "current_orchestration_digest": {
+            "what_it_is": "a bounded observational-only compression surface that summarizes the mature current orchestration picture for compact operator-facing and downstream bounded consumers",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_digest",
+            "classifications": [
+                "mature_current_picture",
+                "cautionary_current_picture",
+                "fragmented_current_picture",
+                "contradictory_current_picture",
+                "minimal_current_picture",
+            ],
+            "derived_from_existing_surfaces_only": [
+                "current orchestration state/watchpoint/watchpoint brief/satisfaction",
+                "re-evaluation trigger + current re-evaluation basis brief",
+                "current resumption candidate + resumed readiness",
+                "current wake-readiness detector + pressure signal",
+                "proposal-packet continuity review",
+                "current orchestration next-move brief + handoff packet brief + operator-facing brief + resolution-path brief + closure brief + coherence brief",
+            ],
+            "strict_boundaries": [
+                "non-sovereign, non-authoritative, non-executing",
+                "digest compression only; not a scheduler/planner/decision engine/execution venue",
+                "does not create a new truth source or mutable orchestration store",
+                "does not imply permission to execute",
+            ],
+        },
         "unified_orchestration_result": {
             "what_it_is": "a bounded venue-aware resolver surface that normalizes internal execution closure and external fulfillment closure into one typed result shape",
             "machine_surface": "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -38,6 +38,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_resolution_path_brief,
     resolve_current_orchestration_closure_brief,
     resolve_current_orchestration_coherence_brief,
+    resolve_current_orchestration_digest,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
     derive_next_venue_recommendation,
@@ -540,6 +541,26 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         operator_resolution_influence=operator_influence,
         unified_result=unified_result,
     )
+    current_orchestration_digest = resolve_current_orchestration_digest(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
+        watchpoint_satisfaction=current_watchpoint_satisfaction,
+        re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_re_evaluation_basis_brief=current_re_evaluation_basis_brief,
+        current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        proposal_packet_continuity_review=proposal_packet_continuity_review,
+        current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+        current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+        current_operator_facing_orchestration_brief=current_operator_facing_orchestration_brief,
+        current_orchestration_resolution_path_brief=current_orchestration_resolution_path_brief,
+        current_orchestration_closure_brief=current_orchestration_closure_brief,
+        current_orchestration_coherence_brief=current_orchestration_coherence_brief,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -660,6 +681,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_resolution_path_brief": current_orchestration_resolution_path_brief,
             "current_orchestration_closure_brief": current_orchestration_closure_brief,
             "current_orchestration_coherence_brief": current_orchestration_coherence_brief,
+            "current_orchestration_digest": current_orchestration_digest,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -739,6 +761,10 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_coherence_cross_surface_aligned": (
                     current_orchestration_coherence_brief.get("cross_surface_alignment") or {}
                 ).get("continuity_pressure_wake_next_move_path_closure_aligned"),
+                "current_digest_classification": current_orchestration_digest.get("digest_classification"),
+                "current_digest_overall_picture_posture": current_orchestration_digest.get("overall_picture_posture"),
+                "current_digest_resumed_bounded_motion": current_orchestration_digest.get("resumed_bounded_motion"),
+                "current_digest_posture": current_orchestration_digest.get("digest_posture"),
                 "ready_for_re_evaluation": (current_watchpoint_satisfaction.get("wake_readiness_summary") or {}).get(
                     "ready_for_re_evaluation"
                 ),
@@ -765,6 +791,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "current_orchestration_resolution_path_brief_only": True,
                     "current_orchestration_closure_brief_only": True,
                     "current_orchestration_coherence_brief_only": True,
+                    "current_orchestration_digest_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -54,6 +54,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_resolution_path_brief,
     resolve_current_orchestration_closure_brief,
     resolve_current_orchestration_coherence_brief,
+    resolve_current_orchestration_digest,
     resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_resumption_candidate,
     resolve_current_orchestration_watchpoint_brief,
@@ -6218,6 +6219,188 @@ def test_current_orchestration_coherence_brief_is_derived_only_non_authoritative
     assert before["handoff_outcome"] == after["handoff_outcome"]
 
 
+@pytest.mark.parametrize(
+    (
+        "coherence_classification",
+        "pressure_classification",
+        "continuity_classification",
+        "next_move_classification",
+        "path_classification",
+        "closure_classification",
+        "recommendation",
+        "readiness_verdict",
+        "wake_classification",
+        "state_class",
+        "watchpoint_class",
+        "wait_kind",
+        "satisfaction_status",
+        "expected",
+    ),
+    [
+        (
+            "coherent_current_picture",
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "continue_current_packet_next",
+            "packet_centered_path",
+            "closure_materially_reachable",
+            "clear_wait_and_continue_current_packet",
+            "ready_to_proceed",
+            "wake_ready",
+            "waiting_for_internal_result",
+            "await_internal_execution_result",
+            "awaiting_internal_result_closure",
+            "watchpoint_satisfied",
+            "mature_current_picture",
+        ),
+        (
+            "strained_but_coherent",
+            "hold_pressure",
+            "hold_heavy_continuity",
+            "hold_for_operator_review_next",
+            "operator_resolution_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "hold_for_operator_review",
+            "wake_blocked_pending_operator",
+            "waiting_for_operator_resolution",
+            "await_operator_resolution",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "cautionary_current_picture",
+        ),
+        (
+            "fragmentation_dominant",
+            "fragmentation_pressure",
+            "fragmented_continuity",
+            "rerun_packet_synthesis_next",
+            "fragmented_path",
+            "closure_blocked_by_fragmentation",
+            "rerun_packet_synthesis",
+            "not_ready",
+            "wake_blocked_by_fragmentation",
+            "held_due_to_fragmentation",
+            "await_packetization_relief",
+            "continuity_uncertain",
+            "watchpoint_fragmented",
+            "fragmented_current_picture",
+        ),
+        (
+            "materially_contradictory",
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "continue_current_packet_next",
+            "completed_or_no_active_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "hold_for_operator_review",
+            "wake_ready",
+            "waiting_for_operator_resolution",
+            "await_operator_resolution",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "contradictory_current_picture",
+        ),
+        (
+            "insufficient_current_signal",
+            "insufficient_signal",
+            "coherent_proposal_packet_continuity",
+            "no_current_next_move",
+            "no_current_resolution_path",
+            "no_current_closure_posture",
+            "no_re_evaluation_needed",
+            "not_ready",
+            "not_wake_ready",
+            "no_active_orchestration_item",
+            "no_watchpoint_needed",
+            "no_active_watchpoint",
+            "no_active_watchpoint",
+            "minimal_current_picture",
+        ),
+    ],
+)
+def test_current_orchestration_digest_classification_cases(
+    tmp_path: Path,
+    coherence_classification: str,
+    pressure_classification: str,
+    continuity_classification: str,
+    next_move_classification: str,
+    path_classification: str,
+    closure_classification: str,
+    recommendation: str,
+    readiness_verdict: str,
+    wake_classification: str,
+    state_class: str,
+    watchpoint_class: str,
+    wait_kind: str,
+    satisfaction_status: str,
+    expected: str,
+) -> None:
+    digest = resolve_current_orchestration_digest(
+        tmp_path,
+        current_orchestration_state={
+            "current_orchestration_state_id": "cos-digest",
+            "current_supervisory_state": state_class,
+        },
+        current_orchestration_watchpoint={
+            "orchestration_watchpoint_id": "cow-digest",
+            "watchpoint_class": watchpoint_class,
+        },
+        current_orchestration_watchpoint_brief={"wait_kind": wait_kind},
+        watchpoint_satisfaction={
+            "watchpoint_satisfaction_id": "cws-digest",
+            "satisfaction_status": satisfaction_status,
+        },
+        re_evaluation_trigger_recommendation={
+            "re_evaluation_trigger_id": "ret-digest",
+            "recommendation": recommendation,
+        },
+        current_re_evaluation_basis_brief={"basis_classification": "operator_resolution_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={
+            "orchestration_resumption_candidate_id": "crc-digest",
+            "bounded_resume_mode": "hold_for_manual_review",
+        },
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": readiness_verdict},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        proposal_packet_continuity_review={"review_classification": continuity_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": "continuing_active_packet"},
+        current_operator_facing_orchestration_brief={
+            "operator_facing_classification": "operator_should_review_hold",
+            "loop_posture": "cautionary" if expected == "cautionary_current_picture" else "informational",
+        },
+        current_orchestration_resolution_path_brief={"resolution_path_classification": path_classification},
+        current_orchestration_closure_brief={"closure_classification": closure_classification},
+        current_orchestration_coherence_brief={"coherence_classification": coherence_classification},
+    )
+    assert digest["digest_classification"] == expected
+
+
+def test_current_orchestration_digest_is_derived_only_non_authoritative_and_non_executing(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    digest = resolve_current_orchestration_digest(
+        tmp_path,
+        current_orchestration_state={"current_orchestration_state_id": "cos-boundary"},
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-boundary"},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-boundary"},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-boundary"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-boundary"},
+        current_orchestration_coherence_brief={"coherence_classification": "insufficient_current_signal"},
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert digest["basis"]["historical_honesty"]["derived_from_existing_surfaces_only"] is True
+    assert digest["current_orchestration_digest_only"] is True
+    assert digest["boundaries"]["non_authoritative"] is True
+    assert digest["boundaries"]["non_executing"] is True
+    assert digest["does_not_execute_or_route_work"] is True
+    assert digest["decision_power"] == "none"
+    assert before["handoff_outcome"] == after["handoff_outcome"]
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -6266,6 +6449,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     current_resolution_path_brief = diagnostic["orchestration_handoff"]["current_orchestration_resolution_path_brief"]
     current_closure_brief = diagnostic["orchestration_handoff"]["current_orchestration_closure_brief"]
     current_coherence_brief = diagnostic["orchestration_handoff"]["current_orchestration_coherence_brief"]
+    current_digest = diagnostic["orchestration_handoff"]["current_orchestration_digest"]
     current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
@@ -6459,6 +6643,18 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_coherence_brief["coherence_posture"] in {"informational_only", "conservative_caution"}
     assert current_coherence_brief["boundaries"]["non_authoritative"] is True
     assert current_coherence_brief["does_not_execute_or_route_work"] is True
+    assert current_digest["schema_version"] == "current_orchestration_digest.v1"
+    assert current_digest["digest_classification"] in {
+        "mature_current_picture",
+        "cautionary_current_picture",
+        "fragmented_current_picture",
+        "contradictory_current_picture",
+        "minimal_current_picture",
+    }
+    assert current_digest["overall_picture_posture"] in {"aligned", "cautionary", "fragmented", "contradictory"}
+    assert current_digest["resumed_bounded_motion"] in {"plausible", "blocked", "not_applicable"}
+    assert current_digest["boundaries"]["non_authoritative"] is True
+    assert current_digest["does_not_execute_or_route_work"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
     assert current_watchpoint_summary["re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
@@ -6544,6 +6740,10 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
             "continuity_pressure_wake_next_move_path_closure_aligned"
         )
     )
+    assert current_watchpoint_summary["current_digest_classification"] == current_digest["digest_classification"]
+    assert current_watchpoint_summary["current_digest_overall_picture_posture"] == current_digest["overall_picture_posture"]
+    assert current_watchpoint_summary["current_digest_resumed_bounded_motion"] == current_digest["resumed_bounded_motion"]
+    assert current_watchpoint_summary["current_digest_posture"] == current_digest["digest_posture"]
     assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["wake_readiness_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["re_entry_recommendation_only"] is True
@@ -6559,6 +6759,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_resolution_path_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_closure_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_coherence_brief_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_digest_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True


### PR DESCRIPTION
### Motivation

- Provide a single, bounded, operator-facing compression of the mature current orchestration picture derived only from existing current surfaces for easier inspection by humans and downstream bounded consumers. 
- Keep the surface explicitly observational, non-sovereign, non-executing, and strictly derived from existing resolver outputs so it does not change admission, scheduling, or execution behavior. 

### Description

- Added a new derived resolver `resolve_current_orchestration_digest` in `sentientos/orchestration_intent_fabric.py` that classifies the current orchestration picture into a compact set: `mature_current_picture`, `cautionary_current_picture`, `fragmented_current_picture`, `contradictory_current_picture`, and `minimal_current_picture`, together with an alignment posture and resumed-motion plausibility. 
- Implemented digest helpers and enums (`_CURRENT_ORCHESTRATION_DIGEST_CLASSIFICATIONS`, `_CURRENT_ORCHESTRATION_DIGEST_ALIGNMENT`, `_CURRENT_ORCHESTRATION_DIGEST_RESUMED_MOTION`, and `_current_orchestration_digest_id`) and ensured the digest is derived only from existing surfaces (watchpoint, satisfaction, next-move, pressure, wake, path, closure, coherence, etc.) with explicit anti-sovereignty metadata. 
- Surfaced the digest in `sentientos/scoped_lifecycle_diagnostic.py` by resolving it alongside existing orchestration surfaces and exposing `orchestration_handoff.current_orchestration_digest` and summary fields on `current_orchestration_watchpoint_summary` (`current_digest_classification`, `current_digest_overall_picture_posture`, `current_digest_resumed_bounded_motion`, `current_digest_posture`), preserving non-sovereign boundaries. 
- Updated the orchestration note `sentientos/orchestration_intent_fabric_note.py` with a brief documenting the digest surface and its strict observational boundaries. 
- Tests: added focused tests in `sentientos/tests/test_orchestration_intent_fabric.py`: `test_current_orchestration_digest_classification_cases` and `test_current_orchestration_digest_is_derived_only_non_authoritative_and_non_executing`, and extended the existing consumer diagnostic test to assert digest surfacing and linkage.

Files changed:
- `sentientos/orchestration_intent_fabric.py` (resolver, helpers, enums added)
- `sentientos/scoped_lifecycle_diagnostic.py` (resolver wired in and digest surfaced in diagnostic)
- `sentientos/orchestration_intent_fabric_note.py` (note updated)
- `sentientos/tests/test_orchestration_intent_fabric.py` (tests added/extended)

Resolver added:
- `resolve_current_orchestration_digest` in `sentientos/orchestration_intent_fabric.py`

Diagnostic surface added:
- `orchestration_handoff.current_orchestration_digest`
- Summary fields in `orchestration_handoff.current_orchestration_watchpoint_summary`: `current_digest_classification`, `current_digest_overall_picture_posture`, `current_digest_resumed_bounded_motion`, `current_digest_posture`

Tests added/extended:
- `test_current_orchestration_digest_classification_cases`
- `test_current_orchestration_digest_is_derived_only_non_authoritative_and_non_executing`
- Extended `test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative` to assert digest surfacing and linkage

### Testing

- Ran targeted pytest selection: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "current_orchestration_digest or current_orchestration_coherence_brief_is_derived_only_non_authoritative_and_non_executing or current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative"` and observed all focused tests pass. 
- Verified the diagnostic wiring by calling `build_scoped_lifecycle_diagnostic` in tests and asserting the digest shape, classification membership, resume posture, and non-sovereign boundaries. 
- Confirmed the new digest is purely observational by asserting no changes in existing admission/handoff behavior in boundary tests (before/after admit checks remained equal).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8300449448320b125b007625f761b)