### PR TITLE
[codex:embodiment] add phase44 ingress gating proposals

### DIFF
--- a/docs/architecture/phase44_embodiment_ingress_gates_execplan.md
+++ b/docs/architecture/phase44_embodiment_ingress_gates_execplan.md
@@ -1,0 +1,33 @@
+# Phase 44 ExecPlan: Embodiment ingress gates
+
+1. **Current Phase-43 fusion state**
+   - `sentientos.embodiment_fusion` produces deterministic non-authoritative snapshots with modality/risk/provenance fields.
+2. **Mutation/action sinks inspected**
+   - `mic_bridge.py` memory append path.
+   - `feedback.py` feedback side-effect action path.
+   - `vision_tracker.py`, `multimodal_tracker.py`, `screen_awareness.py` direct JSONL logs + sensitive telemetry.
+   - `task_admission.py`, `task_executor.py`, `sentientos/control_api.py`, `sentientos/ledger_api.py`, `sentientos/orchestration_intent_fabric.py`, `sentientos/embodiment/consent.py`, `sentientos/introspection/spine.py` checked for boundary relationship (no direct ingress coupling).
+3. **Target gate shape**
+   - New canonical `sentientos.embodiment_ingress` module.
+   - Input: Phase-42/43 compatible telemetry/snapshots.
+   - Output: non-authoritative ingress receipt with recommendation posture and optional candidates.
+4. **Memory/action pressure classes**
+   - memory write pressure (audio/stt)
+   - feedback action pressure
+   - biometric/emotion pressure
+   - multimodal summary pressure
+   - screen/OCR privacy pressure
+   - incomplete context pressure
+5. **Consent/privacy/retention considerations**
+   - privacy/biometric pathways return hold postures.
+   - raw retention and consent-required signals degrade to hold.
+   - no mutation authority delegated.
+6. **Relationship to admission/control/orchestration APIs**
+   - ingress is proposal-only; does not import admission/execution/control internals.
+   - downstream systems may consume receipts later via approved facades.
+7. **Tests to add/update**
+   - new focused ingress tests for posture classification, determinism, provenance.
+   - architecture boundary assertions + manifest declaration.
+8. **Unresolved risks and deferred work**
+   - legacy modules still write memory/actions/logs; this phase only adds canonical ingress visibility.
+   - full runtime replacement and enforcement remains deferred to later phases.

--- a/feedback.py
+++ b/feedback.py
@@ -21,6 +21,8 @@ import importlib
 import os
 from pathlib import Path
 from sentientos.perception_api import build_feedback_observation, emit_legacy_perception_telemetry
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import json
 import uuid
@@ -109,6 +111,7 @@ class FeedbackManager:
                 action_id = uuid.uuid4().hex
                 observation = build_feedback_observation(user=user_id, emotion=rule.emotion, value=value, action=rule.action, timestamp=ts)
                 _ = emit_legacy_perception_telemetry("feedback", observation, source_module="feedback", can_trigger_actions=True, legacy_quarantine=True, quarantine_risk="action_side_effects")
+                _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
                 entry = {"id": action_id, "time": ts, **observation}
                 self.history.append(entry)
                 self.log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -35,6 +35,8 @@ if is_headless():
 
 from memory_manager import append_memory
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_audio_observation
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
 
 
 class MicResult(TypedDict):
@@ -124,6 +126,7 @@ def recognize_from_mic(save_audio: bool = True) -> MicResult:
 
     _obs = normalize_audio_observation(message=text, source="mic", audio_file=str(audio_path) if audio_path else None, emotion_features=features)
     _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
+    _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
     return {
         "message": text,
         "source": "mic",
@@ -170,6 +173,7 @@ def recognize_from_file(path: str) -> MicResult:
 
     _obs = normalize_audio_observation(message=text, source="file", audio_file=path, emotion_features=features)
     _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
+    _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
     return {
         "message": text,
         "source": "file",

--- a/multimodal_tracker.py
+++ b/multimodal_tracker.py
@@ -53,6 +53,8 @@ from scene_recognizer import ObjectRecognitionModule
 from screen_awareness import ScreenAwareness
 from vision_tracker import FaceEmotionTracker
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_multimodal_observation
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
 
 
 class VoiceObservation(TypedDict, total=False):
@@ -155,6 +157,7 @@ class MultiModalEmotionTracker:
         path = self.log_dir / f"{person_id}.jsonl"
         payload = normalize_multimodal_observation(timestamp=float(entry.get("timestamp", time.time())), vision=entry.get("vision", {}), voice=entry.get("voice", {}), scene=entry.get("scene"), screen=entry.get("screen"))
         _ = emit_legacy_perception_telemetry("multimodal", payload, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
+        _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(payload, ensure_ascii=False) + "\n")
 

--- a/screen_awareness.py
+++ b/screen_awareness.py
@@ -27,6 +27,8 @@ from logging_config import get_log_path
 from perception_journal import PerceptionJournal
 from utils import is_headless
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_screen_observation
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
 
 try:  # pragma: no cover - optional dependency
     import mss  # type: ignore[import-untyped]
@@ -117,7 +119,8 @@ class ScreenAwareness:
 
     def _log_snapshot(self, snapshot: ScreenSnapshot) -> None:
         payload = normalize_screen_observation(timestamp=snapshot.timestamp, text=snapshot.text, ocr_confidence=snapshot.ocr_confidence, width=snapshot.width, height=snapshot.height)
-        _ = emit_legacy_perception_telemetry("screen", payload, source="screen_awareness")
+        _ = emit_legacy_perception_telemetry("screen", payload, source_module="screen_awareness", legacy_quarantine=True, quarantine_risk="ocr_privacy")
+        _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
         try:
             with self.log_path.open("a", encoding="utf-8") as handle:
                 handle.write(os.getenv("JSON_DUMP_PREFIX", "") + json.dumps(payload, ensure_ascii=False) + "\n")

--- a/sentientos/embodiment_ingress.py
+++ b/sentientos/embodiment_ingress.py
@@ -1,0 +1,143 @@
+"""Canonical non-authoritative embodiment ingress gate.
+
+This module evaluates embodiment/perception snapshots and returns proposal-only
+candidates describing memory/action/operator-attention pressure.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = "embodiment.ingress.v1"
+
+
+def embodiment_ingress_receipt_ref(snapshot: Mapping[str, Any], *, salt: str = "") -> str:
+    material = {
+        "snapshot_id": snapshot.get("snapshot_id"),
+        "source_event_refs": list(snapshot.get("source_event_refs", [])),
+        "correlation_id": snapshot.get("correlation_id"),
+        "salt": salt,
+    }
+    digest = hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return f"ingress:{digest}"
+
+
+def classify_embodied_pressure(snapshot: Mapping[str, Any]) -> list[str]:
+    classes: list[str] = []
+    modalities = set(snapshot.get("modalities_present", []))
+    if "audio" in modalities or snapshot.get("current_audio_context", {}).get("message"):
+        classes.append("memory_write_pressure")
+    if "feedback" in modalities:
+        classes.append("feedback_action_pressure")
+    if "vision" in modalities:
+        classes.append("biometric_emotion_pressure")
+    if "multimodal" in modalities:
+        classes.append("multimodal_summary_pressure")
+    if "screen" in modalities:
+        classes.append("screen_privacy_pressure")
+    if not modalities:
+        classes.append("incomplete_context_pressure")
+    return sorted(set(classes))
+
+
+def build_memory_ingress_candidate(snapshot: Mapping[str, Any]) -> dict[str, Any] | None:
+    audio = snapshot.get("current_audio_context") or {}
+    message = audio.get("message")
+    if not message:
+        return None
+    return {
+        "candidate_type": "memory",
+        "candidate_ref": embodiment_ingress_receipt_ref(snapshot, salt="memory"),
+        "source": audio.get("source", "audio"),
+        "proposed_text": str(message),
+        "requires_review": True,
+        "non_authoritative": True,
+    }
+
+
+def build_feedback_ingress_candidate(snapshot: Mapping[str, Any]) -> dict[str, Any] | None:
+    feedback = snapshot.get("current_feedback_context") or {}
+    action = feedback.get("action")
+    if not action:
+        return None
+    return {
+        "candidate_type": "feedback",
+        "candidate_ref": embodiment_ingress_receipt_ref(snapshot, salt="feedback"),
+        "action": str(action),
+        "blocked": True,
+        "requires_operator_review": True,
+        "non_authoritative": True,
+    }
+
+
+def build_operator_attention_candidate(snapshot: Mapping[str, Any], pressure: Sequence[str]) -> dict[str, Any] | None:
+    if not pressure:
+        return None
+    return {
+        "candidate_type": "operator_attention",
+        "candidate_ref": embodiment_ingress_receipt_ref(snapshot, salt="attention"),
+        "recommended": True,
+        "reasons": list(pressure),
+        "non_authoritative": True,
+    }
+
+
+def resolve_embodiment_ingress_posture(snapshot: Mapping[str, Any], pressure: Sequence[str]) -> str:
+    conf = (snapshot.get("confidence_posture") or {}) if isinstance(snapshot.get("confidence_posture"), Mapping) else {}
+    if conf.get("completeness") in {"empty", "partial"}:
+        return "incomplete_context_hold"
+    if "biometric_emotion_pressure" in pressure:
+        return "biometric_sensitive_hold"
+    if "screen_privacy_pressure" in pressure:
+        return "privacy_sensitive_hold"
+    if snapshot.get("raw_retention_present"):
+        return "privacy_sensitive_hold"
+    if snapshot.get("consent_required"):
+        return "consent_required_hold"
+    if "feedback_action_pressure" in pressure:
+        return "action_candidate_blocked"
+    if "memory_write_pressure" in pressure:
+        return "memory_candidate_requires_review"
+    if "multimodal_summary_pressure" in pressure:
+        return "operator_attention_recommended"
+    return "no_ingress_needed"
+
+
+def evaluate_embodiment_ingress(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    pressure = classify_embodied_pressure(snapshot)
+    posture = resolve_embodiment_ingress_posture(snapshot, pressure)
+    risk_flags = dict(snapshot.get("risk_flags", {})) if isinstance(snapshot.get("risk_flags"), Mapping) else {}
+    receipt = {
+        "schema_version": SCHEMA_VERSION,
+        "ingress_id": embodiment_ingress_receipt_ref(snapshot),
+        "source_snapshot_ref": str(snapshot.get("snapshot_id", "")),
+        "source_event_refs": list(snapshot.get("source_event_refs", [])),
+        "pressure_classifications": pressure,
+        "recommended_posture": posture,
+        "memory_candidate": build_memory_ingress_candidate(snapshot),
+        "feedback_candidate": build_feedback_ingress_candidate(snapshot),
+        "operator_attention_candidate": build_operator_attention_candidate(snapshot, pressure),
+        "privacy_retention_posture": "hold" if "privacy_sensitive_hold" == posture else "review",
+        "consent_posture": "consent_required" if posture == "consent_required_hold" else "not_asserted",
+        "risk_flags": risk_flags,
+        "rationale": [f"pressure:{p}" for p in pressure] or ["pressure:none"],
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+    return receipt
+
+
+__all__ = [
+    "evaluate_embodiment_ingress",
+    "classify_embodied_pressure",
+    "build_memory_ingress_candidate",
+    "build_feedback_ingress_candidate",
+    "build_operator_attention_candidate",
+    "resolve_embodiment_ingress_posture",
+    "embodiment_ingress_receipt_ref",
+]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -122,6 +122,37 @@
         "mic_bridge",
         "multimodal_tracker"
       ]
+    },
+    "embodiment_ingress": {
+      "module_globs": [
+        "sentientos/embodiment_ingress.py"
+      ],
+      "classification": "canonical_proposal_gate",
+      "proposal_only": true,
+      "derived_only": true,
+      "non_authoritative": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_admission_execution": true,
+      "consumes": [
+        "sentientos.embodiment_fusion",
+        "sentientos.perception_api"
+      ],
+      "produces": [
+        "ingress_candidates",
+        "ingress_receipts"
+      ],
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "memory_manager",
+        "feedback",
+        "mic_bridge",
+        "vision_tracker",
+        "multimodal_tracker",
+        "screen_awareness"
+      ]
     }
   },
   "protected_sinks": {
@@ -213,7 +244,7 @@
       "rule": "legacy_perception_quarantine",
       "detail": "legacy OCR privacy risk and direct jsonl write; routed shaping via sentientos.perception_api; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "medium",
-      "remediation": "maintain quarantine markers and migrate write path to pulse adapter; keep quarantine until direct write/action/memory behavior is migrated",
+      "remediation": "maintain quarantine markers and migrate write path to pulse adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
@@ -222,7 +253,7 @@
       "rule": "legacy_perception_quarantine",
       "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated",
+      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
@@ -231,7 +262,7 @@
       "rule": "legacy_perception_quarantine",
       "detail": "legacy vision biometric/emotion direct jsonl write risk; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter; keep quarantine until direct write/action/memory behavior is migrated",
+      "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "pulse_bus",
       "requires_quarantine_annotation": true
     },
@@ -240,7 +271,7 @@
       "rule": "legacy_perception_quarantine",
       "detail": "legacy multimodal fusion direct per-person/environment jsonl writes; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "medium",
-      "remediation": "preserve quarantine and route fusion emission to perception bus envelopes; keep quarantine until direct write/action/memory behavior is migrated",
+      "remediation": "preserve quarantine and route fusion emission to perception bus envelopes; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
@@ -249,7 +280,7 @@
       "rule": "legacy_perception_quarantine",
       "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api",
       "severity": "high",
-      "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated",
+      "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -388,3 +388,36 @@ def test_phase43_embodiment_fusion_manifest_contract() -> None:
     assert layer["no_direct_hardware_access"] is True
     assert layer["no_direct_memory_write"] is True
     assert layer["no_action_trigger"] is True
+
+def test_phase44_embodiment_ingress_manifest_and_import_boundaries() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_ingress"]
+    assert layer["proposal_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["no_direct_memory_write"] is True
+    text = (ROOT / "sentientos/embodiment_ingress.py").read_text(encoding="utf-8")
+    banned = [
+        "import task_executor",
+        "import task_admission",
+        "import control_plane",
+        "import memory_manager",
+        "import mic_bridge",
+        "import feedback",
+        "import vision_tracker",
+        "import multimodal_tracker",
+        "import screen_awareness",
+    ]
+    for marker in banned:
+        assert marker not in text
+
+
+def test_phase44_no_new_direct_sink_mutation_in_perception_fusion_ingress() -> None:
+    for rel in [
+        "sentientos/embodiment_fusion.py",
+        "sentientos/embodiment_ingress.py",
+        "sentientos/perception_api.py",
+    ]:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "append_memory(" not in text
+        assert "task_executor" not in text
+        assert "task_admission" not in text

--- a/tests/test_phase44_embodiment_ingress.py
+++ b/tests/test_phase44_embodiment_ingress.py
@@ -1,0 +1,48 @@
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+
+
+def _snapshot(events):
+    return build_embodiment_snapshot(events, created_at=100.0, correlation_id="c1")
+
+
+def test_memory_pressure_requires_review() -> None:
+    snap = _snapshot([{"modality": "audio", "timestamp": 1.0, "source_module": "mic_bridge", "observation": {"message": "remember this"}}])
+    rec = evaluate_embodiment_ingress(snap)
+    assert rec["recommended_posture"] in {"memory_candidate_requires_review", "incomplete_context_hold", "privacy_sensitive_hold", "consent_required_hold"}
+    assert rec["does_not_write_memory"] is True
+
+
+def test_feedback_pressure_blocked_or_attention() -> None:
+    snap = _snapshot([{"modality": "feedback", "timestamp": 1.0, "source_module": "feedback", "observation": {"action": "cue"}}])
+    rec = evaluate_embodiment_ingress(snap)
+    assert rec["recommended_posture"] in {"action_candidate_blocked", "operator_attention_recommended", "incomplete_context_hold"}
+    assert rec["does_not_trigger_feedback"] is True
+
+
+def test_vision_is_biometric_hold() -> None:
+    snap = _snapshot([{"modality": "vision", "timestamp": 1.0, "source_module": "vision_tracker", "observation": {"faces": [{"dominant": "joy"}]}}])
+    rec = evaluate_embodiment_ingress(snap)
+    assert rec["recommended_posture"] in {"biometric_sensitive_hold", "incomplete_context_hold"}
+
+
+def test_screen_privacy_hold() -> None:
+    snap = _snapshot([{"modality": "screen", "timestamp": 1.0, "source_module": "screen_awareness", "observation": {"text": "password"}}])
+    rec = evaluate_embodiment_ingress(snap)
+    assert rec["recommended_posture"] in {"privacy_sensitive_hold", "incomplete_context_hold"}
+
+
+def test_incomplete_context_hold() -> None:
+    rec = evaluate_embodiment_ingress(_snapshot([]))
+    assert rec["recommended_posture"] == "incomplete_context_hold"
+
+
+def test_deterministic_and_provenance() -> None:
+    snap = _snapshot([{"modality": "multimodal", "timestamp": 1.0, "source_module": "multimodal_tracker", "observation": {"summary": "ok"}}])
+    a = evaluate_embodiment_ingress(snap)
+    b = evaluate_embodiment_ingress(snap)
+    assert a == b
+    assert a["source_snapshot_ref"] == snap["snapshot_id"]
+    assert isinstance(a["source_event_refs"], list)
+    for k in ["non_authoritative", "decision_power", "does_not_admit_work", "does_not_execute_or_route_work"]:
+        assert k in a

--- a/vision_tracker.py
+++ b/vision_tracker.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, List, Optional
 from logging_config import get_log_path
 from utils import is_headless
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_vision_observation
+from sentientos.embodiment_fusion import build_embodiment_snapshot
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress
 
 HEADLESS = is_headless()
 
@@ -162,6 +164,7 @@ class FaceEmotionTracker:
     def log_result(self, data: Dict[str, Any]) -> None:
         payload = normalize_vision_observation(faces=data.get("faces", []), timestamp=float(data.get("timestamp", time.time())))
         _ = emit_legacy_perception_telemetry("vision", payload, source_module="vision_tracker", privacy_class="restricted", legacy_quarantine=True, quarantine_risk="biometric_emotion")
+        _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
         with open(self.log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(payload) + "\n")
 


### PR DESCRIPTION
### Motivation

- Introduce a canonical, non-authoritative ingress gate between embodiment/perception fusion outputs and mutation-capable sinks so embodied signals become explicit proposals rather than silent mutations. 
- Surface memory/action/privacy/consent pressure from legacy perception/fusion without changing runtime mutation behavior in this phase.

### Description

- Add `sentientos/embodiment_ingress.py` implementing `evaluate_embodiment_ingress`, `classify_embodied_pressure`, `build_memory_ingress_candidate`, `build_feedback_ingress_candidate`, `build_operator_attention_candidate`, `resolve_embodiment_ingress_posture`, and `embodiment_ingress_receipt_ref`; receipts are proposal-only and include non-authoritative invariants. 
- Add `docs/architecture/phase44_embodiment_ingress_gates_execplan.md` describing Phase‑43 state, sinks inspected, gate shape, pressure classes, consent/privacy, tests, and deferred work. 
- Update `sentientos/system_closure/architecture_boundary_manifest.json` with an `embodiment_ingress` layer (proposal_only, non_authoritative, forbidden import patterns). 
- Add `tests/test_phase44_embodiment_ingress.py` and update `tests/architecture/test_architecture_boundaries.py` to assert manifest/import/mutation boundaries; add wiring in legacy high-risk modules (`mic_bridge.py`, `feedback.py`, `vision_tracker.py`, `multimodal_tracker.py`, `screen_awareness.py`) to optionally evaluate ingress receipts alongside existing behavior (additive only). 

### Testing

- Added focused unit tests: `tests/test_phase44_embodiment_ingress.py` covering memory/feedback/vision/screen/incomplete-context postures, determinism, provenance, and non-authority fields. 
- Updated architecture checks in `tests/architecture/test_architecture_boundaries.py` to validate the ingress manifest and import boundaries and to ensure no new direct sink mutations in perception/fusion/ingress modules. 
- Test commands started in CI-like environment: `python -m scripts.run_tests -q tests/test_phase44_embodiment_ingress.py tests/test_phase43_embodiment_fusion.py tests/test_phase41_perception_api.py` and `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`; they were initiated but the environment spent significant time performing dependency bootstrap and did not produce completed pass/fail output in this run. 
- Local assertions in the test files are self-contained and exercise the new ingress API; further CI runs are recommended to complete full automated validation in the project environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7cc09f0e483208d1236d09ae052f8)