### PR TITLE
[codex:orchestration] normalize projection family inventory docs

### DIFF
--- a/sentientos/orchestration_spine/projection/__init__.py
+++ b/sentientos/orchestration_spine/projection/__init__.py
@@ -5,8 +5,27 @@ from __future__ import annotations
 These modules derive summaries/recommendations from already-materialized
 orchestration evidence. They must not own admission authority, execution routing,
 or canonical lifecycle truth.
+
+Projection family inventory (documentation-only):
+- ``current_state`` current-state/current-brief projections, including current
+  picture compression plus export/receipt/acceptance projections.
+- ``policy_helpers`` policy/recommendation projections that derive bounded
+  guidance from kernel-supplied review surfaces.
 """
 
 from . import current_state, policy_helpers
 
-__all__ = ["current_state", "policy_helpers"]
+PROJECTION_FAMILY_CURRENT_STATE = "current_state"
+PROJECTION_FAMILY_POLICY = "policy"
+PROJECTION_FAMILIES = (
+    PROJECTION_FAMILY_CURRENT_STATE,
+    PROJECTION_FAMILY_POLICY,
+)
+
+__all__ = [
+    "current_state",
+    "policy_helpers",
+    "PROJECTION_FAMILY_CURRENT_STATE",
+    "PROJECTION_FAMILY_POLICY",
+    "PROJECTION_FAMILIES",
+]

--- a/sentientos/orchestration_spine/projection/current_state.py
+++ b/sentientos/orchestration_spine/projection/current_state.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 This module is projection-owned: it derives observational-only current-state
 surfaces from inputs supplied by the orchestration kernel/facade. It must not
 introduce new authority decisions, mutable truth stores, or execution side effects.
+
+Projection families in this module (documentation-only):
+- current-state/current-brief projections: summarize the active orchestration
+  picture from kernel-provided evidence surfaces.
+- current-picture compression projections: condense many current-state inputs
+  into bounded digests/briefs without claiming new authority.
+- export/receipt/acceptance projections: derive bounded handoff consumability
+  posture from existing export and current-picture surfaces.
+
+Kernel ownership boundary reminder:
+- identity/linkage/legality/closure/anti-sovereignty remain kernel authority.
+- projections here remain derived, non-authoritative, and non-executing.
 """
 
 import hashlib
@@ -30,6 +42,29 @@ _CURRENT_ORCHESTRATION_HANDOFF_ACCEPTANCE_POSTURE_CLASSIFICATIONS = {
     "handoff_acceptance_minimal",
     "no_current_handoff_acceptance_posture",
 }
+
+# Projection-family inventory helpers (naming/clarity only; no behavior impact).
+CURRENT_STATE_PROJECTION_FAMILY_CURRENT_BRIEFS = (
+    "resolve_current_orchestration_resumption_candidate_projection",
+    "resolve_current_resumed_operation_readiness_verdict_projection",
+    "resolve_current_orchestration_watchpoint_brief_projection",
+    "resolve_current_orchestration_pressure_signal_projection",
+    "resolve_current_orchestration_wake_readiness_detector_projection",
+    "resolve_current_operator_facing_orchestration_brief_projection",
+    "resolve_current_orchestration_resolution_path_brief_projection",
+    "resolve_current_orchestration_closure_brief_projection",
+    "resolve_current_re_evaluation_basis_brief_projection",
+)
+CURRENT_STATE_PROJECTION_FAMILY_PICTURE_COMPRESSION = (
+    "resolve_current_orchestration_coherence_brief",
+    "resolve_current_orchestration_digest",
+    "resolve_current_orchestration_transition_brief",
+    "resolve_current_orchestration_handoff_packet_brief_projection",
+)
+CURRENT_STATE_PROJECTION_FAMILY_EXPORT_ACCEPTANCE = (
+    "resolve_current_orchestration_export_packet_consumer_receipt",
+    "resolve_current_orchestration_handoff_acceptance_posture",
+)
 
 
 def _iso_utc_now() -> str:

--- a/sentientos/orchestration_spine/projection/policy_helpers.py
+++ b/sentientos/orchestration_spine/projection/policy_helpers.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 These helpers compute derived recommendation projections only. Kernel callers
 remain responsible for canonical schema shaping and anti-sovereignty envelopes.
+They must not own venue authority, admission authority, lifecycle truth, or
+execution routing.
 """
 
 from typing import Any, Mapping
+
+POLICY_PROJECTION_FAMILY_RECOMMENDATION = (
+    "derive_attention_projection",
+    "derive_next_venue_projection",
+)
 
 
 def derive_attention_projection(

--- a/sentientos/tests/test_orchestration_spine_module_boundaries.py
+++ b/sentientos/tests/test_orchestration_spine_module_boundaries.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from sentientos import orchestration_internal_adapters
 from sentientos import orchestration_projection_policy
 from sentientos.orchestration_spine.adapters import internal_maintenance
-from sentientos.orchestration_spine.projection import policy_helpers
+from sentientos.orchestration_spine.projection import (
+    PROJECTION_FAMILIES,
+    PROJECTION_FAMILY_CURRENT_STATE,
+    PROJECTION_FAMILY_POLICY,
+    current_state,
+    policy_helpers,
+)
 
 
 def test_projection_policy_compatibility_shim_exports_same_callable() -> None:
@@ -12,3 +18,11 @@ def test_projection_policy_compatibility_shim_exports_same_callable() -> None:
 
 def test_internal_adapter_compatibility_shim_exports_same_callable() -> None:
     assert orchestration_internal_adapters.build_internal_maintenance_task is internal_maintenance.build_internal_maintenance_task
+
+
+def test_projection_module_exposes_documented_family_inventory() -> None:
+    assert PROJECTION_FAMILIES == (PROJECTION_FAMILY_CURRENT_STATE, PROJECTION_FAMILY_POLICY)
+    assert PROJECTION_FAMILY_CURRENT_STATE == "current_state"
+    assert PROJECTION_FAMILY_POLICY == "policy"
+    assert "resolve_current_orchestration_digest" in current_state.CURRENT_STATE_PROJECTION_FAMILY_PICTURE_COMPRESSION
+    assert "derive_next_venue_projection" in policy_helpers.POLICY_PROJECTION_FAMILY_RECOMMENDATION


### PR DESCRIPTION
### Motivation
- Make the extracted orchestration projection layer more legible and self-documenting so contributors can tell which projection surfaces belong together and which remain non-authoritative. 
- Clarify boundaries between kernel authority and projection-derived, observational surfaces without changing behavior or lifecycle semantics. 
- Provide a small, machine-checkable contract at the package boundary so importers can assert projection-family inventory consistency.

### Description
- Add package-level, documentation-only projection-family inventory and export constants in `sentientos/orchestration_spine/projection/__init__.py` documenting the `current_state` and `policy` families. 
- Add code-near documentation and three small grouping constants in `sentientos/orchestration_spine/projection/current_state.py` that classify resolvers into `CURRENT_BRIEFS`, `PICTURE_COMPRESSION`, and `EXPORT_ACCEPTANCE` projection tuples and reiterate kernel ownership boundaries. 
- Add a policy-family inventory tuple `POLICY_PROJECTION_FAMILY_RECOMMENDATION` and a short boundary reminder in `sentientos/orchestration_spine/projection/policy_helpers.py`. 
- Add a focused unit test `sentientos/tests/test_orchestration_spine_module_boundaries.py` that asserts the exported `PROJECTION_FAMILIES` and representative membership without altering resolver behavior.

### Testing
- Ran the targeted orchestration module-boundary test with `pytest -q sentientos/tests/test_orchestration_spine_module_boundaries.py` and it passed (3 tests, all successful). 
- No other automated test suites were executed as this is a bounded documentation/normalization pass limited to the projection layer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed567613a08320a98b2098af8f0492)