### PR TITLE
[codex:context-hygiene] preserve blocked context pollution risk

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -40,3 +40,12 @@ Key assertions:
 - Relevance is not equivalent to truth.
 - Exclusion reasons are mandatory for every dropped candidate.
 - Embodiment privacy/sanitization policy remains deferred to Phase 63 (raw embodiment candidates are excluded by default).
+
+
+## Phase 62B risk-contract alignment
+- `PollutionRisk` supports `low|medium|high|blocked`.
+- `blocked` is distinct from `high`: blocked means ineligible for active lanes; high means eligible with caution.
+- Packet pollution risk is an assembly-level aggregate over attempted candidates, not only included lanes.
+- If any attempted candidate is blocked, packet risk is `blocked` and blocked candidates remain visible in `excluded_refs`/`exclusion_reasons`.
+- `provenance_complete` reflects all attempted candidates; included refs remain provenance-bearing.
+- This lands before Phase 63 so privacy/embodiment blocked states are preserved instead of silently degrading to `high`.

--- a/docs/architecture/phase62b_context_risk_contract_alignment_execplan.md
+++ b/docs/architecture/phase62b_context_risk_contract_alignment_execplan.md
@@ -1,0 +1,36 @@
+# Phase 62B Context Risk Contract Alignment
+
+## Goal
+Preserve `blocked` as first-class `ContextPacket.pollution_risk` so attempted blocked candidates are not normalized to `high`.
+
+## Non-goals
+No prompt assembly wiring, no memory retrieval/runtime changes, no truth runtime changes, no embodiment ingress runtime changes, and no routing/execution/retention behavior changes.
+
+## Phase 62 seam
+Phase 62 could return `blocked` from pollution guard but packet schema only allowed low/medium/high, collapsing blocked into high.
+
+## Chosen semantics
+- Included lanes never contain blocked candidates.
+- `packet.pollution_risk` is aggregate attempted-candidate risk.
+- Any blocked attempted candidate yields packet-level `blocked`.
+- Packet remains diagnostic/non-authoritative and not prompt-authoritative.
+
+## Provenance semantics
+- `provenance_complete` is computed across attempted candidates.
+- Missing provenance candidates are excluded-only.
+- Included refs remain provenance-bearing.
+
+## Files changed
+- `sentientos/context_hygiene/context_packet.py`
+- `sentientos/context_hygiene/pollution_guard.py`
+- `sentientos/context_hygiene/selector.py`
+- `tests/test_phase61_context_packet_contract.py`
+- `tests/test_phase62_context_truth_selector.py`
+- `tests/test_phase62b_context_risk_contract_alignment.py`
+- `docs/architecture/context_hygiene_spine.md`
+
+## Tests
+Phase61/62 + new Phase62B contract tests + architecture/integrity boundary checks.
+
+## Deferred work
+Prompt-eligibility gating at assembly/runtime boundary is deferred to Phase 63.

--- a/sentientos/context_hygiene/context_packet.py
+++ b/sentientos/context_hygiene/context_packet.py
@@ -43,6 +43,7 @@ class PollutionRisk(str, Enum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    BLOCKED = "blocked"
 
 
 @dataclass(frozen=True)
@@ -148,6 +149,10 @@ def validate_context_packet(packet: ContextPacket) -> list[str]:
         errors.append("packet cannot admit work")
     if not packet.does_not_execute_or_route_work:
         errors.append("packet cannot execute or route work")
+    try:
+        PollutionRisk(packet.pollution_risk)
+    except ValueError:
+        errors.append(f"invalid pollution risk: {packet.pollution_risk}")
     return errors
 
 

--- a/sentientos/context_hygiene/pollution_guard.py
+++ b/sentientos/context_hygiene/pollution_guard.py
@@ -31,19 +31,19 @@ def candidate_is_expired(candidate: Any, now: datetime | None = None) -> bool:
 def classify_pollution_risk(candidate: Any, now: datetime | None = None) -> str:
     ref_type = str(getattr(candidate, "ref_type", "unknown")).lower()
     if not getattr(candidate, "ref_id", ""):
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if not provenance_is_complete(candidate):
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if ref_type not in ALLOWED_REF_TYPES:
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if candidate_is_expired(candidate, now=now):
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if str(getattr(candidate, "truth_ingress_status", "")).lower() in BLOCKING_TRUTH_INGRESS:
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if str(getattr(candidate, "contradiction_status", "")).lower() == "blocked":
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if ref_type == "embodiment" and not bool(getattr(candidate, "already_sanitized_context_summary", False)):
-        return "blocked"
+        return PollutionRisk.BLOCKED.value
     if str(getattr(candidate, "freshness_status", "")).lower() in {"stale", "unknown"}:
         return PollutionRisk.MEDIUM.value
     if str(getattr(candidate, "contradiction_status", "")).lower() in {"warning", "suspected", "contradicted"}:
@@ -55,11 +55,13 @@ def combine_pollution_risk(candidates_or_decisions: Iterable[Any], now: datetime
     risks = [classify_pollution_risk(item, now=now) for item in candidates_or_decisions]
     if not risks:
         return PollutionRisk.MEDIUM.value
-    if "blocked" in risks:
-        return "blocked"
-    if PollutionRisk.HIGH.value in risks:
+    allowed = {risk.value for risk in PollutionRisk}
+    normalized = [risk if risk in allowed else PollutionRisk.BLOCKED.value for risk in risks]
+    if PollutionRisk.BLOCKED.value in normalized:
+        return PollutionRisk.BLOCKED.value
+    if PollutionRisk.HIGH.value in normalized:
         return PollutionRisk.HIGH.value
-    if PollutionRisk.MEDIUM.value in risks:
+    if PollutionRisk.MEDIUM.value in normalized:
         return PollutionRisk.MEDIUM.value
     return PollutionRisk.LOW.value
 

--- a/sentientos/context_hygiene/selector.py
+++ b/sentientos/context_hygiene/selector.py
@@ -142,8 +142,9 @@ def build_context_packet_from_candidates(candidates: Sequence[ContextCandidate],
         if not d.included
     )
     included_candidates = [d.candidate for d in decisions if d.included]
-    pollution = combine_pollution_risk(included_candidates, now=current)
-    packet_pollution = PollutionRisk.HIGH if pollution == "blocked" else PollutionRisk(pollution)
+    attempted_candidates = [d.candidate for d in decisions]
+    pollution = combine_pollution_risk(attempted_candidates, now=current)
+    packet_pollution = PollutionRisk(pollution)
     contradiction = combine_contradiction_status(included_candidates)
     freshness = combine_freshness_status(included_candidates)
     provenance_complete = all(provenance_is_complete(c) for c in candidates)

--- a/tests/test_phase61_context_packet_contract.py
+++ b/tests/test_phase61_context_packet_contract.py
@@ -123,3 +123,10 @@ def test_schema_lanes_and_explicit_statuses_and_no_raw_dump():
     assert packet.contradiction_status in ContradictionStatus
     assert packet.freshness_status in FreshnessStatus
     assert not hasattr(packet, "raw_memory_dump")
+
+
+def test_blocked_pollution_risk_is_valid_and_non_authoritative():
+    packet = _valid_packet()
+    blocked_packet = replace(packet, pollution_risk=PollutionRisk.BLOCKED)
+    assert validate_context_packet(blocked_packet) == []
+    assert blocked_packet.decision_power == "none"

--- a/tests/test_phase62_context_truth_selector.py
+++ b/tests/test_phase62_context_truth_selector.py
@@ -72,6 +72,7 @@ def test_phase62_selector_contracts_and_rules(tmp_path):
     assert any("contested" in reason for reason in packet.inclusion_reasons)
     assert packet.contradiction_status.value in {"suspected", "none"}
     assert packet.provenance_complete is False
+    assert packet.pollution_risk.value == "blocked"
     assert packet.exclusion_reasons and packet.inclusion_reasons
     assert candidates[0].ref_id == "claim_ok"
     assert packet.does_not_admit_work is True and packet.does_not_execute_or_route_work is True

--- a/tests/test_phase62b_context_risk_contract_alignment.py
+++ b/tests/test_phase62b_context_risk_contract_alignment.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+from sentientos.context_hygiene.context_packet import ContextMode, PollutionRisk, validate_context_packet
+from sentientos.context_hygiene.pollution_guard import combine_pollution_risk
+from sentientos.context_hygiene.receipts import append_context_assembly_receipt, build_context_assembly_receipt
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+
+def _c(ref_id: str = "c1", ref_type: str = "claim", **kwargs):
+    base = ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        summary="s",
+        provenance_refs=("p1",),
+        freshness_status="fresh",
+        contradiction_status="none",
+        truth_ingress_status="allowed",
+        already_sanitized_context_summary=True,
+    )
+    return replace(base, **kwargs)
+
+
+def _build(candidates):
+    return build_context_packet_from_candidates(candidates, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=datetime.now(timezone.utc))
+
+
+def test_phase62b_contract_alignment(tmp_path):
+    assert PollutionRisk.BLOCKED.value == "blocked"
+    p = _build([_c(ref_id="ok")])
+    assert validate_context_packet(replace(p, pollution_risk=PollutionRisk.BLOCKED)) == []
+    assert any("invalid pollution risk" in e for e in validate_context_packet(replace(p, pollution_risk="nope")))
+
+    blocked = _build([_c(ref_id="raw", ref_type="embodiment", already_sanitized_context_summary=False)])
+    assert blocked.pollution_risk == PollutionRisk.BLOCKED
+    assert not blocked.included_embodiment_refs and any(r.ref_id == "raw" for r in blocked.excluded_refs)
+
+    highish = _build([_c(ref_id="warn", contradiction_status="warning")])
+    assert highish.pollution_risk == PollutionRisk.MEDIUM
+    assert combine_pollution_risk([_c(), _c(ref_id="b", truth_ingress_status="blocked")]) == PollutionRisk.BLOCKED.value
+    assert combine_pollution_risk([_c()]) == PollutionRisk.LOW.value
+    assert combine_pollution_risk([_c(freshness_status="stale")]) == PollutionRisk.MEDIUM.value
+
+    missing_prov = _build([_c(ref_id="ok2"), _c(ref_id="np", provenance_refs=())])
+    assert missing_prov.provenance_complete is False
+    assert any(r.ref_id == "np" for r in missing_prov.excluded_refs)
+    included = list(missing_prov.included_claim_refs) + list(missing_prov.included_memory_refs) + list(missing_prov.included_evidence_refs) + list(missing_prov.included_stance_refs) + list(missing_prov.included_diagnostic_refs) + list(missing_prov.included_embodiment_refs)
+    assert all(i.provenance for i in included)
+
+    receipt = build_context_assembly_receipt(missing_prov)
+    assert receipt["pollution_risk"] == PollutionRisk.BLOCKED.value
+    assert receipt["provenance_complete"] is False
+    ledger = tmp_path / "r.jsonl"
+    append_context_assembly_receipt(missing_prov, ledger)
+    append_context_assembly_receipt(missing_prov, ledger)
+    assert len(ledger.read_text().splitlines()) == 2
+
+    contra_warn = _build([_c(ref_id="cw", contradiction_status="warning")])
+    assert contra_warn.pollution_risk != PollutionRisk.BLOCKED
+    contra_blocked = _build([_c(ref_id="cb", contradiction_status="blocked")])
+    assert contra_blocked.pollution_risk == PollutionRisk.BLOCKED and not contra_blocked.included_claim_refs
+
+    sanitized = _build([_c(ref_id="embok", ref_type="embodiment", already_sanitized_context_summary=True)])
+    assert any(i.ref_id == "embok" for i in sanitized.included_embodiment_refs)
+
+    orig = _c(ref_id="immut")
+    _build([orig])
+    assert orig.ref_id == "immut"
+
+    import sentientos.context_hygiene.selector as sel
+    txt = open(sel.__file__, encoding="utf-8").read()
+    for forbidden in ["prompt_assembler", "memory_manager", "retention", "task_executor", "embodiment_ingress"]:
+        assert forbidden not in txt
+
+    assert p.decision_power == "none"
+    assert p.context_packet_is_not_memory_write and p.does_not_execute_or_route_work and p.does_not_admit_work


### PR DESCRIPTION
### Motivation
- Phase 62 produced `blocked` classifications at the selector/guard level but the Phase 61 `ContextPacket.PollutionRisk` enum normalized blocked -> high, losing a critical distinction for upcoming embodiment/privacy gating; this change preserves `blocked` as a first-class packet-level state. 
- The packet-level semantics must remain diagnostic/non-authoritative and must not grant execution/memory/routing/retention authority.

### Description
- Add `BLOCKED` to `PollutionRisk` in `sentientos/context_hygiene/context_packet.py` and validate pollution risk values in `validate_context_packet` so invalid strings fail validation. 
- Make `pollution_guard.classify_pollution_risk` return `PollutionRisk.BLOCKED.value` for blocking conditions and update `combine_pollution_risk` to normalize unknown values defensively and preserve blocked as dominant (`low < medium < high < blocked`). 
- Change `selector.build_context_packet_from_candidates` to aggregate attempted-candidate risk (not only included lanes) so any attempted blocked candidate yields packet-level `blocked`, while blocked candidates remain excluded and visible in `excluded_refs`/`exclusion_reasons`; provenance completeness is explicitly computed across attempted candidates. 
- Preserve receipt behavior in `receipts.py` (receipts mirror packet state); add/modify docs and tests and update `docs/architecture/context_hygiene_spine.md` and add `docs/architecture/phase62b_context_risk_contract_alignment_execplan.md` to document chosen semantics. Files changed: `context_packet.py`, `pollution_guard.py`, `selector.py`, `receipts` exports, updated phase61/62 tests, new `tests/test_phase62b_context_risk_contract_alignment.py`, and docs updates.

### Testing
- Ran the targeted new contract test: `python -m scripts.run_tests -q tests/test_phase62b_context_risk_contract_alignment.py` and it passed. 
- Ran Phase 61/62 selector suites: `python -m scripts.run_tests -q tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and they passed. 
- Ran architecture and import-purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f944f158d08320854fd750be750432)