### PR TITLE
[codex:architecture] remediate control-plane bypass via public facade

### DIFF
--- a/autonomous_self_patching_agent.py
+++ b/autonomous_self_patching_agent.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
-from control_plane.records import AuthorizationError, AuthorizationRecord
-import task_executor
-from self_patcher import _validate_gate
+from control_plane.records import AuthorizationError
+from sentientos.control_api import require_self_patch_apply_authority
 
 """Autonomous Self-Patching Agent
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
@@ -29,17 +28,17 @@ def propose(description: str) -> Dict[str, str]:
 
 
 def _require_apply_authority(
-    admission_token: task_executor.AdmissionToken | None,
-    authorization: AuthorizationRecord | None,
+    admission_token: object | None,
+    authorization: object | None,
 ) -> None:
-    _validate_gate(admission_token, authorization, None)
+    require_self_patch_apply_authority(admission_token, authorization)
 
 
 def apply(
     patch_id: int,
     *,
-    admission_token: task_executor.AdmissionToken | None = None,
-    authorization: AuthorizationRecord | None = None,
+    admission_token: object | None = None,
+    authorization: object | None = None,
 ) -> Dict[str, str]:
     _require_apply_authority(admission_token, authorization)
     entry = {"timestamp": datetime.utcnow().isoformat(), "patch_id": patch_id, "status": "applied"}

--- a/sentientos/control_api.py
+++ b/sentientos/control_api.py
@@ -1,0 +1,55 @@
+"""Public control/admission façade for expressive modules.
+
+This boundary surface is DTO/validation-only and delegates to existing
+control-plane and task-admission authority semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from control_plane.enums import Decision, ReasonCode, RequestType
+from control_plane.records import AuthorizationError
+import task_executor
+
+
+def require_authorization_for_request_types(
+    authorization: Any,
+    *,
+    allowed_request_types: Iterable[str],
+) -> Any:
+    if authorization is None:
+        raise AuthorizationError(ReasonCode.MISSING_AUTHORIZATION.value)
+    if getattr(authorization, "decision", None) != Decision.ALLOW:
+        reason = getattr(getattr(authorization, "reason", None), "value", None) or "authorization denied"
+        raise AuthorizationError(str(reason))
+
+    request_type = getattr(authorization, "request_type", None)
+    if request_type not in {RequestType(item) for item in allowed_request_types}:
+        raise AuthorizationError(ReasonCode.INVALID_AUTHORIZATION.value)
+    return authorization
+
+
+def require_self_patch_apply_authority(admission_token: Any, authorization: Any) -> None:
+    if admission_token is None:
+        raise AuthorizationError("admission token required for self-healing apply")
+    if authorization is None:
+        raise AuthorizationError("authorization required for self-healing apply")
+    authorization.require(RequestType.TASK_EXECUTION)
+    if admission_token.issued_by != "task_admission":
+        raise AuthorizationError("admission token issuer invalid")
+    if not isinstance(admission_token.provenance, task_executor.AuthorityProvenance):
+        raise AuthorizationError("admission token provenance missing")
+    fingerprint_value = admission_token.request_fingerprint.value
+    if not isinstance(fingerprint_value, str) or len(fingerprint_value) != 64:
+        raise AuthorizationError("admission token fingerprint missing")
+    try:
+        int(fingerprint_value, 16)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise AuthorizationError("admission token fingerprint missing") from exc
+
+
+__all__ = [
+    "require_authorization_for_request_types",
+    "require_self_patch_apply_authority",
+]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_33_repository_architecture_boundary_enforcement_wave",
+  "generated_for_phase": "phase_35_control_plane_bypass_facade_remediation_wave",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -141,13 +141,6 @@
     ]
   },
   "known_violations": [
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "speech_to_avatar_bridge.py",
-      "detail": "imports control_plane enums and records",
-      "severity": "high",
-      "remediation": "route via fa\u00e7ade DTO boundary"
-    },
     {
       "rule": "expressive_forbidden_import",
       "file": "ritual_cli.py",

--- a/speech_to_avatar_bridge.py
+++ b/speech_to_avatar_bridge.py
@@ -10,8 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Optional
 
-from control_plane.enums import Decision, ReasonCode, RequestType
-from control_plane.records import AuthorizationError, AuthorizationRecord
+from sentientos.control_api import require_authorization_for_request_types
 from avatar_state import AvatarStateEmitter, resolve_mode
 from speech_emitter import DEFAULT_BASE_STATE, SpeechEmitter, _coerce_viseme_timeline
 from speech_log import append_speech_log, build_speech_log_entry
@@ -115,9 +114,9 @@ class SpeechToAvatarBridge:
         mode: Optional[str] = None,
         metadata: Mapping[str, Any] | None = None,
         started_at: Any | None = None,
-        authorization: AuthorizationRecord | None = None,
+        authorization: Any | None = None,
     ) -> MutableMapping[str, Any]:
-        _ensure_authorization(authorization, {RequestType.AVATAR_EMISSION, RequestType.SPEECH_TTS})
+        _ensure_authorization(authorization, {"avatar_emission", "speech_tts"})
         started_value = self._started_at(started_at) if phrase.strip() else None
         self._last_started_at = started_value
         muted_value = self._should_mute(muted, mode)
@@ -167,9 +166,9 @@ class SpeechToAvatarBridge:
         return payload
 
     def emit_idle(
-        self, *, log: bool = True, authorization: AuthorizationRecord | None = None
+        self, *, log: bool = True, authorization: Any | None = None
     ) -> MutableMapping[str, Any]:
-        _ensure_authorization(authorization, {RequestType.AVATAR_EMISSION, RequestType.SPEECH_TTS})
+        _ensure_authorization(authorization, {"avatar_emission", "speech_tts"})
         self._last_started_at = None
         payload = self.speech_emitter.emit_idle(authorization=authorization)
         if log:
@@ -229,9 +228,9 @@ class SpeechToAvatarBridge:
         append_speech_log(entry, log_path=log_target, max_entries=self.max_log_entries)
 
     def handle_event(
-        self, speech_event: Mapping[str, Any], *, authorization: AuthorizationRecord | None = None
+        self, speech_event: Mapping[str, Any], *, authorization: Any | None = None
     ) -> MutableMapping[str, Any]:
-        _ensure_authorization(authorization, {RequestType.AVATAR_EMISSION, RequestType.SPEECH_TTS})
+        _ensure_authorization(authorization, {"avatar_emission", "speech_tts"})
         status = str(speech_event.get("status") or speech_event.get("event") or "start").lower()
         phrase = str(speech_event.get("text") or speech_event.get("utterance") or "")
         viseme_source = speech_event.get("visemes") or speech_event.get("viseme_path") or speech_event.get("viseme_json")
@@ -274,10 +273,10 @@ class SpeechToAvatarBridge:
         metadata: Mapping[str, Any] | None = None,
         started_at: Any | None = None,
         voice: Optional[str] = None,
-        authorization: AuthorizationRecord | None = None,
+        authorization: Any | None = None,
     ) -> MutableMapping[str, Any]:
         """Speak a phrase through the TTS backend while syncing avatar state."""
-        _ensure_authorization(authorization, {RequestType.SPEECH_TTS})
+        _ensure_authorization(authorization, {"speech_tts"})
         started_value = self._started_at(started_at) if phrase.strip() else None
         start_payload = self.emit_phrase(
             phrase,
@@ -316,13 +315,8 @@ class SpeechToAvatarBridge:
 __all__ = ["SpeechToAvatarBridge", "TtsAudioPlayer"]
 
 
-def _ensure_authorization(
-    authorization: AuthorizationRecord | None, allowed_types: set[RequestType]
-) -> AuthorizationRecord:
-    if authorization is None:
-        raise AuthorizationError(ReasonCode.MISSING_AUTHORIZATION.value)
-    if authorization.decision != Decision.ALLOW:
-        raise AuthorizationError(authorization.reason.value)
-    if authorization.request_type not in allowed_types:
-        raise AuthorizationError(ReasonCode.INVALID_AUTHORIZATION.value)
-    return authorization
+def _ensure_authorization(authorization: Any | None, allowed_types: set[str]) -> Any:
+    return require_authorization_for_request_types(
+        authorization,
+        allowed_request_types=allowed_types,
+    )

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -174,3 +174,23 @@ def test_phase34_migrated_modules_avoid_direct_append_writes_to_canonical_sinks(
         assert '.open("a"' not in text
         assert "Path.write_text(" not in text or rel == "blessing_recap_cli.py"
 
+
+
+def test_phase35_migrated_modules_use_public_control_facade() -> None:
+    speech_text = (ROOT / "speech_to_avatar_bridge.py").read_text(encoding="utf-8")
+    assert "from sentientos.control_api import require_authorization_for_request_types" in speech_text
+    assert "from control_plane.enums" not in speech_text
+    assert "from control_plane.records" not in speech_text
+
+    patch_agent_text = (ROOT / "autonomous_self_patching_agent.py").read_text(encoding="utf-8")
+    assert "from sentientos.control_api import require_self_patch_apply_authority" in patch_agent_text
+    assert "import task_executor" not in patch_agent_text
+
+
+def test_phase35_control_facade_public_contract_is_narrow() -> None:
+    facade_text = (ROOT / "sentientos/control_api.py").read_text(encoding="utf-8")
+    assert "__all__" in facade_text
+    assert "AdmissionToken" not in facade_text
+    assert "AuthorizationRecord" not in facade_text
+    assert "def require_authorization_for_request_types" in facade_text
+    assert "def require_self_patch_apply_authority" in facade_text


### PR DESCRIPTION
### Motivation
- Reduce a high-risk control-plane bypass pattern where expressive/root-facing modules imported raw control-plane/task-executor substrate instead of a bounded public surface. 
- Target the manifest-listed high-severity violation in `speech_to_avatar_bridge.py` and a mechanically safe secondary caller `autonomous_self_patching_agent.py` to make a focused, behavior-preserving remediation.

### Description
- Add a narrow public façade `sentientos/control_api.py` exposing `require_authorization_for_request_types` and `require_self_patch_apply_authority` as DTO/validation-only helpers that delegate to existing control-plane semantics. 
- Migrate `speech_to_avatar_bridge.py` to use `sentientos.control_api.require_authorization_for_request_types` and stop importing `control_plane.enums` / `control_plane.records` directly. 
- Migrate `autonomous_self_patching_agent.py` to call `sentientos.control_api.require_self_patch_apply_authority` and remove the direct `task_executor`/_validate gate coupling while preserving `apply(...)` behavior and signatures. 
- Update `sentientos/system_closure/architecture_boundary_manifest.json` to advance the phase metadata and remove the remediated `speech_to_avatar_bridge.py` known violation, and strengthen `tests/architecture/test_architecture_boundaries.py` with Phase 35 assertions that migrated callers use the façade and the façade exposes a narrow public contract. 

### Testing
- Ran boundary and import-purity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed. 
- Ran orchestration spine smoke tests with `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` and they passed. 
- Ran focused unit tests for the migrated callers with `python -m scripts.run_tests -q tests/test_speech_to_avatar_bridge_tts.py tests/test_autonomous_self_patching_agent.py` and they passed (an earlier invocation hit an environment TTS native dependency error which was not a regression from this change and was resolved before final validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f779674d948320bfd46dc87b0a30b8)