### PR TITLE
[codex:orchestration] document Phase 12 kernel boundary ownership inventory

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -1,5 +1,29 @@
 from __future__ import annotations
 
+"""Orchestration authority kernel/facade for the bounded orchestration spine.
+
+Phase 12 boundary inventory (code-near):
+- Kernel authority responsibilities (must remain here):
+  - Canonical identity + linkage invariants for intents/proposals/packets/receipts.
+  - Admission legality + executability gating for handoff into existing substrates.
+  - Closure semantics for internal execution and externally reported fulfillment.
+  - Anti-sovereignty guarantees and non-authoritative payload boundaries.
+- Facade compatibility wrappers (owned here, delegated implementation elsewhere):
+  - Wrapper resolvers that forward to ``sentientos.orchestration_spine.projection``
+    while preserving canonical schema constants and anti-sovereignty payload shape.
+  - Wrapper helpers that forward internal-maintenance substrate specifics to
+    ``sentientos.orchestration_spine.adapters.internal_maintenance``.
+- Injected boundary primitives consumed by projection/adapter modules:
+  - Immutable classification sets and id builders.
+  - ``_anti_sovereignty_payload`` + ``_normalized_current_surface_boundaries``.
+  - Ledger read/write utilities used to keep append-only evidence consistent.
+
+Dependency direction invariant:
+``orchestration_intent_fabric (kernel/facade) -> orchestration_spine.projection|adapters``.
+Projection modules are observational/derived only; adapters are substrate-specific
+helpers only. Neither layer owns authority mutation, admission law, or closure truth.
+"""
+
 import hashlib
 import json
 from datetime import datetime, timezone
@@ -11,11 +35,23 @@ import task_executor
 from sentientos.orchestration_spine.adapters import internal_maintenance
 from sentientos.orchestration_spine.projection import current_state, policy_helpers
 
-# Kernel/facade inventory (Phase 11 bounded normalization):
-# - Kernel authority surfaces in this module own intent admission, handoff, and resolution.
-# - Projection and adapter helpers are consumed from ``sentientos.orchestration_spine.*``.
-# - Legacy shim modules remain for external compatibility; internal orchestration code
-#   should prefer canonical orchestration_spine import paths.
+# Phase 12 inventory anchors (intentionally concise and code-near).
+_KERNEL_AUTHORITY_OWNERSHIP = (
+    "canonical identity and linkage invariants",
+    "executability/admission legality and handoff authority",
+    "closure semantics and result resolution truth",
+    "anti-sovereignty guarantees and non-authoritative boundaries",
+)
+_FACADE_COMPATIBILITY_OWNERSHIP = (
+    "projection wrapper entry points with canonical schema constants",
+    "internal-maintenance adapter wrapper entry points",
+    "legacy import continuity for orchestration callers",
+)
+_INJECTED_BOUNDARY_PRIMITIVE_OWNERSHIP = (
+    "classification sets and id builders injected into projection/adapters",
+    "anti-sovereignty payload + normalized-current-boundary builders",
+    "append-only ledger utilities for proof-visible orchestration history",
+)
 
 _INTENT_KINDS = {
     "internal_maintenance_execution",
@@ -868,14 +904,17 @@ def _validate_handoff_minimum_fields(intent: Mapping[str, Any]) -> list[str]:
 
 
 def _build_internal_maintenance_task(intent: Mapping[str, Any]) -> task_executor.Task:
+    """Kernel-owned facade wrapper for substrate-specific maintenance task shaping."""
     return internal_maintenance.build_internal_maintenance_task(intent)
 
 
 def _default_admission_context() -> task_admission.AdmissionContext:
+    """Kernel-owned facade wrapper for adapter-provided default admission context."""
     return internal_maintenance.default_admission_context(_iso_utc_now())
 
 
 def _default_admission_policy() -> task_admission.AdmissionPolicy:
+    """Kernel-owned facade wrapper for adapter-provided default admission policy."""
     return internal_maintenance.default_admission_policy()
 
 
@@ -2396,7 +2435,7 @@ def derive_orchestration_venue_mix_review(
 def derive_orchestration_attention_recommendation(
     outcome_review: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Derive bounded operator-attention recommendation from orchestration outcome review only."""
+    """Facade wrapper over policy projection; kernel still owns anti-sovereignty envelope."""
     projection = policy_helpers.derive_attention_projection(
         outcome_review,
         allowed_recommendations=_ORCHESTRATION_ATTENTION_RECOMMENDATIONS,
@@ -2441,7 +2480,7 @@ def derive_next_venue_recommendation(
     venue_mix_review: Mapping[str, Any],
     attention_recommendation: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Derive a bounded next-venue recommendation from existing orchestration signals only."""
+    """Facade wrapper over policy projection; kernel remains schema/invariant owner."""
     projection = policy_helpers.derive_next_venue_projection(
         delegated_judgment,
         outcome_review,
@@ -5431,6 +5470,7 @@ def resolve_current_orchestration_resumption_candidate(
     packetization_gate: Mapping[str, Any] | None = None,
     unified_result: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Facade compatibility wrapper for current-state projection computation."""
     return current_state.resolve_current_orchestration_resumption_candidate_projection(
         repo_root,
         anti_sovereignty_payload_builder=_anti_sovereignty_payload,

--- a/sentientos/orchestration_spine/__init__.py
+++ b/sentientos/orchestration_spine/__init__.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 """Bounded orchestration-spine package.
 
-This package clarifies orchestration-internal module boundaries:
-- projection/* for current-state and policy projection helpers
-- adapters/* for orchestration-internal adapter glue
+Boundary ownership:
+- ``projection/*`` owns observational/derived projection logic only.
+- ``adapters/*`` owns substrate-specific helper logic only.
+- authority kernel ownership remains in ``sentientos.orchestration_intent_fabric``.
+
+Dependency direction is intentionally one-way:
+``orchestration_intent_fabric -> orchestration_spine.(projection|adapters)``.
+Projection and adapter modules must not become new authority or truth sources.
 """
 
 __all__ = ["projection", "adapters"]

--- a/sentientos/orchestration_spine/adapters/__init__.py
+++ b/sentientos/orchestration_spine/adapters/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-"""Orchestration-internal adapter helpers."""
+"""Substrate-specific helpers consumed by the orchestration kernel/facade.
+
+Adapter modules can shape calls into concrete substrates, but they do not own
+orchestration authority policy, lifecycle closure semantics, or new truth sources.
+"""
 
 from . import internal_maintenance
 

--- a/sentientos/orchestration_spine/adapters/internal_maintenance.py
+++ b/sentientos/orchestration_spine/adapters/internal_maintenance.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Internal-maintenance adapter primitives for orchestration handoff.
+
+This module is adapter-owned and substrate-specific. It shapes maintenance tasks
+and default admission inputs, while kernel authority decisions remain in
+``sentientos.orchestration_intent_fabric``.
+"""
+
 import json
 from pathlib import Path
 from typing import Any, Callable, Mapping

--- a/sentientos/orchestration_spine/projection/__init__.py
+++ b/sentientos/orchestration_spine/projection/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Projection helpers used by the orchestration spine."""
+"""Observational projection helpers for orchestration.
+
+These modules derive summaries/recommendations from already-materialized
+orchestration evidence. They must not own admission authority, execution routing,
+or canonical lifecycle truth.
+"""
 
 from . import current_state, policy_helpers
 

--- a/sentientos/orchestration_spine/projection/current_state.py
+++ b/sentientos/orchestration_spine/projection/current_state.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Current-state orchestration projections.
+
+This module is projection-owned: it derives observational-only current-state
+surfaces from inputs supplied by the orchestration kernel/facade. It must not
+introduce new authority decisions, mutable truth stores, or execution side effects.
+"""
+
 import hashlib
 import json
 from datetime import datetime, timezone

--- a/sentientos/orchestration_spine/projection/policy_helpers.py
+++ b/sentientos/orchestration_spine/projection/policy_helpers.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+"""Policy projection helpers for bounded orchestration recommendations.
+
+These helpers compute derived recommendation projections only. Kernel callers
+remain responsible for canonical schema shaping and anti-sovereignty envelopes.
+"""
+
 from typing import Any, Mapping
 
 


### PR DESCRIPTION
### Motivation
- Make the remaining orchestration authority kernel explicit and easier to read so future work does not accidentally re-centralize projection logic or leak authority into adapters. 
- Provide a bounded, code-near Phase 12 inventory that clarifies what must remain kernel-owned (identity/linkage, admission gating, closure semantics, anti-sovereignty) without changing behavior or lifecycle semantics.

### Description
- Add a Phase 12 code-near boundary inventory and dependency-direction invariant to `sentientos/orchestration_intent_fabric.py` describing kernel ownership, facade compatibility wrappers, and injected boundary primitives. 
- Mark a handful of kernel facade wrapper entry points with concise docstrings (`_build_internal_maintenance_task`, `_default_admission_context`, `_default_admission_policy`, `derive_*` wrappers, and `resolve_current_orchestration_resumption_candidate`) to make their role explicit while retaining existing forwarding behavior. 
- Expand package/module docstrings in the orchestration spine to assert that `projection/*` is observational-only and `adapters/*` are substrate helpers and to record the intended one-way dependency `orchestration_intent_fabric -> orchestration_spine.(projection|adapters)`. 
- Files changed: `sentientos/orchestration_intent_fabric.py`, `sentientos/orchestration_spine/__init__.py`, `sentientos/orchestration_spine/projection/__init__.py`, `sentientos/orchestration_spine/adapters/__init__.py`, `sentientos/orchestration_spine/projection/current_state.py`, `sentientos/orchestration_spine/projection/policy_helpers.py`, and `sentientos/orchestration_spine/adapters/internal_maintenance.py`.

### Testing
- Compiled the modified modules with `python -m compileall ...` which succeeded. 
- Attempted to run the orchestration-focused test `pytest -q tests/test_codex_orchestration.py` but the run exited due to the repository editable-install airlock guard in `tests/conftest.py` (environment gating), so the failure is an environment/setup guard and not a code regression. 
- All changes are documentation/wrapper-only and preserve existing import/forwarding behavior, so no orchestration surface or authority semantics were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecfdd2b3a883208a3c8ba4bc551c85)