### PR TITLE
[codex:orchestration] document adapter family inventory and normalize grouping

### DIFF
--- a/sentientos/orchestration_spine/adapters/__init__.py
+++ b/sentientos/orchestration_spine/adapters/__init__.py
@@ -4,8 +4,22 @@ from __future__ import annotations
 
 Adapter modules can shape calls into concrete substrates, but they do not own
 orchestration authority policy, lifecycle closure semantics, or new truth sources.
+
+Adapter family inventory (documentation-only):
+- ``internal_maintenance`` substrate handoff helpers for internal-maintenance
+  execution through ``task_admission``/``task_executor`` surfaces.
+
+Kernel/facade ownership remains canonical for identity/linkage/legality/closure
+meaning; adapters only normalize and relay substrate-local evidence.
 """
 
 from . import internal_maintenance
 
-__all__ = ["internal_maintenance"]
+ADAPTER_FAMILY_INTERNAL_MAINTENANCE = "internal_maintenance"
+ADAPTER_FAMILIES = (ADAPTER_FAMILY_INTERNAL_MAINTENANCE,)
+
+__all__ = [
+    "internal_maintenance",
+    "ADAPTER_FAMILY_INTERNAL_MAINTENANCE",
+    "ADAPTER_FAMILIES",
+]

--- a/sentientos/orchestration_spine/adapters/internal_maintenance.py
+++ b/sentientos/orchestration_spine/adapters/internal_maintenance.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 This module is adapter-owned and substrate-specific. It shapes maintenance tasks
 and default admission inputs, while kernel authority decisions remain in
 ``sentientos.orchestration_intent_fabric``.
+
+Adapter responsibility groups in this module:
+- maintenance task materialization into ``task_executor.Task`` payloads
+- admission/log handshake helpers for ``task_admission`` substrate calls
+- task-executor result linkage helpers over raw jsonl substrate evidence
+
+These helpers must never redefine canonical intent identity, legal/illegal
+meaning, linkage authority, or closure semantics; those remain kernel-owned.
 """
 
 import json
@@ -14,8 +22,23 @@ from typing import Any, Callable, Mapping
 import task_admission
 import task_executor
 
+ADAPTER_GROUP_MAINTENANCE_TASK_MATERIALIZATION = "maintenance_task_materialization"
+ADAPTER_GROUP_ADMISSION_HANDSHAKE = "admission_log_handshake"
+ADAPTER_GROUP_EXECUTOR_RESULT_LINKAGE = "executor_result_linkage"
+ADAPTER_GROUPS = (
+    ADAPTER_GROUP_MAINTENANCE_TASK_MATERIALIZATION,
+    ADAPTER_GROUP_ADMISSION_HANDSHAKE,
+    ADAPTER_GROUP_EXECUTOR_RESULT_LINKAGE,
+)
+
 
 def build_internal_maintenance_task(intent: Mapping[str, Any]) -> task_executor.Task:
+    """Materialize bounded internal-maintenance work into executor substrate shape.
+
+    Consumes already-derived orchestration intent evidence and emits a concrete
+    ``task_executor.Task`` compatible payload. This adapter does not decide
+    authority, legitimacy, or lifecycle outcomes.
+    """
     source = intent.get("source_delegated_judgment")
     source_mapping = source if isinstance(source, Mapping) else {}
     return task_executor.Task(
@@ -48,6 +71,11 @@ def build_internal_maintenance_task(intent: Mapping[str, Any]) -> task_executor.
 
 
 def default_admission_context(now_utc_iso: str) -> task_admission.AdmissionContext:
+    """Provide adapter-local default admission context for substrate invocation.
+
+    This is wiring convenience for ``task_admission``; canonical actor/identity
+    authority still resides in the orchestration kernel/facade contract.
+    """
     return task_admission.AdmissionContext(
         actor="orchestration_intent_fabric",
         mode="autonomous",
@@ -59,6 +87,7 @@ def default_admission_context(now_utc_iso: str) -> task_admission.AdmissionConte
 
 
 def default_admission_policy() -> task_admission.AdmissionPolicy:
+    """Return the bounded admission policy handle used for handoff calls."""
     return task_admission.AdmissionPolicy(policy_version="orchestration_intent_handoff.v1")
 
 
@@ -70,6 +99,11 @@ def admit_internal_maintenance_intent(
     admission_policy: task_admission.AdmissionPolicy | None,
     now_utc_iso: str,
 ) -> dict[str, Any]:
+    """Bridge internal-maintenance intent into admission substrate + log evidence.
+
+    Shapes substrate call arguments, performs admission invocation/logging, and
+    returns a normalized evidence map for upstream orchestration reporting.
+    """
     ctx = admission_context or default_admission_context(now_utc_iso)
     policy = admission_policy or default_admission_policy()
     task = build_internal_maintenance_task(intent)
@@ -92,6 +126,11 @@ def resolve_task_executor_result_linkage(
     executor_log_path: Path,
     read_jsonl: Callable[[Path], list[dict[str, Any]]],
 ) -> dict[str, Any]:
+    """Resolve executor-side evidence rows linked to an admitted handoff task.
+
+    Consumes handoff details plus raw executor jsonl rows and returns linkage
+    evidence only; it does not establish canonical linkage semantics.
+    """
     details = handoff.get("details")
     detail_map = details if isinstance(details, Mapping) else {}
     task_admission_details = detail_map.get("task_admission")
@@ -104,3 +143,16 @@ def resolve_task_executor_result_linkage(
         "task_rows": matching_rows,
         "task_result_rows": task_result_rows,
     }
+
+
+__all__ = [
+    "ADAPTER_GROUP_MAINTENANCE_TASK_MATERIALIZATION",
+    "ADAPTER_GROUP_ADMISSION_HANDSHAKE",
+    "ADAPTER_GROUP_EXECUTOR_RESULT_LINKAGE",
+    "ADAPTER_GROUPS",
+    "build_internal_maintenance_task",
+    "default_admission_context",
+    "default_admission_policy",
+    "admit_internal_maintenance_intent",
+    "resolve_task_executor_result_linkage",
+]

--- a/sentientos/tests/test_orchestration_spine_module_boundaries.py
+++ b/sentientos/tests/test_orchestration_spine_module_boundaries.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from sentientos import orchestration_internal_adapters
 from sentientos import orchestration_projection_policy
-from sentientos.orchestration_spine.adapters import internal_maintenance
+from sentientos.orchestration_spine.adapters import (
+    ADAPTER_FAMILIES,
+    ADAPTER_FAMILY_INTERNAL_MAINTENANCE,
+    internal_maintenance,
+)
 from sentientos.orchestration_spine.projection import (
     PROJECTION_FAMILIES,
     PROJECTION_FAMILY_CURRENT_STATE,
@@ -26,3 +30,13 @@ def test_projection_module_exposes_documented_family_inventory() -> None:
     assert PROJECTION_FAMILY_POLICY == "policy"
     assert "resolve_current_orchestration_digest" in current_state.CURRENT_STATE_PROJECTION_FAMILY_PICTURE_COMPRESSION
     assert "derive_next_venue_projection" in policy_helpers.POLICY_PROJECTION_FAMILY_RECOMMENDATION
+
+
+def test_adapter_module_exposes_documented_family_inventory() -> None:
+    assert ADAPTER_FAMILIES == (ADAPTER_FAMILY_INTERNAL_MAINTENANCE,)
+    assert ADAPTER_FAMILY_INTERNAL_MAINTENANCE == "internal_maintenance"
+    assert internal_maintenance.ADAPTER_GROUPS == (
+        internal_maintenance.ADAPTER_GROUP_MAINTENANCE_TASK_MATERIALIZATION,
+        internal_maintenance.ADAPTER_GROUP_ADMISSION_HANDSHAKE,
+        internal_maintenance.ADAPTER_GROUP_EXECUTOR_RESULT_LINKAGE,
+    )


### PR DESCRIPTION
### Motivation
- Clarify and document the extracted orchestration adapter family so future contributors can tell which helpers belong in the adapter layer and what they must not own. 
- Provide a concise, code-near inventory and grouping for the internal-maintenance adapter without changing authority, lifecycle semantics, or behavior.

### Description
- Added a package-level adapter-family inventory and stable constants in `sentientos.orchestration_spine.adapters` (`ADAPTER_FAMILY_INTERNAL_MAINTENANCE`, `ADAPTER_FAMILIES`) and expanded the package docstring to state adapter non-ownership of canonical authority/closure semantics. (file: `sentientos/orchestration_spine/adapters/__init__.py`)
- Documented and normalized `internal_maintenance` into three explicit adapter responsibility groups and exported group constants: `maintenance_task_materialization`, `admission_log_handshake`, and `executor_result_linkage`, plus `ADAPTER_GROUPS`. (file: `sentientos/orchestration_spine/adapters/internal_maintenance.py`)
- Added concise docstrings on adapter helpers describing what substrate evidence they consume or shape and reiterating that canonical identity/linkage/legality/closure remain kernel-owned. (file: `sentientos/orchestration_spine/adapters/internal_maintenance.py`)
- Exported an `__all__` for the adapter module symbols to make inventory stable and discoverable. (file: `sentientos/orchestration_spine/adapters/internal_maintenance.py`)
- Added a focused module-boundary test asserting the new adapter family and group inventory to protect the normalization against regressions. (file: `sentientos/tests/test_orchestration_spine_module_boundaries.py`)

### Testing
- Ran the orchestration-focused tests: `python -m pytest -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py -k "task_executor_result_linkage or module_boundaries"` and observed all tests pass (4 passed).
- No other behavioral or integration tests were changed; the pass is purely documentation/normalization and is validated by the added module-boundary assertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed5a2dea448320b0ce4c5eed43e9bd)