### PR TITLE
[codex:orchestration] thin facade by delegating re-evaluation basis projection

### DIFF
--- a/sentientos/orchestration_current_projection.py
+++ b/sentientos/orchestration_current_projection.py
@@ -4133,3 +4133,219 @@ def resolve_current_orchestration_closure_brief_projection(
         ),
     }
 
+
+
+def resolve_current_re_evaluation_basis_brief_projection(
+    repo_root: Path,
+    anti_sovereignty_payload_builder: Callable[..., dict[str, Any]],
+    iso_utc_now: Callable[[], str],
+    current_re_evaluation_basis_brief_id_builder: Callable[..., str],
+    current_re_evaluation_basis_classifications: set[str],
+    current_re_evaluation_basis_primary_drivers: set[str],
+    *,
+    current_orchestration_state: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint: Mapping[str, Any] | None = None,
+    watchpoint_satisfaction: Mapping[str, Any] | None = None,
+    re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
+    current_resumed_operation_readiness: Mapping[str, Any] | None = None,
+    current_orchestration_watchpoint_brief: Mapping[str, Any] | None = None,
+    current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
+    current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
+    active_packet_visibility: Mapping[str, Any] | None = None,
+    current_proposal: Mapping[str, Any] | None = None,
+    operator_resolution_influence: Mapping[str, Any] | None = None,
+    unified_result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve one bounded, non-executing brief for why the current re-evaluation recommendation exists."""
+
+    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
+    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
+    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
+    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
+    candidate_map = (
+        current_orchestration_resumption_candidate
+        if isinstance(current_orchestration_resumption_candidate, Mapping)
+        else {}
+    )
+    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
+    watchpoint_brief_map = (
+        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
+    )
+    pressure_map = (
+        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
+    )
+    wake_map = (
+        current_orchestration_wake_readiness_detector
+        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
+        else {}
+    )
+    influence_map = operator_resolution_influence if isinstance(operator_resolution_influence, Mapping) else {}
+    unified_result_map = unified_result if isinstance(unified_result, Mapping) else {}
+
+    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
+    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "watchpoint_pending")
+    trigger_recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
+    trigger_expected_actor = str(trigger_map.get("expected_actor") or "none")
+    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
+    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
+    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
+    wake_posture = str(wake_map.get("result_posture") or "informational_only")
+    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "continuity_uncertain")
+    operator_influence_state = str(influence_map.get("operator_influence_state") or "no_operator_influence_yet")
+    resolution_path = str(unified_result_map.get("resolution_path") or str(state_map.get("current_resolution_path") or "none"))
+    active_watchpoint = watchpoint_class != "no_watchpoint_needed" and satisfaction_status != "no_active_watchpoint"
+    resume_ready = bool(candidate_map.get("resume_ready"))
+    resumed_motion_implicated = resume_ready and readiness_verdict in {"ready_to_proceed", "proceed_with_caution"}
+    resumed_motion_blocked = readiness_verdict in {"hold_for_operator_review", "not_ready"} or trigger_recommendation in {
+        "hold_for_manual_review",
+        "no_re_evaluation_needed",
+    }
+
+    no_basis = (
+        trigger_recommendation == "no_re_evaluation_needed"
+        and (not active_watchpoint or satisfaction_status in {"watchpoint_pending", "no_active_watchpoint"})
+    )
+    continuity_uncertainty = satisfaction_status in {"watchpoint_stale", "watchpoint_fragmented"} or (
+        trigger_recommendation == "hold_for_manual_review"
+        and (
+            wait_kind == "continuity_uncertain"
+            or pressure_classification in {"fragmentation_pressure", "mixed_pressure", "insufficient_signal"}
+        )
+    )
+    operator_driven = (
+        watchpoint_class == "await_operator_resolution"
+        and satisfaction_status == "watchpoint_satisfied"
+        and trigger_recommendation in {"rerun_packetization_gate", "rerun_packet_synthesis"}
+    ) or operator_influence_state in {
+        "operator_resolution_applied",
+        "operator_redirect_applied",
+    }
+    internal_result_driven = watchpoint_class == "await_internal_execution_result" and satisfaction_status == "watchpoint_satisfied"
+    external_result_driven = (
+        watchpoint_class == "await_external_fulfillment_receipt" and satisfaction_status == "watchpoint_satisfied"
+    )
+    if no_basis:
+        classification = "no_current_re_evaluation_basis"
+        primary_driver = "none"
+        rationale = "no_active_or_materially_actionable_re_evaluation_basis_is_visible_in_current_surfaces"
+    elif continuity_uncertainty:
+        classification = "continuity_uncertainty_driven_re_evaluation"
+        primary_driver = "continuity_uncertainty"
+        rationale = "stale_fragmented_or_under_signaled_continuity_context_is_the_current_re_evaluation_driver"
+    elif operator_driven:
+        classification = "operator_resolution_driven_re_evaluation"
+        primary_driver = "operator_input"
+        rationale = "operator_resolution_visibility_materially_drives_the_current_re_evaluation_recommendation"
+    elif internal_result_driven and resolution_path in {"internal_execution", "none"}:
+        classification = "internal_result_driven_re_evaluation"
+        primary_driver = "result_closure"
+        rationale = "internal_result_closure_visibility_materially_drives_the_current_re_evaluation_recommendation"
+    elif external_result_driven and resolution_path in {"external_fulfillment", "none"}:
+        classification = "external_fulfillment_driven_re_evaluation"
+        primary_driver = "result_closure"
+        rationale = "external_fulfillment_visibility_materially_drives_the_current_re_evaluation_recommendation"
+    elif satisfaction_status == "watchpoint_satisfied":
+        classification = "satisfaction_driven_re_evaluation"
+        primary_driver = "satisfaction"
+        rationale = "watchpoint_satisfaction_is_the_primary_visible_driver_of_current_re_evaluation_recommendation"
+    else:
+        classification = "no_current_re_evaluation_basis"
+        primary_driver = "none"
+        rationale = "current_surfaces_do_not_support_a_stronger_honest_basis_for_re_evaluation"
+
+    if classification not in current_re_evaluation_basis_classifications:
+        classification = "continuity_uncertainty_driven_re_evaluation"
+    if primary_driver not in current_re_evaluation_basis_primary_drivers:
+        primary_driver = "continuity_uncertainty"
+
+    conservative_posture = (
+        classification == "continuity_uncertainty_driven_re_evaluation"
+        or wake_posture == "strongly_blocked"
+        or trigger_recommendation == "hold_for_manual_review"
+    )
+    informational_posture = "conservative_wake_or_re_entry_posture" if conservative_posture else "informational_only"
+
+    state_id = str(state_map.get("current_orchestration_state_id") or "")
+    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
+    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
+    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
+    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
+
+    return {
+        "schema_version": "current_re_evaluation_basis_brief.v1",
+        "resolved_at": iso_utc_now(),
+        "current_re_evaluation_basis_brief_id": current_re_evaluation_basis_brief_id_builder(
+            current_orchestration_state_id=state_id,
+            orchestration_watchpoint_id=watchpoint_id,
+            watchpoint_satisfaction_id=satisfaction_id,
+            re_evaluation_trigger_id=trigger_id,
+            orchestration_resumption_candidate_id=candidate_id,
+            basis_classification=classification,
+        ),
+        "basis_classification": classification,
+        "primary_driver": primary_driver,
+        "resumed_bounded_motion_materially_implicated": resumed_motion_implicated,
+        "resumed_bounded_motion_currently_blocked": resumed_motion_blocked,
+        "posture": informational_posture,
+        "basis": {
+            "compact_rationale": rationale,
+            "basis_evidence": {
+                "watchpoint_class": watchpoint_class,
+                "watchpoint_satisfaction_status": satisfaction_status,
+                "re_evaluation_recommendation": trigger_recommendation,
+                "re_evaluation_expected_actor": trigger_expected_actor,
+                "resumption_candidate_class": str(candidate_map.get("resumption_candidate_class") or "no_resume_candidate"),
+                "resumed_operation_readiness_verdict": readiness_verdict,
+                "wait_kind": wait_kind,
+                "pressure_classification": pressure_classification,
+                "wake_readiness_classification": wake_classification,
+                "wake_readiness_posture": wake_posture,
+                "operator_influence_state": operator_influence_state,
+                "unified_result_resolution_path": resolution_path,
+            },
+            "materially_contributing_surfaces": [
+                "resolve_current_orchestration_watchpoint",
+                "resolve_watchpoint_satisfaction",
+                "resolve_re_evaluation_trigger_recommendation",
+                "resolve_current_orchestration_resumption_candidate",
+                "resolve_current_resumed_operation_readiness_verdict",
+                "resolve_current_orchestration_watchpoint_brief",
+                "resolve_current_orchestration_pressure_signal",
+                "resolve_current_orchestration_wake_readiness_detector",
+                "active handoff packet visibility",
+                "current proposal visibility",
+                "operator-resolution visibility",
+                "unified result visibility",
+            ],
+            "historical_honesty": {
+                "no_new_truth_source": True,
+                "derived_from_existing_surfaces_only": True,
+                "does_not_claim_stronger_causality_than_visible_signals": True,
+            },
+        },
+        "boundaries": {
+            "non_sovereign": True,
+            "non_authoritative": True,
+            "non_executing": True,
+            "diagnostic_only": True,
+            "decision_power": "none",
+            "does_not_plan_or_schedule": True,
+            "does_not_execute_or_route_work": True,
+            "does_not_create_new_truth_source": True,
+            "does_not_imply_permission_to_execute": True,
+        },
+        **anti_sovereignty_payload_builder(
+            recommendation_only=True,
+            diagnostic_only=True,
+            does_not_change_admission_or_execution=True,
+            additional_fields={
+                "re_evaluation_basis_brief_only": True,
+                "non_executing": True,
+                "does_not_execute_or_route_work": True,
+                "does_not_create_new_orchestration_layer": True,
+                "does_not_create_new_authority_surface": True,
+            },
+        ),
+    }
+

--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -5616,196 +5616,27 @@ def resolve_current_re_evaluation_basis_brief(
 ) -> dict[str, Any]:
     """Resolve one bounded, non-executing brief for why the current re-evaluation recommendation exists."""
 
-    state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
-    watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
-    satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
-    trigger_map = re_evaluation_trigger_recommendation if isinstance(re_evaluation_trigger_recommendation, Mapping) else {}
-    candidate_map = (
-        current_orchestration_resumption_candidate
-        if isinstance(current_orchestration_resumption_candidate, Mapping)
-        else {}
+    return orchestration_current_projection.resolve_current_re_evaluation_basis_brief_projection(
+        repo_root,
+        anti_sovereignty_payload_builder=_anti_sovereignty_payload,
+        iso_utc_now=_iso_utc_now,
+        current_re_evaluation_basis_brief_id_builder=_current_re_evaluation_basis_brief_id,
+        current_re_evaluation_basis_classifications=_CURRENT_RE_EVALUATION_BASIS_CLASSIFICATIONS,
+        current_re_evaluation_basis_primary_drivers=_CURRENT_RE_EVALUATION_BASIS_PRIMARY_DRIVERS,
+        current_orchestration_state=current_orchestration_state,
+        current_orchestration_watchpoint=current_orchestration_watchpoint,
+        watchpoint_satisfaction=watchpoint_satisfaction,
+        re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
+        current_resumed_operation_readiness=current_resumed_operation_readiness,
+        current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
+        current_orchestration_pressure_signal=current_orchestration_pressure_signal,
+        current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
+        active_packet_visibility=active_packet_visibility,
+        current_proposal=current_proposal,
+        operator_resolution_influence=operator_resolution_influence,
+        unified_result=unified_result,
     )
-    readiness_map = current_resumed_operation_readiness if isinstance(current_resumed_operation_readiness, Mapping) else {}
-    watchpoint_brief_map = (
-        current_orchestration_watchpoint_brief if isinstance(current_orchestration_watchpoint_brief, Mapping) else {}
-    )
-    pressure_map = (
-        current_orchestration_pressure_signal if isinstance(current_orchestration_pressure_signal, Mapping) else {}
-    )
-    wake_map = (
-        current_orchestration_wake_readiness_detector
-        if isinstance(current_orchestration_wake_readiness_detector, Mapping)
-        else {}
-    )
-    influence_map = operator_resolution_influence if isinstance(operator_resolution_influence, Mapping) else {}
-    unified_result_map = unified_result if isinstance(unified_result, Mapping) else {}
-
-    watchpoint_class = str(watchpoint_map.get("watchpoint_class") or "no_watchpoint_needed")
-    satisfaction_status = str(satisfaction_map.get("satisfaction_status") or "watchpoint_pending")
-    trigger_recommendation = str(trigger_map.get("recommendation") or "no_re_evaluation_needed")
-    trigger_expected_actor = str(trigger_map.get("expected_actor") or "none")
-    readiness_verdict = str(readiness_map.get("resumed_operation_readiness_verdict") or "not_ready")
-    pressure_classification = str(pressure_map.get("pressure_classification") or "insufficient_signal")
-    wake_classification = str(wake_map.get("wake_readiness_classification") or "not_wake_ready")
-    wake_posture = str(wake_map.get("result_posture") or "informational_only")
-    wait_kind = str(watchpoint_brief_map.get("wait_kind") or "continuity_uncertain")
-    operator_influence_state = str(influence_map.get("operator_influence_state") or "no_operator_influence_yet")
-    resolution_path = str(unified_result_map.get("resolution_path") or str(state_map.get("current_resolution_path") or "none"))
-    active_watchpoint = watchpoint_class != "no_watchpoint_needed" and satisfaction_status != "no_active_watchpoint"
-    resume_ready = bool(candidate_map.get("resume_ready"))
-    resumed_motion_implicated = resume_ready and readiness_verdict in {"ready_to_proceed", "proceed_with_caution"}
-    resumed_motion_blocked = readiness_verdict in {"hold_for_operator_review", "not_ready"} or trigger_recommendation in {
-        "hold_for_manual_review",
-        "no_re_evaluation_needed",
-    }
-
-    no_basis = (
-        trigger_recommendation == "no_re_evaluation_needed"
-        and (not active_watchpoint or satisfaction_status in {"watchpoint_pending", "no_active_watchpoint"})
-    )
-    continuity_uncertainty = satisfaction_status in {"watchpoint_stale", "watchpoint_fragmented"} or (
-        trigger_recommendation == "hold_for_manual_review"
-        and (
-            wait_kind == "continuity_uncertain"
-            or pressure_classification in {"fragmentation_pressure", "mixed_pressure", "insufficient_signal"}
-        )
-    )
-    operator_driven = (
-        watchpoint_class == "await_operator_resolution"
-        and satisfaction_status == "watchpoint_satisfied"
-        and trigger_recommendation in {"rerun_packetization_gate", "rerun_packet_synthesis"}
-    ) or operator_influence_state in {
-        "operator_resolution_applied",
-        "operator_redirect_applied",
-    }
-    internal_result_driven = watchpoint_class == "await_internal_execution_result" and satisfaction_status == "watchpoint_satisfied"
-    external_result_driven = (
-        watchpoint_class == "await_external_fulfillment_receipt" and satisfaction_status == "watchpoint_satisfied"
-    )
-    if no_basis:
-        classification = "no_current_re_evaluation_basis"
-        primary_driver = "none"
-        rationale = "no_active_or_materially_actionable_re_evaluation_basis_is_visible_in_current_surfaces"
-    elif continuity_uncertainty:
-        classification = "continuity_uncertainty_driven_re_evaluation"
-        primary_driver = "continuity_uncertainty"
-        rationale = "stale_fragmented_or_under_signaled_continuity_context_is_the_current_re_evaluation_driver"
-    elif operator_driven:
-        classification = "operator_resolution_driven_re_evaluation"
-        primary_driver = "operator_input"
-        rationale = "operator_resolution_visibility_materially_drives_the_current_re_evaluation_recommendation"
-    elif internal_result_driven and resolution_path in {"internal_execution", "none"}:
-        classification = "internal_result_driven_re_evaluation"
-        primary_driver = "result_closure"
-        rationale = "internal_result_closure_visibility_materially_drives_the_current_re_evaluation_recommendation"
-    elif external_result_driven and resolution_path in {"external_fulfillment", "none"}:
-        classification = "external_fulfillment_driven_re_evaluation"
-        primary_driver = "result_closure"
-        rationale = "external_fulfillment_visibility_materially_drives_the_current_re_evaluation_recommendation"
-    elif satisfaction_status == "watchpoint_satisfied":
-        classification = "satisfaction_driven_re_evaluation"
-        primary_driver = "satisfaction"
-        rationale = "watchpoint_satisfaction_is_the_primary_visible_driver_of_current_re_evaluation_recommendation"
-    else:
-        classification = "no_current_re_evaluation_basis"
-        primary_driver = "none"
-        rationale = "current_surfaces_do_not_support_a_stronger_honest_basis_for_re_evaluation"
-
-    if classification not in _CURRENT_RE_EVALUATION_BASIS_CLASSIFICATIONS:
-        classification = "continuity_uncertainty_driven_re_evaluation"
-    if primary_driver not in _CURRENT_RE_EVALUATION_BASIS_PRIMARY_DRIVERS:
-        primary_driver = "continuity_uncertainty"
-
-    conservative_posture = (
-        classification == "continuity_uncertainty_driven_re_evaluation"
-        or wake_posture == "strongly_blocked"
-        or trigger_recommendation == "hold_for_manual_review"
-    )
-    informational_posture = "conservative_wake_or_re_entry_posture" if conservative_posture else "informational_only"
-
-    state_id = str(state_map.get("current_orchestration_state_id") or "")
-    watchpoint_id = str(watchpoint_map.get("orchestration_watchpoint_id") or "")
-    satisfaction_id = str(satisfaction_map.get("watchpoint_satisfaction_id") or "")
-    trigger_id = str(trigger_map.get("re_evaluation_trigger_id") or "")
-    candidate_id = str(candidate_map.get("orchestration_resumption_candidate_id") or "")
-
-    return {
-        "schema_version": "current_re_evaluation_basis_brief.v1",
-        "resolved_at": _iso_utc_now(),
-        "current_re_evaluation_basis_brief_id": _current_re_evaluation_basis_brief_id(
-            current_orchestration_state_id=state_id,
-            orchestration_watchpoint_id=watchpoint_id,
-            watchpoint_satisfaction_id=satisfaction_id,
-            re_evaluation_trigger_id=trigger_id,
-            orchestration_resumption_candidate_id=candidate_id,
-            basis_classification=classification,
-        ),
-        "basis_classification": classification,
-        "primary_driver": primary_driver,
-        "resumed_bounded_motion_materially_implicated": resumed_motion_implicated,
-        "resumed_bounded_motion_currently_blocked": resumed_motion_blocked,
-        "posture": informational_posture,
-        "basis": {
-            "compact_rationale": rationale,
-            "basis_evidence": {
-                "watchpoint_class": watchpoint_class,
-                "watchpoint_satisfaction_status": satisfaction_status,
-                "re_evaluation_recommendation": trigger_recommendation,
-                "re_evaluation_expected_actor": trigger_expected_actor,
-                "resumption_candidate_class": str(candidate_map.get("resumption_candidate_class") or "no_resume_candidate"),
-                "resumed_operation_readiness_verdict": readiness_verdict,
-                "wait_kind": wait_kind,
-                "pressure_classification": pressure_classification,
-                "wake_readiness_classification": wake_classification,
-                "wake_readiness_posture": wake_posture,
-                "operator_influence_state": operator_influence_state,
-                "unified_result_resolution_path": resolution_path,
-            },
-            "materially_contributing_surfaces": [
-                "resolve_current_orchestration_watchpoint",
-                "resolve_watchpoint_satisfaction",
-                "resolve_re_evaluation_trigger_recommendation",
-                "resolve_current_orchestration_resumption_candidate",
-                "resolve_current_resumed_operation_readiness_verdict",
-                "resolve_current_orchestration_watchpoint_brief",
-                "resolve_current_orchestration_pressure_signal",
-                "resolve_current_orchestration_wake_readiness_detector",
-                "active handoff packet visibility",
-                "current proposal visibility",
-                "operator-resolution visibility",
-                "unified result visibility",
-            ],
-            "historical_honesty": {
-                "no_new_truth_source": True,
-                "derived_from_existing_surfaces_only": True,
-                "does_not_claim_stronger_causality_than_visible_signals": True,
-            },
-        },
-        "boundaries": {
-            "non_sovereign": True,
-            "non_authoritative": True,
-            "non_executing": True,
-            "diagnostic_only": True,
-            "decision_power": "none",
-            "does_not_plan_or_schedule": True,
-            "does_not_execute_or_route_work": True,
-            "does_not_create_new_truth_source": True,
-            "does_not_imply_permission_to_execute": True,
-        },
-        **_anti_sovereignty_payload(
-            recommendation_only=True,
-            diagnostic_only=True,
-            does_not_change_admission_or_execution=True,
-            additional_fields={
-                "re_evaluation_basis_brief_only": True,
-                "non_executing": True,
-                "does_not_execute_or_route_work": True,
-                "does_not_create_new_orchestration_layer": True,
-                "does_not_create_new_authority_surface": True,
-            },
-        ),
-    }
-
 
 def resolve_current_orchestration_next_move_brief(
     repo_root: Path,


### PR DESCRIPTION
### Motivation
- Reduce non-kernel weight in the orchestration façade by moving a large observational/projection block out of the authority file so the façade more clearly expresses kernel responsibilities and compatibility wrappers. 
- Keep authority-owned builders, identity generators, classification sets, and anti-sovereignty boundaries in the kernel while letting the projection module own bounded, observational synthesis.

### Description
- Delegated the full implementation of `resolve_current_re_evaluation_basis_brief` from `sentientos/orchestration_intent_fabric.py` into `sentientos/orchestration_current_projection.py` as `resolve_current_re_evaluation_basis_brief_projection` and left a thin compatibility wrapper in the façade that forwards kernel-owned builders/constants (e.g. `_anti_sovereignty_payload`, `_iso_utc_now`, `_current_re_evaluation_basis_brief_id`, and classification sets).
- Preserved the public entry point/API shape and authority boundaries so callers continue to use `resolve_current_re_evaluation_basis_brief(...)` with no lifecycle or authority-model changes.
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/orchestration_current_projection.py`.
- This is a bounded refactor only (no new authority, no lifecycle semantics changed); the façade now clearly delegates projection logic and injects kernel primitives into the projection function.

### Testing
- Ran orchestration-focused test harness: `python -m scripts.run_tests -q tests/test_codex_orchestration.py` and the orchestration test target passed.
- No changes to broader lifecycle behavior were intended and orchestration-focused tests confirm compatibility for this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ead9acd5b883208c3e26ea74f034d6)