### PR TITLE
[codex:architecture] remediate phase39 boundary mega-wave

### DIFF
--- a/autonomous_self_patching_agent.py
+++ b/autonomous_self_patching_agent.py
@@ -16,6 +16,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
+
+GOVERNANCE_ANNOTATION = "phase39_boundary_non_sovereign_autonomy"
+ADMISSION_SURFACE = "caller-invoked CLI/function call with control_api authority checks"
+CONSENT_BOUNDARY = "explicit caller invocation; no autonomous background scheduling"
+PROVENANCE_BOUNDARY = "append-only self_patch_agent log entries with UTC timestamps"
+SIMULATION_ONLY = False
+NON_SOVEREIGNTY = "agent name is historical; execution remains bounded, caller-triggered, and policy-gated"
+
 LOG_PATH = get_log_path("self_patch_agent.jsonl", "SELF_PATCH_LOG")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/docs/architecture/phase39_boundary_remediation_execplan.md
+++ b/docs/architecture/phase39_boundary_remediation_execplan.md
@@ -1,0 +1,32 @@
+# Phase 39 Boundary Remediation Execution Plan
+
+## Selected known violations
+1. `ritual_cli.py` expressive direct imports of `attestation` and `relationship_log`.
+2. `emotion_dashboard.py` dashboard direct `ledger` coupling for Streamlit widget.
+3. `mood_wall.py` dashboard/mood direct `ledger` coupling on mood blessing writes.
+4. `autonomous_self_patching_agent.py` autonomy filename token without governance annotation.
+
+## Why these are safe in one wave
+- All four are module-boundary remediations with no authority model changes.
+- Existing canonical sinks (`attestation`, `relationship_log`, `ledger`) remain unchanged.
+- The changes are import-path and boundary-façade oriented, preserving CLI/data contracts.
+
+## Target façades/helpers
+- Add `sentientos.ritual_api` for ritual event and attestation history/write delegation.
+- Add `sentientos.dashboard_api` for dashboard ledger widget and mood blessing delegation.
+- Reuse existing `sentientos.ledger_api` and `sentientos.control_api` unchanged.
+
+## Behavior-preservation checks
+- Ritual export/timeline still produce the same event + attestation shapes.
+- Emotion dashboard still renders ledger widget via Streamlit sidebar target.
+- Mood wall blessing still writes canonical `mood_blessing` entries with same shape.
+- Self-patching agent runtime behavior unchanged; annotation is doctrine metadata only.
+
+## Tests to run
+- `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`
+- `python -m scripts.run_tests -q tests/test_ritual_cli.py tests/test_emotion_dashboard.py tests/test_mood_wall.py`
+- `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`
+
+## Intentional deferrals
+- Any additional expressive/dashboard ledger coupling not listed in manifest remains deferred to later waves.
+- No mass rename of autonomy/daemon filenames in this phase; annotations first.

--- a/emotion_dashboard.py
+++ b/emotion_dashboard.py
@@ -33,7 +33,7 @@ try:
 except Exception:  # pragma: no cover - optional
     st = None
 
-import ledger
+from sentientos.dashboard_api import render_ledger_widget
 
 
 import reflex_manager as rm
@@ -82,7 +82,7 @@ def run_dashboard(
 
     st.set_page_config(page_title="SentientOS Dashboard", layout="wide")
     st.title("SentientOS Emotion Dashboard")
-    ledger.streamlit_widget(st.sidebar if hasattr(st, "sidebar") else st)
+    render_ledger_widget(st.sidebar if hasattr(st, "sidebar") else st)
 
     # Optional FeedbackManager integration
     fm = None

--- a/mood_wall.py
+++ b/mood_wall.py
@@ -15,7 +15,7 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import ledger
+from sentientos.dashboard_api import log_mood_blessing
 from sentientos.ledger_api import append_audit_record
 try:
     import requests  # type: ignore[import-untyped]  # HTTP client optional
@@ -59,7 +59,7 @@ def top_moods(events: List[Dict[str, object]]) -> Dict[str, int]:
 
 def bless_mood(mood: str, user: str, message: str = "") -> Dict[str, str]:
     phrase = message or f"{user} blesses {mood}"
-    return ledger.log_mood_blessing(user, "public", {mood: 1.0}, phrase)
+    return log_mood_blessing(user, mood, phrase)
 
 
 def sync_wall(peer_log: Path) -> int:

--- a/ritual_cli.py
+++ b/ritual_cli.py
@@ -7,27 +7,26 @@ import argparse
 import json
 import os
 from sentient_banner import print_banner, print_closing, ENTRY_BANNER
-import attestation
-import relationship_log as rl
+from sentientos.ritual_api import add_attestation, ritual_attestations_history, ritual_events_history
 def cmd_attest(args) -> None:
     user = args.user or os.getenv("USER", "anon")
-    attestation.add(args.event, user, comment=args.comment or "", quote=args.quote or "")
+    add_attestation(args.event, user, comment=args.comment or "", quote=args.quote or "")
     print("Attestation recorded")
 
 
 def cmd_export(args) -> None:
     user = args.user
-    events = rl.history(user if user != "all" else None, limit=100000)
-    attest = attestation.history(None, limit=100000)
+    events = ritual_events_history(user if user != "all" else None, limit=100000)
+    attest = ritual_attestations_history(None, limit=100000)
     data = {"events": events, "attestations": attest}
     print(json.dumps(data, indent=2))
 
 
 def cmd_timeline(args) -> None:
-    events = rl.history(args.user if args.user else None, limit=1000)
+    events = ritual_events_history(args.user if args.user else None, limit=1000)
     for e in events:
         print(f"{e.get('time')} {e.get('event')} by {e.get('user')}")
-        atts = attestation.history(e.get("id"), limit=100)
+        atts = ritual_attestations_history(e.get("id"), limit=100)
         for a in atts:
             c = a.get("comment", "")
             print(f"  witness {a.get('user')}: {c}")

--- a/sentientos/dashboard_api.py
+++ b/sentientos/dashboard_api.py
@@ -1,0 +1,23 @@
+"""Public dashboard boundary façade.
+
+Provides dashboard-safe helpers for ledger-derived widgets and mood blessings
+without exposing raw ledger internals to dashboard/expressive modules.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import ledger
+
+
+def render_ledger_widget(target: Any) -> None:
+    """Render the canonical ledger streamlit widget on ``target``."""
+    ledger.streamlit_widget(target)
+
+
+def log_mood_blessing(user: str, mood: str, phrase: str) -> dict[str, str]:
+    """Delegate mood blessing to canonical ledger semantics."""
+    return ledger.log_mood_blessing(user, "public", {mood: 1.0}, phrase)
+
+
+__all__ = ["render_ledger_widget", "log_mood_blessing"]

--- a/sentientos/ritual_api.py
+++ b/sentientos/ritual_api.py
@@ -1,0 +1,34 @@
+"""Public ritual boundary façade.
+
+This module exposes a narrow API for expressive ritual surfaces that need
+relationship timeline and attestation access while avoiding direct coupling to
+formal ritual internals.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import attestation
+import relationship_log
+
+
+def add_attestation(event_id: str, user: str, comment: str = "", quote: str = "") -> str:
+    """Delegate witness attestation writes to canonical attestation storage."""
+    return attestation.add(event_id, user, comment=comment, quote=quote)
+
+
+def ritual_events_history(user: str | None = None, *, limit: int = 20) -> list[dict[str, Any]]:
+    """Return ritual relationship history from canonical relationship log."""
+    return relationship_log.history(user, limit=limit)
+
+
+def ritual_attestations_history(event_id: str | None = None, *, limit: int = 20) -> list[dict[str, Any]]:
+    """Return ritual attestation history from canonical attestation log."""
+    return attestation.history(event_id, limit=limit)
+
+
+__all__ = [
+    "add_attestation",
+    "ritual_events_history",
+    "ritual_attestations_history",
+]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_38_world_presence_adapter_facade_wave",
+  "generated_for_phase": "phase_39_repository_boundary_remediation_mega_wave",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -140,38 +140,6 @@
       "tests/"
     ]
   },
-  "known_violations": [
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "ritual_cli.py",
-      "detail": "imports attestation and relationship_log directly",
-      "severity": "medium",
-      "remediation": "consume typed ritual fa\u00e7ade"
-    },
-    {
-      "rule": "dashboard_forbidden_import",
-      "file": "emotion_dashboard.py",
-      "detail": "uses ledger streamlit_widget + ledger coupling",
-      "severity": "medium",
-      "remediation": "use dashboard-safe view model"
-    },
-    {
-      "rule": "dashboard_forbidden_import",
-      "file": "mood_wall.py",
-      "detail": "retains ledger read coupling; append writes remediated via public facade",
-      "severity": "low",
-      "remediation": "migrate read path to projection API"
-    },
-    {
-      "rule": "autonomy_naming_missing_annotation",
-      "file": "autonomous_self_patching_agent.py",
-      "detail": "autonomy token without explicit governance annotation",
-      "severity": "medium",
-      "remediation": "add governance annotation block"
-    }
-  ],
-  "inventory_mode_rules": [
-    "expressive_forbidden_import",
-    "autonomy_naming_missing_annotation"
-  ]
+  "known_violations": [],
+  "inventory_mode_rules": []
 }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -237,3 +237,45 @@ def test_phase35_control_facade_public_contract_is_narrow() -> None:
     assert "AuthorizationRecord" not in facade_text
     assert "def require_authorization_for_request_types" in facade_text
     assert "def require_self_patch_apply_authority" in facade_text
+
+
+def test_phase39_ritual_cli_uses_ritual_facade() -> None:
+    text = (ROOT / "ritual_cli.py").read_text(encoding="utf-8")
+    assert "from sentientos.ritual_api import add_attestation, ritual_attestations_history, ritual_events_history" in text
+    assert "import attestation" not in text
+    assert "import relationship_log" not in text
+
+
+def test_phase39_dashboard_and_mood_modules_use_dashboard_facade() -> None:
+    emotion_text = (ROOT / "emotion_dashboard.py").read_text(encoding="utf-8")
+    assert "from sentientos.dashboard_api import render_ledger_widget" in emotion_text
+    assert "import ledger" not in emotion_text
+
+    mood_text = (ROOT / "mood_wall.py").read_text(encoding="utf-8")
+    assert "from sentientos.dashboard_api import log_mood_blessing" in mood_text
+    assert "import ledger" not in mood_text
+
+
+def test_phase39_new_facades_remain_narrow_and_presentation_neutral() -> None:
+    ritual_api_text = (ROOT / "sentientos/ritual_api.py").read_text(encoding="utf-8")
+    assert "__all__" in ritual_api_text
+    assert "streamlit" not in ritual_api_text
+    assert "dashboard" not in ritual_api_text
+
+    dashboard_api_text = (ROOT / "sentientos/dashboard_api.py").read_text(encoding="utf-8")
+    assert "__all__" in dashboard_api_text
+    assert "relationship_log" not in dashboard_api_text
+    assert "attestation" not in dashboard_api_text
+
+
+def test_phase39_self_patching_agent_has_governance_annotation_markers() -> None:
+    text = (ROOT / "autonomous_self_patching_agent.py").read_text(encoding="utf-8")
+    for marker in (
+        "GOVERNANCE_ANNOTATION",
+        "ADMISSION_SURFACE",
+        "CONSENT_BOUNDARY",
+        "PROVENANCE_BOUNDARY",
+        "SIMULATION_ONLY",
+        "NON_SOVEREIGNTY",
+    ):
+        assert marker in text

--- a/tests/test_phase39_boundary_facades.py
+++ b/tests/test_phase39_boundary_facades.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+
+from sentientos import dashboard_api, ritual_api
+
+
+def test_ritual_api_round_trip_preserves_record_shape(tmp_path, monkeypatch) -> None:
+    att_path = tmp_path / "att.jsonl"
+    rel_path = tmp_path / "rel.jsonl"
+    monkeypatch.setattr("attestation.LOG_PATH", att_path)
+    monkeypatch.setattr("relationship_log.LOG_PATH", rel_path)
+
+    event_id = ritual_api.add_attestation("evt-1", "tester", comment="ok", quote="q")
+    assert event_id
+
+    att = ritual_api.ritual_attestations_history("evt-1", limit=5)
+    assert att and att[-1]["event"] == "evt-1"
+    assert set(["id", "timestamp", "event", "user", "comment", "quote"]).issubset(att[-1].keys())
+
+
+def test_dashboard_api_mood_blessing_delegates_to_canonical_shape(monkeypatch) -> None:
+    captured = {}
+
+    def _fake(user, scope, emotion, phrase):
+        captured.update({"user": user, "scope": scope, "emotion": emotion, "phrase": phrase})
+        return {"status": "ok"}
+
+    monkeypatch.setattr("ledger.log_mood_blessing", _fake)
+    out = dashboard_api.log_mood_blessing("u", "joy", "u blesses joy")
+    assert out == {"status": "ok"}
+    assert captured == {
+        "user": "u",
+        "scope": "public",
+        "emotion": {"joy": 1.0},
+        "phrase": "u blesses joy",
+    }


### PR DESCRIPTION
### Motivation
- Reduce expressive→formal boundary drift by remediating multiple manifest-listed violations in one coherent wave. 
- Provide narrow public façades so dashboards and ritual surfaces stop importing canonical internals directly. 
- Add governance annotations for autonomy-named modules so naming carries explicit non-sovereignty metadata. 
- Make the manifest truthful and strengthen automated checks to prevent silent regression.

### Description
- Added two narrow public façades: `sentientos/ritual_api.py` (ritual attestation/history delegation) and `sentientos/dashboard_api.py` (ledger widget + mood-blessing delegation). 
- Migrated callers to façades: `ritual_cli.py` now uses `sentientos.ritual_api`, `emotion_dashboard.py` uses `sentientos.dashboard_api.render_ledger_widget`, and `mood_wall.py` uses `sentientos.dashboard_api.log_mood_blessing`. 
- Added governance annotation markers (`GOVERNANCE_ANNOTATION`, `ADMISSION_SURFACE`, `CONSENT_BOUNDARY`, `PROVENANCE_BOUNDARY`, `SIMULATION_ONLY`, `NON_SOVEREIGNTY`) to `autonomous_self_patching_agent.py` without changing runtime semantics. 
- Updated `sentientos/system_closure/architecture_boundary_manifest.json` to reflect Phase 39 truth (cleared remediated known violations and inventory gates), added `docs/architecture/phase39_boundary_remediation_execplan.md`, and strengthened architecture tests in `tests/architecture/test_architecture_boundaries.py` as well as adding focused compatibility tests in `tests/test_phase39_boundary_facades.py`.

### Testing
- Added focused unit tests `tests/test_phase39_boundary_facades.py` to verify ritual façade record shape and dashboard façade delegation contract. 
- Updated architecture tests in `tests/architecture/test_architecture_boundaries.py` to assert migrated modules import façades and that new façades remain presentation-neutral. 
- Ran the requested test invocations via `python -m scripts.run_tests -q ...` (architecture/integrity, focused compatibility, and orchestration smoke suites), but the environment entered dependency bootstrap / package install steps and did not complete to final pytest pass/fail within the session window; no regressions attributable to the changes were observed during edits. 
- CI should run the added tests and the tightened architecture assertions; they are expected to enforce the remediations and prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a414358c8320a8801827e1d0728b)