### PR TITLE
[codex:perception] ingress-gate legacy retention writes for screen/vision/multimodal

### DIFF
--- a/docs/architecture/phase46_ingress_gated_retention_execplan.md
+++ b/docs/architecture/phase46_ingress_gated_retention_execplan.md
@@ -1,0 +1,58 @@
+# Phase 46 ExecPlan: Ingress-Gated Legacy Perception Retention Remediation Wave
+
+## 1) Current Phase 45 gate state
+- `mic_bridge.py` already enforces explicit ingress gate modes for direct memory side effects (`proposal_only` vs `compatibility_legacy`).
+- `feedback.py` already enforces explicit ingress gate modes for direct action callbacks.
+- `sentientos.embodiment_ingress` is non-authoritative and emits receipts/candidates; it currently includes memory/action helpers but no dedicated retention helper family for legacy perception direct writes.
+
+## 2) Direct retention/write paths inspected
+Inspected legacy modules and exact write paths:
+- `screen_awareness.py`
+  - `_log_snapshot`: direct append to `self.log_path` (`screen_awareness.jsonl`) after OCR normalization/telemetry.
+- `vision_tracker.py`
+  - `FaceEmotionTracker.log_result`: direct append to `self.log_path` (`vision.jsonl`) for face/emotion payload.
+- `multimodal_tracker.py`
+  - `_log`: direct append to per-person `{person_id}.jsonl` payloads.
+  - `_log_environment`: direct append to `environment.jsonl`.
+
+## 3) Selected retention-gating strategy
+- Add explicit retention gate markers and default mode constants to all three modules:
+  - `EMBODIMENT_RETENTION_GATE_PRESENT = True`
+  - `EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = "compatibility_legacy"`
+  - `EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED = True`
+  - `LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE = True`
+- Build ingress receipts via `evaluate_embodiment_ingress(build_embodiment_snapshot([event]))`.
+- Add retention-specific ingress helpers in `sentientos.embodiment_ingress` to classify permission and mark fallback preservation state.
+- Thread `ingress_gate_mode` into legacy retention write functions.
+
+## 4) Compatibility fallback strategy
+- Preserve runtime behavior by default (`compatibility_legacy`) for all three modules.
+- In compatibility mode:
+  - Keep current direct file appends unchanged.
+  - Return/record ingress receipt marked with legacy direct retention preserved state.
+- In proposal-only mode:
+  - Build receipt/candidate and block direct retention writes.
+  - Keep telemetry emission and ingress receipt generation active.
+
+## 5) Privacy/retention posture
+- Keep privacy-sensitive posture explicit in receipts:
+  - Screen/OCR paths include `privacy_sensitive_hold` context.
+  - Vision paths include biometric/emotion-sensitive hold posture.
+  - Multimodal paths include fusion/direct-write sensitivity and source modality refs.
+- Explicitly mark compatibility mode as unresolved direct retention risk in manifest details.
+
+## 6) Tests to add/update
+- Add `tests/test_phase46_ingress_gated_retention.py` with focused, hardware-free tests:
+  - Screen proposal-only blocks write, returns receipt.
+  - Screen compatibility preserves write and marks legacy preserved.
+  - Vision proposal-only blocks write and posture is biometric/privacy hold.
+  - Vision compatibility preserves write and marks legacy preserved.
+  - Multimodal proposal-only blocks per-person and environment writes with receipt posture visibility.
+  - Multimodal compatibility preserves writes and marks legacy preserved.
+  - New ingress retention helpers remain non-authoritative and perform no writes.
+- Update architecture boundary tests for new gate markers and manifest visibility expectations.
+
+## 7) Deferred risks and why
+- Direct write paths remain in compatibility mode by design to preserve behavior; full migration to canonical sinks is intentionally deferred.
+- This phase does not alter telemetry bridge publication or canonical perception adapters.
+- This phase does not add authority, admission, or execution semantics to ingress.

--- a/multimodal_tracker.py
+++ b/multimodal_tracker.py
@@ -7,6 +7,10 @@ PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
 CAN_WRITE_MEMORY = False
+EMBODIMENT_RETENTION_GATE_PRESENT = True
+EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = "compatibility_legacy"
+EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED = True
+LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE = True
 MIGRATION_TARGET = "sentientos.perception_api"
 NON_AUTHORITY_RATIONALE = "Legacy perception surface emits telemetry only; migration routes shaping through sentientos.perception_api."
 
@@ -54,7 +58,7 @@ from screen_awareness import ScreenAwareness
 from vision_tracker import FaceEmotionTracker
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_multimodal_observation
 from sentientos.embodiment_fusion import build_embodiment_snapshot
-from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
 
 
 class VoiceObservation(TypedDict, total=False):
@@ -152,21 +156,38 @@ class MultiModalEmotionTracker:
                     journal=self.journal,
                 )
         self.memory = PersonaMemory()
+        self.ingress_gate_mode = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE
 
-    def _log(self, person_id: int, entry: LogEntry) -> None:
+    def _log(self, person_id: int, entry: LogEntry, *, ingress_gate_mode: Optional[str] = None) -> dict[str, Any]:
         path = self.log_dir / f"{person_id}.jsonl"
         payload = normalize_multimodal_observation(timestamp=float(entry.get("timestamp", time.time())), vision=entry.get("vision", {}), voice=entry.get("voice", {}), scene=entry.get("scene"), screen=entry.get("screen"))
         _ = emit_legacy_perception_telemetry("multimodal", payload, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
         _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        mode = ingress_gate_mode or self.ingress_gate_mode
+        _ingress["retention_candidate"] = build_retention_ingress_candidate(build_embodiment_snapshot([_]), retention_surface="multimodal_person", source_refs=list(payload.get("source_modalities", [])))
+        _ingress["retention_gate_mode"] = mode
+        _ingress["retention_risk"] = "fusion_direct_writes"
+        if should_allow_legacy_retention_write(mode):
+            _ingress = mark_legacy_direct_retention_preserved(_ingress, retention_surface="multimodal_person", mode=mode)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        return _ingress
 
-    def _log_environment(self, entry: Dict[str, Any]) -> None:
-        try:
-            with open(self.environment_log, "a", encoding="utf-8") as handle:
-                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
+    def _log_environment(self, entry: Dict[str, Any], *, ingress_gate_mode: Optional[str] = None) -> dict[str, Any]:
+        mode = ingress_gate_mode or self.ingress_gate_mode
+        event = emit_legacy_perception_telemetry("multimodal", entry, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
+        ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([event]))
+        ingress["retention_candidate"] = build_retention_ingress_candidate(build_embodiment_snapshot([event]), retention_surface="multimodal_environment", source_refs=list(entry.keys()))
+        ingress["retention_gate_mode"] = mode
+        ingress["retention_risk"] = "fusion_direct_writes"
+        if should_allow_legacy_retention_write(mode):
+            ingress = mark_legacy_direct_retention_preserved(ingress, retention_surface="multimodal_environment", mode=mode)
+            try:
+                with open(self.environment_log, "a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            except Exception:
+                pass
+        return ingress
 
     def _record_journal(self, tags: List[str], note: str, extra: Optional[Dict[str, Any]] = None) -> None:
         try:

--- a/screen_awareness.py
+++ b/screen_awareness.py
@@ -1,15 +1,19 @@
 """Continuous screen awareness module with optional OCR summarisation."""
+from __future__ import annotations
 LEGACY_PERCEPTION_QUARANTINE = True
 PULSE_COMPATIBLE_TELEMETRY = True
 PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
 CAN_WRITE_MEMORY = False
+EMBODIMENT_RETENTION_GATE_PRESENT = True
+EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = "compatibility_legacy"
+EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED = True
+LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE = True
 MIGRATION_TARGET = "sentientos.perception_api"
 NON_AUTHORITY_RATIONALE = "Legacy perception surface emits telemetry only; migration routes shaping through sentientos.perception_api."
 
 
-from __future__ import annotations
 
 from sentientos.privilege import require_admin_banner, require_lumos_approval
 
@@ -28,7 +32,7 @@ from perception_journal import PerceptionJournal
 from utils import is_headless
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_screen_observation
 from sentientos.embodiment_fusion import build_embodiment_snapshot
-from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
 
 try:  # pragma: no cover - optional dependency
     import mss  # type: ignore[import-untyped]
@@ -117,15 +121,21 @@ class ScreenAwareness:
         )
         return snapshot
 
-    def _log_snapshot(self, snapshot: ScreenSnapshot) -> None:
+    def _log_snapshot(self, snapshot: ScreenSnapshot, *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE) -> dict[str, object]:
         payload = normalize_screen_observation(timestamp=snapshot.timestamp, text=snapshot.text, ocr_confidence=snapshot.ocr_confidence, width=snapshot.width, height=snapshot.height)
         _ = emit_legacy_perception_telemetry("screen", payload, source_module="screen_awareness", legacy_quarantine=True, quarantine_risk="ocr_privacy")
         _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
-        try:
-            with self.log_path.open("a", encoding="utf-8") as handle:
-                handle.write(os.getenv("JSON_DUMP_PREFIX", "") + json.dumps(payload, ensure_ascii=False) + "\n")
-        except Exception:
-            pass
+        _ingress["retention_candidate"] = build_retention_ingress_candidate(build_embodiment_snapshot([_]), retention_surface="screen_ocr", source_refs=["screen", "ocr"])
+        _ingress["retention_gate_mode"] = ingress_gate_mode
+        _ingress["retention_risk"] = "ocr_privacy"
+        if should_allow_legacy_retention_write(ingress_gate_mode):
+            _ingress = mark_legacy_direct_retention_preserved(_ingress, retention_surface="screen_ocr", mode=ingress_gate_mode)
+            try:
+                with self.log_path.open("a", encoding="utf-8") as handle:
+                    handle.write(os.getenv("JSON_DUMP_PREFIX", "") + json.dumps(payload, ensure_ascii=False) + "\n")
+            except Exception:
+                pass
+        return _ingress
 
     def _record_journal(self, snapshot: ScreenSnapshot) -> None:
         if not self.journal:
@@ -141,7 +151,7 @@ class ScreenAwareness:
         except Exception:
             pass
 
-    def capture_once(self) -> Optional[ScreenSnapshot]:
+    def capture_once(self, *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE) -> Optional[ScreenSnapshot]:
         snapshot = self._capture()
         if snapshot is None:
             return None
@@ -150,7 +160,7 @@ class ScreenAwareness:
         if snapshot.text.strip() == self._last_text.strip():
             return None
         self._last_text = snapshot.text
-        self._log_snapshot(snapshot)
+        _ = self._log_snapshot(snapshot, ingress_gate_mode=ingress_gate_mode)
         self._record_journal(snapshot)
         return snapshot
 

--- a/sentientos/embodiment_ingress.py
+++ b/sentientos/embodiment_ingress.py
@@ -132,6 +132,26 @@ def evaluate_embodiment_ingress(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     return receipt
 
 
+
+def should_allow_legacy_retention_write(mode: str) -> bool:
+    return mode == "compatibility_legacy"
+
+
+def build_retention_ingress_candidate(snapshot: Mapping[str, Any], *, retention_surface: str, source_refs: Sequence[str] | None = None) -> dict[str, Any]:
+    return {
+        "candidate_type": "retention",
+        "candidate_ref": embodiment_ingress_receipt_ref(snapshot, salt=f"retention:{retention_surface}"),
+        "retention_surface": retention_surface,
+        "source_refs": list(source_refs or []),
+        "requires_review": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+    }
+
+
+def mark_legacy_direct_retention_preserved(receipt: Mapping[str, Any], *, retention_surface: str, mode: str) -> dict[str, Any]:
+    return mark_legacy_direct_effect_preserved(receipt, effect_type=f"retention:{retention_surface}", mode=mode)
+
 def should_allow_legacy_memory_write(mode: str) -> bool:
     return mode == "compatibility_legacy"
 
@@ -160,4 +180,7 @@ __all__ = [
     "should_allow_legacy_memory_write",
     "should_allow_legacy_feedback_action",
     "mark_legacy_direct_effect_preserved",
+    "should_allow_legacy_retention_write",
+    "build_retention_ingress_candidate",
+    "mark_legacy_direct_retention_preserved",
 ]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -242,7 +242,7 @@
     {
       "file": "screen_awareness.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy OCR privacy risk and direct jsonl write; routed shaping via sentientos.perception_api; pulse-compatible telemetry bridge added via sentientos.perception_api",
+      "detail": "legacy OCR privacy risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes",
       "severity": "medium",
       "remediation": "maintain quarantine markers and migrate write path to pulse adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
@@ -260,7 +260,7 @@
     {
       "file": "vision_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy vision biometric/emotion direct jsonl write risk; pulse-compatible telemetry bridge added via sentientos.perception_api",
+      "detail": "legacy vision/emotion biometric risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes",
       "severity": "high",
       "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "pulse_bus",
@@ -269,7 +269,7 @@
     {
       "file": "multimodal_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy multimodal fusion direct per-person/environment jsonl writes; pulse-compatible telemetry bridge added via sentientos.perception_api",
+      "detail": "legacy multimodal fusion direct-write risk for per-person and environment logs; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes",
       "severity": "medium",
       "remediation": "preserve quarantine and route fusion emission to perception bus envelopes; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -442,3 +442,20 @@ def test_phase44_no_new_direct_sink_mutation_in_perception_fusion_ingress() -> N
         assert "append_memory(" not in text
         assert "task_executor" not in text
         assert "task_admission" not in text
+
+
+def test_phase46_retention_gate_markers_visible_for_legacy_retention_modules() -> None:
+    for rel in ("screen_awareness.py", "vision_tracker.py", "multimodal_tracker.py"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "EMBODIMENT_RETENTION_GATE_PRESENT = True" in text
+        assert "EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = \"compatibility_legacy\"" in text
+        assert "EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED = True" in text
+        assert "LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE = True" in text
+
+
+def test_phase46_known_violations_manifest_visibility_for_retention_gates() -> None:
+    rows = {row["file"]: row for row in _manifest()["known_violations"]}
+    for rel in ("screen_awareness.py", "vision_tracker.py", "multimodal_tracker.py"):
+        assert rel in rows
+        assert "retention gate mode" in rows[rel]["detail"]
+        assert "proposal_only" in rows[rel]["detail"]

--- a/tests/test_phase46_ingress_gated_retention.py
+++ b/tests/test_phase46_ingress_gated_retention.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+import multimodal_tracker
+import screen_awareness
+import vision_tracker
+from sentientos.embodiment_ingress import (
+    build_retention_ingress_candidate,
+    evaluate_embodiment_ingress,
+    mark_legacy_direct_retention_preserved,
+    should_allow_legacy_retention_write,
+)
+
+
+def test_screen_awareness_proposal_only_blocks_persistent_write(tmp_path):
+    s = screen_awareness.ScreenAwareness(log_path=tmp_path / "screen.jsonl")
+    snap = screen_awareness.ScreenSnapshot(timestamp=1.0, text="hello")
+    rec = s._log_snapshot(snap, ingress_gate_mode="proposal_only")
+    assert rec["retention_gate_mode"] == "proposal_only"
+    assert not (tmp_path / "screen.jsonl").exists()
+
+
+def test_screen_awareness_compatibility_legacy_preserves_write(tmp_path):
+    s = screen_awareness.ScreenAwareness(log_path=tmp_path / "screen.jsonl")
+    snap = screen_awareness.ScreenSnapshot(timestamp=1.0, text="hello")
+    rec = s._log_snapshot(snap, ingress_gate_mode="compatibility_legacy")
+    assert (tmp_path / "screen.jsonl").exists()
+    assert rec["legacy_direct_effect_preserved"] is True
+
+
+def test_vision_proposal_only_blocks_write(tmp_path):
+    t = vision_tracker.FaceEmotionTracker(camera_index=None, output_file=str(tmp_path / "vision.jsonl"))
+    rec = t.log_result({"timestamp": 1.0, "faces": []}, ingress_gate_mode="proposal_only")
+    assert rec["retention_gate_mode"] == "proposal_only"
+    assert rec["recommended_posture"] in {"biometric_sensitive_hold", "privacy_sensitive_hold", "no_ingress_needed"}
+    assert not (tmp_path / "vision.jsonl").exists()
+
+
+def test_vision_compatibility_preserves_write(tmp_path):
+    t = vision_tracker.FaceEmotionTracker(camera_index=None, output_file=str(tmp_path / "vision.jsonl"))
+    rec = t.log_result({"timestamp": 1.0, "faces": [{"id": 1, "emotions": {"joy": 0.9}}]}, ingress_gate_mode="compatibility_legacy")
+    assert (tmp_path / "vision.jsonl").exists()
+    assert rec["legacy_direct_effect_preserved"] is True
+
+
+def test_multimodal_proposal_only_blocks_person_and_environment_writes(tmp_path):
+    mm = multimodal_tracker.MultiModalEmotionTracker(enable_vision=False, enable_voice=False, enable_scene=False, enable_screen=False, output_dir=str(tmp_path))
+    rec1 = mm._log(0, {"timestamp": 1.0, "vision": {}, "voice": {}, "screen": {"text": "x"}}, ingress_gate_mode="proposal_only")
+    rec2 = mm._log_environment({"timestamp": 1.0, "screen": {"text": "x"}}, ingress_gate_mode="proposal_only")
+    assert rec1["retention_gate_mode"] == "proposal_only"
+    assert rec2["retention_gate_mode"] == "proposal_only"
+    assert not (tmp_path / "0.jsonl").exists()
+    assert not (tmp_path / "environment.jsonl").exists()
+
+
+def test_multimodal_compatibility_preserves_writes(tmp_path):
+    mm = multimodal_tracker.MultiModalEmotionTracker(enable_vision=False, enable_voice=False, enable_scene=False, enable_screen=False, output_dir=str(tmp_path))
+    rec1 = mm._log(1, {"timestamp": 1.0, "vision": {}, "voice": {}}, ingress_gate_mode="compatibility_legacy")
+    rec2 = mm._log_environment({"timestamp": 1.0, "voice": {"joy": 0.1}}, ingress_gate_mode="compatibility_legacy")
+    assert (tmp_path / "1.jsonl").exists()
+    assert (tmp_path / "environment.jsonl").exists()
+    assert rec1["legacy_direct_effect_preserved"] is True
+    assert rec2["legacy_direct_effect_preserved"] is True
+
+
+def test_ingress_retention_helpers_non_authoritative_contract():
+    snap = {"snapshot_id": "x", "modalities_present": ["screen"]}
+    rec = evaluate_embodiment_ingress(snap)
+    cand = build_retention_ingress_candidate(snap, retention_surface="screen_ocr", source_refs=["screen"])
+    marked = mark_legacy_direct_retention_preserved(rec, retention_surface="screen_ocr", mode="compatibility_legacy")
+    assert should_allow_legacy_retention_write("proposal_only") is False
+    assert should_allow_legacy_retention_write("compatibility_legacy") is True
+    assert cand["decision_power"] == "none"
+    assert rec["decision_power"] == "none"
+    assert marked["legacy_direct_effect_preserved"] is True

--- a/vision_tracker.py
+++ b/vision_tracker.py
@@ -7,6 +7,10 @@ PERCEPTION_AUTHORITY = "none"
 RAW_RETENTION_DEFAULT = False
 CAN_TRIGGER_ACTIONS = False
 CAN_WRITE_MEMORY = False
+EMBODIMENT_RETENTION_GATE_PRESENT = True
+EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = "compatibility_legacy"
+EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED = True
+LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE = True
 MIGRATION_TARGET = "sentientos.perception_api"
 NON_AUTHORITY_RATIONALE = "Legacy perception surface emits telemetry only; migration routes shaping through sentientos.perception_api."
 
@@ -22,7 +26,7 @@ from logging_config import get_log_path
 from utils import is_headless
 from sentientos.perception_api import emit_legacy_perception_telemetry, normalize_vision_observation
 from sentientos.embodiment_fusion import build_embodiment_snapshot
-from sentientos.embodiment_ingress import evaluate_embodiment_ingress
+from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
 
 HEADLESS = is_headless()
 
@@ -161,12 +165,18 @@ class FaceEmotionTracker:
                 )
         return {"timestamp": ts, "faces": faces}
 
-    def log_result(self, data: Dict[str, Any]) -> None:
+    def log_result(self, data: Dict[str, Any], *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE) -> dict[str, Any]:
         payload = normalize_vision_observation(faces=data.get("faces", []), timestamp=float(data.get("timestamp", time.time())))
         _ = emit_legacy_perception_telemetry("vision", payload, source_module="vision_tracker", privacy_class="restricted", legacy_quarantine=True, quarantine_risk="biometric_emotion")
         _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
-        with open(self.log_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload) + "\n")
+        _ingress["retention_candidate"] = build_retention_ingress_candidate(build_embodiment_snapshot([_]), retention_surface="vision_emotion", source_refs=["vision", "emotion"])
+        _ingress["retention_gate_mode"] = ingress_gate_mode
+        _ingress["retention_risk"] = "biometric_emotion"
+        if should_allow_legacy_retention_write(ingress_gate_mode):
+            _ingress = mark_legacy_direct_retention_preserved(_ingress, retention_surface="vision_emotion", mode=ingress_gate_mode)
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(payload) + "\n")
+        return _ingress
 
     def update_voice_sentiment(self, face_id: int, sentiment: Dict[str, float]) -> None:
         """Optionally update emotional history and feedback from voice sentiment."""


### PR DESCRIPTION
### Motivation
- Extend Phase 45 ingress-gating pattern from memory/action side effects to legacy perception direct-retention paths to ensure screen/OCR, vision/emotion, and multimodal fusion writes are explicit, receipt-marked, and test-protected. 
- Preserve default compatibility behavior while providing a tested `proposal_only` mode that prevents legacy direct retention writes.

### Description
- Added retention-gate markers and defaults to the three legacy perception modules (`screen_awareness.py`, `vision_tracker.py`, `multimodal_tracker.py`) including `EMBODIMENT_RETENTION_GATE_PRESENT`, `EMBODIMENT_RETENTION_GATE_DEFAULT_MODE = "compatibility_legacy"`, `EMBODIMENT_RETENTION_GATE_PROPOSAL_ONLY_SUPPORTED`, and `LEGACY_DIRECT_RETENTION_REQUIRES_EXPLICIT_MODE`.
- Extended `sentientos.embodiment_ingress` with non-authoritative retention helpers: `should_allow_legacy_retention_write`, `build_retention_ingress_candidate`, and `mark_legacy_direct_retention_preserved`, while preserving `decision_power == "none"` and ensuring helpers do not perform writes.
- Gate legacy writes by evaluating ingress receipts/candidates and threading an `ingress_gate_mode` into write points so that `proposal_only` blocks file appends and `compatibility_legacy` preserves previous behavior and marks receipts as legacy-preserved.
- Updated manifest entries (`sentientos/system_closure/architecture_boundary_manifest.json`) and architecture assertions to surface retention-gate presence and compatibility fallback, and added an execution plan at `docs/architecture/phase46_ingress_gated_retention_execplan.md`.
- Added focused hardware-free tests (`tests/test_phase46_ingress_gated_retention.py`) and enriched architecture tests (`tests/architecture/test_architecture_boundaries.py`) to validate the gating, receipts, and non-authoritative ingress contract.

### Testing
- Added and executed the focused Phase 46 tests via `python -m scripts.run_tests -q tests/test_phase46_ingress_gated_retention.py tests/test_phase45_ingress_gated_effects.py`, which completed collection and ran in this environment as skip-heavy (no failing assertions in that focused run). 
- Ran architecture and integrity checks via `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and those suites passed. 
- Ran orchestration boundary smoke tests via `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, and those suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7d16a753c83209917fe5b958d2534)