### PR TITLE
[codex:context-hygiene] add truth-gated context selector

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -29,3 +29,14 @@ The schema intentionally separates memory/claim/evidence/stance/diagnostic/embod
 - Distiller
 - Pruner
 - Prompt adapter / runtime middleware
+
+
+## Phase 62: Truth-Gated Context Selector Alpha
+
+Phase 62 adds a pure selector layer that evaluates normalized candidates before prompt use. The selector is non-authoritative and returns a Phase 61 `ContextPacket` only.
+
+Key assertions:
+- Truth validation is not automatic inclusion.
+- Relevance is not equivalent to truth.
+- Exclusion reasons are mandatory for every dropped candidate.
+- Embodiment privacy/sanitization policy remains deferred to Phase 63 (raw embodiment candidates are excluded by default).

--- a/docs/architecture/phase62_truth_gated_context_selector_execplan.md
+++ b/docs/architecture/phase62_truth_gated_context_selector_execplan.md
@@ -1,0 +1,41 @@
+# Phase 62 Truth-Gated Context Selector Execplan
+
+## Goal
+Implement a pure context-selection contract that takes normalized context candidates and emits a non-authoritative Phase 61 `ContextPacket` with explicit inclusion/exclusion reasoning.
+
+## Non-goals
+- No prompt assembly integration.
+- No memory retrieval changes.
+- No truth runtime behavior changes.
+- No action, embodiment runtime, or retention side effects.
+
+## Selector contract
+- Input: candidate list + scope + mode + time + optional budget.
+- Output: immutable Phase 61 `ContextPacket`.
+- Packet invariants: non-authoritative, decision power none, no memory write/admit/execute behavior.
+
+## Candidate shape
+`ContextCandidate` includes ref identity/type, scope fields, summary, provenance refs, timestamps, freshness/contradiction/truth ingress statuses, priority, and metadata.
+
+## Inclusion rules
+- Include only provenance-complete candidates.
+- Include claims only when source-backed claims include evidence refs.
+- Include dialogue only when scoped and provenance-bearing.
+- Include stance only when stance refs and provenance are complete.
+- Include sanitized embodiment summaries only (raw embodiment excluded in Phase 62).
+
+## Exclusion rules
+- Missing ref_id.
+- Missing provenance refs.
+- Expired candidates.
+- Truth ingress blocked states (`blocked`, `unsupported`, `underconstrained`, etc.).
+- Contradiction blocked state.
+- Scope mismatch.
+- Unknown ref type.
+
+## Tests
+- Added Phase 62 selector tests covering eligibility, exclusions, contradiction warning caveats, provenance semantics, lane separation, append-only receipt compatibility, and import purity.
+
+## Deferred work
+- Full embodiment/privacy integration and policy-enforced context transformation (Phase 63).
+- Runtime wiring into prompt assembly pipeline.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -38,4 +38,33 @@ __all__ = [
     "packet_is_expired",
     "summarize_packet_for_diagnostics",
     "validate_context_packet",
+    "ContextCandidate",
+    "ContextSelectionDecision",
+    "build_context_packet_from_candidates",
+    "candidate_is_context_eligible",
+    "explain_candidate_exclusion",
+    "select_context_candidates",
+    "candidate_is_expired",
+    "classify_pollution_risk",
+    "combine_contradiction_status",
+    "combine_freshness_status",
+    "combine_pollution_risk",
+    "provenance_is_complete",
 ]
+
+from sentientos.context_hygiene.selector import (
+    ContextCandidate,
+    ContextSelectionDecision,
+    build_context_packet_from_candidates,
+    candidate_is_context_eligible,
+    explain_candidate_exclusion,
+    select_context_candidates,
+)
+from sentientos.context_hygiene.pollution_guard import (
+    candidate_is_expired,
+    classify_pollution_risk,
+    combine_contradiction_status,
+    combine_freshness_status,
+    combine_pollution_risk,
+    provenance_is_complete,
+)

--- a/sentientos/context_hygiene/pollution_guard.py
+++ b/sentientos/context_hygiene/pollution_guard.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from sentientos.context_hygiene.context_packet import ContradictionStatus, FreshnessStatus, PollutionRisk
+
+BLOCKING_TRUTH_INGRESS = {
+    "blocked",
+    "underconstrained",
+    "unsupported",
+    "contradiction-blocked",
+    "no-new-evidence-reversal",
+    "unknown-source-backed",
+}
+ALLOWED_REF_TYPES = {"memory", "claim", "evidence", "stance", "diagnostic", "embodiment", "dialogue"}
+
+
+def provenance_is_complete(candidate: Any) -> bool:
+    return bool(getattr(candidate, "provenance_refs", None))
+
+
+def candidate_is_expired(candidate: Any, now: datetime | None = None) -> bool:
+    expiry = getattr(candidate, "expires_at", None) or getattr(candidate, "valid_until", None)
+    if expiry is None:
+        return False
+    current = now or datetime.now(timezone.utc)
+    return current >= expiry
+
+
+def classify_pollution_risk(candidate: Any, now: datetime | None = None) -> str:
+    ref_type = str(getattr(candidate, "ref_type", "unknown")).lower()
+    if not getattr(candidate, "ref_id", ""):
+        return "blocked"
+    if not provenance_is_complete(candidate):
+        return "blocked"
+    if ref_type not in ALLOWED_REF_TYPES:
+        return "blocked"
+    if candidate_is_expired(candidate, now=now):
+        return "blocked"
+    if str(getattr(candidate, "truth_ingress_status", "")).lower() in BLOCKING_TRUTH_INGRESS:
+        return "blocked"
+    if str(getattr(candidate, "contradiction_status", "")).lower() == "blocked":
+        return "blocked"
+    if ref_type == "embodiment" and not bool(getattr(candidate, "already_sanitized_context_summary", False)):
+        return "blocked"
+    if str(getattr(candidate, "freshness_status", "")).lower() in {"stale", "unknown"}:
+        return PollutionRisk.MEDIUM.value
+    if str(getattr(candidate, "contradiction_status", "")).lower() in {"warning", "suspected", "contradicted"}:
+        return PollutionRisk.MEDIUM.value
+    return PollutionRisk.LOW.value
+
+
+def combine_pollution_risk(candidates_or_decisions: Iterable[Any], now: datetime | None = None) -> str:
+    risks = [classify_pollution_risk(item, now=now) for item in candidates_or_decisions]
+    if not risks:
+        return PollutionRisk.MEDIUM.value
+    if "blocked" in risks:
+        return "blocked"
+    if PollutionRisk.HIGH.value in risks:
+        return PollutionRisk.HIGH.value
+    if PollutionRisk.MEDIUM.value in risks:
+        return PollutionRisk.MEDIUM.value
+    return PollutionRisk.LOW.value
+
+
+def combine_freshness_status(candidates_or_decisions: Iterable[Any]) -> FreshnessStatus:
+    statuses = {str(getattr(item, "freshness_status", "unknown")).lower() for item in candidates_or_decisions}
+    if not statuses or statuses == {"unknown"}:
+        return FreshnessStatus.UNKNOWN
+    if statuses == {"fresh"}:
+        return FreshnessStatus.FRESH
+    if statuses == {"stale"}:
+        return FreshnessStatus.STALE
+    return FreshnessStatus.MIXED
+
+
+def combine_contradiction_status(candidates_or_decisions: Iterable[Any]) -> ContradictionStatus:
+    statuses = {str(getattr(item, "contradiction_status", "unknown")).lower() for item in candidates_or_decisions}
+    if not statuses or statuses == {"unknown"}:
+        return ContradictionStatus.UNKNOWN
+    if "warning" in statuses or "suspected" in statuses:
+        return ContradictionStatus.SUSPECTED
+    if "contradicted" in statuses:
+        return ContradictionStatus.CONTRADICTED
+    return ContradictionStatus.NONE

--- a/sentientos/context_hygiene/selector.py
+++ b/sentientos/context_hygiene/selector.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from sentientos.context_hygiene.context_packet import (
+    ContextMode,
+    ContextPacket,
+    ContextPacketItem,
+    ContradictionStatus,
+    ExcludedContextRef,
+    FreshnessStatus,
+    PollutionRisk,
+    ProvenanceStatus,
+    make_context_packet,
+)
+from sentientos.context_hygiene.pollution_guard import (
+    BLOCKING_TRUTH_INGRESS,
+    candidate_is_expired,
+    classify_pollution_risk,
+    combine_contradiction_status,
+    combine_freshness_status,
+    combine_pollution_risk,
+    provenance_is_complete,
+)
+
+
+@dataclass(frozen=True)
+class ContextCandidate:
+    ref_id: str
+    ref_type: str
+    packet_scope: str | None = None
+    conversation_scope_id: str | None = None
+    task_scope_id: str | None = None
+    summary: str | None = None
+    provenance_refs: tuple[str, ...] = field(default_factory=tuple)
+    source_locator: str | None = None
+    created_at: datetime | None = None
+    observed_at: datetime | None = None
+    valid_until: datetime | None = None
+    expires_at: datetime | None = None
+    freshness_status: str = "unknown"
+    contradiction_status: str = "unknown"
+    provenance_status: str = "partial"
+    epistemic_status: str | None = None
+    truth_ingress_status: str | None = None
+    stance_status: str | None = None
+    source_priority: str | None = None
+    pollution_risk: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    evidence_refs: tuple[str, ...] = field(default_factory=tuple)
+    stance_refs: tuple[str, ...] = field(default_factory=tuple)
+    already_sanitized_context_summary: bool = False
+
+
+@dataclass(frozen=True)
+class ContextSelectionDecision:
+    candidate: ContextCandidate
+    included: bool
+    lane: str
+    reason: str
+
+
+def _scope_conflicts(candidate: ContextCandidate, packet_scope: str, conversation_scope_id: str, task_scope_id: str) -> bool:
+    if candidate.packet_scope and candidate.packet_scope != packet_scope:
+        return True
+    if candidate.conversation_scope_id and candidate.conversation_scope_id != conversation_scope_id:
+        return True
+    if candidate.task_scope_id and candidate.task_scope_id != task_scope_id:
+        return True
+    return False
+
+
+def explain_candidate_exclusion(candidate: ContextCandidate, packet_scope: str, conversation_scope_id: str, task_scope_id: str, now: datetime) -> str | None:
+    if not candidate.ref_id:
+        return "excluded: missing ref_id"
+    if not provenance_is_complete(candidate):
+        return "excluded: missing provenance"
+    if _scope_conflicts(candidate, packet_scope, conversation_scope_id, task_scope_id):
+        return "excluded: scope mismatch"
+    if candidate_is_expired(candidate, now=now):
+        return "excluded: expired candidate"
+    if candidate.ref_type == "unknown":
+        return "excluded: unknown ref_type"
+    if candidate.ref_type == "claim" and candidate.metadata.get("source_backed") and not candidate.evidence_refs:
+        return "excluded: source-backed claim missing evidence refs"
+    if str(candidate.truth_ingress_status or "").lower() in BLOCKING_TRUTH_INGRESS:
+        return f"excluded: truth ingress blocked ({candidate.truth_ingress_status})"
+    if str(candidate.contradiction_status).lower() == "blocked":
+        return "excluded: contradiction blocked"
+    if candidate.ref_type == "stance" and (not candidate.stance_refs):
+        return "excluded: stance candidate missing stance refs"
+    if candidate.ref_type == "dialogue" and (not candidate.packet_scope and not candidate.conversation_scope_id and not candidate.task_scope_id):
+        return "excluded: dialogue candidate requires scope"
+    if candidate.ref_type == "embodiment" and not candidate.already_sanitized_context_summary:
+        return "excluded: embodiment candidate not sanitized (Phase 63)"
+    return None
+
+
+def candidate_is_context_eligible(candidate: ContextCandidate, packet_scope: str, conversation_scope_id: str, task_scope_id: str, now: datetime) -> bool:
+    return explain_candidate_exclusion(candidate, packet_scope, conversation_scope_id, task_scope_id, now) is None
+
+
+def select_context_candidates(candidates: Sequence[ContextCandidate], packet_scope: str, conversation_scope_id: str, task_scope_id: str, now: datetime | None = None) -> tuple[ContextSelectionDecision, ...]:
+    current = now or datetime.now(timezone.utc)
+    decisions: list[ContextSelectionDecision] = []
+    for candidate in candidates:
+        reason = explain_candidate_exclusion(candidate, packet_scope, conversation_scope_id, task_scope_id, current)
+        lane = candidate.ref_type if candidate.ref_type in {"memory", "claim", "evidence", "stance", "diagnostic", "embodiment"} else "diagnostic"
+        if reason:
+            decisions.append(ContextSelectionDecision(candidate, False, lane, reason))
+            continue
+        include_reason = "included: provenance-complete and scope-compatible"
+        if str(candidate.contradiction_status).lower() in {"warning", "suspected"}:
+            include_reason = "included with caveat: contested/contradiction warning"
+        decisions.append(ContextSelectionDecision(candidate, True, lane, include_reason))
+    return tuple(decisions)
+
+
+def build_context_packet_from_candidates(candidates: Sequence[ContextCandidate], packet_scope: str, conversation_scope_id: str, task_scope_id: str, context_mode: ContextMode = ContextMode.RESPONSE, now: datetime | None = None, valid_until: datetime | None = None, budget: int | None = None) -> ContextPacket:
+    current = now or datetime.now(timezone.utc)
+    decisions = list(select_context_candidates(candidates, packet_scope, conversation_scope_id, task_scope_id, now=current))
+    if budget is not None:
+        included = [d for d in decisions if d.included][:budget]
+        excluded = [d for d in decisions if not d.included] + [
+            ContextSelectionDecision(d.candidate, False, d.lane, "excluded: budget exceeded")
+            for d in decisions
+            if d.included and d not in included
+        ]
+        decisions = included + excluded
+
+    def mk_item(d: ContextSelectionDecision) -> ContextPacketItem:
+        return ContextPacketItem(d.candidate.ref_id, d.candidate.ref_type, {"provenance_refs": list(d.candidate.provenance_refs), "source_locator": d.candidate.source_locator})
+
+    def lane_items(lane: str) -> tuple[ContextPacketItem, ...]:
+        return tuple(mk_item(d) for d in decisions if d.included and d.lane == lane)
+
+    excluded_refs = tuple(
+        ExcludedContextRef(d.candidate.ref_id or "(missing)", d.lane, d.reason, d.candidate.source_locator, {"provenance_refs": list(d.candidate.provenance_refs)})
+        for d in decisions
+        if not d.included
+    )
+    included_candidates = [d.candidate for d in decisions if d.included]
+    pollution = combine_pollution_risk(included_candidates, now=current)
+    packet_pollution = PollutionRisk.HIGH if pollution == "blocked" else PollutionRisk(pollution)
+    contradiction = combine_contradiction_status(included_candidates)
+    freshness = combine_freshness_status(included_candidates)
+    provenance_complete = all(provenance_is_complete(c) for c in candidates)
+    provenance_status = ProvenanceStatus.COMPLETE if provenance_complete else ProvenanceStatus.PARTIAL
+    return make_context_packet(
+        packet_scope=packet_scope,
+        conversation_scope_id=conversation_scope_id,
+        task_scope_id=task_scope_id,
+        context_mode=context_mode,
+        valid_until=valid_until or (current + timedelta(minutes=5)),
+        included_memory_refs=lane_items("memory"),
+        included_claim_refs=lane_items("claim"),
+        included_evidence_refs=lane_items("evidence"),
+        included_stance_refs=lane_items("stance"),
+        included_diagnostic_refs=lane_items("diagnostic"),
+        included_embodiment_refs=lane_items("embodiment"),
+        excluded_refs=excluded_refs,
+        inclusion_reasons=tuple(d.reason for d in decisions if d.included),
+        exclusion_reasons=tuple(d.reason for d in decisions if not d.included),
+        freshness_status=freshness,
+        contradiction_status=contradiction,
+        provenance_complete=provenance_complete,
+        provenance_status=provenance_status,
+        source_priority=tuple(c.source_priority for c in included_candidates if c.source_priority),
+        pollution_risk=packet_pollution,
+    )

--- a/tests/test_phase62_context_truth_selector.py
+++ b/tests/test_phase62_context_truth_selector.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+from sentientos.context_hygiene.context_packet import ContextMode, validate_context_packet
+from sentientos.context_hygiene.receipts import append_context_assembly_receipt, build_context_assembly_receipt
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+
+def _candidate(ref_id: str = "c1", ref_type: str = "claim", **kwargs):
+    base = ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv1",
+        task_scope_id="task1",
+        summary="s",
+        provenance_refs=("prov1",),
+        freshness_status="fresh",
+        contradiction_status="none",
+        truth_ingress_status="allowed",
+    )
+    return replace(base, **kwargs)
+
+
+def test_phase62_selector_contracts_and_rules(tmp_path):
+    now = datetime.now(timezone.utc)
+    candidates = [
+        _candidate(ref_id="claim_ok", ref_type="claim", metadata={"source_backed": True}, evidence_refs=("e1",)),
+        _candidate(ref_id="claim_no_evidence", ref_type="claim", metadata={"source_backed": True}, evidence_refs=()),
+        _candidate(ref_id="", ref_type="memory"),
+        _candidate(ref_id="missing_prov", provenance_refs=()),
+        _candidate(ref_id="expired", valid_until=now - timedelta(seconds=1)),
+        _candidate(ref_id="blocked_contra", contradiction_status="blocked"),
+        _candidate(ref_id="warn_contra", contradiction_status="warning"),
+        _candidate(ref_id="truth_blocked", truth_ingress_status="blocked"),
+        _candidate(ref_id="stale", freshness_status="stale"),
+        _candidate(ref_id="unknown_type", ref_type="unknown"),
+        _candidate(ref_id="mem_ok", ref_type="memory", truth_ingress_status="allowed"),
+        _candidate(ref_id="mem_blocked", ref_type="memory", truth_ingress_status="unsupported"),
+        _candidate(ref_id="dialogue_ok", ref_type="dialogue"),
+        _candidate(ref_id="dialogue_unscoped", ref_type="dialogue", packet_scope=None, conversation_scope_id=None, task_scope_id=None),
+        _candidate(ref_id="emb_raw", ref_type="embodiment", already_sanitized_context_summary=False),
+        _candidate(ref_id="emb_sanitized", ref_type="embodiment", already_sanitized_context_summary=True),
+        _candidate(ref_id="scope_mismatch", conversation_scope_id="other"),
+        _candidate(ref_id="stance_missing", ref_type="stance", stance_refs=()),
+        _candidate(ref_id="stance_ok", ref_type="stance", stance_refs=("st1",)),
+        _candidate(ref_id="evidence_ok", ref_type="evidence", source_priority="high"),
+    ]
+    packet = build_context_packet_from_candidates(
+        candidates,
+        packet_scope="turn",
+        conversation_scope_id="conv1",
+        task_scope_id="task1",
+        context_mode=ContextMode.RESPONSE,
+        now=now,
+    )
+
+    assert validate_context_packet(packet) == []
+    assert any(i.ref_id == "claim_ok" for i in packet.included_claim_refs)
+    assert any(i.ref_id == "evidence_ok" for i in packet.included_evidence_refs)
+    assert any(i.ref_id == "mem_ok" for i in packet.included_memory_refs)
+    assert any(i.ref_id == "stance_ok" for i in packet.included_stance_refs)
+    assert any(i.ref_id == "dialogue_ok" for i in packet.included_diagnostic_refs)
+    assert any(i.ref_id == "emb_sanitized" for i in packet.included_embodiment_refs)
+
+    excluded_ids = {r.ref_id for r in packet.excluded_refs}
+    for ref in ["claim_no_evidence", "(missing)", "missing_prov", "expired", "blocked_contra", "truth_blocked", "unknown_type", "mem_blocked", "dialogue_unscoped", "emb_raw", "scope_mismatch", "stance_missing"]:
+        assert ref in excluded_ids
+
+    assert any("contested" in reason for reason in packet.inclusion_reasons)
+    assert packet.contradiction_status.value in {"suspected", "none"}
+    assert packet.provenance_complete is False
+    assert packet.exclusion_reasons and packet.inclusion_reasons
+    assert candidates[0].ref_id == "claim_ok"
+    assert packet.does_not_admit_work is True and packet.does_not_execute_or_route_work is True
+
+    receipt = build_context_assembly_receipt(packet)
+    assert receipt["context_packet_id"] == packet.context_packet_id
+    ledger = tmp_path / "r.jsonl"
+    append_context_assembly_receipt(packet, ledger)
+    append_context_assembly_receipt(packet, ledger)
+    assert len(ledger.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_selector_import_purity_and_no_runtime_hooks():
+    import sentientos.context_hygiene.selector as selector
+
+    text = open(selector.__file__, encoding="utf-8").read()
+    for forbidden in [
+        "prompt_assembler",
+        "memory_manager",
+        "task_executor",
+        "retention",
+        "embodiment_ingress",
+    ]:
+        assert forbidden not in text


### PR DESCRIPTION
### Motivation
- Implement Phase 62: a pure, non-authoritative selector layer that gates normalized context candidates by provenance, scope, freshness, contradiction and truth-ingress eligibility before they may enter context lanes. 
- Preserve Phase 61 context packet schema and safety invariants while making the first selection rules real without wiring into prompt assembly or changing memory/truth/embodiment/action/retention runtimes. 

### Description
- Added `sentientos/context_hygiene/selector.py` providing frozen `ContextCandidate` and `ContextSelectionDecision` dataclasses, plus `select_context_candidates(...)`, `explain_candidate_exclusion(...)`, `candidate_is_context_eligible(...)`, and `build_context_packet_from_candidates(...)` which assemble a Phase 61 `ContextPacket` with preserved non-authoritative invariants. 
- Added `sentientos/context_hygiene/pollution_guard.py` with pure helpers `provenance_is_complete`, `candidate_is_expired`, `classify_pollution_risk`, `combine_pollution_risk`, `combine_freshness_status`, and `combine_contradiction_status` to classify low/medium/high/blocked risks and aggregate statuses. 
- Exported selector/pollution helpers via `sentientos/context_hygiene/__init__.py` and added documentation `docs/architecture/phase62_truth_gated_context_selector_execplan.md` plus a short Phase 62 note in `docs/architecture/context_hygiene_spine.md`. 
- Selection rules implemented include provenance completeness, missing `ref_id`, expiry, truth-ingress blocking, contradiction-blocked, scope mismatch, unknown ref type, source-backed-claim-without-evidence exclusion, dialogue/stance scoping and embodiment deferral (raw embodiment excluded unless sanitized); contradiction warnings are allowed as caveated inclusions. 

### Testing
- Ran the new selector suite: `python -m scripts.run_tests -q tests/test_phase62_context_truth_selector.py` and it passed. 
- Ran compatibility and purity suites: `python -m scripts.run_tests -q tests/test_phase61_context_packet_contract.py` and `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and they all passed. 
- Tests validate packet contract, inclusion/exclusion scenarios (evidence-backed inclusion, missing-provenance/ref_id, expiry, contradiction blocking/warning caveats, truth-ingress blocks, scope mismatch, embodiment deferral), append-only receipt compatibility, lane separation, and import purity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f941c05c5c8320a072a50f98e82e32)