### PR TITLE
[codex:orchestration] stabilize current-brief signature alignment

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -353,6 +353,11 @@ _CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS = {
     "no_current_packet_brief",
 }
 
+_CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_POSTURES = {
+    "informational_only",
+    "conservative_or_uncertain",
+}
+
 _CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS = {
     "operator_attention_not_currently_needed",
     "operator_should_review_hold",
@@ -360,6 +365,12 @@ _CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS = {
     "operator_should_review_packet_refresh_context",
     "operator_should_review_redirect_or_constraint_path",
     "operator_should_confirm_no_current_action",
+}
+
+_CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_POSTURES = {
+    "informational",
+    "cautionary",
+    "blocked",
 }
 
 _CURRENT_ORCHESTRATION_RESOLUTION_PATH_BRIEF_CLASSIFICATIONS = {
@@ -379,6 +390,12 @@ _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CENTERS = {
     "operator",
     "result_or_fulfillment",
     "none",
+}
+
+_CURRENT_ORCHESTRATION_RESOLUTION_PATH_POSTURES = {
+    "informational",
+    "cautionary",
+    "blocked",
 }
 
 _CURRENT_ORCHESTRATION_CLOSURE_BRIEF_CLASSIFICATIONS = {
@@ -5879,36 +5896,40 @@ def resolve_current_orchestration_handoff_packet_brief(
     current_orchestration_pressure_signal: Mapping[str, Any] | None = None,
     current_orchestration_wake_readiness_detector: Mapping[str, Any] | None = None,
     re_evaluation_trigger_recommendation: Mapping[str, Any] | None = None,
+    current_re_evaluation_basis_brief: Mapping[str, Any] | None = None,
     current_orchestration_resumption_candidate: Mapping[str, Any] | None = None,
     current_resumed_operation_readiness: Mapping[str, Any] | None = None,
     current_orchestration_next_move_brief: Mapping[str, Any] | None = None,
     active_packet_visibility: Mapping[str, Any] | None = None,
     current_proposal: Mapping[str, Any] | None = None,
     packetization_gate: Mapping[str, Any] | None = None,
+    operator_resolution_influence: Mapping[str, Any] | None = None,
     proposal_packet_continuity_review: Mapping[str, Any] | None = None,
     unified_result: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve one bounded, non-executing brief for current orchestration handoff packet posture."""
+    _ = proposal_packet_continuity_review
 
     return current_state.resolve_current_orchestration_handoff_packet_brief_projection(
         repo_root,
         _anti_sovereignty_payload=_anti_sovereignty_payload,
-        _current_handoff_packet_brief_id=_current_handoff_packet_brief_id,
-        _CURRENT_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS=_CURRENT_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS,
-        _CURRENT_HANDOFF_PACKET_BRIEF_POSTURES=_CURRENT_HANDOFF_PACKET_BRIEF_POSTURES,
+        _current_handoff_packet_brief_id=_current_orchestration_handoff_packet_brief_id,
+        _CURRENT_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS=_CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS,
+        _CURRENT_HANDOFF_PACKET_BRIEF_POSTURES=_CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_POSTURES,
         current_orchestration_state=current_orchestration_state,
         current_orchestration_watchpoint=current_orchestration_watchpoint,
         watchpoint_satisfaction=watchpoint_satisfaction,
         current_orchestration_pressure_signal=current_orchestration_pressure_signal,
         current_orchestration_wake_readiness_detector=current_orchestration_wake_readiness_detector,
         re_evaluation_trigger_recommendation=re_evaluation_trigger_recommendation,
+        current_re_evaluation_basis_brief=current_re_evaluation_basis_brief,
         current_orchestration_resumption_candidate=current_orchestration_resumption_candidate,
         current_resumed_operation_readiness=current_resumed_operation_readiness,
         current_orchestration_next_move_brief=current_orchestration_next_move_brief,
         active_packet_visibility=active_packet_visibility,
         current_proposal=current_proposal,
         packetization_gate=packetization_gate,
-        proposal_packet_continuity_review=proposal_packet_continuity_review,
+        operator_resolution_influence=operator_resolution_influence,
         unified_result=unified_result,
     )
 
@@ -5930,6 +5951,7 @@ def resolve_current_operator_facing_orchestration_brief(
     active_packet_visibility: Mapping[str, Any] | None = None,
     operator_action_brief_visibility: Mapping[str, Any] | None = None,
     operator_resolution_influence: Mapping[str, Any] | None = None,
+    current_proposal: Mapping[str, Any] | None = None,
     unified_result: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve one compact, derived operator-facing orchestration brief for current understanding only."""
@@ -5937,9 +5959,9 @@ def resolve_current_operator_facing_orchestration_brief(
     return current_state.resolve_current_operator_facing_orchestration_brief_projection(
         repo_root,
         _anti_sovereignty_payload=_anti_sovereignty_payload,
-        _current_operator_facing_brief_id=_current_operator_facing_brief_id,
-        _CURRENT_OPERATOR_FACING_CLASSIFICATIONS=_CURRENT_OPERATOR_FACING_CLASSIFICATIONS,
-        _CURRENT_OPERATOR_LOOP_POSTURES=_CURRENT_OPERATOR_LOOP_POSTURES,
+        _current_operator_facing_brief_id=_current_operator_facing_orchestration_brief_id,
+        _CURRENT_OPERATOR_FACING_CLASSIFICATIONS=_CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS,
+        _CURRENT_OPERATOR_LOOP_POSTURES=_CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_POSTURES,
         current_orchestration_state=current_orchestration_state,
         current_orchestration_watchpoint=current_orchestration_watchpoint,
         current_orchestration_watchpoint_brief=current_orchestration_watchpoint_brief,
@@ -5955,6 +5977,7 @@ def resolve_current_operator_facing_orchestration_brief(
         active_packet_visibility=active_packet_visibility,
         operator_action_brief_visibility=operator_action_brief_visibility,
         operator_resolution_influence=operator_resolution_influence,
+        current_proposal=current_proposal,
         unified_result=unified_result,
     )
 
@@ -5987,7 +6010,8 @@ def resolve_current_orchestration_resolution_path_brief(
         repo_root,
         _anti_sovereignty_payload=_anti_sovereignty_payload,
         _current_orchestration_resolution_path_brief_id=_current_orchestration_resolution_path_brief_id,
-        _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CLASSIFICATIONS=_CURRENT_ORCHESTRATION_RESOLUTION_PATH_CLASSIFICATIONS,
+        _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CLASSIFICATIONS=_CURRENT_ORCHESTRATION_RESOLUTION_PATH_BRIEF_CLASSIFICATIONS,
+        _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CENTERS=_CURRENT_ORCHESTRATION_RESOLUTION_PATH_CENTERS,
         _CURRENT_ORCHESTRATION_RESOLUTION_PATH_POSTURES=_CURRENT_ORCHESTRATION_RESOLUTION_PATH_POSTURES,
         current_orchestration_state=current_orchestration_state,
         current_orchestration_watchpoint=current_orchestration_watchpoint,

--- a/sentientos/orchestration_spine/projection/current_state.py
+++ b/sentientos/orchestration_spine/projection/current_state.py
@@ -2938,6 +2938,7 @@ def resolve_current_orchestration_handoff_packet_brief_projection(
     """Resolve one bounded, non-executing brief for current orchestration handoff packet posture."""
 
     _ = repo_root.resolve()
+    _ = _CURRENT_HANDOFF_PACKET_BRIEF_POSTURES
     state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
     watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
     satisfaction_map = watchpoint_satisfaction if isinstance(watchpoint_satisfaction, Mapping) else {}
@@ -3049,7 +3050,7 @@ def resolve_current_orchestration_handoff_packet_brief_projection(
         rationale = "active_packet_is_visible_but_current_surfaces_do_not_honestly_support_stronger_packet_continuity_claims"
         conservative_or_uncertain = True
 
-    if classification not in _CURRENT_ORCHESTRATION_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS:
+    if classification not in _CURRENT_HANDOFF_PACKET_BRIEF_CLASSIFICATIONS:
         classification = "packet_continuity_uncertain"
         conservative_or_uncertain = True
 
@@ -3069,7 +3070,7 @@ def resolve_current_orchestration_handoff_packet_brief_projection(
     return {
         "schema_version": "current_orchestration_handoff_packet_brief.v1",
         "resolved_at": _iso_utc_now(),
-        "current_orchestration_handoff_packet_brief_id": _current_orchestration_handoff_packet_brief_id(
+        "current_orchestration_handoff_packet_brief_id": _current_handoff_packet_brief_id(
             current_orchestration_state_id=state_id,
             orchestration_watchpoint_id=watchpoint_id,
             watchpoint_satisfaction_id=satisfaction_id,
@@ -3185,6 +3186,7 @@ def resolve_current_operator_facing_orchestration_brief_projection(
     """Resolve one compact, derived operator-facing orchestration brief for current understanding only."""
 
     _ = repo_root.resolve()
+    _ = _CURRENT_OPERATOR_LOOP_POSTURES
     state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
     watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
     watchpoint_brief_map = (
@@ -3299,7 +3301,7 @@ def resolve_current_operator_facing_orchestration_brief_projection(
         classification = "operator_attention_not_currently_needed"
         rationale = "current_surfaces_do_not_show_meaningful_operator_dependency_for_the_current_path"
 
-    if classification not in _CURRENT_OPERATOR_FACING_ORCHESTRATION_BRIEF_CLASSIFICATIONS:
+    if classification not in _CURRENT_OPERATOR_FACING_CLASSIFICATIONS:
         classification = "operator_should_review_hold"
 
     loop_posture = "informational"
@@ -3331,7 +3333,7 @@ def resolve_current_operator_facing_orchestration_brief_projection(
     return {
         "schema_version": "current_operator_facing_orchestration_brief.v1",
         "resolved_at": _iso_utc_now(),
-        "current_operator_facing_orchestration_brief_id": _current_operator_facing_orchestration_brief_id(
+        "current_operator_facing_orchestration_brief_id": _current_operator_facing_brief_id(
             current_orchestration_state_id=state_id,
             orchestration_watchpoint_id=watchpoint_id,
             watchpoint_satisfaction_id=satisfaction_id,
@@ -3424,6 +3426,7 @@ def resolve_current_orchestration_resolution_path_brief_projection(
     _anti_sovereignty_payload: Callable[..., dict[str, Any]],
     _current_orchestration_resolution_path_brief_id: Callable[..., str],
     _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CLASSIFICATIONS: set[str],
+    _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CENTERS: set[str],
     _CURRENT_ORCHESTRATION_RESOLUTION_PATH_POSTURES: set[str],
     *,
     current_orchestration_state: Mapping[str, Any] | None = None,
@@ -3449,6 +3452,7 @@ def resolve_current_orchestration_resolution_path_brief_projection(
     """Resolve one bounded, observational brief describing the current orchestration resolution-path center of gravity."""
 
     _ = repo_root.resolve()
+    _ = _CURRENT_ORCHESTRATION_RESOLUTION_PATH_POSTURES
     state_map = current_orchestration_state if isinstance(current_orchestration_state, Mapping) else {}
     watchpoint_map = current_orchestration_watchpoint if isinstance(current_orchestration_watchpoint, Mapping) else {}
     watchpoint_brief_map = (
@@ -3632,7 +3636,7 @@ def resolve_current_orchestration_resolution_path_brief_projection(
         centered_on = "none"
         rationale = "current_surfaces_do_not_support_a_stronger_honest_resolution_path_center"
 
-    if classification not in _CURRENT_ORCHESTRATION_RESOLUTION_PATH_BRIEF_CLASSIFICATIONS:
+    if classification not in _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CLASSIFICATIONS:
         classification = "fragmented_path"
     if centered_on not in _CURRENT_ORCHESTRATION_RESOLUTION_PATH_CENTERS:
         centered_on = "none"
@@ -4348,4 +4352,3 @@ def resolve_current_re_evaluation_basis_brief_projection(
             },
         ),
     }
-


### PR DESCRIPTION
### Motivation
- Repair a signature/coherence regression on the scoped lifecycle diagnostic -> handoff-packet-brief call path so the decomposed orchestration spine remains contract-coherent after recent refactors.

### Description
- Restored façade compatibility for `resolve_current_orchestration_handoff_packet_brief` by accepting and forwarding `current_re_evaluation_basis_brief` and `operator_resolution_influence` (while preserving legacy acceptance of `proposal_packet_continuity_review`).
- Aligned wrapper-to-projection wiring for the related chain by fixing resolver identifier/constant names and forwarding the missing `current_proposal` into `resolve_current_operator_facing_orchestration_brief` and the projection calls.
- Introduced missing local posture sets used by wrappers and adjusted projection helpers to accept/use the passed-in classification/posture/center parameters rather than stale internal names (no authority or lifecycle semantics changed).
- Files changed: `sentientos/orchestration_intent_fabric.py` and `sentientos/orchestration_spine/projection/current_state.py`.
- Fix type: a mix of wrapper compatibility (façade signature acceptance) and projection signature/alignment (parameter and identifier reconciliation), plus small compatibility-preserving no-op forwardings to avoid unused-arg regressions.

### Testing
- Ran the targeted tests: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "scoped_lifecycle or handoff_packet_brief"`, and they passed after the fixes (previously failed due to `TypeError` signature mismatch).
- Ran the whole file tests: `pytest -q sentientos/tests/test_orchestration_intent_fabric.py`, and they passed (no orchestration-intent regressions observed).
- Attempted `pytest -q tests/test_codex_orchestration.py -k "orchestration and handoff"` but the run was blocked by the local editable-install guard in this environment; this is unrelated to the signature fixes.
- Conclusion: the `scoped_lifecycle_diagnostic` -> `resolve_current_orchestration_handoff_packet_brief(...)` path is coherent again and the orchestration-focused tests that were previously blocked by the signature mismatch now succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec22668c448320b46650bc8b15dcb0)