### PR TITLE
[codex:orchestration_spine] extract intent synthesis kernel slice

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -33,7 +33,12 @@ from typing import Any, Mapping
 import task_admission
 import task_executor
 from sentientos.orchestration_spine.adapters import internal_maintenance
-from sentientos.orchestration_spine.kernel import resolve_unified_orchestration_result_kernel
+from sentientos.orchestration_spine.kernel import (
+    resolve_unified_orchestration_result_kernel,
+    source_judgment_linkage as _source_judgment_linkage_kernel,
+    synthesize_orchestration_intent_kernel,
+    translate_orchestration_kind as _translate_kind_kernel,
+)
 from sentientos.orchestration_spine.projection import current_state, policy_helpers
 
 # Facade module aliases keep wrapper boundaries explicit and visually consistent.
@@ -740,91 +745,12 @@ def _intent_id(source_judgment: Mapping[str, Any], created_at: str) -> str:
     )
 
 
-def _classify_authority_posture(judgment: Mapping[str, Any]) -> str:
-    escalation = str(judgment.get("escalation_classification") or "")
-    venue = str(judgment.get("recommended_venue") or "")
-    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
-        return "insufficient_context_blocked"
-    if escalation == "escalate_for_operator_priority":
-        return "operator_priority_required"
-    if venue in {"codex_implementation", "deep_research_audit", "operator_decision_required"}:
-        return "operator_approval_required"
-    return "no_additional_operator_approval_required"
-
-
 def _translate_kind(judgment: Mapping[str, Any]) -> tuple[str, str, str]:
-    venue = str(judgment.get("recommended_venue") or "")
-    work_class = str(judgment.get("work_class") or "")
-    escalation = str(judgment.get("escalation_classification") or "")
-
-    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
-        return "hold_no_action", "no_execution_target_yet", "blocked_insufficient_context"
-
-    if venue == "internal_direct_execution" and work_class == "internal_runtime_maintenance":
-        return "internal_maintenance_execution", "task_admission_executor", "executable_now"
-
-    if venue == "codex_implementation":
-        return "codex_work_order", "no_execution_target_yet", "stageable_external_work_order"
-
-    if venue == "deep_research_audit":
-        return "deep_research_work_order", "no_execution_target_yet", "stageable_external_work_order"
-
-    if venue == "operator_decision_required":
-        return "operator_review_request", "no_execution_target_yet", "blocked_operator_required"
-
-    if work_class == "external_tool_orchestration":
-        return "operator_review_request", "external_tool_placeholder", "stageable_external_work_order"
-
-    return "hold_no_action", "no_execution_target_yet", "no_action_recommended"
-
-
-def _derive_admission_state(executability: str, authority_posture: str) -> str:
-    if executability == "executable_now" and authority_posture == "no_additional_operator_approval_required":
-        return "admitted_for_internal_staging"
-    if authority_posture == "operator_priority_required":
-        return "deferred_operator_priority"
-    if authority_posture == "insufficient_context_blocked":
-        return "deferred_insufficient_context"
-    if executability == "stageable_external_work_order":
-        return "staged_non_executable_work_order"
-    if executability == "blocked_operator_required":
-        return "deferred_operator_approval"
-    return "no_action"
+    return _translate_kind_kernel(judgment)
 
 
 def _source_judgment_linkage(judgment: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        "work_class": str(judgment.get("work_class") or "operator_required"),
-        "recommended_venue": str(judgment.get("recommended_venue") or "insufficient_context"),
-        "next_move_posture": str(judgment.get("next_move_posture") or "hold"),
-        "consolidation_expansion_posture": str(judgment.get("consolidation_expansion_posture") or "insufficient_context"),
-        "escalation_classification": str(judgment.get("escalation_classification") or "escalate_for_missing_context"),
-        "readiness_basis": {
-            "orchestration_substitution_readiness": judgment.get("orchestration_substitution_readiness", {}),
-            "basis": judgment.get("basis", {}),
-        },
-    }
-
-
-def _work_order_payload(intent_kind: str, source_linkage: Mapping[str, Any], executability: str, authority_posture: str) -> dict[str, Any] | None:
-    if intent_kind not in {"codex_work_order", "deep_research_work_order", "operator_review_request"}:
-        return None
-
-    venue = str(source_linkage.get("recommended_venue") or "")
-    rationale = source_linkage.get("readiness_basis", {}).get("basis", {}) if isinstance(source_linkage.get("readiness_basis"), Mapping) else {}
-    return {
-        "work_order_kind": intent_kind,
-        "intended_venue": venue,
-        "bounded_rationale": {
-            "signal_reasons": list(rationale.get("signal_reasons") or []),
-            "slice_health_status": rationale.get("slice_health_status"),
-            "slice_stability_classification": rationale.get("slice_stability_classification"),
-            "slice_review_classification": rationale.get("slice_review_classification"),
-        },
-        "authority_posture": authority_posture,
-        "executability_classification": executability,
-        "staged_only": executability != "executable_now",
-    }
+    return _source_judgment_linkage_kernel(judgment)
 
 
 def synthesize_orchestration_intent(
@@ -834,50 +760,17 @@ def synthesize_orchestration_intent(
 ) -> dict[str, Any]:
     """Translate delegated judgment into a bounded, governed orchestration intent."""
 
-    source_linkage = _source_judgment_linkage(delegated_judgment)
-    authority_posture = _classify_authority_posture(delegated_judgment)
-    intent_kind, execution_target, executability = _translate_kind(delegated_judgment)
-    admission_state = _derive_admission_state(executability, authority_posture)
-    timestamp = created_at or _iso_utc_now()
-    intent_id = _intent_id(source_linkage, timestamp)
-
-    if intent_kind not in _INTENT_KINDS:
-        intent_kind = "hold_no_action"
-    if authority_posture not in _AUTHORITY_POSTURES:
-        authority_posture = "insufficient_context_blocked"
-    if execution_target not in _EXECUTION_TARGETS:
-        execution_target = "no_execution_target_yet"
-    if executability not in _EXECUTABILITY:
-        executability = "blocked_insufficient_context"
-    if admission_state not in _ADMISSION_STATES:
-        admission_state = "deferred_insufficient_context"
-
-    requires_operator_approval = authority_posture != "no_additional_operator_approval_required"
-    work_order = _work_order_payload(intent_kind, source_linkage, executability, authority_posture)
-
-    return {
-        "schema_version": "orchestration_intent.v1",
-        "intent_id": intent_id,
-        "created_at": timestamp,
-        "intent_kind": intent_kind,
-        "source_delegated_judgment": source_linkage,
-        "required_authority_posture": authority_posture,
-        "execution_target": execution_target,
-        "executability_classification": executability,
-        "handoff_admission_state": admission_state,
-        "work_order": work_order,
-        "requires_admission": execution_target in {"task_admission_executor", "mutation_router", "federation_canonical_execution"},
-        "requires_operator_approval": requires_operator_approval,
-        **_anti_sovereignty_payload(
-            recommendation_only=False,
-            diagnostic_only=False,
-            does_not_invoke_external_tools=True,
-        ),
-        "staged_handoff_only": executability != "executable_now",
-        "does_not_override_existing_admission": True,
-        "does_not_override_kernel_or_governor": True,
-        "does_not_replace_operator_authority": True,
-    }
+    return synthesize_orchestration_intent_kernel(
+        delegated_judgment,
+        created_at=created_at,
+        iso_utc_now=_iso_utc_now,
+        anti_sovereignty_payload=_anti_sovereignty_payload,
+        intent_kinds=_INTENT_KINDS,
+        authority_postures=_AUTHORITY_POSTURES,
+        execution_targets=_EXECUTION_TARGETS,
+        executability_classes=_EXECUTABILITY,
+        admission_states=_ADMISSION_STATES,
+    )
 
 
 def append_orchestration_intent_ledger(repo_root: Path, intent: Mapping[str, Any]) -> Path:

--- a/sentientos/orchestration_spine/kernel/__init__.py
+++ b/sentientos/orchestration_spine/kernel/__init__.py
@@ -1,5 +1,11 @@
 """Authority-kernel internal modules for orchestration spine decomposition."""
 
+from .intent_synthesis import source_judgment_linkage, synthesize_orchestration_intent_kernel, translate_orchestration_kind
 from .unified_results import resolve_unified_orchestration_result_kernel
 
-__all__ = ["resolve_unified_orchestration_result_kernel"]
+__all__ = [
+    "resolve_unified_orchestration_result_kernel",
+    "synthesize_orchestration_intent_kernel",
+    "translate_orchestration_kind",
+    "source_judgment_linkage",
+]

--- a/sentientos/orchestration_spine/kernel/intent_synthesis.py
+++ b/sentientos/orchestration_spine/kernel/intent_synthesis.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Mapping
+
+
+def _intent_id(source_judgment: Mapping[str, Any], created_at: str) -> str:
+    canonical = json.dumps(
+        {
+            "created_at": created_at,
+            "source_judgment": dict(source_judgment),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"orh-{hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:16]}"
+
+
+def classify_authority_posture(judgment: Mapping[str, Any]) -> str:
+    escalation = str(judgment.get("escalation_classification") or "")
+    venue = str(judgment.get("recommended_venue") or "")
+    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
+        return "insufficient_context_blocked"
+    if escalation == "escalate_for_operator_priority":
+        return "operator_priority_required"
+    if venue in {"codex_implementation", "deep_research_audit", "operator_decision_required"}:
+        return "operator_approval_required"
+    return "no_additional_operator_approval_required"
+
+
+def translate_orchestration_kind(judgment: Mapping[str, Any]) -> tuple[str, str, str]:
+    venue = str(judgment.get("recommended_venue") or "")
+    work_class = str(judgment.get("work_class") or "")
+    escalation = str(judgment.get("escalation_classification") or "")
+
+    if escalation == "escalate_for_missing_context" or venue == "insufficient_context":
+        return "hold_no_action", "no_execution_target_yet", "blocked_insufficient_context"
+
+    if venue == "internal_direct_execution" and work_class == "internal_runtime_maintenance":
+        return "internal_maintenance_execution", "task_admission_executor", "executable_now"
+
+    if venue == "codex_implementation":
+        return "codex_work_order", "no_execution_target_yet", "stageable_external_work_order"
+
+    if venue == "deep_research_audit":
+        return "deep_research_work_order", "no_execution_target_yet", "stageable_external_work_order"
+
+    if venue == "operator_decision_required":
+        return "operator_review_request", "no_execution_target_yet", "blocked_operator_required"
+
+    if work_class == "external_tool_orchestration":
+        return "operator_review_request", "external_tool_placeholder", "stageable_external_work_order"
+
+    return "hold_no_action", "no_execution_target_yet", "no_action_recommended"
+
+
+def derive_admission_state(executability: str, authority_posture: str) -> str:
+    if executability == "executable_now" and authority_posture == "no_additional_operator_approval_required":
+        return "admitted_for_internal_staging"
+    if authority_posture == "operator_priority_required":
+        return "deferred_operator_priority"
+    if authority_posture == "insufficient_context_blocked":
+        return "deferred_insufficient_context"
+    if executability == "stageable_external_work_order":
+        return "staged_non_executable_work_order"
+    if executability == "blocked_operator_required":
+        return "deferred_operator_approval"
+    return "no_action"
+
+
+def source_judgment_linkage(judgment: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "work_class": str(judgment.get("work_class") or "operator_required"),
+        "recommended_venue": str(judgment.get("recommended_venue") or "insufficient_context"),
+        "next_move_posture": str(judgment.get("next_move_posture") or "hold"),
+        "consolidation_expansion_posture": str(judgment.get("consolidation_expansion_posture") or "insufficient_context"),
+        "escalation_classification": str(judgment.get("escalation_classification") or "escalate_for_missing_context"),
+        "readiness_basis": {
+            "orchestration_substitution_readiness": judgment.get("orchestration_substitution_readiness", {}),
+            "basis": judgment.get("basis", {}),
+        },
+    }
+
+
+def _work_order_payload(intent_kind: str, source_linkage: Mapping[str, Any], executability: str, authority_posture: str) -> dict[str, Any] | None:
+    if intent_kind not in {"codex_work_order", "deep_research_work_order", "operator_review_request"}:
+        return None
+
+    venue = str(source_linkage.get("recommended_venue") or "")
+    rationale = source_linkage.get("readiness_basis", {}).get("basis", {}) if isinstance(source_linkage.get("readiness_basis"), Mapping) else {}
+    return {
+        "work_order_kind": intent_kind,
+        "intended_venue": venue,
+        "bounded_rationale": {
+            "signal_reasons": list(rationale.get("signal_reasons") or []),
+            "slice_health_status": rationale.get("slice_health_status"),
+            "slice_stability_classification": rationale.get("slice_stability_classification"),
+            "slice_review_classification": rationale.get("slice_review_classification"),
+        },
+        "authority_posture": authority_posture,
+        "executability_classification": executability,
+        "staged_only": executability != "executable_now",
+    }
+
+
+def synthesize_orchestration_intent_kernel(
+    delegated_judgment: Mapping[str, Any],
+    *,
+    created_at: str | None,
+    iso_utc_now: Callable[[], str],
+    anti_sovereignty_payload: Callable[..., dict[str, Any]],
+    intent_kinds: set[str],
+    authority_postures: set[str],
+    execution_targets: set[str],
+    executability_classes: set[str],
+    admission_states: set[str],
+) -> dict[str, Any]:
+    """Kernel authority for canonical intent synthesis/typing/classification."""
+
+    source_linkage = source_judgment_linkage(delegated_judgment)
+    authority_posture = classify_authority_posture(delegated_judgment)
+    intent_kind, execution_target, executability = translate_orchestration_kind(delegated_judgment)
+    admission_state = derive_admission_state(executability, authority_posture)
+    timestamp = created_at or iso_utc_now()
+    intent_id = _intent_id(source_linkage, timestamp)
+
+    if intent_kind not in intent_kinds:
+        intent_kind = "hold_no_action"
+    if authority_posture not in authority_postures:
+        authority_posture = "insufficient_context_blocked"
+    if execution_target not in execution_targets:
+        execution_target = "no_execution_target_yet"
+    if executability not in executability_classes:
+        executability = "blocked_insufficient_context"
+    if admission_state not in admission_states:
+        admission_state = "deferred_insufficient_context"
+
+    requires_operator_approval = authority_posture != "no_additional_operator_approval_required"
+    work_order = _work_order_payload(intent_kind, source_linkage, executability, authority_posture)
+
+    return {
+        "schema_version": "orchestration_intent.v1",
+        "intent_id": intent_id,
+        "created_at": timestamp,
+        "intent_kind": intent_kind,
+        "source_delegated_judgment": source_linkage,
+        "required_authority_posture": authority_posture,
+        "execution_target": execution_target,
+        "executability_classification": executability,
+        "handoff_admission_state": admission_state,
+        "work_order": work_order,
+        "requires_admission": execution_target in {"task_admission_executor", "mutation_router", "federation_canonical_execution"},
+        "requires_operator_approval": requires_operator_approval,
+        **anti_sovereignty_payload(
+            recommendation_only=False,
+            diagnostic_only=False,
+            does_not_invoke_external_tools=True,
+        ),
+        "staged_handoff_only": executability != "executable_now",
+        "does_not_override_existing_admission": True,
+        "does_not_override_kernel_or_governor": True,
+        "does_not_replace_operator_authority": True,
+    }
+
+
+__all__ = [
+    "source_judgment_linkage",
+    "translate_orchestration_kind",
+    "synthesize_orchestration_intent_kernel",
+]

--- a/tests/test_orchestration_kernel_intent_synthesis.py
+++ b/tests/test_orchestration_kernel_intent_synthesis.py
@@ -1,0 +1,118 @@
+from sentientos.orchestration_spine.kernel.intent_synthesis import (
+    source_judgment_linkage,
+    synthesize_orchestration_intent_kernel,
+    translate_orchestration_kind,
+)
+
+
+_INTENT_KINDS = {
+    "internal_maintenance_execution",
+    "codex_work_order",
+    "deep_research_work_order",
+    "operator_review_request",
+    "hold_no_action",
+}
+
+_AUTHORITY_POSTURES = {
+    "no_additional_operator_approval_required",
+    "operator_approval_required",
+    "operator_priority_required",
+    "insufficient_context_blocked",
+}
+
+_EXECUTION_TARGETS = {
+    "task_admission_executor",
+    "mutation_router",
+    "federation_canonical_execution",
+    "no_execution_target_yet",
+    "external_tool_placeholder",
+}
+
+_EXECUTABILITY = {
+    "executable_now",
+    "stageable_external_work_order",
+    "blocked_operator_required",
+    "blocked_insufficient_context",
+    "no_action_recommended",
+}
+
+_ADMISSION_STATES = {
+    "admitted_for_internal_staging",
+    "deferred_operator_approval",
+    "deferred_operator_priority",
+    "deferred_insufficient_context",
+    "staged_non_executable_work_order",
+    "no_action",
+}
+
+
+def _anti_sovereignty_payload(**_kwargs: object) -> dict[str, object]:
+    return {
+        "non_authoritative": True,
+        "decision_power": "none",
+    }
+
+
+def test_kernel_translate_kind_external_tool_stageable() -> None:
+    kind, target, executability = translate_orchestration_kind(
+        {
+            "recommended_venue": "internal_direct_execution",
+            "work_class": "external_tool_orchestration",
+            "escalation_classification": "none",
+        }
+    )
+
+    assert kind == "operator_review_request"
+    assert target == "external_tool_placeholder"
+    assert executability == "stageable_external_work_order"
+
+
+def test_kernel_synthesize_orchestration_intent_deterministic_identity() -> None:
+    delegated_judgment = {
+        "work_class": "internal_runtime_maintenance",
+        "recommended_venue": "internal_direct_execution",
+        "next_move_posture": "expand",
+        "consolidation_expansion_posture": "consolidate",
+        "escalation_classification": "none",
+        "basis": {
+            "signal_reasons": ["keep-runtime-healthy"],
+            "slice_health_status": "healthy",
+            "slice_stability_classification": "stable",
+            "slice_review_classification": "clean_recent_orchestration",
+        },
+    }
+
+    first = synthesize_orchestration_intent_kernel(
+        delegated_judgment,
+        created_at="2026-04-12T00:00:00Z",
+        iso_utc_now=lambda: "2026-04-12T00:00:00Z",
+        anti_sovereignty_payload=_anti_sovereignty_payload,
+        intent_kinds=_INTENT_KINDS,
+        authority_postures=_AUTHORITY_POSTURES,
+        execution_targets=_EXECUTION_TARGETS,
+        executability_classes=_EXECUTABILITY,
+        admission_states=_ADMISSION_STATES,
+    )
+    second = synthesize_orchestration_intent_kernel(
+        delegated_judgment,
+        created_at="2026-04-12T00:00:00Z",
+        iso_utc_now=lambda: "2026-04-12T00:00:00Z",
+        anti_sovereignty_payload=_anti_sovereignty_payload,
+        intent_kinds=_INTENT_KINDS,
+        authority_postures=_AUTHORITY_POSTURES,
+        execution_targets=_EXECUTION_TARGETS,
+        executability_classes=_EXECUTABILITY,
+        admission_states=_ADMISSION_STATES,
+    )
+
+    assert first["intent_id"] == second["intent_id"]
+    assert first["intent_kind"] == "internal_maintenance_execution"
+    assert first["executability_classification"] == "executable_now"
+
+
+def test_kernel_source_linkage_preserves_canonical_defaults() -> None:
+    linkage = source_judgment_linkage({})
+
+    assert linkage["work_class"] == "operator_required"
+    assert linkage["recommended_venue"] == "insufficient_context"
+    assert linkage["escalation_classification"] == "escalate_for_missing_context"


### PR DESCRIPTION
### Motivation
- Continue kernel-internal decomposition by moving the upstream authority logic that determines canonical orchestration intent identity, intent typing/synthesis, and executability classification into a dedicated kernel module to reduce embedding in the façade while preserving the public surface. 
- Keep the public façade stable and preserve authority, lifecycle, and anti-sovereignty semantics while making the intent synthesis/typing/classification slice a first-class kernel-internal unit.

### Description
- Added a new kernel-internal module `sentientos/orchestration_spine/kernel/intent_synthesis.py` that owns canonical identity formation, source-linkage shaping, authority-posture classification, kind/executability translation, admission-state derivation, and canonical intent construction (kernel entry: `synthesize_orchestration_intent_kernel`).
- Updated `sentientos/orchestration_spine/kernel/__init__.py` to export the new kernel primitives (`synthesize_orchestration_intent_kernel`, `translate_orchestration_kind`, `source_judgment_linkage`).
- Modified the public façade `sentientos/orchestration_intent_fabric.py` to delegate the extracted upstream slice to the new kernel module while preserving the façade functions and compatibility points (`synthesize_orchestration_intent`, `_translate_kind`, `_source_judgment_linkage`) and continuing to inject boundary primitives (timestamp, anti-sovereignty payload, enum sets).
- Added focused unit tests `tests/test_orchestration_kernel_intent_synthesis.py` that exercise kind translation, deterministic intent identity, and canonical source-linkage defaults; no projection/adapter or admission/handoff logic was moved.

### Testing
- Ran the repository test harness on the selected targets with `python -m scripts.run_tests -q tests/test_orchestration_kernel_intent_synthesis.py tests/test_orchestration_kernel_unified_results.py sentientos/tests/test_orchestration_intent_fabric.py`, which completed successfully (editable install performed and no test failures for the selected targets).
- Ran focused pytest `pytest -q tests/test_orchestration_kernel_intent_synthesis.py tests/test_orchestration_kernel_unified_results.py`, which executed under the repo gating policy (tests were subject to test-gating markers and reported as skipped under the environment but produced no failures).
- New kernel-focused tests added: `tests/test_orchestration_kernel_intent_synthesis.py` (all assertions exercised in the harness); targeted orchestration-unified-result kernel tests were also run and passed under the harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eead18d9848320a0d3fbfd3abfcf5f)