### PR TITLE
[codex:ledger] purify ledger formal imports via neutral helpers

### DIFF
--- a/ledger.py
+++ b/ledger.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from presence_analytics import load_entries, presence_metrics
-from cathedral_const import PUBLIC_LOG, log_json
+from sentientos.formal_logging import PUBLIC_LOG, log_json
 from log_utils import append_json
 
 class _DoctrineProxy:
@@ -428,8 +428,8 @@ def streamlit_widget(st_module: Any) -> None:
     sup = summarize_log(get_log_path("support_log.jsonl"))
     fed = summarize_log(get_log_path("federation_log.jsonl"))
     music = summarize_log(get_log_path("music_log.jsonl"))
-    import presence_ledger as pl
-    priv = pl.recent_privilege_attempts()
+    from sentientos.presence_api import recent_privilege_attempts
+    priv = recent_privilege_attempts()
     st_module.write(
         f"Support blessings: {sup['count']} • Federation blessings: {fed['count']}"
         f" • Music events: {music['count']}"

--- a/sentientos/presence_api.py
+++ b/sentientos/presence_api.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Neutral presence read helpers for formal-core consumers.
+
+This module provides read-only accessors that preserve existing presence ledger
+record shapes while keeping formal modules free of presentation/symbolic imports.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from logging_config import get_log_path
+
+
+def _presence_ledger_path() -> Path:
+    return get_log_path("user_presence.jsonl", "USER_PRESENCE_LOG")
+
+
+def recent_privilege_attempts(limit: int = 5) -> list[dict[str, Any]]:
+    """Return the most recent privilege-check entries from the presence ledger."""
+    ledger_path = _presence_ledger_path()
+    if not ledger_path.exists():
+        return []
+    lines = reversed(ledger_path.read_text(encoding="utf-8").splitlines())
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(obj, dict) and obj.get("event") == "admin_privilege_check":
+            out.append(obj)
+            if len(out) == limit:
+                break
+    return list(reversed(out))

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_36_formal_core_symbolic_import_purification_wave",
+  "generated_for_phase": "phase_37_ledger_core_purification_wave",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -163,13 +163,6 @@
       "remediation": "migrate read path to projection API"
     },
     {
-      "rule": "formal_symbolic_import",
-      "file": "ledger.py",
-      "detail": "imports cathedral_const and presence_ledger",
-      "severity": "high",
-      "remediation": "remove symbolic coupling from formal sink"
-    },
-    {
       "rule": "world_forbidden_import",
       "file": "resonite_guest_agent_consent_feedback_wizard.py",
       "detail": "imports presence_ledger",
@@ -186,7 +179,6 @@
   ],
   "inventory_mode_rules": [
     "expressive_forbidden_import",
-    "formal_symbolic_import",
     "autonomy_naming_missing_annotation"
   ]
 }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -118,7 +118,7 @@ def test_formal_layers_do_not_import_symbolic_modules() -> None:
     violations: list[str] = []
     for path in _all_python_files():
         rel = path.relative_to(ROOT).as_posix()
-        if rel not in {"ledger.py", "audit_chain.py", "agent_privilege_policy_engine.py", "healing_sprint_ledger.py", "sentientos/formal_logging.py", "sentientos/integrity_metrics.py"}:
+        if rel not in {"ledger.py", "audit_chain.py", "agent_privilege_policy_engine.py", "healing_sprint_ledger.py", "sentientos/formal_logging.py", "sentientos/integrity_metrics.py", "sentientos/presence_api.py"}:
             continue
         for mod, _ in _imports(path):
             for token in forbidden:
@@ -145,6 +145,18 @@ def test_phase36_formal_modules_use_neutral_helpers() -> None:
     assert "from sentientos.integrity_metrics import gather_integrity_issues, parse_contributors" in sprint_text
     assert "from cathedral_wounds_dashboard import gather_integrity_issues, parse_contributors" not in sprint_text
 
+
+
+
+def test_phase37_ledger_uses_neutral_formal_helpers() -> None:
+    ledger_text = (ROOT / "ledger.py").read_text(encoding="utf-8")
+    assert "from sentientos.formal_logging import PUBLIC_LOG, log_json" in ledger_text
+    assert "from cathedral_const import PUBLIC_LOG, log_json" not in ledger_text
+    assert "import presence_ledger" not in ledger_text
+    assert "from sentientos.presence_api import recent_privilege_attempts" in ledger_text
+
+    presence_api_text = (ROOT / "sentientos/presence_api.py").read_text(encoding="utf-8")
+    assert "import presence_ledger" not in presence_api_text
 
 def test_autonomy_filenames_have_governance_annotation_or_allowlist() -> None:
     manifest = _manifest()

--- a/tests/integrity/test_ledger_phase37_compatibility.py
+++ b/tests/integrity/test_ledger_phase37_compatibility.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_presence_api_recent_privilege_attempts_compatible(tmp_path, monkeypatch) -> None:
+    ledger_path = tmp_path / "presence.jsonl"
+    ledger_path.write_text(
+        '\n'.join([
+            '{"event":"other","user":"a"}',
+            '{"event":"admin_privilege_check","user":"u1","status":"ok"}',
+            '{"event":"admin_privilege_check","user":"u2","status":"denied"}',
+        ]) + '\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("USER_PRESENCE_LOG", str(ledger_path))
+    module = importlib.import_module("sentientos.presence_api")
+
+    recent = module.recent_privilege_attempts(limit=1)
+    assert len(recent) == 1
+    assert recent[0]["user"] == "u2"
+    assert recent[0]["event"] == "admin_privilege_check"


### PR DESCRIPTION
### Motivation

- Remove formal-core contamination in `ledger.py` by eliminating direct imports of presentation/symbolic modules (`cathedral_const`, `presence_ledger`) so the ledger honors the formal/presentation boundary.
- Provide neutral, read-only helpers to preserve existing ledger semantics and record shapes without introducing new truth sources or changing append-only behavior.

### Description

- Replaced `from cathedral_const import PUBLIC_LOG, log_json` in `ledger.py` with `from sentientos.formal_logging import PUBLIC_LOG, log_json` and routed the Streamlit privilege read path through a neutral accessor. 
- Added `sentientos/presence_api.py` as a small, boundary-respecting read-only helper that exposes `recent_privilege_attempts()` and reads the canonical presence ledger path using the existing `USER_PRESENCE_LOG` contract. 
- Updated the architecture manifest `sentientos/system_closure/architecture_boundary_manifest.json` to mark Phase 37 and remove the remediated `ledger.py` known `formal_symbolic_import` entry so the manifest reflects the remediation. 
- Strengthened tests by adding `tests/integrity/test_ledger_phase37_compatibility.py` for `recent_privilege_attempts()` behavior and updating `tests/architecture/test_architecture_boundaries.py` to assert that `ledger.py` uses `sentientos.formal_logging` and `sentientos.presence_api` instead of symbolic imports. 

### Testing

- Ran the focused architecture/import checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, observed an initial failure during iteration that was addressed by tightening tests and manifest entries. 
- Re-ran the expanded validation including the new compatibility test with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py tests/integrity/test_ledger_phase37_compatibility.py sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` and all selected tests completed successfully. 
- The added compatibility test `tests/integrity/test_ledger_phase37_compatibility.py` verifies ordering, filtering, and limit behavior of `sentientos.presence_api.recent_privilege_attempts()` and passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f79e754e2083209d52f7c66bf2515c)