### PR TITLE
[codex:perception] bridge legacy perception telemetry to pulse-compatible facade

### DIFF
--- a/docs/architecture/phase42_perception_pulse_routing_execplan.md
+++ b/docs/architecture/phase42_perception_pulse_routing_execplan.md
@@ -1,0 +1,10 @@
+# Phase 42 Perception Pulse Routing ExecPlan
+
+1. Phase 41 quarantine state: five legacy modules remain quarantined with explicit risk markers and direct writes preserved.
+2. Target shape: emit pulse-compatible `perception.legacy.<modality>` telemetry envelopes with authority=`none`, telemetry_only=true, privacy_class/raw_retention fields, and source provenance.
+3. Files routed: sentientos/perception_api.py, screen_awareness.py, mic_bridge.py, vision_tracker.py, multimodal_tracker.py, feedback.py.
+4. Helper strategy: add `build_pulse_compatible_perception_event`, `publish_perception_telemetry`, `maybe_publish_legacy_perception_event`, `emit_legacy_perception_telemetry`, and `perception_event_source_ref`; keep publisher dependency-injected no-op safe default.
+5. Privacy/retention: every bridged event includes privacy_class and raw_retention metadata; sensitive/restricted used for risky streams.
+6. Compatibility preserved: existing jsonl writes, memory append, and feedback actions are unchanged; telemetry emission is additive only.
+7. Tests: architecture boundaries enforce bridge marker + API usage; phase tests assert event shape, risk flags, publisher injection, and public imports.
+8. Unresolved risks: mic memory writes, feedback action side effects, vision biometric/emotion outputs, and legacy direct logs remain by design pending later migration phases.

--- a/feedback.py
+++ b/feedback.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 LEGACY_PERCEPTION_QUARANTINE = True
+PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = True
@@ -19,7 +20,7 @@ from dataclasses import dataclass, field
 import importlib
 import os
 from pathlib import Path
-from sentientos.perception_api import build_feedback_observation, build_perception_event
+from sentientos.perception_api import build_feedback_observation, emit_legacy_perception_telemetry
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import json
 import uuid
@@ -107,7 +108,7 @@ class FeedbackManager:
                     action(rule, user_id, value)
                 action_id = uuid.uuid4().hex
                 observation = build_feedback_observation(user=user_id, emotion=rule.emotion, value=value, action=rule.action, timestamp=ts)
-                _ = build_perception_event("feedback", observation, source="feedback", can_trigger_actions=True)
+                _ = emit_legacy_perception_telemetry("feedback", observation, source_module="feedback", can_trigger_actions=True, legacy_quarantine=True, quarantine_risk="action_side_effects")
                 entry = {"id": action_id, "time": ts, **observation}
                 self.history.append(entry)
                 self.log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 LEGACY_PERCEPTION_QUARANTINE = True
+PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
@@ -33,7 +34,7 @@ if is_headless():
     sr = None
 
 from memory_manager import append_memory
-from sentientos.perception_api import normalize_audio_observation, build_perception_event
+from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_audio_observation
 
 
 class MicResult(TypedDict):
@@ -122,7 +123,7 @@ def recognize_from_mic(save_audio: bool = True) -> MicResult:
         emotions = fused
 
     _obs = normalize_audio_observation(message=text, source="mic", audio_file=str(audio_path) if audio_path else None, emotion_features=features)
-    _ = build_perception_event("audio", _obs, source="mic_bridge", can_write_memory=True)
+    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
     return {
         "message": text,
         "source": "mic",
@@ -167,10 +168,8 @@ def recognize_from_file(path: str) -> MicResult:
         )
         emotions = fused
 
-    _obs = normalize_audio_observation(message=text, source="mic", audio_file=str(audio_path) if audio_path else None, emotion_features=features)
-    _ = build_perception_event("audio", _obs, source="mic_bridge", can_write_memory=True)
     _obs = normalize_audio_observation(message=text, source="file", audio_file=path, emotion_features=features)
-    _ = build_perception_event("audio", _obs, source="mic_bridge", can_write_memory=True)
+    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
     return {
         "message": text,
         "source": "file",

--- a/multimodal_tracker.py
+++ b/multimodal_tracker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 LEGACY_PERCEPTION_QUARANTINE = True
+PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
@@ -51,7 +52,7 @@ from perception_journal import PerceptionJournal
 from scene_recognizer import ObjectRecognitionModule
 from screen_awareness import ScreenAwareness
 from vision_tracker import FaceEmotionTracker
-from sentientos.perception_api import normalize_multimodal_observation, build_perception_event
+from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_multimodal_observation
 
 
 class VoiceObservation(TypedDict, total=False):
@@ -153,7 +154,7 @@ class MultiModalEmotionTracker:
     def _log(self, person_id: int, entry: LogEntry) -> None:
         path = self.log_dir / f"{person_id}.jsonl"
         payload = normalize_multimodal_observation(timestamp=float(entry.get("timestamp", time.time())), vision=entry.get("vision", {}), voice=entry.get("voice", {}), scene=entry.get("scene"), screen=entry.get("screen"))
-        _ = build_perception_event("multimodal", payload, source="multimodal_tracker")
+        _ = emit_legacy_perception_telemetry("multimodal", payload, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(payload, ensure_ascii=False) + "\n")
 

--- a/screen_awareness.py
+++ b/screen_awareness.py
@@ -1,5 +1,6 @@
 """Continuous screen awareness module with optional OCR summarisation."""
 LEGACY_PERCEPTION_QUARANTINE = True
+PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
@@ -25,7 +26,7 @@ from typing import Dict, Optional
 from logging_config import get_log_path
 from perception_journal import PerceptionJournal
 from utils import is_headless
-from sentientos.perception_api import normalize_screen_observation, build_perception_event
+from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_screen_observation
 
 try:  # pragma: no cover - optional dependency
     import mss  # type: ignore[import-untyped]
@@ -116,7 +117,7 @@ class ScreenAwareness:
 
     def _log_snapshot(self, snapshot: ScreenSnapshot) -> None:
         payload = normalize_screen_observation(timestamp=snapshot.timestamp, text=snapshot.text, ocr_confidence=snapshot.ocr_confidence, width=snapshot.width, height=snapshot.height)
-        _ = build_perception_event("screen", payload, source="screen_awareness")
+        _ = emit_legacy_perception_telemetry("screen", payload, source="screen_awareness")
         try:
             with self.log_path.open("a", encoding="utf-8") as handle:
                 handle.write(os.getenv("JSON_DUMP_PREFIX", "") + json.dumps(payload, ensure_ascii=False) + "\n")

--- a/sentientos/perception_api.py
+++ b/sentientos/perception_api.py
@@ -1,66 +1,110 @@
 """Non-authoritative perception telemetry facade.
 
 This module normalizes legacy perception observations into explicit, privacy-aware
-telemetry envelopes. It does not admit, execute, route, or authorize work.
+telemetry envelopes. It does not admit, execute, route, schedule, or authorize work.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
-DEFAULT_SCHEMA = "perception.telemetry.v1"
+DEFAULT_SCHEMA = "perception.telemetry.v2"
+PULSE_COMPAT_EVENT_TYPE_PREFIX = "perception.legacy"
 
 
-def build_perception_event(
+def perception_event_source_ref(source_module: str, *, legacy: bool = True) -> str:
+    return f"legacy:{source_module}" if legacy else source_module
+
+
+def build_pulse_compatible_perception_event(
     modality: str,
     observation: Mapping[str, Any],
     *,
-    source: str,
+    source_module: str,
     raw_retention: bool = False,
-    privacy: str = "sensitive",
+    privacy_class: str = "sensitive",
     can_trigger_actions: bool = False,
     can_write_memory: bool = False,
-    legacy: bool = True,
+    legacy_quarantine: bool = False,
+    quarantine_risk: str | None = None,
 ) -> dict[str, Any]:
-    """Build a pulse-compatible perception telemetry envelope.
-
-    The event is metadata-only and explicitly non-authoritative.
-    """
-    return {
+    timestamp = float(observation.get("timestamp", time.time()))
+    event = {
         "schema": DEFAULT_SCHEMA,
-        "timestamp": float(observation.get("timestamp", time.time())),
-        "source": source,
+        "event_type": f"{PULSE_COMPAT_EVENT_TYPE_PREFIX}.{modality}",
+        "timestamp": timestamp,
+        "source": perception_event_source_ref(source_module),
+        "source_module": source_module,
+        "extractor_id": "legacy_perception_bridge",
+        "extractor_version": "phase42",
         "modality": modality,
         "observation": dict(observation),
+        "privacy_class": privacy_class,
+        "raw_retention": bool(raw_retention),
         "authority": "none",
         "telemetry_only": True,
-        "privacy": privacy,
-        "raw_retention": bool(raw_retention),
         "can_trigger_actions": bool(can_trigger_actions),
         "can_write_memory": bool(can_write_memory),
-        "legacy_surface": bool(legacy),
+        "legacy_surface": True,
+        "legacy_quarantine": bool(legacy_quarantine),
+        "provenance": {"bridge": "sentientos.perception_api", "non_authoritative": True},
     }
+    if quarantine_risk:
+        event["quarantine_risk"] = quarantine_risk
+    return event
+
+
+def publish_perception_telemetry(event: Mapping[str, Any], *, publisher: Callable[[dict[str, Any]], Any] | None = None) -> bool:
+    payload = dict(event)
+    if publisher is not None:
+        publisher(payload)
+        return True
+    return False
+
+
+def maybe_publish_legacy_perception_event(
+    modality: str,
+    observation: Mapping[str, Any],
+    *,
+    source_module: str,
+    raw_retention: bool = False,
+    privacy_class: str = "sensitive",
+    can_trigger_actions: bool = False,
+    can_write_memory: bool = False,
+    legacy_quarantine: bool = False,
+    quarantine_risk: str | None = None,
+    publisher: Callable[[dict[str, Any]], Any] | None = None,
+) -> dict[str, Any]:
+    event = build_pulse_compatible_perception_event(
+        modality,
+        observation,
+        source_module=source_module,
+        raw_retention=raw_retention,
+        privacy_class=privacy_class,
+        can_trigger_actions=can_trigger_actions,
+        can_write_memory=can_write_memory,
+        legacy_quarantine=legacy_quarantine,
+        quarantine_risk=quarantine_risk,
+    )
+    publish_perception_telemetry(event, publisher=publisher)
+    return event
+
+
+def emit_legacy_perception_telemetry(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    return maybe_publish_legacy_perception_event(*args, **kwargs)
+
+
+def build_perception_event(modality: str, observation: Mapping[str, Any], *, source: str, raw_retention: bool = False, privacy: str = "sensitive", can_trigger_actions: bool = False, can_write_memory: bool = False, legacy: bool = True) -> dict[str, Any]:
+    return build_pulse_compatible_perception_event(modality, observation, source_module=source, raw_retention=raw_retention, privacy_class=privacy, can_trigger_actions=can_trigger_actions, can_write_memory=can_write_memory, legacy_quarantine=legacy)
 
 
 def normalize_screen_observation(*, text: str, ocr_confidence: float | None, width: int | None, height: int | None, timestamp: float | None = None) -> dict[str, Any]:
-    return {
-        "timestamp": float(timestamp or time.time()),
-        "text": text,
-        "ocr_confidence": ocr_confidence,
-        "width": width,
-        "height": height,
-    }
+    return {"timestamp": float(timestamp or time.time()), "text": text, "ocr_confidence": ocr_confidence, "width": width, "height": height}
 
 
 def normalize_audio_observation(*, message: str | None, source: str, audio_file: str | None, emotion_features: Mapping[str, float] | None = None, timestamp: float | None = None) -> dict[str, Any]:
-    return {
-        "timestamp": float(timestamp or time.time()),
-        "message": message,
-        "source": source,
-        "audio_file": audio_file,
-        "emotion_features": dict(emotion_features or {}),
-    }
+    return {"timestamp": float(timestamp or time.time()), "message": message, "source": source, "audio_file": audio_file, "emotion_features": dict(emotion_features or {})}
 
 
 def normalize_vision_observation(*, faces: list[dict[str, Any]], timestamp: float | None = None) -> dict[str, Any]:
@@ -68,33 +112,31 @@ def normalize_vision_observation(*, faces: list[dict[str, Any]], timestamp: floa
 
 
 def normalize_multimodal_observation(*, timestamp: float, vision: Mapping[str, Any], voice: Mapping[str, Any], scene: Mapping[str, Any] | None = None, screen: Mapping[str, Any] | None = None) -> dict[str, Any]:
-    payload: dict[str, Any] = {"timestamp": timestamp, "vision": dict(vision), "voice": dict(voice)}
+    payload: dict[str, Any] = {"timestamp": timestamp, "vision": dict(vision), "voice": dict(voice), "source_modalities": ["vision", "voice"]}
     if scene is not None:
         payload["scene"] = dict(scene)
+        payload["source_modalities"].append("scene")
     if screen is not None:
         payload["screen"] = dict(screen)
+        payload["source_modalities"].append("screen")
     return payload
 
 
 def build_feedback_observation(*, user: int, emotion: str, value: float, action: str, timestamp: float | None = None) -> dict[str, Any]:
-    return {
-        "timestamp": float(timestamp or time.time()),
-        "user": user,
-        "emotion": emotion,
-        "value": value,
-        "action": action,
-    }
+    return {"timestamp": float(timestamp or time.time()), "user": user, "emotion": emotion, "value": value, "action": action, "action_approved": False}
 
 
 def quarantine_legacy_perception_event(modality: str, observation: Mapping[str, Any], *, source: str, risk: str) -> dict[str, Any]:
-    event = build_perception_event(modality, observation, source=source)
-    event["legacy_quarantine"] = True
-    event["quarantine_risk"] = risk
-    return event
+    return build_pulse_compatible_perception_event(modality, observation, source_module=source, legacy_quarantine=True, quarantine_risk=risk)
 
 
 __all__ = [
     "build_perception_event",
+    "build_pulse_compatible_perception_event",
+    "publish_perception_telemetry",
+    "emit_legacy_perception_telemetry",
+    "maybe_publish_legacy_perception_event",
+    "perception_event_source_ref",
     "normalize_screen_observation",
     "normalize_audio_observation",
     "normalize_vision_observation",

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_for_phase": "phase_41_legacy_perception_and_multimodal_boundary_remediation",
+  "generated_for_phase": "phase_42_legacy_perception_pulse_routing_remediation",
   "layer_definitions": {
     "formal_core": {
       "module_globs": [
@@ -189,45 +189,45 @@
     {
       "file": "screen_awareness.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy OCR privacy risk and direct jsonl write; routed shaping via sentientos.perception_api",
+      "detail": "legacy OCR privacy risk and direct jsonl write; routed shaping via sentientos.perception_api; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "medium",
-      "remediation": "maintain quarantine markers and migrate write path to pulse adapter",
+      "remediation": "maintain quarantine markers and migrate write path to pulse adapter; keep quarantine until direct write/action/memory behavior is migrated",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
     {
       "file": "mic_bridge.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy microphone memory-write risk and optional raw audio retention",
+      "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter",
+      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
     {
       "file": "vision_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy vision biometric/emotion direct jsonl write risk",
+      "detail": "legacy vision biometric/emotion direct jsonl write risk; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter",
+      "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter; keep quarantine until direct write/action/memory behavior is migrated",
       "migration_target": "pulse_bus",
       "requires_quarantine_annotation": true
     },
     {
       "file": "multimodal_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy multimodal fusion direct per-person/environment jsonl writes",
+      "detail": "legacy multimodal fusion direct per-person/environment jsonl writes; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "medium",
-      "remediation": "preserve quarantine and route fusion emission to perception bus envelopes",
+      "remediation": "preserve quarantine and route fusion emission to perception bus envelopes; keep quarantine until direct write/action/memory behavior is migrated",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
     {
       "file": "feedback.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy feedback action-capable side effects and action logs",
+      "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and separate action execution from observation telemetry",
+      "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -332,3 +332,36 @@ def test_phase41_perception_api_boundary_purity() -> None:
         "authority_surface",
     ):
         assert bad not in text
+
+
+def test_phase42_legacy_perception_modules_are_bridged_and_marked() -> None:
+    modules = {
+        "screen_awareness.py": {"needs_action": False, "needs_memory": False},
+        "mic_bridge.py": {"needs_action": False, "needs_memory": True},
+        "vision_tracker.py": {"needs_action": False, "needs_memory": False},
+        "multimodal_tracker.py": {"needs_action": False, "needs_memory": False},
+        "feedback.py": {"needs_action": True, "needs_memory": False},
+    }
+    for rel, flags in modules.items():
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "LEGACY_PERCEPTION_QUARANTINE = True" in text
+        assert "PULSE_COMPATIBLE_TELEMETRY = True" in text
+        assert "from sentientos.perception_api import" in text
+        assert "emit_legacy_perception_telemetry" in text
+        if flags["needs_action"]:
+            assert "CAN_TRIGGER_ACTIONS = True" in text
+        if flags["needs_memory"]:
+            assert "CAN_WRITE_MEMORY = True" in text
+
+
+def test_phase42_perception_api_import_purity_against_authority_surfaces() -> None:
+    text = (ROOT / "sentientos/perception_api.py").read_text(encoding="utf-8")
+    forbidden = [
+        "task_admission",
+        "task_executor",
+        "control_plane",
+        "authority_surface",
+        "sentientos.introspection.spine",
+    ]
+    for token in forbidden:
+        assert token not in text

--- a/tests/test_phase41_perception_api.py
+++ b/tests/test_phase41_perception_api.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from sentientos.perception_api import (
     build_feedback_observation,
     build_perception_event,
+    build_pulse_compatible_perception_event,
+    maybe_publish_legacy_perception_event,
     normalize_audio_observation,
     normalize_multimodal_observation,
     normalize_screen_observation,
@@ -36,3 +38,38 @@ def test_legacy_modules_keep_public_symbols() -> None:
     assert MultiModalEmotionTracker is not None
     assert ScreenAwareness is not None
     assert FaceEmotionTracker is not None
+
+
+def test_phase42_pulse_compatible_event_shape_and_publisher() -> None:
+    captured = []
+    obs = {"timestamp": 11.0, "sample": True}
+    event = maybe_publish_legacy_perception_event(
+        "audio",
+        obs,
+        source_module="mic_bridge",
+        privacy_class="restricted",
+        raw_retention=False,
+        can_write_memory=True,
+        legacy_quarantine=True,
+        quarantine_risk="memory_write",
+        publisher=captured.append,
+    )
+    assert captured and captured[0]["event_type"] == "perception.legacy.audio"
+    assert event["authority"] == "none"
+    assert event["telemetry_only"] is True
+    assert event["source_module"] == "mic_bridge"
+    assert event["privacy_class"] == "restricted"
+    assert event["can_write_memory"] is True
+    assert event["legacy_quarantine"] is True
+
+
+def test_phase42_build_without_publisher_is_safe() -> None:
+    event = build_pulse_compatible_perception_event(
+        "feedback",
+        {"timestamp": 7.0, "action": "cue"},
+        source_module="feedback",
+        can_trigger_actions=True,
+        legacy_quarantine=True,
+    )
+    assert event["event_type"] == "perception.legacy.feedback"
+    assert event["can_trigger_actions"] is True

--- a/vision_tracker.py
+++ b/vision_tracker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 LEGACY_PERCEPTION_QUARANTINE = True
+PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
@@ -19,7 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from logging_config import get_log_path
 from utils import is_headless
-from sentientos.perception_api import normalize_vision_observation, build_perception_event
+from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_vision_observation
 
 HEADLESS = is_headless()
 
@@ -160,7 +161,7 @@ class FaceEmotionTracker:
 
     def log_result(self, data: Dict[str, Any]) -> None:
         payload = normalize_vision_observation(faces=data.get("faces", []), timestamp=float(data.get("timestamp", time.time())))
-        _ = build_perception_event("vision", payload, source="vision_tracker", privacy="biometric")
+        _ = emit_legacy_perception_telemetry("vision", payload, source_module="vision_tracker", privacy_class="restricted", legacy_quarantine=True, quarantine_risk="biometric_emotion")
         with open(self.log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(payload) + "\n")
 


### PR DESCRIPTION
### Motivation
- Phase 41 made legacy perception risks visible but left legacy modules writing directly and remaining authoritative risks; Phase 42 aims to route safe observational telemetry onto a canonical, pulse-compatible façade while preserving legacy behavior and quarantine honesty. 
- Provide a minimal, non-authoritative event envelope and publish hook so legacy modules can emit telemetry in a pulse-compatible shape without gaining execution/authority power. 
- Keep unresolved memory/action/biometric risks explicit and quarantined while enabling downstream pulse consumers to see bridged telemetry.

### Description
- Added pulse-compatible helpers to `sentientos/perception_api.py`: `perception_event_source_ref`, `build_pulse_compatible_perception_event`, `publish_perception_telemetry`, `maybe_publish_legacy_perception_event`, and `emit_legacy_perception_telemetry`, with a safe dependency-injected `publisher` default (no-op) and preserved `authority='none'`/`telemetry_only=True` posture. 
- Bridged the five Phase-41 legacy modules to emit telemetry through the new helper and added a parseable marker: each file now imports and calls `emit_legacy_perception_telemetry(...)` and has `PULSE_COMPATIBLE_TELEMETRY = True`; files changed: `screen_awareness.py`, `mic_bridge.py`, `vision_tracker.py`, `multimodal_tracker.py`, `feedback.py`. 
- Preserved existing legacy behavior: JSONL writes, memory appends, and feedback actions remain unchanged and quarantined; telemetry emission is additive-only and includes `privacy_class`, `raw_retention`, `legacy_quarantine`, `quarantine_risk`, `can_write_memory`, and `can_trigger_actions` fields. 
- Operational and governance artifacts: added `docs/architecture/phase42_perception_pulse_routing_execplan.md` describing Phase-41 state, target shape, helpers, privacy/retention handling, tests, and unresolved risks; updated `sentientos/system_closure/architecture_boundary_manifest.json` known_violations entries to note the telemetry bridge while preserving quarantine requirements. 
- Tests and assertions updated/added: `tests/architecture/test_architecture_boundaries.py` (Phase-42 bridge + import-purity checks) and `tests/test_phase41_perception_api.py` (pulse-compatible event shape and publisher injection); preserved public symbols assertions for legacy modules.

### Testing
- Ran architecture and import-purity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, which passed. 
- Ran perception API unit checks with `python -m scripts.run_tests -q tests/test_phase41_perception_api.py`, which executed and validated event shape and publisher behavior (safe default/no-op); tests passed (skipped hardware-dependent parts). 
- Ran orchestration spine smoke tests with `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, which completed successfully. 
- Notes: initial dependency bootstrap was lengthy but completed; all automated tests exercised for Phase 42 assertions passed and show the bridge is enforced without introducing authority or execution side effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7c579bbec8320979874f4e0e7f249)