### PR TITLE
[codex:embodiment] add phase52 fulfillment candidate and receipt surfaces

### DIFF
--- a/docs/architecture/phase52_embodied_fulfillment_candidates_execplan.md
+++ b/docs/architecture/phase52_embodied_fulfillment_candidates_execplan.md
@@ -1,0 +1,84 @@
+# Phase 52 ExecPlan: Embodied Fulfillment Candidate + Receipt Surface
+
+## 1) Current Phase 51 handoff/bridge state
+Phase 51 ships deterministic, non-authoritative handoff candidates and governance bridge candidates.
+The chain currently ends at `sentientos.embodiment_governance_bridge` with explicit invariants:
+- approval is not execution
+- handoff is not fulfillment
+- bridge is not admission
+- no memory/action/admission/execution effects
+
+## 2) Wave C target from masterplan
+Implement Wave C from `embodiment_completion_masterplan.md`:
+- fulfillment candidate surface (derived from governance bridge candidates)
+- fulfillment receipt surface (append-only, non-effect classification)
+- diagnostic visibility for fulfillment posture
+
+## 3) Fulfillment candidate shape
+Add canonical `embodiment.fulfillment_candidate.v1` rows with:
+- source refs (bridge/handoff/proposal/review/ingress/events/correlation)
+- mapped fulfillment kind
+- fulfillment posture (eligible vs blocked reason)
+- risk/privacy/consent context and rationale
+- strict non-authority/non-effect invariants (`decision_power=none`, no write/trigger/admit/execute)
+
+## 4) Fulfillment receipt shape
+Add canonical `embodiment.fulfillment_receipt.v1` rows with:
+- source fulfillment candidate refs and upstream refs
+- allowed fulfillment outcome classification
+- fulfiller kind + label/ref
+- rationale + provenance context
+- strict non-effect invariants (`fulfillment_receipt_is_not_effect`, `receipt_does_not_prove_side_effect`)
+
+## 5) Allowed fulfillment outcomes
+Enumerate and enforce:
+- `pending_fulfillment_review`
+- `fulfillment_declined`
+- `fulfillment_expired`
+- `fulfillment_superseded`
+- `fulfillment_failed_validation`
+- `fulfilled_external_manual`
+- `fulfilled_by_governed_path`
+
+These remain classification-only in Phase 52.
+
+## 6) Append-only + provenance strategy
+- Build deterministic IDs from stable source material where practical.
+- Persist receipts append-only through `sentientos.ledger_api.append_audit_record` to JSONL.
+- Keep provenance references in both candidate and receipt rows.
+
+## 7) Why this is still not effect execution
+This phase adds only derived candidates and append-only receipts.
+It does not call admission/executor/control-plane APIs and does not mutate memory/feedback/retention sinks.
+Even “fulfilled_*” outcomes are record labels, not effect proof.
+
+## 8) Diagnostic integration plan
+Extend `sentientos.embodiment_proposal_diagnostic.summarize_recent_embodied_proposals` additively with:
+- fulfillment candidate count
+- counts by candidate kind
+- blocked counts by reason
+- counts by outcome
+- pending review count
+- fulfilled receipt count
+- fulfillment posture
+
+No existing keys removed or behavior made authoritative.
+
+## 9) Tests to add/update
+- New focused suite `tests/test_phase52_embodied_fulfillment.py` for builders/resolvers/append/list/state/summary/boundaries.
+- Update architecture boundary tests for:
+  - forbidden imports for fulfillment module
+  - manifest fulfillment invariants
+  - candidate/receipt invariant fields
+- Keep Phase 49-51 focused suites green.
+
+## 10) Deferred risks + future Waves D-F
+Deferred:
+- governed admission linkage semantics
+- standardized consent taxonomy breadth
+- fulfillment-to-effect receipt correlation contract
+Future waves:
+- D memory ingress execution path
+- E feedback/action governed path
+- F retention governed path
+All behind explicit consent/policy/admission and effect receipt contracts.

--- a/sentientos/embodiment_fulfillment.py
+++ b/sentientos/embodiment_fulfillment.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_governance_bridge import embodied_governance_bridge_candidate_ref
+from sentientos.ledger_api import append_audit_record
+
+CANDIDATE_SCHEMA_VERSION = "embodiment.fulfillment_candidate.v1"
+RECEIPT_SCHEMA_VERSION = "embodiment.fulfillment_receipt.v1"
+DEFAULT_FULFILLMENT_RECEIPT_LOG = Path("logs/embodiment_fulfillment_receipts.jsonl")
+
+_FULFILLMENT_KIND_BY_BRIDGE_KIND = {
+    "memory_governance_review_candidate": "memory_fulfillment_candidate",
+    "feedback_action_governance_review_candidate": "feedback_action_fulfillment_candidate",
+    "screen_retention_governance_review_candidate": "screen_retention_fulfillment_candidate",
+    "vision_retention_governance_review_candidate": "vision_retention_fulfillment_candidate",
+    "multimodal_retention_governance_review_candidate": "multimodal_retention_fulfillment_candidate",
+    "operator_attention_governance_review_candidate": "operator_attention_fulfillment_candidate",
+}
+
+ALLOWED_FULFILLMENT_OUTCOMES = {
+    "pending_fulfillment_review",
+    "fulfillment_declined",
+    "fulfillment_expired",
+    "fulfillment_superseded",
+    "fulfillment_failed_validation",
+    "fulfilled_external_manual",
+    "fulfilled_by_governed_path",
+}
+
+
+def embodied_fulfillment_candidate_ref(record: Mapping[str, Any]) -> str:
+    return f"fulfillment_candidate:{record['fulfillment_candidate_id']}"
+
+
+def embodied_fulfillment_receipt_ref(record: Mapping[str, Any]) -> str:
+    return f"fulfillment_receipt:{record['fulfillment_receipt_id']}"
+
+
+def classify_embodied_fulfillment_candidate_kind(bridge_candidate_kind: str) -> str:
+    return _FULFILLMENT_KIND_BY_BRIDGE_KIND.get(str(bridge_candidate_kind or ""), "unsupported_fulfillment_candidate")
+
+
+def classify_embodied_fulfillment_outcome(outcome: str) -> str:
+    normalized = str(outcome or "pending_fulfillment_review")
+    if normalized in ALLOWED_FULFILLMENT_OUTCOMES:
+        return normalized
+    return "fulfillment_failed_validation"
+
+
+def _resolve_fulfillment_posture(bridge_candidate: Mapping[str, Any], kind: str) -> str:
+    if not bridge_candidate:
+        return "blocked_missing_governance_bridge"
+    if kind == "unsupported_fulfillment_candidate":
+        return "blocked_unsupported_kind"
+    bridge_posture = str(bridge_candidate.get("bridge_posture") or "")
+    if bridge_posture != "eligible_for_governance_review":
+        return "blocked_bridge_not_eligible"
+    privacy = str(bridge_candidate.get("privacy_retention_posture") or "")
+    consent = str(bridge_candidate.get("consent_posture") or "")
+    if privacy in {"restricted", "sensitive"} and consent in {"", "unknown", "not_asserted", "required"}:
+        return "blocked_privacy_or_consent_required"
+    return "eligible_for_fulfillment_review"
+
+
+def build_embodied_fulfillment_candidate(*, governance_bridge_candidate: Mapping[str, Any], created_at: float | None = None) -> dict[str, Any]:
+    kind = classify_embodied_fulfillment_candidate_kind(str(governance_bridge_candidate.get("governance_bridge_candidate_kind") or ""))
+    posture = _resolve_fulfillment_posture(governance_bridge_candidate, kind)
+    material = {
+        "governance_bridge_candidate_id": governance_bridge_candidate.get("governance_bridge_candidate_id"),
+        "fulfillment_candidate_kind": kind,
+        "fulfillment_posture": posture,
+    }
+    candidate_id = "efc_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return {
+        "schema_version": CANDIDATE_SCHEMA_VERSION,
+        "fulfillment_candidate_id": candidate_id,
+        "fulfillment_candidate_kind": kind,
+        "source_governance_bridge_candidate_id": governance_bridge_candidate.get("governance_bridge_candidate_id"),
+        "source_governance_bridge_candidate_ref": embodied_governance_bridge_candidate_ref(governance_bridge_candidate),
+        "source_handoff_candidate_ref": governance_bridge_candidate.get("source_handoff_candidate_ref"),
+        "source_proposal_id": governance_bridge_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": governance_bridge_candidate.get("source_review_receipt_id"),
+        "source_ingress_receipt_ref": governance_bridge_candidate.get("source_ingress_receipt_ref"),
+        "source_event_refs": list(governance_bridge_candidate.get("source_event_refs") or []),
+        "correlation_id": governance_bridge_candidate.get("correlation_id"),
+        "source_module": governance_bridge_candidate.get("source_module"),
+        "proposal_kind": governance_bridge_candidate.get("proposal_kind"),
+        "fulfillment_posture": posture,
+        "risk_flags": dict(governance_bridge_candidate.get("risk_flags") or {}),
+        "privacy_retention_posture": governance_bridge_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": governance_bridge_candidate.get("consent_posture", "not_asserted"),
+        "candidate_payload_summary": dict(governance_bridge_candidate.get("candidate_payload_summary") or {}),
+        "rationale": list(governance_bridge_candidate.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_commit_retention": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+        "bridge_is_not_admission": True,
+        "fulfillment_candidate_is_not_effect": True,
+    }
+
+
+def resolve_embodied_fulfillment_candidates(*, governance_bridge_candidates: Sequence[Mapping[str, Any]], created_at: float | None = None) -> dict[str, Any]:
+    candidates = []
+    by_kind: dict[str, int] = {}
+    by_posture: dict[str, int] = {}
+    for bridge in governance_bridge_candidates:
+        row = build_embodied_fulfillment_candidate(governance_bridge_candidate=bridge, created_at=created_at)
+        by_posture[row["fulfillment_posture"]] = by_posture.get(row["fulfillment_posture"], 0) + 1
+        if row["fulfillment_posture"] == "eligible_for_fulfillment_review":
+            by_kind[row["fulfillment_candidate_kind"]] = by_kind.get(row["fulfillment_candidate_kind"], 0) + 1
+            candidates.append(row)
+    return {
+        "fulfillment_candidates": candidates,
+        "fulfillment_counts_by_kind": dict(sorted(by_kind.items())),
+        "blocked_fulfillment_counts_by_reason": dict(sorted((k, v) for k, v in by_posture.items() if k != "eligible_for_fulfillment_review")),
+        "counts_by_fulfillment_posture": dict(sorted(by_posture.items())),
+    }
+
+
+def build_embodied_fulfillment_receipt(*, fulfillment_candidate: Mapping[str, Any], fulfillment_outcome: str, fulfiller_kind: str, created_at: float | None = None, fulfiller_ref: str | None = None, fulfiller_label: str | None = None, fulfillment_rationale: str | None = None) -> dict[str, Any]:
+    outcome = classify_embodied_fulfillment_outcome(fulfillment_outcome)
+    material = {
+        "fulfillment_candidate_id": fulfillment_candidate.get("fulfillment_candidate_id"),
+        "fulfillment_outcome": outcome,
+        "fulfiller_kind": fulfiller_kind,
+        "fulfiller_ref": fulfiller_ref,
+        "fulfiller_label": fulfiller_label,
+    }
+    receipt_id = "efr_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "fulfillment_receipt_id": receipt_id,
+        "source_fulfillment_candidate_id": fulfillment_candidate.get("fulfillment_candidate_id"),
+        "source_fulfillment_candidate_ref": embodied_fulfillment_candidate_ref(fulfillment_candidate),
+        "source_governance_bridge_candidate_ref": fulfillment_candidate.get("source_governance_bridge_candidate_ref"),
+        "source_handoff_candidate_ref": fulfillment_candidate.get("source_handoff_candidate_ref"),
+        "source_proposal_id": fulfillment_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": fulfillment_candidate.get("source_review_receipt_id"),
+        "fulfillment_candidate_kind": fulfillment_candidate.get("fulfillment_candidate_kind"),
+        "fulfillment_outcome": outcome,
+        "fulfiller_kind": str(fulfiller_kind or "diagnostic"),
+        "fulfiller_ref": fulfiller_ref,
+        "fulfiller_label": fulfiller_label,
+        "fulfillment_rationale": fulfillment_rationale,
+        "source_event_refs": list(fulfillment_candidate.get("source_event_refs") or []),
+        "correlation_id": fulfillment_candidate.get("correlation_id"),
+        "risk_flags": dict(fulfillment_candidate.get("risk_flags") or {}),
+        "privacy_retention_posture": fulfillment_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": fulfillment_candidate.get("consent_posture", "not_asserted"),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "fulfillment_receipt_is_not_effect": True,
+        "receipt_does_not_prove_side_effect": True,
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_commit_retention": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def append_embodied_fulfillment_receipt(*, path: Path = DEFAULT_FULFILLMENT_RECEIPT_LOG, receipt: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(append_audit_record(path, dict(receipt)))
+
+
+def list_recent_embodied_fulfillment_receipts(*, path: Path = DEFAULT_FULFILLMENT_RECEIPT_LOG, limit: int = 200) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            rows.append(record)
+    return rows[-max(1, int(limit)):]
+
+
+def resolve_embodied_fulfillment_state(*, fulfillment_candidate: Mapping[str, Any], fulfillment_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    candidate_id = str(fulfillment_candidate.get("fulfillment_candidate_id") or "")
+    matched = [r for r in fulfillment_receipts if str(r.get("source_fulfillment_candidate_id") or "") == candidate_id]
+    if not matched:
+        return {"fulfillment_outcome": "pending_fulfillment_review", "latest_fulfillment_receipt_ref": None}
+    latest = max(matched, key=lambda row: (float(row.get("created_at") or 0.0), str(row.get("fulfillment_receipt_id") or "")))
+    return {
+        "fulfillment_outcome": classify_embodied_fulfillment_outcome(str(latest.get("fulfillment_outcome") or "pending_fulfillment_review")),
+        "latest_fulfillment_receipt_ref": embodied_fulfillment_receipt_ref(latest),
+    }
+
+
+def summarize_embodied_fulfillment_status(*, fulfillment_candidates: Sequence[Mapping[str, Any]], fulfillment_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    counts_by_kind: dict[str, int] = {}
+    counts_by_outcome: dict[str, int] = {}
+    pending = 0
+    fulfilled = 0
+    high_risk_pending = 0
+    for c in fulfillment_candidates:
+        kind = str(c.get("fulfillment_candidate_kind") or "unknown")
+        counts_by_kind[kind] = counts_by_kind.get(kind, 0) + 1
+        state = resolve_embodied_fulfillment_state(fulfillment_candidate=c, fulfillment_receipts=fulfillment_receipts)
+        out = state["fulfillment_outcome"]
+        counts_by_outcome[out] = counts_by_outcome.get(out, 0) + 1
+        if out == "pending_fulfillment_review":
+            pending += 1
+            if kind in {"memory_fulfillment_candidate", "feedback_action_fulfillment_candidate", "vision_retention_fulfillment_candidate", "screen_retention_fulfillment_candidate", "multimodal_retention_fulfillment_candidate"}:
+                high_risk_pending += 1
+        if out in {"fulfilled_external_manual", "fulfilled_by_governed_path"}:
+            fulfilled += 1
+
+    if not fulfillment_candidates:
+        posture = "no_fulfillment_candidates"
+    else:
+        labels = ["fulfillment_candidates_available"]
+        if pending > 0:
+            labels.append("pending_fulfillment_review")
+        if fulfilled > 0:
+            labels.append("fulfilled_receipts_present")
+        if high_risk_pending > 0:
+            labels.append("high_risk_fulfillment_review_available")
+        if len(counts_by_outcome) > 1:
+            labels.append("mixed_fulfillment_state")
+        if len(labels) == 1:
+            posture = labels[0]
+        elif len(labels) > 1:
+            posture = "mixed_fulfillment_state" if "mixed_fulfillment_state" in labels else labels[-1]
+    return {
+        "fulfillment_candidate_count": len(fulfillment_candidates),
+        "fulfillment_counts_by_kind": dict(sorted(counts_by_kind.items())),
+        "fulfillment_counts_by_outcome": dict(sorted(counts_by_outcome.items())),
+        "pending_fulfillment_review_count": pending,
+        "fulfilled_receipt_count": fulfilled,
+        "high_risk_fulfillment_pending_count": high_risk_pending,
+        "fulfillment_posture": posture,
+    }
+
+
+__all__ = [k for k in globals().keys() if k.startswith(("CANDIDATE_", "RECEIPT_", "DEFAULT_", "build_", "resolve_", "embodied_", "classify_", "append_", "list_", "summarize_", "ALLOWED_"))]

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -10,6 +10,7 @@ from sentientos.embodiment_proposals import embodied_proposal_ref, list_recent_e
 from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG, list_recent_embodied_proposal_review_receipts, summarize_embodied_proposal_review_status
 from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_candidates
 from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates
+from sentientos.embodiment_fulfillment import resolve_embodied_fulfillment_candidates, summarize_embodied_fulfillment_status
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -106,6 +107,8 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
     review_summary = summarize_embodied_proposal_review_status(proposals=proposals, review_receipts=list(review_receipts or []))
     handoff_resolution = resolve_embodied_handoff_candidates(proposals=proposals, review_receipts=list(review_receipts or []), created_at=generated_at)
     bridge_resolution = resolve_embodied_governance_bridge_candidates(handoff_candidates=handoff_resolution["handoff_candidates"], created_at=generated_at)
+    fulfillment_resolution = resolve_embodied_fulfillment_candidates(governance_bridge_candidates=bridge_resolution["governance_bridge_candidates"], created_at=generated_at)
+    fulfillment_summary = summarize_embodied_fulfillment_status(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], fulfillment_receipts=[])
     next_stage_postures = []
     if handoff_resolution["handoff_candidates"]:
         next_stage_postures.append("handoff_candidates_available")
@@ -115,6 +118,8 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         next_stage_postures.append("privacy_or_consent_holds_present")
     if risk.get("biometric_or_emotion_sensitive", 0) > 0 and handoff_resolution["handoff_candidates"]:
         next_stage_postures.append("high_risk_next_stage_review_available")
+    if fulfillment_resolution["blocked_fulfillment_counts_by_reason"].get("blocked_privacy_or_consent_required", 0) > 0:
+        next_stage_postures.append("privacy_or_consent_holds_present")
     if not next_stage_postures:
         next_stage_posture = "no_review_approved_candidates"
     elif len(next_stage_postures) > 1:
@@ -142,6 +147,13 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         "governance_bridge_counts_by_kind": bridge_resolution["governance_bridge_counts_by_kind"],
         "blocked_bridge_counts_by_reason": bridge_resolution["blocked_bridge_counts_by_reason"],
         "next_stage_posture": next_stage_posture,
+        "fulfillment_candidate_count": len(fulfillment_resolution["fulfillment_candidates"]),
+        "fulfillment_counts_by_kind": fulfillment_resolution["fulfillment_counts_by_kind"],
+        "blocked_fulfillment_counts_by_reason": fulfillment_resolution["blocked_fulfillment_counts_by_reason"],
+        "fulfillment_counts_by_outcome": fulfillment_summary["fulfillment_counts_by_outcome"],
+        "pending_fulfillment_review_count": fulfillment_summary["pending_fulfillment_review_count"],
+        "fulfilled_receipt_count": fulfillment_summary["fulfilled_receipt_count"],
+        "fulfillment_posture": fulfillment_summary["fulfillment_posture"],
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -283,6 +283,35 @@
         "no_scheduler_planner_autonomous_behavior",
         "bridge_is_not_admission"
       ]
+    },
+    "embodiment_fulfillment": {
+      "module_globs": [
+        "sentientos/embodiment_fulfillment.py"
+      ],
+      "classification": "fulfillment_candidate_and_receipt_surface",
+      "candidate_receipt_only": true,
+      "non_authoritative": true,
+      "append_only_receipts": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_retention_commit": true,
+      "no_admission_execution": true,
+      "no_control_plane_mutation": true,
+      "no_scheduler_planner_autonomy": true,
+      "fulfillment_candidate_is_not_effect": true,
+      "fulfillment_receipt_is_not_effect": true,
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -581,3 +581,51 @@ def test_phase51_candidate_output_invariants() -> None:
     assert handoff["handoff_is_not_fulfillment"] is True
     bridge = build_embodied_governance_bridge_candidate(handoff_candidate=handoff)
     assert bridge["bridge_is_not_admission"] is True
+
+def test_phase52_fulfillment_manifest_invariants_declared() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_fulfillment"]
+    assert layer["candidate_receipt_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["append_only_receipts"] is True
+    assert layer["fulfillment_candidate_is_not_effect"] is True
+    assert layer["fulfillment_receipt_is_not_effect"] is True
+
+
+def test_phase52_fulfillment_module_forbidden_imports_not_present() -> None:
+    text = (ROOT / "sentientos/embodiment_fulfillment.py").read_text(encoding="utf-8")
+    forbidden = [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "memory_manager",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+    ]
+    for token in forbidden:
+        assert token not in text
+
+
+def test_phase52_fulfillment_candidate_and_receipt_non_effect_markers() -> None:
+    from sentientos.embodiment_fulfillment import build_embodied_fulfillment_candidate, build_embodied_fulfillment_receipt
+
+    candidate = build_embodied_fulfillment_candidate(
+        governance_bridge_candidate={
+            "governance_bridge_candidate_id": "g1",
+            "governance_bridge_candidate_kind": "memory_governance_review_candidate",
+            "bridge_posture": "eligible_for_governance_review",
+            "source_handoff_candidate_ref": "handoff_candidate:h1",
+        },
+        created_at=1.0,
+    )
+    receipt = build_embodied_fulfillment_receipt(
+        fulfillment_candidate=candidate,
+        fulfillment_outcome="fulfilled_external_manual",
+        fulfiller_kind="test_fixture",
+        created_at=2.0,
+    )
+    assert candidate["fulfillment_candidate_is_not_effect"] is True
+    assert receipt["fulfillment_receipt_is_not_effect"] is True
+    assert receipt["receipt_does_not_prove_side_effect"] is True

--- a/tests/test_phase52_embodied_fulfillment.py
+++ b/tests/test_phase52_embodied_fulfillment.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+from sentientos.embodiment_fulfillment import (
+    append_embodied_fulfillment_receipt,
+    build_embodied_fulfillment_candidate,
+    build_embodied_fulfillment_receipt,
+    classify_embodied_fulfillment_candidate_kind,
+    classify_embodied_fulfillment_outcome,
+    list_recent_embodied_fulfillment_receipts,
+    resolve_embodied_fulfillment_candidates,
+    resolve_embodied_fulfillment_state,
+    summarize_embodied_fulfillment_status,
+)
+from sentientos.embodiment_proposal_diagnostic import summarize_recent_embodied_proposals
+
+
+def _bridge(kind="memory_governance_review_candidate", posture="eligible_for_governance_review", privacy="review", consent="granted"):
+    return {
+        "governance_bridge_candidate_id": "gbc_1",
+        "governance_bridge_candidate_kind": kind,
+        "bridge_posture": posture,
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "p1",
+        "source_review_receipt_id": "r1",
+        "source_ingress_receipt_ref": "ing:p1",
+        "source_event_refs": ["evt:p1"],
+        "correlation_id": "c1",
+        "source_module": "sentientos.embodiment_ingress",
+        "proposal_kind": "memory_ingress_candidate",
+        "risk_flags": {"biometric_sensitive": True},
+        "privacy_retention_posture": privacy,
+        "consent_posture": consent,
+        "candidate_payload_summary": {"x": 1},
+        "rationale": ["r"],
+    }
+
+
+def test_candidate_builder_shape_and_invariants():
+    row = build_embodied_fulfillment_candidate(governance_bridge_candidate=_bridge(), created_at=1.0)
+    assert row["schema_version"].endswith("v1")
+    assert row["fulfillment_candidate_kind"] == "memory_fulfillment_candidate"
+    assert row["decision_power"] == "none"
+    assert row["fulfillment_candidate_is_not_effect"] is True
+
+
+def test_candidate_resolver_filters_and_blocks():
+    ok = _bridge()
+    blocked = _bridge(posture="blocked_handoff_not_eligible")
+    unsupported = _bridge(kind="weird_kind")
+    out = resolve_embodied_fulfillment_candidates(governance_bridge_candidates=[ok, blocked, unsupported], created_at=2.0)
+    assert len(out["fulfillment_candidates"]) == 1
+    assert out["blocked_fulfillment_counts_by_reason"]["blocked_bridge_not_eligible"] == 1
+    assert out["blocked_fulfillment_counts_by_reason"]["blocked_unsupported_kind"] == 1
+
+
+def test_privacy_consent_hold_and_kind_classification():
+    row = build_embodied_fulfillment_candidate(governance_bridge_candidate=_bridge(privacy="sensitive", consent="required"))
+    assert row["fulfillment_posture"] == "blocked_privacy_or_consent_required"
+    assert classify_embodied_fulfillment_candidate_kind("vision_retention_governance_review_candidate") == "vision_retention_fulfillment_candidate"
+
+
+def test_receipt_builder_and_outcome_normalization():
+    candidate = build_embodied_fulfillment_candidate(governance_bridge_candidate=_bridge(), created_at=1.0)
+    receipt = build_embodied_fulfillment_receipt(fulfillment_candidate=candidate, fulfillment_outcome="bogus", fulfiller_kind="test_fixture", created_at=2.0)
+    assert receipt["fulfillment_outcome"] == "fulfillment_failed_validation"
+    assert classify_embodied_fulfillment_outcome("fulfilled_by_governed_path") == "fulfilled_by_governed_path"
+    assert receipt["fulfillment_receipt_is_not_effect"] is True
+    assert receipt["receipt_does_not_prove_side_effect"] is True
+
+
+def test_append_and_list_receipts(tmp_path: Path):
+    p = tmp_path / "receipts.jsonl"
+    candidate = build_embodied_fulfillment_candidate(governance_bridge_candidate=_bridge())
+    r1 = build_embodied_fulfillment_receipt(fulfillment_candidate=candidate, fulfillment_outcome="fulfillment_declined", fulfiller_kind="operator")
+    append_embodied_fulfillment_receipt(path=p, receipt=r1)
+    rows = list_recent_embodied_fulfillment_receipts(path=p)
+    assert len(rows) == 1
+
+
+def test_fulfillment_state_and_summary():
+    c = build_embodied_fulfillment_candidate(governance_bridge_candidate=_bridge(), created_at=1.0)
+    state = resolve_embodied_fulfillment_state(fulfillment_candidate=c, fulfillment_receipts=[])
+    assert state["fulfillment_outcome"] == "pending_fulfillment_review"
+    r1 = build_embodied_fulfillment_receipt(fulfillment_candidate=c, fulfillment_outcome="fulfillment_declined", fulfiller_kind="operator", created_at=2.0)
+    r2 = build_embodied_fulfillment_receipt(fulfillment_candidate=c, fulfillment_outcome="fulfilled_external_manual", fulfiller_kind="operator", created_at=3.0)
+    state2 = resolve_embodied_fulfillment_state(fulfillment_candidate=c, fulfillment_receipts=[r1, r2])
+    assert state2["fulfillment_outcome"] == "fulfilled_external_manual"
+    summary = summarize_embodied_fulfillment_status(fulfillment_candidates=[c], fulfillment_receipts=[r1, r2])
+    assert summary["fulfillment_counts_by_kind"]["memory_fulfillment_candidate"] == 1
+    assert summary["fulfilled_receipt_count"] == 1
+
+
+def test_diagnostic_additive_fulfillment_fields_present():
+    proposals = [{"proposal_id": "p1", "proposal_kind": "memory_ingress_candidate", "source_module": "sentientos.embodiment_ingress", "source_event_refs": [], "rationale": [], "risk_flags": {}, "review_status": "pending_review", "ingress_receipt_ref": "ing:p1", "privacy_retention_posture": "review", "consent_posture": "granted", "candidate_payload_summary": {}}]
+    reviews = [{"proposal_id": "p1", "review_outcome": "reviewed_approved_for_next_stage", "created_at": 1.0, "review_receipt_id": "r1"}]
+    s = summarize_recent_embodied_proposals(proposals, review_receipts=reviews, generated_at=1.0)
+    for key in ["fulfillment_candidate_count", "fulfillment_counts_by_kind", "blocked_fulfillment_counts_by_reason", "fulfillment_counts_by_outcome", "pending_fulfillment_review_count", "fulfilled_receipt_count", "fulfillment_posture"]:
+        assert key in s


### PR DESCRIPTION
### Motivation
- Implement Wave C of the Embodiment Completion Masterplan to provide a bounded, non-authoritative fulfillment candidate and receipt surface for governance bridge candidates without performing effects. 
- Expose fulfillment posture and counts in diagnostics while preserving Phase 51 invariants (no memory writes, feedback triggers, retention commits, admissions, or executions).

### Description
- Add `sentientos/embodiment_fulfillment.py` implementing candidate/receipt shapes, deterministic IDs, kind mapping, posture resolution, receipt append/list via `sentientos.ledger_api.append_audit_record`, state resolution, and summary helpers with explicit non-effect markers (e.g. `fulfillment_candidate_is_not_effect`, `fulfillment_receipt_is_not_effect`).
- Extend `sentientos/embodiment_proposal_diagnostic.py` additively to include fulfillment candidate counts, counts by kind/outcome, blocked counts by reason, pending/fulfilled counts, and a fulfillment posture rollup.
- Update `sentientos/system_closure/architecture_boundary_manifest.json` to add an `embodiment_fulfillment` layer declaring candidate/receipt-only, append-only receipts, non-authoritative invariants, and forbidden imports; add boundary checks in `tests/architecture/test_architecture_boundaries.py`.
- Add ExecPlan at `docs/architecture/phase52_embodied_fulfillment_candidates_execplan.md` and focused tests in `tests/test_phase52_embodied_fulfillment.py` covering builders, resolvers, receipt append/list, state resolution, summary, and diagnostic invariants.

### Testing
- Ran focused Phase 52 and prior focused suites with `python -m scripts.run_tests -q tests/test_phase52_embodied_fulfillment.py tests/test_phase51_embodied_handoff_and_bridge.py tests/test_phase50_embodied_proposal_review_receipts.py tests/test_phase49_embodied_proposal_visibility.py`, which completed with 8 passed and 12 skipped and no failures. 
- Ran architecture/import checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and all tests passed.
- All new tests for candidate/receipt invariants, append-only behavior, resolver state, and diagnostic additions passed; no new memory/write/feedback/admission/execution semantics were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7f25723988320a6b0adb7c69b774f)