### PR TITLE
[codex:embodiment] add phase54 action ingress validation surface

### DIFF
--- a/docs/architecture/phase54_feedback_action_ingress_validation_execplan.md
+++ b/docs/architecture/phase54_feedback_action_ingress_validation_execplan.md
@@ -1,0 +1,76 @@
+# Phase 54 ExecPlan: Governed Feedback/Action Ingress Validation Surface
+
+## 1) Current Phase 53 memory ingress state
+Phase 53 introduced `sentientos.embodiment_memory_ingress` as a validation-only layer that consumes fulfillment candidates and emits non-authoritative validation records. It enforces provenance/consent/privacy checks, produces deterministic IDs, adds diagnostic rollups, and explicitly preserves non-effect invariants (`decision_power="none"`, no memory write/action trigger/admission/execution).
+
+## 2) Wave E target from `embodiment_completion_masterplan`
+From the masterplan Wave D/E/F sequence, Wave E is the sibling to memory ingress for feedback/action ingress. Target is an additive, governed ingress validation surface for action candidates, while still deferring actual feedback/action execution semantics.
+
+## 3) Feedback/action ingress validation shape
+Add canonical module `sentientos.embodiment_action_ingress` with helpers:
+- `action_ingress_validation_ref`
+- `classify_action_ingress_validation_outcome`
+- `build_action_ingress_validation_record`
+- `validate_action_fulfillment_candidate`
+- `resolve_action_ingress_validations`
+- `summarize_action_ingress_validation_status`
+
+Record shape includes provenance chain refs, candidate summary, privacy/consent/risk posture, non-authoritative invariants, and explicit markers that validation is not execution or trigger.
+
+## 4) Relationship to fulfillment candidates/receipts
+Inputs:
+- `feedback_action_fulfillment_candidate` records from `sentientos.embodiment_fulfillment`
+- optional fulfillment receipt rows for traceability only
+
+Outputs:
+- action ingress validation records and outcome summaries
+
+No mutation of fulfillment candidates or receipts; no side-effect callback invocation.
+
+## 5) Consent/safety/provenance/action-risk checks
+Deterministic classifier rules:
+1. Unsupported candidate kinds block.
+2. Missing provenance chain fields block.
+3. Missing/unknown/not_asserted/required consent blocks.
+4. Conditional/review consent posture yields needs-more-context.
+5. Privacy-sensitive/restricted posture blocks unless explicit allow marker.
+6. Unsafe/external-side-effect flags block as unsafe unless explicit allow marker.
+7. High-risk flags block unless explicit allow marker.
+8. Operator confirmation required without explicit confirmation marker yields needs-more-context.
+9. Otherwise validate for future trigger (still non-authoritative).
+
+## 6) Why validation is still not feedback trigger or action execution
+All produced records hardcode non-effect invariants:
+- `non_authoritative: true`
+- `decision_power: "none"`
+- `validation_is_not_action_trigger: true`
+- `does_not_trigger_feedback: true`
+- `does_not_execute_or_route_work: true`
+- `does_not_admit_work: true`
+- `does_not_write_memory: true`
+- `does_not_commit_retention: true`
+
+No imports of executor/admission/control-plane/feedback effect modules are introduced.
+
+## 7) Tests to add/update
+Add `tests/test_phase54_action_ingress_validation.py` covering:
+- record shape + invariants
+- supported/unsupported kind outcomes
+- missing consent/provenance outcomes
+- privacy-sensitive risk behavior with and without allow markers
+- unsafe/high-risk behavior with and without allow markers
+- operator confirmation holds
+- aggregate summary counts/posture
+- boundary non-effect assertions
+
+Update architecture boundary tests and manifest assertions for new module/layer invariants. Keep Phase 51–53 tests green.
+
+## 8) Deferred actual feedback/action execution semantics
+Explicitly deferred beyond Phase 54:
+- action trigger or feedback dispatch
+- task admission/execution calls
+- control-plane mutation
+- retention commit and memory write effects
+- authority tokenization of ingress validations
+
+Phase 54 only provides a governed validation envelope for future downstream governed action paths.

--- a/sentientos/embodiment_action_ingress.py
+++ b/sentientos/embodiment_action_ingress.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_fulfillment import embodied_fulfillment_candidate_ref, embodied_fulfillment_receipt_ref
+
+VALIDATION_SCHEMA_VERSION = "embodiment.action_ingress_validation.v1"
+SUPPORTED_FULFILLMENT_KIND = "feedback_action_fulfillment_candidate"
+
+ALLOWED_OUTCOMES = {
+    "action_ingress_validated_for_future_trigger",
+    "action_ingress_blocked_missing_consent",
+    "action_ingress_blocked_missing_provenance",
+    "action_ingress_blocked_unsafe_action",
+    "action_ingress_blocked_high_risk_action",
+    "action_ingress_blocked_privacy_sensitive",
+    "action_ingress_blocked_unsupported_kind",
+    "action_ingress_needs_more_context",
+}
+
+
+def action_ingress_validation_ref(record: Mapping[str, Any]) -> str:
+    return f"action_ingress_validation:{record['action_ingress_validation_id']}"
+
+
+def classify_action_ingress_validation_outcome(candidate: Mapping[str, Any]) -> str:
+    kind = str(candidate.get("fulfillment_candidate_kind") or "")
+    if kind != SUPPORTED_FULFILLMENT_KIND:
+        return "action_ingress_blocked_unsupported_kind"
+
+    if not all([
+        candidate.get("fulfillment_candidate_id"),
+        candidate.get("source_governance_bridge_candidate_ref"),
+        candidate.get("source_handoff_candidate_ref"),
+        candidate.get("source_proposal_id"),
+        candidate.get("source_review_receipt_id"),
+    ]):
+        return "action_ingress_blocked_missing_provenance"
+
+    consent_posture = str(candidate.get("consent_posture") or "")
+    if consent_posture in {"", "unknown", "not_asserted", "required"}:
+        return "action_ingress_blocked_missing_consent"
+    if consent_posture in {"review", "conditional"}:
+        return "action_ingress_needs_more_context"
+
+    risk_flags = dict(candidate.get("risk_flags") or {})
+    privacy_posture = str(candidate.get("privacy_retention_posture") or "")
+    if privacy_posture in {"sensitive", "restricted"} and not bool(risk_flags.get("allow_privacy_sensitive_action_ingress")):
+        return "action_ingress_blocked_privacy_sensitive"
+
+    candidate_payload = dict(candidate.get("candidate_payload_summary") or {})
+    requires_operator_confirmation = bool(
+        candidate_payload.get("requires_operator_confirmation")
+        or risk_flags.get("requires_operator_confirmation")
+    )
+    operator_confirmed = bool(
+        candidate_payload.get("operator_confirmation_present")
+        or risk_flags.get("operator_confirmation_present")
+    )
+    if requires_operator_confirmation and not operator_confirmed:
+        return "action_ingress_needs_more_context"
+
+    unsafe_requested = bool(
+        risk_flags.get("unsafe_action")
+        or risk_flags.get("action_dangerous")
+        or risk_flags.get("external_side_effect")
+        or candidate_payload.get("external_side_effect")
+    )
+    if unsafe_requested and not bool(risk_flags.get("allow_unsafe_action_ingress")):
+        return "action_ingress_blocked_unsafe_action"
+
+    high_risk = bool(risk_flags.get("high_risk_action") or risk_flags.get("action_high_risk"))
+    if high_risk and not bool(risk_flags.get("allow_high_risk_action_ingress")):
+        return "action_ingress_blocked_high_risk_action"
+
+    return "action_ingress_validated_for_future_trigger"
+
+
+def build_action_ingress_validation_record(*, feedback_action_fulfillment_candidate: Mapping[str, Any], validation_outcome: str | None = None, source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    outcome = validation_outcome or classify_action_ingress_validation_outcome(feedback_action_fulfillment_candidate)
+    if outcome not in ALLOWED_OUTCOMES:
+        outcome = "action_ingress_needs_more_context"
+
+    material = {
+        "source_fulfillment_candidate_id": feedback_action_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "validation_outcome": outcome,
+        "source_review_receipt_id": feedback_action_fulfillment_candidate.get("source_review_receipt_id"),
+    }
+    validation_id = "aiv_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    payload = dict(feedback_action_fulfillment_candidate.get("candidate_payload_summary") or {})
+    risk_flags = dict(feedback_action_fulfillment_candidate.get("risk_flags") or {})
+    return {
+        "schema_version": VALIDATION_SCHEMA_VERSION,
+        "action_ingress_validation_id": validation_id,
+        "source_fulfillment_candidate_id": feedback_action_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "source_fulfillment_candidate_ref": embodied_fulfillment_candidate_ref(feedback_action_fulfillment_candidate),
+        "source_governance_bridge_candidate_ref": feedback_action_fulfillment_candidate.get("source_governance_bridge_candidate_ref"),
+        "source_handoff_candidate_ref": feedback_action_fulfillment_candidate.get("source_handoff_candidate_ref"),
+        "source_proposal_id": feedback_action_fulfillment_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": feedback_action_fulfillment_candidate.get("source_review_receipt_id"),
+        "source_ingress_receipt_ref": feedback_action_fulfillment_candidate.get("source_ingress_receipt_ref"),
+        "source_event_refs": list(feedback_action_fulfillment_candidate.get("source_event_refs") or []),
+        "correlation_id": feedback_action_fulfillment_candidate.get("correlation_id"),
+        "source_module": feedback_action_fulfillment_candidate.get("source_module"),
+        "source_fulfillment_receipt_ref": embodied_fulfillment_receipt_ref(source_fulfillment_receipt) if source_fulfillment_receipt else None,
+        "validation_outcome": outcome,
+        "action_candidate_summary": payload,
+        "privacy_retention_posture": feedback_action_fulfillment_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": feedback_action_fulfillment_candidate.get("consent_posture", "not_asserted"),
+        "risk_flags": risk_flags,
+        "provenance_complete": outcome != "action_ingress_blocked_missing_provenance",
+        "action_risk_class": "high" if (risk_flags.get("high_risk_action") or risk_flags.get("action_high_risk")) else ("unsafe" if (risk_flags.get("unsafe_action") or risk_flags.get("action_dangerous") or risk_flags.get("external_side_effect")) else "low"),
+        "requires_operator_confirmation": bool(payload.get("requires_operator_confirmation") or risk_flags.get("requires_operator_confirmation")),
+        "rationale": list(feedback_action_fulfillment_candidate.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "validation_is_not_action_trigger": True,
+        "does_not_trigger_feedback": True,
+        "does_not_execute_or_route_work": True,
+        "does_not_admit_work": True,
+        "does_not_write_memory": True,
+        "does_not_commit_retention": True,
+    }
+
+
+def validate_action_fulfillment_candidate(*, feedback_action_fulfillment_candidate: Mapping[str, Any], source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    return build_action_ingress_validation_record(
+        feedback_action_fulfillment_candidate=feedback_action_fulfillment_candidate,
+        source_fulfillment_receipt=source_fulfillment_receipt,
+        created_at=created_at,
+    )
+
+
+def resolve_action_ingress_validations(*, fulfillment_candidates: Sequence[Mapping[str, Any]], fulfillment_receipts: Sequence[Mapping[str, Any]] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    receipt_by_candidate = {str(r.get("source_fulfillment_candidate_id") or ""): r for r in (fulfillment_receipts or []) if isinstance(r, Mapping)}
+    rows: list[dict[str, Any]] = []
+    by_outcome: dict[str, int] = {}
+    for candidate in fulfillment_candidates:
+        row = validate_action_fulfillment_candidate(
+            feedback_action_fulfillment_candidate=candidate,
+            source_fulfillment_receipt=receipt_by_candidate.get(str(candidate.get("fulfillment_candidate_id") or "")),
+            created_at=created_at,
+        )
+        rows.append(row)
+        by_outcome[row["validation_outcome"]] = by_outcome.get(row["validation_outcome"], 0) + 1
+    return {
+        "action_ingress_validations": rows,
+        "action_ingress_validation_counts_by_outcome": dict(sorted(by_outcome.items())),
+    }
+
+
+def summarize_action_ingress_validation_status(*, action_ingress_validations: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    counts_by_outcome: dict[str, int] = {}
+    validated = 0
+    blocked = 0
+    for row in action_ingress_validations:
+        outcome = str(row.get("validation_outcome") or "action_ingress_needs_more_context")
+        counts_by_outcome[outcome] = counts_by_outcome.get(outcome, 0) + 1
+        if outcome == "action_ingress_validated_for_future_trigger":
+            validated += 1
+        elif outcome.startswith("action_ingress_blocked"):
+            blocked += 1
+
+    if not action_ingress_validations:
+        posture = "no_action_ingress_candidates"
+    else:
+        labels = []
+        if blocked > 0:
+            labels.append("action_ingress_blocked_items_present")
+        if validated > 0:
+            labels.append("action_ingress_future_trigger_candidates_present")
+        posture = "mixed_action_ingress_state" if len(labels) > 1 else (labels[0] if labels else "action_ingress_validations_present")
+
+    return {
+        "action_ingress_validation_count": len(action_ingress_validations),
+        "action_ingress_validation_counts_by_outcome": dict(sorted(counts_by_outcome.items())),
+        "action_ingress_validated_for_future_trigger_count": validated,
+        "action_ingress_blocked_count": blocked,
+        "action_ingress_posture": posture,
+    }
+
+
+__all__ = [k for k in globals().keys() if k.startswith(("VALIDATION_", "SUPPORTED_", "ALLOWED_", "build_", "validate_", "resolve_", "classify_", "summarize_", "action_ingress_"))]

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -12,6 +12,7 @@ from sentientos.embodiment_proposal_handoff import resolve_embodied_handoff_cand
 from sentientos.embodiment_governance_bridge import resolve_embodied_governance_bridge_candidates
 from sentientos.embodiment_fulfillment import resolve_embodied_fulfillment_candidates, summarize_embodied_fulfillment_status
 from sentientos.embodiment_memory_ingress import resolve_memory_ingress_validations, summarize_memory_ingress_validation_status
+from sentientos.embodiment_action_ingress import resolve_action_ingress_validations, summarize_action_ingress_validation_status
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -112,6 +113,8 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
     fulfillment_summary = summarize_embodied_fulfillment_status(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], fulfillment_receipts=[])
     memory_ingress_resolution = resolve_memory_ingress_validations(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], created_at=generated_at)
     memory_ingress_summary = summarize_memory_ingress_validation_status(memory_ingress_validations=memory_ingress_resolution["memory_ingress_validations"])
+    action_ingress_resolution = resolve_action_ingress_validations(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], created_at=generated_at)
+    action_ingress_summary = summarize_action_ingress_validation_status(action_ingress_validations=action_ingress_resolution["action_ingress_validations"])
     next_stage_postures = []
     if handoff_resolution["handoff_candidates"]:
         next_stage_postures.append("handoff_candidates_available")
@@ -162,6 +165,11 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         "memory_ingress_validated_for_future_write_count": memory_ingress_summary["memory_ingress_validated_for_future_write_count"],
         "memory_ingress_blocked_count": memory_ingress_summary["memory_ingress_blocked_count"],
         "memory_ingress_posture": memory_ingress_summary["memory_ingress_posture"],
+        "action_ingress_validation_count": action_ingress_summary["action_ingress_validation_count"],
+        "action_ingress_validation_counts_by_outcome": action_ingress_summary["action_ingress_validation_counts_by_outcome"],
+        "action_ingress_validated_for_future_trigger_count": action_ingress_summary["action_ingress_validated_for_future_trigger_count"],
+        "action_ingress_blocked_count": action_ingress_summary["action_ingress_blocked_count"],
+        "action_ingress_posture": action_ingress_summary["action_ingress_posture"],
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -339,6 +339,32 @@
         "multimodal_tracker",
         "sentientos.perception_api"
       ]
+    },
+    "embodiment_action_ingress": {
+      "module_globs": [
+        "sentientos/embodiment_action_ingress.py"
+      ],
+      "classification": "governed_feedback_action_ingress_validation_surface",
+      "validation_only": true,
+      "non_authoritative": true,
+      "no_feedback_trigger": true,
+      "no_action_execution": true,
+      "no_task_admission": true,
+      "no_execution": true,
+      "no_control_plane_mutation": true,
+      "no_memory_write": true,
+      "no_retention_commit": true,
+      "validation_is_not_action_trigger": true,
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "sentientos.embodiment_ingress",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -666,3 +666,44 @@ def test_phase53_memory_ingress_module_forbidden_imports_and_non_effect_flags() 
     assert '"does_not_trigger_feedback": True' in text
     assert '"does_not_admit_work": True' in text
     assert '"does_not_execute_or_route_work": True' in text
+
+def test_phase54_action_ingress_module_import_boundaries() -> None:
+    text = (ROOT / "sentientos/embodiment_action_ingress.py").read_text(encoding="utf-8")
+    assert "import task_executor" not in text
+    assert "import task_admission" not in text
+    assert "import control_plane" not in text
+    assert "import feedback" not in text
+    assert "memory_manager" not in text
+
+
+def test_phase54_manifest_declares_action_ingress_invariants() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_action_ingress"]
+    assert layer["validation_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["no_feedback_trigger"] is True
+    assert layer["no_action_execution"] is True
+    assert layer["no_task_admission"] is True
+    assert layer["no_execution"] is True
+    assert layer["no_control_plane_mutation"] is True
+    assert layer["no_memory_write"] is True
+    assert layer["no_retention_commit"] is True
+    assert layer["validation_is_not_action_trigger"] is True
+
+
+def test_phase54_action_validation_output_non_effect_markers() -> None:
+    from sentientos.embodiment_action_ingress import build_action_ingress_validation_record
+
+    row = build_action_ingress_validation_record(feedback_action_fulfillment_candidate={
+        "fulfillment_candidate_id": "efc_x",
+        "fulfillment_candidate_kind": "feedback_action_fulfillment_candidate",
+        "source_governance_bridge_candidate_ref": "governance_bridge_candidate:g1",
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "p1",
+        "source_review_receipt_id": "r1",
+        "consent_posture": "granted",
+        "risk_flags": {},
+        "candidate_payload_summary": {},
+    })
+    assert row["validation_is_not_action_trigger"] is True
+    assert row["does_not_trigger_feedback"] is True

--- a/tests/test_phase54_action_ingress_validation.py
+++ b/tests/test_phase54_action_ingress_validation.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from sentientos.embodiment_action_ingress import (
+    build_action_ingress_validation_record,
+    resolve_action_ingress_validations,
+    summarize_action_ingress_validation_status,
+    validate_action_fulfillment_candidate,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _candidate(kind: str = "feedback_action_fulfillment_candidate", **overrides):
+    row = {
+        "fulfillment_candidate_id": "efc_a1",
+        "fulfillment_candidate_kind": kind,
+        "source_governance_bridge_candidate_ref": "governance_bridge_candidate:gb1",
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "p1",
+        "source_review_receipt_id": "r1",
+        "source_ingress_receipt_ref": "ingress_receipt:ir1",
+        "source_event_refs": ["evt:1"],
+        "correlation_id": "corr-1",
+        "source_module": "sentientos.embodiment_fulfillment",
+        "privacy_retention_posture": "review",
+        "consent_posture": "granted",
+        "risk_flags": {},
+        "candidate_payload_summary": {"action": "notify_operator"},
+        "rationale": ["ok"],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_phase54_validation_builder_shape_and_non_authority_fields():
+    row = build_action_ingress_validation_record(feedback_action_fulfillment_candidate=_candidate(), created_at=1.0)
+    assert row["schema_version"].endswith("v1")
+    assert row["decision_power"] == "none"
+    assert row["non_authoritative"] is True
+    assert row["validation_is_not_action_trigger"] is True
+    assert row["does_not_trigger_feedback"] is True
+
+
+def test_phase54_supported_kind_validates_for_future_trigger():
+    row = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate())
+    assert row["validation_outcome"] == "action_ingress_validated_for_future_trigger"
+
+
+@pytest.mark.parametrize("kind", ["memory_fulfillment_candidate", "screen_retention_fulfillment_candidate", "vision_retention_fulfillment_candidate", "multimodal_retention_fulfillment_candidate"])
+def test_phase54_unsupported_kind_blocks(kind: str):
+    row = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(kind=kind))
+    assert row["validation_outcome"] == "action_ingress_blocked_unsupported_kind"
+
+
+def test_phase54_missing_consent_blocks_or_holds():
+    row = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(consent_posture="not_asserted"))
+    assert row["validation_outcome"] in {"action_ingress_blocked_missing_consent", "action_ingress_needs_more_context"}
+
+
+def test_phase54_missing_provenance_blocks():
+    row = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(source_review_receipt_id=None))
+    assert row["validation_outcome"] == "action_ingress_blocked_missing_provenance"
+
+
+def test_phase54_privacy_sensitive_blocks_unless_allowed():
+    blocked = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive"))
+    assert blocked["validation_outcome"] == "action_ingress_blocked_privacy_sensitive"
+    allowed = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive", risk_flags={"allow_privacy_sensitive_action_ingress": True}))
+    assert allowed["validation_outcome"] == "action_ingress_validated_for_future_trigger"
+
+
+def test_phase54_unsafe_and_high_risk_block_unless_allowed():
+    unsafe = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(risk_flags={"unsafe_action": True}))
+    assert unsafe["validation_outcome"] == "action_ingress_blocked_unsafe_action"
+    unsafe_ok = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(risk_flags={"unsafe_action": True, "allow_unsafe_action_ingress": True}))
+    assert unsafe_ok["validation_outcome"] == "action_ingress_validated_for_future_trigger"
+
+    high = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(risk_flags={"high_risk_action": True}))
+    assert high["validation_outcome"] == "action_ingress_blocked_high_risk_action"
+    high_ok = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(risk_flags={"high_risk_action": True, "allow_high_risk_action_ingress": True}))
+    assert high_ok["validation_outcome"] == "action_ingress_validated_for_future_trigger"
+
+
+def test_phase54_operator_confirmation_requires_context_unless_confirmed():
+    hold = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(candidate_payload_summary={"requires_operator_confirmation": True}))
+    assert hold["validation_outcome"] == "action_ingress_needs_more_context"
+    ok = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate(candidate_payload_summary={"requires_operator_confirmation": True, "operator_confirmation_present": True}))
+    assert ok["validation_outcome"] == "action_ingress_validated_for_future_trigger"
+
+
+def test_phase54_diagnostic_summary_counts_and_posture():
+    rows = resolve_action_ingress_validations(fulfillment_candidates=[
+        _candidate(fulfillment_candidate_id="a"),
+        _candidate(fulfillment_candidate_id="b", consent_posture="not_asserted"),
+    ])["action_ingress_validations"]
+    summary = summarize_action_ingress_validation_status(action_ingress_validations=rows)
+    assert summary["action_ingress_validation_count"] == 2
+    assert summary["action_ingress_validated_for_future_trigger_count"] == 1
+    assert summary["action_ingress_blocked_count"] == 1
+    assert summary["action_ingress_posture"] == "mixed_action_ingress_state"
+
+
+def test_phase54_boundary_invariants():
+    row = validate_action_fulfillment_candidate(feedback_action_fulfillment_candidate=_candidate())
+    assert row["does_not_trigger_feedback"] is True
+    assert row["does_not_execute_or_route_work"] is True
+    assert row["does_not_admit_work"] is True
+    assert row["does_not_write_memory"] is True
+    assert row["decision_power"] == "none"


### PR DESCRIPTION
### Motivation
- Add Wave E (Phase 54) validation-only surface to validate governed feedback/action fulfillment candidates without executing or admitting effects. 
- Provide deterministic, non-authoritative validation records for `feedback_action_fulfillment_candidate` to enforce provenance/consent/privacy/risk checks before any future governed trigger. 
- Surface additive diagnostics so operators and diagnostics tooling can observe action-ingress posture without changing runtime behavior. 

### Description
- Add `sentientos/embodiment_action_ingress.py` implementing helpers `action_ingress_validation_ref`, `classify_action_ingress_validation_outcome`, `build_action_ingress_validation_record`, `validate_action_fulfillment_candidate`, `resolve_action_ingress_validations`, and `summarize_action_ingress_validation_status` with deterministic validation outcomes and non-effect invariants. 
- Create `docs/architecture/phase54_feedback_action_ingress_validation_execplan.md` describing Phase 53 state, Wave E targets, record shape, checks, tests, and deferred execution semantics. 
- Integrate action ingress rollups into `sentientos/embodiment_proposal_diagnostic.py` as additive diagnostics (`action_ingress_validation_count`, counts by outcome, posture, blocked/validated counts). 
- Update `sentientos/system_closure/architecture_boundary_manifest.json` with a new `embodiment_action_ingress` layer declaring `validation_only`, `non_authoritative`, and no-effect/forbidden-import invariants. 
- Add focused tests `tests/test_phase54_action_ingress_validation.py` and extend `tests/architecture/test_architecture_boundaries.py` with import/manifest/output invariants to ensure validation-only boundaries. 

### Testing
- Ran focused Phase 54 and sibling focused tests with: `python -m scripts.run_tests -q tests/test_phase54_action_ingress_validation.py tests/test_phase53_memory_ingress_validation.py tests/test_phase52_embodied_fulfillment.py tests/test_phase51_embodied_handoff_and_bridge.py`, and observed all tests pass with no unexpected skips. 
- Ran architecture and import-purity checks with: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and observed all tests pass. 
- Ran orchestration/diagnostic spine smoke tests with: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, and observed all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f84c4d51f48320a35ec20dbc4f8410)