### PR TITLE
[codex:tests] unskip phase48-50 embodied proposal focused tests

### DIFF
--- a/tests/test_phase48_embodied_proposals.py
+++ b/tests/test_phase48_embodied_proposals.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+
 import types
 import sys
 

--- a/tests/test_phase49_embodied_proposal_visibility.py
+++ b/tests/test_phase49_embodied_proposal_visibility.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+
 from pathlib import Path
 
 from sentientos.embodiment_proposal_diagnostic import (

--- a/tests/test_phase50_embodied_proposal_review_receipts.py
+++ b/tests/test_phase50_embodied_proposal_review_receipts.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+
 from pathlib import Path
 
 from sentientos.embodiment_proposal_diagnostic import summarize_recent_embodied_proposals


### PR DESCRIPTION
### Motivation
- The Phase 48/49/50 focused embodied proposal/review tests were being quarantined by the legacy skip policy and therefore did not execute; unskipping them restores meaningful hardware-free behavioral coverage for embodiment proposals, diagnostics, and review receipts.

### Description
- Added `import pytest` and `pytestmark = pytest.mark.no_legacy_skip` to `tests/test_phase48_embodied_proposals.py`, `tests/test_phase49_embodied_proposal_visibility.py`, and `tests/test_phase50_embodied_proposal_review_receipts.py`, and corrected marker/import ordering to avoid a `NameError`; no production code or proposal/review semantics were modified.

### Testing
- Executed `python -m scripts.run_tests -q tests/test_phase48_embodied_proposals.py tests/test_phase49_embodied_proposal_visibility.py tests/test_phase50_embodied_proposal_review_receipts.py` (result: focused suites ran with real tests: 11 passed, 0 skipped), ran `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` (result: all passed), and ran `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` (result: all passed); initial collection `NameError` from placing `pytestmark` before importing `pytest` was fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7e97e42988320997e7f705810f290)