### PR TITLE
[codex:embodiment] add phase51 masterplan with handoff and governance bridge candidates

### DIFF
--- a/docs/architecture/embodiment_completion_masterplan.md
+++ b/docs/architecture/embodiment_completion_masterplan.md
@@ -1,0 +1,88 @@
+# Embodiment Completion Masterplan (Post-Phase 50)
+
+## Current implemented layers
+- Phase 41: legacy perception quarantine + `sentientos.perception_api`.
+- Phase 42: pulse telemetry bridge.
+- Phase 43: `sentientos.embodiment_fusion` deterministic bounded snapshots.
+- Phase 44: `sentientos.embodiment_ingress` non-authoritative ingress candidates.
+- Phase 45/46: ingress-gated mic/feedback and screen/vision/multimodal retention paths.
+- Phase 47: `sentientos.embodiment_gate_policy` shared policy.
+- Phase 48: `sentientos.embodiment_proposals` append-only proposal queue.
+- Phase 49: `sentientos.embodiment_proposal_diagnostic` visibility.
+- Phase 50: `sentientos.embodiment_proposal_review` append-only review receipts and derived state.
+
+## Intended full ladder
+SENSE → FUSE → PRESSURE → GATE → PROPOSE → DIAGNOSE → REVIEW → HANDOFF → GOVERNANCE/ADMISSION BRIDGE → FULFILLMENT CANDIDATE → CONSENT/POLICY/ADMISSION CHECK → EFFECT RECEIPT → ACTUAL EFFECT.
+
+## Boundary law
+- Perception is telemetry only.
+- Fusion is derived-only.
+- Ingress is proposal-only.
+- Review approval is not execution.
+- Handoff is not admission.
+- Governance bridge is not fulfillment.
+- Fulfillment candidate is not effect.
+- Effect requires consent/policy/admission and receipt.
+
+## Remaining waves
+### Wave A: reviewed proposal handoff/export candidates
+Purpose: derive non-authoritative handoff candidates from latest approved reviews only.
+Inputs: Phase 48 proposals + Phase 50 review receipts.
+Outputs: handoff candidate records and summaries.
+Modules: `sentientos.embodiment_proposal_handoff`.
+Non-authoritative: no memory/action/admission/execution/control-plane mutation.
+Tests: kind mapping, latest review wins, blocked outcomes filtered.
+Out of scope: any admission/execution/fulfillment.
+
+### Wave B: governance/admission bridge candidates
+Purpose: derive governance-review candidates from eligible handoff candidates.
+Inputs: Wave A handoff candidates.
+Outputs: governance bridge candidates + blocked reasons.
+Modules: `sentientos.embodiment_governance_bridge`.
+Non-authoritative: no admission, no executor, no mutable state.
+Tests: mapping, privacy/consent hold, unsupported kind handling.
+Out of scope: task admission tokens, execution permissions.
+
+### Wave C: fulfillment candidate + receipt surfaces
+Purpose: normalize future executable intents and future receipts.
+Inputs: governance-approved bridge outputs.
+Outputs: fulfillment-candidate draft envelopes + non-effect receipts.
+Modules likely: `sentientos.embodiment_fulfillment_candidates`, `sentientos.embodiment_fulfillment_receipts`.
+Non-authoritative: candidate creation only.
+Tests: envelope invariants, deterministic identity.
+Out of scope: actual effect write.
+
+### Wave D/E/F: governed ingress by effect class
+- D memory ingress, E feedback/action ingress, F retention ingress.
+- Purpose: execute only through consent/policy/admission contract.
+- Inputs: fulfillment candidates + policy + consent + admission.
+- Outputs: effect receipts + bounded effect APIs.
+- Tests: denied admission, allowed admission, receipt requirement.
+- Out of scope: bypass paths.
+
+### Wave G: diagnostic/operator review consolidation
+Purpose: unify proposal/review/handoff/bridge/fulfillment visibility.
+Tests: additive schema stability and posture rollups.
+
+### Wave H: default flip
+Purpose: default gate mode to `proposal_only` from `compatibility_legacy` after coverage.
+Tests: migration safety and compatibility.
+
+### Wave I: quarantine burn-down
+Purpose: deprecate legacy pathways with explicit migration gates.
+Tests: no legacy writes to protected sinks.
+
+## Concise implementation sequence
+1) Build handoff derivation + tests.
+2) Build governance bridge derivation + tests.
+3) Add additive diagnostics and manifest boundaries.
+4) Add fulfillment candidate surfaces.
+5) Bind admission/consent/policy checks and effect receipts.
+6) Flip defaults once green.
+7) Remove legacy execution paths.
+
+## Deferred risks
+- Consent posture vocabulary may require stronger normalization.
+- Privacy posture policy granularity may drift between modules.
+- Future admission APIs must avoid accidental “candidate == token” coupling.
+- Operator UX debt could hide blocked reasons if not consolidated in Wave G.

--- a/sentientos/embodiment_governance_bridge.py
+++ b/sentientos/embodiment_governance_bridge.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_proposal_handoff import embodied_handoff_candidate_ref
+
+SCHEMA_VERSION = "embodiment.governance_bridge_candidate.v1"
+
+_BRIDGE_KIND_BY_HANDOFF_KIND = {
+    "memory_ingress_handoff_candidate": "memory_governance_review_candidate",
+    "feedback_action_handoff_candidate": "feedback_action_governance_review_candidate",
+    "screen_retention_handoff_candidate": "screen_retention_governance_review_candidate",
+    "vision_retention_handoff_candidate": "vision_retention_governance_review_candidate",
+    "multimodal_retention_handoff_candidate": "multimodal_retention_governance_review_candidate",
+    "operator_attention_handoff_candidate": "operator_attention_governance_review_candidate",
+}
+
+
+def embodied_governance_bridge_candidate_ref(record: Mapping[str, Any]) -> str:
+    return f"governance_bridge_candidate:{record['governance_bridge_candidate_id']}"
+
+
+def classify_embodied_governance_bridge_kind(handoff_candidate_kind: str) -> str:
+    return _BRIDGE_KIND_BY_HANDOFF_KIND.get(str(handoff_candidate_kind or ""), "unsupported_governance_bridge_candidate")
+
+
+def map_handoff_candidate_to_governance_bridge(handoff_candidate: Mapping[str, Any]) -> tuple[str, str]:
+    posture = str(handoff_candidate.get("handoff_posture") or "")
+    kind = classify_embodied_governance_bridge_kind(str(handoff_candidate.get("handoff_candidate_kind") or ""))
+    if kind == "unsupported_governance_bridge_candidate":
+        return kind, "blocked_unsupported_kind"
+    if posture != "eligible_for_next_stage_review":
+        return kind, "blocked_handoff_not_eligible"
+    privacy = str(handoff_candidate.get("privacy_retention_posture") or "")
+    consent = str(handoff_candidate.get("consent_posture") or "")
+    if privacy in {"restricted", "sensitive"} and consent in {"", "unknown", "not_asserted", "required"}:
+        return kind, "blocked_privacy_or_consent_required"
+    return kind, "eligible_for_governance_review"
+
+
+def build_embodied_governance_bridge_candidate(*, handoff_candidate: Mapping[str, Any], created_at: float | None = None) -> dict[str, Any]:
+    kind, posture = map_handoff_candidate_to_governance_bridge(handoff_candidate)
+    material = {
+        "handoff_candidate_id": handoff_candidate.get("handoff_candidate_id"),
+        "handoff_kind": handoff_candidate.get("handoff_candidate_kind"),
+        "bridge_kind": kind,
+        "bridge_posture": posture,
+    }
+    bridge_id = "egbc_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "governance_bridge_candidate_id": bridge_id,
+        "governance_bridge_candidate_kind": kind,
+        "source_handoff_candidate_id": handoff_candidate.get("handoff_candidate_id"),
+        "source_handoff_candidate_ref": embodied_handoff_candidate_ref(handoff_candidate),
+        "source_proposal_id": handoff_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": handoff_candidate.get("source_review_receipt_id"),
+        "source_ingress_receipt_ref": handoff_candidate.get("source_ingress_receipt_ref"),
+        "source_event_refs": list(handoff_candidate.get("source_event_refs") or []),
+        "correlation_id": handoff_candidate.get("correlation_id"),
+        "source_module": handoff_candidate.get("source_module"),
+        "proposal_kind": handoff_candidate.get("proposal_kind"),
+        "risk_flags": dict(handoff_candidate.get("risk_flags") or {}),
+        "privacy_retention_posture": handoff_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": handoff_candidate.get("consent_posture", "not_asserted"),
+        "bridge_posture": posture,
+        "candidate_payload_summary": dict(handoff_candidate.get("candidate_payload_summary") or {}),
+        "rationale": list(handoff_candidate.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+        "approval_is_not_execution": True,
+        "handoff_is_not_fulfillment": True,
+        "bridge_is_not_admission": True,
+    }
+
+
+def resolve_embodied_governance_bridge_candidates(*, handoff_candidates: Sequence[Mapping[str, Any]], created_at: float | None = None) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    by_kind: dict[str, int] = {}
+    by_posture: dict[str, int] = {}
+    for handoff in handoff_candidates:
+        row = build_embodied_governance_bridge_candidate(handoff_candidate=handoff, created_at=created_at)
+        by_posture[row["bridge_posture"]] = by_posture.get(row["bridge_posture"], 0) + 1
+        if row["bridge_posture"] == "eligible_for_governance_review":
+            by_kind[row["governance_bridge_candidate_kind"]] = by_kind.get(row["governance_bridge_candidate_kind"], 0) + 1
+            rows.append(row)
+    return {
+        "governance_bridge_candidates": rows,
+        "governance_bridge_counts_by_kind": dict(sorted(by_kind.items())),
+        "blocked_bridge_counts_by_reason": dict(sorted((k, v) for k, v in by_posture.items() if k != "eligible_for_governance_review")),
+        "counts_by_bridge_posture": dict(sorted(by_posture.items())),
+    }
+
+
+def summarize_embodied_governance_bridge_candidates(candidates: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_kind: dict[str, int] = {}
+    blocked: dict[str, int] = {}
+    for row in candidates:
+        by_kind[row.get("governance_bridge_candidate_kind", "unknown")] = by_kind.get(row.get("governance_bridge_candidate_kind", "unknown"), 0) + 1
+        posture = str(row.get("bridge_posture") or "")
+        if posture != "eligible_for_governance_review":
+            blocked[posture] = blocked.get(posture, 0) + 1
+    return {
+        "governance_bridge_candidate_count": len(candidates),
+        "governance_bridge_counts_by_kind": dict(sorted(by_kind.items())),
+        "blocked_bridge_counts_by_reason": dict(sorted(blocked.items())),
+    }
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "build_embodied_governance_bridge_candidate",
+    "resolve_embodied_governance_bridge_candidates",
+    "embodied_governance_bridge_candidate_ref",
+    "classify_embodied_governance_bridge_kind",
+    "summarize_embodied_governance_bridge_candidates",
+    "map_handoff_candidate_to_governance_bridge",
+]

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -8,6 +8,8 @@ from typing import Any, Iterable, Mapping
 
 from sentientos.embodiment_proposals import embodied_proposal_ref, list_recent_embodied_proposals
 from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG, list_recent_embodied_proposal_review_receipts, summarize_embodied_proposal_review_status
+from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_candidates
+from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -102,6 +104,23 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
     }
     digest = hashlib.sha256(json.dumps(summary_material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:20]
     review_summary = summarize_embodied_proposal_review_status(proposals=proposals, review_receipts=list(review_receipts or []))
+    handoff_resolution = resolve_embodied_handoff_candidates(proposals=proposals, review_receipts=list(review_receipts or []), created_at=generated_at)
+    bridge_resolution = resolve_embodied_governance_bridge_candidates(handoff_candidates=handoff_resolution["handoff_candidates"], created_at=generated_at)
+    next_stage_postures = []
+    if handoff_resolution["handoff_candidates"]:
+        next_stage_postures.append("handoff_candidates_available")
+    if bridge_resolution["governance_bridge_candidates"]:
+        next_stage_postures.append("governance_bridge_candidates_available")
+    if bridge_resolution["blocked_bridge_counts_by_reason"].get("blocked_privacy_or_consent_required", 0) > 0:
+        next_stage_postures.append("privacy_or_consent_holds_present")
+    if risk.get("biometric_or_emotion_sensitive", 0) > 0 and handoff_resolution["handoff_candidates"]:
+        next_stage_postures.append("high_risk_next_stage_review_available")
+    if not next_stage_postures:
+        next_stage_posture = "no_review_approved_candidates"
+    elif len(next_stage_postures) > 1:
+        next_stage_posture = "mixed_next_stage_state"
+    else:
+        next_stage_posture = next_stage_postures[0]
     return {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "summary_id": f"eprs_{digest}",
@@ -116,6 +135,13 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         "newest_pending_created_at": max(pending_times) if pending_times else None,
         "recommended_review_posture": posture,
         **review_summary,
+        "handoff_candidate_count": len(handoff_resolution["handoff_candidates"]),
+        "handoff_counts_by_kind": handoff_resolution["counts_by_proposal_kind"],
+        "blocked_handoff_counts_by_reason": {k: v for k, v in handoff_resolution["counts_by_handoff_posture"].items() if k != "eligible_for_next_stage_review"},
+        "governance_bridge_candidate_count": len(bridge_resolution["governance_bridge_candidates"]),
+        "governance_bridge_counts_by_kind": bridge_resolution["governance_bridge_counts_by_kind"],
+        "blocked_bridge_counts_by_reason": bridge_resolution["blocked_bridge_counts_by_reason"],
+        "next_stage_posture": next_stage_posture,
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,

--- a/sentientos/embodiment_proposal_handoff.py
+++ b/sentientos/embodiment_proposal_handoff.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_proposals import embodied_proposal_ref
+from sentientos.embodiment_proposal_review import classify_embodied_proposal_review_outcome, embodied_proposal_review_receipt_ref
+
+SCHEMA_VERSION = "embodiment.proposal.handoff_candidate.v1"
+
+_HANDOFF_KIND_BY_PROPOSAL_KIND = {
+    "memory_ingress_candidate": "memory_ingress_handoff_candidate",
+    "feedback_action_candidate": "feedback_action_handoff_candidate",
+    "screen_retention_candidate": "screen_retention_handoff_candidate",
+    "vision_retention_candidate": "vision_retention_handoff_candidate",
+    "multimodal_retention_candidate": "multimodal_retention_handoff_candidate",
+    "operator_attention_candidate": "operator_attention_handoff_candidate",
+}
+
+
+def embodied_handoff_candidate_ref(record: Mapping[str, Any]) -> str:
+    return f"handoff_candidate:{record['handoff_candidate_id']}"
+
+
+def classify_embodied_handoff_candidate_kind(proposal_kind: str) -> str:
+    return _HANDOFF_KIND_BY_PROPOSAL_KIND.get(str(proposal_kind or ""), "unsupported_handoff_candidate")
+
+
+def _latest_review_receipts(review_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    latest: dict[str, tuple[float, str, Mapping[str, Any]]] = {}
+    for row in review_receipts:
+        pid = str(row.get("proposal_id") or "")
+        if not pid:
+            continue
+        created_at = float(row.get("created_at") or 0.0)
+        receipt_id = str(row.get("review_receipt_id") or "")
+        cur = latest.get(pid)
+        if cur is None or (created_at, receipt_id) >= (cur[0], cur[1]):
+            latest[pid] = (created_at, receipt_id, row)
+    return {k: v[2] for k, v in latest.items()}
+
+
+def filter_review_approved_embodied_proposals(*, proposals: Sequence[Mapping[str, Any]], review_receipts: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    latest = _latest_review_receipts(review_receipts)
+    approved: list[Mapping[str, Any]] = []
+    for proposal in proposals:
+        pid = str(proposal.get("proposal_id") or "")
+        review = latest.get(pid)
+        if not review:
+            continue
+        if classify_embodied_proposal_review_outcome(str(review.get("review_outcome") or "pending_review")) == "reviewed_approved_for_next_stage":
+            approved.append(proposal)
+    return approved
+
+
+def build_embodied_handoff_candidate(*, proposal_record: Mapping[str, Any], review_receipt: Mapping[str, Any], created_at: float | None = None) -> dict[str, Any]:
+    proposal_kind = str(proposal_record.get("proposal_kind") or "unknown")
+    handoff_kind = classify_embodied_handoff_candidate_kind(proposal_kind)
+    review_outcome = classify_embodied_proposal_review_outcome(str(review_receipt.get("review_outcome") or "pending_review"))
+
+    posture = {
+        "pending_review": "blocked_missing_review",
+        "reviewed_rejected": "blocked_rejected",
+        "reviewed_deferred": "blocked_deferred",
+        "reviewed_needs_more_context": "blocked_needs_more_context",
+        "reviewed_approved_for_next_stage": "eligible_for_next_stage_review",
+    }[review_outcome]
+    if handoff_kind == "unsupported_handoff_candidate":
+        posture = "blocked_unsupported_kind"
+
+    material = {
+        "proposal_id": proposal_record.get("proposal_id"),
+        "review_receipt_id": review_receipt.get("review_receipt_id"),
+        "handoff_kind": handoff_kind,
+        "posture": posture,
+    }
+    candidate_id = "ehc_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "handoff_candidate_id": candidate_id,
+        "handoff_candidate_kind": handoff_kind,
+        "source_proposal_id": proposal_record.get("proposal_id"),
+        "source_proposal_ref": embodied_proposal_ref(proposal_record),
+        "source_review_receipt_id": review_receipt.get("review_receipt_id"),
+        "source_review_receipt_ref": embodied_proposal_review_receipt_ref(review_receipt),
+        "source_ingress_receipt_ref": proposal_record.get("ingress_receipt_ref"),
+        "source_event_refs": list(proposal_record.get("source_event_refs") or []),
+        "source_snapshot_ref": proposal_record.get("source_snapshot_ref"),
+        "correlation_id": proposal_record.get("correlation_id") or review_receipt.get("correlation_id"),
+        "source_module": proposal_record.get("source_module"),
+        "proposal_kind": proposal_kind,
+        "review_outcome": "reviewed_approved_for_next_stage" if posture == "eligible_for_next_stage_review" else review_outcome,
+        "handoff_posture": posture,
+        "risk_flags": dict(proposal_record.get("risk_flags") or {}),
+        "privacy_retention_posture": proposal_record.get("privacy_retention_posture", "review"),
+        "consent_posture": proposal_record.get("consent_posture", "not_asserted"),
+        "candidate_payload_summary": dict(proposal_record.get("candidate_payload_summary") or {}),
+        "rationale": list(proposal_record.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+        "approval_is_not_execution": True,
+        "handoff_is_not_fulfillment": True,
+    }
+
+
+def resolve_embodied_handoff_candidates(*, proposals: Sequence[Mapping[str, Any]], review_receipts: Sequence[Mapping[str, Any]], created_at: float | None = None) -> dict[str, Any]:
+    latest = _latest_review_receipts(review_receipts)
+    candidates: list[dict[str, Any]] = []
+    by_kind: dict[str, int] = {}
+    by_posture: dict[str, int] = {}
+    for proposal in proposals:
+        pid = str(proposal.get("proposal_id") or "")
+        review = latest.get(pid)
+        if not review:
+            continue
+        candidate = build_embodied_handoff_candidate(proposal_record=proposal, review_receipt=review, created_at=created_at)
+        posture = str(candidate["handoff_posture"])
+        by_posture[posture] = by_posture.get(posture, 0) + 1
+        if posture == "eligible_for_next_stage_review":
+            kind = str(candidate["handoff_candidate_kind"])
+            by_kind[kind] = by_kind.get(kind, 0) + 1
+            candidates.append(candidate)
+    return {
+        "handoff_candidates": candidates,
+        "counts_by_proposal_kind": dict(sorted(by_kind.items())),
+        "counts_by_handoff_posture": dict(sorted(by_posture.items())),
+    }
+
+
+def summarize_embodied_handoff_candidates(candidates: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_kind: dict[str, int] = {}
+    blocked: dict[str, int] = {}
+    for row in candidates:
+        kind = str(row.get("handoff_candidate_kind") or "unknown")
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        posture = str(row.get("handoff_posture") or "")
+        if posture != "eligible_for_next_stage_review":
+            blocked[posture] = blocked.get(posture, 0) + 1
+    return {
+        "handoff_candidate_count": len(candidates),
+        "handoff_counts_by_kind": dict(sorted(by_kind.items())),
+        "blocked_handoff_counts_by_reason": dict(sorted(blocked.items())),
+    }
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "build_embodied_handoff_candidate",
+    "resolve_embodied_handoff_candidates",
+    "embodied_handoff_candidate_ref",
+    "classify_embodied_handoff_candidate_kind",
+    "summarize_embodied_handoff_candidates",
+    "filter_review_approved_embodied_proposals",
+]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -249,6 +249,40 @@
         "screen_awareness",
         "sentientos.perception_api"
       ]
+    },
+    "embodiment_proposal_handoff": {
+      "description": "Derived handoff candidates from review-approved embodiment proposals.",
+      "allowed_roots": [
+        "sentientos/embodiment_proposal_handoff.py"
+      ],
+      "invariants": [
+        "derived_only",
+        "non_authoritative",
+        "does_not_write_memory",
+        "does_not_trigger_feedback",
+        "does_not_admit_work",
+        "does_not_execute_or_route_work",
+        "no_control_plane_mutation",
+        "no_scheduler_planner_autonomous_behavior",
+        "handoff_is_not_fulfillment"
+      ]
+    },
+    "embodiment_governance_bridge": {
+      "description": "Derived governance review bridge candidates from handoff candidates.",
+      "allowed_roots": [
+        "sentientos/embodiment_governance_bridge.py"
+      ],
+      "invariants": [
+        "derived_only",
+        "non_authoritative",
+        "does_not_write_memory",
+        "does_not_trigger_feedback",
+        "does_not_admit_work",
+        "does_not_execute_or_route_work",
+        "no_control_plane_mutation",
+        "no_scheduler_planner_autonomous_behavior",
+        "bridge_is_not_admission"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -554,3 +554,30 @@ def test_phase50_review_module_forbidden_imports_and_semantics() -> None:
     text = path.read_text(encoding="utf-8")
     assert '"approval_is_not_execution": True' in text
     assert '"decision_power": "none"' in text
+
+def test_phase51_handoff_and_bridge_import_boundaries_and_manifest_invariants() -> None:
+    handoff_text = (ROOT / "sentientos/embodiment_proposal_handoff.py").read_text(encoding="utf-8")
+    bridge_text = (ROOT / "sentientos/embodiment_governance_bridge.py").read_text(encoding="utf-8")
+    banned = ["task_executor", "task_admission", "control_plane", "authority_surface", "screen_awareness", "mic_bridge", "vision_tracker"]
+    for token in banned:
+        assert token not in handoff_text
+        assert token not in bridge_text
+
+    manifest = _manifest()
+    handoff = manifest["layer_definitions"]["embodiment_proposal_handoff"]
+    bridge = manifest["layer_definitions"]["embodiment_governance_bridge"]
+    assert "handoff_is_not_fulfillment" in handoff["invariants"]
+    assert "bridge_is_not_admission" in bridge["invariants"]
+
+
+def test_phase51_candidate_output_invariants() -> None:
+    from sentientos.embodiment_proposal_handoff import build_embodied_handoff_candidate
+    from sentientos.embodiment_governance_bridge import build_embodied_governance_bridge_candidate
+
+    proposal = {"proposal_id": "p1", "proposal_kind": "memory_ingress_candidate", "source_module": "x"}
+    review = {"proposal_id": "p1", "review_outcome": "reviewed_approved_for_next_stage", "review_receipt_id": "r1"}
+    handoff = build_embodied_handoff_candidate(proposal_record=proposal, review_receipt=review)
+    assert handoff["approval_is_not_execution"] is True
+    assert handoff["handoff_is_not_fulfillment"] is True
+    bridge = build_embodied_governance_bridge_candidate(handoff_candidate=handoff)
+    assert bridge["bridge_is_not_admission"] is True

--- a/tests/test_phase51_embodied_handoff_and_bridge.py
+++ b/tests/test_phase51_embodied_handoff_and_bridge.py
@@ -1,0 +1,86 @@
+from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_candidates, build_embodied_handoff_candidate
+from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates, build_embodied_governance_bridge_candidate
+from sentientos.embodiment_proposal_diagnostic import summarize_recent_embodied_proposals
+
+
+def _proposal(pid: str, kind: str):
+    return {
+        "proposal_id": pid,
+        "proposal_kind": kind,
+        "source_module": "sentientos.embodiment_ingress",
+        "ingress_receipt_ref": f"ing:{pid}",
+        "source_event_refs": [f"evt:{pid}"],
+        "risk_flags": {},
+        "privacy_retention_posture": "review",
+        "consent_posture": "granted",
+        "candidate_payload_summary": {"x": 1},
+        "rationale": ["r"],
+    }
+
+
+def _review(pid: str, outcome: str, ts: float, rid: str):
+    return {"proposal_id": pid, "review_outcome": outcome, "created_at": ts, "review_receipt_id": rid}
+
+
+def test_handoff_filters_only_review_approved_and_latest_wins():
+    proposals = [_proposal("p1", "memory_ingress_candidate"), _proposal("p2", "feedback_action_candidate")]
+    reviews = [
+        _review("p1", "reviewed_rejected", 1.0, "r1"),
+        _review("p1", "reviewed_approved_for_next_stage", 2.0, "r2"),
+        _review("p2", "reviewed_deferred", 3.0, "r3"),
+    ]
+    resolved = resolve_embodied_handoff_candidates(proposals=proposals, review_receipts=reviews, created_at=10.0)
+    assert len(resolved["handoff_candidates"]) == 1
+    row = resolved["handoff_candidates"][0]
+    assert row["source_proposal_id"] == "p1"
+    assert row["handoff_posture"] == "eligible_for_next_stage_review"
+    assert row["handoff_is_not_fulfillment"] is True
+
+
+def test_handoff_kind_mapping_and_non_authority_fields():
+    kinds = {
+        "memory_ingress_candidate": "memory_ingress_handoff_candidate",
+        "feedback_action_candidate": "feedback_action_handoff_candidate",
+        "screen_retention_candidate": "screen_retention_handoff_candidate",
+        "vision_retention_candidate": "vision_retention_handoff_candidate",
+        "multimodal_retention_candidate": "multimodal_retention_handoff_candidate",
+        "operator_attention_candidate": "operator_attention_handoff_candidate",
+    }
+    for i, (pk, hk) in enumerate(kinds.items()):
+        row = build_embodied_handoff_candidate(
+            proposal_record=_proposal(f"p{i}", pk),
+            review_receipt=_review(f"p{i}", "reviewed_approved_for_next_stage", 1.0, f"r{i}"),
+        )
+        assert row["handoff_candidate_kind"] == hk
+        assert row["approval_is_not_execution"] is True
+        assert row["does_not_admit_work"] is True
+
+
+def test_bridge_candidate_behavior_and_privacy_hold():
+    handoff = build_embodied_handoff_candidate(
+        proposal_record={**_proposal("p9", "screen_retention_candidate"), "privacy_retention_posture": "sensitive", "consent_posture": "not_asserted"},
+        review_receipt=_review("p9", "reviewed_approved_for_next_stage", 1.0, "r9"),
+    )
+    bridge = build_embodied_governance_bridge_candidate(handoff_candidate=handoff)
+    assert bridge["bridge_posture"] == "blocked_privacy_or_consent_required"
+    assert bridge["bridge_is_not_admission"] is True
+
+
+def test_bridge_resolver_emits_only_eligible_and_no_executor_imports():
+    ok = build_embodied_handoff_candidate(
+        proposal_record=_proposal("p10", "memory_ingress_candidate"),
+        review_receipt=_review("p10", "reviewed_approved_for_next_stage", 1.0, "r10"),
+    )
+    blocked = {**ok, "handoff_candidate_id": "x2", "handoff_candidate_kind": "unsupported"}
+    out = resolve_embodied_governance_bridge_candidates(handoff_candidates=[ok, blocked], created_at=5.0)
+    assert len(out["governance_bridge_candidates"]) == 1
+    assert out["blocked_bridge_counts_by_reason"]["blocked_unsupported_kind"] == 1
+
+
+def test_diagnostic_additive_fields_present():
+    proposals = [_proposal("p11", "memory_ingress_candidate")]
+    reviews = [_review("p11", "reviewed_approved_for_next_stage", 1.0, "r11")]
+    summary = summarize_recent_embodied_proposals(proposals, review_receipts=reviews, generated_at=2.0)
+    assert "review_counts_by_outcome" in summary
+    assert "handoff_candidate_count" in summary
+    assert "governance_bridge_candidate_count" in summary


### PR DESCRIPTION
### Motivation
- Deliver Phase 51: a durable repository-level Embodiment Completion Masterplan covering the remaining ladder from review→handoff→governance→fulfillment, and record deferred risks and sequence of waves.
- Implement Waves A+B to produce derived, non-authoritative, deterministic handoff and governance-bridge candidate surfaces that are explicitly not admission or execution surfaces.
- Preserve existing Phase 48/49/50 semantics and diagnostic compatibility while adding additive visibility for next-stage posture.

### Description
- Added `docs/architecture/embodiment_completion_masterplan.md` describing current layers, the full ladder, Waves A–I, boundary law, implementation sequence, and deferred risks.
- Implemented Wave A in `sentientos/embodiment_proposal_handoff.py` with public helpers: `build_embodied_handoff_candidate`, `resolve_embodied_handoff_candidates`, `embodied_handoff_candidate_ref`, `classify_embodied_handoff_candidate_kind`, `summarize_embodied_handoff_candidates`, and `filter_review_approved_embodied_proposals`; candidates are derived-only, deterministic where practical, and include non-authority flags like `approval_is_not_execution` and `handoff_is_not_fulfillment`.
- Implemented Wave B in `sentientos/embodiment_governance_bridge.py` with public helpers: `build_embodied_governance_bridge_candidate`, `resolve_embodied_governance_bridge_candidates`, `embodied_governance_bridge_candidate_ref`, `classify_embodied_governance_bridge_kind`, `summarize_embodied_governance_bridge_candidates`, and `map_handoff_candidate_to_governance_bridge`; bridge candidates are derived-only and include `bridge_is_not_admission` and privacy/consent hold logic.
- Integrated additive diagnostic fields into `sentientos/embodiment_proposal_diagnostic.py` by deriving handoff and bridge summaries (fields added: `handoff_candidate_count`, `handoff_counts_by_kind`, `blocked_handoff_counts_by_reason`, `governance_bridge_candidate_count`, `governance_bridge_counts_by_kind`, `blocked_bridge_counts_by_reason`, `next_stage_posture`) while preserving existing review summary output.
- Updated `sentientos/system_closure/architecture_boundary_manifest.json` to declare two new layers (`embodiment_proposal_handoff`, `embodiment_governance_bridge`) with explicit invariants (derived-only, non-authoritative, no writes/admission/execution, `handoff_is_not_fulfillment`, `bridge_is_not_admission`).
- Added focused and architecture tests: `tests/test_phase51_embodied_handoff_and_bridge.py` and extended `tests/architecture/test_architecture_boundaries.py` with import/manifest/output invariants checks.

### Testing
- Ran focused Phase 51 + Phase 48/49/50 regression tests with: `python -m scripts.run_tests -q tests/test_phase51_embodied_handoff_and_bridge.py tests/test_phase50_embodied_proposal_review_receipts.py tests/test_phase49_embodied_proposal_visibility.py tests/test_phase48_embodied_proposals.py`; result: tests executed and passed (hardware-free; legacy-suite skips preserved). 
- Ran architecture/import purity checks with: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`; result: all tests passed.
- All added assertions verify the required non-authority invariants (no `task_admission`/`task_executor`/control-plane imports), manifest entries exist with required invariants, and diagnostic fields are additive and present; these checks succeeded in the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7ed6a4010832085ec94c7e9e9ee73)