### PR TITLE
[codex:embodiment] add governed retention ingress validation surface (Phase 55)

### DIFF
--- a/docs/architecture/phase55_retention_ingress_validation_execplan.md
+++ b/docs/architecture/phase55_retention_ingress_validation_execplan.md
@@ -1,0 +1,67 @@
+# Phase 55 ExecPlan: Governed Retention Ingress Validation Surface
+
+## 1) Current Phase 53 memory ingress state
+Phase 53 added `sentientos.embodiment_memory_ingress` as a validation-only, non-authoritative surface for `memory_fulfillment_candidate` records. It classifies outcomes, emits deterministic validation IDs, and preserves provenance/consent/privacy context while explicitly not writing memory, not triggering feedback, and not admitting/executing work.
+
+## 2) Current Phase 54 action ingress state
+Phase 54 added `sentientos.embodiment_action_ingress` as a sibling validation-only, non-authoritative surface for `feedback_action_fulfillment_candidate` records. It enforces provenance/consent/privacy/action-risk checks and emits validation records that explicitly do not trigger feedback, do not execute, and do not mutate control-plane state.
+
+## 3) Wave F target from embodiment completion masterplan
+Wave F extends the ladder with a governed retention ingress validation layer that sits after fulfillment candidate generation and alongside memory/action ingress validation. This layer must validate retention eligibility signals for future governed commit without committing retention.
+
+## 4) Retention ingress validation shape
+Add `sentientos.embodiment_retention_ingress` with canonical helpers:
+- `retention_ingress_validation_ref`
+- `classify_retention_ingress_validation_outcome`
+- `build_retention_ingress_validation_record`
+- `validate_retention_fulfillment_candidate`
+- `resolve_retention_ingress_validations`
+- `summarize_retention_ingress_validation_status`
+
+The module consumes fulfillment candidates (and optional receipts), emits non-authoritative validation records, and remains effect-free.
+
+## 5) Relationship to fulfillment candidates/receipts
+Input candidates:
+- `screen_retention_fulfillment_candidate`
+- `vision_retention_fulfillment_candidate`
+- `multimodal_retention_fulfillment_candidate`
+
+Optional receipt linkage preserves `source_fulfillment_receipt_ref`. Provenance chain fields are preserved from fulfillment candidates (bridge/handoff/proposal/review/ingress/source_event/correlation/source_module).
+
+## 6) Consent/privacy/raw-retention/biometric/provenance checks
+Deterministic checks:
+- unsupported kind -> blocked unsupported
+- missing provenance refs -> blocked missing provenance
+- missing/unknown consent -> blocked missing consent (or hold)
+- privacy sensitive/restricted without explicit allow -> blocked privacy
+- raw retention requested without explicit allow -> blocked raw retention
+- vision biometric/emotion-sensitive without explicit allow -> blocked biometric/emotion sensitive
+- multimodal context/fusion-sensitive without explicit allow -> blocked multimodal context sensitive
+- required operator confirmation without marker -> needs more context
+- otherwise -> validated for future commit
+
+## 7) Why validation is still not retention commit
+All outputs carry non-authoritative and explicit non-effect markers:
+- `decision_power = "none"`
+- `validation_is_not_retention_commit = True`
+- `does_not_commit_retention = True`
+- `does_not_write_memory = True`
+- `does_not_trigger_feedback = True`
+- `does_not_admit_work = True`
+- `does_not_execute_or_route_work = True`
+
+This phase provides diagnostic readiness only; no retention data write path is introduced.
+
+## 8) Tests to add/update
+- Add `tests/test_phase55_retention_ingress_validation.py` for record shape, supported kinds, blocker/hold scenarios, summaries, and boundary invariants.
+- Update architecture boundary tests for retention ingress import boundaries, manifest invariants, and non-effect output markers.
+- Extend diagnostic coverage via retention summary expectations in phase55 tests.
+
+## 9) Deferred actual retention commit semantics
+Deferred to a later phase:
+- any authority-bearing retention approval
+- actual screen/vision/multimodal retention writes
+- state mutation/admission/execution integration
+- retention receipt semantics proving side effects
+
+Phase 55 remains strictly validation-only and non-committing.

--- a/sentientos/embodiment_proposal_diagnostic.py
+++ b/sentientos/embodiment_proposal_diagnostic.py
@@ -13,6 +13,7 @@ from sentientos.embodiment_governance_bridge import resolve_embodied_governance_
 from sentientos.embodiment_fulfillment import resolve_embodied_fulfillment_candidates, summarize_embodied_fulfillment_status
 from sentientos.embodiment_memory_ingress import resolve_memory_ingress_validations, summarize_memory_ingress_validation_status
 from sentientos.embodiment_action_ingress import resolve_action_ingress_validations, summarize_action_ingress_validation_status
+from sentientos.embodiment_retention_ingress import resolve_retention_ingress_validations, summarize_retention_ingress_validation_status
 
 SUMMARY_SCHEMA_VERSION = "embodiment.proposal.review_summary.v1"
 
@@ -115,6 +116,8 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
     memory_ingress_summary = summarize_memory_ingress_validation_status(memory_ingress_validations=memory_ingress_resolution["memory_ingress_validations"])
     action_ingress_resolution = resolve_action_ingress_validations(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], created_at=generated_at)
     action_ingress_summary = summarize_action_ingress_validation_status(action_ingress_validations=action_ingress_resolution["action_ingress_validations"])
+    retention_ingress_resolution = resolve_retention_ingress_validations(fulfillment_candidates=fulfillment_resolution["fulfillment_candidates"], created_at=generated_at)
+    retention_ingress_summary = summarize_retention_ingress_validation_status(retention_ingress_validations=retention_ingress_resolution["retention_ingress_validations"])
     next_stage_postures = []
     if handoff_resolution["handoff_candidates"]:
         next_stage_postures.append("handoff_candidates_available")
@@ -170,6 +173,12 @@ def summarize_recent_embodied_proposals(proposals: list[Mapping[str, Any]], *, r
         "action_ingress_validated_for_future_trigger_count": action_ingress_summary["action_ingress_validated_for_future_trigger_count"],
         "action_ingress_blocked_count": action_ingress_summary["action_ingress_blocked_count"],
         "action_ingress_posture": action_ingress_summary["action_ingress_posture"],
+        "retention_ingress_validation_count": retention_ingress_summary["retention_ingress_validation_count"],
+        "retention_ingress_validation_counts_by_outcome": retention_ingress_summary["retention_ingress_validation_counts_by_outcome"],
+        "retention_ingress_validated_for_future_commit_count": retention_ingress_summary["retention_ingress_validated_for_future_commit_count"],
+        "retention_ingress_blocked_count": retention_ingress_summary["retention_ingress_blocked_count"],
+        "retention_ingress_counts_by_candidate_kind": retention_ingress_summary["retention_ingress_counts_by_candidate_kind"],
+        "retention_ingress_posture": retention_ingress_summary["retention_ingress_posture"],
         "non_authoritative": True,
         "decision_power": "none",
         "does_not_write_memory": True,

--- a/sentientos/embodiment_retention_ingress.py
+++ b/sentientos/embodiment_retention_ingress.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+from sentientos.embodiment_fulfillment import embodied_fulfillment_candidate_ref, embodied_fulfillment_receipt_ref
+
+VALIDATION_SCHEMA_VERSION = "embodiment.retention_ingress_validation.v1"
+SUPPORTED_RETENTION_CANDIDATE_KINDS = {
+    "screen_retention_fulfillment_candidate",
+    "vision_retention_fulfillment_candidate",
+    "multimodal_retention_fulfillment_candidate",
+}
+
+ALLOWED_OUTCOMES = {
+    "retention_ingress_validated_for_future_commit",
+    "retention_ingress_blocked_missing_consent",
+    "retention_ingress_blocked_missing_provenance",
+    "retention_ingress_blocked_privacy_sensitive",
+    "retention_ingress_blocked_raw_retention",
+    "retention_ingress_blocked_biometric_or_emotion_sensitive",
+    "retention_ingress_blocked_multimodal_context_sensitive",
+    "retention_ingress_blocked_unsupported_kind",
+    "retention_ingress_needs_more_context",
+}
+
+
+def retention_ingress_validation_ref(record: Mapping[str, Any]) -> str:
+    return f"retention_ingress_validation:{record['retention_ingress_validation_id']}"
+
+
+def classify_retention_ingress_validation_outcome(candidate: Mapping[str, Any]) -> str:
+    kind = str(candidate.get("fulfillment_candidate_kind") or "")
+    if kind not in SUPPORTED_RETENTION_CANDIDATE_KINDS:
+        return "retention_ingress_blocked_unsupported_kind"
+
+    if not all([
+        candidate.get("fulfillment_candidate_id"),
+        candidate.get("source_governance_bridge_candidate_ref"),
+        candidate.get("source_handoff_candidate_ref"),
+        candidate.get("source_proposal_id"),
+        candidate.get("source_review_receipt_id"),
+    ]):
+        return "retention_ingress_blocked_missing_provenance"
+
+    consent_posture = str(candidate.get("consent_posture") or "")
+    if consent_posture in {"", "unknown", "not_asserted", "required"}:
+        return "retention_ingress_blocked_missing_consent"
+    if consent_posture in {"review", "conditional"}:
+        return "retention_ingress_needs_more_context"
+
+    risk_flags = dict(candidate.get("risk_flags") or {})
+    payload = dict(candidate.get("candidate_payload_summary") or {})
+
+    privacy_posture = str(candidate.get("privacy_retention_posture") or "")
+    if privacy_posture in {"sensitive", "restricted"} and not bool(risk_flags.get("allow_privacy_sensitive_retention_ingress")):
+        return "retention_ingress_blocked_privacy_sensitive"
+
+    raw_requested = bool(risk_flags.get("raw_retention_requested") or payload.get("raw_retention_requested"))
+    raw_allowed = bool(risk_flags.get("allow_raw_retention_ingress") or payload.get("allow_raw_retention_ingress"))
+    if raw_requested and not raw_allowed:
+        return "retention_ingress_blocked_raw_retention"
+
+    biometric_sensitive = bool(
+        risk_flags.get("biometric_sensitive")
+        or risk_flags.get("emotion_sensitive")
+        or payload.get("biometric_sensitive")
+        or payload.get("emotion_sensitive")
+    )
+    if kind == "vision_retention_fulfillment_candidate" and biometric_sensitive and not bool(risk_flags.get("allow_biometric_or_emotion_sensitive_retention_ingress")):
+        return "retention_ingress_blocked_biometric_or_emotion_sensitive"
+
+    multimodal_sensitive = bool(
+        risk_flags.get("multimodal_context_sensitive")
+        or risk_flags.get("per_person_environment_fusion_sensitive")
+        or payload.get("multimodal_context_sensitive")
+        or payload.get("per_person_environment_fusion_sensitive")
+    )
+    if kind == "multimodal_retention_fulfillment_candidate" and multimodal_sensitive and not bool(risk_flags.get("allow_multimodal_context_sensitive_retention_ingress")):
+        return "retention_ingress_blocked_multimodal_context_sensitive"
+
+    requires_confirmation = bool(payload.get("requires_operator_confirmation") or risk_flags.get("requires_operator_confirmation"))
+    confirmed = bool(payload.get("operator_confirmation_present") or risk_flags.get("operator_confirmation_present"))
+    if requires_confirmation and not confirmed:
+        return "retention_ingress_needs_more_context"
+
+    return "retention_ingress_validated_for_future_commit"
+
+
+def build_retention_ingress_validation_record(*, retention_fulfillment_candidate: Mapping[str, Any], validation_outcome: str | None = None, source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    outcome = validation_outcome or classify_retention_ingress_validation_outcome(retention_fulfillment_candidate)
+    if outcome not in ALLOWED_OUTCOMES:
+        outcome = "retention_ingress_needs_more_context"
+    material = {
+        "source_fulfillment_candidate_id": retention_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "validation_outcome": outcome,
+        "source_review_receipt_id": retention_fulfillment_candidate.get("source_review_receipt_id"),
+    }
+    validation_id = "riv_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    kind = str(retention_fulfillment_candidate.get("fulfillment_candidate_kind") or "")
+    risk_flags = dict(retention_fulfillment_candidate.get("risk_flags") or {})
+    payload = dict(retention_fulfillment_candidate.get("candidate_payload_summary") or {})
+    return {
+        "schema_version": VALIDATION_SCHEMA_VERSION,
+        "retention_ingress_validation_id": validation_id,
+        "source_fulfillment_candidate_id": retention_fulfillment_candidate.get("fulfillment_candidate_id"),
+        "source_fulfillment_candidate_ref": embodied_fulfillment_candidate_ref(retention_fulfillment_candidate),
+        "source_governance_bridge_candidate_ref": retention_fulfillment_candidate.get("source_governance_bridge_candidate_ref"),
+        "source_handoff_candidate_ref": retention_fulfillment_candidate.get("source_handoff_candidate_ref"),
+        "source_proposal_id": retention_fulfillment_candidate.get("source_proposal_id"),
+        "source_review_receipt_id": retention_fulfillment_candidate.get("source_review_receipt_id"),
+        "source_ingress_receipt_ref": retention_fulfillment_candidate.get("source_ingress_receipt_ref"),
+        "source_event_refs": list(retention_fulfillment_candidate.get("source_event_refs") or []),
+        "correlation_id": retention_fulfillment_candidate.get("correlation_id"),
+        "source_module": retention_fulfillment_candidate.get("source_module"),
+        "source_fulfillment_receipt_ref": embodied_fulfillment_receipt_ref(source_fulfillment_receipt) if source_fulfillment_receipt else None,
+        "retention_candidate_kind": kind,
+        "validation_outcome": outcome,
+        "retention_candidate_summary": payload,
+        "privacy_retention_posture": retention_fulfillment_candidate.get("privacy_retention_posture", "review"),
+        "consent_posture": retention_fulfillment_candidate.get("consent_posture", "not_asserted"),
+        "risk_flags": risk_flags,
+        "provenance_complete": outcome != "retention_ingress_blocked_missing_provenance",
+        "raw_retention_allowed": bool(risk_flags.get("allow_raw_retention_ingress") or payload.get("allow_raw_retention_ingress")),
+        "biometric_or_emotion_sensitive": bool(risk_flags.get("biometric_sensitive") or risk_flags.get("emotion_sensitive") or payload.get("biometric_sensitive") or payload.get("emotion_sensitive")),
+        "multimodal_context_sensitive": bool(risk_flags.get("multimodal_context_sensitive") or risk_flags.get("per_person_environment_fusion_sensitive") or payload.get("multimodal_context_sensitive") or payload.get("per_person_environment_fusion_sensitive")),
+        "requires_operator_confirmation": bool(payload.get("requires_operator_confirmation") or risk_flags.get("requires_operator_confirmation")),
+        "rationale": list(retention_fulfillment_candidate.get("rationale") or []),
+        "created_at": float(created_at if created_at is not None else time.time()),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "validation_is_not_retention_commit": True,
+        "does_not_commit_retention": True,
+        "does_not_write_memory": True,
+        "does_not_trigger_feedback": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def validate_retention_fulfillment_candidate(*, retention_fulfillment_candidate: Mapping[str, Any], source_fulfillment_receipt: Mapping[str, Any] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    return build_retention_ingress_validation_record(retention_fulfillment_candidate=retention_fulfillment_candidate, source_fulfillment_receipt=source_fulfillment_receipt, created_at=created_at)
+
+
+def resolve_retention_ingress_validations(*, fulfillment_candidates: Sequence[Mapping[str, Any]], fulfillment_receipts: Sequence[Mapping[str, Any]] | None = None, created_at: float | None = None) -> dict[str, Any]:
+    receipt_by_candidate = {str(r.get("source_fulfillment_candidate_id") or ""): r for r in (fulfillment_receipts or []) if isinstance(r, Mapping)}
+    rows: list[dict[str, Any]] = []
+    by_outcome: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    for candidate in fulfillment_candidates:
+        row = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=candidate, source_fulfillment_receipt=receipt_by_candidate.get(str(candidate.get("fulfillment_candidate_id") or "")), created_at=created_at)
+        rows.append(row)
+        by_outcome[row["validation_outcome"]] = by_outcome.get(row["validation_outcome"], 0) + 1
+        k = str(row.get("retention_candidate_kind") or "unknown")
+        by_kind[k] = by_kind.get(k, 0) + 1
+    return {
+        "retention_ingress_validations": rows,
+        "retention_ingress_validation_counts_by_outcome": dict(sorted(by_outcome.items())),
+        "retention_ingress_counts_by_candidate_kind": dict(sorted(by_kind.items())),
+    }
+
+
+def summarize_retention_ingress_validation_status(*, retention_ingress_validations: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_outcome: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    validated = blocked = 0
+    privacy_or_bio_holds = 0
+    for row in retention_ingress_validations:
+        outcome = str(row.get("validation_outcome") or "retention_ingress_needs_more_context")
+        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+        kind = str(row.get("retention_candidate_kind") or "unknown")
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        if outcome == "retention_ingress_validated_for_future_commit":
+            validated += 1
+        elif outcome.startswith("retention_ingress_blocked"):
+            blocked += 1
+        if outcome in {"retention_ingress_blocked_privacy_sensitive", "retention_ingress_blocked_biometric_or_emotion_sensitive", "retention_ingress_blocked_multimodal_context_sensitive"}:
+            privacy_or_bio_holds += 1
+    if not retention_ingress_validations:
+        posture = "no_retention_ingress_candidates"
+    else:
+        labels = []
+        if blocked > 0:
+            labels.append("retention_ingress_blocked_items_present")
+        if validated > 0:
+            labels.append("retention_ingress_future_commit_candidates_present")
+        if privacy_or_bio_holds > 0:
+            labels.append("privacy_or_biometric_retention_holds_present")
+        posture = "mixed_retention_ingress_state" if len(labels) > 1 else (labels[0] if labels else "retention_ingress_validations_present")
+    return {
+        "retention_ingress_validation_count": len(retention_ingress_validations),
+        "retention_ingress_validation_counts_by_outcome": dict(sorted(by_outcome.items())),
+        "retention_ingress_validated_for_future_commit_count": validated,
+        "retention_ingress_blocked_count": blocked,
+        "retention_ingress_counts_by_candidate_kind": dict(sorted(by_kind.items())),
+        "retention_ingress_posture": posture,
+    }
+
+
+__all__ = [k for k in globals().keys() if k.startswith(("VALIDATION_", "SUPPORTED_", "ALLOWED_", "build_", "validate_", "resolve_", "classify_", "summarize_", "retention_ingress_"))]

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -365,6 +365,34 @@
         "sentientos.embodiment_ingress",
         "sentientos.perception_api"
       ]
+    },
+    "embodiment_retention_ingress": {
+      "module_globs": [
+        "sentientos/embodiment_retention_ingress.py"
+      ],
+      "classification": "governed_retention_ingress_validation_surface",
+      "validation_only": true,
+      "non_authoritative": true,
+      "validation_is_not_retention_commit": true,
+      "no_retention_commit": true,
+      "no_retained_record_write": true,
+      "no_memory_write": true,
+      "no_feedback_trigger": true,
+      "no_task_admission": true,
+      "no_execution": true,
+      "no_control_plane_mutation": true,
+      "forbidden_import_patterns": [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "feedback",
+        "memory_manager",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+        "sentientos.perception_api"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -707,3 +707,58 @@ def test_phase54_action_validation_output_non_effect_markers() -> None:
     })
     assert row["validation_is_not_action_trigger"] is True
     assert row["does_not_trigger_feedback"] is True
+
+def test_phase55_retention_ingress_module_import_boundaries() -> None:
+    path = ROOT / "sentientos/embodiment_retention_ingress.py"
+    text = path.read_text(encoding="utf-8")
+    imports = _imports(path)
+    for forbidden in (
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "sentientos.authority_surface",
+        "memory_manager",
+        "feedback",
+        "screen_awareness",
+        "vision_tracker",
+        "multimodal_tracker",
+        "sentientos.perception_api",
+    ):
+        assert not any(mod == forbidden or mod.startswith(f"{forbidden}.") for mod, _ in imports)
+    assert '"validation_is_not_retention_commit": True' in text
+    assert '"does_not_commit_retention": True' in text
+
+
+def test_phase55_manifest_declares_retention_ingress_invariants() -> None:
+    manifest = _manifest()
+    layer = manifest["layer_definitions"]["embodiment_retention_ingress"]
+    assert layer["validation_only"] is True
+    assert layer["non_authoritative"] is True
+    assert layer["validation_is_not_retention_commit"] is True
+    assert layer["no_retention_commit"] is True
+    assert layer["no_retained_record_write"] is True
+    assert layer["no_memory_write"] is True
+    assert layer["no_feedback_trigger"] is True
+    assert layer["no_task_admission"] is True
+    assert layer["no_execution"] is True
+    assert layer["no_control_plane_mutation"] is True
+
+
+def test_phase55_retention_validation_output_non_effect_markers() -> None:
+    from sentientos.embodiment_retention_ingress import build_retention_ingress_validation_record
+
+    row = build_retention_ingress_validation_record(retention_fulfillment_candidate={
+        "fulfillment_candidate_id": "rfc_x",
+        "fulfillment_candidate_kind": "screen_retention_fulfillment_candidate",
+        "source_governance_bridge_candidate_ref": "governance_bridge_candidate:g1",
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "p1",
+        "source_review_receipt_id": "r1",
+        "consent_posture": "granted",
+        "risk_flags": {},
+        "candidate_payload_summary": {},
+    })
+    assert row["validation_is_not_retention_commit"] is True
+    assert row["does_not_commit_retention"] is True
+    assert row["does_not_write_memory"] is True
+    assert row["does_not_trigger_feedback"] is True

--- a/tests/test_phase55_retention_ingress_validation.py
+++ b/tests/test_phase55_retention_ingress_validation.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from sentientos.embodiment_retention_ingress import (
+    build_retention_ingress_validation_record,
+    resolve_retention_ingress_validations,
+    summarize_retention_ingress_validation_status,
+    validate_retention_fulfillment_candidate,
+)
+
+
+def _candidate(**overrides):
+    base = {
+        "fulfillment_candidate_id": "rfc_1",
+        "fulfillment_candidate_kind": "screen_retention_fulfillment_candidate",
+        "source_governance_bridge_candidate_ref": "governance_bridge_candidate:g1",
+        "source_handoff_candidate_ref": "handoff_candidate:h1",
+        "source_proposal_id": "proposal_1",
+        "source_review_receipt_id": "review_1",
+        "source_ingress_receipt_ref": "embodiment_ingress_receipt:ir1",
+        "source_event_refs": ["event:1"],
+        "correlation_id": "corr-1",
+        "source_module": "sentientos.embodiment_fulfillment",
+        "consent_posture": "granted",
+        "privacy_retention_posture": "low",
+        "risk_flags": {},
+        "candidate_payload_summary": {},
+        "rationale": ["test"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_phase55_builder_shape_and_non_authority_fields():
+    row = build_retention_ingress_validation_record(retention_fulfillment_candidate=_candidate(), created_at=1.0)
+    assert row["schema_version"].endswith("v1")
+    assert row["decision_power"] == "none"
+    assert row["non_authoritative"] is True
+    assert row["validation_is_not_retention_commit"] is True
+    assert row["does_not_commit_retention"] is True
+
+
+def test_phase55_supported_kinds_can_validate():
+    screen = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate())
+    vision = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_id="rfc_2", fulfillment_candidate_kind="vision_retention_fulfillment_candidate"))
+    multi = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_id="rfc_3", fulfillment_candidate_kind="multimodal_retention_fulfillment_candidate"))
+    assert screen["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+    assert vision["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+    assert multi["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+
+
+def test_phase55_unsupported_kind_blocks():
+    for kind in ("memory_fulfillment_candidate", "feedback_action_fulfillment_candidate"):
+        row = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_kind=kind))
+        assert row["validation_outcome"] == "retention_ingress_blocked_unsupported_kind"
+
+
+def test_phase55_missing_consent_and_provenance_blocks():
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(consent_posture="not_asserted"))["validation_outcome"] in {"retention_ingress_blocked_missing_consent", "retention_ingress_needs_more_context"}
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(source_review_receipt_id=None))["validation_outcome"] == "retention_ingress_blocked_missing_provenance"
+
+
+def test_phase55_privacy_and_raw_retention_rules():
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive"))["validation_outcome"] == "retention_ingress_blocked_privacy_sensitive"
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(privacy_retention_posture="sensitive", risk_flags={"allow_privacy_sensitive_retention_ingress": True}))["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(risk_flags={"raw_retention_requested": True}))["validation_outcome"] == "retention_ingress_blocked_raw_retention"
+    assert validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(risk_flags={"raw_retention_requested": True, "allow_raw_retention_ingress": True}))["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+
+
+def test_phase55_vision_biometric_and_multimodal_context_rules():
+    v_block = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_kind="vision_retention_fulfillment_candidate", risk_flags={"biometric_sensitive": True}))
+    assert v_block["validation_outcome"] == "retention_ingress_blocked_biometric_or_emotion_sensitive"
+    v_ok = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_kind="vision_retention_fulfillment_candidate", risk_flags={"biometric_sensitive": True, "allow_biometric_or_emotion_sensitive_retention_ingress": True}))
+    assert v_ok["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+
+    m_block = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_kind="multimodal_retention_fulfillment_candidate", risk_flags={"multimodal_context_sensitive": True}))
+    assert m_block["validation_outcome"] == "retention_ingress_blocked_multimodal_context_sensitive"
+    m_ok = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(fulfillment_candidate_kind="multimodal_retention_fulfillment_candidate", risk_flags={"multimodal_context_sensitive": True, "allow_multimodal_context_sensitive_retention_ingress": True}))
+    assert m_ok["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+
+
+def test_phase55_operator_confirmation_hold_unless_confirmed():
+    hold = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(candidate_payload_summary={"requires_operator_confirmation": True}))
+    assert hold["validation_outcome"] == "retention_ingress_needs_more_context"
+    ok = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate(candidate_payload_summary={"requires_operator_confirmation": True, "operator_confirmation_present": True}))
+    assert ok["validation_outcome"] == "retention_ingress_validated_for_future_commit"
+
+
+def test_phase55_diagnostic_summary_counts_kind_and_posture():
+    rows = resolve_retention_ingress_validations(fulfillment_candidates=[
+        _candidate(fulfillment_candidate_id="a", fulfillment_candidate_kind="screen_retention_fulfillment_candidate"),
+        _candidate(fulfillment_candidate_id="b", fulfillment_candidate_kind="vision_retention_fulfillment_candidate", risk_flags={"biometric_sensitive": True}),
+    ])["retention_ingress_validations"]
+    summary = summarize_retention_ingress_validation_status(retention_ingress_validations=rows)
+    assert summary["retention_ingress_validation_count"] == 2
+    assert summary["retention_ingress_validated_for_future_commit_count"] == 1
+    assert summary["retention_ingress_blocked_count"] == 1
+    assert summary["retention_ingress_counts_by_candidate_kind"]["screen_retention_fulfillment_candidate"] == 1
+    assert summary["retention_ingress_posture"] == "mixed_retention_ingress_state"
+
+
+def test_phase55_boundary_invariants():
+    row = validate_retention_fulfillment_candidate(retention_fulfillment_candidate=_candidate())
+    assert row["does_not_commit_retention"] is True
+    assert row["does_not_write_memory"] is True
+    assert row["does_not_trigger_feedback"] is True
+    assert row["does_not_admit_work"] is True
+    assert row["does_not_execute_or_route_work"] is True
+    assert row["decision_power"] == "none"


### PR DESCRIPTION
### Motivation
- Add a sibling Wave F validation-only layer to Phase 53/54 that validates retention fulfillment candidates (screen/vision/multimodal) for possible future governed retention commit without committing retention. 
- Enforce consent/provenance/privacy/raw-retention/biometric/multimodal/operator-confirmation invariants at ingress time and surface deterministic, non-authoritative validation outcomes for diagnostics. 
- Preserve the non-effect architecture: no retention commit, no retained-record write, no memory write, no feedback trigger, no task admission/execution, and no control-plane mutation.

### Description
- Added `sentientos/embodiment_retention_ingress.py` implementing helpers `retention_ingress_validation_ref`, `classify_retention_ingress_validation_outcome`, `build_retention_ingress_validation_record`, `validate_retention_fulfillment_candidate`, `resolve_retention_ingress_validations`, and `summarize_retention_ingress_validation_status` with a compact validation record shape and explicit non-effect flags. 
- Integrated retention ingress visibility into diagnostics by calling `resolve_retention_ingress_validations` and adding additive summary fields to `sentientos/embodiment_proposal_diagnostic.py`. 
- Declared the new validation layer in `sentientos/system_closure/architecture_boundary_manifest.json` as `embodiment_retention_ingress` with validation-only, non-authoritative, and no-retention/no-effect invariants and forbidden import patterns. 
- Added focused tests in `tests/test_phase55_retention_ingress_validation.py` and updated architecture boundary tests in `tests/architecture/test_architecture_boundaries.py`, and included the planning artifact `docs/architecture/phase55_retention_ingress_validation_execplan.md` describing the exec plan and rationale. 
- Files changed: `sentientos/embodiment_retention_ingress.py`, `sentientos/embodiment_proposal_diagnostic.py`, `sentientos/system_closure/architecture_boundary_manifest.json`, `tests/test_phase55_retention_ingress_validation.py`, `tests/architecture/test_architecture_boundaries.py`, and `docs/architecture/phase55_retention_ingress_validation_execplan.md`.

### Testing
- Ran focused validation and compatibility chain: `python -m scripts.run_tests -q tests/test_phase55_retention_ingress_validation.py tests/test_phase54_action_ingress_validation.py tests/test_phase53_memory_ingress_validation.py tests/test_phase52_embodied_fulfillment.py tests/test_phase51_embodied_handoff_and_bridge.py`, which executed to completion and produced passing outcomes (with pre-existing skips in the environment bootstrap output). 
- Ran architecture and import purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, which passed. 
- Ran orchestration/diagnostic smoke tests: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, which passed. 
- All new tests added for Phase 55 passed and assert the non-effect invariants (`validation_is_not_retention_commit`, `does_not_commit_retention`, `does_not_write_memory`, `does_not_trigger_feedback`, `decision_power == 'none'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8df9721048320951d0ce600b7039a)