### PR TITLE
[codex:orchestration] add current handoff acceptance posture resolver

### DIFF
--- a/docs/orchestration_next_move_proposal_note.md
+++ b/docs/orchestration_next_move_proposal_note.md
@@ -211,3 +211,31 @@ This differs from trust/readiness layers:
 It does **not** add authority, execution, planning, new goals, new venues, or workflow sovereignty.
 It remains explicit current-state visibility only (`non_authoritative`, `diagnostic_only`,
 `decision_power: none`, `does_not_execute_or_route_work`).
+
+## Current handoff acceptance posture (observational compression only)
+
+`current_orchestration_handoff_acceptance_posture.v1` is a narrow, derived resolver that summarizes
+the **current handoff acceptance posture** for the current orchestration export packet in light of the
+current export-packet consumer receipt.
+
+It is computed only from existing surfaces (no new truth source), including:
+
+- `current_orchestration_export_packet`
+- `current_orchestration_export_packet_consumer_receipt`
+- neighboring current surfaces (`digest`, `coherence`, `transition`, `closure`, `next_move`,
+  `handoff_packet_brief`, `operator_facing_brief`, `resolution_path_brief`, `pressure_signal`,
+  `resumed_operation_readiness`, `wake_readiness_detector`)
+
+Bounded posture classes:
+
+- `handoff_acceptance_clear`
+- `handoff_acceptance_cautionary`
+- `handoff_acceptance_fragmented`
+- `handoff_acceptance_contradicted`
+- `handoff_acceptance_minimal`
+- `no_current_handoff_acceptance_posture`
+
+This resolver is observational-only (`non_sovereign`, `non_authoritative`, `non_executing`,
+`diagnostic_only`, `decision_power: none`). It does not schedule, plan, execute, admit, route,
+or authorize downstream work; it only compresses current acceptance legibility with explicit linkage
+back to the export packet and consumer receipt surfaces.

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -480,6 +480,15 @@ _CURRENT_ORCHESTRATION_EXPORT_PACKET_CONSUMER_RECEIPT_CLASSIFICATIONS = {
     "no_current_receipt_needed",
 }
 
+_CURRENT_ORCHESTRATION_HANDOFF_ACCEPTANCE_POSTURE_CLASSIFICATIONS = {
+    "handoff_acceptance_clear",
+    "handoff_acceptance_cautionary",
+    "handoff_acceptance_fragmented",
+    "handoff_acceptance_contradicted",
+    "handoff_acceptance_minimal",
+    "no_current_handoff_acceptance_posture",
+}
+
 _CURRENT_ORCHESTRATION_SUPERVISORY_STATES = {
     "ready_to_packetize",
     "packet_ready_for_internal_trigger",
@@ -4825,6 +4834,30 @@ def _current_orchestration_export_packet_consumer_receipt_id(
         ).encode("utf-8")
     )
     return f"ocr-{digest.hexdigest()[:16]}"
+
+
+def _current_orchestration_handoff_acceptance_posture_id(
+    *,
+    current_orchestration_state_id: str,
+    current_orchestration_export_packet_id: str,
+    current_orchestration_export_packet_consumer_receipt_id: str,
+    handoff_acceptance_classification: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            {
+                "current_orchestration_state_id": current_orchestration_state_id,
+                "current_orchestration_export_packet_id": current_orchestration_export_packet_id,
+                "current_orchestration_export_packet_consumer_receipt_id": (
+                    current_orchestration_export_packet_consumer_receipt_id
+                ),
+                "handoff_acceptance_classification": handoff_acceptance_classification,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return f"ohp-{digest.hexdigest()[:16]}"
 
 
 def resolve_current_orchestration_state(
@@ -10071,6 +10104,275 @@ def resolve_current_orchestration_export_packet_consumer_receipt(
             does_not_change_admission_or_execution=True,
             additional_fields={
                 "current_orchestration_export_packet_consumer_receipt_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+
+
+def resolve_current_orchestration_handoff_acceptance_posture(
+    repo_root: Path,
+    *,
+    current_orchestration_export_packet: Mapping[str, Any] | None = None,
+    current_orchestration_export_packet_consumer_receipt: Mapping[str, Any] | None = None,
+    current_orchestration_digest: Mapping[str, Any] | None = None,
+    current_orchestration_coherence_brief: Mapping[str, Any] | None = None,
+    current_orchestration_transition_brief: Mapping[str, Any] | None = None,
+    current_orchestration_closure_brief: Mapping[str, Any] | None = None,
+    current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
+    current_orchestration_handoff_packet_brief: Mapping[str, Any] | None = None,
+    current_operator_facing_orchestration_brief: Mapping[str, Any] | None = None,
+    current_orchestration_resolution_path_brief: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, observational-only current handoff acceptance posture."""
+
+    _ = repo_root.resolve()
+    export_packet_map = (
+        current_orchestration_export_packet if isinstance(current_orchestration_export_packet, Mapping) else {}
+    )
+    receipt_map = (
+        current_orchestration_export_packet_consumer_receipt
+        if isinstance(current_orchestration_export_packet_consumer_receipt, Mapping)
+        else {}
+    )
+    digest_map = current_orchestration_digest if isinstance(current_orchestration_digest, Mapping) else {}
+    coherence_map = (
+        current_orchestration_coherence_brief if isinstance(current_orchestration_coherence_brief, Mapping) else {}
+    )
+    transition_map = (
+        current_orchestration_transition_brief if isinstance(current_orchestration_transition_brief, Mapping) else {}
+    )
+    closure_map = (
+        current_orchestration_closure_brief if isinstance(current_orchestration_closure_brief, Mapping) else {}
+    )
+    next_move_map = (
+        current_orchestration_next_move_brief if isinstance(current_orchestration_next_move_brief, Mapping) else {}
+    )
+    handoff_map = (
+        current_orchestration_handoff_packet_brief
+        if isinstance(current_orchestration_handoff_packet_brief, Mapping)
+        else {}
+    )
+    operator_map = (
+        current_operator_facing_orchestration_brief
+        if isinstance(current_operator_facing_orchestration_brief, Mapping)
+        else {}
+    )
+    path_map = (
+        current_orchestration_resolution_path_brief
+        if isinstance(current_orchestration_resolution_path_brief, Mapping)
+        else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    resumed_map = (
+        current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    )
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+
+    export_packet_id = str(export_packet_map.get("current_orchestration_export_packet_id") or "")
+    export_packet_classification = str(export_packet_map.get("export_packet_classification") or "export_packet_minimal")
+    export_packet_maturity = str(export_packet_map.get("export_packet_maturity_posture") or "minimal")
+    receipt_id = str(receipt_map.get("current_orchestration_export_packet_consumer_receipt_id") or "")
+    receipt_classification = str(receipt_map.get("receipt_classification") or "no_current_receipt_needed")
+    receipt_consumable = bool(receipt_map.get("consumable_as_bounded_observational_packet"))
+    receipt_linkage_present = bool(receipt_map.get("linkage_to_underlying_current_surfaces_present"))
+    receipt_linkage_sufficient = bool(receipt_map.get("linkage_to_underlying_current_surfaces_sufficient"))
+
+    digest_classification = str(digest_map.get("digest_classification") or "minimal_current_picture")
+    coherence_classification = str(coherence_map.get("coherence_classification") or "insufficient_current_signal")
+    transition_classification = str(transition_map.get("transition_classification") or "transition_uncertain")
+    closure_classification = str(closure_map.get("closure_classification") or "no_current_closure_posture")
+    next_move_classification = str(next_move_map.get("next_move_classification") or "no_current_next_move")
+    handoff_classification = str(handoff_map.get("handoff_packet_brief_classification") or "no_current_packet_brief")
+    operator_loop_posture = str(operator_map.get("loop_posture") or "informational")
+    path_classification = str(path_map.get("resolution_path_classification") or "no_current_resolution_path")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    resumed_verdict = str(resumed_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+
+    state_id = str(
+        ((((export_packet_map.get("basis") or {}).get("basis_evidence") or {}).get("current_orchestration_state_id")) or "")
+    )
+    if not state_id:
+        state_id = str(
+            ((((receipt_map.get("basis") or {}).get("basis_evidence") or {}).get("current_orchestration_state_id")) or "")
+        )
+
+    contradictory = (
+        export_packet_classification == "export_packet_contradicted"
+        or receipt_classification == "receipt_contradicted"
+        or digest_classification == "contradictory_current_picture"
+        or coherence_classification == "materially_contradictory"
+        or transition_classification == "transition_contradicted"
+    )
+    fragmented = (
+        export_packet_classification == "export_packet_fragmented"
+        or receipt_classification == "receipt_fragmented"
+        or handoff_classification == "packet_continuity_uncertain"
+        or path_classification == "fragmented_path"
+        or pressure_classification == "fragmentation_pressure"
+        or closure_classification == "closure_blocked_by_fragmentation"
+    )
+    cautionary = (
+        export_packet_classification == "export_packet_cautionary"
+        or receipt_classification == "receipt_consumable_with_caution"
+        or export_packet_maturity == "cautionary"
+        or operator_loop_posture == "cautionary"
+        or wake_classification in {"wake_ready_with_caution", "wake_blocked_pending_operator"}
+        or resumed_verdict in {"hold_for_operator_review", "not_ready"}
+        or next_move_classification in {"hold_for_operator_review_next", "rerun_packetization_gate_next"}
+    )
+    minimal = (
+        export_packet_classification == "export_packet_minimal"
+        or receipt_classification in {"receipt_minimal", "no_current_receipt_needed"}
+        or export_packet_maturity == "minimal"
+    )
+    no_current = (
+        export_packet_classification == "export_packet_minimal"
+        and receipt_classification == "no_current_receipt_needed"
+        and digest_classification == "minimal_current_picture"
+        and coherence_classification == "insufficient_current_signal"
+        and transition_classification == "transition_uncertain"
+        and closure_classification == "no_current_closure_posture"
+        and next_move_classification == "no_current_next_move"
+        and handoff_classification == "no_current_packet_brief"
+        and path_classification == "no_current_resolution_path"
+        and pressure_classification == "insufficient_signal"
+        and wake_classification == "not_wake_ready"
+        and resumed_verdict == "not_ready"
+    )
+
+    export_receipt_alignment_clean = (
+        export_packet_classification == "export_packet_ready"
+        and receipt_classification == "receipt_structurally_consumable"
+        and receipt_consumable
+        and not contradictory
+        and not fragmented
+        and not cautionary
+    )
+    linkage_present = bool(export_packet_id and receipt_id and receipt_linkage_present)
+    linkage_sufficient = bool(linkage_present and receipt_linkage_sufficient)
+
+    if contradictory:
+        classification = "handoff_acceptance_contradicted"
+        rationale = "current_export_packet_and_consumer_receipt_materially_disagree"
+    elif fragmented:
+        classification = "handoff_acceptance_fragmented"
+        rationale = "current_handoff_picture_is_materially_fragmented_for_acceptance_posture"
+    elif no_current:
+        classification = "no_current_handoff_acceptance_posture"
+        rationale = "current_surfaces_do_not_show_a_meaningful_active_handoff_acceptance_posture"
+    elif export_receipt_alignment_clean and linkage_sufficient:
+        classification = "handoff_acceptance_clear"
+        rationale = "current_export_packet_and_receipt_align_cleanly_for_bounded_observational_acceptance"
+    elif minimal:
+        classification = "handoff_acceptance_minimal"
+        rationale = "current_handoff_picture_is_sparse_but_still_boundedly_interpretable"
+    else:
+        classification = "handoff_acceptance_cautionary"
+        rationale = "current_handoff_picture_is_usable_but_material_caution_signals_remain"
+
+    if classification not in _CURRENT_ORCHESTRATION_HANDOFF_ACCEPTANCE_POSTURE_CLASSIFICATIONS:
+        classification = "no_current_handoff_acceptance_posture"
+
+    return {
+        "schema_version": "current_orchestration_handoff_acceptance_posture.v1",
+        "resolved_at": _iso_utc_now(),
+        "current_orchestration_handoff_acceptance_posture_id": _current_orchestration_handoff_acceptance_posture_id(
+            current_orchestration_state_id=state_id,
+            current_orchestration_export_packet_id=export_packet_id,
+            current_orchestration_export_packet_consumer_receipt_id=receipt_id,
+            handoff_acceptance_classification=classification,
+        ),
+        "handoff_acceptance_classification": classification,
+        "export_packet_and_consumer_receipt_align_cleanly": export_receipt_alignment_clean,
+        "bounded_downstream_acceptance_posture_supported": classification
+        in {"handoff_acceptance_clear", "handoff_acceptance_cautionary", "handoff_acceptance_minimal"},
+        "linkage_to_export_packet_and_consumer_receipt_present": linkage_present,
+        "linkage_to_export_packet_and_consumer_receipt_sufficient": linkage_sufficient,
+        "accepted_picture_posture": classification.removeprefix("handoff_acceptance_"),
+        "observational_only_posture": True,
+        "source_current_orchestration_export_packet_ref": {
+            "current_orchestration_export_packet_id": export_packet_id or None,
+            "export_packet_classification": export_packet_classification,
+            "surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_export_packet",
+        },
+        "source_current_orchestration_export_packet_consumer_receipt_ref": {
+            "current_orchestration_export_packet_consumer_receipt_id": receipt_id or None,
+            "receipt_classification": receipt_classification,
+            "surface": "sentientos.orchestration_intent_fabric.resolve_current_orchestration_export_packet_consumer_receipt",
+        },
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "export_packet_classification": export_packet_classification,
+                "export_packet_maturity_posture": export_packet_maturity,
+                "receipt_classification": receipt_classification,
+                "receipt_consumable_as_bounded_observational_packet": receipt_consumable,
+                "current_digest_classification": digest_classification,
+                "current_coherence_classification": coherence_classification,
+                "current_transition_classification": transition_classification,
+                "current_closure_classification": closure_classification,
+                "current_next_move_classification": next_move_classification,
+                "current_handoff_packet_brief_classification": handoff_classification,
+                "current_operator_loop_posture": operator_loop_posture,
+                "current_resolution_path_classification": path_classification,
+                "current_pressure_classification": pressure_classification,
+                "current_resumed_operation_readiness_verdict": resumed_verdict,
+                "current_wake_readiness_classification": wake_classification,
+            },
+            "compressed_surface_linkage": {
+                "current_orchestration_export_packet_surface": "resolve_current_orchestration_export_packet",
+                "current_orchestration_export_packet_consumer_receipt_surface": (
+                    "resolve_current_orchestration_export_packet_consumer_receipt"
+                ),
+                "current_orchestration_digest_surface": "resolve_current_orchestration_digest",
+                "current_orchestration_coherence_brief_surface": "resolve_current_orchestration_coherence_brief",
+                "current_orchestration_transition_brief_surface": "resolve_current_orchestration_transition_brief",
+                "current_orchestration_closure_brief_surface": "resolve_current_orchestration_closure_brief",
+                "current_orchestration_next_move_brief_surface": "resolve_current_orchestration_next_move_brief",
+                "current_orchestration_handoff_packet_brief_surface": "resolve_current_orchestration_handoff_packet_brief",
+                "current_operator_facing_orchestration_brief_surface": "resolve_current_operator_facing_orchestration_brief",
+                "current_orchestration_resolution_path_brief_surface": "resolve_current_orchestration_resolution_path_brief",
+                "current_orchestration_pressure_signal_surface": "resolve_current_orchestration_pressure_signal",
+                "current_resumed_operation_readiness_surface": "resolve_current_resumed_operation_readiness_verdict",
+                "current_orchestration_wake_readiness_detector_surface": "resolve_current_orchestration_wake_readiness_detector",
+            },
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_overstate_downstream_acceptance_confidence": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_create_new_orchestration_layer": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **_anti_sovereignty_payload(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "current_orchestration_handoff_acceptance_posture_only": True,
                 "non_executing": True,
                 "does_not_execute_or_route_work": True,
                 "does_not_create_new_authority_surface": True,

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -41,6 +41,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_digest,
     resolve_current_orchestration_export_packet,
     resolve_current_orchestration_export_packet_consumer_receipt,
+    resolve_current_orchestration_handoff_acceptance_posture,
     resolve_current_orchestration_transition_brief,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_watchpoint_brief,
@@ -624,6 +625,22 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
         )
     )
+    current_orchestration_handoff_acceptance_posture = resolve_current_orchestration_handoff_acceptance_posture(
+        root,
+        current_orchestration_export_packet=current_orchestration_export_packet,
+        current_orchestration_export_packet_consumer_receipt=current_orchestration_export_packet_consumer_receipt,
+        current_orchestration_digest=current_orchestration_digest,
+        current_orchestration_coherence_brief=current_orchestration_coherence_brief,
+        current_orchestration_transition_brief=current_orchestration_transition_brief,
+        current_orchestration_closure_brief=current_orchestration_closure_brief,
+        current_orchestration_next_move_brief=current_orchestration_next_move_brief,
+        current_orchestration_handoff_packet_brief=current_orchestration_handoff_packet_brief,
+        current_operator_facing_orchestration_brief=current_operator_facing_orchestration_brief,
+        current_orchestration_resolution_path_brief=current_orchestration_resolution_path_brief,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+    )
     delegated_operation_readiness = derive_delegated_operation_readiness_verdict(
         orchestration_trust_confidence_posture,
         proposal_packet_continuity_review,
@@ -748,6 +765,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "current_orchestration_transition_brief": current_orchestration_transition_brief,
             "current_orchestration_export_packet": current_orchestration_export_packet,
             "current_orchestration_export_packet_consumer_receipt": current_orchestration_export_packet_consumer_receipt,
+            "current_orchestration_handoff_acceptance_posture": current_orchestration_handoff_acceptance_posture,
             "current_orchestration_watchpoint_summary": {
                 "current_orchestration_state": current_orchestration_state.get("current_supervisory_state"),
                 "current_watchpoint_class": current_orchestration_watchpoint.get("watchpoint_class"),
@@ -862,6 +880,15 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                         "consumable_as_bounded_observational_packet"
                     )
                 ),
+                "current_handoff_acceptance_classification": current_orchestration_handoff_acceptance_posture.get(
+                    "handoff_acceptance_classification"
+                ),
+                "current_handoff_acceptance_align_cleanly": current_orchestration_handoff_acceptance_posture.get(
+                    "export_packet_and_consumer_receipt_align_cleanly"
+                ),
+                "current_handoff_acceptance_posture_supported": current_orchestration_handoff_acceptance_posture.get(
+                    "bounded_downstream_acceptance_posture_supported"
+                ),
                 "current_transition_classification": current_orchestration_transition_brief.get("transition_classification"),
                 "current_transition_posture": current_orchestration_transition_brief.get("transition_posture"),
                 "current_transition_resumed_bounded_motion": current_orchestration_transition_brief.get(
@@ -898,6 +925,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
                     "current_orchestration_transition_brief_only": True,
                     "current_orchestration_export_packet_only": True,
                     "current_orchestration_export_packet_consumer_receipt_only": True,
+                    "current_orchestration_handoff_acceptance_posture_only": True,
                     "does_not_execute_or_route_work": True,
                 },
             },

--- a/tests/test_codex_orchestration.py
+++ b/tests/test_codex_orchestration.py
@@ -7,6 +7,7 @@ from codex.strategy import CodexStrategy, StrategyPlan, configure_strategy_root
 from integration_memory import configure_integration_root
 from sentientos import scoped_lifecycle_diagnostic
 from sentientos.orchestration_intent_fabric import (
+    resolve_current_orchestration_handoff_acceptance_posture,
     resolve_current_orchestration_export_packet_consumer_receipt,
     resolve_current_orchestration_next_move_brief,
     resolve_current_re_evaluation_basis_brief,
@@ -651,3 +652,146 @@ def test_current_orchestration_export_packet_consumer_receipt_is_derived_non_aut
 def test_current_orchestration_export_packet_consumer_receipt_surface_is_in_scoped_lifecycle_diagnostic() -> None:
     source = inspect.getsource(scoped_lifecycle_diagnostic.build_scoped_lifecycle_diagnostic)
     assert "current_orchestration_export_packet_consumer_receipt" in source
+
+
+def _resolve_handoff_acceptance_posture(
+    tmp_path: Path,
+    *,
+    export_packet_classification: str,
+    receipt_classification: str,
+    export_packet_maturity_posture: str = "mature",
+    receipt_consumable: bool = True,
+    digest_classification: str = "mature_current_picture",
+    coherence_classification: str = "coherent_current_picture",
+    transition_classification: str = "poised_for_resumed_progress",
+    closure_classification: str = "closure_pending_on_internal_result",
+    next_move_classification: str = "continue_current_packet_next",
+    handoff_classification: str = "packet_ready_for_continuation",
+    operator_loop_posture: str = "informational",
+    path_classification: str = "path_following_current_watchpoint",
+    pressure_classification: str = "stable_or_low_pressure",
+    resumed_readiness_verdict: str = "ready_to_proceed",
+    wake_classification: str = "wake_ready",
+    linkage_present: bool = True,
+    linkage_sufficient: bool = True,
+) -> dict[str, object]:
+    return resolve_current_orchestration_handoff_acceptance_posture(
+        tmp_path,
+        current_orchestration_export_packet={
+            "current_orchestration_export_packet_id": "oep-test-1",
+            "export_packet_classification": export_packet_classification,
+            "export_packet_maturity_posture": export_packet_maturity_posture,
+            "basis": {"basis_evidence": {"current_orchestration_state_id": "state-1"}},
+        },
+        current_orchestration_export_packet_consumer_receipt={
+            "current_orchestration_export_packet_consumer_receipt_id": "ocr-test-1",
+            "receipt_classification": receipt_classification,
+            "consumable_as_bounded_observational_packet": receipt_consumable,
+            "linkage_to_underlying_current_surfaces_present": linkage_present,
+            "linkage_to_underlying_current_surfaces_sufficient": linkage_sufficient,
+        },
+        current_orchestration_digest={"digest_classification": digest_classification},
+        current_orchestration_coherence_brief={"coherence_classification": coherence_classification},
+        current_orchestration_transition_brief={"transition_classification": transition_classification},
+        current_orchestration_closure_brief={"closure_classification": closure_classification},
+        current_orchestration_next_move_brief={"next_move_classification": next_move_classification},
+        current_orchestration_handoff_packet_brief={"handoff_packet_brief_classification": handoff_classification},
+        current_operator_facing_orchestration_brief={"loop_posture": operator_loop_posture},
+        current_orchestration_resolution_path_brief={"resolution_path_classification": path_classification},
+        current_orchestration_pressure_signal={"pressure_classification": pressure_classification},
+        current_resumed_operation_readiness={"resumed_operation_readiness_verdict": resumed_readiness_verdict},
+        current_orchestration_wake_readiness_detector={"wake_readiness_classification": wake_classification},
+    )
+
+
+def test_current_orchestration_handoff_acceptance_posture_classifications(tmp_path: Path) -> None:
+    clear = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_ready",
+        receipt_classification="receipt_structurally_consumable",
+    )
+    assert clear["handoff_acceptance_classification"] == "handoff_acceptance_clear"
+
+    cautionary = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_cautionary",
+        receipt_classification="receipt_consumable_with_caution",
+        operator_loop_posture="cautionary",
+        wake_classification="wake_ready_with_caution",
+    )
+    assert cautionary["handoff_acceptance_classification"] == "handoff_acceptance_cautionary"
+
+    fragmented = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_fragmented",
+        receipt_classification="receipt_fragmented",
+        handoff_classification="packet_continuity_uncertain",
+        path_classification="fragmented_path",
+        pressure_classification="fragmentation_pressure",
+    )
+    assert fragmented["handoff_acceptance_classification"] == "handoff_acceptance_fragmented"
+
+    contradicted = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_contradicted",
+        receipt_classification="receipt_contradicted",
+        digest_classification="contradictory_current_picture",
+        coherence_classification="materially_contradictory",
+        transition_classification="transition_contradicted",
+    )
+    assert contradicted["handoff_acceptance_classification"] == "handoff_acceptance_contradicted"
+
+    minimal = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_minimal",
+        receipt_classification="receipt_minimal",
+        export_packet_maturity_posture="minimal",
+    )
+    assert minimal["handoff_acceptance_classification"] == "handoff_acceptance_minimal"
+
+    no_current = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_minimal",
+        receipt_classification="no_current_receipt_needed",
+        export_packet_maturity_posture="minimal",
+        receipt_consumable=False,
+        digest_classification="minimal_current_picture",
+        coherence_classification="insufficient_current_signal",
+        transition_classification="transition_uncertain",
+        closure_classification="no_current_closure_posture",
+        next_move_classification="no_current_next_move",
+        handoff_classification="no_current_packet_brief",
+        path_classification="no_current_resolution_path",
+        pressure_classification="insufficient_signal",
+        resumed_readiness_verdict="not_ready",
+        wake_classification="not_wake_ready",
+    )
+    assert no_current["handoff_acceptance_classification"] == "no_current_handoff_acceptance_posture"
+
+
+def test_current_orchestration_handoff_acceptance_posture_is_derived_non_authoritative_and_linked(tmp_path: Path) -> None:
+    posture = _resolve_handoff_acceptance_posture(
+        tmp_path,
+        export_packet_classification="export_packet_ready",
+        receipt_classification="receipt_structurally_consumable",
+    )
+    assert posture["source_current_orchestration_export_packet_ref"]["current_orchestration_export_packet_id"] == "oep-test-1"
+    assert (
+        posture["source_current_orchestration_export_packet_consumer_receipt_ref"][
+            "current_orchestration_export_packet_consumer_receipt_id"
+        ]
+        == "ocr-test-1"
+    )
+    assert posture["linkage_to_export_packet_and_consumer_receipt_present"] is True
+    assert posture["linkage_to_export_packet_and_consumer_receipt_sufficient"] is True
+    boundaries = posture.get("boundaries", {})
+    assert boundaries.get("non_authoritative") is True
+    assert boundaries.get("non_executing") is True
+    assert boundaries.get("does_not_execute_or_route_work") is True
+    assert posture.get("decision_power") == "none"
+    assert posture.get("basis", {}).get("historical_honesty", {}).get("derived_from_existing_surfaces_only") is True
+
+
+def test_current_orchestration_handoff_acceptance_posture_surface_is_in_scoped_lifecycle_diagnostic() -> None:
+    source = inspect.getsource(scoped_lifecycle_diagnostic.build_scoped_lifecycle_diagnostic)
+    assert "current_orchestration_handoff_acceptance_posture" in source


### PR DESCRIPTION
### Motivation
- Provide a narrow, observational-only summary of whether the current orchestration export packet and its consumer receipt align sufficiently for bounded downstream acceptance.
- Keep the new surface strictly derived from existing current-orchestration signals (export packet, consumer receipt, digest, coherence, transition, closure, next-move, handoff brief, operator brief, resolution path, pressure, resumed-readiness, wake detector) with explicit non-sovereign boundaries.
- Make handoff acceptance legible to diagnostics without adding authority, execution, scheduling, or new truth stores.

### Description
- Added a compact resolver `resolve_current_orchestration_handoff_acceptance_posture` in `sentientos/orchestration_intent_fabric.py` that classifies the present acceptance state into: `handoff_acceptance_clear`, `handoff_acceptance_cautionary`, `handoff_acceptance_fragmented`, `handoff_acceptance_contradicted`, `handoff_acceptance_minimal`, or `no_current_handoff_acceptance_posture` and emits compact basis evidence and explicit linkage back to the export packet and consumer receipt.
- Introduced `_current_orchestration_handoff_acceptance_posture_id` and a classification set `_CURRENT_ORCHESTRATION_HANDOFF_ACCEPTANCE_POSTURE_CLASSIFICATIONS` to match existing idempotent id patterns and normalization conventions. 
- Surfaced the posture in `build_scoped_lifecycle_diagnostic` via `sentientos/scoped_lifecycle_diagnostic.py` so it appears alongside neighboring orchestration surfaces and summary fields and preserved the same diagnostic-only/non-authoritative boundaries. 
- Updated documentation `docs/orchestration_next_move_proposal_note.md` with a short section describing the new observational posture and added focused tests in `tests/test_codex_orchestration.py` exercising clear, cautionary, fragmented, contradicted, minimal, and no-current cases plus linkage and non-authoritative invariants.

### Testing
- Ran `pytest -q tests/test_codex_orchestration.py` which initially aborted in the test harness due to the environment requiring an editable install; this is an environment-level check and not a code failure. 
- Executed the repository test harness with `python -m scripts.run_tests -q tests/test_codex_orchestration.py` and the orchestration test module passed (all tests in that file succeeded). 
- Tests added: focused unit scenarios in `tests/test_codex_orchestration.py` validating each posture classification, linkage back to export packet and receipt, and that the posture is derived-only and non-executing.

Files changed:
- `sentientos/orchestration_intent_fabric.py` (resolver, id helper, classification set)
- `sentientos/scoped_lifecycle_diagnostic.py` (diagnostic surface wiring and summary fields)
- `tests/test_codex_orchestration.py` (new posture tests and helper)
- `docs/orchestration_next_move_proposal_note.md` (brief documentation of the posture)

Resolver added:
- `resolve_current_orchestration_handoff_acceptance_posture` (observational-only, derived from existing surfaces)

Diagnostic surface added:
- `current_orchestration_handoff_acceptance_posture` (surfaced in the scoped lifecycle diagnostic)

Tests added:
- Focused tests for clear / cautionary / fragmented / contradicted / minimal / no-current classifications and for linkage and non-authoritative invariants in `tests/test_codex_orchestration.py`.

Validation:
- `python -m scripts.run_tests -q tests/test_codex_orchestration.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea3c5083b48320809d3a149d66ed40)