### PR TITLE
[codex:architecture] implement phase 40 boundary remediation wave ii

### DIFF
--- a/agent_privilege_policy_engine.py
+++ b/agent_privilege_policy_engine.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
+
+GOVERNANCE_ANNOTATION = "phase40_boundary_governance_annotation"
+ADMISSION_SURFACE = "caller-invoked entrypoints and bounded process lifecycle"
+CONSENT_BOUNDARY = "explicit operator/config invocation; no unilateral sovereignty"
+PROVENANCE_BOUNDARY = "append-only logs and existing canonical records"
+SIMULATION_ONLY = False
+NON_SOVEREIGNTY = "name is descriptive legacy; authority remains policy-gated and bounded"
+CALLER_TRIGGERED_OR_BOUNDED_RUNTIME = "bounded-runtime"
+
 """Agent Privilege Policy Engine
 
 Sanctuary Privilege Ritual: Do not remove. See doctrine for details.

--- a/autonomous_self_patching_agent.py
+++ b/autonomous_self_patching_agent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
-from control_plane.records import AuthorizationError
+from sentientos.control_api import AuthorizationError
 from sentientos.control_api import require_self_patch_apply_authority
 
 """Autonomous Self-Patching Agent

--- a/avatar_autonomous_ritual_scheduler.py
+++ b/avatar_autonomous_ritual_scheduler.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 from logging_config import get_log_path
 
+
+GOVERNANCE_ANNOTATION = "phase40_boundary_governance_annotation"
+ADMISSION_SURFACE = "caller-invoked entrypoints and bounded process lifecycle"
+CONSENT_BOUNDARY = "explicit operator/config invocation; no unilateral sovereignty"
+PROVENANCE_BOUNDARY = "append-only logs and existing canonical records"
+SIMULATION_ONLY = False
+NON_SOVEREIGNTY = "name is descriptive legacy; authority remains policy-gated and bounded"
+CALLER_TRIGGERED_OR_BOUNDED_RUNTIME = "bounded-runtime"
+
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details.
 
 Avatar Autonomous Ritual Scheduler.

--- a/daemon_autonomy_supervisor.py
+++ b/daemon_autonomy_supervisor.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+
+GOVERNANCE_ANNOTATION = "phase40_boundary_governance_annotation"
+ADMISSION_SURFACE = "caller-invoked entrypoints and bounded process lifecycle"
+CONSENT_BOUNDARY = "explicit operator/config invocation; no unilateral sovereignty"
+PROVENANCE_BOUNDARY = "append-only logs and existing canonical records"
+SIMULATION_ONLY = False
+NON_SOVEREIGNTY = "name is descriptive legacy; authority remains policy-gated and bounded"
+CALLER_TRIGGERED_OR_BOUNDED_RUNTIME = "bounded-runtime"
+
 import json
 import os
 import subprocess

--- a/docs/architecture/phase40_boundary_remediation_execplan.md
+++ b/docs/architecture/phase40_boundary_remediation_execplan.md
@@ -1,0 +1,53 @@
+# Phase 40 Boundary Remediation ExecPlan
+
+## 1) Remaining known violations from manifest
+- `autonomous_self_patching_agent.py` expressive forbidden import.
+- `self_patcher.py` expressive forbidden import.
+- `speech_emitter.py` expressive forbidden import.
+- `tts_test.py` expressive forbidden import.
+
+## 2) Additional discovered violations (same classes)
+- Additional expressive coupling in legacy speech/self-patch tooling via `control_plane`/`task_executor` direct imports.
+- Governance-annotation policy currently relies on a broad `approved_paths` allowlist; many approved files still lacked parseable governance markers.
+
+## 3) Selected remediation batch
+- Migrate speech/self-patch callers (`speech_emitter.py`, `self_patcher.py`, `tts_test.py`) to public control façade APIs.
+- Remove remaining expressive direct formal import in `autonomous_self_patching_agent.py`.
+- Add governance annotation constants to selected daemon/agent/scheduler modules:
+  - `daemon_autonomy_supervisor.py`
+  - `avatar_autonomous_ritual_scheduler.py`
+  - `sentientos/forge_daemon.py`
+  - `agent_privilege_policy_engine.py`
+- Tighten architecture boundary tests so approved autonomy files must still carry parseable governance markers.
+- Update manifest truth and promote stricter autonomy annotation enforcement posture.
+
+## 4) Why this batch is safe together
+- All touched callers are boundary adapters/CLIs and can delegate to existing canonical control semantics through `sentientos.control_api` without changing authority behavior.
+- Governance annotation additions are metadata-only and do not change runtime.
+- Test + manifest changes align machine enforcement with repository truth.
+
+## 5) Target façades/helpers/annotations
+- Extend `sentientos.control_api` with narrow delegation helpers for speech authorization/admission and self-patch provenance serialization.
+- Use consistent markers: `GOVERNANCE_ANNOTATION`, `ADMISSION_SURFACE`, `CONSENT_BOUNDARY`, `PROVENANCE_BOUNDARY`, `SIMULATION_ONLY`, `NON_SOVEREIGNTY`, `CALLER_TRIGGERED_OR_BOUNDED_RUNTIME`.
+
+## 6) Exact files expected to change
+- `docs/architecture/phase40_boundary_remediation_execplan.md`
+- `sentientos/control_api.py`
+- `speech_emitter.py`
+- `self_patcher.py`
+- `tts_test.py`
+- `autonomous_self_patching_agent.py`
+- `daemon_autonomy_supervisor.py`
+- `avatar_autonomous_ritual_scheduler.py`
+- `sentientos/forge_daemon.py`
+- `agent_privilege_policy_engine.py`
+- `sentientos/system_closure/architecture_boundary_manifest.json`
+- `tests/architecture/test_architecture_boundaries.py`
+
+## 7) Validation and compatibility strategy
+- Run architecture + import purity tests.
+- Run orchestration smoke tests requested for boundary safety.
+- Preserve all existing record shapes/paths and admission semantics by delegating instead of re-implementing policy.
+
+## 8) Deferred violations
+- Broad protected-sink write normalization across many expressive/world scripts remains deferred due to scope/compatibility risk; this wave focuses on control-boundary coupling and governance enforcement hardening while keeping manifest truthful.

--- a/self_patcher.py
+++ b/self_patcher.py
@@ -9,13 +9,11 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from control_plane import RequestType
-from control_plane.records import AuthorizationError, AuthorizationRecord
 import memory_manager as mm
 from notification import send as notify
 import reflection_stream as rs
-import task_executor
 import final_approval
+from sentientos.control_api import canonicalize_admission_provenance, require_request_fingerprint_match, require_self_patch_apply_authority
 
 PATCH_PATH = mm.MEMORY_DIR / "patches.json"
 PATCH_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -55,36 +53,20 @@ def propose_patch(note: str) -> dict:
 
 
 def _validate_gate(
-    admission_token: task_executor.AdmissionToken | None,
-    authorization: AuthorizationRecord | None,
-    request_fingerprint: task_executor.RequestFingerprint | None,
+    admission_token: object | None,
+    authorization: object | None,
+    request_fingerprint: object | None,
 ) -> None:
-    if admission_token is None:
-        raise AuthorizationError("admission token required for self-healing apply")
-    if authorization is None:
-        raise AuthorizationError("authorization required for self-healing apply")
-    authorization.require(RequestType.TASK_EXECUTION)
-    if admission_token.issued_by != "task_admission":
-        raise AuthorizationError("admission token issuer invalid")
-    if not isinstance(admission_token.provenance, task_executor.AuthorityProvenance):
-        raise AuthorizationError("admission token provenance missing")
-    fingerprint_value = admission_token.request_fingerprint.value
-    if not isinstance(fingerprint_value, str) or len(fingerprint_value) != 64:
-        raise AuthorizationError("admission token fingerprint missing")
-    try:
-        int(fingerprint_value, 16)
-    except ValueError as exc:  # pragma: no cover - defensive
-        raise AuthorizationError("admission token fingerprint missing") from exc
-    if request_fingerprint is not None and request_fingerprint.value != fingerprint_value:
-        raise AuthorizationError("request fingerprint mismatch for self-healing apply")
+    require_self_patch_apply_authority(admission_token, authorization)
+    require_request_fingerprint_match(admission_token, request_fingerprint)
 
 
 def apply_patch(
     note: str,
     *,
-    admission_token: task_executor.AdmissionToken,
-    authorization: AuthorizationRecord,
-    request_fingerprint: task_executor.RequestFingerprint | None = None,
+    admission_token: object,
+    authorization: object,
+    request_fingerprint: object | None = None,
 ) -> dict:
     """Apply a vetted patch; requires admission + authorization."""
 
@@ -99,7 +81,7 @@ def apply_patch(
         "approved": True,
         "rejected": False,
         "status": "applied",
-        "provenance": task_executor.canonicalise_provenance(admission_token.provenance),
+        "provenance": canonicalize_admission_provenance(admission_token.provenance),
         "request_fingerprint": admission_token.request_fingerprint.value,
     }
     patches = _load()

--- a/sentientos/control_api.py
+++ b/sentientos/control_api.py
@@ -6,10 +6,11 @@ control-plane and task-admission authority semantics.
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from control_plane.enums import Decision, ReasonCode, RequestType
 from control_plane.records import AuthorizationError
+from control_plane import admit_request
 import task_executor
 
 
@@ -49,7 +50,30 @@ def require_self_patch_apply_authority(admission_token: Any, authorization: Any)
         raise AuthorizationError("admission token fingerprint missing") from exc
 
 
+def admit_tts_request(*, requester_id: str, intent_hash: str, context_hash: str, policy_version: str, metadata: Mapping[str, Any] | None = None) -> Any:
+    return admit_request(
+        request_type=RequestType.SPEECH_TTS,
+        requester_id=requester_id,
+        intent_hash=intent_hash,
+        context_hash=context_hash,
+        policy_version=policy_version,
+        metadata=dict(metadata or {}),
+    )
+
+
+def canonicalize_admission_provenance(provenance: Any) -> dict[str, Any]:
+    return task_executor.canonicalise_provenance(provenance)
+
+
+def require_request_fingerprint_match(admission_token: Any, request_fingerprint: Any | None) -> None:
+    if request_fingerprint is not None and request_fingerprint.value != admission_token.request_fingerprint.value:
+        raise AuthorizationError("request fingerprint mismatch for self-healing apply")
+
+
 __all__ = [
     "require_authorization_for_request_types",
     "require_self_patch_apply_authority",
+    "admit_tts_request",
+    "canonicalize_admission_provenance",
+    "require_request_fingerprint_match",
 ]

--- a/sentientos/forge_daemon.py
+++ b/sentientos/forge_daemon.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+
+GOVERNANCE_ANNOTATION = "phase40_boundary_governance_annotation"
+ADMISSION_SURFACE = "caller-invoked entrypoints and bounded process lifecycle"
+CONSENT_BOUNDARY = "explicit operator/config invocation; no unilateral sovereignty"
+PROVENANCE_BOUNDARY = "append-only logs and existing canonical records"
+SIMULATION_ONLY = False
+NON_SOVEREIGNTY = "name is descriptive legacy; authority remains policy-gated and bounded"
+CALLER_TRIGGERED_OR_BOUNDED_RUNTIME = "bounded-runtime"
+
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import contextlib

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_39_repository_boundary_remediation_mega_wave",
+  "generated_for_phase": "phase_40_repository_boundary_remediation_mega_wave_ii",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -185,39 +185,6 @@
       "tests/"
     ]
   },
-  "known_violations": [
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "autonomous_self_patching_agent.py",
-      "detail": "matches forbidden pattern",
-      "severity": "medium",
-      "phase": "phase_39",
-      "remediation": "Planned for later boundary waves; tracked as explicit legacy coupling."
-    },
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "self_patcher.py",
-      "detail": "matches forbidden pattern",
-      "severity": "medium",
-      "phase": "phase_39",
-      "remediation": "Planned for later boundary waves; tracked as explicit legacy coupling."
-    },
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "speech_emitter.py",
-      "detail": "matches forbidden pattern",
-      "severity": "medium",
-      "phase": "phase_39",
-      "remediation": "Planned for later boundary waves; tracked as explicit legacy coupling."
-    },
-    {
-      "rule": "expressive_forbidden_import",
-      "file": "tts_test.py",
-      "detail": "matches forbidden pattern",
-      "severity": "medium",
-      "phase": "phase_39",
-      "remediation": "Planned for later boundary waves; tracked as explicit legacy coupling."
-    }
-  ],
+  "known_violations": [],
   "inventory_mode_rules": []
 }

--- a/speech_emitter.py
+++ b/speech_emitter.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence
 
-from control_plane.enums import ReasonCode, RequestType
-from control_plane.records import AuthorizationError, AuthorizationRecord
+from typing import Any
+from sentientos.control_api import require_authorization_for_request_types
 from avatar_state import AvatarStateEmitter
 
 DEFAULT_BASE_STATE: Dict[str, Any] = {
@@ -78,7 +78,7 @@ class SpeechEmitter:
         started_at: float | None = None,
         muted: bool = False,
         metadata: Mapping[str, Any] | None = None,
-        authorization: AuthorizationRecord | None = None,
+        authorization: Any | None = None,
     ) -> Dict[str, Any]:
         _require_avatar_authorization(authorization)
         spoken = phrase.strip()
@@ -107,7 +107,7 @@ class SpeechEmitter:
             payload["metadata"] = dict(metadata)
         return self.avatar_state_emitter.emit(payload)
 
-    def emit_idle(self, *, authorization: AuthorizationRecord | None = None) -> Dict[str, Any]:
+    def emit_idle(self, *, authorization: Any | None = None) -> Dict[str, Any]:
         _require_avatar_authorization(authorization)
         payload: Dict[str, Any] = {
             **DEFAULT_BASE_STATE,
@@ -124,7 +124,7 @@ class SpeechEmitter:
         return self.avatar_state_emitter.emit(payload)
 
     def emit_from_tts(
-        self, speech: Mapping[str, Any], *, authorization: AuthorizationRecord | None = None
+        self, speech: Mapping[str, Any], *, authorization: Any | None = None
     ) -> Dict[str, Any]:
         phrase = str(speech.get("text", speech.get("utterance", "")))
         viseme_source = speech.get("visemes") or speech.get("viseme_path") or speech.get("viseme_json")
@@ -144,8 +144,8 @@ class SpeechEmitter:
 __all__ = ["SpeechEmitter", "DEFAULT_VISEME_DURATION"]
 
 
-def _require_avatar_authorization(authorization: AuthorizationRecord | None) -> AuthorizationRecord:
-    if authorization is None:
-        raise AuthorizationError(ReasonCode.MISSING_AUTHORIZATION.value)
-    authorization.require(RequestType.AVATAR_EMISSION)
-    return authorization
+def _require_avatar_authorization(authorization: Any | None) -> Any:
+    return require_authorization_for_request_types(
+        authorization,
+        allowed_request_types=("avatar_emission",),
+    )

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -279,3 +279,24 @@ def test_phase39_self_patching_agent_has_governance_annotation_markers() -> None
         "NON_SOVEREIGNTY",
     ):
         assert marker in text
+
+
+def test_phase40_selected_approved_autonomy_files_have_parseable_annotations() -> None:
+    required_markers = (
+        "GOVERNANCE_ANNOTATION",
+        "ADMISSION_SURFACE",
+        "CONSENT_BOUNDARY",
+        "PROVENANCE_BOUNDARY",
+        "SIMULATION_ONLY",
+        "NON_SOVEREIGNTY",
+        "CALLER_TRIGGERED_OR_BOUNDED_RUNTIME",
+    )
+    for rel in (
+        "daemon_autonomy_supervisor.py",
+        "avatar_autonomous_ritual_scheduler.py",
+        "agent_privilege_policy_engine.py",
+        "sentientos/forge_daemon.py",
+    ):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for marker in required_markers:
+            assert marker in text, f"{rel} missing {marker}"

--- a/tests/integrity/test_import_purity.py
+++ b/tests/integrity/test_import_purity.py
@@ -81,4 +81,4 @@ def test_architecture_boundary_manifest_exists_and_parses() -> None:
     assert manifest_path.exists()
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["version"] == 1
-    assert manifest["known_violations"]
+    assert isinstance(manifest["known_violations"], list)

--- a/tts_test.py
+++ b/tts_test.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
-from control_plane import Decision, RequestType, admit_request
+from sentientos.control_api import admit_tts_request
 from avatar_state import AvatarStateEmitter
 from speech_emitter import DEFAULT_BASE_STATE, SpeechEmitter
 from speech_log import get_recent_speech
@@ -63,15 +63,14 @@ def main() -> None:
     if args.no_avatar:
         bridge.forward_avatar = False
 
-    admission = admit_request(
-        request_type=RequestType.SPEECH_TTS,
+    admission = admit_tts_request(
         requester_id="demo-cli",
         intent_hash=args.phrase,
         context_hash="tts-demo",
         policy_version="v1-static",
         metadata={"approved_by": "demo-operator"},
     )
-    if admission.decision is Decision.DENY:
+    if getattr(admission.decision, "name", str(admission.decision)) == "DENY":
         raise SystemExit(f"Control Plane denied TTS request: {admission.reason.value}")
 
     viseme_payload = _load_visemes(args.visemes)


### PR DESCRIPTION
### Motivation
- Continue the repository boundary remediation program by eliminating remaining expressive→formal coupling and hardening autonomy governance so these classes cannot silently reappear. 
- Batch-migrate callers to existing façades where possible, add parseable governance annotations for autonomy‑named modules, and update the manifest truthfully for Phase 40.

### Description
- Added the Phase 40 execution plan at `docs/architecture/phase40_boundary_remediation_execplan.md` describing inventory, selected batch, safety rationale, and deferred items. 
- Extended `sentientos/control_api.py` with narrow delegation helpers (`admit_tts_request`, `canonicalize_admission_provenance`, `require_request_fingerprint_match`) and kept a constrained `__all__`, preserving canonical control-plane semantics. 
- Replaced direct `control_plane` / `task_executor` imports in boundary callers by migrating `speech_emitter.py`, `self_patcher.py`, and `tts_test.py` to the control façade, and updated `autonomous_self_patching_agent.py` to consume the façade error type. 
- Added parseable governance annotation constants to selected autonomy/daemon modules (`daemon_autonomy_supervisor.py`, `avatar_autonomous_ritual_scheduler.py`, `agent_privilege_policy_engine.py`, `sentientos/forge_daemon.py`) without changing runtime semantics. 
- Updated machine manifest `sentientos/system_closure/architecture_boundary_manifest.json` to mark `generated_for_phase` = Phase 40 and cleared remediated known violations; updated tests to assert the new governance markers and adjusted an integrity assertion to accept an empty `known_violations` list. 

### Testing
- Ran the focused architecture and import-purity suites with: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and repaired issues found by migrating callers and adjusting types; the suites passed after changes. 
- Ran the orchestration smoke checks: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, which passed. 
- All modified modules were syntax-checked (`python -m py_compile ...`) and the repository-level test runs completed successfully; dependency bootstrap completed during test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a88257808320a637ae01852c8628)