### PR TITLE
[codex:orchestration] restore current-brief chain symbol import coherence

### DIFF
--- a/sentientos/tests/test_orchestration_intent_fabric.py
+++ b/sentientos/tests/test_orchestration_intent_fabric.py
@@ -54,6 +54,7 @@ from sentientos.orchestration_intent_fabric import (
     resolve_current_orchestration_pressure_signal,
     resolve_current_orchestration_wake_readiness_detector,
     resolve_current_orchestration_handoff_packet_brief,
+    resolve_current_orchestration_next_move_brief,
     resolve_current_orchestration_resolution_path_brief,
     resolve_current_orchestration_closure_brief,
     resolve_current_orchestration_coherence_brief,


### PR DESCRIPTION
### Motivation
- Repair the `NameError` for `resolve_current_orchestration_next_move_brief` encountered in the end-to-end current-brief fragmentation test by restoring minimal call-path coherence while leaving authority, lifecycle semantics, and public API behavior unchanged.

### Description
- Restored a missing façade import by adding `resolve_current_orchestration_next_move_brief` to the `from sentientos.orchestration_intent_fabric import (...)` list in `sentientos/tests/test_orchestration_intent_fabric.py`, fixing the test-side import/export misalignment; this is an import/export alignment (compatibility wiring) fix only.

### Testing
- Ran `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "current_brief_chain_end_to_end_fragmentation_stays_bounded_and_non_authoritative or current_brief_chain_end_to_end_complete_payload_is_internally_linked"` and `pytest -q sentientos/tests/test_orchestration_intent_fabric.py -k "orchestration"`, both passed; `pytest -q tests/test_codex_orchestration.py` was blocked in this environment due to the editable-install precondition rather than a runtime failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f18251980c8320bff62aff89d71af0)