### PR TITLE
[codex:boundary] remediate private append and canonical sink reach-ins

### DIFF
--- a/blessing_recap_cli.py
+++ b/blessing_recap_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import daily_theme
 import ledger
 import heresy_log
+from sentientos.ledger_api import append_audit_record
 BLESSING_LEDGER = get_log_path("blessing_ledger.jsonl", "BLESSING_LEDGER")
 BLESSING_LEDGER.parent.mkdir(parents=True, exist_ok=True)
 HERESY_REVIEW_LOG = get_log_path("heresy_review.jsonl", "HERESY_REVIEW_LOG")
@@ -56,8 +57,7 @@ def log_blessing(officiant: str, summary: str, theme: str, heresy_count: int) ->
         "theme": theme,
         "unresolved_heresy": heresy_count,
     }
-    with BLESSING_LEDGER.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
+    append_audit_record(BLESSING_LEDGER, entry)
     return entry
 
 

--- a/mood_wall.py
+++ b/mood_wall.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import ledger
+from sentientos.ledger_api import append_audit_record
 try:
     import requests  # type: ignore[import-untyped]  # HTTP client optional
 except Exception:  # pragma: no cover - optional
@@ -69,14 +70,13 @@ def sync_wall(peer_log: Path) -> int:
         LOG.touch()
     lines = peer_log.read_text(encoding="utf-8").splitlines()
     count = 0
-    with LOG.open("a", encoding="utf-8") as f:
-        for ln in lines:
+    for ln in lines:
             try:
                 e = json.loads(ln)
             except Exception:
                 continue
             if e.get("event") in ("shared", "mood_blessing"):
-                f.write(json.dumps(e) + "\n")
+                append_audit_record(LOG, e)
                 count += 1
     return count
 
@@ -92,10 +92,9 @@ def sync_wall_http(url: str) -> int:
     r.raise_for_status()
     data = r.json()
     count = 0
-    with LOG.open("a", encoding="utf-8") as f:
-        for e in data:
+    for e in data:
             if e.get("event") in ("shared", "mood_blessing"):
-                f.write(json.dumps(e) + "\n")
+                append_audit_record(LOG, e)
                 count += 1
     return count
 

--- a/ritual_federation_importer.py
+++ b/ritual_federation_importer.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from typing import Dict
 
-from ledger import _append
+from sentientos.ledger_api import append_audit_record
 
 LOG_PATHS = {
     "confession": get_log_path("confessional_log.jsonl"),
@@ -40,7 +40,7 @@ def import_recap(path: Path, source: str = "") -> int:
         if not kind or kind not in LOG_PATHS:
             continue
         entry["source"] = source or str(path)
-        _append(LOG_PATHS[kind], entry)
+        append_audit_record(LOG_PATHS[kind], entry)
         count += 1
     return count
 

--- a/sentientos/ledger_api.py
+++ b/sentientos/ledger_api.py
@@ -1,0 +1,22 @@
+"""Public append-only ledger facade for expressive callers.
+
+This module is a boundary facade: it delegates writes to the existing canonical
+JSONL append behavior and does not own truth-source semantics.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from sentientos.attestation import append_jsonl
+
+
+def append_audit_record(path: Path, record: Mapping[str, object]) -> dict[str, object]:
+    """Append ``record`` to ``path`` using canonical append-only JSONL behavior.
+
+    The facade intentionally performs only minimal normalization (dict copy) and
+    delegates persistence semantics to the existing canonical append utility.
+    """
+    payload = dict(record)
+    append_jsonl(path, payload)
+    return payload

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -149,13 +149,6 @@
       "remediation": "route via fa\u00e7ade DTO boundary"
     },
     {
-      "rule": "expressive_private_import",
-      "file": "ritual_federation_importer.py",
-      "detail": "from ledger import _append",
-      "severity": "high",
-      "remediation": "use public append sink API"
-    },
-    {
       "rule": "expressive_forbidden_import",
       "file": "ritual_cli.py",
       "detail": "imports attestation and relationship_log directly",
@@ -172,9 +165,9 @@
     {
       "rule": "dashboard_forbidden_import",
       "file": "mood_wall.py",
-      "detail": "imports ledger with shared sink coupling",
-      "severity": "medium",
-      "remediation": "use read-only projection API"
+      "detail": "retains ledger read coupling; append writes remediated via public facade",
+      "severity": "low",
+      "remediation": "migrate read path to projection API"
     },
     {
       "rule": "formal_symbolic_import",

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -154,3 +154,23 @@ def test_autonomy_filenames_have_governance_annotation_or_allowlist() -> None:
         assert violations
     else:
         assert not violations, "New autonomy naming policy violations: " + ", ".join(sorted(violations))
+
+
+def test_phase34_migrated_modules_use_public_ledger_facade() -> None:
+    migrated = {
+        "ritual_federation_importer.py": "append_audit_record",
+        "blessing_recap_cli.py": "append_audit_record",
+        "mood_wall.py": "append_audit_record",
+    }
+    for rel, marker in migrated.items():
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "from sentientos.ledger_api import append_audit_record" in text
+        assert marker in text
+
+
+def test_phase34_migrated_modules_avoid_direct_append_writes_to_canonical_sinks() -> None:
+    for rel in ("blessing_recap_cli.py", "mood_wall.py"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert '.open("a"' not in text
+        assert "Path.write_text(" not in text or rel == "blessing_recap_cli.py"
+


### PR DESCRIPTION
### Motivation
- Close a high-risk boundary class where expressive modules reached into private append helpers (`ledger._append`) or wrote directly to canonical sinks, by providing a stable public façade. 
- Reduce real violations surfaced by the Phase 33 manifest and tests rather than only documenting them. 
- Preserve existing append-only semantics and observable behavior while preventing further private-symbol reach-ins.

### Description
- Add a narrow public façade `sentientos/ledger_api.py` exposing `append_audit_record(path, record)` that delegates to the canonical append utility `sentientos.attestation.append_jsonl` and performs only a minimal `dict()` normalization. 
- Migrate callers to the façade: replace `from ledger import _append` / `ledger._append` usage in `ritual_federation_importer.py` with `from sentientos.ledger_api import append_audit_record` and calls to `append_audit_record(...)`. 
- Replace direct append-mode writes in `blessing_recap_cli.py` and `mood_wall.py` with `append_audit_record(...)` calls to preserve append-only behavior and avoid manual `open(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6fd594dc483209f4d8fa8e6054de7)