### PR TITLE
[codex:context-hygiene] add non-authoritative context packet contract

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -1,0 +1,31 @@
+# Context Hygiene Spine
+
+## Separation Contract
+- Memory is durable historical substrate.
+- Context is bounded, scoped, and temporary selection.
+- Truth is adjudicated elsewhere and is not implied by inclusion in context.
+
+## Why Context Packets Exist
+Context packets provide an immutable-ish, typed boundary for selected references used in response construction without changing runtime behavior in this phase.
+
+## Non-Authoritative Invariants
+- Context packets are non-authoritative.
+- Decision power is always `none`.
+- Packets do not write memory.
+- Packets do not admit, execute, or route work.
+- Inclusion and exclusion reasons are retained.
+- Validity bounds are mandatory.
+- Included references require provenance.
+
+## No Raw Memory Dump Invariant
+The schema intentionally separates memory/claim/evidence/stance/diagnostic/embodiment lanes and does not expose any raw memory dump lane.
+
+## Future Integration Points
+- **Truth spine:** contradiction/freshness/provenance statuses are explicit and can be consumed by future truth adjudication.
+- **Embodiment ladder:** embodiment references are isolated in a dedicated lane for future governed fusion.
+
+## Deferred Work
+- Selector
+- Distiller
+- Pruner
+- Prompt adapter / runtime middleware

--- a/docs/architecture/phase61_context_hygiene_spine_alpha_execplan.md
+++ b/docs/architecture/phase61_context_hygiene_spine_alpha_execplan.md
@@ -1,0 +1,42 @@
+# Phase 61 — Context Hygiene Spine Alpha Execplan
+
+## Goal
+Ship schema/contract/test foundations for non-authoritative context packets and append-only assembly receipts.
+
+## Non-goals
+- No runtime prompt assembly changes.
+- No memory retrieval/retention changes.
+- No truth, embodiment ingress, action routing, or execution semantic changes.
+
+## Current Risks
+- Packet validation currently returns errors (does not raise) and callers must enforce policy.
+- Receipt append helper is local JSONL append and depends on filesystem guarantees.
+
+## Files Changed
+- `sentientos/context_hygiene/__init__.py`
+- `sentientos/context_hygiene/context_packet.py`
+- `sentientos/context_hygiene/receipts.py`
+- `tests/test_phase61_context_packet_contract.py`
+- `docs/architecture/context_hygiene_spine.md`
+- `docs/architecture/phase61_context_hygiene_spine_alpha_execplan.md`
+- `sentientos/system_closure/architecture_boundary_manifest.json`
+
+## Schema Contract
+Defines immutable dataclasses and explicit status enums for context hygiene, including validity bounds, provenance checks, safety invariants, and separate context lanes.
+
+## Receipt Contract
+Defines JSON-compatible assembly receipts keyed by packet id and appended to JSONL in append-only mode.
+
+## Tests
+- packet validation and invariants
+- expiry/provenance handling
+- append-only receipt behavior
+- import purity constraints
+- immutability behavior
+- explicit status/lane support
+
+## Deferred Phases
+- governed packet selector
+- freshness/contradiction downgrader
+- runtime prompt adapter integration
+- receipt attestation and cross-ledger indexing

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -1,0 +1,41 @@
+from sentientos.context_hygiene.context_packet import (
+    ContextAssemblyStatus,
+    ContextBudget,
+    ContextMode,
+    ContextPacket,
+    ContextPacketItem,
+    ContradictionStatus,
+    ExcludedContextRef,
+    FreshnessStatus,
+    PollutionRisk,
+    ProvenanceStatus,
+    make_context_packet,
+    packet_has_decision_power,
+    packet_is_expired,
+    summarize_packet_for_diagnostics,
+    validate_context_packet,
+)
+from sentientos.context_hygiene.receipts import (
+    append_context_assembly_receipt,
+    build_context_assembly_receipt,
+)
+
+__all__ = [
+    "ContextAssemblyStatus",
+    "ContextBudget",
+    "ContextMode",
+    "ContextPacket",
+    "ContextPacketItem",
+    "ContradictionStatus",
+    "ExcludedContextRef",
+    "FreshnessStatus",
+    "PollutionRisk",
+    "ProvenanceStatus",
+    "append_context_assembly_receipt",
+    "build_context_assembly_receipt",
+    "make_context_packet",
+    "packet_has_decision_power",
+    "packet_is_expired",
+    "summarize_packet_for_diagnostics",
+    "validate_context_packet",
+]

--- a/sentientos/context_hygiene/context_packet.py
+++ b/sentientos/context_hygiene/context_packet.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping
+from uuid import uuid4
+
+
+class ContextAssemblyStatus(str, Enum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+class ContextMode(str, Enum):
+    RESPONSE = "response"
+    DIAGNOSTIC = "diagnostic"
+    SAFETY = "safety"
+
+
+class FreshnessStatus(str, Enum):
+    FRESH = "fresh"
+    STALE = "stale"
+    MIXED = "mixed"
+    UNKNOWN = "unknown"
+
+
+class ContradictionStatus(str, Enum):
+    NONE = "none"
+    SUSPECTED = "suspected"
+    CONTRADICTED = "contradicted"
+    UNKNOWN = "unknown"
+
+
+class ProvenanceStatus(str, Enum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    MISSING = "missing"
+
+
+class PollutionRisk(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass(frozen=True)
+class ContextPacketItem:
+    ref_id: str
+    source: str
+    provenance: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ExcludedContextRef:
+    ref_id: str
+    lane: str
+    reason: str
+    source: str | None = None
+    provenance: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    max_items: int
+    max_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class ContextPacket:
+    schema_version: str
+    context_packet_id: str
+    packet_scope: str
+    conversation_scope_id: str
+    task_scope_id: str
+    context_mode: ContextMode
+    created_at: datetime
+    valid_until: datetime
+    included_memory_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    included_claim_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    included_evidence_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    included_stance_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    included_diagnostic_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    included_embodiment_refs: tuple[ContextPacketItem, ...] = field(default_factory=tuple)
+    excluded_refs: tuple[ExcludedContextRef, ...] = field(default_factory=tuple)
+    inclusion_reasons: tuple[str, ...] = field(default_factory=tuple)
+    exclusion_reasons: tuple[str, ...] = field(default_factory=tuple)
+    freshness_status: FreshnessStatus = FreshnessStatus.UNKNOWN
+    contradiction_status: ContradictionStatus = ContradictionStatus.UNKNOWN
+    provenance_complete: bool = False
+    provenance_status: ProvenanceStatus = ProvenanceStatus.PARTIAL
+    source_priority: tuple[str, ...] = field(default_factory=tuple)
+    pollution_risk: PollutionRisk = PollutionRisk.MEDIUM
+    non_authoritative: bool = True
+    decision_power: str = "none"
+    context_packet_is_not_truth: bool = True
+    context_packet_is_not_memory_write: bool = True
+    does_not_admit_work: bool = True
+    does_not_execute_or_route_work: bool = True
+
+
+def make_context_packet(*, packet_scope: str, conversation_scope_id: str, task_scope_id: str, context_mode: ContextMode, valid_until: datetime, schema_version: str = "phase61.v1", context_packet_id: str | None = None, **kwargs: Any) -> ContextPacket:
+    return ContextPacket(
+        schema_version=schema_version,
+        context_packet_id=context_packet_id or str(uuid4()),
+        packet_scope=packet_scope,
+        conversation_scope_id=conversation_scope_id,
+        task_scope_id=task_scope_id,
+        context_mode=context_mode,
+        created_at=datetime.now(timezone.utc),
+        valid_until=valid_until,
+        **kwargs,
+    )
+
+
+def _all_included_refs(packet: ContextPacket) -> tuple[ContextPacketItem, ...]:
+    return (
+        packet.included_memory_refs
+        + packet.included_claim_refs
+        + packet.included_evidence_refs
+        + packet.included_stance_refs
+        + packet.included_diagnostic_refs
+        + packet.included_embodiment_refs
+    )
+
+
+def validate_context_packet(packet: ContextPacket) -> list[str]:
+    errors: list[str] = []
+    if not packet.context_packet_id:
+        errors.append("missing packet id")
+    if not packet.packet_scope:
+        errors.append("missing scope")
+    if not packet.valid_until:
+        errors.append("missing expiry")
+    for item in _all_included_refs(packet):
+        if not item.provenance:
+            errors.append(f"included ref without provenance: {item.ref_id}")
+    if packet.decision_power != "none":
+        errors.append("decision_power must be none")
+    if not packet.non_authoritative:
+        errors.append("packet must be non_authoritative")
+    if not packet.context_packet_is_not_truth:
+        errors.append("packet cannot claim truth")
+    if not packet.context_packet_is_not_memory_write:
+        errors.append("packet cannot write memory")
+    if not packet.does_not_admit_work:
+        errors.append("packet cannot admit work")
+    if not packet.does_not_execute_or_route_work:
+        errors.append("packet cannot execute or route work")
+    return errors
+
+
+def packet_is_expired(packet: ContextPacket, now: datetime | None = None) -> bool:
+    current = now or datetime.now(timezone.utc)
+    return current >= packet.valid_until
+
+
+def packet_has_decision_power(packet: ContextPacket) -> bool:
+    return packet.decision_power != "none"
+
+
+def summarize_packet_for_diagnostics(packet: ContextPacket) -> dict[str, Any]:
+    return {
+        "context_packet_id": packet.context_packet_id,
+        "packet_scope": packet.packet_scope,
+        "context_mode": packet.context_mode.value,
+        "created_at": packet.created_at.isoformat(),
+        "valid_until": packet.valid_until.isoformat(),
+        "included_ref_count": len(_all_included_refs(packet)),
+        "excluded_ref_count": len(packet.excluded_refs),
+        "provenance_complete": packet.provenance_complete,
+        "freshness_status": packet.freshness_status.value,
+        "contradiction_status": packet.contradiction_status.value,
+        "pollution_risk": packet.pollution_risk.value,
+    }

--- a/sentientos/context_hygiene/receipts.py
+++ b/sentientos/context_hygiene/receipts.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from sentientos.context_hygiene.context_packet import ContextAssemblyStatus, ContextPacket
+
+
+DEFAULT_LEDGER_PATH = Path("logs/context_hygiene/context_assembly_receipts.jsonl")
+
+
+def build_context_assembly_receipt(packet: ContextPacket) -> dict[str, Any]:
+    included_ref_counts = {
+        "memory": len(packet.included_memory_refs),
+        "claim": len(packet.included_claim_refs),
+        "evidence": len(packet.included_evidence_refs),
+        "stance": len(packet.included_stance_refs),
+        "diagnostic": len(packet.included_diagnostic_refs),
+        "embodiment": len(packet.included_embodiment_refs),
+    }
+    return {
+        "schema_version": packet.schema_version,
+        "receipt_id": str(uuid4()),
+        "context_packet_id": packet.context_packet_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "assembly_status": ContextAssemblyStatus.COMPLETE.value,
+        "included_ref_counts": included_ref_counts,
+        "excluded_ref_counts": {"excluded": len(packet.excluded_refs)},
+        "inclusion_reasons": list(packet.inclusion_reasons),
+        "exclusion_reasons": list(packet.exclusion_reasons),
+        "freshness_status": packet.freshness_status.value,
+        "contradiction_status": packet.contradiction_status.value,
+        "provenance_complete": packet.provenance_complete,
+        "pollution_risk": packet.pollution_risk.value,
+        "non_authoritative": True,
+        "decision_power": "none",
+        "does_not_write_memory": True,
+        "does_not_execute_or_route_work": True,
+    }
+
+
+def append_context_assembly_receipt(packet: ContextPacket, ledger_path: str | Path | None = None) -> dict[str, Any]:
+    receipt = build_context_assembly_receipt(packet)
+    target = Path(ledger_path) if ledger_path else DEFAULT_LEDGER_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(receipt, sort_keys=True) + "\n")
+    return receipt

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -523,6 +523,29 @@
       "no_execution": true,
       "no_control_plane_mutation": true,
       "no_scheduler_or_autonomous_behavior": true
+    },
+    "context_hygiene": {
+      "module_globs": [
+        "sentientos/context_hygiene/**/*.py"
+      ],
+      "classification": "non_authoritative_schema_contract",
+      "non_authoritative": true,
+      "validation_or_schema_only": true,
+      "does_not_write_memory": true,
+      "does_not_execute_or_route_work": true,
+      "does_not_admit_work": true,
+      "no_retrieval": true,
+      "no_web": true,
+      "no_direct_prompt_assembly": true,
+      "no_action_side_effects": true,
+      "forbidden_import_patterns": [
+        "prompt_assembler",
+        "memory_manager",
+        "task_admission",
+        "task_executor",
+        "web",
+        "requests"
+      ]
     }
   },
   "protected_sinks": {

--- a/tests/test_phase61_context_packet_contract.py
+++ b/tests/test_phase61_context_packet_contract.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sentientos.context_hygiene.context_packet import (
+    ContextMode,
+    ContextPacketItem,
+    ContradictionStatus,
+    ExcludedContextRef,
+    FreshnessStatus,
+    PollutionRisk,
+    make_context_packet,
+    packet_is_expired,
+    summarize_packet_for_diagnostics,
+    validate_context_packet,
+)
+from sentientos.context_hygiene.receipts import (
+    append_context_assembly_receipt,
+    build_context_assembly_receipt,
+)
+
+
+def _valid_packet():
+    return make_context_packet(
+        packet_scope="conversation_turn",
+        conversation_scope_id="conv-1",
+        task_scope_id="task-1",
+        context_mode=ContextMode.RESPONSE,
+        valid_until=datetime.now(timezone.utc) + timedelta(minutes=5),
+        included_memory_refs=(ContextPacketItem("m1", "memory", {"source_id": "s1"}),),
+        included_claim_refs=(ContextPacketItem("c1", "claim", {"source_id": "s2"}),),
+        included_evidence_refs=(ContextPacketItem("e1", "evidence", {"source_id": "s3"}),),
+        included_stance_refs=(ContextPacketItem("s1", "stance", {"source_id": "s4"}),),
+        included_diagnostic_refs=(ContextPacketItem("d1", "diagnostic", {"source_id": "s5"}),),
+        included_embodiment_refs=(ContextPacketItem("b1", "embodiment", {"source_id": "s6"}),),
+        excluded_refs=(ExcludedContextRef("x1", "memory", "no provenance"),),
+        inclusion_reasons=("scoped relevance",),
+        exclusion_reasons=("missing provenance",),
+        freshness_status=FreshnessStatus.FRESH,
+        contradiction_status=ContradictionStatus.NONE,
+        provenance_complete=True,
+        pollution_risk=PollutionRisk.LOW,
+    )
+
+
+def test_valid_packet_validates_successfully():
+    assert validate_context_packet(_valid_packet()) == []
+
+
+def test_defaults_non_authoritative_and_none_decision_power():
+    packet = _valid_packet()
+    assert packet.non_authoritative is True
+    assert packet.decision_power == "none"
+
+
+def test_packet_cannot_claim_truth_memory_write_or_work_control():
+    packet = _valid_packet()
+    assert "packet cannot claim truth" in validate_context_packet(replace(packet, context_packet_is_not_truth=False))
+    assert "packet cannot write memory" in validate_context_packet(replace(packet, context_packet_is_not_memory_write=False))
+    assert "packet cannot admit work" in validate_context_packet(replace(packet, does_not_admit_work=False))
+    assert "packet cannot execute or route work" in validate_context_packet(replace(packet, does_not_execute_or_route_work=False))
+
+
+def test_missing_expiry_fails_validation():
+    packet = replace(_valid_packet(), valid_until=None)  # type: ignore[arg-type]
+    assert "missing expiry" in validate_context_packet(packet)
+
+
+def test_missing_provenance_fails_validation():
+    bad = replace(_valid_packet(), included_memory_refs=(ContextPacketItem("m1", "memory", {}),))
+    errors = validate_context_packet(bad)
+    assert any("included ref without provenance" in e for e in errors)
+
+
+def test_excluded_refs_keep_reasons_and_expiry_detection():
+    packet = _valid_packet()
+    assert packet.excluded_refs[0].reason == "no provenance"
+    expired = replace(packet, valid_until=datetime.now(timezone.utc) - timedelta(seconds=1))
+    assert packet_is_expired(expired)
+
+
+def test_receipt_mirrors_packet_and_append_only(tmp_path):
+    packet = _valid_packet()
+    receipt = build_context_assembly_receipt(packet)
+    assert receipt["context_packet_id"] == packet.context_packet_id
+    assert receipt["decision_power"] == "none"
+    assert receipt["non_authoritative"] is True
+    ledger = tmp_path / "receipts.jsonl"
+    first = append_context_assembly_receipt(packet, ledger)
+    second = append_context_assembly_receipt(packet, ledger)
+    rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["receipt_id"] == first["receipt_id"]
+    assert rows[1]["receipt_id"] == second["receipt_id"]
+
+
+def test_import_purity_and_immutability_and_summary():
+    import sentientos.context_hygiene.context_packet as cp
+
+    source = cp.__dict__.get("__file__")
+    assert source
+    text = open(source, encoding="utf-8").read()
+    for forbidden in ["prompt_assembler", "memory_manager", "task_admission", "task_executor"]:
+        assert forbidden not in text
+
+    packet = _valid_packet()
+    before = packet.context_packet_id
+    summary = summarize_packet_for_diagnostics(packet)
+    assert summary["context_packet_id"] == before
+    with pytest.raises(FrozenInstanceError):
+        packet.context_packet_id = "mutated"  # type: ignore[misc]
+
+
+def test_schema_lanes_and_explicit_statuses_and_no_raw_dump():
+    packet = _valid_packet()
+    assert packet.included_memory_refs and packet.included_claim_refs and packet.included_evidence_refs
+    assert packet.included_stance_refs and packet.included_diagnostic_refs and packet.included_embodiment_refs
+    assert packet.pollution_risk in PollutionRisk
+    assert packet.contradiction_status in ContradictionStatus
+    assert packet.freshness_status in FreshnessStatus
+    assert not hasattr(packet, "raw_memory_dump")


### PR DESCRIPTION
### Motivation
- Provide a first-class, non-authoritative, provenance-bearing context packet contract so context hygiene is encoded as a typed schema instead of ad-hoc runtime snippets.  
- Ensure the change is schema/contract/test-only and does not alter prompt assembly, memory retrieval, truth adjudication, embodiment ingress, action routing, or execution semantics.

### Description
- Add a new `sentientos.context_hygiene` package with frozen dataclasses and enums including `ContextPacket`, `ContextPacketItem`, `ExcludedContextRef`, `ContextBudget`, `ContextAssemblyStatus`, `ContextMode`, `FreshnessStatus`, `ContradictionStatus`, `ProvenanceStatus`, and `PollutionRisk`.  
- Implement helpers `make_context_packet`, `validate_context_packet`, `packet_is_expired`, `packet_has_decision_power`, and `summarize_packet_for_diagnostics` in `context_packet.py` that enforce non-authoritative and safety invariants.  
- Add JSON-compatible receipts via `build_context_assembly_receipt` and an append-only `append_context_assembly_receipt` writer (JSONL) in `receipts.py`.  
- Add docs (`docs/architecture/context_hygiene_spine.md`, `docs/architecture/phase61_context_hygiene_spine_alpha_execplan.md`) and register the package in the architecture boundary manifest as a `context_hygiene` non-authoritative, validation/schema-only layer.

### Testing
- Ran the contract/unit tests with `python -m scripts.run_tests -q tests/test_phase61_context_packet_contract.py` and all tests in that file passed.  
- Ran architecture and import-purity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and those suites passed.  
- Tests verify validation invariants, immutability, explicit lanes/statuses, expiry detection, excluded-ref reasons, receipt mirroring and append-only behavior, and import-purity (no runtime module imports); all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9367367d883208929cadae5f308d6)