### PR TITLE
[codex:embodiment] harden phase coverage and add memory ingress validation

### DIFF
--- a/docs/architecture/phase53_memory_ingress_validation_execplan.md
+++ b/docs/architecture/phase53_memory_ingress_validation_execplan.md
@@ -1,0 +1,56 @@
+# Phase 53 ExecPlan: Fulfillment Coverage Hardening + Governed Memory Ingress Validation
+
+## 1) Current late-stage state (Phases 51/52)
+Late-stage ladder coverage exists for handoff, governance bridge, fulfillment candidates, and fulfillment receipts, but focused runs remained skip-heavy due to legacy-skip quarantine markers not being bypassed in all phase files.
+
+## 2) Skip-hardening plan
+- Inspect phase 49–52 test files + `tests/conftest.py` legacy-skip policy.
+- Add `pytest.mark.no_legacy_skip` to Phase 51/52 files lacking it.
+- Keep intentional/explicit skips unchanged.
+- Re-run focused phase files and report pass/skip counts.
+
+## 3) Wave D target from masterplan
+Introduce the first governed ingress layer after fulfillment:
+- `memory_fulfillment_candidate`
+- `memory_ingress_validation` (non-authoritative receipt-like diagnostic)
+- no memory mutation.
+
+## 4) Memory ingress validation shape
+Create `sentientos/embodiment_memory_ingress.py` with:
+- deterministic validation id
+- validation-only record builder
+- resolver over fulfillment candidates
+- outcome classifier
+- diagnostic summary helper
+
+## 5) Relationship to fulfillment candidates/receipts
+Validation consumes fulfillment candidates (and optional fulfillment receipts for traceability), preserving upstream refs:
+proposal/review/handoff/bridge/ingress/event/correlation/source metadata.
+
+## 6) Consent/privacy/retention checks
+Deterministic rules:
+- unsupported kind -> blocked_unsupported_kind
+- missing provenance refs -> blocked_missing_provenance
+- sensitive/restricted privacy without explicit allow marker -> blocked_privacy_sensitive
+- raw retention requested without explicit allow marker -> blocked_raw_retention
+- missing/unknown consent -> blocked_missing_consent or needs_more_context
+- low-risk + complete provenance + present consent -> validated_for_future_write
+
+## 7) Why validation is still not memory write
+All records are explicitly non-authoritative and include invariants:
+- `decision_power: none`
+- `validation_is_not_memory_write: true`
+- `does_not_write_memory: true`
+- `does_not_admit_work/execute/trigger_feedback/commit_retention: true`
+
+## 8) Tests to add/update
+- Add `tests/test_phase53_memory_ingress_validation.py` for builder, outcomes, blockers, summary posture, boundary invariants.
+- Update architecture boundaries test for new layer manifest and forbidden import/non-effect assertions.
+- Update phase 51/52 test markers for no-legacy-skip focused execution.
+
+## 9) Deferred semantics
+Deferred to later phases:
+- actual governed memory append/write
+- authority/admission/execution coupling
+- feedback/action ingress
+- retention commit ingress

--- a/sentientos/embodiment_memory_ingress.py
+++ b/sentientos/embodiment_memory_ingress.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_fulfillment import embodied_fulfillment_candidate_ref, embodied_fulfillment_receipt_ref
+
+VALIDATION_SCHEMA_VERSION = "embodiment.memory_ingress_validation.v1"
+
+SUPPORTED_FULFILLMENT_KIND = "memory_fulfillment_candidate"
+
+ALLOWED_OUTCOMES = {
+    "memory_ingress_validated_for_future_write",
+    "memory_ingress_blocked_missing_consent",
+    "memory_ingress_blocked_privacy_sensitive",
+    "memory_ingress_blocked_raw_retention",
+    "memory_ingress_blocked_missing_provenance",
+    "memory_ingress_blocked_unsupported_kind",
+    "memory_ingress_needs_more_context",
+}
+
+
+def memory_ingress_validation_ref(record: Mapping[str, Any]) -> str:
+    return f"memory_ingress_validation:{record['memory_ingress_validation_id']}"
+
+
+def classify_memory_ingress_validation_outcome(candidate: Mapping[str, Any]) -> str:
+    kind = str(candidate.get("fulfillment_candidate_kind") or "")
+    if kind != SUPPORTED_FULFILLMENT_KIND:
+        return "memory_ingress_blocked_unsupported_kind"
+
+    if not all(
+        [
+            candidate.get("fulfillment_candidate_id"),
+            candidate.get("source_governance_bridge_candidate_ref"),
+            candidate.get("source_handoff_candidate_ref"),
+            candidate.get("source_proposal_id"),
+            candidate.get("source_review_receipt_id"),
+        ]
+    ):
+        return "memory_ingress_blocked_missing_provenance"
+
+    privacy_posture = str(candidate.get("privacy_retention_posture") or "")
+    risk_flags = dict(candidate.get("risk_flags") or {})
+    privacy_allow = bool(risk_flags.get("allow_privacy_sensitive_memory_ingress"))
+    if privacy_posture in {"sensitive", "restricted"} and not privacy_allow:
+        return "memory_ingress_blocked_privacy_sensitive"
+
+    payload = dict(candidate.get("candidate_payload_summary") or {})
+    raw_requested = bool(risk_flags.get("raw_retention_requested") or payload.get("raw_retention_requested"))
+    raw_allowed = bool(risk_flags.get("allow_raw_retention_memory_ingress") or payload.get("allow_raw_retention_memory_ingress"))
+    if raw_requested and not raw_allowed:
+        return "memory_ingress_blocked_raw_retention"
+
+    consent_posture = str(candidate.get("consent_posture") or "")
+    if consent_posture in {"", "unknown", "not_asserted", "required"}:
+        return "memory_ingress_blocked_missing_consent"
+    if consent_posture in {"review", "conditional"}:
+        return "memory_ingress_needs_more_context"
+
+    return "memory_ingress_validated_for_future_write"
+
+
+def build_memory_ingress_validation_record(*, memory_fulfillment_candidate: Mapping[str, Any], validation_outcome: str | None = None, source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    source_ref = embodied_fulfillment_candidate_ref(memory_fulfillment_candidate)
+    outcome = validation_outcome or classify_memory_ingress_validation_outcome(memory_fulfillment_candidate)
+    if outcome not in ALLOWED_OUTCOMES:
+        outcome = "memory_ingress_needs_more_context"
+    material = {
+        "source_fulfillment_candidate_id": memory_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "validation_outcome": outcome,
+        "source_review_receipt_id": memory_fulfillment_candidate.get("source_review_receipt_id"),
+    }
+    validation_id = "miv_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    provenance_complete = outcome != "memory_ingress_blocked_missing_provenance"
+    raw_allowed = bool(
+        (memory_fulfillment_candidate.get("risk_flags") or {}).get("allow_raw_retention_memory_ingress")
+        or (memory_fulfillment_candidate.get("candidate_payload_summary") or {}).get("allow_raw_retention_memory_ingress")
+    )
+    return {
+        "schema_version": VALIDATION_SCHEMA_VERSION,
+        "memory_ingress_validation_id": validation_id,
+        "source_fulfillment_candidate_id": memory_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "source_fulfillment_candidate_ref": source_ref,
+        "source_governance_bridge_candidate_ref": memory_fulfillment_candidate.get("source_governance_bridge_candidate_ref"),
+        "source_handoff_candidate_ref": memory_fulfillment_candidate.get("source_handoff_candidate_ref"),
+        "source_proposal_id": memory_fulfillment_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": memory_fulfillment_candidate.get("source_review_receipt_id"),
+        "source_ingress_receipt_ref": memory_fulfillment_candidate.get("source_ingress_receipt_ref"),
+        "source_event_refs": list(memory_fulfillment_candidate.get("source_event_refs") or []),
+        "correlation_id": memory_fulfillment_candidate.get("correlation_id"),
+        "source_module": memory_fulfillment_candidate.get("source_module"),
+        "source_fulfillment_receipt_ref": embodied_fulfillment_receipt_ref(source_fulfillment_receipt) if source_fulfillment_receipt else None,
+        "validation_outcome": outcome,
+        "memory_candidate_summary": dict(memory_fulfillment_candidate.get("candidate_payload_summary") or {}),
+        "privacy_retention_posture": memory_fulfillment_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": memory_fulfillment_candidate.get("consent_posture", "not_asserted"),
+        "risk_flags": dict(memory_fulfillment_candidate.get("risk_flags") or {}),
+        "provenance_complete": provenance_complete,
+        "raw_retention_allowed": raw_allowed,
+        "rationale": list(memory_fulfillment_candidate.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "validation_is_not_memory_write": True,
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_commit_retention": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def validate_memory_fulfillment_candidate(*, memory_fulfillment_candidate: Mapping[str, Any], source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    return build_memory_ingress_validation_record(
+        memory_fulfillment_candidate=memory_fulfillment_candidate,
+        source_fulfillment_receipt=source_fulfillment_receipt,
+        created_at=created_at,
+    )
+
+
+def resolve_memory_ingress_validations(*, fulfillment_candidates: Sequence[Mapping[str, Any]], fulfillment_receipts: Sequence[Mapping[str, Any]] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    receipt_by_candidate = {
+        str(r.get("source_fulfillment_candidate_id") or ""): r
+        for r in (fulfillment_receipts or [])
+        if isinstance(r, Mapping)
+    }
+    rows: list[dict[str, Any]] = []
+    by_outcome: dict[str, int] = {}
+    for candidate in fulfillment_candidates:
+        candidate_id = str(candidate.get("fulfillment_candidate_id") or "")
+        row = validate_memory_fulfillment_candidate(
+            memory_fulfillment_candidate=candidate,
+            source_fulfillment_receipt=receipt_by_candidate.get(candidate_id),
+            created_at=created_at,
+        )
+        rows.append(row)
+        by_outcome[row["validation_outcome"]] = by_outcome.get(row["validation_outcome"], 0) + 1
+    return {
+        "memory_ingress_validations": rows,
+        "memory_ingress_validation_counts_by_outcome": dict(sorted(by_outcome.items())),
+    }
+
+
+def summarize_memory_ingress_validation_status(*, memory_ingress_validations: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    counts_by_outcome: dict[str, int] = {}
+    validated = 0
+    blocked = 0
+    for row in memory_ingress_validations:
+        outcome = str(row.get("validation_outcome") or "memory_ingress_needs_more_context")
+        counts_by_outcome[outcome] = counts_by_outcome.get(outcome, 0) + 1
+        if outcome == "memory_ingress_validated_for_future_write":
+            validated += 1
+        elif outcome.startswith("memory_ingress_blocked"):
+            blocked += 1
+
+    if not memory_ingress_validations:
+        posture = "no_memory_ingress_candidates"
+    else:
+        flags = []
+        if blocked > 0:
+            flags.append("memory_ingress_blocked_items_present")
+        if validated > 0:
+            flags.append("memory_ingress_future_write_candidates_present")
+        if len(flags) > 1:
+            posture = "mixed_memory_ingress_state"
+        elif flags:
+            posture = flags[0]
+        else:
+            posture = "memory_ingress_validations_present"
+
+    return {
+        "memory_ingress_validation_count": len(memory_ingress_validations),
+        "memory_ingress_validation_counts_by_outcome": dict(sorted(counts_by_outcome.items())),
+        "memory_ingress_validated_for_future_write_count": validated,
+        "memory_ingress_blocked_count": blocked,
+        "memory_ingress_posture": posture,
+    }
+
+
+__all__ = [k for k in globals().keys() if k.startswith(("VALIDATION_", "SUPPORTED_", "ALLOWED_", "build_", "validate_", "resolve_", "classify_", "summarize_", "memory_ingress_"))]

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -11,6 +11,7 @@ from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG, li
 from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_candidates
 from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates
 from sentientos.embodiment_fulfillment import resolve_embodied_fulfillment_candidates, summarize_embodied_fulfillment_status
+from sentientos.embodiment_memory_ingress import resolve_memory_ingress_validations, summarize_memory_ingress_validation_status
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -109,6 +110,8 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
     bridge_resolution = resolve_embodied_governance_bridge_candidates(handoff_candidates=handoff_resolution["handoff_candidates"], created_at=generated_at)
     fulfillment_resolution = resolve_embodied_fulfillment_candidates(governance_bridge_candidates=bridge_resolution["governance_bridge_candidates"], created_at=generated_at)
     fulfillment_summary = summarize_embodied_fulfillment_status(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], fulfillment_receipts=[])
+    memory_ingress_resolution = resolve_memory_ingress_validations(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], created_at=generated_at)
+    memory_ingress_summary = summarize_memory_ingress_validation_status(memory_ingress_validations=memory_ingress_resolution["memory_ingress_validations"])
     next_stage_postures = []
     if handoff_resolution["handoff_candidates"]:
         next_stage_postures.append("handoff_candidates_available")
@@ -154,6 +157,11 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         "pending_fulfillment_review_count": fulfillment_summary["pending_fulfillment_review_count"],
         "fulfilled_receipt_count": fulfillment_summary["fulfilled_receipt_count"],
         "fulfillment_posture": fulfillment_summary["fulfillment_posture"],
+        "memory_ingress_validation_count": memory_ingress_summary["memory_ingress_validation_count"],
+        "memory_ingress_validation_counts_by_outcome": memory_ingress_summary["memory_ingress_validation_counts_by_outcome"],
+        "memory_ingress_validated_for_future_write_count": memory_ingress_summary["memory_ingress_validated_for_future_write_count"],
+        "memory_ingress_blocked_count": memory_ingress_summary["memory_ingress_blocked_count"],
+        "memory_ingress_posture": memory_ingress_summary["memory_ingress_posture"],
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -312,6 +312,33 @@
         "multimodal_tracker",
         "sentientos.perception_api"
       ]
+    },
+    "embodiment_memory_ingress": {
+      "module_globs": [
+        "sentientos/embodiment_memory_ingress.py"
+      ],
+      "classification": "governed_memory_ingress_validation_surface",
+      "validation_only": true,
+      "non_authoritative": true,
+      "validation_is_not_memory_write": true,
+      "no_direct_memory_write": true,
+      "no_action_trigger": true,
+      "no_retention_commit": true,
+      "no_admission_execution": true,
+      "no_control_plane_mutation": true,
+      "no_feedback_trigger": true,
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "memory_manager",
+        "feedback",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -629,3 +629,40 @@ def test_phase52_fulfillment_candidate_and_receipt_non_effect_markers() -> None:
     assert candidate["fulfillment_candidate_is_not_effect"] is True
     assert receipt["fulfillment_receipt_is_not_effect"] is True
     assert receipt["receipt_does_not_prove_side_effect"] is True
+
+def test_phase53_memory_ingress_manifest_invariants_declared() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_memory_ingress"]
+    assert layer["validation_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["validation_is_not_memory_write"] is True
+    assert layer["no_direct_memory_write"] is True
+    assert layer["no_admission_execution"] is True
+    assert layer["no_control_plane_mutation"] is True
+    assert layer["no_feedback_trigger"] is True
+    assert layer["no_retention_commit"] is True
+
+
+def test_phase53_memory_ingress_module_forbidden_imports_and_non_effect_flags() -> None:
+    path = ROOT / "sentientos/embodiment_memory_ingress.py"
+    text = path.read_text(encoding="utf-8")
+    imports = _imports(path)
+    for forbidden in (
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "memory_manager",
+        "feedback",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+        "sentientos.perception_api",
+    ):
+        assert not any(mod == forbidden or mod.startswith(f"{forbidden}.") for mod, _ in imports)
+
+    assert '"validation_is_not_memory_write": True' in text
+    assert '"does_not_write_memory": True' in text
+    assert '"does_not_trigger_feedback": True' in text
+    assert '"does_not_admit_work": True' in text
+    assert '"does_not_execute_or_route_work": True' in text

--- a/tests/test_phase51_embodied_handoff_and_bridge.py
+++ b/tests/test_phase51_embodied_handoff_and_bridge.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
 from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_candidates, build_embodied_handoff_candidate
 from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates, build_embodied_governance_bridge_candidate
 from sentientos.embodiment_proposal_diagnostic import summarize_recent_embodied_proposals

--- a/tests/test_phase52_embodied_fulfillment.py
+++ b/tests/test_phase52_embodied_fulfillment.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
 from sentientos.embodiment_fulfillment import (
     append_embodied_fulfillment_receipt,
     build_embodied_fulfillment_candidate,

--- a/tests/test_phase53_memory_ingress_validation.py
+++ b/tests/test_phase53_memory_ingress_validation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from sentientos.embodiment_memory_ingress import (
+    build_memory_ingress_validation_record,
+    resolve_memory_ingress_validations,
+    summarize_memory_ingress_validation_status,
+    validate_memory_fulfillment_candidate,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _candidate(kind: str = "memory_fulfillment_candidate", **overrides):
+    row = {
+        "fulfillment_candidate_id": "efc_1",
+        "fulfillment_candidate_kind": kind,
+        "source_governance_bridge_candidate_ref": "governance_bridge_candidate:gb1",
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "p1",
+        "source_review_receipt_id": "r1",
+        "source_ingress_receipt_ref": "ing:p1",
+        "source_event_refs": ["evt:p1"],
+        "correlation_id": "c1",
+        "source_module": "sentientos.embodiment_ingress",
+        "privacy_retention_posture": "review",
+        "consent_posture": "granted",
+        "risk_flags": {},
+        "candidate_payload_summary": {"summary": "ok"},
+        "rationale": ["r"],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_phase53_validation_builder_shape_and_non_authority_fields():
+    row = build_memory_ingress_validation_record(memory_fulfillment_candidate=_candidate(), created_at=1.0)
+    assert row["schema_version"].endswith("v1")
+    assert row["decision_power"] == "none"
+    assert row["non_authoritative"] is True
+    assert row["validation_is_not_memory_write"] is True
+    assert row["does_not_write_memory"] is True
+
+
+def test_phase53_supported_kind_validates_for_future_write():
+    row = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate())
+    assert row["validation_outcome"] == "memory_ingress_validated_for_future_write"
+
+
+@pytest.mark.parametrize("kind", ["feedback_action_fulfillment_candidate", "screen_retention_fulfillment_candidate", "vision_retention_fulfillment_candidate", "multimodal_retention_fulfillment_candidate"])
+def test_phase53_unsupported_kind_blocks(kind: str):
+    row = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(kind=kind))
+    assert row["validation_outcome"] == "memory_ingress_blocked_unsupported_kind"
+
+
+def test_phase53_missing_consent_blocks_or_holds():
+    row = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(consent_posture="not_asserted"))
+    assert row["validation_outcome"] in {"memory_ingress_blocked_missing_consent", "memory_ingress_needs_more_context"}
+
+
+def test_phase53_privacy_sensitive_blocks_without_allow_and_passes_with_allow():
+    blocked = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive"))
+    assert blocked["validation_outcome"] == "memory_ingress_blocked_privacy_sensitive"
+    allowed = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive", risk_flags={"allow_privacy_sensitive_memory_ingress": True}))
+    assert allowed["validation_outcome"] == "memory_ingress_validated_for_future_write"
+
+
+def test_phase53_raw_retention_blocks_without_allow_and_passes_with_allow():
+    blocked = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(risk_flags={"raw_retention_requested": True}))
+    assert blocked["validation_outcome"] == "memory_ingress_blocked_raw_retention"
+    allowed = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(risk_flags={"raw_retention_requested": True, "allow_raw_retention_memory_ingress": True}))
+    assert allowed["validation_outcome"] == "memory_ingress_validated_for_future_write"
+
+
+def test_phase53_missing_provenance_blocks():
+    row = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate(source_review_receipt_id=None))
+    assert row["validation_outcome"] == "memory_ingress_blocked_missing_provenance"
+
+
+def test_phase53_diagnostic_summary_counts_and_posture():
+    rows = resolve_memory_ingress_validations(fulfillment_candidates=[
+        _candidate(fulfillment_candidate_id="a"),
+        _candidate(fulfillment_candidate_id="b", consent_posture="not_asserted"),
+    ])["memory_ingress_validations"]
+    summary = summarize_memory_ingress_validation_status(memory_ingress_validations=rows)
+    assert summary["memory_ingress_validation_count"] == 2
+    assert summary["memory_ingress_validated_for_future_write_count"] == 1
+    assert summary["memory_ingress_blocked_count"] == 1
+    assert summary["memory_ingress_posture"] == "mixed_memory_ingress_state"
+
+
+def test_phase53_boundary_invariants():
+    row = validate_memory_fulfillment_candidate(memory_fulfillment_candidate=_candidate())
+    assert row["does_not_write_memory"] is True
+    assert row["does_not_trigger_feedback"] is True
+    assert row["does_not_admit_work"] is True
+    assert row["does_not_execute_or_route_work"] is True
+    assert row["decision_power"] == "none"


### PR DESCRIPTION
### Motivation
- Harden late-stage Phase 51/52 test coverage so the late-stage embodiment ladder is meaningfully exercised by focused suites rather than being quarantine-skipped.
- Introduce the first Wave D validation surface for governed memory ingress that consumes fulfillment candidates and emits non-authoritative validation receipts without performing any memory writes or admissions.
- Provide diagnostic visibility and manifest-level architecture metadata for the new validation surface while preserving all non-effect invariants.

### Description
- Added a validation-only memory ingress module `sentientos/embodiment_memory_ingress.py` with builders/resolvers/classifiers (`build_memory_ingress_validation_record`, `validate_memory_fulfillment_candidate`, `resolve_memory_ingress_validations`, `summarize_memory_ingress_validation_status`, etc.) that consume fulfillment candidates and return deterministic, non-authoritative validation records.
- Integrated memory-ingress rollups into proposal diagnostics via `sentientos/embodiment_proposal_diagnostic.py` so summaries expose validation counts, counts-by-outcome, validated-for-future-write and blocked counts without mutating state.
- Updated architecture manifest `sentientos/system_closure/architecture_boundary_manifest.json` to declare a new `embodiment_memory_ingress` layer with explicit invariants (validation-only, non-authoritative, no memory write/admission/execution/control-plane mutation, no feedback/retention commit) and added boundary tests enforcing forbidden imports and non-effect flags.
- Hardened focused suites by adding `pytest.mark.no_legacy_skip` to Phase 51/52 test files, added `tests/test_phase53_memory_ingress_validation.py` for validation behavior, and added architecture tests to assert manifest invariants and module import boundaries; also added the planning artifact `docs/architecture/phase53_memory_ingress_validation_execplan.md`.

### Testing
- Ran focused late-stage suites: `python -m scripts.run_tests -q tests/test_phase52_embodied_fulfillment.py tests/test_phase51_embodied_handoff_and_bridge.py tests/test_phase50_embodied_proposal_review_receipts.py tests/test_phase49_embodied_proposal_visibility.py` which completed with 20 passed and 0 skipped.
- Ran Phase 53 + Phase 51/52 focused suites: `python -m scripts.run_tests -q tests/test_phase53_memory_ingress_validation.py tests/test_phase52_embodied_fulfillment.py tests/test_phase51_embodied_handoff_and_bridge.py tests/test_phase50_embodied_proposal_review_receipts.py` which completed with 28 passed and 0 skipped.
- Ran architecture/integrity and orchestration boundary checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` which completed with 51 passed, and `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` which completed with 293 passed.
- All new tests and diagnostic integrations are passing in the focused runs; no code path performs memory writes, admission, execution, or control-plane mutation as enforced by tests and manifest invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8045f06ec8320910fa9422bce487d)