### PR TITLE
[codex:truth] implement Phase 57 evidence diagnostics + memory-ingress guard

### DIFF
--- a/docs/architecture/phase57_evidence_diagnostic_memory_guard_execplan.md
+++ b/docs/architecture/phase57_evidence_diagnostic_memory_guard_execplan.md
@@ -1,0 +1,48 @@
+# Phase 57 ExecPlan: Evidence Stability Diagnostic + Truth Memory-Ingress Guard
+
+1. **Current Phase 56 truth spine state**
+   - Phase 56 supplies append-only claim/evidence/stance/contradiction receipts with deterministic ids and non-authority invariants.
+   - It detects no-new-evidence reversal, unsupported dilution, and unsupported source undermining but does not summarize posture or gate ingress.
+
+2. **Existing diagnostics inspected**
+   - `sentientos/scoped_lifecycle_diagnostic.py`
+   - Existing embodiment ingress validators (`sentientos/embodiment_memory_ingress.py`)
+   - Architecture manifest + architecture boundary tests.
+
+3. **Diagnostic summary shape**
+   - Add `sentientos/truth/evidence_diagnostic.py` producing a read-only summary: counts, active stance, contradiction classes, posture classification, and explicit non-authority metadata.
+
+4. **Memory-ingress guard shape**
+   - Add `sentientos/truth/memory_ingress_guard.py` producing per-claim guard records and a summary; outcome vocabulary explicitly includes blocked/needs-review/validated-for-future-memory (validation-only).
+
+5. **Relationship to embodiment memory ingress validation**
+   - Truth guard is independent and additive. It does not call or alter embodiment memory write paths.
+   - Embodiment memory ingress semantics remain unchanged.
+
+6. **Inputs consumed**
+   - Claim receipts, evidence receipts, stance receipts, contradiction receipts.
+   - No retrieval or external data acquisition.
+
+7. **Validation rules for memory eligibility**
+   - Missing evidence blocks source-backed claims.
+   - Underconstrained/plausible/unknown/blocked statuses block active memory ingress.
+   - Blocking contradiction severity/adjudication blocks or holds.
+   - Specific contradiction types (`no_new_evidence_reversal`, `unsupported_dilution`, `unsupported_source_undermining`, `quote_fidelity_failure`) block.
+   - Retracted/superseded/contradicted statuses block active memory ingress.
+   - Active stance must match claim or preserve prior claim via `policy_block_but_preserve`.
+   - Supported statuses with evidence and no blocking contradictions validate for future memory path.
+
+8. **Why guard validation is not memory write**
+   - Guard records include explicit invariants: `guard_is_not_memory_write`, `validation_is_not_memory_write`, `does_not_write_memory`, `decision_power: none`.
+   - No mutation APIs are imported or invoked.
+
+9. **Tests to add/update**
+   - Add focused phase57 tests for diagnostic posture/counts/non-authority flags, guard outcomes/rules, policy preserve handling, and caller immutability.
+   - Update architecture boundaries tests for import isolation + manifest invariants for new truth layers.
+   - Validate scoped lifecycle diagnostic additive field behavior.
+
+10. **Deferred waves**
+   - Research response gate.
+   - Multi-turn adversarial harness.
+   - Response-time stance consistency middleware.
+   - Actual memory/effect integration with governed write pathways.

--- a/sentientos/scoped_lifecycle_diagnostic.py
+++ b/sentientos/scoped_lifecycle_diagnostic.py
@@ -14,6 +14,8 @@ from sentientos.delegated_judgment_fabric import collect_delegated_judgment_evid
 from sentientos.embodiment_proposal_diagnostic import build_embodied_proposal_review_summary
 from sentientos.embodiment_proposals import DEFAULT_PROPOSAL_LOG
 from sentientos.embodiment_proposal_review import DEFAULT_REVIEW_RECEIPT_LOG
+from sentientos.truth.evidence_diagnostic import build_evidence_stability_diagnostic
+from sentientos.truth.memory_ingress_guard import summarize_truth_memory_ingress_guard_status
 from sentientos.orchestration_intent_fabric import (
     admit_orchestration_intent,
     append_handoff_packet_ledger,
@@ -402,6 +404,8 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         resolve_lifecycle=resolve_deep_research_staged_work_order_lifecycle,
         schema_version="deep_research_staged_venue_diagnostic.v1",
     )
+    evidence_stability_diagnostic = build_evidence_stability_diagnostic(claim_receipts=[], evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    truth_memory_ingress_guard_summary = summarize_truth_memory_ingress_guard_status(truth_memory_ingress_guard_records=[])
     embodiment_proposal_review_summary = build_embodied_proposal_review_summary(
         path=root / DEFAULT_PROPOSAL_LOG,
         review_receipt_path=root / DEFAULT_REVIEW_RECEIPT_LOG,
@@ -558,4 +562,6 @@ def build_scoped_lifecycle_diagnostic(repo_root: Path) -> dict[str, Any]:
         },
         "actions": rows,
         "embodiment_proposal_review_summary": embodiment_proposal_review_summary,
+        "evidence_stability_diagnostic": evidence_stability_diagnostic,
+        "truth_memory_ingress_guard_summary": truth_memory_ingress_guard_summary,
     }

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -436,6 +436,32 @@
       "stance_receipts_are_not_memory": true,
       "contradiction_receipts_are_not_execution": true,
       "policy_block_must_preserve_prior_source_backed_claim": true
+    },
+    "truth_evidence_diagnostic": {
+      "description": "Read-only evidence/stance stability diagnostics",
+      "non_authoritative": true,
+      "decision_power": "none",
+      "does_not_write_memory": true,
+      "does_not_trigger_feedback": true,
+      "does_not_admit_work": true,
+      "does_not_execute_or_route_work": true,
+      "does_not_mutate_control_plane": true,
+      "no_scheduler_or_autonomous_behavior": true
+    },
+    "truth_memory_ingress_guard": {
+      "description": "Validation-only truth claim memory ingress guard",
+      "non_authoritative": true,
+      "decision_power": "none",
+      "does_not_write_memory": true,
+      "does_not_trigger_feedback": true,
+      "does_not_admit_work": true,
+      "does_not_execute_or_route_work": true,
+      "does_not_mutate_control_plane": true,
+      "no_scheduler_or_autonomous_behavior": true,
+      "guard_is_not_memory_write": true,
+      "truth_memory_ingress_validated_for_future_memory_is_not_memory_write": true,
+      "unstable_claims_cannot_enter_active_memory": true,
+      "no_new_evidence_reversal_blocks_memory_ingress": true
     }
   },
   "protected_sinks": {

--- a/sentientos/truth/__init__.py
+++ b/sentientos/truth/__init__.py
@@ -5,6 +5,8 @@ from .claim_ledger import append_claim_receipt, build_claim_receipt, claim_recei
 from .evidence_ledger import append_evidence_receipt, build_evidence_receipt, evidence_receipt_ref, hash_evidence_span, list_recent_evidence_receipts, normalize_evidence_locator
 from .epistemic_status import epistemic_status_ref, is_blocked_epistemic_status, is_revision_status, is_supported_epistemic_status, normalize_epistemic_status
 from .stance_receipts import build_contradiction_receipt, build_stance_receipt, classify_stance_transition, contradiction_receipt_ref, detect_no_new_evidence_reversal, resolve_active_stance, stance_receipt_ref, summarize_stance_lock_status, validate_stance_transition
+from .evidence_diagnostic import build_evidence_stability_diagnostic, classify_evidence_stability_posture, count_claims_by_epistemic_status, count_contradictions_by_type, evidence_stability_diagnostic_ref, summarize_claim_evidence_state, summarize_stance_contradictions
+from .memory_ingress_guard import build_truth_memory_ingress_guard_record, classify_truth_memory_ingress_outcome, resolve_truth_memory_ingress_guards, summarize_truth_memory_ingress_guard_status, truth_memory_ingress_guard_ref, validate_claim_for_memory_ingress
 from .epistemic_orientation import (
     BeliefEnforcer,
     ContradictionRegistry,
@@ -59,6 +61,19 @@ __all__ = [
     "stance_receipt_ref",
     "summarize_stance_lock_status",
     "validate_stance_transition",
+    "validate_claim_for_memory_ingress",
+    "truth_memory_ingress_guard_ref",
+    "summarize_truth_memory_ingress_guard_status",
+    "resolve_truth_memory_ingress_guards",
+    "classify_truth_memory_ingress_outcome",
+    "build_truth_memory_ingress_guard_record",
+    "summarize_stance_contradictions",
+    "summarize_claim_evidence_state",
+    "evidence_stability_diagnostic_ref",
+    "count_contradictions_by_type",
+    "count_claims_by_epistemic_status",
+    "classify_evidence_stability_posture",
+    "build_evidence_stability_diagnostic",
     "BeliefEnforcer",
     "BeliefVerifier",
     "ContradictionRegistry",

--- a/sentientos/truth/evidence_diagnostic.py
+++ b/sentientos/truth/evidence_diagnostic.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = "phase57.evidence_diagnostic.v1"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def evidence_stability_diagnostic_ref(record: Mapping[str, Any]) -> str:
+    return f"evidence_diagnostic:{record['diagnostic_id']}"
+
+
+def count_claims_by_epistemic_status(claim_receipts: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in claim_receipts:
+        status = str(row.get("epistemic_status") or "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _count_claims_by_kind(claim_receipts: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in claim_receipts:
+        kind = str(row.get("claim_kind") or "unknown")
+        counts[kind] = counts.get(kind, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def count_contradictions_by_type(contradiction_receipts: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in contradiction_receipts:
+        ctype = str(row.get("contradiction_type") or "unknown")
+        counts[ctype] = counts.get(ctype, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def summarize_claim_evidence_state(*, claim_receipts: Sequence[Mapping[str, Any]], evidence_receipts: Sequence[Mapping[str, Any]], stance_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    active_stance = stance_receipts[-1] if stance_receipts else {}
+    active_claim_id = str(active_stance.get("active_claim_id") or (claim_receipts[-1].get("claim_id") if claim_receipts else ""))
+    active_claim = next((c for c in claim_receipts if str(c.get("claim_id") or "") == active_claim_id), claim_receipts[-1] if claim_receipts else {})
+    return {
+        "claim_count_total": len(claim_receipts),
+        "evidence_count_total": len(evidence_receipts),
+        "stance_receipt_count": len(stance_receipts),
+        "active_claim_id": active_claim_id or None,
+        "active_epistemic_status": str(active_claim.get("epistemic_status") or "unknown") if active_claim else "unknown",
+        "active_evidence_ids": list(active_claim.get("evidence_ids") or []),
+        "counts_by_epistemic_status": count_claims_by_epistemic_status(claim_receipts),
+        "counts_by_claim_kind": _count_claims_by_kind(claim_receipts),
+    }
+
+
+def summarize_stance_contradictions(*, contradiction_receipts: Sequence[Mapping[str, Any]], stance_receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    blocking = [c for c in contradiction_receipts if str(c.get("severity") or "") == "blocking" or str(c.get("adjudication") or "") in {"block_revision", "require_new_evidence"}]
+    warning = [c for c in contradiction_receipts if str(c.get("severity") or "") == "warning"]
+    tcounts = count_contradictions_by_type(contradiction_receipts)
+    policy_preserve = sum(1 for s in stance_receipts if str(s.get("transition_type") or "") == "policy_block_but_preserve")
+    return {
+        "contradiction_count_total": len(contradiction_receipts),
+        "counts_by_contradiction_type": tcounts,
+        "blocking_contradiction_count": len(blocking),
+        "warning_contradiction_count": len(warning),
+        "no_new_evidence_reversal_count": tcounts.get("no_new_evidence_reversal", 0),
+        "unsupported_dilution_count": tcounts.get("unsupported_dilution", 0),
+        "unsupported_source_undermining_count": tcounts.get("unsupported_source_undermining", 0),
+        "policy_block_preserved_count": policy_preserve,
+        "open_review_required_count": len(warning) + tcounts.get("quote_fidelity_failure", 0),
+    }
+
+
+def classify_evidence_stability_posture(*, claim_count_total: int, active_epistemic_status: str, blocking_contradiction_count: int, warning_contradiction_count: int, no_new_evidence_reversal_count: int, unsupported_source_undermining_count: int) -> str:
+    if claim_count_total == 0:
+        return "no_claims_recorded"
+    if no_new_evidence_reversal_count > 0:
+        return "blocked_due_to_no_new_evidence_reversal"
+    if unsupported_source_undermining_count > 0:
+        return "blocked_due_to_unsupported_source_undermining"
+    if blocking_contradiction_count > 0:
+        return "mixed_or_contested_stance"
+    if active_epistemic_status in {"underconstrained", "plausible_but_unverified", "unknown", "blocked"}:
+        return "provisional_or_underconstrained_stance"
+    if warning_contradiction_count > 0:
+        return "review_required_due_to_warnings"
+    if active_epistemic_status in {"directly_supported", "provisional_supported", "strongly_inferred"}:
+        return "stable_supported_stance"
+    return "mixed_or_contested_stance"
+
+
+def build_evidence_stability_diagnostic(*, claim_receipts: Sequence[Mapping[str, Any]], evidence_receipts: Sequence[Mapping[str, Any]], stance_receipts: Sequence[Mapping[str, Any]], contradiction_receipts: Sequence[Mapping[str, Any]], topic_id: str | None = None, generated_at: str | None = None) -> dict[str, Any]:
+    claims = list(claim_receipts)
+    evidence = list(evidence_receipts)
+    stances = list(stance_receipts)
+    contradictions = list(contradiction_receipts)
+    claim_summary = summarize_claim_evidence_state(claim_receipts=claims, evidence_receipts=evidence, stance_receipts=stances)
+    contradiction_summary = summarize_stance_contradictions(contradiction_receipts=contradictions, stance_receipts=stances)
+    posture = classify_evidence_stability_posture(
+        claim_count_total=claim_summary["claim_count_total"],
+        active_epistemic_status=claim_summary["active_epistemic_status"],
+        blocking_contradiction_count=contradiction_summary["blocking_contradiction_count"],
+        warning_contradiction_count=contradiction_summary["warning_contradiction_count"],
+        no_new_evidence_reversal_count=contradiction_summary["no_new_evidence_reversal_count"],
+        unsupported_source_undermining_count=contradiction_summary["unsupported_source_undermining_count"],
+    )
+    material = f"{topic_id or 'none'}|{claim_summary['active_claim_id'] or 'none'}|{claim_summary['claim_count_total']}|{contradiction_summary['contradiction_count_total']}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_id": "esd_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:24],
+        "generated_at": generated_at or _utc_now(),
+        "topic_id": topic_id,
+        **claim_summary,
+        **contradiction_summary,
+        "evidence_stability_posture": posture,
+        "user_visible_note": "Diagnostic-only epistemic stability summary. No memory or work routing effects.",
+        "non_authoritative": True,
+        "decision_power": "none",
+        "diagnostic_is_not_memory": True,
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+    }

--- a/sentientos/truth/memory_ingress_guard.py
+++ b/sentientos/truth/memory_ingress_guard.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = "phase57.truth_memory_ingress_guard.v1"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def truth_memory_ingress_guard_ref(record: Mapping[str, Any]) -> str:
+    return f"truth_memory_ingress_guard:{record['truth_memory_ingress_guard_id']}"
+
+
+def classify_truth_memory_ingress_outcome(*, claim: Mapping[str, Any], contradictions: Sequence[Mapping[str, Any]], active_stance: Mapping[str, Any] | None) -> tuple[str, list[str]]:
+    rationale: list[str] = []
+    status = str(claim.get("epistemic_status") or "unknown")
+    kind = str(claim.get("claim_kind") or "unknown")
+    evidence_ids = list(claim.get("evidence_ids") or [])
+    evidence_refs = list(claim.get("evidence_refs") or [])
+
+    if kind in {"source_backed_claim", "source_backed_implication"} and not (evidence_ids or evidence_refs):
+        return "truth_memory_ingress_blocked_missing_evidence", ["source-backed claim requires evidence linkage"]
+    if status in {"underconstrained", "plausible_but_unverified", "unknown", "blocked"}:
+        return "truth_memory_ingress_blocked_underconstrained", [f"epistemic status {status} not eligible for active memory"]
+    if status in {"retracted_due_to_error", "superseded_by_new_evidence", "contradicted_by_new_evidence"}:
+        return "truth_memory_ingress_blocked_retracted_or_superseded", [f"status {status} is non-active truth"]
+
+    c_types = {str(c.get("contradiction_type") or "") for c in contradictions}
+    if "no_new_evidence_reversal" in c_types:
+        return "truth_memory_ingress_blocked_no_new_evidence_reversal", ["blocking no-new-evidence reversal present"]
+    if "unsupported_dilution" in c_types:
+        return "truth_memory_ingress_blocked_unsupported_dilution", ["unsupported dilution present"]
+    if "unsupported_source_undermining" in c_types:
+        return "truth_memory_ingress_blocked_unsupported_source_undermining", ["unsupported source undermining present"]
+    if "quote_fidelity_failure" in c_types:
+        return "truth_memory_ingress_blocked_quote_fidelity_failure", ["quote fidelity failure present"]
+
+    has_blocking = any(str(c.get("severity") or "") == "blocking" or str(c.get("adjudication") or "") in {"block_revision", "require_new_evidence"} for c in contradictions)
+    if has_blocking:
+        return "truth_memory_ingress_needs_review", ["blocking contradiction adjudication present"]
+
+    if active_stance:
+        transition = str(active_stance.get("transition_type") or "")
+        active_claim_id = str(active_stance.get("active_claim_id") or "")
+        claim_id = str(claim.get("claim_id") or "")
+        prev_claim_id = str(active_stance.get("previous_claim_id") or "")
+        if active_claim_id != claim_id and not (transition == "policy_block_but_preserve" and prev_claim_id == claim_id):
+            return "truth_memory_ingress_needs_review", ["active stance does not match claim"]
+        if transition == "policy_block_but_preserve" and prev_claim_id == claim_id:
+            rationale.append("policy block preserves prior supported claim")
+
+    if status in {"directly_supported", "provisional_supported", "strongly_inferred"}:
+        rationale.append("supported status with required evidence and no blocking contradiction")
+        return "truth_memory_ingress_validated_for_future_memory", rationale
+
+    return "truth_memory_ingress_blocked_unknown_status", [f"unhandled epistemic status {status}"]
+
+
+def build_truth_memory_ingress_guard_record(*, claim_receipt: Mapping[str, Any], evidence_receipts: Sequence[Mapping[str, Any]], stance_receipts: Sequence[Mapping[str, Any]], contradiction_receipts: Sequence[Mapping[str, Any]], created_at: str | None = None) -> dict[str, Any]:
+    claim_id = str(claim_receipt.get("claim_id") or "")
+    linked_contradictions = [c for c in contradiction_receipts if claim_id in {str(c.get("old_claim_id") or ""), str(c.get("new_claim_id") or "")}]
+    blocking_ids = [str(c.get("contradiction_id") or "") for c in linked_contradictions if str(c.get("severity") or "") == "blocking" or str(c.get("adjudication") or "") in {"block_revision", "require_new_evidence"}]
+    active_stance = stance_receipts[-1] if stance_receipts else None
+    outcome, rationale = classify_truth_memory_ingress_outcome(claim=claim_receipt, contradictions=linked_contradictions, active_stance=active_stance)
+    material = f"{claim_id}|{outcome}|{','.join(sorted(blocking_ids))}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "truth_memory_ingress_guard_id": "tmg_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:24],
+        "claim_id": claim_id,
+        "claim_ref": f"claim:{claim_id}",
+        "topic_id": claim_receipt.get("topic_id"),
+        "epistemic_status": claim_receipt.get("epistemic_status", "unknown"),
+        "claim_kind": claim_receipt.get("claim_kind", "unknown"),
+        "evidence_ids": list(claim_receipt.get("evidence_ids") or []),
+        "active_stance_lock_id": None if not active_stance else active_stance.get("stance_lock_id"),
+        "contradiction_ids": [str(c.get("contradiction_id") or "") for c in linked_contradictions],
+        "blocking_contradiction_ids": blocking_ids,
+        "validation_outcome": outcome,
+        "evidence_complete": bool((claim_receipt.get("evidence_ids") or []) or (claim_receipt.get("evidence_refs") or [])),
+        "active_stance_matches_claim": True if not active_stance else (str(active_stance.get("active_claim_id") or "") == claim_id or (str(active_stance.get("transition_type") or "") == "policy_block_but_preserve" and str(active_stance.get("previous_claim_id") or "") == claim_id)),
+        "contradiction_free": not linked_contradictions,
+        "rationale": rationale,
+        "created_at": created_at or _utc_now(),
+        "non_authoritative": True,
+        "decision_power": "none",
+        "guard_is_not_memory_write": True,
+        "validation_is_not_memory_write": True,
+        "does_not_write_memory": True,
+        "does_not_admit_work": True,
+        "does_not_execute_or_route_work": True,
+        "does_not_trigger_feedback": True,
+    }
+
+
+def validate_claim_for_memory_ingress(**kwargs: Any) -> dict[str, Any]:
+    return build_truth_memory_ingress_guard_record(**kwargs)
+
+
+def resolve_truth_memory_ingress_guards(*, claim_receipts: Sequence[Mapping[str, Any]], evidence_receipts: Sequence[Mapping[str, Any]], stance_receipts: Sequence[Mapping[str, Any]], contradiction_receipts: Sequence[Mapping[str, Any]], created_at: str | None = None) -> dict[str, Any]:
+    rows = [
+        validate_claim_for_memory_ingress(
+            claim_receipt=claim,
+            evidence_receipts=evidence_receipts,
+            stance_receipts=stance_receipts,
+            contradiction_receipts=contradiction_receipts,
+            created_at=created_at,
+        )
+        for claim in claim_receipts
+    ]
+    return {
+        "truth_memory_ingress_guard_records": rows,
+        "truth_memory_ingress_guard_summary": summarize_truth_memory_ingress_guard_status(truth_memory_ingress_guard_records=rows),
+    }
+
+
+def summarize_truth_memory_ingress_guard_status(*, truth_memory_ingress_guard_records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_outcome: dict[str, int] = {}
+    for row in truth_memory_ingress_guard_records:
+        outcome = str(row.get("validation_outcome") or "truth_memory_ingress_blocked_unknown_status")
+        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+    return {
+        "truth_memory_ingress_guard_count": len(truth_memory_ingress_guard_records),
+        "truth_memory_ingress_guard_counts_by_outcome": dict(sorted(by_outcome.items())),
+        "validated_for_future_memory_count": by_outcome.get("truth_memory_ingress_validated_for_future_memory", 0),
+        "blocked_count": sum(v for k, v in by_outcome.items() if k.startswith("truth_memory_ingress_blocked")),
+    }

--- a/tests/architecture/test_architecture_boundaries.py
+++ b/tests/architecture/test_architecture_boundaries.py
@@ -815,3 +815,44 @@ def test_phase56_truth_receipt_invariants() -> None:
         assert row["does_not_write_memory"] is True
         assert row["does_not_admit_work"] is True
         assert row["does_not_execute_or_route_work"] is True
+
+def test_phase57_truth_modules_avoid_authority_effect_imports() -> None:
+    blocked = (
+        "task_executor",
+        "task_admission",
+        "control_plane",
+        "authority_surface",
+        "embodiment_memory",
+        "feedback_action",
+        "retention",
+        "legacy_perception",
+    )
+    for rel in ("sentientos/truth/evidence_diagnostic.py", "sentientos/truth/memory_ingress_guard.py"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for token in blocked:
+            assert token not in text
+
+
+def test_phase57_manifest_truth_layers_and_non_authority_invariants() -> None:
+    manifest = _manifest()
+    layers = manifest["layer_definitions"]
+    diag = layers["truth_evidence_diagnostic"]
+    guard = layers["truth_memory_ingress_guard"]
+    assert diag["non_authoritative"] is True
+    assert diag["does_not_write_memory"] is True
+    assert guard["guard_is_not_memory_write"] is True
+    assert guard["truth_memory_ingress_validated_for_future_memory_is_not_memory_write"] is True
+    assert guard["unstable_claims_cannot_enter_active_memory"] is True
+    assert guard["no_new_evidence_reversal_blocks_memory_ingress"] is True
+
+
+def test_phase57_truth_outputs_expose_non_authority_flags() -> None:
+    from sentientos.truth.evidence_diagnostic import build_evidence_stability_diagnostic
+    from sentientos.truth.memory_ingress_guard import build_truth_memory_ingress_guard_record
+    from sentientos.truth.claim_ledger import build_claim_receipt
+
+    claim = build_claim_receipt(conversation_scope_id="c", turn_id="1", topic_id="t", claim_text="x", claim_kind="source_backed_claim", epistemic_status="directly_supported", evidence_ids=["e1"])
+    diag = build_evidence_stability_diagnostic(claim_receipts=[claim], evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    guard = build_truth_memory_ingress_guard_record(claim_receipt=claim, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    assert diag["non_authoritative"] is True and diag["decision_power"] == "none"
+    assert guard["guard_is_not_memory_write"] is True and guard["validation_is_not_memory_write"] is True

--- a/tests/test_phase57_evidence_diagnostic_memory_guard.py
+++ b/tests/test_phase57_evidence_diagnostic_memory_guard.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from sentientos.truth import (
+    build_claim_receipt,
+    build_contradiction_receipt,
+    build_evidence_stability_diagnostic,
+    build_stance_receipt,
+    build_truth_memory_ingress_guard_record,
+)
+
+
+def _claim(turn: str, status: str = "directly_supported", kind: str = "source_backed_claim", evidence_ids=None):
+    kwargs = dict(conversation_scope_id="c", turn_id=turn, topic_id="t", claim_text=f"claim-{turn}", claim_kind=kind, epistemic_status=status)
+    if evidence_ids is not None:
+        kwargs["evidence_ids"] = evidence_ids
+    elif not (kind in {"source_backed_claim", "source_backed_implication"} and status not in {"underconstrained", "unknown"}):
+        kwargs["evidence_ids"] = []
+    return build_claim_receipt(**kwargs)
+
+
+def test_phase57_diagnostic_empty_and_supported_postures():
+    empty = build_evidence_stability_diagnostic(claim_receipts=[], evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    assert empty["evidence_stability_posture"] == "no_claims_recorded"
+    c1 = _claim("1", evidence_ids=["e1"])
+    stable = build_evidence_stability_diagnostic(claim_receipts=[c1], evidence_receipts=[{"evidence_id": "e1"}], stance_receipts=[], contradiction_receipts=[])
+    assert stable["evidence_stability_posture"] == "stable_supported_stance"
+    under = _claim("2", status="underconstrained")
+    assert build_evidence_stability_diagnostic(claim_receipts=[under], evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])["evidence_stability_posture"] == "provisional_or_underconstrained_stance"
+
+
+def test_phase57_diagnostic_contradiction_postures_and_counts():
+    prev = _claim("1", evidence_ids=["e1"])
+    new = _claim("2", status="plausible_but_unverified", kind="uncertainty_statement", evidence_ids=["e1"])
+    c1 = build_contradiction_receipt(topic_id="t", old_claim_id=prev["claim_id"], new_claim_id=new["claim_id"], contradiction_type="no_new_evidence_reversal", severity="blocking", adjudication="require_new_evidence")
+    out = build_evidence_stability_diagnostic(claim_receipts=[prev, new], evidence_receipts=[{"evidence_id": "e1"}], stance_receipts=[], contradiction_receipts=[c1])
+    assert out["evidence_stability_posture"] == "blocked_due_to_no_new_evidence_reversal"
+    c2 = build_contradiction_receipt(topic_id="t", old_claim_id=prev["claim_id"], new_claim_id=new["claim_id"], contradiction_type="unsupported_source_undermining", severity="blocking", adjudication="block_revision")
+    out2 = build_evidence_stability_diagnostic(claim_receipts=[prev, new], evidence_receipts=[], stance_receipts=[], contradiction_receipts=[c2])
+    assert out2["evidence_stability_posture"] == "blocked_due_to_unsupported_source_undermining"
+    assert out2["counts_by_claim_kind"]["source_backed_claim"] == 1
+    assert out2["counts_by_contradiction_type"]["unsupported_source_undermining"] == 1
+    assert out2["non_authoritative"] is True and out2["decision_power"] == "none"
+
+
+def test_phase57_memory_guard_outcomes_and_policy_preserve():
+    good = _claim("1", evidence_ids=["e1"])
+    ok = build_truth_memory_ingress_guard_record(claim_receipt=good, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    assert ok["validation_outcome"] == "truth_memory_ingress_validated_for_future_memory"
+    missing = _claim("2", status="underconstrained")
+    blocked_under = build_truth_memory_ingress_guard_record(claim_receipt=missing, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])
+    assert blocked_under["validation_outcome"] == "truth_memory_ingress_blocked_underconstrained"
+    bad = dict(good)
+    bad["evidence_ids"] = []
+    bad["evidence_refs"] = []
+    assert build_truth_memory_ingress_guard_record(claim_receipt=bad, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])["validation_outcome"] == "truth_memory_ingress_blocked_missing_evidence"
+    no_new = build_contradiction_receipt(topic_id="t", old_claim_id=good["claim_id"], new_claim_id="x", contradiction_type="no_new_evidence_reversal", severity="blocking", adjudication="require_new_evidence")
+    assert build_truth_memory_ingress_guard_record(claim_receipt=good, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[no_new])["validation_outcome"] == "truth_memory_ingress_blocked_no_new_evidence_reversal"
+    quote = build_contradiction_receipt(topic_id="t", old_claim_id=good["claim_id"], new_claim_id="x", contradiction_type="quote_fidelity_failure", severity="blocking", adjudication="block_revision")
+    assert build_truth_memory_ingress_guard_record(claim_receipt=good, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[quote])["validation_outcome"] == "truth_memory_ingress_blocked_quote_fidelity_failure"
+    retract = _claim("3", status="retracted_due_to_error", kind="correction", evidence_ids=[])
+    assert build_truth_memory_ingress_guard_record(claim_receipt=retract, evidence_receipts=[], stance_receipts=[], contradiction_receipts=[])["validation_outcome"] == "truth_memory_ingress_blocked_retracted_or_superseded"
+    other = _claim("4", evidence_ids=["e1"])
+    mismatch_stance = build_stance_receipt(topic_id="t", active_claim_id=other["claim_id"], previous_claim_id=good["claim_id"], transition_type="hold_revision")
+    assert build_truth_memory_ingress_guard_record(claim_receipt=good, evidence_receipts=[], stance_receipts=[mismatch_stance], contradiction_receipts=[])["validation_outcome"] == "truth_memory_ingress_needs_review"
+    policy = build_stance_receipt(topic_id="t", active_claim_id=other["claim_id"], previous_claim_id=good["claim_id"], transition_type="policy_block_but_preserve")
+    preserved = build_truth_memory_ingress_guard_record(claim_receipt=good, evidence_receipts=[], stance_receipts=[policy], contradiction_receipts=[])
+    assert preserved["active_stance_matches_claim"] is True
+    assert preserved["guard_is_not_memory_write"] is True and preserved["decision_power"] == "none"
+
+
+def test_phase57_no_input_mutation_and_scoped_additive():
+    claim = _claim("1", evidence_ids=["e1"])
+    claims = [claim]
+    evidence = [{"evidence_id": "e1"}]
+    stances = []
+    contradictions = []
+    snap = deepcopy((claims, evidence, stances, contradictions))
+    build_evidence_stability_diagnostic(claim_receipts=claims, evidence_receipts=evidence, stance_receipts=stances, contradiction_receipts=contradictions)
+    build_truth_memory_ingress_guard_record(claim_receipt=claim, evidence_receipts=evidence, stance_receipts=stances, contradiction_receipts=contradictions)
+    assert (claims, evidence, stances, contradictions) == snap
+
+    from sentientos.scoped_lifecycle_diagnostic import build_scoped_lifecycle_diagnostic
+    out = build_scoped_lifecycle_diagnostic(__import__('pathlib').Path('.'))
+    assert "actions" in out
+    assert "evidence_stability_diagnostic" in out


### PR DESCRIPTION
### Motivation
- Provide canonical, deterministic, non-authoritative visibility into current evidence/stance stability so the system can summarize epistemic posture without taking action. 
- Add a validation-only truth memory-ingress guard that decides whether a claim is eligible for future memory writing while explicitly not performing any memory writes or effect admission. 
- Surface lightweight, additive lifecycle diagnostics and manifest boundaries so architecture tests can enforce non-authority/no-write invariants.

### Description
- Added a deterministic read-only evidence stability diagnostic module `sentientos/truth/evidence_diagnostic.py` exposing `build_evidence_stability_diagnostic`, posture classification, claim/evidence/contradiction counters and non-authority flags. 
- Added a validation-only memory-ingress guard `sentientos/truth/memory_ingress_guard.py` exposing `build_truth_memory_ingress_guard_record`, `validate_claim_for_memory_ingress`, `resolve_truth_memory_ingress_guards`, and deterministic outcome vocabulary (validated/blocked/needs_review) with explicit `guard_is_not_memory_write` semantics. 
- Exported the new helpers from `sentientos/truth/__init__.py` and added additive scoped lifecycle fields in `sentientos/scoped_lifecycle_diagnostic.py` (`evidence_stability_diagnostic`, `truth_memory_ingress_guard_summary`) as safe stubs. 
- Declared two new manifest layers in `sentientos/system_closure/architecture_boundary_manifest.json` (`truth_evidence_diagnostic`, `truth_memory_ingress_guard`) with non-authoritative/no-write/no-admission/no-execution invariants. 
- Added focused architecture checks and a focused Phase 57 test suite `tests/test_phase57_evidence_diagnostic_memory_guard.py` plus manifest/import tests updates in `tests/architecture/test_architecture_boundaries.py` to assert output invariants and forbidden imports.

### Testing
- Ran the focused Phase 57 and related truth tests: `python -m scripts.run_tests -q tests/test_phase57_evidence_diagnostic_memory_guard.py tests/test_phase56_evidence_stability_spine.py tests/test_epistemic_orientation.py sentientos/tests/test_provisional_assertions.py sentientos/tests/test_wan_contradiction_policy.py` and the focused Phase 57 tests passed (diagnostic postures, guard outcomes, policy-preserve behavior, and immutability checks succeeded). 
- Ran architecture and import purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and these suites passed. 
- Ran embodiment/ingress smoke suites: `python -m scripts.run_tests -q tests/test_phase55_retention_ingress_validation.py tests/test_phase54_action_ingress_validation.py tests/test_phase53_memory_ingress_validation.py` and orchestration smoke tests: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py`, all executed successfully in the CI bootstrap; some unrelated pre-existing tests in the larger repo are skipped by design but did not indicate regressions. 
- All added tests are hardware-free and deterministic; new modules avoid importing or calling any memory-write, admission, execution, control-plane, or feedback APIs as enforced by updated architecture tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8f90d94488320a0ef6d239a5e18b6)