### PR TITLE
[codex:orchestration] extract bounded projection policy from intent fabric

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping
 import task_admission
 import task_executor
 from sentientos import orchestration_internal_adapters
+from sentientos import orchestration_projection_policy
 
 _INTENT_KINDS = {
     "internal_maintenance_execution",
@@ -2402,55 +2403,15 @@ def derive_orchestration_attention_recommendation(
     outcome_review: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Derive bounded operator-attention recommendation from orchestration outcome review only."""
-
-    review_classification = str(outcome_review.get("review_classification") or "insufficient_history")
-    records_considered = int(outcome_review.get("records_considered") or 0)
-    condition_flags_raw = outcome_review.get("condition_flags")
-    condition_flags = condition_flags_raw if isinstance(condition_flags_raw, Mapping) else {}
-    blocked_heavy = bool(condition_flags.get("blocked_heavy"))
-    failure_heavy = bool(condition_flags.get("failure_heavy"))
-    stall_heavy = bool(condition_flags.get("stall_heavy"))
-    recent_counts_raw = outcome_review.get("recent_outcome_counts")
-    recent_outcome_counts = recent_counts_raw if isinstance(recent_counts_raw, Mapping) else {}
-    handoff_not_admitted = int(recent_outcome_counts.get("handoff_not_admitted") or 0)
-    light_block_pattern = handoff_not_admitted >= 1 and not blocked_heavy
-
-    recommendation = "insufficient_context"
-    rationale = "insufficient_orchestration_history_for_confident_attention_guidance"
-
-    if review_classification == "clean_recent_orchestration":
-        recommendation = "none"
-        rationale = "recent_internal_orchestration_outcomes_are_clean_and_loop_closure_is_healthy"
-    elif review_classification == "handoff_block_heavy" or blocked_heavy:
-        recommendation = "inspect_handoff_blocks"
-        rationale = "recent_history_shows_block_heavy_internal_handoff_behavior"
-    elif review_classification == "execution_failure_heavy" or failure_heavy:
-        recommendation = "inspect_execution_failures"
-        rationale = "recent_history_shows_execution_failure_heavy_pattern_after_admission"
-    elif review_classification == "pending_stall_pattern" or stall_heavy:
-        recommendation = "inspect_pending_stall"
-        rationale = "recent_history_shows_pending_or_missing_result_stall_pattern"
-    elif review_classification == "mixed_orchestration_stress":
-        recommendation = "review_mixed_orchestration_stress"
-        rationale = "recent_history_shows_mixed_orchestration_stress_needing_human_interpretation"
-    elif review_classification == "insufficient_history":
-        recommendation = "insufficient_context"
-        rationale = "insufficient_recent_orchestration_history_for_specific_attention_recommendation"
-    elif light_block_pattern and records_considered >= 3 and review_classification not in {"clean_recent_orchestration"}:
-        recommendation = "observe"
-        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
-
-    if (
-        light_block_pattern
-        and review_classification == "mixed_orchestration_stress"
-        and recommendation == "review_mixed_orchestration_stress"
-    ):
-        recommendation = "observe"
-        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
-
-    if recommendation not in _ORCHESTRATION_ATTENTION_RECOMMENDATIONS:
-        recommendation = "insufficient_context"
-        rationale = "unrecognized_review_pattern_defaulted_to_insufficient_context"
+    projection = orchestration_projection_policy.derive_attention_projection(
+        outcome_review,
+        allowed_recommendations=_ORCHESTRATION_ATTENTION_RECOMMENDATIONS,
+    )
+    review_classification = str(projection.get("review_classification") or "insufficient_history")
+    recommendation = str(projection.get("operator_attention_recommendation") or "insufficient_context")
+    records_considered = int(projection.get("records_considered") or 0)
+    basis = projection.get("basis")
+    basis_map = basis if isinstance(basis, Mapping) else {}
 
     return {
         "schema_version": "orchestration_attention_recommendation.v1",
@@ -2463,21 +2424,9 @@ def derive_orchestration_attention_recommendation(
         "operator_attention_recommendation": recommendation,
         "basis": {
             "records_considered": records_considered,
-            "condition_flags": {
-                "blocked_heavy": blocked_heavy,
-                "failure_heavy": failure_heavy,
-                "stall_heavy": stall_heavy,
-                "light_block_pattern": light_block_pattern,
-            },
-            "recent_outcome_counts": {
-                "execution_succeeded": int(recent_outcome_counts.get("execution_succeeded") or 0),
-                "execution_failed": int(recent_outcome_counts.get("execution_failed") or 0),
-                "handoff_admitted_pending_result": int(recent_outcome_counts.get("handoff_admitted_pending_result") or 0),
-                "execution_still_pending": int(recent_outcome_counts.get("execution_still_pending") or 0),
-                "execution_result_missing": int(recent_outcome_counts.get("execution_result_missing") or 0),
-                "handoff_not_admitted": handoff_not_admitted,
-            },
-            "rationale": rationale,
+            "condition_flags": dict(basis_map.get("condition_flags") or {}),
+            "recent_outcome_counts": dict(basis_map.get("recent_outcome_counts") or {}),
+            "rationale": str(basis_map.get("rationale") or ""),
             "derived_from_existing_signals_only": [
                 "orchestration_outcome_review.review_classification",
                 "orchestration_outcome_review.condition_flags",
@@ -2499,159 +2448,33 @@ def derive_next_venue_recommendation(
     attention_recommendation: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Derive a bounded next-venue recommendation from existing orchestration signals only."""
-
-    delegated_venue = str(delegated_judgment.get("recommended_venue") or "insufficient_context")
-    escalation_classification = str(delegated_judgment.get("escalation_classification") or "")
-    outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
-    venue_mix_classification = str(venue_mix_review.get("review_classification") or "insufficient_history")
-    attention_signal = str(attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
-    outcome_records = int(outcome_review.get("records_considered") or 0)
-    venue_mix_records = int(venue_mix_review.get("records_considered") or 0)
-    blocked_heavy = bool((outcome_review.get("condition_flags") or {}).get("blocked_heavy"))
-    failure_heavy = bool((outcome_review.get("condition_flags") or {}).get("failure_heavy"))
-    stall_heavy = bool((outcome_review.get("condition_flags") or {}).get("stall_heavy"))
-    operator_heavy = venue_mix_classification == "operator_escalation_heavy"
-    external_contribution = venue_mix_review.get("external_fulfillment_contribution")
-    external_contribution_map = external_contribution if isinstance(external_contribution, Mapping) else {}
-    by_venue = external_contribution_map.get("by_venue")
-    by_venue_map = by_venue if isinstance(by_venue, Mapping) else {}
-
-    def _venue_external_health(venue: str) -> dict[str, int]:
-        venue_map = by_venue_map.get(venue)
-        venue_metrics = venue_map if isinstance(venue_map, Mapping) else {}
-        return {
-            "healthy": int(venue_metrics.get("healthy") or 0),
-            "stressed": int(venue_metrics.get("stressed") or 0),
-            "blocked_or_unusable": int(venue_metrics.get("blocked_or_unusable") or 0),
-            "fulfilled_externally": int(venue_metrics.get("fulfilled_externally") or 0),
-            "fulfilled_externally_with_issues": int(venue_metrics.get("fulfilled_externally_with_issues") or 0),
-            "externally_declined": int(venue_metrics.get("externally_declined") or 0),
-            "externally_abandoned": int(venue_metrics.get("externally_abandoned") or 0),
-            "externally_result_unusable": int(venue_metrics.get("externally_result_unusable") or 0),
-        }
-
-    codex_external = _venue_external_health("codex_implementation")
-    deep_external = _venue_external_health("deep_research_audit")
-    delegated_external = _venue_external_health(delegated_venue) if delegated_venue in {
-        "codex_implementation",
-        "deep_research_audit",
-    } else _venue_external_health("")
-    delegated_external_total = delegated_external["healthy"] + delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
-    delegated_external_healthy_strong = delegated_external["healthy"] >= 2 and (
-        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
-    ) == 0
-    delegated_external_stressed = delegated_external_total >= 2 and (
-        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
-    ) >= delegated_external["healthy"]
-    external_signal_present = bool(external_contribution_map.get("signal_present"))
-    alternative_external_healthy = (
-        deep_external["healthy"] >= 2 and (deep_external["stressed"] + deep_external["blocked_or_unusable"]) == 0
-        if delegated_venue == "codex_implementation"
-        else (
-            codex_external["healthy"] >= 2 and (codex_external["stressed"] + codex_external["blocked_or_unusable"]) == 0
-            if delegated_venue == "deep_research_audit"
-            else False
-        )
+    projection = orchestration_projection_policy.derive_next_venue_projection(
+        delegated_judgment,
+        outcome_review,
+        venue_mix_review,
+        attention_recommendation,
+        allowed_recommendations=_NEXT_VENUE_RECOMMENDATIONS,
+        allowed_relations=_NEXT_VENUE_RELATIONS,
     )
-
-    delegated_to_next = {
-        "internal_direct_execution": "prefer_internal_execution",
-        "codex_implementation": "prefer_codex_implementation",
-        "deep_research_audit": "prefer_deep_research_audit",
-        "operator_decision_required": "prefer_operator_decision",
-    }
-    delegated_next = delegated_to_next.get(delegated_venue)
-
-    recommendation = "insufficient_context"
-    relation = "insufficient_context"
-    rationale = "insufficient_or_conflicting_recent_signal_basis_for_next_venue"
-
-    operator_escalation_dominant = (
-        delegated_venue == "operator_decision_required"
-        or escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
-        or operator_heavy
-        or (
-            attention_signal in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall"}
-            and (blocked_heavy or failure_heavy or stall_heavy)
-        )
-    )
-    has_minimum_history = outcome_records >= 3 and venue_mix_records >= 3
-    stress_signals_present = (
-        outcome_classification in {
-            "handoff_block_heavy",
-            "execution_failure_heavy",
-            "pending_stall_pattern",
-            "mixed_orchestration_stress",
-        }
-        or venue_mix_classification == "mixed_venue_stress"
-    )
-    external_feedback_affirming = delegated_external_healthy_strong
-    external_feedback_stressed = delegated_external_stressed
-
-    if operator_escalation_dominant:
-        recommendation = "prefer_operator_decision"
-        relation = "escalating"
-        rationale = "operator_required_or_escalation_signals_dominate_recent_orchestration_pattern"
-    elif not has_minimum_history or delegated_next is None:
-        recommendation = "insufficient_context"
-        relation = "insufficient_context"
-        rationale = "insufficient_recent_orchestration_history_or_delegated_judgment_venue_unavailable"
-    elif (
-        delegated_venue in {"internal_direct_execution", "codex_implementation"}
-        and venue_mix_classification in {"mixed_venue_stress", "deep_research_heavy"}
-        and outcome_classification in {"mixed_orchestration_stress", "execution_failure_heavy"}
-    ):
-        recommendation = "prefer_deep_research_audit"
-        relation = "nudging"
-        rationale = "recent_stress_or_architectural_ambiguity_pattern_nudges_toward_deep_research_audit"
-    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed and alternative_external_healthy:
-        recommendation = "prefer_deep_research_audit" if delegated_venue == "codex_implementation" else "prefer_codex_implementation"
-        relation = "nudging"
-        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_while_alternative_external_venue_is_recently_healthy"
-    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed:
-        recommendation = "hold_current_venue_mix"
-        relation = "holding"
-        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_without_a_clear_healthy_external_alternative"
-    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_affirming:
-        recommendation = delegated_next if delegated_next is not None else "insufficient_context"
-        relation = "affirming"
-        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_healthy_and_supports_affirmation"
-    elif delegated_venue == "internal_direct_execution" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
-        "balanced_recent_venue_mix",
-        "internal_execution_heavy",
-    }:
-        recommendation = "prefer_internal_execution"
-        relation = "affirming"
-        rationale = "clean_recent_internal_outcomes_and_compatible_venue_mix_affirm_internal_execution"
-    elif delegated_venue == "codex_implementation" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
-        "balanced_recent_venue_mix",
-        "codex_heavy",
-    }:
-        recommendation = "prefer_codex_implementation"
-        relation = "affirming"
-        rationale = "clean_recent_outcomes_and_compatible_codex_usage_affirm_codex_implementation"
-    elif delegated_venue == "deep_research_audit" and venue_mix_classification in {
-        "balanced_recent_venue_mix",
-        "deep_research_heavy",
-    } and outcome_classification in {"clean_recent_orchestration", "mixed_orchestration_stress", "execution_failure_heavy"}:
-        recommendation = "prefer_deep_research_audit"
-        relation = "affirming"
-        rationale = "delegated_judgment_and_recent_venue_patterns_support_deep_research_audit"
-    elif stress_signals_present:
-        recommendation = "hold_current_venue_mix"
-        relation = "holding"
-        rationale = "recent_venue_behavior_is_stressed_or_unstable_without_clear_safe_correction_target"
-    elif delegated_next is not None:
-        recommendation = delegated_next
-        relation = "affirming"
-        rationale = "delegated_judgment_is_compatible_with_recent_orchestration_signals"
-
-    if recommendation not in _NEXT_VENUE_RECOMMENDATIONS:
-        recommendation = "insufficient_context"
-        relation = "insufficient_context"
-        rationale = "unrecognized_next_venue_recommendation_defaulted_to_insufficient_context"
-    if relation not in _NEXT_VENUE_RELATIONS:
-        relation = "insufficient_context"
+    delegated_venue = str(projection.get("delegated_venue") or "insufficient_context")
+    escalation_classification = str(projection.get("escalation_classification") or "")
+    recommendation = str(projection.get("next_venue_recommendation") or "insufficient_context")
+    relation = str(projection.get("relation_to_delegated_judgment") or "insufficient_context")
+    attention_signal = str(projection.get("attention_signal") or "insufficient_context")
+    outcome_classification = str(projection.get("outcome_classification") or "insufficient_history")
+    venue_mix_classification = str(projection.get("venue_mix_classification") or "insufficient_history")
+    outcome_records = int(projection.get("outcome_records") or 0)
+    venue_mix_records = int(projection.get("venue_mix_records") or 0)
+    blocked_heavy = bool(projection.get("blocked_heavy"))
+    failure_heavy = bool(projection.get("failure_heavy"))
+    stall_heavy = bool(projection.get("stall_heavy"))
+    external_signal_present = bool(projection.get("external_signal_present"))
+    delegated_external = dict(projection.get("delegated_external") or {})
+    codex_external = dict(projection.get("codex_external") or {})
+    deep_external = dict(projection.get("deep_external") or {})
+    external_feedback_affirming = bool(projection.get("external_feedback_affirming"))
+    external_feedback_stressed = bool(projection.get("external_feedback_stressed"))
+    rationale = str(projection.get("rationale") or "")
 
     return {
         "schema_version": "next_venue_recommendation.v1",

--- a/sentientos/orchestration_projection_policy.py
+++ b/sentientos/orchestration_projection_policy.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def derive_attention_projection(
+    outcome_review: Mapping[str, Any],
+    *,
+    allowed_recommendations: set[str],
+) -> dict[str, Any]:
+    """Derive bounded operator-attention projection from outcome review state."""
+
+    review_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    records_considered = int(outcome_review.get("records_considered") or 0)
+    condition_flags_raw = outcome_review.get("condition_flags")
+    condition_flags = condition_flags_raw if isinstance(condition_flags_raw, Mapping) else {}
+    blocked_heavy = bool(condition_flags.get("blocked_heavy"))
+    failure_heavy = bool(condition_flags.get("failure_heavy"))
+    stall_heavy = bool(condition_flags.get("stall_heavy"))
+    recent_counts_raw = outcome_review.get("recent_outcome_counts")
+    recent_outcome_counts = recent_counts_raw if isinstance(recent_counts_raw, Mapping) else {}
+    handoff_not_admitted = int(recent_outcome_counts.get("handoff_not_admitted") or 0)
+    light_block_pattern = handoff_not_admitted >= 1 and not blocked_heavy
+
+    recommendation = "insufficient_context"
+    rationale = "insufficient_orchestration_history_for_confident_attention_guidance"
+
+    if review_classification == "clean_recent_orchestration":
+        recommendation = "none"
+        rationale = "recent_internal_orchestration_outcomes_are_clean_and_loop_closure_is_healthy"
+    elif review_classification == "handoff_block_heavy" or blocked_heavy:
+        recommendation = "inspect_handoff_blocks"
+        rationale = "recent_history_shows_block_heavy_internal_handoff_behavior"
+    elif review_classification == "execution_failure_heavy" or failure_heavy:
+        recommendation = "inspect_execution_failures"
+        rationale = "recent_history_shows_execution_failure_heavy_pattern_after_admission"
+    elif review_classification == "pending_stall_pattern" or stall_heavy:
+        recommendation = "inspect_pending_stall"
+        rationale = "recent_history_shows_pending_or_missing_result_stall_pattern"
+    elif review_classification == "mixed_orchestration_stress":
+        recommendation = "review_mixed_orchestration_stress"
+        rationale = "recent_history_shows_mixed_orchestration_stress_needing_human_interpretation"
+    elif review_classification == "insufficient_history":
+        recommendation = "insufficient_context"
+        rationale = "insufficient_recent_orchestration_history_for_specific_attention_recommendation"
+    elif light_block_pattern and records_considered >= 3 and review_classification not in {"clean_recent_orchestration"}:
+        recommendation = "observe"
+        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
+
+    if (
+        light_block_pattern
+        and review_classification == "mixed_orchestration_stress"
+        and recommendation == "review_mixed_orchestration_stress"
+    ):
+        recommendation = "observe"
+        rationale = "light_non_failure_handoff_block_pattern_detected_observe_before_deeper_intervention"
+
+    if recommendation not in allowed_recommendations:
+        recommendation = "insufficient_context"
+        rationale = "unrecognized_review_pattern_defaulted_to_insufficient_context"
+
+    return {
+        "review_classification": review_classification,
+        "records_considered": records_considered,
+        "operator_attention_recommendation": recommendation,
+        "basis": {
+            "condition_flags": {
+                "blocked_heavy": blocked_heavy,
+                "failure_heavy": failure_heavy,
+                "stall_heavy": stall_heavy,
+                "light_block_pattern": light_block_pattern,
+            },
+            "recent_outcome_counts": {
+                "execution_succeeded": int(recent_outcome_counts.get("execution_succeeded") or 0),
+                "execution_failed": int(recent_outcome_counts.get("execution_failed") or 0),
+                "handoff_admitted_pending_result": int(recent_outcome_counts.get("handoff_admitted_pending_result") or 0),
+                "execution_still_pending": int(recent_outcome_counts.get("execution_still_pending") or 0),
+                "execution_result_missing": int(recent_outcome_counts.get("execution_result_missing") or 0),
+                "handoff_not_admitted": handoff_not_admitted,
+            },
+            "rationale": rationale,
+        },
+    }
+
+
+def derive_next_venue_projection(
+    delegated_judgment: Mapping[str, Any],
+    outcome_review: Mapping[str, Any],
+    venue_mix_review: Mapping[str, Any],
+    attention_recommendation: Mapping[str, Any],
+    *,
+    allowed_recommendations: set[str],
+    allowed_relations: set[str],
+) -> dict[str, Any]:
+    """Derive bounded next-venue projection from existing orchestration signals."""
+
+    delegated_venue = str(delegated_judgment.get("recommended_venue") or "insufficient_context")
+    escalation_classification = str(delegated_judgment.get("escalation_classification") or "")
+    outcome_classification = str(outcome_review.get("review_classification") or "insufficient_history")
+    venue_mix_classification = str(venue_mix_review.get("review_classification") or "insufficient_history")
+    attention_signal = str(attention_recommendation.get("operator_attention_recommendation") or "insufficient_context")
+    outcome_records = int(outcome_review.get("records_considered") or 0)
+    venue_mix_records = int(venue_mix_review.get("records_considered") or 0)
+    blocked_heavy = bool((outcome_review.get("condition_flags") or {}).get("blocked_heavy"))
+    failure_heavy = bool((outcome_review.get("condition_flags") or {}).get("failure_heavy"))
+    stall_heavy = bool((outcome_review.get("condition_flags") or {}).get("stall_heavy"))
+    operator_heavy = venue_mix_classification == "operator_escalation_heavy"
+    external_contribution = venue_mix_review.get("external_fulfillment_contribution")
+    external_contribution_map = external_contribution if isinstance(external_contribution, Mapping) else {}
+    by_venue = external_contribution_map.get("by_venue")
+    by_venue_map = by_venue if isinstance(by_venue, Mapping) else {}
+
+    def _venue_external_health(venue: str) -> dict[str, int]:
+        venue_map = by_venue_map.get(venue)
+        venue_metrics = venue_map if isinstance(venue_map, Mapping) else {}
+        return {
+            "healthy": int(venue_metrics.get("healthy") or 0),
+            "stressed": int(venue_metrics.get("stressed") or 0),
+            "blocked_or_unusable": int(venue_metrics.get("blocked_or_unusable") or 0),
+            "fulfilled_externally": int(venue_metrics.get("fulfilled_externally") or 0),
+            "fulfilled_externally_with_issues": int(venue_metrics.get("fulfilled_externally_with_issues") or 0),
+            "externally_declined": int(venue_metrics.get("externally_declined") or 0),
+            "externally_abandoned": int(venue_metrics.get("externally_abandoned") or 0),
+            "externally_result_unusable": int(venue_metrics.get("externally_result_unusable") or 0),
+        }
+
+    codex_external = _venue_external_health("codex_implementation")
+    deep_external = _venue_external_health("deep_research_audit")
+    delegated_external = _venue_external_health(delegated_venue) if delegated_venue in {
+        "codex_implementation",
+        "deep_research_audit",
+    } else _venue_external_health("")
+    delegated_external_total = delegated_external["healthy"] + delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    delegated_external_healthy_strong = delegated_external["healthy"] >= 2 and (
+        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    ) == 0
+    delegated_external_stressed = delegated_external_total >= 2 and (
+        delegated_external["stressed"] + delegated_external["blocked_or_unusable"]
+    ) >= delegated_external["healthy"]
+    external_signal_present = bool(external_contribution_map.get("signal_present"))
+    alternative_external_healthy = (
+        deep_external["healthy"] >= 2 and (deep_external["stressed"] + deep_external["blocked_or_unusable"]) == 0
+        if delegated_venue == "codex_implementation"
+        else (
+            codex_external["healthy"] >= 2 and (codex_external["stressed"] + codex_external["blocked_or_unusable"]) == 0
+            if delegated_venue == "deep_research_audit"
+            else False
+        )
+    )
+
+    delegated_to_next = {
+        "internal_direct_execution": "prefer_internal_execution",
+        "codex_implementation": "prefer_codex_implementation",
+        "deep_research_audit": "prefer_deep_research_audit",
+        "operator_decision_required": "prefer_operator_decision",
+    }
+    delegated_next = delegated_to_next.get(delegated_venue)
+
+    recommendation = "insufficient_context"
+    relation = "insufficient_context"
+    rationale = "insufficient_or_conflicting_recent_signal_basis_for_next_venue"
+
+    operator_escalation_dominant = (
+        delegated_venue == "operator_decision_required"
+        or escalation_classification in {"escalate_for_missing_context", "escalate_for_operator_priority"}
+        or operator_heavy
+        or (
+            attention_signal in {"inspect_handoff_blocks", "inspect_execution_failures", "inspect_pending_stall"}
+            and (blocked_heavy or failure_heavy or stall_heavy)
+        )
+    )
+    has_minimum_history = outcome_records >= 3 and venue_mix_records >= 3
+    stress_signals_present = (
+        outcome_classification in {
+            "handoff_block_heavy",
+            "execution_failure_heavy",
+            "pending_stall_pattern",
+            "mixed_orchestration_stress",
+        }
+        or venue_mix_classification == "mixed_venue_stress"
+    )
+    external_feedback_affirming = delegated_external_healthy_strong
+    external_feedback_stressed = delegated_external_stressed
+
+    if operator_escalation_dominant:
+        recommendation = "prefer_operator_decision"
+        relation = "escalating"
+        rationale = "operator_required_or_escalation_signals_dominate_recent_orchestration_pattern"
+    elif not has_minimum_history or delegated_next is None:
+        recommendation = "insufficient_context"
+        relation = "insufficient_context"
+        rationale = "insufficient_recent_orchestration_history_or_delegated_judgment_venue_unavailable"
+    elif (
+        delegated_venue in {"internal_direct_execution", "codex_implementation"}
+        and venue_mix_classification in {"mixed_venue_stress", "deep_research_heavy"}
+        and outcome_classification in {"mixed_orchestration_stress", "execution_failure_heavy"}
+    ):
+        recommendation = "prefer_deep_research_audit"
+        relation = "nudging"
+        rationale = "recent_stress_or_architectural_ambiguity_pattern_nudges_toward_deep_research_audit"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed and alternative_external_healthy:
+        recommendation = "prefer_deep_research_audit" if delegated_venue == "codex_implementation" else "prefer_codex_implementation"
+        relation = "nudging"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_while_alternative_external_venue_is_recently_healthy"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_stressed:
+        recommendation = "hold_current_venue_mix"
+        relation = "holding"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_stressed_without_a_clear_healthy_external_alternative"
+    elif delegated_venue in {"codex_implementation", "deep_research_audit"} and external_feedback_affirming:
+        recommendation = delegated_next if delegated_next is not None else "insufficient_context"
+        relation = "affirming"
+        rationale = "recent_external_fulfillment_for_delegated_external_venue_is_healthy_and_supports_affirmation"
+    elif delegated_venue == "internal_direct_execution" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "internal_execution_heavy",
+    }:
+        recommendation = "prefer_internal_execution"
+        relation = "affirming"
+        rationale = "clean_recent_internal_outcomes_and_compatible_venue_mix_affirm_internal_execution"
+    elif delegated_venue == "codex_implementation" and outcome_classification == "clean_recent_orchestration" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "codex_heavy",
+    }:
+        recommendation = "prefer_codex_implementation"
+        relation = "affirming"
+        rationale = "clean_recent_outcomes_and_compatible_codex_usage_affirm_codex_implementation"
+    elif delegated_venue == "deep_research_audit" and venue_mix_classification in {
+        "balanced_recent_venue_mix",
+        "deep_research_heavy",
+    } and outcome_classification in {"clean_recent_orchestration", "mixed_orchestration_stress", "execution_failure_heavy"}:
+        recommendation = "prefer_deep_research_audit"
+        relation = "affirming"
+        rationale = "delegated_judgment_and_recent_venue_patterns_support_deep_research_audit"
+    elif stress_signals_present:
+        recommendation = "hold_current_venue_mix"
+        relation = "holding"
+        rationale = "recent_venue_behavior_is_stressed_or_unstable_without_clear_safe_correction_target"
+    elif delegated_next is not None:
+        recommendation = delegated_next
+        relation = "affirming"
+        rationale = "delegated_judgment_is_compatible_with_recent_orchestration_signals"
+
+    if recommendation not in allowed_recommendations:
+        recommendation = "insufficient_context"
+        relation = "insufficient_context"
+        rationale = "unrecognized_next_venue_recommendation_defaulted_to_insufficient_context"
+    if relation not in allowed_relations:
+        relation = "insufficient_context"
+
+    return {
+        "delegated_venue": delegated_venue,
+        "escalation_classification": escalation_classification,
+        "next_venue_recommendation": recommendation,
+        "relation_to_delegated_judgment": relation,
+        "attention_signal": attention_signal,
+        "outcome_classification": outcome_classification,
+        "venue_mix_classification": venue_mix_classification,
+        "outcome_records": outcome_records,
+        "venue_mix_records": venue_mix_records,
+        "blocked_heavy": blocked_heavy,
+        "failure_heavy": failure_heavy,
+        "stall_heavy": stall_heavy,
+        "external_signal_present": external_signal_present,
+        "delegated_external": delegated_external,
+        "codex_external": codex_external,
+        "deep_external": deep_external,
+        "external_feedback_affirming": external_feedback_affirming,
+        "external_feedback_stressed": external_feedback_stressed,
+        "rationale": rationale,
+    }

--- a/sentientos/tests/test_orchestration_projection_policy.py
+++ b/sentientos/tests/test_orchestration_projection_policy.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from sentientos import orchestration_projection_policy
+
+
+def test_attention_projection_mixed_light_block_observe() -> None:
+    projection = orchestration_projection_policy.derive_attention_projection(
+        {
+            "review_classification": "mixed_orchestration_stress",
+            "records_considered": 4,
+            "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+            "recent_outcome_counts": {"handoff_not_admitted": 1},
+        },
+        allowed_recommendations={
+            "none",
+            "observe",
+            "inspect_handoff_blocks",
+            "inspect_execution_failures",
+            "inspect_pending_stall",
+            "review_mixed_orchestration_stress",
+            "insufficient_context",
+        },
+    )
+
+    assert projection["operator_attention_recommendation"] == "observe"
+
+
+def test_next_venue_projection_escalates_operator() -> None:
+    projection = orchestration_projection_policy.derive_next_venue_projection(
+        {"recommended_venue": "operator_decision_required", "escalation_classification": ""},
+        {"review_classification": "clean_recent_orchestration", "records_considered": 8, "condition_flags": {}},
+        {"review_classification": "balanced_recent_venue_mix", "records_considered": 8},
+        {"operator_attention_recommendation": "none"},
+        allowed_recommendations={
+            "prefer_internal_execution",
+            "prefer_codex_implementation",
+            "prefer_deep_research_audit",
+            "prefer_operator_decision",
+            "hold_current_venue_mix",
+            "insufficient_context",
+        },
+        allowed_relations={"affirming", "nudging", "holding", "escalating", "insufficient_context"},
+    )
+
+    assert projection["next_venue_recommendation"] == "prefer_operator_decision"
+    assert projection["relation_to_delegated_judgment"] == "escalating"
+
+
+def test_next_venue_projection_affirms_internal() -> None:
+    projection = orchestration_projection_policy.derive_next_venue_projection(
+        {"recommended_venue": "internal_direct_execution", "escalation_classification": ""},
+        {
+            "review_classification": "clean_recent_orchestration",
+            "records_considered": 4,
+            "condition_flags": {"blocked_heavy": False, "failure_heavy": False, "stall_heavy": False},
+        },
+        {"review_classification": "balanced_recent_venue_mix", "records_considered": 4},
+        {"operator_attention_recommendation": "observe"},
+        allowed_recommendations={
+            "prefer_internal_execution",
+            "prefer_codex_implementation",
+            "prefer_deep_research_audit",
+            "prefer_operator_decision",
+            "hold_current_venue_mix",
+            "insufficient_context",
+        },
+        allowed_relations={"affirming", "nudging", "holding", "escalating", "insufficient_context"},
+    )
+
+    assert projection["next_venue_recommendation"] == "prefer_internal_execution"
+    assert projection["relation_to_delegated_judgment"] == "affirming"


### PR DESCRIPTION
### Motivation
- Move projection/policy logic out of the authority fabric so review/attention/next-venue surfaces become consumers of canonical state rather than embedded inside the kernel.  
- Preserve the orchestration kernel as the single authority for identity, admissibility, closure, and execution semantics while enabling a bounded projection slice to be evolved independently.  
- Make a minimal, backwards-compatible physical split to prove the decomposition direction without changing lifecycle or authority semantics.

### Description
- Added a new bounded projection module `sentientos/orchestration_projection_policy.py` that implements `derive_attention_projection(...)` and `derive_next_venue_projection(...)` and encapsulates the classification/rationale logic for attention and next-venue recommendations.  
- Updated the facade in `sentientos/orchestration_intent_fabric.py` to delegate derivation to the new projection module, then wrap results with the same anti-sovereignty / diagnostic envelope and output shape so public entry points remain stable.  
- Kept authority-owned responsibilities in the kernel: canonical entry points, anti-sovereignty payloads, diagnostic/recommendation envelope, and all admission/execution/closure semantics remain in `orchestration_intent_fabric.py`.  
- Files changed: `sentientos/orchestration_intent_fabric.py` (delegation + envelope preserved), new `sentientos/orchestration_projection_policy.py` (extracted projection logic), new tests `sentientos/tests/test_orchestration_projection_policy.py` (focused unit tests for projections).

### Testing
- Ran unit tests: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_intent_fabric.py sentientos/tests/test_orchestration_projection_policy.py` — tests covering the orchestration module and new projection logic passed.  
- Type-check: `mypy scripts/ sentientos/` — reported pre-existing repository-wide typing failures unrelated to this change.  
- Audit verification: `python scripts/verify_audits.py --strict` — reported a pre-existing runtime audit-chain break (outside the scope of this refactor).  
- Audit immutability verifier: `python scripts/audit_immutability_verifier.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea782ff2c48320bd22a2ce6957d585)