### PR TITLE
[codex:formal-core] purify symbolic imports via neutral formal helpers

### DIFF
--- a/agent_privilege_policy_engine.py
+++ b/agent_privilege_policy_engine.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Any
 
-from cathedral_const import log_json
+from sentientos.formal_logging import log_json
 
 LOG_PATH = get_log_path("privilege_policy.jsonl", "PRIVILEGE_POLICY_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/audit_chain.py
+++ b/audit_chain.py
@@ -9,7 +9,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
-from cathedral_const import validate_log_entry
+from sentientos.formal_logging import validate_log_entry
 
 @dataclass
 class AuditEntry:

--- a/healing_sprint_ledger.py
+++ b/healing_sprint_ledger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from logging_config import get_log_path
-from cathedral_wounds_dashboard import gather_integrity_issues, parse_contributors
+from sentientos.integrity_metrics import gather_integrity_issues, parse_contributors
 
 """Generate a healing sprint ledger with community metrics."""
 

--- a/sentientos/formal_logging.py
+++ b/sentientos/formal_logging.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Neutral formal logging helpers for audit/privilege modules.
+
+This module is intentionally presentation-free and symbolic-free. It preserves
+existing JSONL validation and healing behavior used by formal core modules.
+"""
+
+from datetime import datetime
+import gzip
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from logging_config import get_log_path
+
+REQUIRED_FIELDS = {"timestamp", "data"}
+PUBLIC_LOG: Path = get_log_path("public_rituals.jsonl", "PUBLIC_RITUAL_LOG")
+_MAX_BYTES = int(os.getenv("LOG_JSON_MAX_BYTES", "0"))
+
+
+def validate_log_entry(entry: dict[str, Any]) -> None:
+    """Raise ``ValueError`` if required fields are missing."""
+    missing = REQUIRED_FIELDS - entry.keys()
+    if missing:
+        raise ValueError(f"log entry missing required fields: {', '.join(sorted(missing))}")
+    if "foo" in entry:
+        raise ValueError("legacy field 'foo' is not allowed")
+
+
+def log_json(path: Path, obj: dict[str, Any]) -> None:
+    """Append a JSON object to a JSONL log with schema healing and validation."""
+    if "timestamp" not in obj:
+        obj["timestamp"] = datetime.utcnow().isoformat()
+    if "data" not in obj:
+        obj["data"] = {}
+    obj.pop("foo", None)
+    validate_log_entry(obj)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _MAX_BYTES and path.exists() and path.stat().st_size >= _MAX_BYTES:
+        rotated = path.with_suffix(path.suffix + ".1.gz")
+        with path.open("rb") as src, gzip.open(rotated, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        path.unlink()
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(obj) + "\n")

--- a/sentientos/integrity_metrics.py
+++ b/sentientos/integrity_metrics.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Neutral formal integrity metrics helpers.
+
+These parsers are pure data extraction primitives for formal/reporting modules,
+without dashboard or symbolic dependencies.
+"""
+
+from pathlib import Path
+from typing import Dict
+
+from logging_config import get_log_path
+
+
+def gather_integrity_issues() -> Dict[str, int]:
+    """Return mapping of integrity issue files to entry counts."""
+    log_dir = get_log_path("dummy").parent
+    counts: Dict[str, int] = {}
+    for file in log_dir.glob("*.wounds"):
+        lines = [ln for ln in file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        counts[file.name] = len(lines)
+    for log in log_dir.glob("*.jsonl"):
+        if log.with_suffix(log.suffix + ".wounds") not in counts:
+            counts[log.name + ".wounds"] = 0
+    return counts
+
+
+def parse_contributors(path: Path | None = None) -> list[str]:
+    """Parse CONTRIBUTORS.md audit contributor section."""
+    contributors_path = path or Path("CONTRIBUTORS.md")
+    text = contributors_path.read_text(encoding="utf-8").splitlines()
+    names: list[str] = []
+    start = False
+    for line in text:
+        if line.strip() == "## Audit Contributors":
+            start = True
+            continue
+        if start:
+            if line.startswith("#"):
+                break
+            line = line.strip()
+            if line:
+                names.append(line.lstrip("- "))
+    return names

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_35_control_plane_bypass_facade_remediation_wave",
+  "generated_for_phase": "phase_36_formal_core_symbolic_import_purification_wave",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -168,20 +168,6 @@
       "detail": "imports cathedral_const and presence_ledger",
       "severity": "high",
       "remediation": "remove symbolic coupling from formal sink"
-    },
-    {
-      "rule": "formal_symbolic_import",
-      "file": "audit_chain.py",
-      "detail": "imports cathedral_const validation",
-      "severity": "medium",
-      "remediation": "move validation primitive to formal package"
-    },
-    {
-      "rule": "formal_symbolic_import",
-      "file": "agent_privilege_policy_engine.py",
-      "detail": "imports cathedral_const logging",
-      "severity": "medium",
-      "remediation": "depend on formal logger surface"
     },
     {
       "rule": "world_forbidden_import",

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -118,7 +118,7 @@ def test_formal_layers_do_not_import_symbolic_modules() -> None:
     violations: list[str] = []
     for path in _all_python_files():
         rel = path.relative_to(ROOT).as_posix()
-        if rel not in {"ledger.py", "audit_chain.py", "agent_privilege_policy_engine.py"}:
+        if rel not in {"ledger.py", "audit_chain.py", "agent_privilege_policy_engine.py", "healing_sprint_ledger.py", "sentientos/formal_logging.py", "sentientos/integrity_metrics.py"}:
             continue
         for mod, _ in _imports(path):
             for token in forbidden:
@@ -130,6 +130,20 @@ def test_formal_layers_do_not_import_symbolic_modules() -> None:
         assert violations
     else:
         assert not violations, "New formal->symbolic violations:\n" + "\n".join(sorted(violations))
+
+
+def test_phase36_formal_modules_use_neutral_helpers() -> None:
+    audit_text = (ROOT / "audit_chain.py").read_text(encoding="utf-8")
+    assert "from sentientos.formal_logging import validate_log_entry" in audit_text
+    assert "from cathedral_const import validate_log_entry" not in audit_text
+
+    policy_text = (ROOT / "agent_privilege_policy_engine.py").read_text(encoding="utf-8")
+    assert "from sentientos.formal_logging import log_json" in policy_text
+    assert "from cathedral_const import log_json" not in policy_text
+
+    sprint_text = (ROOT / "healing_sprint_ledger.py").read_text(encoding="utf-8")
+    assert "from sentientos.integrity_metrics import gather_integrity_issues, parse_contributors" in sprint_text
+    assert "from cathedral_wounds_dashboard import gather_integrity_issues, parse_contributors" not in sprint_text
 
 
 def test_autonomy_filenames_have_governance_annotation_or_allowlist() -> None:

--- a/tests/test_formal_neutral_helpers.py
+++ b/tests/test_formal_neutral_helpers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sentientos import formal_logging
+from sentientos.integrity_metrics import gather_integrity_issues, parse_contributors
+
+
+def test_validate_log_entry_requires_timestamp_and_data() -> None:
+    with pytest.raises(ValueError):
+        formal_logging.validate_log_entry({"timestamp": "x"})
+
+
+def test_log_json_heals_and_appends(tmp_path: Path) -> None:
+    out = tmp_path / "x.jsonl"
+    formal_logging.log_json(out, {"data": {"k": "v"}})
+    text = out.read_text(encoding="utf-8")
+    assert '"timestamp"' in text
+    assert '"data"' in text
+
+
+def test_parse_contributors_extracts_audit_section(tmp_path: Path) -> None:
+    c = tmp_path / "CONTRIBUTORS.md"
+    c.write_text("# T\n\n## Audit Contributors\n- A\n- B\n\n## Other\n- X\n", encoding="utf-8")
+    assert parse_contributors(c) == ["A", "B"]
+
+
+def test_gather_integrity_issues_counts_wounds(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "a.wounds").write_text("x\n\ny\n", encoding="utf-8")
+    (logs_dir / "b.jsonl").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr("sentientos.integrity_metrics.get_log_path", lambda _: logs_dir / "dummy")
+    counts = gather_integrity_issues()
+    assert counts["a.wounds"] == 2
+    assert counts["b.jsonl.wounds"] == 0


### PR DESCRIPTION
### Motivation
- Remove P1-class reverse contamination where formal/core modules depended on symbolic/presentation surfaces for validation/logging/parsing primitives.
- Provide narrowly scoped, presentation-free formal helpers so formal modules can keep canonical semantics without pulling dashboard/ritual dependencies.
- Preserve existing audit/ledger/privilege behavior while making the architecture manifest and tests reflect real remediation progress.

### Description
- Added neutral helper modules `sentientos/formal_logging.py` (validation + JSONL append/rotation) and `sentientos/integrity_metrics.py` (integrity counts and contributor parsing) that contain presentation-free primitives mirroring prior behavior.
- Migrated formal callers to use the new helpers: `audit_chain.py` now imports `validate_log_entry` from `sentientos.formal_logging`, `agent_privilege_policy_engine.py` now uses `sentientos.formal_logging.log_json`, and `healing_sprint_ledger.py` now uses `sentientos.integrity_metrics` helpers.
- Updated the architecture manifest `sentientos/system_closure/architecture_boundary_manifest.json` to mark this wave (`phase_36_formal_core_symbolic_import_purification_wave`) and removed the now-remediated known violations for `audit_chain.py` and `agent_privilege_policy_engine.py` while leaving `ledger.py` explicitly unresolved.
- Strengthened boundary tests and added focused unit tests: extended `tests/architecture/test_architecture_boundaries.py` with phase-36 assertions and added `tests/test_formal_neutral_helpers.py` to verify helper behavior and parsing.

### Testing
- Ran `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed.
- Ran `python -m scripts.run_tests -q tests/test_formal_neutral_helpers.py sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` and they passed.
- Added unit tests covering `validate_log_entry`, `log_json`, `parse_contributors`, and `gather_integrity_issues`, all of which succeeded in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f78c260a708320bfebfb84e1996647)