### PR TITLE
Ingress gate: gate legacy memory writes and feedback actions behind proposal/compatibility modes

### DIFF
--- a/docs/architecture/phase45_ingress_gated_memory_action_execplan.md
+++ b/docs/architecture/phase45_ingress_gated_memory_action_execplan.md
@@ -1,0 +1,37 @@
+# Phase 45 ExecPlan: Ingress-Gated Legacy Memory/Action Remediation
+
+## 1) Current Phase-44 ingress state
+Phase 44 established `sentientos.embodiment_ingress` as a non-authoritative proposal/receipt layer over embodiment fusion snapshots. It classifies pressure and emits hold/review postures but does not perform effects.
+
+## 2) Direct memory/action paths inspected
+- `mic_bridge.py`: direct `append_memory(...)` on recognized transcript.
+- `feedback.py`: direct invocation of configured action callbacks in `FeedbackManager.process(...)`.
+- Supporting paths: `sentientos/embodiment_ingress.py`, `sentientos/perception_api.py`, `sentientos/embodiment_fusion.py`.
+
+## 3) Selected paths for gating
+- Mic memory append path (high-risk mutable side effect).
+- Feedback action trigger path (high-risk external side effect).
+
+## 4) Compatibility strategy
+Introduce explicit ingress gate mode with defaults preserving behavior:
+- `proposal_only`: evaluate ingress + emit transition receipt; block direct side effects.
+- `compatibility_legacy` (default): evaluate ingress + emit transition receipt; preserve direct side effects.
+- Unsupported/other values naturally behave as non-legacy allow=false.
+
+## 5) Transitional fallback behavior
+Fallback remains explicit and visible:
+- Receipts include `ingress_gate_mode`, `legacy_direct_effect`, `legacy_direct_effect_preserved`, `transition_state`.
+- Module markers advertise gated-but-not-yet-fully-migrated state.
+
+## 6) Tests to add/update
+- Add `tests/test_phase45_ingress_gated_effects.py`:
+  - mic proposal_only blocks memory append.
+  - mic compatibility_legacy preserves memory append.
+  - feedback proposal_only blocks action callback.
+  - feedback compatibility_legacy preserves action callback.
+  - ingress remains non-authoritative.
+- Update architecture test coverage for gate marker visibility + known-violation visibility.
+
+## 7) Deferred risks and why
+- Other legacy direct JSONL writes remain in quarantined modules outside Phase 45 scope.
+- Full admission/authorization replacement for legacy side effects is deferred to later phases to avoid orchestration and runtime semantic changes in this pass.

--- a/feedback.py
+++ b/feedback.py
@@ -1,12 +1,17 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+import os
 LEGACY_PERCEPTION_QUARANTINE = True
 PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = True
 CAN_WRITE_MEMORY = False
+EMBODIMENT_INGRESS_GATE_MODE = os.getenv("EMBODIMENT_INGRESS_GATE_MODE", "compatibility_legacy")
+INGRESS_GATE_PRESENT = True
+INGRESS_GATE_PROPOSAL_ONLY_SUPPORTED = True
+LEGACY_DIRECT_ACTION_REQUIRES_EXPLICIT_MODE = True
 MIGRATION_TARGET = "sentientos.perception_api"
 NON_AUTHORITY_RATIONALE = "Feedback triggers side-effect actions; telemetry observation shaping is routed through sentientos.perception_api while action risk remains explicit."
 
@@ -18,11 +23,14 @@ import json
 import time
 from dataclasses import dataclass, field
 import importlib
-import os
 from pathlib import Path
 from sentientos.perception_api import build_feedback_observation, emit_legacy_perception_telemetry
 from sentientos.embodiment_fusion import build_embodiment_snapshot
-from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+from sentientos.embodiment_ingress import (
+    evaluate_embodiment_ingress,
+    mark_legacy_direct_effect_preserved,
+    should_allow_legacy_feedback_action,
+)
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import json
 import uuid
@@ -106,13 +114,19 @@ class FeedbackManager:
                     continue
                 self.last_trigger[key] = ts
                 action = self.actions.get(rule.action)
-                if action:
+                legacy_action_allowed = should_allow_legacy_feedback_action(EMBODIMENT_INGRESS_GATE_MODE)
+                if action and legacy_action_allowed:
                     action(rule, user_id, value)
                 action_id = uuid.uuid4().hex
                 observation = build_feedback_observation(user=user_id, emotion=rule.emotion, value=value, action=rule.action, timestamp=ts)
                 _ = emit_legacy_perception_telemetry("feedback", observation, source_module="feedback", can_trigger_actions=True, legacy_quarantine=True, quarantine_risk="action_side_effects")
-                _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
+                _ingress = mark_legacy_direct_effect_preserved(
+                    evaluate_embodiment_ingress(build_embodiment_snapshot([_])),
+                    effect_type="feedback_action",
+                    mode=EMBODIMENT_INGRESS_GATE_MODE,
+                )
                 entry = {"id": action_id, "time": ts, **observation}
+                entry["ingress_receipt"] = _ingress
                 self.history.append(entry)
                 self.log_path.parent.mkdir(parents=True, exist_ok=True)
                 with open(self.log_path, "a", encoding="utf-8") as f:

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -1,12 +1,17 @@
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
 from __future__ import annotations
 from sentientos.privilege import require_admin_banner, require_lumos_approval
+import os
 LEGACY_PERCEPTION_QUARANTINE = True
 PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
 CAN_WRITE_MEMORY = True
+EMBODIMENT_INGRESS_GATE_MODE = os.getenv("EMBODIMENT_INGRESS_GATE_MODE", "compatibility_legacy")
+INGRESS_GATE_PRESENT = True
+INGRESS_GATE_PROPOSAL_ONLY_SUPPORTED = True
+LEGACY_DIRECT_MEMORY_WRITE_REQUIRES_EXPLICIT_MODE = True
 MIGRATION_TARGET = "sentientos.perception_api"
 NON_AUTHORITY_RATIONALE = "Legacy microphone capture still appends memory records; observation shaping now routes through sentientos.perception_api."
 
@@ -14,7 +19,6 @@ NON_AUTHORITY_RATIONALE = "Legacy microphone capture still appends memory record
 require_admin_banner()
 require_lumos_approval()
 from logging_config import get_log_path
-import os
 import json
 import time
 from pathlib import Path
@@ -36,7 +40,7 @@ if is_headless():
 from memory_manager import append_memory
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_audio_observation
 from sentientos.embodiment_fusion import build_embodiment_snapshot
-from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress, mark_legacy_direct_effect_preserved, should_allow_legacy_memory_write
 
 
 class MicResult(TypedDict):
@@ -45,12 +49,13 @@ class MicResult(TypedDict):
     audio_file: str | None
     emotions: Emotion
     emotion_features: Dict[str, float]
+    ingress_receipt: Dict[str, object] | None
 
 AUDIO_DIR = get_log_path("audio", "AUDIO_LOG_DIR")
 AUDIO_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def recognize_from_mic(save_audio: bool = True) -> MicResult:
+def recognize_from_mic(save_audio: bool = True, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE) -> MicResult:
     """Capture a single phrase from the default microphone."""
     if sr is None:
         if is_headless():
@@ -111,32 +116,35 @@ def recognize_from_mic(save_audio: bool = True) -> MicResult:
             print(f"[MIC] Recognition failed: {e}")
             text = None
 
+    ingress_receipt = None
     if text:
         text_vec = eu.text_sentiment(text)
+        audio_emotions = emotions
         fused = eu.fuse(emotions, text_vec)
+        emotions = fused
+    _obs = normalize_audio_observation(message=text, source="mic", audio_file=str(audio_path) if audio_path else None, emotion_features=features)
+    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
+    ingress_receipt = mark_legacy_direct_effect_preserved(evaluate_embodiment_ingress(build_embodiment_snapshot([_])), effect_type="memory_write", mode=ingress_gate_mode)
+    if text and should_allow_legacy_memory_write(ingress_gate_mode):
         append_memory(
             text,
             tags=["voice", "input"],
             source="mic",
-            emotions=fused,
+            emotions=emotions,
             emotion_features=features,
-            emotion_breakdown={"audio": emotions, "text": text_vec},
+            emotion_breakdown={"audio": audio_emotions, "text": text_vec},
         )
-        emotions = fused
-
-    _obs = normalize_audio_observation(message=text, source="mic", audio_file=str(audio_path) if audio_path else None, emotion_features=features)
-    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
-    _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
     return {
         "message": text,
         "source": "mic",
         "audio_file": str(audio_path) if audio_path else None,
         "emotions": emotions,
         "emotion_features": features,
+        "ingress_receipt": ingress_receipt,
     }
 
 
-def recognize_from_file(path: str) -> MicResult:
+def recognize_from_file(path: str, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE) -> MicResult:
     """Recognize speech from a WAV file."""
     if sr is None:
         return {
@@ -158,28 +166,31 @@ def recognize_from_file(path: str) -> MicResult:
     except Exception:
         pass
 
+    ingress_receipt = None
     if text:
         text_vec = eu.text_sentiment(text)
+        audio_emotions = emotions
         fused = eu.fuse(emotions, text_vec)
+        emotions = fused
+    _obs = normalize_audio_observation(message=text, source="file", audio_file=path, emotion_features=features)
+    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
+    ingress_receipt = mark_legacy_direct_effect_preserved(evaluate_embodiment_ingress(build_embodiment_snapshot([_])), effect_type="memory_write", mode=ingress_gate_mode)
+    if text and should_allow_legacy_memory_write(ingress_gate_mode):
         append_memory(
             text,
             tags=["voice", "input"],
             source="file",
-            emotions=fused,
+            emotions=emotions,
             emotion_features=features,
-            emotion_breakdown={"audio": emotions, "text": text_vec},
+            emotion_breakdown={"audio": audio_emotions, "text": text_vec},
         )
-        emotions = fused
-
-    _obs = normalize_audio_observation(message=text, source="file", audio_file=path, emotion_features=features)
-    _ = emit_legacy_perception_telemetry("audio", _obs, source_module="mic_bridge", can_write_memory=True, legacy_quarantine=True, quarantine_risk="memory_write")
-    _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
     return {
         "message": text,
         "source": "file",
         "audio_file": path,
         "emotions": emotions,
         "emotion_features": features,
+        "ingress_receipt": ingress_receipt,
     }
 
 if __name__ == "__main__":  # pragma: no cover - manual utility

--- a/sentientos/embodiment_ingress.py
+++ b/sentientos/embodiment_ingress.py
@@ -132,6 +132,23 @@ def evaluate_embodiment_ingress(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     return receipt
 
 
+def should_allow_legacy_memory_write(mode: str) -> bool:
+    return mode == "compatibility_legacy"
+
+
+def should_allow_legacy_feedback_action(mode: str) -> bool:
+    return mode == "compatibility_legacy"
+
+
+def mark_legacy_direct_effect_preserved(receipt: Mapping[str, Any], *, effect_type: str, mode: str) -> dict[str, Any]:
+    marked = dict(receipt)
+    marked["ingress_gate_mode"] = mode
+    marked["legacy_direct_effect"] = effect_type
+    marked["legacy_direct_effect_preserved"] = mode == "compatibility_legacy"
+    marked["transition_state"] = "legacy_fallback" if mode == "compatibility_legacy" else "proposal_only"
+    return marked
+
+
 __all__ = [
     "evaluate_embodiment_ingress",
     "classify_embodied_pressure",
@@ -140,4 +157,7 @@ __all__ = [
     "build_operator_attention_candidate",
     "resolve_embodiment_ingress_posture",
     "embodiment_ingress_receipt_ref",
+    "should_allow_legacy_memory_write",
+    "should_allow_legacy_feedback_action",
+    "mark_legacy_direct_effect_preserved",
 ]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -251,9 +251,9 @@
     {
       "file": "mic_bridge.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api",
+      "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy",
       "severity": "high",
-      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
+      "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress; move default to proposal_only after downstream admission path readiness",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     },
@@ -278,9 +278,9 @@
     {
       "file": "feedback.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api",
+      "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy",
       "severity": "high",
-      "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
+      "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress; move default to proposal_only after operator-approved action admission path exists",
       "migration_target": "sentientos.perception_api",
       "requires_quarantine_annotation": true
     }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -318,6 +318,27 @@ def test_phase41_legacy_perception_modules_have_quarantine_annotations() -> None
             assert marker in text, f"{rel} missing {marker}"
 
 
+def test_phase45_ingress_gate_markers_visible_for_legacy_direct_effect_modules() -> None:
+    mic_text = (ROOT / "mic_bridge.py").read_text(encoding="utf-8")
+    assert "INGRESS_GATE_PRESENT = True" in mic_text
+    assert "INGRESS_GATE_PROPOSAL_ONLY_SUPPORTED = True" in mic_text
+    assert "LEGACY_DIRECT_MEMORY_WRITE_REQUIRES_EXPLICIT_MODE = True" in mic_text
+
+    feedback_text = (ROOT / "feedback.py").read_text(encoding="utf-8")
+    assert "INGRESS_GATE_PRESENT = True" in feedback_text
+    assert "INGRESS_GATE_PROPOSAL_ONLY_SUPPORTED = True" in feedback_text
+    assert "LEGACY_DIRECT_ACTION_REQUIRES_EXPLICIT_MODE = True" in feedback_text
+
+
+def test_phase45_known_violations_remain_manifest_visible_for_direct_effect_risk() -> None:
+    manifest = _manifest()
+    rows = {row["file"]: row for row in manifest["known_violations"]}
+    assert "mic_bridge.py" in rows
+    assert "ingress gate mode" in rows["mic_bridge.py"]["detail"]
+    assert "feedback.py" in rows
+    assert "ingress gate mode" in rows["feedback.py"]["detail"]
+
+
 def test_phase41_perception_api_boundary_purity() -> None:
     text = (ROOT / "sentientos/perception_api.py").read_text(encoding="utf-8")
     for bad in (

--- a/tests/test_phase45_ingress_gated_effects.py
+++ b/tests/test_phase45_ingress_gated_effects.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+import types
+
+sys.modules.setdefault("notification", types.SimpleNamespace(send=lambda *a, **k: None))
+import feedback
+import mic_bridge
+
+
+def test_mic_bridge_proposal_only_blocks_memory_write(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mic_bridge, "append_memory", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(mic_bridge.eu, "detect", lambda path: ({"joy": 0.1}, {}))
+    monkeypatch.setattr(mic_bridge.eu, "text_sentiment", lambda text: {"joy": 0.2})
+    monkeypatch.setattr(mic_bridge.eu, "fuse", lambda a, b: {"joy": 0.3})
+
+    class DummyRec:
+        def record(self, source):
+            return object()
+        def recognize_google(self, audio):
+            return "remember this"
+
+    class DummyAudioFile:
+        def __init__(self, path):
+            self.path = path
+        def __enter__(self):
+            return object()
+        def __exit__(self, *args):
+            return False
+
+    class SR:
+        Recognizer = DummyRec
+        AudioFile = DummyAudioFile
+
+    monkeypatch.setattr(mic_bridge, "sr", SR)
+    out = mic_bridge.recognize_from_file("fake.wav", ingress_gate_mode="proposal_only")
+    assert calls == []
+    assert out["ingress_receipt"]["ingress_gate_mode"] == "proposal_only"
+
+
+def test_mic_bridge_compatibility_legacy_preserves_memory_write(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mic_bridge, "append_memory", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(mic_bridge.eu, "detect", lambda path: ({"joy": 0.1}, {}))
+    monkeypatch.setattr(mic_bridge.eu, "text_sentiment", lambda text: {"joy": 0.2})
+    monkeypatch.setattr(mic_bridge.eu, "fuse", lambda a, b: {"joy": 0.3})
+
+    class DummyRec:
+        def record(self, source):
+            return object()
+        def recognize_google(self, audio):
+            return "remember this"
+
+    class DummyAudioFile:
+        def __init__(self, path):
+            self.path = path
+        def __enter__(self):
+            return object()
+        def __exit__(self, *args):
+            return False
+
+    class SR:
+        Recognizer = DummyRec
+        AudioFile = DummyAudioFile
+
+    monkeypatch.setattr(mic_bridge, "sr", SR)
+    out = mic_bridge.recognize_from_file("fake.wav", ingress_gate_mode="compatibility_legacy")
+    assert len(calls) == 1
+    assert out["ingress_receipt"]["legacy_direct_effect_preserved"] is True
+
+
+def test_feedback_proposal_only_blocks_actions(monkeypatch):
+    monkeypatch.setattr(feedback, "EMBODIMENT_INGRESS_GATE_MODE", "proposal_only")
+    manager = feedback.FeedbackManager()
+    rule = feedback.FeedbackRule(emotion="joy", threshold=0.1, action="x")
+    manager.add_rule(rule)
+    action_calls = []
+    manager.register_action("x", lambda r, u, v: action_calls.append((r, u, v)))
+    monkeypatch.setattr(manager, "request_feedback", lambda *a, **k: None)
+    manager.process(1, {"joy": 0.9})
+    assert action_calls == []
+    assert manager.history[-1]["ingress_receipt"]["ingress_gate_mode"] == "proposal_only"
+
+
+def test_feedback_compatibility_legacy_preserves_actions(monkeypatch):
+    monkeypatch.setattr(feedback, "EMBODIMENT_INGRESS_GATE_MODE", "compatibility_legacy")
+    manager = feedback.FeedbackManager()
+    rule = feedback.FeedbackRule(emotion="joy", threshold=0.1, action="x")
+    manager.add_rule(rule)
+    action_calls = []
+    manager.register_action("x", lambda r, u, v: action_calls.append((r, u, v)))
+    monkeypatch.setattr(manager, "request_feedback", lambda *a, **k: None)
+    manager.process(1, {"joy": 0.9})
+    assert len(action_calls) == 1
+    assert manager.history[-1]["ingress_receipt"]["legacy_direct_effect_preserved"] is True
+
+
+def test_ingress_non_authoritative_contract():
+    from sentientos.embodiment_fusion import build_embodiment_snapshot
+    from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+
+    snap = build_embodiment_snapshot([])
+    rec = evaluate_embodiment_ingress(snap)
+    assert rec["decision_power"] == "none"
+    assert rec["does_not_write_memory"] is True
+    assert rec["does_not_trigger_feedback"] is True


### PR DESCRIPTION
### Motivation
- Introduce an explicit ingress gating mode to remediate legacy direct memory writes and feedback-triggered actions while preserving a clear migration path. 
- Allow a transitional `compatibility_legacy` mode that preserves current behavior while supporting a `proposal_only` mode that blocks direct side effects and emits non-authoritative receipts.

### Description
- Add environment-configurable gate markers and mode defaults via `EMBODIMENT_INGRESS_GATE_MODE` and flags in `mic_bridge.py` and `feedback.py` so modules advertise ingress-gating support. 
- Implement helper APIs in `sentientos/embodiment_ingress.py`: `should_allow_legacy_memory_write`, `should_allow_legacy_feedback_action`, and `mark_legacy_direct_effect_preserved` to annotate receipts and decide allowance. 
- Update `mic_bridge` to emit telemetry through `sentientos.perception_api`, attach an `ingress_receipt` to microphone results, and conditionally call `append_memory` based on the ingress gate mode. 
- Update `feedback.FeedbackManager.process` to consult the ingress gate before executing registered actions, emit telemetry, annotate the ingress receipt, and record it in history. 
- Update the architecture manifest `sentientos/system_closure/architecture_boundary_manifest.json` to mention ingress gate mode for known violations and add a Phase-45 architecture exec plan document at `docs/architecture/phase45_ingress_gated_memory_action_execplan.md`. 
- Add tests `tests/test_phase45_ingress_gated_effects.py` and extend `tests/architecture/test_architecture_boundaries.py` to validate marker visibility and gating behavior.

### Testing
- Ran the new gating unit tests `tests/test_phase45_ingress_gated_effects.py`, which exercise `proposal_only` and `compatibility_legacy` behavior for both `mic_bridge` and `feedback`, and they passed. 
- Ran architecture boundary tests in `tests/architecture/test_architecture_boundaries.py` (including the new marker/manifest assertions), and they passed. 
- Ran the repository test suite via `pytest` to validate integration of the changes and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7cd941004832092123be216b78486)