### PR TITLE
[codex:orchestration] add bounded current orchestration export packet

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -455,6 +455,22 @@ _CURRENT_ORCHESTRATION_TRANSITION_BRIEF_POSTURES = {
     "conservative_caution",
 }
 
+_CURRENT_ORCHESTRATION_EXPORT_PACKET_CLASSIFICATIONS = {
+    "export_packet_ready",
+    "export_packet_cautionary",
+    "export_packet_fragmented",
+    "export_packet_contradicted",
+    "export_packet_minimal",
+}
+
+_CURRENT_ORCHESTRATION_EXPORT_PACKET_MATURITY = {
+    "mature",
+    "cautionary",
+    "fragmented",
+    "contradicted",
+    "minimal",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4754,6 +4770,32 @@ def _current_orchestration_transition_brief_id(
         ).encode("utf-8")
     )
     return f"otb-{digest.hexdigest()[:16]}"
+
+
+def _current_orchestration_export_packet_id(
+    *,
+    current_orchestration_state_id: str,
+    orchestration_watchpoint_id: str,
+    watchpoint_satisfaction_id: str,
+    re_evaluation_trigger_id: str,
+    orchestration_resumption_candidate_id: str,
+    export_packet_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "orchestration_watchpoint_id": orchestration_watchpoint_id,
+                "watchpoint_satisfaction_id": watchpoint_satisfaction_id,
+                "re_evaluation_trigger_id": re_evaluation_trigger_id,
+                "orchestration_resumption_candidate_id": orchestration_resumption_candidate_id,
+                "export_packet_classification": export_packet_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"oep-{digest.hexdigest()[:16]}"
 
 
 def resolve_current_orchestration_state(
@@ -9449,6 +9491,310 @@ def resolve_current_orchestration_transition_brief(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_transition_brief_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_export_packet(
+    repo_root: Path,
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint_brief: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_re_evaluation_basis_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    proposal_packet_continuity_review: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    current_operator_facing_orchestration_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resolution_path_brief: Mapping[str, Any] | None = None,
+    current_orchestration_closure_brief: Mapping[str, Any] | None = None,
+    current_orchestration_coherence_brief: Mapping[str, Any] | None = None,
+    current_orchestration_digest: Mapping[str, Any] | None = None,
+    current_orchestration_transition_brief: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, derived export packet for the current orchestration picture."""
+
+    _ = repo_root.resolve()
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    watchpoint_brief_map = (
+        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
+    )
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
+    basis_map = current_re_evaluation_basis_brief if isinstance(current_re_evaluation_basis_brief, Mapping) else {}
+    candidate_map = (
+        current_orchestration_resumption_candidate
+        if isinstance(current_orchestration_resumption_candidate, Mapping)
+        else {}
+    )
+    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    continuity_map = proposal_packet_continuity_review if isinstance(proposal_packet_continuity_review, Mapping) else {}
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_map = (
+        current_operator_facing_orchestration_brief
+        if isinstance(current_operator_facing_orchestration_brief, Mapping)
+        else {}
+    )
+    path_map = (
+        current_orchestration_resolution_path_brief
+        if isinstance(current_orchestration_resolution_path_brief, Mapping)
+        else {}
+    )
+    closure_map = (
+        current_orchestration_closure_brief if isinstance(current_orchestration_closure_brief, Mapping) else {}
+    )
+    coherence_map = (
+        current_orchestration_coherence_brief if isinstance(current_orchestration_coherence_brief, Mapping) else {}
+    )
+    digest_map = current_orchestration_digest if isinstance(current_orchestration_digest, Mapping) else {}
+    transition_map = (
+        current_orchestration_transition_brief if isinstance(current_orchestration_transition_brief, Mapping) else {}
+    )
+
+    state_class = str(state_map.get("current_supervisory_state") or "no_active_orchestration_item")
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "no_active_watchpoint")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "no_active_watchpoint")
+    recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
+    basis_classification = str(basis_map.get("basis_classification") or "no_current_re_evaluation_basis")
+    resume_mode = str(candidate_map.get("bounded_resume_mode") or "no_re_evaluation_needed")
+    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    continuity_classification = str(continuity_map.get("review_classification") or "insufficient_history")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    handoff_classification = str(handoff_map.get("handoff_packet_brief_classification") or "no_current_packet_brief")
+    operator_classification = str(
+        operator_map.get("operator_facing_classification") or "operator_attention_not_currently_needed"
+    )
+    operator_loop_posture = str(operator_map.get("loop_posture") or "informational")
+    path_classification = str(path_map.get("resolution_path_classification") or "no_current_resolution_path")
+    closure_classification = str(closure_map.get("closure_classification") or "no_current_closure_posture")
+    coherence_classification = str(coherence_map.get("coherence_classification") or "insufficient_current_signal")
+    digest_classification = str(digest_map.get("digest_classification") or "minimal_current_picture")
+    transition_classification = str(transition_map.get("transition_classification") or "transition_uncertain")
+
+    evidence_count = sum(
+        1
+        for present in (
+            state_class != "no_active_orchestration_item",
+            watchpoint_class != "no_watchpoint_needed",
+            satisfaction_status != "no_active_watchpoint",
+            recommendation != "no_re_evaluation_needed",
+            wake_classification != "not_wake_ready",
+            pressure_classification != "insufficient_signal",
+            continuity_classification != "insufficient_history",
+            next_move_classification != "no_current_next_move",
+            path_classification != "no_current_resolution_path",
+            closure_classification != "no_current_closure_posture",
+            coherence_classification != "insufficient_current_signal",
+            digest_classification != "minimal_current_picture",
+            transition_classification != "transition_uncertain",
+        )
+        if present
+    )
+
+    contradictory = (
+        coherence_classification == "materially_contradictory"
+        or digest_classification == "contradictory_current_picture"
+        or transition_classification == "transition_contradicted"
+        or (
+            path_classification == "completed_or_no_active_path"
+            and closure_classification
+            in {
+                "closure_pending_on_operator_resolution",
+                "closure_pending_on_internal_result",
+                "closure_pending_on_external_fulfillment",
+                "closure_pending_on_packet_continuity",
+            }
+        )
+        or (closure_classification == "closure_already_satisfied" and next_move_classification != "no_current_next_move")
+    )
+    fragmented = (
+        coherence_classification == "fragmentation_dominant"
+        or pressure_classification == "fragmentation_pressure"
+        or continuity_classification == "fragmented_continuity"
+        or path_classification == "fragmented_path"
+        or closure_classification == "closure_blocked_by_fragmentation"
+        or satisfaction_status in {"watchpoint_fragmented", "watchpoint_stale"}
+        or wait_kind == "continuity_uncertain"
+        or handoff_classification == "packet_continuity_uncertain"
+        or digest_classification == "fragmented_current_picture"
+    )
+    cautionary = (
+        recommendation == "hold_for_manual_review"
+        or readiness_verdict in {"hold_for_operator_review", "not_ready"}
+        or wake_classification in {"wake_ready_with_caution", "wake_blocked_pending_operator"}
+        or pressure_classification in {"hold_pressure", "redirect_pressure", "repacketization_pressure", "mixed_pressure"}
+        or continuity_classification in {"hold_heavy_continuity", "redirect_heavy_continuity", "repacketization_churn"}
+        or operator_loop_posture == "cautionary"
+        or next_move_classification in {"hold_for_operator_review_next", "rerun_packetization_gate_next", "rerun_packet_synthesis_next"}
+        or closure_classification
+        in {
+            "closure_pending_on_operator_resolution",
+            "closure_pending_on_internal_result",
+            "closure_pending_on_external_fulfillment",
+            "closure_pending_on_packet_continuity",
+        }
+        or coherence_classification == "strained_but_coherent"
+        or digest_classification == "cautionary_current_picture"
+    )
+    mature_and_aligned = (
+        coherence_classification == "coherent_current_picture"
+        and digest_classification == "mature_current_picture"
+        and transition_classification in {"poised_for_resumed_progress", "poised_for_no_material_transition", "poised_for_result_closure"}
+        and not cautionary
+        and not fragmented
+        and not contradictory
+        and recommendation in {"clear_wait_and_continue_current_packet", "rerun_delegated_judgment", "no_re_evaluation_needed"}
+        and next_move_classification in {"continue_current_packet_next", "rerun_delegated_judgment_next", "no_current_next_move"}
+    )
+
+    if contradictory:
+        classification = "export_packet_contradicted"
+        maturity_posture = "contradicted"
+        rationale = "neighboring_current_surfaces_materially_disagree_so_export_must_remain_conservative"
+    elif fragmented:
+        classification = "export_packet_fragmented"
+        maturity_posture = "fragmented"
+        rationale = "fragmentation_materially_dominates_current_orchestration_visibility"
+    elif evidence_count <= 4:
+        classification = "export_packet_minimal"
+        maturity_posture = "minimal"
+        rationale = "current_evidence_is_sparse_so_only_minimal_honest_export_is_supported"
+    elif mature_and_aligned:
+        classification = "export_packet_ready"
+        maturity_posture = "mature"
+        rationale = "current_orchestration_surfaces_are_mature_and_cleanly_aligned_for_bounded_export"
+    else:
+        classification = "export_packet_cautionary"
+        maturity_posture = "cautionary"
+        rationale = "current_picture_is_partially_aligned_but_material_caution_signals_remain"
+
+    if classification not in _CURRENT_ORCHESTRATION_EXPORT_PACKET_CLASSIFICATIONS:
+        classification = "export_packet_minimal"
+    if maturity_posture not in _CURRENT_ORCHESTRATION_EXPORT_PACKET_MATURITY:
+        maturity_posture = "minimal"
+
+    suitability = classification in {"export_packet_ready", "export_packet_cautionary", "export_packet_minimal"}
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
+    return {
+        "schema_version": "current_orchestration_export_packet.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_export_packet_id": _current_orchestration_export_packet_id(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            export_packet_classification=classification,
+        ),
+        "export_packet_classification": classification,
+        "export_packet_maturity_posture": maturity_posture,
+        "suitable_for_bounded_downstream_inspection": suitability,
+        "bounded_export_summary": {
+            "current_path": path_classification,
+            "current_next_move": next_move_classification,
+            "current_closure_posture": closure_classification,
+            "current_coherence_posture": coherence_classification,
+            "current_operator_facing_posture": operator_classification,
+            "current_resumed_motion_posture": transition_classification,
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "current_supervisory_state": state_class,
+                "watchpoint_class": watchpoint_class,
+                "watchpoint_wait_kind": wait_kind,
+                "watchpoint_satisfaction_status": satisfaction_status,
+                "re_evaluation_recommendation": recommendation,
+                "re_evaluation_basis_classification": basis_classification,
+                "resumption_mode": resume_mode,
+                "resumed_operation_readiness_verdict": readiness_verdict,
+                "wake_readiness_classification": wake_classification,
+                "pressure_classification": pressure_classification,
+                "proposal_packet_continuity_classification": continuity_classification,
+                "current_handoff_packet_brief_classification": handoff_classification,
+                "current_digest_classification": digest_classification,
+                "current_transition_classification": transition_classification,
+                "evidence_count": evidence_count,
+            },
+            "compressed_surface_linkage": {
+                "current_orchestration_state_surface": "resolve_current_orchestration_state",
+                "current_orchestration_watchpoint_surface": "resolve_current_orchestration_watchpoint",
+                "current_orchestration_watchpoint_brief_surface": "resolve_current_orchestration_watchpoint_brief",
+                "watchpoint_satisfaction_surface": "resolve_watchpoint_satisfaction",
+                "re_evaluation_trigger_surface": "resolve_re_evaluation_trigger_recommendation",
+                "current_re_evaluation_basis_brief_surface": "resolve_current_re_evaluation_basis_brief",
+                "current_orchestration_resumption_candidate_surface": "resolve_current_orchestration_resumption_candidate",
+                "current_resumed_operation_readiness_surface": "resolve_current_resumed_operation_readiness_verdict",
+                "current_orchestration_wake_readiness_detector_surface": "resolve_current_orchestration_wake_readiness_detector",
+                "current_orchestration_pressure_signal_surface": "resolve_current_orchestration_pressure_signal",
+                "proposal_packet_continuity_review_surface": "derive_proposal_packet_continuity_review",
+                "current_orchestration_next_move_brief_surface": "resolve_current_orchestration_next_move_brief",
+                "current_orchestration_handoff_packet_brief_surface": "resolve_current_orchestration_handoff_packet_brief",
+                "current_operator_facing_orchestration_brief_surface": "resolve_current_operator_facing_orchestration_brief",
+                "current_orchestration_resolution_path_brief_surface": "resolve_current_orchestration_resolution_path_brief",
+                "current_orchestration_closure_brief_surface": "resolve_current_orchestration_closure_brief",
+                "current_orchestration_coherence_brief_surface": "resolve_current_orchestration_coherence_brief",
+                "current_orchestration_digest_surface": "resolve_current_orchestration_digest",
+                "current_orchestration_transition_brief_surface": "resolve_current_orchestration_transition_brief",
+            },
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_flatten_material_ambiguity_into_fake_clarity": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_orchestration_export_packet_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -425,6 +425,32 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not imply permission to execute",
             ],
         },
+        "current_orchestration_export_packet": {
+            "what_it_is": "a bounded observational-only export compression surface that packages the mature current orchestration picture for compact downstream inspection",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_export_packet",
+            "classifications": [
+                "export_packet_ready",
+                "export_packet_cautionary",
+                "export_packet_fragmented",
+                "export_packet_contradicted",
+                "export_packet_minimal",
+            ],
+            "derived_from_existing_surfaces_only": [
+                "current orchestration state/watchpoint/watchpoint brief/satisfaction",
+                "re-evaluation trigger + current re-evaluation basis brief",
+                "current resumption candidate + resumed readiness",
+                "current wake-readiness detector + pressure signal",
+                "proposal-packet continuity review",
+                "current orchestration next-move brief + handoff packet brief + operator-facing brief + resolution-path brief + closure brief + coherence brief",
+                "current orchestration digest + transition brief",
+            ],
+            "strict_boundaries": [
+                "non-sovereign, non-authoritative, non-executing",
+                "export compression only; not a scheduler/planner/decision engine/execution venue",
+                "does not create a new truth source or mutable orchestration store",
+                "does not imply permission to execute",
+            ],
+        },
         "unified_orchestration_result": {
             "what_it_is": "a bounded venue-aware resolver surface that normalizes internal execution closure and external fulfillment closure into one typed result shape",
             "machine_surface": "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -39,6 +39,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_closure_brief,
     resolve_current_orchestration_coherence_brief,
     resolve_current_orchestration_digest,
+    resolve_current_orchestration_export_packet,
     resolve_current_orchestration_transition_brief,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
@@ -583,6 +584,28 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         current_orchestration_coherence_brief=current_orchestration_coherence_brief,
         current_orchestration_digest=current_orchestration_digest,
     )
+    current_orchestration_export_packet = resolve_current_orchestration_export_packet(
+        root,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
+        watchpoint_satisfaction=current_watchpoint_satisfaction,
+        re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_re_evaluation_basis_brief=current_re_evaluation_basis_brief,
+        current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        proposal_packet_continuity_review=proposal_packet_continuity_review,
+        current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+        current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+        current_operator_facing_orchestration_brief=current_operator_facing_orchestration_brief,
+        current_orchestration_resolution_path_brief=current_orchestration_resolution_path_brief,
+        current_orchestration_closure_brief=current_orchestration_closure_brief,
+        current_orchestration_coherence_brief=current_orchestration_coherence_brief,
+        current_orchestration_digest=current_orchestration_digest,
+        current_orchestration_transition_brief=current_orchestration_transition_brief,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -705,6 +728,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_coherence_brief": current_orchestration_coherence_brief,
             "current_orchestration_digest": current_orchestration_digest,
             "current_orchestration_transition_brief": current_orchestration_transition_brief,
+            "current_orchestration_export_packet": current_orchestration_export_packet,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "current_watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -802,6 +826,15 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_digest_overall_picture_posture": current_orchestration_digest.get("overall_picture_posture"),
                 "current_digest_resumed_bounded_motion": current_orchestration_digest.get("resumed_bounded_motion"),
                 "current_digest_posture": current_orchestration_digest.get("digest_posture"),
+                "current_export_packet_classification": current_orchestration_export_packet.get(
+                    "export_packet_classification"
+                ),
+                "current_export_packet_maturity_posture": current_orchestration_export_packet.get(
+                    "export_packet_maturity_posture"
+                ),
+                "current_export_packet_suitable_for_bounded_downstream_inspection": current_orchestration_export_packet.get(
+                    "suitable_for_bounded_downstream_inspection"
+                ),
                 "current_transition_classification": current_orchestration_transition_brief.get("transition_classification"),
                 "current_transition_posture": current_orchestration_transition_brief.get("transition_posture"),
                 "current_transition_resumed_bounded_motion": current_orchestration_transition_brief.get(
@@ -836,6 +869,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "current_orchestration_coherence_brief_only": True,
                     "current_orchestration_digest_only": True,
                     "current_orchestration_transition_brief_only": True,
+                    "current_orchestration_export_packet_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -55,6 +55,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_closure_brief,
     resolve_current_orchestration_coherence_brief,
     resolve_current_orchestration_digest,
+    resolve_current_orchestration_export_packet,
     resolve_current_orchestration_transition_brief,
     resolve_current_operator_facing_orchestration_brief,
     resolve_current_orchestration_resumption_candidate,
@@ -6635,6 +6636,174 @@ def test_current_orchestration_transition_brief_is_derived_only_non_authoritativ
     assert before["handoff_outcome"] == after["handoff_outcome"]
 
 
+@pytest.mark.parametrize(
+    (
+        "coherence_classification",
+        "digest_classification",
+        "transition_classification",
+        "pressure_classification",
+        "continuity_classification",
+        "next_move_classification",
+        "path_classification",
+        "closure_classification",
+        "recommendation",
+        "readiness_verdict",
+        "wake_classification",
+        "wait_kind",
+        "satisfaction_status",
+        "expected",
+    ),
+    [
+        (
+            "coherent_current_picture",
+            "mature_current_picture",
+            "poised_for_resumed_progress",
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "continue_current_packet_next",
+            "internal_result_path",
+            "closure_materially_reachable",
+            "clear_wait_and_continue_current_packet",
+            "ready_to_proceed",
+            "wake_ready",
+            "awaiting_internal_result_closure",
+            "watchpoint_satisfied",
+            "export_packet_ready",
+        ),
+        (
+            "strained_but_coherent",
+            "cautionary_current_picture",
+            "poised_for_conservative_hold",
+            "hold_pressure",
+            "hold_heavy_continuity",
+            "hold_for_operator_review_next",
+            "operator_resolution_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "hold_for_operator_review",
+            "wake_blocked_pending_operator",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "export_packet_cautionary",
+        ),
+        (
+            "fragmentation_dominant",
+            "fragmented_current_picture",
+            "transition_uncertain",
+            "fragmentation_pressure",
+            "fragmented_continuity",
+            "rerun_packet_synthesis_next",
+            "fragmented_path",
+            "closure_blocked_by_fragmentation",
+            "rerun_packet_synthesis",
+            "not_ready",
+            "wake_blocked_by_fragmentation",
+            "continuity_uncertain",
+            "watchpoint_fragmented",
+            "export_packet_fragmented",
+        ),
+        (
+            "materially_contradictory",
+            "contradictory_current_picture",
+            "transition_contradicted",
+            "stable_or_low_pressure",
+            "coherent_proposal_packet_continuity",
+            "continue_current_packet_next",
+            "completed_or_no_active_path",
+            "closure_pending_on_operator_resolution",
+            "hold_for_manual_review",
+            "hold_for_operator_review",
+            "wake_ready",
+            "awaiting_operator_resolution",
+            "watchpoint_pending",
+            "export_packet_contradicted",
+        ),
+        (
+            "insufficient_current_signal",
+            "minimal_current_picture",
+            "transition_uncertain",
+            "insufficient_signal",
+            "insufficient_history",
+            "no_current_next_move",
+            "no_current_resolution_path",
+            "no_current_closure_posture",
+            "no_re_evaluation_needed",
+            "not_ready",
+            "not_wake_ready",
+            "no_active_watchpoint",
+            "no_active_watchpoint",
+            "export_packet_minimal",
+        ),
+    ],
+)
+def test_current_orchestration_export_packet_classification_cases(
+    tmp_path: Path,
+    coherence_classification: str,
+    digest_classification: str,
+    transition_classification: str,
+    pressure_classification: str,
+    continuity_classification: str,
+    next_move_classification: str,
+    path_classification: str,
+    closure_classification: str,
+    recommendation: str,
+    readiness_verdict: str,
+    wake_classification: str,
+    wait_kind: str,
+    satisfaction_status: str,
+    expected: str,
+) -> None:
+    packet = resolve_current_orchestration_export_packet(
+        tmp_path,
+        current_orchestration_state={"current_orchestration_state_id": "cos-export", "current_supervisory_state": "waiting_for_internal_result"},
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-export", "watchpoint_class": "await_internal_execution_result"},
+        current_orchestration_watchpoint_brief={"wait_kind": wait_kind},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-export", "satisfaction_status": satisfaction_status},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-export", "recommendation": recommendation},
+        current_re_evaluation_basis_brief={"basis_classification": "satisfaction_driven_re_evaluation"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-export", "bounded_resume_mode": "clear_wait_and_continue_current_packet"},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": readiness_verdict},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        proposal_packet_continuity_review={"review_classification": continuity_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": "continuing_active_packet"},
+        current_operator_facing_orchestration_brief={"operator_facing_classification": "operator_attention_not_currently_needed"},
+        current_orchestration_resolution_path_brief={"resolution_path_classification": path_classification},
+        current_orchestration_closure_brief={"closure_classification": closure_classification},
+        current_orchestration_coherence_brief={"coherence_classification": coherence_classification},
+        current_orchestration_digest={"digest_classification": digest_classification},
+        current_orchestration_transition_brief={"transition_classification": transition_classification},
+    )
+    assert packet["export_packet_classification"] == expected
+
+
+def test_current_orchestration_export_packet_is_derived_only_non_authoritative_and_non_executing(tmp_path: Path) -> None:
+    judgment = synthesize_delegated_judgment(_base_evidence())
+    intent = synthesize_orchestration_intent(judgment, created_at="2026-04-12T00:00:00Z")
+    append_orchestration_intent_ledger(tmp_path, intent)
+    before = admit_orchestration_intent(tmp_path, intent)
+    packet = resolve_current_orchestration_export_packet(
+        tmp_path,
+        current_orchestration_state={"current_orchestration_state_id": "cos-export-boundary"},
+        current_orchestration_watchpoint={"orchestration_watchpoint_id": "cow-export-boundary"},
+        watchpoint_satisfaction={"watchpoint_satisfaction_id": "cws-export-boundary"},
+        re_evaluation_trigger_recommendation={"re_evaluation_trigger_id": "ret-export-boundary"},
+        current_orchestration_resumption_candidate={"orchestration_resumption_candidate_id": "crc-export-boundary"},
+        current_orchestration_coherence_brief={"coherence_classification": "insufficient_current_signal"},
+    )
+    after = admit_orchestration_intent(tmp_path, intent)
+    assert packet["basis"]["historical_honesty"]["derived_from_existing_surfaces_only"] is True
+    assert packet["current_orchestration_export_packet_only"] is True
+    assert packet["boundaries"]["non_authoritative"] is True
+    assert packet["boundaries"]["non_executing"] is True
+    assert packet["does_not_execute_or_route_work"] is True
+    assert packet["decision_power"] == "none"
+    assert "current_orchestration_digest_surface" in packet["basis"]["compressed_surface_linkage"]
+    assert "current_orchestration_transition_brief_surface" in packet["basis"]["compressed_surface_linkage"]
+    assert before["handoff_outcome"] == after["handoff_outcome"]
+
+
 def test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("sentientos.scoped_lifecycle_diagnostic.SCOPED_ACTION_IDS", ("sentientos.manifest.generate",))
 
@@ -6685,6 +6854,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     current_coherence_brief = diagnostic["orchestration_handoff"]["current_orchestration_coherence_brief"]
     current_digest = diagnostic["orchestration_handoff"]["current_orchestration_digest"]
     current_transition_brief = diagnostic["orchestration_handoff"]["current_orchestration_transition_brief"]
+    current_export_packet = diagnostic["orchestration_handoff"]["current_orchestration_export_packet"]
     current_watchpoint_summary = diagnostic["orchestration_handoff"]["current_orchestration_watchpoint_summary"]
     readiness = diagnostic["orchestration_handoff"]["delegated_operation_readiness"]
 
@@ -6888,6 +7058,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_coherence_brief["does_not_execute_or_route_work"] is True
     assert current_digest["schema_version"] == "current_orchestration_digest.v1"
     assert current_transition_brief["schema_version"] == "current_orchestration_transition_brief.v1"
+    assert current_export_packet["schema_version"] == "current_orchestration_export_packet.v1"
     assert current_digest["digest_classification"] in {
         "mature_current_picture",
         "cautionary_current_picture",
@@ -6899,6 +7070,22 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_digest["resumed_bounded_motion"] in {"plausible", "blocked", "not_applicable"}
     assert current_digest["boundaries"]["non_authoritative"] is True
     assert current_digest["does_not_execute_or_route_work"] is True
+    assert current_export_packet["export_packet_classification"] in {
+        "export_packet_ready",
+        "export_packet_cautionary",
+        "export_packet_fragmented",
+        "export_packet_contradicted",
+        "export_packet_minimal",
+    }
+    assert current_export_packet["export_packet_maturity_posture"] in {
+        "mature",
+        "cautionary",
+        "fragmented",
+        "contradicted",
+        "minimal",
+    }
+    assert current_export_packet["boundaries"]["non_authoritative"] is True
+    assert current_export_packet["does_not_execute_or_route_work"] is True
     assert current_watchpoint_summary["watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["current_watchpoint_class"] == current_watchpoint["watchpoint_class"]
     assert current_watchpoint_summary["watchpoint_satisfaction_status"] == current_watchpoint_satisfaction["satisfaction_status"]
@@ -7006,6 +7193,18 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["current_digest_resumed_bounded_motion"] == current_digest["resumed_bounded_motion"]
     assert current_watchpoint_summary["current_digest_posture"] == current_digest["digest_posture"]
     assert (
+        current_watchpoint_summary["current_export_packet_classification"]
+        == current_export_packet["export_packet_classification"]
+    )
+    assert (
+        current_watchpoint_summary["current_export_packet_maturity_posture"]
+        == current_export_packet["export_packet_maturity_posture"]
+    )
+    assert (
+        current_watchpoint_summary["current_export_packet_suitable_for_bounded_downstream_inspection"]
+        == current_export_packet["suitable_for_bounded_downstream_inspection"]
+    )
+    assert (
         current_watchpoint_summary["current_transition_classification"]
         == current_transition_brief["transition_classification"]
     )
@@ -7032,6 +7231,7 @@ def test_current_orchestration_state_surface_is_present_in_consumer_and_non_auth
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_coherence_brief_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_digest_only"] is True
     assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_transition_brief_only"] is True
+    assert current_watchpoint_summary["non_sovereign_boundaries"]["current_orchestration_export_packet_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["basis_only"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["does_not_change_verdict_logic"] is True
     assert readiness["summary"]["current_orchestration_state_basis"]["watchpoint_basis"]["basis_only"] is True


### PR DESCRIPTION
### Motivation
- Provide a single bounded, derived export packet that compresses the mature normalized current orchestration picture for compact downstream inspection without adding authority or execution capability.
- Keep the export packet purely observational and strictly derived from existing normalized current-surface family so it does not create a new truth source or mutable store.
- Surface the packet alongside existing orchestration watchpoint artifacts so bounded consumers can inspect a compact summary with explicit non-sovereign boundaries.

### Description
- Added a narrow resolver `resolve_current_orchestration_export_packet` and deterministic id helper `_current_orchestration_export_packet_id` in `sentientos/orchestration_intent_fabric.py`, together with compact classification vocabularies (`export_packet_ready`, `export_packet_cautionary`, `export_packet_fragmented`, `export_packet_contradicted`, `export_packet_minimal`) and maturity postures.  
- The export packet is explicitly non-sovereign/non-authoritative/non-executing and contains a bounded compressed view (`bounded_export_summary`) of current path/next-move/closure/coherence/operator/resumed-motion, compressed `basis` evidence, `compressed_surface_linkage` back to the underlying current surfaces, and honesty flags (`derived_from_existing_surfaces_only`, `no_new_truth_source`).  
- Wired the export packet into `build_scoped_lifecycle_diagnostic` in `sentientos/scoped_lifecycle_diagnostic.py` so `orchestration_handoff` now includes `current_orchestration_export_packet` and the watchpoint summary exposes `current_export_packet_*` fields and non-sovereign boundary flags.  
- Updated documentation in `sentientos/orchestration_intent_fabric_note.py` and added focused tests in `sentientos/tests/test_orchestration_intent_fabric.py` that validate classification cases and non-authoritative/diagnostic-only behavior.
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/scoped_lifecycle_diagnostic.py`, `sentientos/orchestration_intent_fabric_note.py`, `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Added tests: `test_current_orchestration_export_packet_classification_cases` and `test_current_orchestration_export_packet_is_derived_only_non_authoritative_and_non_executing`, and extended consumer/diagnostic assertions in existing `test_current_orchestration_state_surface_is_present_in_consumer_and_non_authoritative` in `sentientos/tests/test_orchestration_intent_fabric.py`.
- Ran the orchestration test module: `pytest sentientos/tests/test_orchestration_intent_fabric.py -q`, which completed successfully with all tests passing.
- The tests verify the packet is derived-only from existing surfaces, remains non-authoritative/non-executing, classifies ready/cautionary/fragmented/contradicted/minimal correctly, links back to underlying surfaces, and does not change admission/authority behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e978bb4f988320865a6ecd4a3366b1)