### PR TITLE
[codex:diagnostics] add embodied proposal review visibility summary

### DIFF
--- a/docs/architecture/phase49_embodied_proposal_visibility_execplan.md
+++ b/docs/architecture/phase49_embodied_proposal_visibility_execplan.md
@@ -1,0 +1,63 @@
+# Phase 49 ExecPlan: Embodied Proposal Diagnostic and Operator-Review Visibility
+
+## 1) Current Phase 48 proposal queue state
+- `sentientos/embodiment_proposals.py` provides append-only proposal creation and JSONL listing (`build_embodied_proposal_record`, `append_embodied_proposal`, `list_recent_embodied_proposals`).
+- Records are explicitly non-authoritative (`decision_power: "none"`, no memory/action/admission/execute flags).
+- Queue exists but no canonical compact summary surface for pending review pressure.
+
+## 2) Existing diagnostic/operator surfaces inspected
+- `sentientos/embodiment_proposals.py`
+- `sentientos/scoped_lifecycle_diagnostic.py`
+- `sentientos/orchestration_intent_fabric.py`
+- `sentientos/orchestration_spine/projection/current_state.py`
+- `sentientos/ledger_api.py`
+- scoped lifecycle/orchestration tests in `sentientos/tests/test_orchestration_intent_fabric.py`
+- architecture manifest: `sentientos/system_closure/architecture_boundary_manifest.json`
+- architecture boundary tests: `tests/architecture/test_architecture_boundaries.py`
+
+## 3) Target visibility shape
+Add a compact review summary containing:
+- `schema_version`, `summary_id`, `generated_at`
+- `proposal_count_total`, `pending_review_count`
+- `counts_by_kind`, `counts_by_source_module`
+- `high_risk_counts`:
+  - `memory_write_pressure`
+  - `action_trigger_pressure`
+  - `privacy_sensitive_retention`
+  - `biometric_or_emotion_sensitive`
+  - `multimodal_retention`
+- `most_recent_proposal_refs`
+- `oldest_pending_created_at`, `newest_pending_created_at`
+- `recommended_review_posture`
+- explicit non-authority booleans
+
+## 4) Proposal summary/filter strategy
+- Introduce read-only helper module `sentientos/embodiment_proposal_diagnostic.py`.
+- Consume records from `list_recent_embodied_proposals` (path/limit injectable for tests).
+- Filter pending proposals using `review_status == "pending_review"`.
+- Group/count deterministically by kind/source/risk from record fields.
+- Stable recent refs ordered by `created_at` descending with proposal_id tie-break.
+
+## 5) Non-authority boundaries
+- Helper module performs read + summarize only.
+- No writes to proposal queue, memory, feedback, admission, task execution, or routing.
+- Add explicit summary flags documenting non-authoritative posture.
+- Architecture manifest + tests enforce forbidden authority imports and declared read-only posture.
+
+## 6) Tests to add/update
+- New focused tests: `tests/test_phase49_embodied_proposal_visibility.py`:
+  - empty summary behavior
+  - mixed record counts/risk/posture
+  - list/read integration via temp JSONL
+  - scoped lifecycle diagnostic additive integration
+  - non-authority fields
+- Update `tests/architecture/test_architecture_boundaries.py`:
+  - manifest declaration checks for new layer
+  - forbidden import checks on diagnostic modules
+  - no legacy perception imports
+- Keep existing Phase 48 tests unchanged except compatibility.
+
+## 7) Deferred risks and why
+- No approval/rejection/execution workflow is added (out of scope).
+- Risk taxonomy remains heuristic from proposal fields; future phases can enrich risk provenance.
+- Scoped lifecycle diagnostic growth continues; future refactor may split orchestration and embodiment diagnostics for size/manageability.

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from sentientos.embodiment_proposals import embodied_proposal_ref, list_recent_embodied_proposals
+
+SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
+
+
+def group_embodied_proposals_by_kind(proposals: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    grouped: dict[str, int] = {}
+    for row in proposals:
+        kind = str(row.get("proposal_kind") or "unknown")
+        grouped[kind] = grouped.get(kind, 0) + 1
+    return dict(sorted(grouped.items()))
+
+
+def count_pending_embodied_proposals(proposals: Iterable[Mapping[str, Any]]) -> int:
+    return sum(1 for row in proposals if str(row.get("review_status") or "") == "pending_review")
+
+
+def _counts_by_source_module(proposals: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    grouped: dict[str, int] = {}
+    for row in proposals:
+        source = str(row.get("source_module") or "unknown")
+        grouped[source] = grouped.get(source, 0) + 1
+    return dict(sorted(grouped.items()))
+
+
+def _truthy(value: Any) -> bool:
+    return bool(value) and value not in {"none", "not_asserted", "unknown"}
+
+
+def _high_risk_counts(pending: list[Mapping[str, Any]]) -> dict[str, int]:
+    out = {
+        "memory_write_pressure": 0,
+        "action_trigger_pressure": 0,
+        "privacy_sensitive_retention": 0,
+        "biometric_or_emotion_sensitive": 0,
+        "multimodal_retention": 0,
+    }
+    for row in pending:
+        kind = str(row.get("proposal_kind") or "")
+        blocked = str(row.get("blocked_effect_type") or "")
+        risk_flags = row.get("risk_flags") if isinstance(row.get("risk_flags"), Mapping) else {}
+        privacy = str(row.get("privacy_retention_posture") or "")
+        candidate = row.get("candidate_payload_summary") if isinstance(row.get("candidate_payload_summary"), Mapping) else {}
+
+        if kind == "memory_ingress_candidate" or blocked == "memory_write":
+            out["memory_write_pressure"] += 1
+        if kind == "feedback_action_candidate" or blocked == "feedback_action":
+            out["action_trigger_pressure"] += 1
+        if "retention" in kind or blocked.startswith("retention:"):
+            if privacy in {"review", "restricted", "sensitive"}:
+                out["privacy_sensitive_retention"] += 1
+        if kind == "multimodal_retention_candidate" or blocked.startswith("retention:multimodal"):
+            out["multimodal_retention"] += 1
+        if _truthy(risk_flags.get("biometric_sensitive")) or _truthy(risk_flags.get("emotion_sensitive")) or _truthy(candidate.get("emotion")):
+            out["biometric_or_emotion_sensitive"] += 1
+    return out
+
+
+def classify_embodied_proposal_review_posture(*, pending_review_count: int, high_risk_counts: Mapping[str, int]) -> str:
+    if pending_review_count <= 0:
+        return "no_pending_embodied_proposals"
+
+    has_memory_or_action = (high_risk_counts.get("memory_write_pressure", 0) > 0 or high_risk_counts.get("action_trigger_pressure", 0) > 0)
+    has_privacy = high_risk_counts.get("privacy_sensitive_retention", 0) > 0
+    if has_memory_or_action and has_privacy:
+        return "pending_mixed_high_risk_review"
+    if has_memory_or_action:
+        return "pending_action_or_memory_review"
+    if has_privacy:
+        return "pending_privacy_sensitive_review"
+    return "pending_low_risk_review"
+
+
+def _recent_refs(proposals: list[Mapping[str, Any]], *, limit: int = 5) -> list[str]:
+    ordered = sorted(
+        proposals,
+        key=lambda row: (float(row.get("created_at") or 0.0), str(row.get("proposal_id") or "")),
+        reverse=True,
+    )
+    return [embodied_proposal_ref(row) for row in ordered[: max(1, limit)] if "proposal_id" in row]
+
+
+def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, generated_at: float | None = None) -> dict[str, Any]:
+    pending = [row for row in proposals if str(row.get("review_status") or "") == "pending_review"]
+    pending_times = [float(row.get("created_at")) for row in pending if isinstance(row.get("created_at"), (int, float))]
+    risk = _high_risk_counts(pending)
+    posture = classify_embodied_proposal_review_posture(pending_review_count=len(pending), high_risk_counts=risk)
+    summary_material = {
+        "pending_review_count": len(pending),
+        "counts_by_kind": group_embodied_proposals_by_kind(pending),
+        "counts_by_source_module": _counts_by_source_module(pending),
+        "posture": posture,
+    }
+    digest = hashlib.sha256(json.dumps(summary_material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:20]
+    return {
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "summary_id": f"eprs_{digest}",
+        "generated_at": float(generated_at if generated_at is not None else time.time()),
+        "proposal_count_total": len(proposals),
+        "pending_review_count": len(pending),
+        "counts_by_kind": group_embodied_proposals_by_kind(pending),
+        "counts_by_source_module": _counts_by_source_module(pending),
+        "high_risk_counts": risk,
+        "most_recent_proposal_refs": _recent_refs(pending),
+        "oldest_pending_created_at": min(pending_times) if pending_times else None,
+        "newest_pending_created_at": max(pending_times) if pending_times else None,
+        "recommended_review_posture": posture,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def build_embodied_proposal_review_summary(*, path: Path, limit: int = 200, generated_at: float | None = None) -> dict[str, Any]:
+    proposals = list_recent_embodied_proposals(path=path, limit=limit)
+    return summarize_recent_embodied_proposals(proposals, generated_at=generated_at)
+
+
+__all__ = [
+    "SUMMARY_SCHEMA_VERSION",
+    "build_embodied_proposal_review_summary",
+    "summarize_recent_embodied_proposals",
+    "classify_embodied_proposal_review_posture",
+    "group_embodied_proposals_by_kind",
+    "count_pending_embodied_proposals",
+]

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -11,6 +11,8 @@ from sentientos.scoped_slice_stability import derive_scoped_slice_stability
 from sentientos.scoped_slice_retrospective_integrity import derive_scoped_slice_retrospective_integrity_review
 from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice_attention_recommendation
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
+from sentientos.embodiment_proposal_diagnostic import build_embodied_proposal_review_summary
+from sentientos.embodiment_proposals import DEFAULT_PROPOSAL_LOG
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_handoff_packet_ledger,
@@ -399,6 +401,11 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         resolve_lifecycle=resolve_deep_research_staged_work_order_lifecycle,
         schema_version="deep_research_staged_venue_diagnostic.v1",
     )
+    embodiment_proposal_review_summary = build_embodied_proposal_review_summary(
+        path=root / DEFAULT_PROPOSAL_LOG,
+        limit=200,
+    )
+
     return {
         "scope": "constitutional_execution_fabric_scoped_slice",
         "overall_outcome": overall,
@@ -548,4 +555,5 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
             "deep_research_staged_venue": deep_research_staged_venue,
         },
         "actions": rows,
+        "embodiment_proposal_review_summary": embodiment_proposal_review_summary,
     }

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -184,6 +184,38 @@
         "multimodal_tracker",
         "screen_awareness"
       ]
+    },
+    "embodiment_proposal_diagnostic": {
+      "module_globs": [
+        "sentientos/embodiment_proposal_diagnostic.py"
+      ],
+      "classification": "embodied_proposal_review_visibility",
+      "read_only": true,
+      "summary_only": true,
+      "non_authoritative": true,
+      "no_proposal_mutation": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_admission_execution": true,
+      "consumes": [
+        "sentientos.embodiment_proposals"
+      ],
+      "produces": [
+        "embodied_proposal_review_summaries"
+      ],
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "mic_bridge",
+        "vision_tracker",
+        "multimodal_tracker",
+        "screen_awareness",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -499,3 +499,30 @@ def test_phase48_manifest_known_violations_include_proposal_visibility() -> None
     rows = {r["file"]: r for r in manifest["known_violations"]}
     for rel in ("mic_bridge.py", "feedback.py", "screen_awareness.py", "vision_tracker.py", "multimodal_tracker.py"):
         assert "proposal_only now records blocked-effect proposals" in rows[rel]["detail"]
+
+
+def test_phase49_manifest_declares_embodiment_proposal_diagnostic_non_authoritative() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_proposal_diagnostic"]
+    assert layer["read_only"] is True
+    assert layer["summary_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["no_proposal_mutation"] is True
+    assert layer["no_admission_execution"] is True
+
+
+def test_phase49_embodiment_proposal_diagnostic_forbidden_imports() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_proposal_diagnostic"]
+    text = (ROOT / "sentientos/embodiment_proposal_diagnostic.py").read_text(encoding="utf-8")
+    for pattern in layer["forbidden_import_patterns"]:
+        assert f"import {pattern}" not in text
+        assert f"from {pattern} import" not in text
+
+
+def test_phase49_scoped_lifecycle_diagnostic_does_not_mutate_or_execute_proposals() -> None:
+    text = (ROOT / "sentientos/scoped_lifecycle_diagnostic.py").read_text(encoding="utf-8")
+    assert "build_embodied_proposal_review_summary" in text
+    assert "append_embodied_proposal" not in text
+    assert "record_blocked_embodiment_effect" not in text
+    assert "task_executor" not in text

--- a/tests/test_phase49_embodied_proposal_visibility.py
+++ b/tests/test_phase49_embodied_proposal_visibility.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sentientos.embodiment_proposal_diagnostic import (
+    build_embodied_proposal_review_summary,
+    summarize_recent_embodied_proposals,
+)
+from sentientos.embodiment_proposals import append_embodied_proposal, build_embodied_proposal_record, list_recent_embodied_proposals
+from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
+
+
+def _proposal(kind_effect: str, source: str, *, t: float, risk_flags=None, privacy="review"):
+    return build_embodied_proposal_record(
+        source_module=source,
+        gate_mode="proposal_only",
+        blocked_effect_type=kind_effect,
+        ingress_receipt={"ingress_id": f"i-{source}-{t}", "risk_flags": risk_flags or {}},
+        created_at=t,
+        privacy_retention_posture=privacy,
+    )
+
+
+def test_phase49_summary_empty() -> None:
+    summary = summarize_recent_embodied_proposals([], generated_at=10.0)
+    assert summary["recommended_review_posture"] == "no_pending_embodied_proposals"
+    assert summary["proposal_count_total"] == 0
+    assert summary["pending_review_count"] == 0
+    assert summary["counts_by_kind"] == {}
+    assert summary["counts_by_source_module"] == {}
+    assert summary["non_authoritative"] is True
+    assert summary["decision_power"] == "none"
+
+
+def test_phase49_summary_mixed_risk_and_stable_recent_refs() -> None:
+    proposals = [
+        _proposal("memory_write", "mic_bridge", t=1.0),
+        _proposal("feedback_action", "feedback", t=2.0),
+        _proposal("retention:screen_ocr", "screen_awareness", t=3.0, risk_flags={"emotion_sensitive": True}),
+        _proposal("retention:multimodal:scene_voice", "multimodal_tracker", t=4.0, risk_flags={"biometric_sensitive": True}),
+    ]
+    summary = summarize_recent_embodied_proposals(proposals, generated_at=11.0)
+    assert summary["counts_by_kind"]["memory_ingress_candidate"] == 1
+    assert summary["counts_by_kind"]["feedback_action_candidate"] == 1
+    assert summary["counts_by_source_module"]["mic_bridge"] == 1
+    assert summary["counts_by_source_module"]["multimodal_tracker"] == 1
+    assert summary["high_risk_counts"]["memory_write_pressure"] == 1
+    assert summary["high_risk_counts"]["action_trigger_pressure"] == 1
+    assert summary["high_risk_counts"]["privacy_sensitive_retention"] == 2
+    assert summary["high_risk_counts"]["multimodal_retention"] == 1
+    assert summary["recommended_review_posture"] == "pending_mixed_high_risk_review"
+    assert summary["most_recent_proposal_refs"][0].startswith("proposal:")
+
+
+def test_phase49_read_list_integration(tmp_path: Path) -> None:
+    path = tmp_path / "embodied_proposals.jsonl"
+    append_embodied_proposal(_proposal("memory_write", "mic_bridge", t=1.0), path=path)
+    append_embodied_proposal(_proposal("retention:vision_emotion", "vision_tracker", t=2.0), path=path)
+    recent = list_recent_embodied_proposals(path=path, limit=20)
+    summary = build_embodied_proposal_review_summary(path=path, limit=20, generated_at=20.0)
+    assert len(recent) == 2
+    assert summary["proposal_count_total"] == 2
+    assert summary["pending_review_count"] == 2
+
+
+def test_phase49_scoped_lifecycle_additive_integration(tmp_path: Path) -> None:
+    proposal_path = tmp_path / "logs/embodiment_proposals.jsonl"
+    append_embodied_proposal(_proposal("memory_write", "mic_bridge", t=1.0), path=proposal_path)
+    diagnostic = build_scoped_lifecycle_diagnostic(tmp_path)
+    assert "scope" in diagnostic
+    assert "actions" in diagnostic
+    assert "embodiment_proposal_review_summary" in diagnostic
+    summary = diagnostic["embodiment_proposal_review_summary"]
+    assert summary["decision_power"] == "none"
+    assert summary["does_not_trigger_feedback"] is True
+    assert summary["does_not_write_memory"] is True


### PR DESCRIPTION
### Motivation
- Provide a canonical, non-authoritative visibility surface for Phase 48 embodied proposals so operator/diagnostic surfaces can inspect pending memory/action/retention pressure without granting execution, admission, or write authority.
- Surface that summary additively into the existing scoped lifecycle diagnostic so operators see embodied proposal pressure alongside other orchestration diagnostics.

### Description
- Add `sentientos/embodiment_proposal_diagnostic.py` providing deterministic read-only helpers: `build_embodied_proposal_review_summary`, `summarize_recent_embodied_proposals`, `classify_embodied_proposal_review_posture`, `group_embodied_proposals_by_kind`, and `count_pending_embodied_proposals` which consume Phase 48 JSONL proposal records and emit a compact summary shape with explicit non-authoritative flags.
- Integrate the summary additively into `build_scoped_lifecycle_diagnostic` as `embodiment_proposal_review_summary` (reads `logs/embodiment_proposals.jsonl` via the diagnostic helper) without mutating proposals.
- Update `sentientos/system_closure/architecture_boundary_manifest.json` to declare a new `embodiment_proposal_diagnostic` layer with `read_only`/`summary_only`/`non_authoritative` constraints and forbidden authority imports.
- Add `docs/architecture/phase49_embodied_proposal_visibility_execplan.md` and focused tests in `tests/test_phase49_embodied_proposal_visibility.py` plus architecture boundary enforcement in `tests/architecture/test_architecture_boundaries.py` to assert non-authority and import boundaries.

### Testing
- Ran focused Phase 49 and Phase 48 tests: `python -m scripts.run_tests -q tests/test_phase49_embodied_proposal_visibility.py tests/test_phase48_embodied_proposals.py tests/test_phase47_embodiment_gate_policy.py` and they passed (focused suite completed successfully).
- Ran architecture and import-purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed.
- Ran orchestration/diagnostic smoke tests: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` and they passed, confirming additive diagnostic integration and boundary safety.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7e0cd6e5c8320ba30c0a28014ad9f)