### PR TITLE
[codex:embodiment] add append-only proposal review receipt surface

### DIFF
--- a/docs/architecture/phase50_embodied_proposal_review_receipts_execplan.md
+++ b/docs/architecture/phase50_embodied_proposal_review_receipts_execplan.md
@@ -1,0 +1,37 @@
+# Phase 50 ExecPlan: Embodied Proposal Review Receipts
+
+## 1) Current Phase 48/49 state
+- Phase 48 provides append-only proposal records in `sentientos.embodiment_proposals`.
+- Phase 49 provides read-only diagnostics in `sentientos.embodiment_proposal_diagnostic` and scoped lifecycle additive inclusion.
+- Gap: no canonical append-only review receipt layer for adjudication outcomes.
+
+## 2) Target review receipt shape
+- Add `sentientos.embodiment_proposal_review` with compact JSON-serializable review receipt schema.
+- Receipt includes proposal provenance, reviewer metadata, outcome, rationale, risk/privacy/consent posture, and explicit non-authority flags.
+
+## 3) Allowed review outcomes
+- `pending_review`
+- `reviewed_deferred`
+- `reviewed_rejected`
+- `reviewed_needs_more_context`
+- `reviewed_approved_for_next_stage`
+
+## 4) Append-only/provenance strategy
+- Append via `sentientos.ledger_api.append_audit_record` to `logs/embodiment_proposal_reviews.jsonl`.
+- Deterministic receipt ID from stable hash material.
+- Preserve `proposal_id`, `proposal_ref`, ingress ref, source event refs, and correlation id.
+
+## 5) Relationship to future fulfillment/admission
+- This phase is non-authoritative and non-executing.
+- `reviewed_approved_for_next_stage` is explicitly **not execution** and does not admit work.
+- Future admission/fulfillment layers must consume these receipts explicitly and remain separate.
+
+## 6) Tests to add/update
+- New focused tests for builder, append/list, resolver, summary integration, and non-authority invariants.
+- Update Phase 49 tests for additive review fields.
+- Update architecture boundaries test + manifest declaration checks.
+
+## 7) Deferred risks
+- No fulfillment/admission coupling yet (deferred to future phase by design).
+- No operator UI (deferred).
+- No cross-process compaction/indexing for large ledgers (deferred; append-only is sufficient for this phase).

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from sentientos.embodiment_proposals import embodied_proposal_ref, list_recent_embodied_proposals
+from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG, list_recent_embodied_proposal_review_receipts, summarize_embodied_proposal_review_status
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -88,7 +89,7 @@ def _recent_refs(proposals: list[Mapping[str, Any]], *, limit: int = 5) -> list[
     return [embodied_proposal_ref(row) for row in ordered[: max(1, limit)] if "proposal_id" in row]
 
 
-def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, generated_at: float | None = None) -> dict[str, Any]:
+def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, review_receipts: list[Mapping[str, Any]] | None = None, generated_at: float | None = None) -> dict[str, Any]:
     pending = [row for row in proposals if str(row.get("review_status") or "") == "pending_review"]
     pending_times = [float(row.get("created_at")) for row in pending if isinstance(row.get("created_at"), (int, float))]
     risk = _high_risk_counts(pending)
@@ -100,6 +101,7 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, g
         "posture": posture,
     }
     digest = hashlib.sha256(json.dumps(summary_material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:20]
+    review_summary = summarize_embodied_proposal_review_status(proposals=proposals, review_receipts=list(review_receipts or []))
     return {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "summary_id": f"eprs_{digest}",
@@ -113,6 +115,7 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, g
         "oldest_pending_created_at": min(pending_times) if pending_times else None,
         "newest_pending_created_at": max(pending_times) if pending_times else None,
         "recommended_review_posture": posture,
+        **review_summary,
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,
@@ -122,9 +125,10 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, g
     }
 
 
-def build_embodied_proposal_review_summary(*, path: Path, limit: int = 200, generated_at: float | None = None) -> dict[str, Any]:
+def build_embodied_proposal_review_summary(*, path: Path, review_receipt_path: Path | None = None, limit: int = 200, generated_at: float | None = None) -> dict[str, Any]:
     proposals = list_recent_embodied_proposals(path=path, limit=limit)
-    return summarize_recent_embodied_proposals(proposals, generated_at=generated_at)
+    review_rows = list_recent_embodied_proposal_review_receipts(path=review_receipt_path or DEFAULT_REVIEW_RECEIPT_LOG, limit=limit)
+    return summarize_recent_embodied_proposals(proposals, review_receipts=review_rows, generated_at=generated_at)
 
 
 __all__ = [

--- a/sentientos/embodiment_proposal_review.py
+++ b/sentientos/embodiment_proposal_review.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sentientos.ledger_api import append_audit_record
+from sentientos.embodiment_proposals import DEFAULT_PROPOSAL_LOG, embodied_proposal_ref, list_recent_embodied_proposals
+
+SCHEMA_VERSION = "embodiment.proposal.review_receipt.v1"
+DEFAULT_REVIEW_RECEIPT_LOG = Path("logs/embodiment_proposal_reviews.jsonl")
+
+ALLOWED_REVIEW_OUTCOMES = {
+    "pending_review",
+    "reviewed_deferred",
+    "reviewed_rejected",
+    "reviewed_needs_more_context",
+    "reviewed_approved_for_next_stage",
+}
+ALLOWED_REVIEWER_KINDS = {"operator", "system_policy", "diagnostic", "test_fixture"}
+
+
+def classify_embodied_proposal_review_outcome(review_outcome: str) -> str:
+    outcome = str(review_outcome or "").strip().lower()
+    if outcome not in ALLOWED_REVIEW_OUTCOMES:
+        raise ValueError(f"unsupported review_outcome: {review_outcome}")
+    return outcome
+
+
+def embodied_proposal_review_receipt_ref(record: Mapping[str, Any]) -> str:
+    return f"proposal_review:{record['review_receipt_id']}"
+
+
+def _review_receipt_id(material: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return f"eprr_{digest}"
+
+
+def build_embodied_proposal_review_receipt(*, proposal_record: Mapping[str, Any], review_outcome: str, reviewer_kind: str,
+                                           reviewer_ref: str | None = None, reviewer_label: str | None = None,
+                                           review_rationale: str | None = None, source_event_refs: Sequence[str] | None = None,
+                                           risk_flags: Mapping[str, Any] | None = None, correlation_id: str | None = None,
+                                           created_at: float | None = None) -> dict[str, Any]:
+    outcome = classify_embodied_proposal_review_outcome(review_outcome)
+    reviewer_kind_normalized = str(reviewer_kind or "").strip().lower()
+    if reviewer_kind_normalized not in ALLOWED_REVIEWER_KINDS:
+        raise ValueError(f"unsupported reviewer_kind: {reviewer_kind}")
+
+    proposal_ref = embodied_proposal_ref(proposal_record)
+    material = {
+        "proposal_id": proposal_record.get("proposal_id"),
+        "proposal_ref": proposal_ref,
+        "review_outcome": outcome,
+        "reviewer_kind": reviewer_kind_normalized,
+        "reviewer_ref": reviewer_ref,
+        "reviewer_label": reviewer_label,
+        "review_rationale": review_rationale,
+        "correlation_id": correlation_id if correlation_id is not None else proposal_record.get("correlation_id"),
+        "source_event_refs": list(source_event_refs if source_event_refs is not None else proposal_record.get("source_event_refs", [])),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "review_receipt_id": _review_receipt_id(material),
+        "proposal_id": proposal_record.get("proposal_id"),
+        "proposal_ref": proposal_ref,
+        "proposal_kind": str(proposal_record.get("proposal_kind") or "unknown"),
+        "review_outcome": outcome,
+        "reviewer_kind": reviewer_kind_normalized,
+        "reviewer_ref": reviewer_ref,
+        "reviewer_label": reviewer_label,
+        "review_rationale": review_rationale or "review_recorded",
+        "source_proposal_ref": proposal_ref,
+        "source_ingress_receipt_ref": proposal_record.get("ingress_receipt_ref"),
+        "source_event_refs": list(source_event_refs if source_event_refs is not None else proposal_record.get("source_event_refs", [])),
+        "correlation_id": correlation_id if correlation_id is not None else proposal_record.get("correlation_id"),
+        "risk_flags": dict(risk_flags or proposal_record.get("risk_flags") or {}),
+        "privacy_retention_posture": proposal_record.get("privacy_retention_posture", "review"),
+        "consent_posture": proposal_record.get("consent_posture", "not_asserted"),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+        "approval_is_not_execution": True,
+    }
+
+
+def append_embodied_proposal_review_receipt(record: Mapping[str, Any], *, path: Path = DEFAULT_REVIEW_RECEIPT_LOG) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return append_audit_record(path, record)
+
+
+def list_recent_embodied_proposal_review_receipts(*, path: Path = DEFAULT_REVIEW_RECEIPT_LOG, limit: int = 50) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return rows[-max(1, limit):]
+
+
+def resolve_embodied_proposal_review_state(*, proposals: Sequence[Mapping[str, Any]], review_receipts: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    latest: dict[str, tuple[float, str, str]] = {}
+    for row in review_receipts:
+        pid = str(row.get("proposal_id") or "")
+        if not pid:
+            continue
+        ts = float(row.get("created_at") or 0.0)
+        rid = str(row.get("review_receipt_id") or "")
+        outcome = classify_embodied_proposal_review_outcome(str(row.get("review_outcome") or "pending_review"))
+        current = latest.get(pid)
+        if current is None or (ts, rid) >= (current[0], current[1]):
+            latest[pid] = (ts, rid, outcome)
+
+    resolved: dict[str, str] = {}
+    for proposal in proposals:
+        pid = str(proposal.get("proposal_id") or "")
+        if not pid:
+            continue
+        outcome = latest.get(pid, (0.0, "", "pending_review"))[2]
+        mapped = {
+            "pending_review": "pending_review",
+            "reviewed_deferred": "deferred",
+            "reviewed_rejected": "rejected",
+            "reviewed_needs_more_context": "needs_more_context",
+            "reviewed_approved_for_next_stage": "approved_for_next_stage",
+        }[outcome]
+        resolved[pid] = mapped
+    return resolved
+
+
+def summarize_embodied_proposal_review_status(*, proposals: Sequence[Mapping[str, Any]], review_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    states = resolve_embodied_proposal_review_state(proposals=proposals, review_receipts=review_receipts)
+    counts = {"pending_review": 0, "approved_for_next_stage": 0, "rejected": 0, "deferred": 0, "needs_more_context": 0}
+    for state in states.values():
+        counts[state] = counts.get(state, 0) + 1
+    high_risk_pending = 0
+    by_id = {str(p.get("proposal_id") or ""): p for p in proposals}
+    for pid, state in states.items():
+        if state != "pending_review":
+            continue
+        row = by_id.get(pid, {})
+        flags = row.get("risk_flags") if isinstance(row.get("risk_flags"), Mapping) else {}
+        if flags.get("biometric_sensitive") or flags.get("emotion_sensitive"):
+            high_risk_pending += 1
+
+    if not proposals or counts["pending_review"] == 0:
+        posture = "no_pending_review_activity"
+    elif counts["pending_review"] > 0 and counts["approved_for_next_stage"] == 0 and counts["rejected"] == 0 and counts["deferred"] == 0 and counts["needs_more_context"] == 0:
+        posture = "pending_review_items"
+    elif counts["pending_review"] == 0 and counts["approved_for_next_stage"] > 0:
+        posture = "reviewed_items_waiting_next_stage"
+    elif high_risk_pending > 0:
+        posture = "high_risk_review_pending"
+    else:
+        posture = "mixed_review_state"
+
+    return {
+        "review_counts_by_outcome": counts,
+        "pending_without_review_count": counts["pending_review"],
+        "approved_for_next_stage_count": counts["approved_for_next_stage"],
+        "rejected_count": counts["rejected"],
+        "deferred_count": counts["deferred"],
+        "needs_more_context_count": counts["needs_more_context"],
+        "review_posture": posture,
+    }
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "DEFAULT_REVIEW_RECEIPT_LOG",
+    "ALLOWED_REVIEW_OUTCOMES",
+    "build_embodied_proposal_review_receipt",
+    "append_embodied_proposal_review_receipt",
+    "list_recent_embodied_proposal_review_receipts",
+    "embodied_proposal_review_receipt_ref",
+    "classify_embodied_proposal_review_outcome",
+    "resolve_embodied_proposal_review_state",
+    "summarize_embodied_proposal_review_status",
+    "DEFAULT_PROPOSAL_LOG",
+    "list_recent_embodied_proposals",
+]

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -13,6 +13,7 @@ from sentientos.scoped_slice_attention_recommendation import derive_scoped_slice
 from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evidence, synthesize_delegated_judgment
 from sentientos.embodiment_proposal_diagnostic import build_embodied_proposal_review_summary
 from sentientos.embodiment_proposals import DEFAULT_PROPOSAL_LOG
+from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_handoff_packet_ledger,
@@ -403,6 +404,7 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
     )
     embodiment_proposal_review_summary = build_embodied_proposal_review_summary(
         path=root / DEFAULT_PROPOSAL_LOG,
+        review_receipt_path=root / DEFAULT_REVIEW_RECEIPT_LOG,
         limit=200,
     )
 

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -216,6 +216,39 @@
         "screen_awareness",
         "sentientos.perception_api"
       ]
+    },
+    "embodiment_proposal_review": {
+      "module_globs": [
+        "sentientos/embodiment_proposal_review.py"
+      ],
+      "classification": "append_only_review_receipt_surface",
+      "append_only": true,
+      "review_only": true,
+      "non_authoritative": true,
+      "approval_is_not_execution": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_admission_execution": true,
+      "consumes": [
+        "sentientos.embodiment_proposals",
+        "sentientos.ledger_api"
+      ],
+      "produces": [
+        "embodied_proposal_review_receipts"
+      ],
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "mic_bridge",
+        "vision_tracker",
+        "multimodal_tracker",
+        "screen_awareness",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -526,3 +526,31 @@ def test_phase49_scoped_lifecycle_diagnostic_does_not_mutate_or_execute_proposal
     assert "append_embodied_proposal" not in text
     assert "record_blocked_embodiment_effect" not in text
     assert "task_executor" not in text
+
+def test_phase50_review_module_manifest_and_invariants() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_proposal_review"]
+    assert layer["append_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["approval_is_not_execution"] is True
+
+
+def test_phase50_review_module_forbidden_imports_and_semantics() -> None:
+    path = ROOT / "sentientos/embodiment_proposal_review.py"
+    imports = _imports(path)
+    forbidden_tokens = [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "memory_manager",
+        "feedback",
+        "sentientos.perception_api",
+    ]
+    for mod, symbol in imports:
+        imp = f"{mod}.{symbol}" if symbol else mod
+        for token in forbidden_tokens:
+            assert not (mod == token or mod.startswith(token) or imp == token)
+    text = path.read_text(encoding="utf-8")
+    assert '"approval_is_not_execution": True' in text
+    assert '"decision_power": "none"' in text

--- a/tests/test_phase49_embodied_proposal_visibility.py
+++ b/tests/test_phase49_embodied_proposal_visibility.py
@@ -30,6 +30,7 @@ def test_phase49_summary_empty() -> None:
     assert summary["counts_by_source_module"] == {}
     assert summary["non_authoritative"] is True
     assert summary["decision_power"] == "none"
+    assert summary["review_counts_by_outcome"]["pending_review"] == 0
 
 
 def test_phase49_summary_mixed_risk_and_stable_recent_refs() -> None:
@@ -61,6 +62,7 @@ def test_phase49_read_list_integration(tmp_path: Path) -> None:
     assert len(recent) == 2
     assert summary["proposal_count_total"] == 2
     assert summary["pending_review_count"] == 2
+    assert summary["pending_without_review_count"] == 2
 
 
 def test_phase49_scoped_lifecycle_additive_integration(tmp_path: Path) -> None:

--- a/tests/test_phase50_embodied_proposal_review_receipts.py
+++ b/tests/test_phase50_embodied_proposal_review_receipts.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sentientos.embodiment_proposal_diagnostic import summarize_recent_embodied_proposals
+from sentientos.embodiment_proposal_review import (
+    append_embodied_proposal_review_receipt,
+    build_embodied_proposal_review_receipt,
+    list_recent_embodied_proposal_review_receipts,
+    resolve_embodied_proposal_review_state,
+)
+from sentientos.embodiment_proposals import build_embodied_proposal_record
+
+
+def _proposal(pid: str, *, t: float = 1.0):
+    row = build_embodied_proposal_record(source_module="mic_bridge", gate_mode="proposal_only", blocked_effect_type="memory_write", ingress_receipt={"ingress_id": f"i-{pid}"}, created_at=t)
+    row["proposal_id"] = pid
+    return row
+
+
+def test_phase50_review_builder_shape_and_non_authority():
+    proposal = _proposal("p1")
+    receipt = build_embodied_proposal_review_receipt(proposal_record=proposal, review_outcome="reviewed_approved_for_next_stage", reviewer_kind="operator", reviewer_label="alice")
+    assert receipt["proposal_id"] == "p1"
+    assert receipt["review_outcome"] == "reviewed_approved_for_next_stage"
+    assert receipt["decision_power"] == "none"
+    assert receipt["approval_is_not_execution"] is True
+    assert receipt["does_not_write_memory"] is True
+    assert receipt["does_not_trigger_feedback"] is True
+
+
+def test_phase50_append_and_list_review_receipts(tmp_path: Path):
+    proposal = _proposal("p2")
+    r1 = build_embodied_proposal_review_receipt(proposal_record=proposal, review_outcome="reviewed_deferred", reviewer_kind="test_fixture")
+    r2 = build_embodied_proposal_review_receipt(proposal_record=proposal, review_outcome="reviewed_rejected", reviewer_kind="test_fixture", created_at=5.0)
+    path = tmp_path / "reviews.jsonl"
+    append_embodied_proposal_review_receipt(r1, path=path)
+    append_embodied_proposal_review_receipt(r2, path=path)
+    rows = list_recent_embodied_proposal_review_receipts(path=path, limit=10)
+    assert len(rows) == 2
+    assert rows[-1]["review_outcome"] == "reviewed_rejected"
+
+
+def test_phase50_review_state_resolver_latest_receipt_wins():
+    p = _proposal("p3")
+    older = build_embodied_proposal_review_receipt(proposal_record=p, review_outcome="reviewed_needs_more_context", reviewer_kind="diagnostic", created_at=1.0)
+    newer = build_embodied_proposal_review_receipt(proposal_record=p, review_outcome="reviewed_approved_for_next_stage", reviewer_kind="operator", created_at=3.0)
+    state = resolve_embodied_proposal_review_state(proposals=[p], review_receipts=[older, newer])
+    assert state["p3"] == "approved_for_next_stage"
+    assert resolve_embodied_proposal_review_state(proposals=[p], review_receipts=[])["p3"] == "pending_review"
+
+
+def test_phase50_summary_integration_review_counts():
+    p1 = _proposal("p4", t=1.0)
+    p2 = _proposal("p5", t=2.0)
+    r1 = build_embodied_proposal_review_receipt(proposal_record=p1, review_outcome="reviewed_rejected", reviewer_kind="operator")
+    summary = summarize_recent_embodied_proposals([p1, p2], review_receipts=[r1], generated_at=9.0)
+    assert summary["rejected_count"] == 1
+    assert summary["pending_without_review_count"] == 1
+    assert summary["approved_for_next_stage_count"] == 0
+    assert summary["decision_power"] == "none"


### PR DESCRIPTION
### Motivation

- Provide an append-only, non-authoritative adjudication surface for Phase 50 so embodied proposals can receive explicit review outcomes without admission, execution, memory writes, or feedback triggers.
- Maintain Phase 48/49 read/diagnostic compatibility while enabling deterministic, provenance-preserving review receipts that downstream fulfillment layers may consume later.

### Description

- Add `sentientos/embodiment_proposal_review.py` implementing a compact review-receipt schema and helpers including `build_embodied_proposal_review_receipt`, `append_embodied_proposal_review_receipt`, `list_recent_embodied_proposal_review_receipts`, `embodied_proposal_review_receipt_ref`, `classify_embodied_proposal_review_outcome`, `resolve_embodied_proposal_review_state`, and `summarize_embodied_proposal_review_status`.
- Integrate review-derived summary fields additively into `sentientos/embodiment_proposal_diagnostic.py` and wire scoped lifecycle diagnostic to read review receipts without mutating proposals.
- Add `docs/architecture/phase50_embodied_proposal_review_receipts_execplan.md` describing schema, allowed outcomes, append/provenance strategy, tests, and deferred risks.
- Update `sentientos/system_closure/architecture_boundary_manifest.json` to declare the new `embodiment_proposal_review` layer with non-authoritative, append-only, no-execution/no-mutation constraints and forbidden import patterns.
- Add focused tests `tests/test_phase50_embodied_proposal_review_receipts.py` and extend `tests/test_phase49_embodied_proposal_visibility.py` plus architecture boundary assertions to ensure boundary/import invariants and that approval-is-not-execution semantics are present.

### Testing

- Ran focused Phase 50/49/48 suite with `python -m scripts.run_tests -q tests/test_phase50_embodied_proposal_review_receipts.py tests/test_phase49_embodied_proposal_visibility.py tests/test_phase48_embodied_proposals.py` which completed with no failures (the environment marked some tests as skipped for hardware-free constraints).
- Ran architecture and import-purity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and these passed after a local fix to the boundary test implementation.
- Ran orchestration/diagnostic smoke tests with `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, and these passed.
- All modified-code assertions in the added/updated tests succeeded in CI-like runs; dependency bootstrap occurred during runs and a small AST-import check was adjusted to avoid false positives in file-content matching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7e2da6b7c8320a9bc8d85a72dabaf)