### PR TITLE
[codex:orchestration] extract phase-27 mechanical facade assembly slice

### DIFF
--- a/sentientos/orchestration_intent_fabric.py
+++ b/sentientos/orchestration_intent_fabric.py
@@ -78,6 +78,12 @@ _FACADE_LEDGER_ASSEMBLY_READINESS = {
     "future_split_ready_mechanical": (
         "_normalized_compact_string_refs helper (string trimming/filter only)",
         "_handoff_evidence_pointers pointer deduplication/order preservation helper",
+        "_staged_work_order_id deterministic id payload builder",
+        "_fulfillment_receipt_id deterministic id payload builder",
+        "_operator_resolution_receipt_id deterministic id payload builder",
+        "_build_staged_external_work_order status-classification branch",
+        "_resolve_staged_external_work_order_lifecycle lifecycle-state classification branch",
+        "ingest_operator_resolution_receipt resolution lifecycle-state mapping",
     ),
     "facade_adjacent_but_not_split_ready": (
         "handoff packet envelope shaping linked to public facade schema stability",
@@ -859,13 +865,11 @@ def _default_admission_policy() -> task_admission.AdmissionPolicy:
 
 
 def _staged_work_order_id(intent: Mapping[str, Any], created_at: str, *, prefix: str) -> str:
-    return _stable_prefixed_id(
-        f"{prefix}-wo",
-        {
-            "created_at": created_at,
-            "intent_id": str(intent.get("intent_id") or ""),
-            "source_judgment": dict(intent.get("source_delegated_judgment") or {}),
-        },
+    return _FACADE_MECHANICAL_ASSEMBLY.staged_work_order_id(
+        intent,
+        created_at,
+        prefix=prefix,
+        stable_prefixed_id=_stable_prefixed_id,
     )
 
 
@@ -940,14 +944,12 @@ def _fulfillment_receipt_id(
     venue: str,
     fulfillment_kind: str,
 ) -> str:
-    return _stable_prefixed_id(
-        "frc",
-        {
-            "created_at": created_at,
-            "handoff_packet_id": handoff_packet_id,
-            "venue": venue,
-            "fulfillment_kind": fulfillment_kind,
-        },
+    return _FACADE_MECHANICAL_ASSEMBLY.fulfillment_receipt_id(
+        created_at=created_at,
+        handoff_packet_id=handoff_packet_id,
+        venue=venue,
+        fulfillment_kind=fulfillment_kind,
+        stable_prefixed_id=_stable_prefixed_id,
     )
 
 
@@ -957,13 +959,11 @@ def _operator_resolution_receipt_id(
     operator_action_brief_id: str,
     resolution_kind: str,
 ) -> str:
-    return _stable_prefixed_id(
-        "orr",
-        {
-            "created_at": created_at,
-            "operator_action_brief_id": operator_action_brief_id,
-            "resolution_kind": resolution_kind,
-        },
+    return _FACADE_MECHANICAL_ASSEMBLY.operator_resolution_receipt_id(
+        created_at=created_at,
+        operator_action_brief_id=operator_action_brief_id,
+        resolution_kind=resolution_kind,
+        stable_prefixed_id=_stable_prefixed_id,
     )
 
 
@@ -1034,15 +1034,10 @@ def _build_staged_external_work_order(
     source = intent.get("source_delegated_judgment")
     source_map = source if isinstance(source, Mapping) else {}
     posture = str(intent.get("required_authority_posture") or "insufficient_context_blocked")
-    if handoff_outcome == "blocked_by_operator_requirement":
-        status = "blocked_operator_required"
-    elif handoff_outcome == "blocked_by_insufficient_context":
-        status = "blocked_insufficient_context"
-    else:
-        status = "staged"
-
-    if status not in _STAGED_EXTERNAL_WORK_ORDER_STATUSES:
-        status = "blocked_insufficient_context"
+    status = _FACADE_MECHANICAL_ASSEMBLY.staged_external_work_order_status(
+        handoff_outcome,
+        staged_external_work_order_statuses=_STAGED_EXTERNAL_WORK_ORDER_STATUSES,
+    )
 
     work_order = {
         "schema_version": schema_version,
@@ -1135,22 +1130,13 @@ def _resolve_staged_external_work_order_lifecycle(
     linked = [row for row in records if str(row.get("source_intent_id") or "") == intent_id]
     latest = linked[-1] if linked else None
     handoff_outcome = str(handoff.get("handoff_outcome") or "")
-
-    if latest is None:
-        lifecycle_state = "fragmented_unlinked_work_order_state"
-    elif handoff_outcome == "blocked_by_operator_requirement":
-        lifecycle_state = "blocked_operator_required"
-    elif handoff_outcome == "blocked_by_insufficient_context":
-        lifecycle_state = "blocked_insufficient_context"
-    elif str(latest.get("status") or "") == "staged":
-        lifecycle_state = "staged_cleanly"
-    elif str(latest.get("status") or "") == "fulfilled_externally_unverified":
-        lifecycle_state = "fulfilled_externally_with_issues"
-    else:
-        lifecycle_state = "fragmented_unlinked_work_order_state"
-
-    if lifecycle_state not in _STAGED_EXTERNAL_LIFECYCLE_STATES:
-        lifecycle_state = "fragmented_unlinked_work_order_state"
+    latest_status = str(latest.get("status") or "") if isinstance(latest, Mapping) else ""
+    lifecycle_state = _FACADE_MECHANICAL_ASSEMBLY.staged_external_work_order_lifecycle_state(
+        handoff_outcome=handoff_outcome,
+        latest_work_order_status=latest_status,
+        work_order_present=latest is not None,
+        staged_external_lifecycle_states=_STAGED_EXTERNAL_LIFECYCLE_STATES,
+    )
 
     lifecycle = {
         "schema_version": schema_version,
@@ -3457,15 +3443,7 @@ def ingest_operator_resolution_receipt(
     # Mechanical assembly only: compact refs preserve append-only readability.
     normalized_refs = _normalized_compact_string_refs(updated_context_refs)
     timestamp = created_at or _iso_utc_now()
-    resolution_state = {
-        "approved_continue": "operator_approved_continue",
-        "approved_with_constraints": "operator_approved_with_constraints",
-        "declined": "operator_declined",
-        "deferred": "operator_deferred",
-        "supplied_missing_context": "operator_supplied_missing_context",
-        "redirected_venue": "operator_redirected",
-        "cancelled": "operator_declined",
-    }[resolution_kind]
+    resolution_state = _FACADE_MECHANICAL_ASSEMBLY.operator_resolution_lifecycle_state(resolution_kind)
 
     receipt = {
         "schema_version": "operator_resolution_receipt.v1",

--- a/sentientos/orchestration_spine/facade_mechanical_assembly.py
+++ b/sentientos/orchestration_spine/facade_mechanical_assembly.py
@@ -44,3 +44,122 @@ def normalized_compact_string_refs(values: list[str] | None) -> list[str]:
         for value in (values or [])
         if isinstance(value, str) and value.strip()
     ]
+
+
+def staged_work_order_id(
+    intent: Mapping[str, Any],
+    created_at: str,
+    *,
+    prefix: str,
+    stable_prefixed_id: Any,
+) -> str:
+    """Build deterministic staged-work-order ids via injected stable id primitive."""
+
+    return stable_prefixed_id(
+        f"{prefix}-wo",
+        {
+            "created_at": created_at,
+            "intent_id": str(intent.get("intent_id") or ""),
+            "source_judgment": dict(intent.get("source_delegated_judgment") or {}),
+        },
+    )
+
+
+def fulfillment_receipt_id(
+    *,
+    created_at: str,
+    handoff_packet_id: str,
+    venue: str,
+    fulfillment_kind: str,
+    stable_prefixed_id: Any,
+) -> str:
+    """Build deterministic fulfillment receipt ids via injected stable id primitive."""
+
+    return stable_prefixed_id(
+        "frc",
+        {
+            "created_at": created_at,
+            "handoff_packet_id": handoff_packet_id,
+            "venue": venue,
+            "fulfillment_kind": fulfillment_kind,
+        },
+    )
+
+
+def operator_resolution_receipt_id(
+    *,
+    created_at: str,
+    operator_action_brief_id: str,
+    resolution_kind: str,
+    stable_prefixed_id: Any,
+) -> str:
+    """Build deterministic operator-resolution receipt ids via injected id primitive."""
+
+    return stable_prefixed_id(
+        "orr",
+        {
+            "created_at": created_at,
+            "operator_action_brief_id": operator_action_brief_id,
+            "resolution_kind": resolution_kind,
+        },
+    )
+
+
+def staged_external_work_order_status(
+    handoff_outcome: str,
+    *,
+    staged_external_work_order_statuses: set[str],
+) -> str:
+    """Resolve staged external work-order status from handoff outcome."""
+
+    if handoff_outcome == "blocked_by_operator_requirement":
+        status = "blocked_operator_required"
+    elif handoff_outcome == "blocked_by_insufficient_context":
+        status = "blocked_insufficient_context"
+    else:
+        status = "staged"
+
+    if status not in staged_external_work_order_statuses:
+        return "blocked_insufficient_context"
+    return status
+
+
+def staged_external_work_order_lifecycle_state(
+    *,
+    handoff_outcome: str,
+    latest_work_order_status: str,
+    work_order_present: bool,
+    staged_external_lifecycle_states: set[str],
+) -> str:
+    """Resolve lifecycle-state classification from latest linked work-order status."""
+
+    if not work_order_present:
+        lifecycle_state = "fragmented_unlinked_work_order_state"
+    elif handoff_outcome == "blocked_by_operator_requirement":
+        lifecycle_state = "blocked_operator_required"
+    elif handoff_outcome == "blocked_by_insufficient_context":
+        lifecycle_state = "blocked_insufficient_context"
+    elif latest_work_order_status == "staged":
+        lifecycle_state = "staged_cleanly"
+    elif latest_work_order_status == "fulfilled_externally_unverified":
+        lifecycle_state = "fulfilled_externally_with_issues"
+    else:
+        lifecycle_state = "fragmented_unlinked_work_order_state"
+
+    if lifecycle_state not in staged_external_lifecycle_states:
+        return "fragmented_unlinked_work_order_state"
+    return lifecycle_state
+
+
+def operator_resolution_lifecycle_state(resolution_kind: str) -> str:
+    """Map operator resolution kind to stable receipt lifecycle-state label."""
+
+    return {
+        "approved_continue": "operator_approved_continue",
+        "approved_with_constraints": "operator_approved_with_constraints",
+        "declined": "operator_declined",
+        "deferred": "operator_deferred",
+        "supplied_missing_context": "operator_supplied_missing_context",
+        "redirected_venue": "operator_redirected",
+        "cancelled": "operator_declined",
+    }[resolution_kind]


### PR DESCRIPTION
### Motivation
- Reduce mechanical and wrapper-level congestion in the façade region by consolidating a larger, coherent set of already-marked `future_split_ready_mechanical` helpers into the façade mechanical helper module. 
- Preserve the façade public surface, authority ownership, append-only ledger wrappers, and lifecycle semantics while removing local duplication and noisy branching in the façade file.

### Description
- Added mechanical-only helpers to `sentientos/orchestration_spine/facade_mechanical_assembly.py` including deterministic id builders (`staged_work_order_id`, `fulfillment_receipt_id`, `operator_resolution_receipt_id`), staged work-order status/lifecycle classifiers (`staged_external_work_order_status`, `staged_external_work_order_lifecycle_state`), and `operator_resolution_lifecycle_state` mapping. 
- Rewired `sentientos/orchestration_intent_fabric.py` to delegate to the new façade helpers via thin local wrappers for `_staged_work_order_id`, `_fulfillment_receipt_id`, `_operator_resolution_receipt_id`, staged status/lifecycle decision points, and operator-resolution lifecycle mapping. 
- Updated the Phase 25 split-readiness inventory in `sentientos/orchestration_intent_fabric.py` to reflect the extracted slice. 
- Removed stale local branching/mapping duplication for staged-work-order status and lifecycle decisions and operator-resolution lifecycle mapping while intentionally leaving append-only ledger wrappers, compatibility envelope shaping, and anti-sovereignty assembly in-place in the façade module. 
- Files changed: `sentientos/orchestration_spine/facade_mechanical_assembly.py` and `sentientos/orchestration_intent_fabric.py`.

### Testing
- Ran the targeted orchestration-focused harness invocation: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_intent_fabric.py -k "external_venues_remain_staged_only_without_internal_admission or compact_ref_normalization_is_deterministic_and_input_immutable or operator_resolution_receipt_compact_ref_assembly_is_mechanical_only or end_to_end_staged_to_external_fulfillment_receipt_to_diagnostic_visibility"`. 
- Result: the 4 selected orchestration-focused tests passed (harness performed initial dependency install before running pytest).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1068a23648320b54ff5f866ac8b82)