### PR TITLE
[codex:truth] phase56 evidence stability spine: claim/evidence ledgers, stance locks & contradiction receipts

### DIFF
--- a/docs/architecture/phase56_evidence_stability_spine_execplan.md
+++ b/docs/architecture/phase56_evidence_stability_spine_execplan.md
@@ -1,0 +1,85 @@
+# Phase 56 ExecPlan: Evidence Stability Spine (Wave Alpha + Wave Beta)
+
+## 1) Current truth primitives inspected
+- `sentientos/truth/__init__.py`
+- `sentientos/truth/epistemic_orientation.py`
+- `sentientos/truth/provisional_assertion.py`
+- `sentientos/truth/belief_verifier.py`
+- `sentientos/lab/contradiction_policy.py`
+- `docs/WAN_EVIDENCE_COMPLETENESS.md`
+- `sentientos/scoped_lifecycle_diagnostic.py`
+- `sentientos/system_closure/architecture_boundary_manifest.json`
+- `tests/test_epistemic_orientation.py`
+- `sentientos/tests/test_provisional_assertions.py`
+- `sentientos/tests/test_wan_contradiction_policy.py`
+- `tests/architecture/test_architecture_boundaries.py`
+- `sentientos/embodiment_memory_ingress.py`
+- `sentientos/embodiment_action_ingress.py`
+- `sentientos/embodiment_retention_ingress.py`
+
+## 2) Embodiment validation state and ordering rationale
+SentientOS has completed memory/action/retention ingress validation surfaces (proposal/receipt and validation), but has not crossed into effect commit semantics. Epistemic stability must precede effects so unstable source-backed claims do not contaminate memory ingestion, diagnostics, review, admission, or future effect layers.
+
+## 3) Failure mode definition
+- **Source-backed claim drift:** initial source-backed claim weakens/reverses over turns.
+- **No-new-evidence reversal:** reversal occurs with no new evidence IDs.
+- **Unsupported hedging/dilution:** confidence/status drifts to uncertainty without basis.
+- **Source undermining after citation:** source reliability is downgraded without new quality finding.
+
+## 4) Target modules and boundaries
+- `sentientos/truth/epistemic_status.py` (pure vocabulary helpers)
+- `sentientos/truth/evidence_ledger.py` (append-only evidence receipts)
+- `sentientos/truth/claim_ledger.py` (append-only claim receipts)
+- `sentientos/truth/stance_receipts.py` (deterministic stance transition + contradiction receipts)
+- No memory write, no work admission, no execution/routing, no control-plane mutation.
+
+## 5) Claim ledger schema
+Fields: schema_version, claim_id, conversation_scope_id, turn_id, topic_id, claim_text, normalized_claim, claim_kind, epistemic_status, confidence_band, evidence_ids, evidence_refs, source_quality_summary, caveats, what_would_change_the_claim, supersedes_claim_id, created_at, non_authoritative, decision_power, claim_is_not_memory, does_not_write_memory, does_not_admit_work, does_not_execute_or_route_work.
+
+## 6) Evidence ledger schema
+Fields: schema_version, evidence_id, source_type, source_id, locator, quote_text, quote_hash, retrieval_query_id, observed_at, created_at, source_trust_tier, source_quality_notes, non_authoritative, decision_power, does_not_write_memory, does_not_admit_work, does_not_execute_or_route_work.
+
+## 7) Epistemic status vocabulary
+Canonical statuses:
+- directly_supported
+- provisional_supported
+- strongly_inferred
+- plausible_but_unverified
+- underconstrained
+- contested
+- contradicted_by_new_evidence
+- superseded_by_new_evidence
+- retracted_due_to_error
+- policy_blocked_but_preserved
+- quote_fidelity_failed
+- no_new_evidence_reversal_blocked
+- unknown
+
+## 8) Stance receipt schema
+Fields: schema_version, stance_lock_id, topic_id, active_claim_id, previous_claim_id, transition_type, evidence_ids, new_evidence_ids, allowed, reason, created_at, non_authoritative, decision_power, stance_is_not_memory, does_not_write_memory, does_not_admit_work, does_not_execute_or_route_work.
+
+## 9) Contradiction receipt schema
+Fields: schema_version, contradiction_id, topic_id, old_claim_id, new_claim_id, evidence_ids_compared, new_evidence_ids, contradiction_type, severity, adjudication, detected_at, created_at, non_authoritative, decision_power, contradiction_is_not_memory, does_not_write_memory, does_not_admit_work, does_not_execute_or_route_work.
+
+## 10) Allowed stance transitions
+Without new evidence: initial_stance, preserve, narrow, qualify (non-contradictory), policy_block_but_preserve, hold_revision.
+With new evidence: weaken_with_new_evidence, supersede_with_new_evidence, contradicted_by_new_evidence / major reversal.
+With explicit error receipt: retract_due_to_error (requires rationale marker).
+
+## 11) Forbidden stance transitions
+- Reverse source-backed claim with no new evidence.
+- Unsupported dilution into uncertainty with no new evidence / no explicit underconstrained posture.
+- Source undermining without a new source-quality finding.
+- Policy/tone hedging that erases prior source-backed stance.
+- Silent removal of evidence links.
+
+## 12) Tests to add/update
+- Add `tests/test_phase56_evidence_stability_spine.py` for builders, validation, transition rules, contradiction detection, append-only and non-authority invariants.
+- Update `tests/architecture/test_architecture_boundaries.py` for import boundary and manifest/layer invariants.
+
+## 13) Deferred waves
+- Diagnostic summary integration.
+- Memory ingress guard.
+- Research response gate.
+- Adversarial regression harness.
+- Effect-layer integration guardrails.

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -393,6 +393,49 @@
         "multimodal_tracker",
         "sentientos.perception_api"
       ]
+    },
+    "truth_evidence_ledger": {
+      "module_globs": [
+        "sentientos/truth/evidence_ledger.py"
+      ],
+      "classification": "append_only_truth_provenance",
+      "append_only": true,
+      "non_authoritative": true,
+      "no_direct_memory_write": true,
+      "no_feedback_trigger": true,
+      "no_admission_execution": true,
+      "no_control_plane_mutation": true,
+      "no_scheduler_planner_autonomy": true
+    },
+    "truth_claim_ledger": {
+      "module_globs": [
+        "sentientos/truth/claim_ledger.py"
+      ],
+      "classification": "append_only_truth_claims",
+      "append_only": true,
+      "non_authoritative": true,
+      "no_direct_memory_write": true,
+      "no_feedback_trigger": true,
+      "no_admission_execution": true,
+      "no_control_plane_mutation": true,
+      "no_scheduler_planner_autonomy": true
+    },
+    "truth_stance_receipts": {
+      "module_globs": [
+        "sentientos/truth/stance_receipts.py"
+      ],
+      "classification": "derived_epistemic_stance_validation",
+      "derived_only": true,
+      "non_authoritative": true,
+      "no_direct_memory_write": true,
+      "no_feedback_trigger": true,
+      "no_admission_execution": true,
+      "no_control_plane_mutation": true,
+      "no_scheduler_planner_autonomy": true,
+      "no_new_evidence_no_reversal": true,
+      "stance_receipts_are_not_memory": true,
+      "contradiction_receipts_are_not_execution": true,
+      "policy_block_must_preserve_prior_source_backed_claim": true
     }
   },
   "protected_sinks": {

--- a/sentientos/truth/__init__.py
+++ b/sentientos/truth/__init__.py
@@ -1,6 +1,10 @@
 """Truth verification utilities."""
 
 from .belief_verifier import BeliefVerifier
+from .claim_ledger import append_claim_receipt, build_claim_receipt, claim_receipt_ref, classify_claim_kind, link_claim_to_evidence, list_recent_claim_receipts, normalize_claim_scope
+from .evidence_ledger import append_evidence_receipt, build_evidence_receipt, evidence_receipt_ref, hash_evidence_span, list_recent_evidence_receipts, normalize_evidence_locator
+from .epistemic_status import epistemic_status_ref, is_blocked_epistemic_status, is_revision_status, is_supported_epistemic_status, normalize_epistemic_status
+from .stance_receipts import build_contradiction_receipt, build_stance_receipt, classify_stance_transition, contradiction_receipt_ref, detect_no_new_evidence_reversal, resolve_active_stance, stance_receipt_ref, summarize_stance_lock_status, validate_stance_transition
 from .epistemic_orientation import (
     BeliefEnforcer,
     ContradictionRegistry,
@@ -28,6 +32,33 @@ from .provisional_assertion import (
 )
 
 __all__ = [
+    "append_claim_receipt",
+    "append_evidence_receipt",
+    "build_claim_receipt",
+    "build_contradiction_receipt",
+    "build_evidence_receipt",
+    "build_stance_receipt",
+    "claim_receipt_ref",
+    "classify_claim_kind",
+    "classify_stance_transition",
+    "contradiction_receipt_ref",
+    "detect_no_new_evidence_reversal",
+    "epistemic_status_ref",
+    "evidence_receipt_ref",
+    "hash_evidence_span",
+    "is_blocked_epistemic_status",
+    "is_revision_status",
+    "is_supported_epistemic_status",
+    "link_claim_to_evidence",
+    "list_recent_claim_receipts",
+    "list_recent_evidence_receipts",
+    "normalize_claim_scope",
+    "normalize_epistemic_status",
+    "normalize_evidence_locator",
+    "resolve_active_stance",
+    "stance_receipt_ref",
+    "summarize_stance_lock_status",
+    "validate_stance_transition",
     "BeliefEnforcer",
     "BeliefVerifier",
     "ContradictionRegistry",

--- a/sentientos/truth/claim_ledger.py
+++ b/sentientos/truth/claim_ledger.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from sentientos.attestation import read_jsonl
+from sentientos.ledger_api import append_audit_record
+from sentientos.truth.epistemic_status import normalize_epistemic_status
+
+SCHEMA_VERSION = "phase56.claim.v1"
+DEFAULT_CLAIM_LEDGER = Path("logs/truth/claim_ledger.jsonl")
+CLAIM_KINDS = {
+    "direct_extraction", "source_backed_claim", "source_backed_implication", "model_inference", "user_claim", "policy_override", "uncertainty_statement", "correction", "unknown",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_claim_scope(value: str | None) -> str:
+    return str(value or "global").strip() or "global"
+
+
+def classify_claim_kind(value: str | None) -> str:
+    v = str(value or "unknown").strip().lower()
+    return v if v in CLAIM_KINDS else "unknown"
+
+
+def link_claim_to_evidence(evidence_ids: list[str] | None = None, evidence_refs: list[str] | None = None) -> dict[str, list[str]]:
+    return {"evidence_ids": list(evidence_ids or []), "evidence_refs": list(evidence_refs or [])}
+
+
+def build_claim_receipt(*, conversation_scope_id: str, turn_id: str, topic_id: str, claim_text: str, claim_kind: str = "unknown", epistemic_status: str = "unknown", confidence_band: str = "unknown", evidence_ids: list[str] | None = None, evidence_refs: list[str] | None = None, source_quality_summary: str = "", caveats: list[str] | None = None, what_would_change_the_claim: str = "", supersedes_claim_id: str | None = None, created_at: str | None = None) -> dict[str, Any]:
+    kind = classify_claim_kind(claim_kind)
+    status = normalize_epistemic_status(epistemic_status)
+    links = link_claim_to_evidence(evidence_ids, evidence_refs)
+    if kind in {"source_backed_claim", "source_backed_implication"} and not (links["evidence_ids"] or links["evidence_refs"]):
+        if status not in {"underconstrained", "unknown"}:
+            raise ValueError("source-backed claims require evidence unless underconstrained or unknown")
+    normalized_claim = " ".join(claim_text.strip().lower().split())
+    claim_id = hashlib.sha256("|".join([normalize_claim_scope(conversation_scope_id), str(turn_id), topic_id, normalized_claim, kind, status]).encode("utf-8")).hexdigest()[:24]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "claim_id": claim_id,
+        "conversation_scope_id": normalize_claim_scope(conversation_scope_id),
+        "turn_id": str(turn_id),
+        "topic_id": topic_id,
+        "claim_text": claim_text,
+        "normalized_claim": normalized_claim,
+        "claim_kind": kind,
+        "epistemic_status": status,
+        "confidence_band": confidence_band if confidence_band in {"low", "medium", "high", "unknown"} else "unknown",
+        "evidence_ids": links["evidence_ids"],
+        "evidence_refs": links["evidence_refs"],
+        "source_quality_summary": source_quality_summary,
+        "caveats": list(caveats or []),
+        "what_would_change_the_claim": what_would_change_the_claim,
+        "supersedes_claim_id": supersedes_claim_id,
+        "created_at": created_at or _utc_now(),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "claim_is_not_memory": True,
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def claim_receipt_ref(receipt: dict[str, Any]) -> str:
+    return f"claim:{receipt['claim_id']}"
+
+
+def append_claim_receipt(receipt: dict[str, Any], *, path: Path = DEFAULT_CLAIM_LEDGER) -> dict[str, Any]:
+    return append_audit_record(path, dict(receipt))
+
+
+def list_recent_claim_receipts(*, path: Path = DEFAULT_CLAIM_LEDGER, limit: int = 50) -> list[dict[str, Any]]:
+    rows = [row for row in read_jsonl(path) if isinstance(row, dict)]
+    return rows[-max(0, limit) :]

--- a/sentientos/truth/epistemic_status.py
+++ b/sentientos/truth/epistemic_status.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Final
+
+EPISTEMIC_STATUSES: Final[tuple[str, ...]] = (
+    "directly_supported",
+    "provisional_supported",
+    "strongly_inferred",
+    "plausible_but_unverified",
+    "underconstrained",
+    "contested",
+    "contradicted_by_new_evidence",
+    "superseded_by_new_evidence",
+    "retracted_due_to_error",
+    "policy_blocked_but_preserved",
+    "quote_fidelity_failed",
+    "no_new_evidence_reversal_blocked",
+    "unknown",
+)
+
+SUPPORTED_EPISTEMIC_STATUSES: Final[set[str]] = {
+    "directly_supported",
+    "provisional_supported",
+    "strongly_inferred",
+}
+BLOCKED_EPISTEMIC_STATUSES: Final[set[str]] = {
+    "quote_fidelity_failed",
+    "no_new_evidence_reversal_blocked",
+}
+REVISION_EPISTEMIC_STATUSES: Final[set[str]] = {
+    "contradicted_by_new_evidence",
+    "superseded_by_new_evidence",
+    "retracted_due_to_error",
+}
+
+
+def normalize_epistemic_status(value: str | None) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized if normalized in EPISTEMIC_STATUSES else "unknown"
+
+
+def is_supported_epistemic_status(value: str | None) -> bool:
+    return normalize_epistemic_status(value) in SUPPORTED_EPISTEMIC_STATUSES
+
+
+def is_blocked_epistemic_status(value: str | None) -> bool:
+    return normalize_epistemic_status(value) in BLOCKED_EPISTEMIC_STATUSES
+
+
+def is_revision_status(value: str | None) -> bool:
+    return normalize_epistemic_status(value) in REVISION_EPISTEMIC_STATUSES
+
+
+def epistemic_status_ref(value: str | None) -> str:
+    return f"epistemic_status:{normalize_epistemic_status(value)}"
+

--- a/sentientos/truth/evidence_ledger.py
+++ b/sentientos/truth/evidence_ledger.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from sentientos.ledger_api import append_audit_record
+from sentientos.attestation import read_jsonl
+
+SCHEMA_VERSION = "phase56.evidence.v1"
+DEFAULT_EVIDENCE_LEDGER = Path("logs/truth/evidence_ledger.jsonl")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_evidence_locator(locator: str | dict[str, Any] | None) -> str:
+    if locator is None:
+        return ""
+    if isinstance(locator, dict):
+        return "|".join(f"{k}={locator[k]}" for k in sorted(locator))
+    return str(locator).strip()
+
+
+def hash_evidence_span(quote_text: str | None) -> str:
+    return hashlib.sha256(str(quote_text or "").encode("utf-8")).hexdigest()
+
+
+def build_evidence_receipt(*, source_type: str, source_id: str, locator: str | dict[str, Any] | None = None, quote_text: str = "", retrieval_query_id: str | None = None, observed_at: str | None = None, created_at: str | None = None, source_trust_tier: str = "unknown", source_quality_notes: str = "") -> dict[str, Any]:
+    normalized_locator = normalize_evidence_locator(locator)
+    quote_hash = hash_evidence_span(quote_text)
+    evidence_basis = "|".join([source_type, source_id, normalized_locator, quote_hash, retrieval_query_id or ""])
+    evidence_id = hashlib.sha256(evidence_basis.encode("utf-8")).hexdigest()[:24]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_id": evidence_id,
+        "source_type": source_type if source_type else "unknown",
+        "source_id": source_id,
+        "locator": normalized_locator,
+        "quote_text": quote_text,
+        "quote_hash": quote_hash,
+        "retrieval_query_id": retrieval_query_id,
+        "observed_at": observed_at or _utc_now(),
+        "created_at": created_at or _utc_now(),
+        "source_trust_tier": source_trust_tier,
+        "source_quality_notes": source_quality_notes,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def evidence_receipt_ref(receipt: dict[str, Any]) -> str:
+    return f"evidence:{receipt['evidence_id']}"
+
+
+def append_evidence_receipt(receipt: dict[str, Any], *, path: Path = DEFAULT_EVIDENCE_LEDGER) -> dict[str, Any]:
+    return append_audit_record(path, dict(receipt))
+
+
+def list_recent_evidence_receipts(*, path: Path = DEFAULT_EVIDENCE_LEDGER, limit: int = 50) -> list[dict[str, Any]]:
+    rows = [row for row in read_jsonl(path) if isinstance(row, dict)]
+    return rows[-max(0, limit) :]

--- a/sentientos/truth/stance_receipts.py
+++ b/sentientos/truth/stance_receipts.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from typing import Any
+
+TRANSITIONS_WITHOUT_NEW_EVIDENCE = {"initial_stance", "preserve", "narrow", "qualify", "policy_block_but_preserve", "hold_revision"}
+TRANSITIONS_REQUIRE_NEW_EVIDENCE = {"weaken_with_new_evidence", "supersede_with_new_evidence"}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def classify_stance_transition(value: str | None) -> str:
+    normalized = str(value or "hold_revision").strip().lower()
+    allowed = TRANSITIONS_WITHOUT_NEW_EVIDENCE | TRANSITIONS_REQUIRE_NEW_EVIDENCE | {"strengthen", "retract_due_to_error"}
+    return normalized if normalized in allowed else "hold_revision"
+
+
+def validate_stance_transition(*, transition_type: str, new_evidence_ids: list[str] | None = None, contradictory: bool = False, rationale: str = "", has_new_source_quality_finding: bool = False) -> tuple[bool, str]:
+    t = classify_stance_transition(transition_type)
+    new_evidence = list(new_evidence_ids or [])
+    if t in TRANSITIONS_REQUIRE_NEW_EVIDENCE and not new_evidence:
+        return False, "new evidence required"
+    if t == "qualify" and contradictory:
+        return False, "qualify transition cannot contradict prior claim without new evidence"
+    if t == "retract_due_to_error" and not rationale.strip():
+        return False, "retraction requires explicit rationale"
+    if t == "policy_block_but_preserve" and not has_new_source_quality_finding:
+        return True, "policy block allowed; prior source-backed stance preserved"
+    return True, "transition allowed"
+
+
+def build_stance_receipt(*, topic_id: str, active_claim_id: str, previous_claim_id: str | None = None, transition_type: str = "hold_revision", evidence_ids: list[str] | None = None, new_evidence_ids: list[str] | None = None, contradictory: bool = False, rationale: str = "") -> dict[str, Any]:
+    allowed, reason = validate_stance_transition(transition_type=transition_type, new_evidence_ids=new_evidence_ids, contradictory=contradictory, rationale=rationale)
+    material = "|".join([topic_id, str(previous_claim_id or ""), active_claim_id, classify_stance_transition(transition_type), ",".join(sorted(evidence_ids or [])), ",".join(sorted(new_evidence_ids or []))])
+    return {
+        "schema_version": "phase56.stance.v1",
+        "stance_lock_id": hashlib.sha256(material.encode("utf-8")).hexdigest()[:24],
+        "topic_id": topic_id,
+        "active_claim_id": active_claim_id,
+        "previous_claim_id": previous_claim_id,
+        "transition_type": classify_stance_transition(transition_type),
+        "evidence_ids": list(evidence_ids or []),
+        "new_evidence_ids": list(new_evidence_ids or []),
+        "allowed": allowed,
+        "reason": reason,
+        "created_at": _utc_now(),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "stance_is_not_memory": True,
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def build_contradiction_receipt(*, topic_id: str, old_claim_id: str, new_claim_id: str, contradiction_type: str, evidence_ids_compared: list[str] | None = None, new_evidence_ids: list[str] | None = None, severity: str = "warning", adjudication: str = "warn") -> dict[str, Any]:
+    material = "|".join([topic_id, old_claim_id, new_claim_id, contradiction_type, ",".join(sorted(evidence_ids_compared or [])), ",".join(sorted(new_evidence_ids or []))])
+    return {
+        "schema_version": "phase56.contradiction.v1",
+        "contradiction_id": hashlib.sha256(material.encode("utf-8")).hexdigest()[:24],
+        "topic_id": topic_id,
+        "old_claim_id": old_claim_id,
+        "new_claim_id": new_claim_id,
+        "evidence_ids_compared": list(evidence_ids_compared or []),
+        "new_evidence_ids": list(new_evidence_ids or []),
+        "contradiction_type": contradiction_type,
+        "severity": severity,
+        "adjudication": adjudication,
+        "detected_at": _utc_now(),
+        "created_at": _utc_now(),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "contradiction_is_not_memory": True,
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def detect_no_new_evidence_reversal(*, previous_claim: dict[str, Any], new_claim: dict[str, Any], transition_type: str, new_evidence_ids: list[str] | None = None, has_new_source_quality_finding: bool = False) -> dict[str, Any] | None:
+    if previous_claim.get("topic_id") != new_claim.get("topic_id"):
+        return None
+    if previous_claim.get("epistemic_status") not in {"directly_supported", "provisional_supported", "strongly_inferred"}:
+        return None
+    new_ids = list(new_evidence_ids or [])
+    t = classify_stance_transition(transition_type)
+    if t in {"weaken_with_new_evidence", "supersede_with_new_evidence"} and not new_ids:
+        return build_contradiction_receipt(topic_id=str(new_claim.get("topic_id") or "unknown"), old_claim_id=str(previous_claim.get("claim_id") or "unknown"), new_claim_id=str(new_claim.get("claim_id") or "unknown"), contradiction_type="no_new_evidence_reversal", evidence_ids_compared=list(previous_claim.get("evidence_ids") or []), new_evidence_ids=new_ids, severity="blocking", adjudication="require_new_evidence")
+    if t == "qualify" and new_claim.get("epistemic_status") in {"plausible_but_unverified", "underconstrained"} and not new_ids:
+        return build_contradiction_receipt(topic_id=str(new_claim.get("topic_id") or "unknown"), old_claim_id=str(previous_claim.get("claim_id") or "unknown"), new_claim_id=str(new_claim.get("claim_id") or "unknown"), contradiction_type="unsupported_dilution", evidence_ids_compared=list(previous_claim.get("evidence_ids") or []), new_evidence_ids=new_ids, severity="blocking", adjudication="block_revision")
+    if t == "policy_block_but_preserve" and not has_new_source_quality_finding and new_claim.get("source_quality_summary") == "undermined":
+        return build_contradiction_receipt(topic_id=str(new_claim.get("topic_id") or "unknown"), old_claim_id=str(previous_claim.get("claim_id") or "unknown"), new_claim_id=str(new_claim.get("claim_id") or "unknown"), contradiction_type="unsupported_source_undermining", evidence_ids_compared=list(previous_claim.get("evidence_ids") or []), new_evidence_ids=new_ids, severity="blocking", adjudication="hold_revision_require_explanation")
+    return None
+
+
+def resolve_active_stance(previous_claim: dict[str, Any], new_claim: dict[str, Any], transition_type: str) -> str:
+    return str(previous_claim.get("claim_id")) if classify_stance_transition(transition_type) == "policy_block_but_preserve" else str(new_claim.get("claim_id"))
+
+
+def summarize_stance_lock_status(stance_receipt: dict[str, Any], contradiction_receipt: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {"allowed": bool(stance_receipt.get("allowed")), "transition_type": stance_receipt.get("transition_type"), "active_claim_id": stance_receipt.get("active_claim_id"), "contradiction": contradiction_receipt}
+
+
+def stance_receipt_ref(receipt: dict[str, Any]) -> str:
+    return f"stance:{receipt['stance_lock_id']}"
+
+
+def contradiction_receipt_ref(receipt: dict[str, Any]) -> str:
+    return f"contradiction:{receipt['contradiction_id']}"

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -762,3 +762,56 @@ def test_phase55_retention_validation_output_non_effect_markers() -> None:
     assert row["does_not_commit_retention"] is True
     assert row["does_not_write_memory"] is True
     assert row["does_not_trigger_feedback"] is True
+
+def test_phase56_truth_spine_modules_avoid_authority_imports() -> None:
+    forbidden = [
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "authority_surface",
+        "memory_manager",
+        "feedback",
+        "retention",
+        "screen_awareness",
+        "vision_tracker",
+        "mic_bridge",
+        "multimodal_tracker",
+    ]
+    for rel in [
+        "sentientos/truth/evidence_ledger.py",
+        "sentientos/truth/claim_ledger.py",
+        "sentientos/truth/stance_receipts.py",
+    ]:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in text
+
+
+def test_phase56_manifest_truth_layers_and_invariants() -> None:
+    manifest = _manifest()
+    layers = manifest["layer_definitions"]
+    for key in ["truth_evidence_ledger", "truth_claim_ledger", "truth_stance_receipts"]:
+        assert key in layers
+        assert layers[key]["non_authoritative"] is True
+        assert layers[key]["no_direct_memory_write"] is True
+        assert layers[key]["no_admission_execution"] is True
+    stance = layers["truth_stance_receipts"]
+    assert stance["no_new_evidence_no_reversal"] is True
+    assert stance["stance_receipts_are_not_memory"] is True
+    assert stance["contradiction_receipts_are_not_execution"] is True
+    assert stance["policy_block_must_preserve_prior_source_backed_claim"] is True
+
+
+def test_phase56_truth_receipt_invariants() -> None:
+    from sentientos.truth import build_claim_receipt, build_contradiction_receipt, build_evidence_receipt, build_stance_receipt
+
+    claim = build_claim_receipt(conversation_scope_id="c", turn_id="t", topic_id="k", claim_text="x", claim_kind="model_inference")
+    evidence = build_evidence_receipt(source_type="unknown", source_id="s")
+    stance = build_stance_receipt(topic_id="k", active_claim_id=claim["claim_id"], transition_type="initial_stance")
+    contradiction = build_contradiction_receipt(topic_id="k", old_claim_id="a", new_claim_id="b", contradiction_type="unknown")
+    for row in [claim, evidence, stance, contradiction]:
+        assert row["non_authoritative"] is True
+        assert row["decision_power"] == "none"
+        assert row["does_not_write_memory"] is True
+        assert row["does_not_admit_work"] is True
+        assert row["does_not_execute_or_route_work"] is True

--- a/tests/test_phase56_evidence_stability_spine.py
+++ b/tests/test_phase56_evidence_stability_spine.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sentientos.truth import (
+    append_claim_receipt,
+    append_evidence_receipt,
+    build_claim_receipt,
+    build_evidence_receipt,
+    build_stance_receipt,
+    detect_no_new_evidence_reversal,
+    hash_evidence_span,
+    is_blocked_epistemic_status,
+    is_revision_status,
+    is_supported_epistemic_status,
+    list_recent_claim_receipts,
+    list_recent_evidence_receipts,
+    normalize_epistemic_status,
+    resolve_active_stance,
+)
+
+
+def test_evidence_receipt_builder_and_append_list(tmp_path: Path) -> None:
+    p = tmp_path / "evidence.jsonl"
+    assert hash_evidence_span("x") == hash_evidence_span("x")
+    receipt = build_evidence_receipt(source_type="web_page", source_id="u1", quote_text="hello")
+    assert receipt["non_authoritative"] is True
+    assert receipt["decision_power"] == "none"
+    append_evidence_receipt(receipt, path=p)
+    rows = list_recent_evidence_receipts(path=p)
+    assert rows[-1]["quote_hash"] == receipt["quote_hash"]
+
+
+def test_claim_receipt_rules_and_determinism(tmp_path: Path) -> None:
+    with_evidence = build_claim_receipt(conversation_scope_id="c1", turn_id="t1", topic_id="topic", claim_text="A", claim_kind="source_backed_claim", epistemic_status="directly_supported", evidence_ids=["e1"])
+    assert with_evidence["claim_id"] == build_claim_receipt(conversation_scope_id="c1", turn_id="t1", topic_id="topic", claim_text="A", claim_kind="source_backed_claim", epistemic_status="directly_supported", evidence_ids=["e1"])["claim_id"]
+    p = tmp_path / "claim.jsonl"
+    append_claim_receipt(with_evidence, path=p)
+    assert list_recent_claim_receipts(path=p)
+
+
+def test_claim_requires_evidence_unless_underconstrained() -> None:
+    try:
+        build_claim_receipt(conversation_scope_id="c1", turn_id="t1", topic_id="topic", claim_text="A", claim_kind="source_backed_claim", epistemic_status="directly_supported")
+        assert False
+    except ValueError:
+        pass
+    ok = build_claim_receipt(conversation_scope_id="c1", turn_id="t1", topic_id="topic", claim_text="A", claim_kind="source_backed_claim", epistemic_status="underconstrained")
+    assert ok["epistemic_status"] == "underconstrained"
+
+
+def test_epistemic_status_helpers() -> None:
+    assert is_supported_epistemic_status("directly_supported")
+    assert is_blocked_epistemic_status("no_new_evidence_reversal_blocked")
+    assert is_revision_status("superseded_by_new_evidence")
+    assert normalize_epistemic_status("not_real") == "unknown"
+
+
+def test_stance_and_contradiction_detection() -> None:
+    prev = build_claim_receipt(conversation_scope_id="c1", turn_id="1", topic_id="t", claim_text="X", claim_kind="source_backed_claim", epistemic_status="directly_supported", evidence_ids=["e1"])
+    new = build_claim_receipt(conversation_scope_id="c1", turn_id="2", topic_id="t", claim_text="not X", claim_kind="source_backed_claim", epistemic_status="plausible_but_unverified", evidence_ids=["e1"])
+    stance = build_stance_receipt(topic_id="t", active_claim_id=new["claim_id"], previous_claim_id=prev["claim_id"], transition_type="weaken_with_new_evidence", new_evidence_ids=[])
+    assert stance["allowed"] is False
+    contradiction = detect_no_new_evidence_reversal(previous_claim=prev, new_claim=new, transition_type="weaken_with_new_evidence", new_evidence_ids=[])
+    assert contradiction and contradiction["contradiction_type"] == "no_new_evidence_reversal"
+
+
+def test_other_transition_paths() -> None:
+    prev = build_claim_receipt(conversation_scope_id="c", turn_id="1", topic_id="t", claim_text="X", claim_kind="source_backed_claim", epistemic_status="directly_supported", evidence_ids=["e1"])
+    dil = build_claim_receipt(conversation_scope_id="c", turn_id="2", topic_id="t", claim_text="maybe X", claim_kind="uncertainty_statement", epistemic_status="underconstrained", evidence_ids=["e1"])
+    c1 = detect_no_new_evidence_reversal(previous_claim=prev, new_claim=dil, transition_type="qualify", new_evidence_ids=[])
+    assert c1 and c1["contradiction_type"] == "unsupported_dilution"
+    und = dict(dil)
+    und["source_quality_summary"] = "undermined"
+    c2 = detect_no_new_evidence_reversal(previous_claim=prev, new_claim=und, transition_type="policy_block_but_preserve", new_evidence_ids=[])
+    assert c2 and c2["contradiction_type"] == "unsupported_source_undermining"
+    ok = detect_no_new_evidence_reversal(previous_claim=prev, new_claim=dil, transition_type="supersede_with_new_evidence", new_evidence_ids=["e2"])
+    assert ok is None
+    retract = build_stance_receipt(topic_id="t", active_claim_id=dil["claim_id"], previous_claim_id=prev["claim_id"], transition_type="retract_due_to_error", rationale="calc bug")
+    assert retract["allowed"] is True
+    keep = resolve_active_stance(prev, dil, "policy_block_but_preserve")
+    assert keep == prev["claim_id"]


### PR DESCRIPTION
### Motivation
- Prevent source-backed claim drift and no-new-evidence reversals before any memory/action/retention effect layers are introduced. 
- Provide a deterministic, append-only truth-plane that records provenance and stance decisions without granting authority to mutate memory or admit/execute work. 
- Deliver Wave Alpha (claim + evidence ledger primitives) and Wave Beta (stance locks + contradiction/no-new-evidence receipts) as foundation for later gating and memory-guard waves. 

### Description
- Added an ExecPlan at `docs/architecture/phase56_evidence_stability_spine_execplan.md` that documents inspected primitives, failure modes, schemas, allowed/forbidden stance transitions, and deferred waves. 
- Implemented epistemic vocabulary and helpers in `sentientos/truth/epistemic_status.py` and exported deterministic helpers from `sentientos/truth/__init__.py`. 
- Implemented append-only evidence primitives in `sentientos/truth/evidence_ledger.py` and claim primitives in `sentientos/truth/claim_ledger.py` with deterministic IDs, source-backed evidence requirements, and explicit non-authoritative/no-effect markers. 
- Implemented stance receipts, transition validation, contradiction receipts, and a no-new-evidence reversal detector in `sentientos/truth/stance_receipts.py`, and declared three new non-authoritative truth layers in `sentientos/system_closure/architecture_boundary_manifest.json`. 

### Testing
- Added focused hardware-free tests in `tests/test_phase56_evidence_stability_spine.py` and updated architecture boundary checks in `tests/architecture/test_architecture_boundaries.py`. 
- Ran the focused and integration test sets with: `python -m scripts.run_tests -q tests/test_phase56_evidence_stability_spine.py tests/test_epistemic_orientation.py sentientos/tests/test_provisional_assertions.py sentientos/tests/test_wan_contradiction_policy.py`, `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and orchestration/embodiment smoke tests; all invoked test runs completed successfully. 
- Tests validate deterministic receipt shapes, append/list behavior, evidence requirements for source-backed claims, stance transition validation, emission of blocking `no_new_evidence_reversal` and related contradiction receipts, and manifest/invariant coverage for non-authority boundaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8eeb3af388320bd1db23455208f8c)