### PR TITLE
[codex:orchestration] normalize current-surface boundary and summary coherence

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -610,6 +610,26 @@ def _anti_sovereignty_payload(
     return payload
 
 
+def _normalized_current_surface_boundaries(
+    *,
+    does_not_schedule_or_trigger_events: bool = False,
+    does_not_create_new_orchestration_layer: bool = True,
+) -> dict[str, Any]:
+    return {
+        "non_sovereign": True,
+        "non_authoritative": True,
+        "non_executing": True,
+        "diagnostic_only": True,
+        "decision_power": "none",
+        "does_not_plan_or_schedule": True,
+        "does_not_execute_or_route_work": True,
+        "does_not_create_new_truth_source": True,
+        "does_not_create_new_orchestration_layer": does_not_create_new_orchestration_layer,
+        "does_not_imply_permission_to_execute": True,
+        "does_not_schedule_or_trigger_events": does_not_schedule_or_trigger_events,
+    }
+
+
 def _iso_utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -4476,6 +4496,32 @@ def _current_wake_readiness_detector_id(
     return f"owr-{digest.hexdigest()[:16]}"
 
 
+def _current_resumed_operation_readiness_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    re_evaluation_trigger_id: str,
+    orchestration_resumption_candidate_id: str,
+    resumed_operation_readiness_verdict: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "re_evaluation_trigger_id": re_evaluation_trigger_id,
+                "orchestration_resumption_candidate_id": orchestration_resumption_candidate_id,
+                "resumed_operation_readiness_verdict": resumed_operation_readiness_verdict,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ord-{digest.hexdigest()[:16]}"
+
+
 def _current_re_evaluation_basis_brief_id(
     *,
     current_orchestration_state_id: str,
@@ -4947,6 +4993,7 @@ def resolve_current_orchestration_state(
                 "orchestration_unified_results",
             ],
         },
+        "boundaries": _normalized_current_surface_boundaries(),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -5093,6 +5140,7 @@ def resolve_current_orchestration_watchpoint(
             "decision_power": "none",
             "watchpoint_only": True,
         },
+        "boundaries": _normalized_current_surface_boundaries(does_not_schedule_or_trigger_events=True),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -5323,6 +5371,7 @@ def resolve_watchpoint_satisfaction(
             "decision_power": "none",
             "wake_readiness_only": True,
         },
+        "boundaries": _normalized_current_surface_boundaries(does_not_schedule_or_trigger_events=True),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -5528,6 +5577,7 @@ def resolve_re_evaluation_trigger_recommendation(
                 "re_entry_recommendation_only": True,
             },
         },
+        "boundaries": _normalized_current_surface_boundaries(does_not_schedule_or_trigger_events=True),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -5764,6 +5814,7 @@ def resolve_current_orchestration_resumption_candidate(
             "decision_power": "none",
             "non_executing": True,
         },
+        "boundaries": _normalized_current_surface_boundaries(does_not_schedule_or_trigger_events=True),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,
@@ -5878,6 +5929,12 @@ def resolve_current_resumed_operation_readiness_verdict(
         or watchpoint_class == "no_watchpoint_needed"
     )
 
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
     if explicit_manual_review_hold or stale_or_fragmented_wake_context or unresolved_operator_influence:
         verdict = "hold_for_operator_review"
         rationale = "wake_context_or_operator_resolution_state_requires_operator_review_before_resumed_continuation"
@@ -5903,6 +5960,14 @@ def resolve_current_resumed_operation_readiness_verdict(
 
     return {
         "schema_version": "current_resumed_operation_readiness_verdict.v1",
+        "current_resumed_operation_readiness_id": _current_resumed_operation_readiness_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            resumed_operation_readiness_verdict=verdict,
+        ),
         "readiness_kind": "bounded_resumed_operation_readiness",
         "resumed_operation_readiness_verdict": verdict,
         "basis": {
@@ -5941,6 +6006,24 @@ def resolve_current_resumed_operation_readiness_verdict(
                 "resolve_unified_orchestration_result",
             ],
         },
+        "source_linkage": {
+            "current_orchestration_state_ref": {
+                "current_orchestration_state_id": state_id or None,
+            },
+            "current_orchestration_watchpoint_ref": {
+                "orchestration_watchpoint_id": watchpoint_id or None,
+            },
+            "watchpoint_satisfaction_ref": {
+                "watchpoint_satisfaction_id": satisfaction_id or None,
+            },
+            "re_evaluation_trigger_ref": {
+                "re_evaluation_trigger_id": trigger_id or None,
+            },
+            "current_orchestration_resumption_candidate_ref": {
+                "orchestration_resumption_candidate_id": candidate_id or None,
+            },
+        },
+        "boundaries": _normalized_current_surface_boundaries(does_not_schedule_or_trigger_events=True),
         **_anti_sovereignty_payload(
             recommendation_only=True,
             diagnostic_only=True,

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -707,19 +707,30 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_transition_brief": current_orchestration_transition_brief,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
+                "current_watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
                 "watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
                 "watchpoint_satisfaction_status": current_watchpoint_satisfaction.get("satisfaction_status"),
+                "current_watchpoint_satisfaction_status": current_watchpoint_satisfaction.get("satisfaction_status"),
                 "expected_actor": current_orchestration_watchpoint.get("expected_actor"),
                 "expected_signal_type": current_orchestration_watchpoint.get("expected_signal_type"),
+                "current_watchpoint_expected_actor": current_orchestration_watchpoint.get("expected_actor"),
+                "current_watchpoint_expected_signal_type": current_orchestration_watchpoint.get("expected_signal_type"),
                 "satisfaction_status": current_watchpoint_satisfaction.get("satisfaction_status"),
                 "satisfied_by_actor": current_watchpoint_satisfaction.get("satisfied_by_actor"),
                 "satisfied_by_signal_type": current_watchpoint_satisfaction.get("satisfied_by_signal_type"),
                 "re_evaluation_trigger_recommendation": re_evaluation_trigger_recommendation.get("recommendation"),
+                "current_re_evaluation_trigger_recommendation": re_evaluation_trigger_recommendation.get("recommendation"),
                 "re_evaluation_expected_actor": re_evaluation_trigger_recommendation.get("expected_actor"),
                 "current_resumption_candidate_mode": current_orchestration_resumption_candidate.get("bounded_resume_mode"),
                 "current_resumption_continuity_posture": current_orchestration_resumption_candidate.get("continuity_posture"),
+                "current_resumption_candidate_continuity_posture": current_orchestration_resumption_candidate.get(
+                    "continuity_posture"
+                ),
                 "current_resumed_operation_readiness_verdict": current_resumed_operation_readiness.get(
                     "resumed_operation_readiness_verdict"
+                ),
+                "current_resumed_operation_readiness_id": current_resumed_operation_readiness.get(
+                    "current_resumed_operation_readiness_id"
                 ),
                 "current_watchpoint_wait_kind": current_orchestration_watchpoint_brief.get("wait_kind"),
                 "watchpoint_brief_requires_conservative_hold": (
@@ -740,6 +751,9 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_re_evaluation_basis_classification": current_re_evaluation_basis_brief.get("basis_classification"),
                 "current_re_evaluation_basis_primary_driver": current_re_evaluation_basis_brief.get("primary_driver"),
                 "current_re_evaluation_basis_posture": current_re_evaluation_basis_brief.get("posture"),
+                "current_next_move_brief_classification": current_orchestration_next_move_brief.get(
+                    "next_move_classification"
+                ),
                 "current_next_move_classification": current_orchestration_next_move_brief.get("next_move_classification"),
                 "current_next_move_posture": current_orchestration_next_move_brief.get("next_move_posture"),
                 "current_next_move_continues_existing_packet": current_orchestration_next_move_brief.get(
@@ -809,6 +823,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "re_entry_recommendation_only": True,
                     "resumption_candidate_only": True,
                     "resumption_readiness_only": True,
+                    "current_resumed_operation_readiness_only": True,
                     "watchpoint_brief_only": True,
                     "pressure_signal_only": True,
                     "wake_readiness_detector_only": True,

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -6701,6 +6701,8 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_state["awaiting_actor"] in {"none", "operator", "internal_substrate", "external_actor"}
     assert current_state["non_authoritative"] is True
     assert current_state["does_not_execute_or_route_work"] is True
+    assert current_state["boundaries"]["non_authoritative"] is True
+    assert current_state["boundaries"]["does_not_execute_or_route_work"] is True
     assert current_watchpoint["schema_version"] == "current_orchestration_watchpoint.v1"
     assert current_watchpoint["watchpoint_class"] in {
         "await_operator_resolution",
@@ -6712,6 +6714,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     }
     assert current_watchpoint["wake_condition_summary"]["decision_power"] == "none"
     assert current_watchpoint["does_not_schedule_or_trigger_events"] is True
+    assert current_watchpoint["boundaries"]["does_not_schedule_or_trigger_events"] is True
     assert current_watchpoint_satisfaction["schema_version"] == "current_orchestration_watchpoint_satisfaction.v1"
     assert current_watchpoint_satisfaction["satisfaction_status"] in {
         "watchpoint_pending",
@@ -6722,6 +6725,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     }
     assert current_watchpoint_satisfaction["wake_readiness_summary"]["wake_readiness_only"] is True
     assert current_watchpoint_satisfaction["does_not_schedule_or_trigger_events"] is True
+    assert current_watchpoint_satisfaction["boundaries"]["does_not_schedule_or_trigger_events"] is True
     assert re_evaluation_trigger["schema_version"] == "orchestration_re_evaluation_trigger.v1"
     assert re_evaluation_trigger["recommendation"] in {
         "rerun_delegated_judgment",
@@ -6734,6 +6738,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert re_evaluation_trigger["expected_actor"] in {"orchestration_body", "operator", "none"}
     assert re_evaluation_trigger["re_entry_summary"]["non_sovereign_boundaries"]["decision_power"] == "none"
     assert re_evaluation_trigger["re_entry_recommendation_only"] is True
+    assert re_evaluation_trigger["boundaries"]["does_not_schedule_or_trigger_events"] is True
     assert current_resumption_candidate["schema_version"] == "current_orchestration_resumption_candidate.v1"
     assert current_resumption_candidate["bounded_resume_mode"] in {
         "rerun_delegated_judgment",
@@ -6751,7 +6756,9 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     }
     assert current_resumption_candidate["resumption_summary"]["non_executing"] is True
     assert current_resumption_candidate["does_not_execute_or_route_work"] is True
+    assert current_resumption_candidate["boundaries"]["does_not_schedule_or_trigger_events"] is True
     assert resumed_readiness["schema_version"] == "current_resumed_operation_readiness_verdict.v1"
+    assert resumed_readiness["current_resumed_operation_readiness_id"].startswith("ord-")
     assert resumed_readiness["resumed_operation_readiness_verdict"] in {
         "ready_to_proceed",
         "proceed_with_caution",
@@ -6761,6 +6768,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert resumed_readiness["non_authoritative"] is True
     assert resumed_readiness["non_executing"] is True
     assert resumed_readiness["does_not_imply_permission_to_execute"] is True
+    assert resumed_readiness["boundaries"]["does_not_schedule_or_trigger_events"] is True
     assert current_watchpoint_brief["schema_version"] == "current_orchestration_watchpoint_brief.v1"
     assert current_watchpoint_brief["wait_kind"] in {
         "awaiting_external_fulfillment",
@@ -6892,15 +6900,28 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_digest["boundaries"]["non_authoritative"] is True
     assert current_digest["does_not_execute_or_route_work"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
+    assert current_watchpoint_summary["current_watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
+    assert (
+        current_watchpoint_summary["current_watchpoint_satisfaction_status"]
+        == current_watchpoint_satisfaction["satisfaction_status"]
+    )
     assert current_watchpoint_summary["re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
+    assert current_watchpoint_summary["current_re_evaluation_trigger_recommendation"] == re_evaluation_trigger["recommendation"]
     assert current_watchpoint_summary["re_evaluation_expected_actor"] == re_evaluation_trigger["expected_actor"]
     assert current_watchpoint_summary["current_resumption_candidate_mode"] == current_resumption_candidate["bounded_resume_mode"]
     assert current_watchpoint_summary["current_resumption_continuity_posture"] == current_resumption_candidate["continuity_posture"]
     assert (
+        current_watchpoint_summary["current_resumption_candidate_continuity_posture"]
+        == current_resumption_candidate["continuity_posture"]
+    )
+    assert (
         current_watchpoint_summary["current_resumed_operation_readiness_verdict"]
         == resumed_readiness["resumed_operation_readiness_verdict"]
     )
+    assert current_watchpoint_summary["current_resumed_operation_readiness_id"] == resumed_readiness[
+        "current_resumed_operation_readiness_id"
+    ]
     assert current_watchpoint_summary["current_watchpoint_wait_kind"] == current_watchpoint_brief["wait_kind"]
     assert (
         current_watchpoint_summary["watchpoint_brief_requires_conservative_hold"]
@@ -6924,6 +6945,10 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert (
         current_watchpoint_summary["current_handoff_packet_brief_classification"]
         == current_handoff_packet_brief["handoff_packet_brief_classification"]
+    )
+    assert (
+        current_watchpoint_summary["current_next_move_brief_classification"]
+        == current_next_move["next_move_classification"]
     )
     assert (
         current_watchpoint_summary["current_handoff_packet_continues_active_packet"]
@@ -6994,6 +7019,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["non_sovereign_boundaries"]["re_entry_recommendation_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["resumption_candidate_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["resumption_readiness_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["current_resumed_operation_readiness_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["watchpoint_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["pressure_signal_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["wake_readiness_detector_only"] is True


### PR DESCRIPTION
### Motivation
- Reduce accidental shape drift across the family of mature "current" orchestration surfaces so consumer-facing summaries, boundary fields, linkage patterns, and ID patterns are consistent. 
- Preserve observational/non-executing semantics and existing authority behaviour while making summary projections coherent and easier to consume. 
- Make minimal, compatibility-preserving repairs rather than adding execution or new orchestration authority.

### Description
- Added a small normalization helper `_normalized_current_surface_boundaries` and applied it to mature current surfaces to centralize the non-sovereign/non-authoritative/non-executing boundary shape instead of ad-hoc top-level flags. 
- Introduced a deterministic ID generator `_current_resumed_operation_readiness_id` (prefix `ord-...`) and surfaced `current_resumed_operation_readiness_id` and `source_linkage` fields for the resumed-readiness surface to align ID/linkage patterns with neighboring current surfaces. 
- Added compatibility-preserving summary aliases into the scoped lifecycle consumer projection (`current_orchestration_watchpoint_summary`) so fields like `current_watchpoint_class`, `current_watchpoint_satisfaction_status`, `current_re_evaluation_trigger_recommendation`, `current_resumption_candidate_continuity_posture`, `current_next_move_brief_classification`, and the readiness ID are available alongside the existing keys. 
- Kept all legacy top-level flags intact and only added nested `boundaries` objects or aliases where needed so existing consumers remain compatible. 
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, and `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Ran the orchestration test module: `python -m pytest sentientos/tests/test_orchestration_intent_fabric.py -q` and all tests passed (100% green). 
- Tests were extended/updated to assert boundary object presence, the new `ord-` readiness id, summary alias fields, and preserved non-authoritative/non-executing semantics; these assertions succeeded.
- No execution/scheduler behavior changed and admission/authority behavior remained unchanged as validated by existing orchestration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9535d61bc8320b5453e671813e665)