### PR TITLE
[codex:orchestration] extract bounded mechanical facade assembly slice

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -30,6 +30,7 @@ from typing import Any, Mapping
 import task_admission
 import task_executor
 from sentientos.orchestration_spine.adapters import internal_maintenance
+from sentientos.orchestration_spine import facade_mechanical_assembly
 from sentientos.orchestration_spine.kernel import (
     derive_packetization_gate_kernel,
     resolve_admission_handoff_outcome_kernel,
@@ -46,6 +47,7 @@ from sentientos.orchestration_spine.projection import current_state, policy_help
 _INTERNAL_MAINTENANCE_ADAPTER = internal_maintenance
 _CURRENT_STATE_PROJECTIONS = current_state
 _POLICY_PROJECTIONS = policy_helpers
+_FACADE_MECHANICAL_ASSEMBLY = facade_mechanical_assembly
 
 # Phase 12 inventory anchors (intentionally concise and code-near).
 _KERNEL_AUTHORITY_OWNERSHIP = (
@@ -995,35 +997,13 @@ def _compact_handoff_rationale(
 def _handoff_evidence_pointers(
     delegated_judgment: Mapping[str, Any],
 ) -> list[str]:
-    delegated_basis = delegated_judgment.get("basis")
-    delegated_basis_map = delegated_basis if isinstance(delegated_basis, Mapping) else {}
-    pointers = [
-        "glow/orchestration/orchestration_next_move_proposals.jsonl",
-        "glow/orchestration/orchestration_handoffs.jsonl",
-        "glow/orchestration/orchestration_intents.jsonl",
-    ]
-    artifacts = delegated_basis_map.get("artifacts_read")
-    if isinstance(artifacts, Mapping):
-        for value in artifacts.values():
-            if isinstance(value, str) and value:
-                pointers.append(value)
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for pointer in pointers:
-        if pointer not in seen:
-            ordered.append(pointer)
-            seen.add(pointer)
-    return ordered
+    return _FACADE_MECHANICAL_ASSEMBLY.handoff_evidence_pointers(delegated_judgment)
 
 
 def _normalized_compact_string_refs(values: list[str] | None) -> list[str]:
     """Normalize optional free-form refs into compact, non-empty string rows."""
 
-    return [
-        value.strip()
-        for value in (values or [])
-        if isinstance(value, str) and value.strip()
-    ]
+    return _FACADE_MECHANICAL_ASSEMBLY.normalized_compact_string_refs(values)
 
 
 # ---------------------------------------------------------------------------

--- a/sentientos/orchestration_spine/facade_mechanical_assembly.py
+++ b/sentientos/orchestration_spine/facade_mechanical_assembly.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Mechanical-only façade assembly helpers extracted from orchestration_intent_fabric.
+
+These helpers are intentionally narrow and non-authoritative:
+- no schema-envelope shaping
+- no authority decisions
+- no ledger append behavior
+"""
+
+from typing import Any, Mapping
+
+
+def handoff_evidence_pointers(delegated_judgment: Mapping[str, Any]) -> list[str]:
+    """Build compact, deduplicated artifact pointers while preserving insertion order."""
+
+    delegated_basis = delegated_judgment.get("basis")
+    delegated_basis_map = delegated_basis if isinstance(delegated_basis, Mapping) else {}
+    pointers = [
+        "glow/orchestration/orchestration_next_move_proposals.jsonl",
+        "glow/orchestration/orchestration_handoffs.jsonl",
+        "glow/orchestration/orchestration_intents.jsonl",
+    ]
+    artifacts = delegated_basis_map.get("artifacts_read")
+    if isinstance(artifacts, Mapping):
+        for value in artifacts.values():
+            if isinstance(value, str) and value:
+                pointers.append(value)
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for pointer in pointers:
+        if pointer not in seen:
+            ordered.append(pointer)
+            seen.add(pointer)
+    return ordered
+
+
+def normalized_compact_string_refs(values: list[str] | None) -> list[str]:
+    """Normalize optional free-form refs into compact, non-empty string rows."""
+
+    return [
+        value.strip()
+        for value in (values or [])
+        if isinstance(value, str) and value.strip()
+    ]


### PR DESCRIPTION
### Motivation
- Reduce mechanical clutter in the façade by extracting Phase‑25 marked `future_split_ready_mechanical` helpers so the façade stays focused on public envelope and ledger shaping.
- Isolate deterministic, non-authoritative transformations (compact ref normalization and evidence pointer dedupe) so they are easy to reuse or split later while preserving public compatibility.

### Description
- Added a narrow helper module `sentientos/orchestration_spine/facade_mechanical_assembly.py` containing `handoff_evidence_pointers` and `normalized_compact_string_refs` which implement pointer deduplication/order preservation and compact string ref trimming/filtering respectively.
- Updated `sentientos/orchestration_intent_fabric.py` to import and alias the helper as `_FACADE_MECHANICAL_ASSEMBLY` and replaced the in-file implementations with thin delegating wrappers `_handoff_evidence_pointers(...)` and `_normalized_compact_string_refs(...)` that call the new helpers, preserving façade signatures.
- Intentionally did not move or change any append-only ledger wrappers, public envelope/schema shaping, authority kernels, lifecycle semantics, or any facade-adjacent helpers; only purely mechanical logic was relocated.
- Files changed: `sentientos/orchestration_intent_fabric.py` and new `sentientos/orchestration_spine/facade_mechanical_assembly.py`.

### Testing
- Ran focused orchestration tests that exercise the extracted slice with `python -m scripts.run_tests -q sentientos/tests/test_orchestration_intent_fabric.py::test_codex_next_move_proposal_becomes_typed_staged_handoff_packet sentientos/tests/test_orchestration_intent_fabric.py::test_deep_research_next_move_proposal_becomes_typed_staged_handoff_packet sentientos/tests/test_orchestration_intent_fabric.py::test_compact_ref_normalization_is_deterministic_and_input_immutable sentientos/tests/test_orchestration_intent_fabric.py::test_operator_resolution_receipt_compact_ref_assembly_is_mechanical_only` and these targeted tests passed.
- Ran a small focused set of receipt/compact-ref tests with `-k` filters (`compact_ref_normalization_is_deterministic_and_input_immutable` and related receipt tests) and they passed.
- A full run of `sentientos/tests/test_orchestration_intent_fabric.py` still shows a single unrelated failure: `NameError: resolve_current_orchestration_next_move_brief` in `test_current_brief_chain_end_to_end_fragmentation_stays_bounded_and_non_authoritative`; this failure predates the extraction and no authority/ledger or lifecycle behavior was changed by this PR.
- Commands and CI artifacts used: `python -m scripts.run_tests -q <pytest targets>` (editable install performed as part of the harness); all focused tests invoking the extracted helpers succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0cce71d2883208a34b24e966c0ab3)