### PR TITLE
[codex:embodiment] add append-only proposal queue for blocked legacy effects

### DIFF
--- a/docs/architecture/phase48_embodied_proposal_queue_execplan.md
+++ b/docs/architecture/phase48_embodied_proposal_queue_execplan.md
@@ -1,0 +1,9 @@
+# Phase 48 ExecPlan: embodied ingress proposal queue and review surface
+
+1. **Phase 47 gate state**: legacy perception modules already evaluate ingress receipts and gate side effects by `proposal_only` vs `compatibility_legacy` using `sentientos.embodiment_gate_policy` + `sentientos.embodiment_ingress`.
+2. **Blocked paths**: mic memory append, feedback action callback, screen OCR retention write, vision emotion retention write, multimodal retention writes.
+3. **Target surface**: add `sentientos.embodiment_proposals` as canonical append-only non-authoritative proposal ledger with deterministic IDs and pending-review status.
+4. **Append-only/provenance strategy**: proposal records include ingress receipt refs, source refs, snapshot refs, correlation id, risk/consent/privacy posture, rationale; appends go through `sentientos.ledger_api.append_audit_record`.
+5. **Boundary relationships**: embodiment_ingress remains classifier/receipt source, proposals consume ingress receipts only; no coupling to orchestration admission/execution (`task_admission`, `task_executor`) or control-plane mutation.
+6. **Tests**: add phase48 focused tests for builder/append/list and all five legacy modules in `proposal_only`; keep compatibility behavior assertions; extend architecture boundary tests + manifest checks.
+7. **Deferred risks**: compatibility mode still permits direct effects by design; no approval UI/admission wiring yet; proposal queue is review-only and intentionally non-authoritative.

--- a/feedback.py
+++ b/feedback.py
@@ -32,6 +32,7 @@ from sentientos.embodiment_ingress import (
     mark_legacy_direct_effect_preserved,
     should_allow_legacy_feedback_action,
 )
+from sentientos.embodiment_proposals import record_blocked_embodiment_effect
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import json
 import uuid
@@ -76,6 +77,7 @@ class FeedbackManager:
     user_log_path: Path = get_log_path("reflex_user_feedback.jsonl", "FEEDBACK_USER_LOG")
     tuning_log_path: Path = get_log_path("reflex_tuning.jsonl", "REFLEX_TUNING_LOG")
     learning: bool = False
+    embodiment_proposal_recorder: Callable[[Dict[str, Any]], Dict[str, Any]] | None = None
     rule_stats: Dict[str, Dict[str, int]] = field(default_factory=dict)
     tuning_history: List[Dict[str, Any]] = field(default_factory=list)
 
@@ -127,6 +129,17 @@ class FeedbackManager:
                     effect_type="feedback_action",
                     mode=mode,
                 )
+                if action and (not legacy_action_allowed):
+                    _proposal = record_blocked_embodiment_effect(
+                        source_module="feedback",
+                        gate_mode=mode,
+                        blocked_effect_type="feedback_action",
+                        ingress_receipt=_ingress,
+                        candidate_payload_summary={"action": rule.action, "emotion": rule.emotion, "user": user_id},
+                        rationale=["proposal_only blocked legacy direct feedback action"],
+                        append_proposal=self.embodiment_proposal_recorder,
+                    )
+                    _ingress["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
                 entry = {"id": action_id, "time": ts, **observation}
                 entry["ingress_receipt"] = _ingress
                 self.history.append(entry)

--- a/mic_bridge.py
+++ b/mic_bridge.py
@@ -42,6 +42,7 @@ from sentientos.perception_api import emit_legacy_perception_telemetry, normaliz
 from sentientos.embodiment_fusion import build_embodiment_snapshot
 from sentientos.embodiment_gate_policy import resolve_embodiment_gate_mode
 from sentientos.embodiment_ingress import evaluate_embodiment_ingress, mark_legacy_direct_effect_preserved, should_allow_legacy_memory_write
+from sentientos.embodiment_proposals import record_blocked_embodiment_effect
 
 
 class MicResult(TypedDict):
@@ -56,7 +57,7 @@ AUDIO_DIR = get_log_path("audio", "AUDIO_LOG_DIR")
 AUDIO_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def recognize_from_mic(save_audio: bool = True, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE) -> MicResult:
+def recognize_from_mic(save_audio: bool = True, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE, embodiment_proposal_recorder=None) -> MicResult:
     """Capture a single phrase from the default microphone."""
     if sr is None:
         if is_headless():
@@ -136,6 +137,17 @@ def recognize_from_mic(save_audio: bool = True, ingress_gate_mode: str = EMBODIM
             emotion_features=features,
             emotion_breakdown={"audio": audio_emotions, "text": text_vec},
         )
+    elif text:
+        _proposal = record_blocked_embodiment_effect(
+            source_module="mic_bridge",
+            gate_mode=mode,
+            blocked_effect_type="memory_write",
+            ingress_receipt=ingress_receipt,
+            candidate_payload_summary={"source": "mic", "message": text[:240]},
+            rationale=["proposal_only blocked legacy direct memory append"],
+            append_proposal=embodiment_proposal_recorder,
+        )
+        ingress_receipt["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
     return {
         "message": text,
         "source": "mic",
@@ -146,7 +158,7 @@ def recognize_from_mic(save_audio: bool = True, ingress_gate_mode: str = EMBODIM
     }
 
 
-def recognize_from_file(path: str, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE) -> MicResult:
+def recognize_from_file(path: str, ingress_gate_mode: str = EMBODIMENT_INGRESS_GATE_MODE, embodiment_proposal_recorder=None) -> MicResult:
     """Recognize speech from a WAV file."""
     if sr is None:
         return {
@@ -187,6 +199,17 @@ def recognize_from_file(path: str, ingress_gate_mode: str = EMBODIMENT_INGRESS_G
             emotion_features=features,
             emotion_breakdown={"audio": audio_emotions, "text": text_vec},
         )
+    elif text:
+        _proposal = record_blocked_embodiment_effect(
+            source_module="mic_bridge",
+            gate_mode=mode,
+            blocked_effect_type="memory_write",
+            ingress_receipt=ingress_receipt,
+            candidate_payload_summary={"source": "file", "audio_file": path, "message": text[:240]},
+            rationale=["proposal_only blocked legacy direct memory append"],
+            append_proposal=embodiment_proposal_recorder,
+        )
+        ingress_receipt["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
     return {
         "message": text,
         "source": "file",

--- a/multimodal_tracker.py
+++ b/multimodal_tracker.py
@@ -60,6 +60,7 @@ from sentientos.perception_api import emit_legacy_perception_telemetry, normaliz
 from sentientos.embodiment_fusion import build_embodiment_snapshot
 from sentientos.embodiment_gate_policy import resolve_embodiment_gate_mode
 from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
+from sentientos.embodiment_proposals import record_blocked_embodiment_effect
 
 
 class VoiceObservation(TypedDict, total=False):
@@ -159,7 +160,7 @@ class MultiModalEmotionTracker:
         self.memory = PersonaMemory()
         self.ingress_gate_mode = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE
 
-    def _log(self, person_id: int, entry: LogEntry, *, ingress_gate_mode: Optional[str] = None) -> dict[str, Any]:
+    def _log(self, person_id: int, entry: LogEntry, *, ingress_gate_mode: Optional[str] = None, embodiment_proposal_recorder=None) -> dict[str, Any]:
         path = self.log_dir / f"{person_id}.jsonl"
         payload = normalize_multimodal_observation(timestamp=float(entry.get("timestamp", time.time())), vision=entry.get("vision", {}), voice=entry.get("voice", {}), scene=entry.get("scene"), screen=entry.get("screen"))
         _ = emit_legacy_perception_telemetry("multimodal", payload, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
@@ -172,9 +173,20 @@ class MultiModalEmotionTracker:
             _ingress = mark_legacy_direct_retention_preserved(_ingress, retention_surface="multimodal_person", mode=mode)
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        else:
+            _proposal = record_blocked_embodiment_effect(
+                source_module="multimodal_tracker",
+                gate_mode=mode,
+                blocked_effect_type="retention:multimodal_person",
+                ingress_receipt=_ingress,
+                candidate_payload_summary={"retention_surface": "multimodal_person", "person_id": person_id},
+                rationale=["proposal_only blocked legacy direct retention write"],
+                append_proposal=embodiment_proposal_recorder,
+            )
+            _ingress["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
         return _ingress
 
-    def _log_environment(self, entry: Dict[str, Any], *, ingress_gate_mode: Optional[str] = None) -> dict[str, Any]:
+    def _log_environment(self, entry: Dict[str, Any], *, ingress_gate_mode: Optional[str] = None, embodiment_proposal_recorder=None) -> dict[str, Any]:
         mode = resolve_embodiment_gate_mode(ingress_gate_mode or self.ingress_gate_mode, default_mode=EMBODIMENT_RETENTION_GATE_DEFAULT_MODE)
         event = emit_legacy_perception_telemetry("multimodal", entry, source_module="multimodal_tracker", legacy_quarantine=True, quarantine_risk="fusion_direct_writes")
         ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([event]))
@@ -188,6 +200,17 @@ class MultiModalEmotionTracker:
                     handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
             except Exception:
                 pass
+        else:
+            _proposal = record_blocked_embodiment_effect(
+                source_module="multimodal_tracker",
+                gate_mode=mode,
+                blocked_effect_type="retention:multimodal_environment",
+                ingress_receipt=ingress,
+                candidate_payload_summary={"retention_surface": "multimodal_environment"},
+                rationale=["proposal_only blocked legacy direct retention write"],
+                append_proposal=embodiment_proposal_recorder,
+            )
+            ingress["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
         return ingress
 
     def _record_journal(self, tags: List[str], note: str, extra: Optional[Dict[str, Any]] = None) -> None:

--- a/screen_awareness.py
+++ b/screen_awareness.py
@@ -34,6 +34,7 @@ from sentientos.perception_api import emit_legacy_perception_telemetry, normaliz
 from sentientos.embodiment_fusion import build_embodiment_snapshot
 from sentientos.embodiment_gate_policy import resolve_embodiment_gate_mode
 from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
+from sentientos.embodiment_proposals import record_blocked_embodiment_effect
 
 try:  # pragma: no cover - optional dependency
     import mss  # type: ignore[import-untyped]
@@ -122,7 +123,7 @@ class ScreenAwareness:
         )
         return snapshot
 
-    def _log_snapshot(self, snapshot: ScreenSnapshot, *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE) -> dict[str, object]:
+    def _log_snapshot(self, snapshot: ScreenSnapshot, *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE, embodiment_proposal_recorder=None) -> dict[str, object]:
         payload = normalize_screen_observation(timestamp=snapshot.timestamp, text=snapshot.text, ocr_confidence=snapshot.ocr_confidence, width=snapshot.width, height=snapshot.height)
         _ = emit_legacy_perception_telemetry("screen", payload, source_module="screen_awareness", legacy_quarantine=True, quarantine_risk="ocr_privacy")
         _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
@@ -137,6 +138,17 @@ class ScreenAwareness:
                     handle.write(os.getenv("JSON_DUMP_PREFIX", "") + json.dumps(payload, ensure_ascii=False) + "\n")
             except Exception:
                 pass
+        else:
+            _proposal = record_blocked_embodiment_effect(
+                source_module="screen_awareness",
+                gate_mode=mode,
+                blocked_effect_type="retention:screen_ocr",
+                ingress_receipt=_ingress,
+                candidate_payload_summary={"retention_surface": "screen_ocr"},
+                rationale=["proposal_only blocked legacy direct retention write"],
+                append_proposal=embodiment_proposal_recorder,
+            )
+            _ingress["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
         return _ingress
 
     def _record_journal(self, snapshot: ScreenSnapshot) -> None:

--- a/sentientos/embodiment_proposals.py
+++ b/sentientos/embodiment_proposals.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sentientos.ledger_api import append_audit_record
+
+SCHEMA_VERSION = "embodiment.proposal.v1"
+DEFAULT_PROPOSAL_LOG = Path("logs/embodiment_proposals.jsonl")
+
+
+def classify_embodied_proposal_kind(*, blocked_effect_type: str, source_module: str, ingress_receipt: Mapping[str, Any] | None = None) -> str:
+    effect = blocked_effect_type.strip().lower()
+    if effect == "memory_write":
+        return "memory_ingress_candidate"
+    if effect == "feedback_action":
+        return "feedback_action_candidate"
+    if effect == "retention:screen_ocr":
+        return "screen_retention_candidate"
+    if effect == "retention:vision_emotion":
+        return "vision_retention_candidate"
+    if effect.startswith("retention:multimodal"):
+        return "multimodal_retention_candidate"
+    if effect == "operator_attention":
+        return "operator_attention_candidate"
+    candidate = ingress_receipt.get("operator_attention_candidate") if isinstance(ingress_receipt, Mapping) else None
+    if candidate:
+        return "operator_attention_candidate"
+    if "screen" in source_module:
+        return "screen_retention_candidate"
+    if "vision" in source_module:
+        return "vision_retention_candidate"
+    if "multimodal" in source_module:
+        return "multimodal_retention_candidate"
+    return "operator_attention_candidate"
+
+
+def embodied_proposal_ref(record: Mapping[str, Any]) -> str:
+    return f"proposal:{record['proposal_id']}"
+
+
+def _proposal_id(material: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return f"ep_{digest}"
+
+
+def build_embodied_proposal_record(*, source_module: str, gate_mode: str, blocked_effect_type: str, ingress_receipt: Mapping[str, Any] | None = None,
+                                   source_event_refs: Sequence[str] | None = None, source_snapshot_ref: str | None = None,
+                                   correlation_id: str | None = None, risk_flags: Mapping[str, Any] | None = None,
+                                   candidate_payload_summary: Mapping[str, Any] | None = None, rationale: Sequence[str] | None = None,
+                                   proposal_kind: str | None = None, privacy_retention_posture: str | None = None,
+                                   consent_posture: str | None = None, created_at: float | None = None) -> dict[str, Any]:
+    receipt = dict(ingress_receipt or {})
+    event_refs = list(source_event_refs if source_event_refs is not None else receipt.get("source_event_refs", []))
+    snapshot_ref = source_snapshot_ref if source_snapshot_ref is not None else receipt.get("source_snapshot_ref")
+    corr = correlation_id if correlation_id is not None else receipt.get("correlation_id")
+    material = {
+        "source_module": source_module,
+        "gate_mode": gate_mode,
+        "blocked_effect_type": blocked_effect_type,
+        "ingress_receipt_ref": receipt.get("ingress_id"),
+        "source_snapshot_ref": snapshot_ref,
+        "source_event_refs": event_refs,
+        "correlation_id": corr,
+        "candidate_payload_summary": dict(candidate_payload_summary or {}),
+    }
+    kind = proposal_kind or classify_embodied_proposal_kind(blocked_effect_type=blocked_effect_type, source_module=source_module, ingress_receipt=receipt)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "proposal_id": _proposal_id(material),
+        "proposal_kind": kind,
+        "source_module": source_module,
+        "gate_mode": gate_mode,
+        "blocked_effect_type": blocked_effect_type,
+        "ingress_receipt_ref": receipt.get("ingress_id"),
+        "source_event_refs": event_refs,
+        "source_snapshot_ref": snapshot_ref,
+        "correlation_id": corr,
+        "privacy_retention_posture": privacy_retention_posture or receipt.get("privacy_retention_posture", "review"),
+        "consent_posture": consent_posture or receipt.get("consent_posture", "not_asserted"),
+        "risk_flags": dict(risk_flags or receipt.get("risk_flags", {})),
+        "candidate_payload_summary": dict(candidate_payload_summary or {}),
+        "rationale": list(rationale or receipt.get("rationale", ["blocked_effect:proposal_only"])),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "review_status": "pending_review",
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def append_embodied_proposal(record: Mapping[str, Any], *, path: Path = DEFAULT_PROPOSAL_LOG) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return append_audit_record(path, record)
+
+
+def record_blocked_embodiment_effect(*, source_module: str, gate_mode: str, blocked_effect_type: str, ingress_receipt: Mapping[str, Any] | None = None,
+                                    candidate_payload_summary: Mapping[str, Any] | None = None, rationale: Sequence[str] | None = None,
+                                    append_proposal: Any = None) -> dict[str, Any]:
+    record = build_embodied_proposal_record(
+        source_module=source_module,
+        gate_mode=gate_mode,
+        blocked_effect_type=blocked_effect_type,
+        ingress_receipt=ingress_receipt,
+        candidate_payload_summary=candidate_payload_summary,
+        rationale=rationale,
+    )
+    writer = append_proposal or append_embodied_proposal
+    writer(record)
+    return record
+
+
+def list_recent_embodied_proposals(*, path: Path = DEFAULT_PROPOSAL_LOG, limit: int = 20) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return rows[-max(1, limit):]
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "DEFAULT_PROPOSAL_LOG",
+    "build_embodied_proposal_record",
+    "append_embodied_proposal",
+    "record_blocked_embodiment_effect",
+    "embodied_proposal_ref",
+    "list_recent_embodied_proposals",
+    "classify_embodied_proposal_kind",
+]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -153,6 +153,37 @@
         "multimodal_tracker",
         "screen_awareness"
       ]
+    },
+    "embodiment_proposals": {
+      "module_globs": [
+        "sentientos/embodiment_proposals.py"
+      ],
+      "classification": "canonical_append_only_review_surface",
+      "append_only": true,
+      "proposal_only": true,
+      "non_authoritative": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_admission_execution": true,
+      "consumes": [
+        "sentientos.embodiment_ingress",
+        "sentientos.ledger_api"
+      ],
+      "produces": [
+        "pending_review_proposals"
+      ],
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "mic_bridge",
+        "vision_tracker",
+        "multimodal_tracker",
+        "screen_awareness"
+      ]
     }
   },
   "protected_sinks": {
@@ -242,7 +273,7 @@
     {
       "file": "screen_awareness.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy OCR privacy risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible",
+      "detail": "legacy OCR privacy risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible; proposal_only now records blocked-effect proposals to sentientos.embodiment_proposals append-only review surface; compatibility_legacy fallback still preserves direct effects and remains unresolved migration risk",
       "severity": "medium",
       "remediation": "maintain quarantine markers and migrate write path to pulse adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
@@ -251,7 +282,7 @@
     {
       "file": "mic_bridge.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible",
+      "detail": "legacy microphone memory-write risk and optional raw audio retention; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible; proposal_only now records blocked-effect proposals to sentientos.embodiment_proposals append-only review surface; compatibility_legacy fallback still preserves direct effects and remains unresolved migration risk",
       "severity": "high",
       "remediation": "preserve quarantine and migrate memory write behind non-authoritative telemetry-gated adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress; move default to proposal_only after downstream admission path readiness",
       "migration_target": "sentientos.perception_api",
@@ -260,7 +291,7 @@
     {
       "file": "vision_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy vision/emotion biometric risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible",
+      "detail": "legacy vision/emotion biometric risk and direct jsonl write; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible; proposal_only now records blocked-effect proposals to sentientos.embodiment_proposals append-only review surface; compatibility_legacy fallback still preserves direct effects and remains unresolved migration risk",
       "severity": "high",
       "remediation": "preserve quarantine and migrate publication to canonical perception bus adapter; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "pulse_bus",
@@ -269,7 +300,7 @@
     {
       "file": "multimodal_tracker.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy multimodal fusion direct-write risk for per-person and environment logs; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible",
+      "detail": "legacy multimodal fusion direct-write risk for per-person and environment logs; pulse-compatible telemetry bridge added via sentientos.perception_api; retention gate mode supports proposal_only and compatibility_legacy; proposal_only blocks direct retention while compatibility preserves legacy writes; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible; proposal_only now records blocked-effect proposals to sentientos.embodiment_proposals append-only review surface; compatibility_legacy fallback still preserves direct effects and remains unresolved migration risk",
       "severity": "medium",
       "remediation": "preserve quarantine and route fusion emission to perception bus envelopes; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress",
       "migration_target": "sentientos.perception_api",
@@ -278,7 +309,7 @@
     {
       "file": "feedback.py",
       "rule": "legacy_perception_quarantine",
-      "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible",
+      "detail": "legacy feedback action-capable side effects and action logs; pulse-compatible telemetry bridge added via sentientos.perception_api; ingress gate mode supports proposal_only and compatibility_legacy; centralized gate policy via sentientos.embodiment_gate_policy; proposal_only behavior covered by focused tests; compatibility_legacy fallback retained and risk remains visible; proposal_only now records blocked-effect proposals to sentientos.embodiment_proposals append-only review surface; compatibility_legacy fallback still preserves direct effects and remains unresolved migration risk",
       "severity": "high",
       "remediation": "preserve quarantine and separate action execution from observation telemetry; keep quarantine until direct write/action/memory behavior is migrated; phase44 canonical ingress gate: sentientos.embodiment_ingress; move default to proposal_only after operator-approved action admission path exists",
       "migration_target": "sentientos.perception_api",

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -473,3 +473,29 @@ def test_phase47_manifest_mentions_gate_modes_for_legacy_modules() -> None:
         detail = rows[rel]["detail"]
         assert "proposal_only" in detail
         assert "compatibility_legacy" in detail
+
+def test_phase48_embodiment_proposals_layer_declared_and_non_authoritative() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_proposals"]
+    assert layer["append_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["no_admission_execution"] is True
+
+
+def test_phase48_embodiment_proposals_import_boundary() -> None:
+    text = (ROOT / "sentientos/embodiment_proposals.py").read_text(encoding="utf-8")
+    for forbidden in ("task_executor", "task_admission", "control_plane", "authority_surface", "memory_manager", "mic_bridge", "vision_tracker", "screen_awareness", "multimodal_tracker"):
+        assert forbidden not in text
+
+
+def test_phase48_legacy_modules_wire_proposal_recording() -> None:
+    for rel in ("mic_bridge.py", "feedback.py", "screen_awareness.py", "vision_tracker.py", "multimodal_tracker.py"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "record_blocked_embodiment_effect" in text
+
+
+def test_phase48_manifest_known_violations_include_proposal_visibility() -> None:
+    manifest = _manifest()
+    rows = {r["file"]: r for r in manifest["known_violations"]}
+    for rel in ("mic_bridge.py", "feedback.py", "screen_awareness.py", "vision_tracker.py", "multimodal_tracker.py"):
+        assert "proposal_only now records blocked-effect proposals" in rows[rel]["detail"]

--- a/tests/test_phase48_embodied_proposals.py
+++ b/tests/test_phase48_embodied_proposals.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import types
+import sys
+
+sys.modules.setdefault("notification", types.SimpleNamespace(send=lambda *a, **k: None))
+
+from sentientos.embodiment_proposals import build_embodied_proposal_record, append_embodied_proposal, list_recent_embodied_proposals
+import mic_bridge, feedback, screen_awareness, vision_tracker, multimodal_tracker
+
+
+def test_builder_shape_and_deterministic_id():
+    rec1 = build_embodied_proposal_record(source_module="mic_bridge", gate_mode="proposal_only", blocked_effect_type="memory_write", ingress_receipt={"ingress_id":"i1"}, created_at=1.0)
+    rec2 = build_embodied_proposal_record(source_module="mic_bridge", gate_mode="proposal_only", blocked_effect_type="memory_write", ingress_receipt={"ingress_id":"i1"}, created_at=2.0)
+    assert rec1["proposal_id"] == rec2["proposal_id"]
+    assert rec1["review_status"] == "pending_review"
+    assert rec1["decision_power"] == "none"
+    assert rec1["does_not_write_memory"] is True
+
+
+def test_append_and_list(tmp_path):
+    p = tmp_path / "p.jsonl"
+    rec = build_embodied_proposal_record(source_module="feedback", gate_mode="proposal_only", blocked_effect_type="feedback_action", ingress_receipt={"ingress_id":"i2"})
+    append_embodied_proposal(rec, path=p)
+    out = list_recent_embodied_proposals(path=p, limit=5)
+    assert out[-1]["proposal_id"] == rec["proposal_id"]
+
+
+def test_all_five_modules_emit_proposals_when_blocked(monkeypatch, tmp_path):
+    proposals = []
+    recorder = lambda r: proposals.append(r) or r
+
+    monkeypatch.setattr(mic_bridge, "append_memory", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no memory write")))
+    monkeypatch.setattr(mic_bridge.eu, "detect", lambda path: ({"joy": 0.1}, {}))
+    monkeypatch.setattr(mic_bridge.eu, "text_sentiment", lambda text: {"joy": 0.2})
+    monkeypatch.setattr(mic_bridge.eu, "fuse", lambda a, b: {"joy": 0.3})
+    class DummyRec:
+        def record(self, source): return object()
+        def recognize_google(self, audio): return "remember this"
+    class DummyAudioFile:
+        def __init__(self, path): self.path = path
+        def __enter__(self): return object()
+        def __exit__(self, *args): return False
+    class SR: Recognizer = DummyRec; AudioFile = DummyAudioFile
+    monkeypatch.setattr(mic_bridge, "sr", SR)
+    mic_bridge.recognize_from_file("x.wav", ingress_gate_mode="proposal_only", embodiment_proposal_recorder=recorder)
+
+    mgr = feedback.FeedbackManager(embodiment_proposal_recorder=recorder)
+    mgr.add_rule(feedback.FeedbackRule(emotion="joy", threshold=0.1, action="x"))
+    mgr.register_action("x", lambda *a: (_ for _ in ()).throw(AssertionError("no action")))
+    monkeypatch.setattr(mgr, "request_feedback", lambda *a, **k: None)
+    monkeypatch.setattr(feedback, "EMBODIMENT_INGRESS_GATE_MODE", "proposal_only")
+    mgr.process(1, {"joy": 0.9})
+
+    s = screen_awareness.ScreenAwareness(log_path=tmp_path / "screen.jsonl")
+    s._log_snapshot(screen_awareness.ScreenSnapshot(timestamp=1.0, text="hi"), ingress_gate_mode="proposal_only", embodiment_proposal_recorder=recorder)
+    v = vision_tracker.FaceEmotionTracker(camera_index=None, output_file=str(tmp_path / "vision.jsonl"))
+    v.log_result({"timestamp":1.0, "faces":[]}, ingress_gate_mode="proposal_only", embodiment_proposal_recorder=recorder)
+    mm = multimodal_tracker.MultiModalEmotionTracker(enable_vision=False, enable_voice=False, enable_scene=False, enable_screen=False, output_dir=str(tmp_path))
+    mm._log(0, {"timestamp":1.0, "vision":{}, "voice":{}}, ingress_gate_mode="proposal_only", embodiment_proposal_recorder=recorder)
+
+    kinds = {p["proposal_kind"] for p in proposals}
+    assert "memory_ingress_candidate" in kinds
+    assert "feedback_action_candidate" in kinds
+    assert "screen_retention_candidate" in kinds
+    assert "vision_retention_candidate" in kinds
+    assert "multimodal_retention_candidate" in kinds

--- a/vision_tracker.py
+++ b/vision_tracker.py
@@ -28,6 +28,7 @@ from sentientos.perception_api import emit_legacy_perception_telemetry, normaliz
 from sentientos.embodiment_fusion import build_embodiment_snapshot
 from sentientos.embodiment_gate_policy import resolve_embodiment_gate_mode
 from sentientos.embodiment_ingress import evaluate_embodiment_ingress, should_allow_legacy_retention_write, mark_legacy_direct_retention_preserved, build_retention_ingress_candidate
+from sentientos.embodiment_proposals import record_blocked_embodiment_effect
 
 HEADLESS = is_headless()
 
@@ -166,7 +167,7 @@ class FaceEmotionTracker:
                 )
         return {"timestamp": ts, "faces": faces}
 
-    def log_result(self, data: Dict[str, Any], *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE) -> dict[str, Any]:
+    def log_result(self, data: Dict[str, Any], *, ingress_gate_mode: str = EMBODIMENT_RETENTION_GATE_DEFAULT_MODE, embodiment_proposal_recorder=None) -> dict[str, Any]:
         payload = normalize_vision_observation(faces=data.get("faces", []), timestamp=float(data.get("timestamp", time.time())))
         _ = emit_legacy_perception_telemetry("vision", payload, source_module="vision_tracker", privacy_class="restricted", legacy_quarantine=True, quarantine_risk="biometric_emotion")
         _ingress = evaluate_embodiment_ingress(build_embodiment_snapshot([_]))
@@ -178,6 +179,17 @@ class FaceEmotionTracker:
             _ingress = mark_legacy_direct_retention_preserved(_ingress, retention_surface="vision_emotion", mode=resolve_embodiment_gate_mode(ingress_gate_mode, default_mode=EMBODIMENT_RETENTION_GATE_DEFAULT_MODE))
             with open(self.log_path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(payload) + "\n")
+        else:
+            _proposal = record_blocked_embodiment_effect(
+                source_module="vision_tracker",
+                gate_mode=mode,
+                blocked_effect_type="retention:vision_emotion",
+                ingress_receipt=_ingress,
+                candidate_payload_summary={"retention_surface": "vision_emotion"},
+                rationale=["proposal_only blocked legacy direct retention write"],
+                append_proposal=embodiment_proposal_recorder,
+            )
+            _ingress["blocked_effect_proposal_ref"] = _proposal["proposal_id"]
         return _ingress
 
     def update_voice_sentiment(self, face_id: int, sentiment: Dict[str, float]) -> None:


### PR DESCRIPTION
### Motivation
- Implement a canonical append-only, non-authoritative review surface so `proposal_only` ingress pressure is visible for operator review rather than silently dropped. 
- Ensure the five legacy gated surfaces (mic, feedback, screen OCR, vision/emotion, multimodal fusion) can emit reviewable proposals when blocked without performing side effects. 
- Preserve `compatibility_legacy` behavior as an explicit, visible fallback while preventing any new authority/execution/memory semantics from proposals. 

### Description
- Add `sentientos/embodiment_proposals.py` as the canonical append-only proposal module exposing `build_embodied_proposal_record`, `append_embodied_proposal`, `record_blocked_embodiment_effect`, `embodied_proposal_ref`, `list_recent_embodied_proposals`, and `classify_embodied_proposal_kind`. 
- Wire `record_blocked_embodiment_effect` into the five legacy modules (`mic_bridge.py`, `feedback.py`, `screen_awareness.py`, `vision_tracker.py`, `multimodal_tracker.py`) so blocked paths in `proposal_only` create proposal records and do not execute the blocked side effect, with optional `embodiment_proposal_recorder` injection for tests. 
- Update manifest `sentientos/system_closure/architecture_boundary_manifest.json` to declare an `embodiment_proposals` layer (append-only, non-authoritative) and annotate known-violation rows to surface the new proposal visibility. 
- Add `docs/architecture/phase48_embodied_proposal_queue_execplan.md` and focused hardware-free tests in `tests/test_phase48_embodied_proposals.py`, plus architecture boundary assertions in `tests/architecture/test_architecture_boundaries.py`. 

### Testing
- Ran focused phase tests with `python -m scripts.run_tests -q tests/test_phase48_embodied_proposals.py tests/test_phase47_embodiment_gate_policy.py tests/test_phase45_ingress_gated_effects.py tests/test_phase46_ingress_gated_retention.py` and the suite passed (skips for optional hardware where appropriate). 
- Ran manifest/integrity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` which passed. 
- Ran orchestration smoke checks with `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` which passed; dependency bootstrap occurred but tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7db868a5c8320a4650190dab8a7c0)