### PR TITLE
[codex:orchestration] add bounded current export-packet consumer receipt

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -471,6 +471,15 @@ _CURRENT_ORCHESTRATION_EXPORT_PACKET_MATURITY = {
     "minimal",
 }
 
+_CURRENT_ORCHESTRATION_EXPORT_PACKET_CONSUMER_RECEIPT_CLASSIFICATIONS = {
+    "receipt_structurally_consumable",
+    "receipt_consumable_with_caution",
+    "receipt_fragmented",
+    "receipt_contradicted",
+    "receipt_minimal",
+    "no_current_receipt_needed",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4796,6 +4805,26 @@ def _current_orchestration_export_packet_id(
         ).encode("utf-8")
     )
     return f"oep-{digest.hexdigest()[:16]}"
+
+
+def _current_orchestration_export_packet_consumer_receipt_id(
+    *,
+    current_orchestration_state_id: str,
+    current_orchestration_export_packet_id: str,
+    receipt_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "current_orchestration_export_packet_id": current_orchestration_export_packet_id,
+                "receipt_classification": receipt_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ocr-{digest.hexdigest()[:16]}"
 
 
 def resolve_current_orchestration_state(
@@ -9795,6 +9824,253 @@ def resolve_current_orchestration_export_packet(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_export_packet_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_export_packet_consumer_receipt(
+    repo_root: Path,
+    *,
+    current_orchestration_export_packet: Mapping[str, Any] | None = None,
+    current_orchestration_digest: Mapping[str, Any] | None = None,
+    current_orchestration_coherence_brief: Mapping[str, Any] | None = None,
+    current_orchestration_transition_brief: Mapping[str, Any] | None = None,
+    current_orchestration_closure_brief: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    current_operator_facing_orchestration_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resolution_path_brief: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, observational-only receipt describing current export-packet consumability."""
+
+    _ = repo_root.resolve()
+    export_packet_map = (
+        current_orchestration_export_packet
+        if isinstance(current_orchestration_export_packet, Mapping)
+        else {}
+    )
+    digest_map = current_orchestration_digest if isinstance(current_orchestration_digest, Mapping) else {}
+    coherence_map = (
+        current_orchestration_coherence_brief if isinstance(current_orchestration_coherence_brief, Mapping) else {}
+    )
+    transition_map = (
+        current_orchestration_transition_brief if isinstance(current_orchestration_transition_brief, Mapping) else {}
+    )
+    closure_map = (
+        current_orchestration_closure_brief if isinstance(current_orchestration_closure_brief, Mapping) else {}
+    )
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_map = (
+        current_operator_facing_orchestration_brief
+        if isinstance(current_operator_facing_orchestration_brief, Mapping)
+        else {}
+    )
+    path_map = (
+        current_orchestration_resolution_path_brief
+        if isinstance(current_orchestration_resolution_path_brief, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    resumed_map = (
+        current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    )
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+
+    export_packet_id = str(export_packet_map.get("current_orchestration_export_packet_id") or "")
+    export_packet_classification = str(export_packet_map.get("export_packet_classification") or "export_packet_minimal")
+    export_packet_maturity = str(export_packet_map.get("export_packet_maturity_posture") or "minimal")
+    export_packet_suitable = bool(export_packet_map.get("suitable_for_bounded_downstream_inspection"))
+    state_id = str((((export_packet_map.get("basis") or {}).get("basis_evidence") or {}).get("current_orchestration_state_id") or ""))
+    if not state_id:
+        state_id = str(((export_packet_map.get("basis") or {}).get("basis_evidence") or {}).get("current_supervisory_state_id") or "")
+
+    digest_classification = str(digest_map.get("digest_classification") or "minimal_current_picture")
+    coherence_classification = str(coherence_map.get("coherence_classification") or "insufficient_current_signal")
+    transition_classification = str(transition_map.get("transition_classification") or "transition_uncertain")
+    closure_classification = str(closure_map.get("closure_classification") or "no_current_closure_posture")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    handoff_classification = str(handoff_map.get("handoff_packet_brief_classification") or "no_current_packet_brief")
+    operator_loop_posture = str(operator_map.get("loop_posture") or "informational")
+    path_classification = str(path_map.get("resolution_path_classification") or "no_current_resolution_path")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    resumed_verdict = str(resumed_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+
+    contradiction_present = (
+        export_packet_classification == "export_packet_contradicted"
+        or digest_classification == "contradictory_current_picture"
+        or coherence_classification == "materially_contradictory"
+        or transition_classification == "transition_contradicted"
+    )
+    fragmentation_present = (
+        export_packet_classification == "export_packet_fragmented"
+        or pressure_classification == "fragmentation_pressure"
+        or handoff_classification == "packet_continuity_uncertain"
+        or path_classification == "fragmented_path"
+        or closure_classification == "closure_blocked_by_fragmentation"
+    )
+    caution_present = (
+        export_packet_classification == "export_packet_cautionary"
+        or export_packet_maturity == "cautionary"
+        or operator_loop_posture == "cautionary"
+        or resumed_verdict in {"hold_for_operator_review", "not_ready"}
+        or wake_classification in {"wake_ready_with_caution", "wake_blocked_pending_operator"}
+        or next_move_classification
+        in {"hold_for_operator_review_next", "rerun_packetization_gate_next", "rerun_packet_synthesis_next"}
+    )
+
+    non_default_neighboring_evidence = sum(
+        1
+        for value, default in (
+            (digest_classification, "minimal_current_picture"),
+            (coherence_classification, "insufficient_current_signal"),
+            (transition_classification, "transition_uncertain"),
+            (closure_classification, "no_current_closure_posture"),
+            (next_move_classification, "no_current_next_move"),
+            (handoff_classification, "no_current_packet_brief"),
+            (path_classification, "no_current_resolution_path"),
+            (pressure_classification, "insufficient_signal"),
+            (wake_classification, "not_wake_ready"),
+            (resumed_verdict, "not_ready"),
+        )
+        if value != default
+    )
+    linkage_present = bool(export_packet_id and isinstance(export_packet_map.get("basis"), Mapping))
+    linkage_sufficient = linkage_present and non_default_neighboring_evidence >= 2
+    no_receipt_needed = export_packet_classification == "export_packet_minimal" and non_default_neighboring_evidence <= 1
+
+    if contradiction_present:
+        receipt_classification = "receipt_contradicted"
+        picture_posture = "contradictory"
+        rationale = "current_export_packet_and_neighboring_surfaces_materially_disagree"
+    elif fragmentation_present:
+        receipt_classification = "receipt_fragmented"
+        picture_posture = "fragmented"
+        rationale = "current_export_picture_is_materially_fragmented_for_bounded_consumer_receipt"
+    elif no_receipt_needed:
+        receipt_classification = "no_current_receipt_needed"
+        picture_posture = "minimal"
+        rationale = "current_export_picture_is_sparse_enough_that_additional_receipt_is_not_meaningfully_needed"
+    elif export_packet_classification == "export_packet_minimal":
+        receipt_classification = "receipt_minimal"
+        picture_posture = "minimal"
+        rationale = "current_export_picture_is_sparse_but_still_boundedly_interpretable"
+    elif export_packet_classification == "export_packet_ready" and not caution_present and linkage_sufficient:
+        receipt_classification = "receipt_structurally_consumable"
+        picture_posture = "mature"
+        rationale = "current_export_packet_is_mature_linked_and_coherent_for_bounded_observational_consumption"
+    else:
+        receipt_classification = "receipt_consumable_with_caution"
+        picture_posture = "cautionary"
+        rationale = "current_export_packet_is_observationally_consumable_but_material_caution_signals_remain"
+
+    if receipt_classification not in _CURRENT_ORCHESTRATION_EXPORT_PACKET_CONSUMER_RECEIPT_CLASSIFICATIONS:
+        receipt_classification = "receipt_minimal"
+
+    consumable_observational_packet = receipt_classification in {
+        "receipt_structurally_consumable",
+        "receipt_consumable_with_caution",
+        "receipt_minimal",
+    }
+    export_receipt_id = _current_orchestration_export_packet_consumer_receipt_id(
+        current_orchestration_state_id=state_id,
+        current_orchestration_export_packet_id=export_packet_id,
+        receipt_classification=receipt_classification,
+    )
+    return {
+        "schema_version": "current_orchestration_export_packet_consumer_receipt.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_export_packet_consumer_receipt_id": export_receipt_id,
+        "receipt_classification": receipt_classification,
+        "consumable_as_bounded_observational_packet": consumable_observational_packet,
+        "received_picture_posture": picture_posture,
+        "linkage_to_underlying_current_surfaces_present": linkage_present,
+        "linkage_to_underlying_current_surfaces_sufficient": linkage_sufficient,
+        "observational_only_receipt": True,
+        "source_current_orchestration_export_packet_ref": {
+            "current_orchestration_export_packet_id": export_packet_id or None,
+            "export_packet_classification": export_packet_classification,
+            "export_packet_maturity_posture": export_packet_maturity,
+            "surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_export_packet",
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "export_packet_classification": export_packet_classification,
+                "export_packet_maturity_posture": export_packet_maturity,
+                "export_packet_suitable_for_bounded_downstream_inspection": export_packet_suitable,
+                "current_digest_classification": digest_classification,
+                "current_coherence_classification": coherence_classification,
+                "current_transition_classification": transition_classification,
+                "current_closure_classification": closure_classification,
+                "current_next_move_classification": next_move_classification,
+                "current_handoff_packet_brief_classification": handoff_classification,
+                "current_operator_loop_posture": operator_loop_posture,
+                "current_resolution_path_classification": path_classification,
+                "current_pressure_classification": pressure_classification,
+                "current_resumed_operation_readiness_verdict": resumed_verdict,
+                "current_wake_readiness_classification": wake_classification,
+                "neighboring_evidence_count": non_default_neighboring_evidence,
+            },
+            "compressed_surface_linkage": {
+                "current_orchestration_export_packet_surface": "resolve_current_orchestration_export_packet",
+                "current_orchestration_digest_surface": "resolve_current_orchestration_digest",
+                "current_orchestration_coherence_brief_surface": "resolve_current_orchestration_coherence_brief",
+                "current_orchestration_transition_brief_surface": "resolve_current_orchestration_transition_brief",
+                "current_orchestration_closure_brief_surface": "resolve_current_orchestration_closure_brief",
+                "current_orchestration_next_move_brief_surface": "resolve_current_orchestration_next_move_brief",
+                "current_orchestration_handoff_packet_brief_surface": "resolve_current_orchestration_handoff_packet_brief",
+                "current_operator_facing_orchestration_brief_surface": "resolve_current_operator_facing_orchestration_brief",
+                "current_orchestration_resolution_path_brief_surface": "resolve_current_orchestration_resolution_path_brief",
+                "current_orchestration_pressure_signal_surface": "resolve_current_orchestration_pressure_signal",
+                "current_resumed_operation_readiness_surface": "resolve_current_resumed_operation_readiness_verdict",
+                "current_orchestration_wake_readiness_detector_surface": "resolve_current_orchestration_wake_readiness_detector",
+            },
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_overstate_downstream_consumability": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "receipt_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_orchestration_export_packet_consumer_receipt_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/orchestration_intent_fabric_note.py
+++ b/sentientos/orchestration_intent_fabric_note.py
@@ -451,6 +451,30 @@ def orchestration_intent_fabric_note() -> dict[str, Any]:
                 "does not imply permission to execute",
             ],
         },
+        "current_orchestration_export_packet_consumer_receipt": {
+            "what_it_is": "a narrow observational-only consumer receipt that characterizes how a bounded downstream consumer would currently receive the current orchestration export packet under non-authoritative semantics",
+            "machine_surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_export_packet_consumer_receipt",
+            "classifications": [
+                "receipt_structurally_consumable",
+                "receipt_consumable_with_caution",
+                "receipt_fragmented",
+                "receipt_contradicted",
+                "receipt_minimal",
+                "no_current_receipt_needed",
+            ],
+            "derived_from_existing_surfaces_only": [
+                "current orchestration export packet",
+                "current orchestration digest + coherence brief + transition brief + closure brief",
+                "current orchestration next-move brief + handoff packet brief + operator-facing brief + resolution-path brief",
+                "current orchestration pressure signal + resumed readiness + wake-readiness detector",
+            ],
+            "strict_boundaries": [
+                "non-sovereign, non-authoritative, non-executing",
+                "receipt and consumability characterization only; not downstream action planning or execution",
+                "does not create a new truth source, mutable store, scheduler, or orchestration layer",
+                "does not imply permission to execute",
+            ],
+        },
         "unified_orchestration_result": {
             "what_it_is": "a bounded venue-aware resolver surface that normalizes internal execution closure and external fulfillment closure into one typed result shape",
             "machine_surface": "sentientos.orchestration_intent_fabric.resolve_unified_orchestration_result",

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -40,6 +40,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_coherence_brief,
     resolve_current_orchestration_digest,
     resolve_current_orchestration_export_packet,
+    resolve_current_orchestration_export_packet_consumer_receipt,
     resolve_current_orchestration_transition_brief,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
@@ -606,6 +607,23 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         current_orchestration_digest=current_orchestration_digest,
         current_orchestration_transition_brief=current_orchestration_transition_brief,
     )
+    current_orchestration_export_packet_consumer_receipt = (
+        resolve_current_orchestration_export_packet_consumer_receipt(
+            root,
+            current_orchestration_export_packet=current_orchestration_export_packet,
+            current_orchestration_digest=current_orchestration_digest,
+            current_orchestration_coherence_brief=current_orchestration_coherence_brief,
+            current_orchestration_transition_brief=current_orchestration_transition_brief,
+            current_orchestration_closure_brief=current_orchestration_closure_brief,
+            current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+            current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+            current_operator_facing_orchestration_brief=current_operator_facing_orchestration_brief,
+            current_orchestration_resolution_path_brief=current_orchestration_resolution_path_brief,
+            current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+            current_resumed_operation_readiness=current_resumed_operation_readiness,
+            current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        )
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -729,6 +747,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_digest": current_orchestration_digest,
             "current_orchestration_transition_brief": current_orchestration_transition_brief,
             "current_orchestration_export_packet": current_orchestration_export_packet,
+            "current_orchestration_export_packet_consumer_receipt": current_orchestration_export_packet_consumer_receipt,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "current_watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -835,6 +854,14 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                 "current_export_packet_suitable_for_bounded_downstream_inspection": current_orchestration_export_packet.get(
                     "suitable_for_bounded_downstream_inspection"
                 ),
+                "current_export_packet_consumer_receipt_classification": (
+                    current_orchestration_export_packet_consumer_receipt.get("receipt_classification")
+                ),
+                "current_export_packet_consumer_receipt_consumable_observationally": (
+                    current_orchestration_export_packet_consumer_receipt.get(
+                        "consumable_as_bounded_observational_packet"
+                    )
+                ),
                 "current_transition_classification": current_orchestration_transition_brief.get("transition_classification"),
                 "current_transition_posture": current_orchestration_transition_brief.get("transition_posture"),
                 "current_transition_resumed_bounded_motion": current_orchestration_transition_brief.get(
@@ -870,6 +897,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "current_orchestration_digest_only": True,
                     "current_orchestration_transition_brief_only": True,
                     "current_orchestration_export_packet_only": True,
+                    "current_orchestration_export_packet_consumer_receipt_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/tests/test_codex_orchestration.py
+++ b/tests/test_codex_orchestration.py
@@ -7,6 +7,7 @@ from codex.strategy import CodexStrategy, StrategyPlan, configure_strategy_root
 from integration_memory import configure_integration_root
 from sentientos import scoped_lifecycle_diagnostic
 from sentientos.orchestration_intent_fabric import (
+    resolve_current_orchestration_export_packet_consumer_receipt,
     resolve_current_orchestration_next_move_brief,
     resolve_current_re_evaluation_basis_brief,
 )
@@ -515,3 +516,138 @@ def test_current_orchestration_next_move_brief_is_derived_and_non_authoritative(
 def test_current_orchestration_next_move_brief_surface_is_in_scoped_lifecycle_diagnostic() -> None:
     source = inspect.getsource(scoped_lifecycle_diagnostic.build_scoped_lifecycle_diagnostic)
     assert "current_orchestration_next_move_brief" in source
+
+
+def _resolve_export_packet_consumer_receipt(
+    tmp_path: Path,
+    *,
+    export_packet_classification: str,
+    export_packet_maturity_posture: str,
+    export_packet_suitable: bool = True,
+    digest_classification: str = "mature_current_picture",
+    coherence_classification: str = "coherent_current_picture",
+    transition_classification: str = "poised_for_resumed_progress",
+    closure_classification: str = "closure_pending_on_internal_result",
+    next_move_classification: str = "continue_current_packet_next",
+    handoff_classification: str = "packet_ready_for_continuation",
+    operator_loop_posture: str = "informational",
+    path_classification: str = "path_following_current_watchpoint",
+    pressure_classification: str = "stable_or_low_pressure",
+    resumed_readiness_verdict: str = "ready_to_proceed",
+    wake_classification: str = "wake_ready",
+    include_basis: bool = True,
+) -> dict[str, object]:
+    export_packet: dict[str, object] = {
+        "current_orchestration_export_packet_id": "oep-test-1",
+        "export_packet_classification": export_packet_classification,
+        "export_packet_maturity_posture": export_packet_maturity_posture,
+        "suitable_for_bounded_downstream_inspection": export_packet_suitable,
+    }
+    if include_basis:
+        export_packet["basis"] = {"basis_evidence": {"current_orchestration_state_id": "state-1"}}
+    return resolve_current_orchestration_export_packet_consumer_receipt(
+        tmp_path,
+        current_orchestration_export_packet=export_packet,
+        current_orchestration_digest={"digest_classification": digest_classification},
+        current_orchestration_coherence_brief={"coherence_classification": coherence_classification},
+        current_orchestration_transition_brief={"transition_classification": transition_classification},
+        current_orchestration_closure_brief={"closure_classification": closure_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": handoff_classification},
+        current_operator_facing_orchestration_brief={"loop_posture": operator_loop_posture},
+        current_orchestration_resolution_path_brief={"resolution_path_classification": path_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": resumed_readiness_verdict},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+    )
+
+
+def test_current_orchestration_export_packet_consumer_receipt_classifications(tmp_path: Path) -> None:
+    structurally_consumable = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_ready",
+        export_packet_maturity_posture="mature",
+    )
+    assert structurally_consumable["receipt_classification"] == "receipt_structurally_consumable"
+
+    cautionary = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_cautionary",
+        export_packet_maturity_posture="cautionary",
+        operator_loop_posture="cautionary",
+        wake_classification="wake_ready_with_caution",
+        resumed_readiness_verdict="hold_for_operator_review",
+    )
+    assert cautionary["receipt_classification"] == "receipt_consumable_with_caution"
+
+    fragmented = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_fragmented",
+        export_packet_maturity_posture="fragmented",
+        pressure_classification="fragmentation_pressure",
+        handoff_classification="packet_continuity_uncertain",
+        path_classification="fragmented_path",
+    )
+    assert fragmented["receipt_classification"] == "receipt_fragmented"
+    assert fragmented["consumable_as_bounded_observational_packet"] is False
+
+    contradicted = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_contradicted",
+        export_packet_maturity_posture="contradicted",
+        digest_classification="contradictory_current_picture",
+        coherence_classification="materially_contradictory",
+        transition_classification="transition_contradicted",
+    )
+    assert contradicted["receipt_classification"] == "receipt_contradicted"
+    assert contradicted["consumable_as_bounded_observational_packet"] is False
+
+    minimal = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_minimal",
+        export_packet_maturity_posture="minimal",
+        digest_classification="mature_current_picture",
+        coherence_classification="coherent_current_picture",
+        transition_classification="poised_for_result_closure",
+    )
+    assert minimal["receipt_classification"] == "receipt_minimal"
+
+    no_receipt_needed = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_minimal",
+        export_packet_maturity_posture="minimal",
+        digest_classification="minimal_current_picture",
+        coherence_classification="insufficient_current_signal",
+        transition_classification="transition_uncertain",
+        closure_classification="no_current_closure_posture",
+        next_move_classification="no_current_next_move",
+        handoff_classification="no_current_packet_brief",
+        path_classification="no_current_resolution_path",
+        pressure_classification="insufficient_signal",
+        resumed_readiness_verdict="not_ready",
+        wake_classification="not_wake_ready",
+    )
+    assert no_receipt_needed["receipt_classification"] == "no_current_receipt_needed"
+    assert no_receipt_needed["consumable_as_bounded_observational_packet"] is False
+
+
+def test_current_orchestration_export_packet_consumer_receipt_is_derived_non_authoritative_and_linked(tmp_path: Path) -> None:
+    receipt = _resolve_export_packet_consumer_receipt(
+        tmp_path,
+        export_packet_classification="export_packet_ready",
+        export_packet_maturity_posture="mature",
+    )
+    assert receipt["source_current_orchestration_export_packet_ref"]["current_orchestration_export_packet_id"] == "oep-test-1"
+    assert receipt["linkage_to_underlying_current_surfaces_present"] is True
+    assert receipt["linkage_to_underlying_current_surfaces_sufficient"] is True
+    boundaries = receipt.get("boundaries", {})
+    assert boundaries.get("non_authoritative") is True
+    assert boundaries.get("non_executing") is True
+    assert boundaries.get("does_not_execute_or_route_work") is True
+    assert receipt.get("decision_power") == "none"
+    assert receipt.get("basis", {}).get("historical_honesty", {}).get("derived_from_existing_surfaces_only") is True
+
+
+def test_current_orchestration_export_packet_consumer_receipt_surface_is_in_scoped_lifecycle_diagnostic() -> None:
+    source = inspect.getsource(scoped_lifecycle_diagnostic.build_scoped_lifecycle_diagnostic)
+    assert "current_orchestration_export_packet_consumer_receipt" in source


### PR DESCRIPTION
### Motivation
- Provide a narrow, observational view that describes how a bounded downstream consumer would receive the current orchestration export packet without adding authority or execution semantics.
- Keep the surface strictly derived from existing current-orchestration surfaces and preserve non-sovereign, non-authoritative, and non-executing boundaries.

### Description
- Add `_CURRENT_ORCHESTRATION_EXPORT_PACKET_CONSUMER_RECEIPT_CLASSIFICATIONS` and `_current_orchestration_export_packet_consumer_receipt_id` plus the resolver `resolve_current_orchestration_export_packet_consumer_receipt` in `sentientos/orchestration_intent_fabric.py` to classify consumability with the compact vocabulary requested.
- The resolver is purely derived from existing surfaces (export packet, digest, coherence/transition/closure briefs, next-move/handoff/operator/resolution-path briefs, pressure/readiness/wake detectors) and emits linkage back to the source export packet and compressed surface linkage metadata.
- Surface the new receipt in `build_scoped_lifecycle_diagnostic` inside `sentientos/scoped_lifecycle_diagnostic.py`, including the full consumer-receipt payload and compact summary keys in the watchpoint summary map.
- Add an explanatory entry to `sentientos/orchestration_intent_fabric_note.py` and focused tests in `tests/test_codex_orchestration.py` that cover all receipt classifications, linkage, non-authoritative boundaries, and presence in the scoped diagnostic.

### Testing
- Ran the repository test harness for the orchestration test module with `python -m scripts.run_tests -q tests/test_codex_orchestration.py`, and the targeted orchestration test module completed successfully (all tests in that module passed).
- A direct `pytest tests/test_codex_orchestration.py -q` invocation is guarded by the repository test harness requirements (editable install check) and exited early for environment setup, so the canonical `scripts.run_tests` was used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9aab9164c8320ae020bb305bbbe6a)