### PR TITLE
[codex:test-harness] enforce phase test anti-skip contract

### DIFF
--- a/docs/architecture/phase60_phase_test_harness_contract_execplan.md
+++ b/docs/architecture/phase60_phase_test_harness_contract_execplan.md
@@ -1,0 +1,46 @@
+# Phase 60 ExecPlan: Phase-Focused Test Harness Anti-Skip Contract
+
+## 1) Current legacy skip policy behavior
+- `tests/conftest.py::pytest_collection_modifyitems` labels tests as `legacy` and skips them by default unless `-m legacy` is active.
+- The skip decision is delegated to `tests/legacy_policy.py::is_legacy_candidate(...)`.
+- Current opt-outs rely on:
+  - allowlisted module names in `tests/conftest.py` (`allowed_modules`), or
+  - explicit `pytest.mark.no_legacy_skip` markers.
+- Net effect: newly introduced files can be silently quarantined if authors forget markers/allowlist updates.
+
+## 2) Recent accidental skip incidents
+- Phase 45/46 focused ingress embodiment tests were added and later unskipped.
+- Phase 48/49/50 focused embodied proposal/review tests were added and later unskipped in follow-up hardening.
+- Phase 56/57/58 focused truth tests were added and later unskipped in Phase 59.
+- Pattern: `tests/test_phase*.py` files are phase-focused but vulnerable to legacy quarantine-by-default behavior.
+
+## 3) Target phase-test contract
+- Files matching `tests/test_phase*.py` are **phase-focused** and not legacy by default.
+- They must either:
+  1. run under standard harness by default, or
+  2. declare an explicit module-level skip with a searchable, documented reason.
+- Individual skipped tests are permitted with explicit reason text.
+- Fully skipped phase modules are forbidden unless explicitly and intentionally approved via module-level skip reason.
+
+## 4) Changes to conftest/marker policy
+- Apply a **central policy fix** in `tests/legacy_policy.py`:
+  - Exempt `tests/test_phase*.py` from legacy candidacy by default.
+- Preserve existing legacy semantics for non-phase tests.
+- Keep `no_legacy_skip` marker support unchanged (still valid and explicit).
+
+## 5) Meta-tests to add
+- Add `tests/test_phase_test_harness_contract.py` to statically enforce:
+  - every `tests/test_phase*.py` module either has runnable tests or explicit module-level skip;
+  - module-level skip reasons (when present) are explicit and searchable;
+  - phase modules are not legacy candidates under `is_legacy_candidate(...)` defaults;
+  - representative Phase 45–59 modules satisfy contract.
+
+## 6) Compatibility strategy for intentionally skipped legacy tests
+- No changes to existing legacy-only test behavior.
+- Existing non-phase suites continue to rely on allowlist/markers and legacy quarantine semantics.
+- Intentional skip behavior for phase suites remains possible through explicit module-level skip declarations.
+
+## 7) Risks and deferred cleanup
+- Risk: `test_phase` naming convention drift (e.g., alternate filenames) could bypass contract; deferred: add naming lint if repo starts using alternates.
+- Risk: static checks may miss dynamic skip behavior inside fixtures; mitigated by constraining module-level policy and central legacy exemption.
+- Deferred cleanup: reduce `allowed_modules` sprawl in `tests/conftest.py` via separate policy normalization pass (out of scope).

--- a/docs/architecture/phase_test_harness_contract.md
+++ b/docs/architecture/phase_test_harness_contract.md
@@ -1,0 +1,21 @@
+# Phase Test Harness Contract
+
+## Purpose
+Phase-focused suites (`tests/test_phase*.py`) are product hardening tests, not legacy quarantine candidates.
+
+## Contract
+- New `tests/test_phase*.py` files must run under the standard harness by default.
+- Central policy exemption prevents phase suites from being auto-classified as legacy.
+- Individual test-level skips are allowed, but skip reasons must be explicit.
+- Fully skipped phase suites are forbidden unless they include an explicit, searchable module-level skip reason and approval context.
+
+## Implementation Notes
+- Legacy quarantine remains active for non-phase tests.
+- `pytest.mark.no_legacy_skip` remains valid for explicitness, but phase suites no longer depend on author memory to avoid quarantine.
+- Contract enforcement meta-tests live in `tests/test_phase_test_harness_contract.py`.
+
+## Reviewer Checklist for New Phase Files
+1. File name matches `tests/test_phase*.py`.
+2. Contains real `test_*` coverage (not placeholders).
+3. Any skips include clear reason text.
+4. If module-level skipped, reason is explicit and documented in review notes.

--- a/tests/legacy_policy.py
+++ b/tests/legacy_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Set
+from pathlib import PurePosixPath
 
 LEGACY_SKIP_REASON = "legacy test disabled: run with -m legacy"
 
@@ -11,6 +12,12 @@ def legacy_marker_enabled(markexpr: str | None) -> bool:
     if not markexpr:
         return False
     return "legacy" in markexpr
+
+
+def _is_phase_test_path(path_str: str) -> bool:
+    normalized = path_str.replace("\\", "/")
+    name = PurePosixPath(normalized).name
+    return name.startswith("test_phase") and name.endswith(".py")
 
 
 def is_legacy_candidate(
@@ -24,6 +31,8 @@ def is_legacy_candidate(
     if test_name == "test_placeholder":
         return False
     if test_name.startswith("test_emotion_pump"):
+        return False
+    if _is_phase_test_path(path_str):
         return False
     if "tests/e2e/" in path_str:
         return False

--- a/tests/test_phase_test_harness_contract.py
+++ b/tests/test_phase_test_harness_contract.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tests.legacy_policy import is_legacy_candidate
+
+PHASE_TEST_GLOB = "test_phase*.py"
+APPROVED_EMPTY_PHASE_MODULES: set[str] = set()
+
+
+class _ModuleInspection(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.module_skip_reasons: list[str] = []
+        self.test_functions = 0
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "pytestmark":
+                reason = _extract_module_skip_reason(node.value)
+                if reason is not None:
+                    self.module_skip_reasons.append(reason)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+        target = node.target
+        if isinstance(target, ast.Name) and target.id == "pytestmark" and node.value is not None:
+            reason = _extract_module_skip_reason(node.value)
+            if reason is not None:
+                self.module_skip_reasons.append(reason)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        if node.name.startswith("test_"):
+            self.test_functions += 1
+        self.generic_visit(node)
+
+
+def _extract_module_skip_reason(value: ast.AST) -> str | None:
+    nodes = [value]
+    if isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+        nodes = list(value.elts)
+    for node in nodes:
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr != "skip":
+            continue
+        for kw in node.keywords:
+            if kw.arg == "reason" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+        return ""
+    return None
+
+
+def _phase_test_paths() -> list[Path]:
+    return sorted(Path("tests").glob(PHASE_TEST_GLOB))
+
+
+def _module_name(path: Path) -> str:
+    return ".".join(path.with_suffix("").parts)
+
+
+def test_phase_files_are_not_legacy_candidates_by_default() -> None:
+    for path in _phase_test_paths():
+        assert is_legacy_candidate(
+            module_name=_module_name(path),
+            path_str=str(path),
+            test_name="test_contract_probe",
+            keywords={},
+            allowed_modules=set(),
+        ) is False, f"{path} unexpectedly considered legacy candidate"
+
+
+def test_phase_modules_have_tests_or_approved_module_skip_reason() -> None:
+    for path in _phase_test_paths():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        inspect = _ModuleInspection()
+        inspect.visit(tree)
+
+        if inspect.module_skip_reasons:
+            for reason in inspect.module_skip_reasons:
+                assert reason.strip(), f"{path} has module-level skip without explicit reason"
+                assert "phase" in reason.lower() or "legacy" in reason.lower() or "approved" in reason.lower(), (
+                    f"{path} skip reason must be explicit/searchable: {reason!r}"
+                )
+            continue
+
+        assert inspect.test_functions > 0, f"{path} has no test_* functions"
+        assert str(path) not in APPROVED_EMPTY_PHASE_MODULES, (
+            f"{path} listed as approved empty but has no module-level skip"
+        )
+
+
+def test_phase45_through_phase59_modules_present_and_covered() -> None:
+    expected = {
+        "tests/test_phase45_ingress_gated_effects.py",
+        "tests/test_phase46_ingress_gated_retention.py",
+        "tests/test_phase48_embodied_proposals.py",
+        "tests/test_phase49_embodied_proposal_visibility.py",
+        "tests/test_phase50_embodied_proposal_review_receipts.py",
+        "tests/test_phase56_evidence_stability_spine.py",
+        "tests/test_phase57_evidence_diagnostic_memory_guard.py",
+        "tests/test_phase58_truth_log_fed_preflight.py",
+        "tests/test_phase59_research_response_gate.py",
+    }
+    discovered = {str(p) for p in _phase_test_paths()}
+    missing = expected - discovered
+    assert not missing, f"missing expected phase modules: {sorted(missing)}"


### PR DESCRIPTION
### Motivation
- Prevent newly added `tests/test_phase*.py` suites from being silently quarantined by the repo legacy-skip policy.
- Provide a durable, central contract so future phase-focused tests run by default or fail loudly if intentionally skipped. 
- Preserve existing legacy quarantine semantics for non-phase suites and avoid runtime semantic changes.

### Description
- Exempt phase-focused modules by name from legacy candidacy by adding a path-based check to `tests/legacy_policy.py` so `tests/test_phase*.py` are not considered legacy candidates by default. 
- Add a static meta-test `tests/test_phase_test_harness_contract.py` that enforces the contract: phase modules are not legacy candidates, each phase module has real `test_*` coverage or an explicit module-level skip with an explicit searchable reason, and Phase 45–59 modules are present. 
- Add documentation: `docs/architecture/phase_test_harness_contract.md` (concise contract and reviewer checklist) and `docs/architecture/phase60_phase_test_harness_contract_execplan.md` (exec plan, incidents, risks, and implementation notes).
- Preserve `pytest.mark.no_legacy_skip` and legacy marker behavior for non-phase tests; no changes to `tests/conftest.py` or runtime semantics.

### Testing
- Ran the new meta-test: `python -m scripts.run_tests -q tests/test_phase_test_harness_contract.py` — passed (meta-test validated phase files and contract).
- Ran a representative focused chain: `python -m scripts.run_tests -q tests/test_phase59_research_response_gate.py tests/test_phase58_truth_log_fed_preflight.py tests/test_phase57_evidence_diagnostic_memory_guard.py tests/test_phase56_evidence_stability_spine.py` — passed.
- Ran architecture/import purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` — passed.
- Ran orchestration smoke tests: `python -m scripts.run_tests -q sentientos/tests/test_orchestration_spine_module_boundaries.py sentientos/tests/test_orchestration_intent_fabric.py` — passed.
- Note: an initial attempt encountered an environment/install-related `OSError` during package install; after ensuring the editable install step the automated test runs completed and all targeted runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f90b00faa08320bcc893711b5b98e2)