### PR TITLE
[codex:orchestration] normalize spine import direction and annotate facade inventory

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -11,6 +11,12 @@ import task_executor
 from sentientos.orchestration_spine.adapters import internal_maintenance
 from sentientos.orchestration_spine.projection import current_state, policy_helpers
 
+# Kernel/facade inventory (Phase 11 bounded normalization):
+# - Kernel authority surfaces in this module own intent admission, handoff, and resolution.
+# - Projection and adapter helpers are consumed from ``sentientos.orchestration_spine.*``.
+# - Legacy shim modules remain for external compatibility; internal orchestration code
+#   should prefer canonical orchestration_spine import paths.
+
 _INTENT_KINDS = {
     "internal_maintenance_execution",
     "codex_work_order",

--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -12,7 +12,7 @@ import pytest
 import task_admission
 import task_executor
 from sentientos.delegated_judgment_fabric import synthesize_delegated_judgment
-from sentientos import orchestration_internal_adapters
+from sentientos.orchestration_spine.adapters import internal_maintenance
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_handoff_packet_ledger,
@@ -7709,7 +7709,7 @@ def test_contract_adapter_linkage_stays_raw_and_kernel_keeps_result_semantics(
     )
 
     handoff_before = deepcopy(handoff)
-    linkage = orchestration_internal_adapters.resolve_task_executor_result_linkage(
+    linkage = internal_maintenance.resolve_task_executor_result_linkage(
         handoff=handoff,
         executor_log_path=tmp_path / "logs" / "task_executor.jsonl",
         read_jsonl=lambda path: [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()],

--- a/sentientos/tests/test_orchestration_projection_policy.py
+++ b/sentientos/tests/test_orchestration_projection_policy.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from sentientos import orchestration_projection_policy
+from sentientos.orchestration_spine.projection import policy_helpers
 
 
 def test_attention_projection_mixed_light_block_observe() -> None:
-    projection = orchestration_projection_policy.derive_attention_projection(
+    projection = policy_helpers.derive_attention_projection(
         {
             "review_classification": "mixed_orchestration_stress",
             "records_considered": 4,
@@ -26,7 +26,7 @@ def test_attention_projection_mixed_light_block_observe() -> None:
 
 
 def test_next_venue_projection_escalates_operator() -> None:
-    projection = orchestration_projection_policy.derive_next_venue_projection(
+    projection = policy_helpers.derive_next_venue_projection(
         {"recommended_venue": "operator_decision_required", "escalation_classification": ""},
         {"review_classification": "clean_recent_orchestration", "records_considered": 8, "condition_flags": {}},
         {"review_classification": "balanced_recent_venue_mix", "records_considered": 8},
@@ -47,7 +47,7 @@ def test_next_venue_projection_escalates_operator() -> None:
 
 
 def test_next_venue_projection_affirms_internal() -> None:
-    projection = orchestration_projection_policy.derive_next_venue_projection(
+    projection = policy_helpers.derive_next_venue_projection(
         {"recommended_venue": "internal_direct_execution", "escalation_classification": ""},
         {
             "review_classification": "clean_recent_orchestration",


### PR DESCRIPTION
### Motivation
- Clarify canonical orchestration-side import direction now that `sentientos.orchestration_spine` exists and make the kernel/facade responsibilities in `orchestration_intent_fabric.py` more explicit without changing authority or lifecycle semantics.

### Description
- Added a short kernel/facade inventory comment block to `sentientos/orchestration_intent_fabric.py` that documents ownership of admission/handoff/resolution and recommends canonical `sentientos.orchestration_spine.*` helper imports.
- Normalized imports at orchestration call sites in tests to prefer the canonical spine modules: replaced legacy shim imports with direct `sentientos.orchestration_spine.*` imports in test call sites where compatibility-shim behavior is not under test.
- Preserved legacy shim modules and their tests (no shim removals or behavioral changes were made).
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/tests/test_orchestration_projection_policy.py`, `sentientos/tests/test_orchestration_intent_fabric.py`.

### Testing
- Ran an orchestration-focused test subset: `pytest -q sentientos/tests/test_orchestration_projection_policy.py sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py::test_contract_adapter_linkage_stays_raw_and_kernel_keeps_result_semantics`, and it passed.
- Ran a broader orchestration-focused run: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py sentientos/tests/test_orchestration_projection_policy.py sentientos/tests/test_orchestration_spine_module_boundaries.py`, which failed due to pre-existing signature mismatch in `scoped_lifecycle_diagnostic` (error: `resolve_current_orchestration_handoff_packet_brief()` got unexpected kwarg `current_re_evaluation_basis_brief`), which is unrelated to the bounded import-normalization changes in this PR.
- Summary: targeted import-normalization changes validated; broader failing tests reflect an existing diagnostic/signature mismatch outside the scope of this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec0ec650b483208fe06e14a63ee498)