### PR TITLE
[codex:context-hygiene] add embodiment privacy context eligibility bridge

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -49,3 +49,10 @@ Key assertions:
 - If any attempted candidate is blocked, packet risk is `blocked` and blocked candidates remain visible in `excluded_refs`/`exclusion_reasons`.
 - `provenance_complete` reflects all attempted candidates; included refs remain provenance-bearing.
 - This lands before Phase 63 so privacy/embodiment blocked states are preserved instead of silently degrading to `high`.
+
+
+## Phase 63: Embodiment/Privacy Context Eligibility Bridge
+- Raw perception is not context.
+- Sanitized embodiment summaries may become context candidates.
+- Privacy-sensitive, biometric/emotion-sensitive, raw-retention, and action-capable material is blocked unless explicitly sanitized and allowed.
+- This phase is adapter/eligibility only: not prompt assembly, not memory write, and not embodiment runtime behavior.

--- a/docs/architecture/phase63_embodiment_privacy_context_bridge_execplan.md
+++ b/docs/architecture/phase63_embodiment_privacy_context_bridge_execplan.md
@@ -1,0 +1,35 @@
+# Phase 63 Embodiment/Privacy Context Eligibility Bridge
+
+## Goal
+Add pure adapter/eligibility helpers that transform already-sanitized embodiment artifacts into `ContextCandidate` objects for Phase 62 selection while blocking unsafe/raw artifacts.
+
+## Non-goals
+- No prompt assembly wiring.
+- No memory writes.
+- No embodiment runtime changes.
+- No truth/action/retention/admission/execution routing changes.
+
+## Dependency chain
+- Phase 61: ContextPacket schema/receipts.
+- Phase 62: truth-gated selector.
+- Phase 62B: first-class `PollutionRisk.BLOCKED` with attempted-candidate contamination.
+
+## Eligibility rules
+Implements deterministic blocking/eligibility for source-kind, sanitization, provenance, scope, privacy posture, action capability, and non-authoritative flags.
+
+## Blocked vs high risk
+- Blocked: raw perception, unknown, missing provenance/scope, decision power, non-allowed privacy/biometric/raw-retention/action-capable.
+- High: explicitly allowed + sanitized privacy-sensitive, biometric/emotion-sensitive, or raw-retention summaries.
+
+## Source kind mapping
+Includes raw legacy artifacts, embodiment snapshot/receipt/proposal/review/handoff/bridge/fulfillment paths, and ingress validations.
+
+## ContextCandidate lane mapping
+- `embodiment_proposal_diagnostic` -> `diagnostic`.
+- Other eligible embodiment artifacts -> `embodiment`.
+
+## Tests
+`tests/test_phase63_embodiment_context_eligibility.py` validates all Phase 63 eligibility rules and selector compatibility.
+
+## Deferred work
+Runtime wiring into upstream producers and prompt assembly remains deferred.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -50,6 +50,17 @@ __all__ = [
     "combine_freshness_status",
     "combine_pollution_risk",
     "provenance_is_complete",
+    "EmbodimentContextEligibility",
+    "EmbodimentContextSourceKind",
+    "EmbodimentPrivacyPosture",
+    "build_embodiment_context_candidates",
+    "classify_embodiment_context_source_kind",
+    "classify_embodiment_privacy_posture",
+    "embodiment_artifact_is_context_eligible",
+    "embodiment_artifact_is_sanitized_for_context",
+    "embodiment_artifact_to_context_candidate",
+    "explain_embodiment_context_exclusion",
+    "summarize_embodiment_context_eligibility",
 ]
 
 from sentientos.context_hygiene.selector import (
@@ -67,4 +78,18 @@ from sentientos.context_hygiene.pollution_guard import (
     combine_freshness_status,
     combine_pollution_risk,
     provenance_is_complete,
+)
+
+from sentientos.context_hygiene.embodiment_context import (
+    EmbodimentContextEligibility,
+    EmbodimentContextSourceKind,
+    EmbodimentPrivacyPosture,
+    build_embodiment_context_candidates,
+    classify_embodiment_context_source_kind,
+    classify_embodiment_privacy_posture,
+    embodiment_artifact_is_context_eligible,
+    embodiment_artifact_is_sanitized_for_context,
+    embodiment_artifact_to_context_candidate,
+    explain_embodiment_context_exclusion,
+    summarize_embodiment_context_eligibility,
 )

--- a/sentientos/context_hygiene/embodiment_context.py
+++ b/sentientos/context_hygiene/embodiment_context.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from sentientos.context_hygiene.context_packet import PollutionRisk
+from sentientos.context_hygiene.selector import ContextCandidate
+
+
+class EmbodimentContextSourceKind(str, Enum):
+    RAW_PERCEPTION_EVENT = "raw_perception_event"
+    LEGACY_SCREEN_ARTIFACT = "legacy_screen_artifact"
+    LEGACY_AUDIO_ARTIFACT = "legacy_audio_artifact"
+    LEGACY_VISION_ARTIFACT = "legacy_vision_artifact"
+    LEGACY_MULTIMODAL_ARTIFACT = "legacy_multimodal_artifact"
+    LEGACY_FEEDBACK_ARTIFACT = "legacy_feedback_artifact"
+    EMBODIMENT_SNAPSHOT = "embodiment_snapshot"
+    EMBODIMENT_INGRESS_RECEIPT = "embodiment_ingress_receipt"
+    EMBODIMENT_PROPOSAL = "embodiment_proposal"
+    EMBODIMENT_PROPOSAL_DIAGNOSTIC = "embodiment_proposal_diagnostic"
+    EMBODIMENT_REVIEW_RECEIPT = "embodiment_review_receipt"
+    EMBODIMENT_HANDOFF_CANDIDATE = "embodiment_handoff_candidate"
+    EMBODIMENT_GOVERNANCE_BRIDGE_CANDIDATE = "embodiment_governance_bridge_candidate"
+    EMBODIMENT_FULFILLMENT_CANDIDATE = "embodiment_fulfillment_candidate"
+    EMBODIMENT_FULFILLMENT_RECEIPT = "embodiment_fulfillment_receipt"
+    MEMORY_INGRESS_VALIDATION = "memory_ingress_validation"
+    ACTION_INGRESS_VALIDATION = "action_ingress_validation"
+    RETENTION_INGRESS_VALIDATION = "retention_ingress_validation"
+    UNKNOWN = "unknown"
+
+
+class EmbodimentPrivacyPosture(str, Enum):
+    PUBLIC = "public"
+    LOW_RISK = "low_risk"
+    PRIVACY_SENSITIVE = "privacy_sensitive"
+    BIOMETRIC_OR_EMOTION_SENSITIVE = "biometric_or_emotion_sensitive"
+    RAW_RETENTION_SENSITIVE = "raw_retention_sensitive"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class EmbodimentContextEligibility:
+    eligible: bool
+    blocked: bool
+    reason: str
+    source_kind: EmbodimentContextSourceKind
+    privacy_posture: EmbodimentPrivacyPosture
+
+
+def classify_embodiment_context_source_kind(artifact: Mapping[str, Any]) -> EmbodimentContextSourceKind:
+    raw = str(artifact.get("source_kind") or artifact.get("artifact_kind") or "").strip().lower()
+    for k in EmbodimentContextSourceKind:
+        if raw == k.value:
+            return k
+    return EmbodimentContextSourceKind.UNKNOWN
+
+
+def classify_embodiment_privacy_posture(artifact: Mapping[str, Any]) -> EmbodimentPrivacyPosture:
+    raw = str(artifact.get("privacy_posture") or "").strip().lower()
+    if raw in {p.value for p in EmbodimentPrivacyPosture}:
+        return EmbodimentPrivacyPosture(raw)
+    if artifact.get("contains_biometric_or_emotion"):
+        return EmbodimentPrivacyPosture.BIOMETRIC_OR_EMOTION_SENSITIVE
+    if artifact.get("contains_raw_retention"):
+        return EmbodimentPrivacyPosture.RAW_RETENTION_SENSITIVE
+    return EmbodimentPrivacyPosture.PUBLIC
+
+
+def embodiment_artifact_is_sanitized_for_context(artifact: Mapping[str, Any]) -> bool:
+    return bool(artifact.get("sanitized_context_summary"))
+
+
+def _has_provenance(artifact: Mapping[str, Any]) -> bool:
+    return bool(artifact.get("provenance_refs") or artifact.get("source_refs"))
+
+
+def _has_scope(artifact: Mapping[str, Any]) -> bool:
+    return bool(artifact.get("packet_scope") and artifact.get("conversation_scope_id") and artifact.get("task_scope_id"))
+
+
+def explain_embodiment_context_exclusion(artifact: Mapping[str, Any]) -> str | None:
+    kind = classify_embodiment_context_source_kind(artifact)
+    privacy = classify_embodiment_privacy_posture(artifact)
+    if kind == EmbodimentContextSourceKind.UNKNOWN:
+        return "excluded: unknown embodiment source kind"
+    if artifact.get("decision_power", "none") != "none":
+        return "excluded: embodiment artifact has decision power"
+    if not _has_provenance(artifact):
+        return "excluded: missing provenance/source refs"
+    if not _has_scope(artifact):
+        return "excluded: missing scope"
+    if kind in {
+        EmbodimentContextSourceKind.RAW_PERCEPTION_EVENT,
+        EmbodimentContextSourceKind.LEGACY_SCREEN_ARTIFACT,
+        EmbodimentContextSourceKind.LEGACY_AUDIO_ARTIFACT,
+        EmbodimentContextSourceKind.LEGACY_VISION_ARTIFACT,
+        EmbodimentContextSourceKind.LEGACY_MULTIMODAL_ARTIFACT,
+        EmbodimentContextSourceKind.LEGACY_FEEDBACK_ARTIFACT,
+    }:
+        return "excluded: raw perception artifacts are not context"
+    sanitized = embodiment_artifact_is_sanitized_for_context(artifact)
+    if privacy == EmbodimentPrivacyPosture.BIOMETRIC_OR_EMOTION_SENSITIVE and not (sanitized and artifact.get("allow_context_biometric_or_emotion")):
+        return "excluded: biometric/emotion-sensitive artifact not explicitly allowed"
+    if privacy == EmbodimentPrivacyPosture.RAW_RETENTION_SENSITIVE and not (sanitized and artifact.get("allow_context_raw_retention")):
+        return "excluded: raw retention artifact not explicitly allowed"
+    if privacy == EmbodimentPrivacyPosture.PRIVACY_SENSITIVE and not (sanitized and artifact.get("allow_context_privacy_sensitive")):
+        return "excluded: privacy-sensitive artifact not explicitly allowed"
+    if kind == EmbodimentContextSourceKind.EMBODIMENT_SNAPSHOT and not sanitized:
+        return "excluded: embodiment snapshot not sanitized"
+    if kind == EmbodimentContextSourceKind.EMBODIMENT_INGRESS_RECEIPT and not (sanitized or artifact.get("context_eligible")):
+        return "excluded: ingress receipt not context-eligible"
+    if artifact.get("action_capable") and kind not in {
+        EmbodimentContextSourceKind.EMBODIMENT_PROPOSAL,
+        EmbodimentContextSourceKind.EMBODIMENT_PROPOSAL_DIAGNOSTIC,
+        EmbodimentContextSourceKind.EMBODIMENT_REVIEW_RECEIPT,
+    }:
+        return "excluded: action-capable artifact not converted to non-actioning form"
+    if kind == EmbodimentContextSourceKind.EMBODIMENT_PROPOSAL and str(artifact.get("proposal_status", "")).lower() not in {"reviewable", "pending_review", "non_executing"}:
+        return "excluded: embodiment proposal not in reviewable/non-executing status"
+    checks = {
+        EmbodimentContextSourceKind.EMBODIMENT_HANDOFF_CANDIDATE: "handoff_is_not_fulfillment",
+        EmbodimentContextSourceKind.EMBODIMENT_GOVERNANCE_BRIDGE_CANDIDATE: "bridge_is_not_admission",
+        EmbodimentContextSourceKind.EMBODIMENT_FULFILLMENT_CANDIDATE: "fulfillment_candidate_is_not_effect",
+        EmbodimentContextSourceKind.EMBODIMENT_FULFILLMENT_RECEIPT: "fulfillment_receipt_is_not_effect",
+        EmbodimentContextSourceKind.MEMORY_INGRESS_VALIDATION: "validation_is_not_memory_write",
+        EmbodimentContextSourceKind.ACTION_INGRESS_VALIDATION: "validation_is_not_action_trigger",
+        EmbodimentContextSourceKind.RETENTION_INGRESS_VALIDATION: "validation_is_not_retention_commit",
+    }
+    if kind in checks and not artifact.get(checks[kind]):
+        return f"excluded: required flag missing ({checks[kind]})"
+    if kind == EmbodimentContextSourceKind.EMBODIMENT_FULFILLMENT_RECEIPT and not artifact.get("receipt_does_not_prove_side_effect"):
+        return "excluded: fulfillment receipt may prove side effects"
+    return None
+
+
+def embodiment_artifact_is_context_eligible(artifact: Mapping[str, Any]) -> bool:
+    return explain_embodiment_context_exclusion(artifact) is None
+
+
+def _risk(artifact: Mapping[str, Any], blocked: bool) -> PollutionRisk:
+    if blocked:
+        return PollutionRisk.BLOCKED
+    privacy = classify_embodiment_privacy_posture(artifact)
+    if privacy in {EmbodimentPrivacyPosture.PRIVACY_SENSITIVE, EmbodimentPrivacyPosture.BIOMETRIC_OR_EMOTION_SENSITIVE, EmbodimentPrivacyPosture.RAW_RETENTION_SENSITIVE}:
+        return PollutionRisk.HIGH
+    return PollutionRisk.LOW if embodiment_artifact_is_sanitized_for_context(artifact) else PollutionRisk.MEDIUM
+
+
+def embodiment_artifact_to_context_candidate(artifact: Mapping[str, Any]) -> ContextCandidate:
+    blocked_reason = explain_embodiment_context_exclusion(artifact)
+    kind = classify_embodiment_context_source_kind(artifact)
+    lane = "diagnostic" if kind == EmbodimentContextSourceKind.EMBODIMENT_PROPOSAL_DIAGNOSTIC else "embodiment"
+    return ContextCandidate(
+        ref_id=str(artifact.get("ref_id") or ""),
+        ref_type=lane,
+        packet_scope=artifact.get("packet_scope"),
+        conversation_scope_id=artifact.get("conversation_scope_id"),
+        task_scope_id=artifact.get("task_scope_id"),
+        summary=artifact.get("content_summary"),
+        provenance_refs=tuple(artifact.get("provenance_refs") or artifact.get("source_refs") or ()),
+        source_locator=artifact.get("source_locator") or artifact.get("source_path"),
+        created_at=artifact.get("created_at") if isinstance(artifact.get("created_at"), datetime) else None,
+        observed_at=artifact.get("observed_at") if isinstance(artifact.get("observed_at"), datetime) else None,
+        freshness_status=str(artifact.get("freshness_status") or "unknown"),
+        contradiction_status=str(artifact.get("contradiction_status") or "unknown"),
+        provenance_status=str(artifact.get("provenance_status") or "partial"),
+        pollution_risk=_risk(artifact, blocked_reason is not None).value,
+        metadata={
+            "source_kind": kind.value,
+            "privacy_posture": classify_embodiment_privacy_posture(artifact).value,
+            "sanitized_context_summary": embodiment_artifact_is_sanitized_for_context(artifact),
+            "non_authoritative": bool(artifact.get("non_authoritative", True)),
+            "decision_power": str(artifact.get("decision_power", "none")),
+            "risk_flags": tuple(artifact.get("risk_flags") or ()),
+            "context_eligible": blocked_reason is None,
+            "exclusion_reason": blocked_reason,
+        },
+        already_sanitized_context_summary=(embodiment_artifact_is_sanitized_for_context(artifact) and blocked_reason is None),
+    )
+
+
+def build_embodiment_context_candidates(artifacts: Sequence[Mapping[str, Any]]) -> tuple[ContextCandidate, ...]:
+    return tuple(embodiment_artifact_to_context_candidate(a) for a in artifacts)
+
+
+def summarize_embodiment_context_eligibility(artifacts: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    blocked = 0
+    eligible = 0
+    for artifact in artifacts:
+        if embodiment_artifact_is_context_eligible(artifact):
+            eligible += 1
+        else:
+            blocked += 1
+    return {"total": len(artifacts), "eligible": eligible, "blocked_or_excluded": blocked}

--- a/tests/test_phase63_embodiment_context_eligibility.py
+++ b/tests/test_phase63_embodiment_context_eligibility.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+
+from sentientos.context_hygiene.context_packet import PollutionRisk
+from sentientos.context_hygiene.embodiment_context import build_embodiment_context_candidates, embodiment_artifact_is_context_eligible
+from sentientos.context_hygiene.selector import build_context_packet_from_candidates
+
+
+NOW = datetime.now(timezone.utc)
+
+
+def _a(kind: str, **kwargs):
+    base = {
+        "ref_id": f"{kind}-1",
+        "source_kind": kind,
+        "packet_scope": "turn",
+        "conversation_scope_id": "conv",
+        "task_scope_id": "task",
+        "content_summary": "sanitized summary",
+        "provenance_refs": ["prov:1"],
+        "sanitized_context_summary": True,
+        "decision_power": "none",
+        "non_authoritative": True,
+        "proposal_status": "reviewable",
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_phase63_embodiment_context_eligibility_bridge():
+    blocked_kinds = ["raw_perception_event", "legacy_screen_artifact", "legacy_audio_artifact", "legacy_vision_artifact", "legacy_multimodal_artifact", "legacy_feedback_artifact"]
+    for k in blocked_kinds:
+        assert not embodiment_artifact_is_context_eligible(_a(k))
+
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", sanitized_context_summary=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_snapshot"))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_ingress_receipt", sanitized_context_summary=False, context_eligible=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_ingress_receipt", context_eligible=True, sanitized_context_summary=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_proposal"))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_proposal", provenance_refs=[]))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_proposal_diagnostic"))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_review_receipt"))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_handoff_candidate", handoff_is_not_fulfillment=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_handoff_candidate", handoff_is_not_fulfillment=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_governance_bridge_candidate", bridge_is_not_admission=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_governance_bridge_candidate", bridge_is_not_admission=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_fulfillment_candidate", fulfillment_candidate_is_not_effect=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_fulfillment_candidate", fulfillment_candidate_is_not_effect=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_fulfillment_receipt", fulfillment_receipt_is_not_effect=True, receipt_does_not_prove_side_effect=False))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_fulfillment_receipt", fulfillment_receipt_is_not_effect=True, receipt_does_not_prove_side_effect=True))
+    assert embodiment_artifact_is_context_eligible(_a("memory_ingress_validation", validation_is_not_memory_write=True))
+    assert embodiment_artifact_is_context_eligible(_a("action_ingress_validation", validation_is_not_action_trigger=True))
+    assert embodiment_artifact_is_context_eligible(_a("retention_ingress_validation", validation_is_not_retention_commit=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="biometric_or_emotion_sensitive"))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="biometric_or_emotion_sensitive", allow_context_biometric_or_emotion=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="raw_retention_sensitive"))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="raw_retention_sensitive", allow_context_raw_retention=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="privacy_sensitive"))
+    assert embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", privacy_posture="privacy_sensitive", allow_context_privacy_sensitive=True))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", decision_power="admit"))
+    assert not embodiment_artifact_is_context_eligible(_a("embodiment_snapshot", packet_scope=None))
+    assert not embodiment_artifact_is_context_eligible(_a("unknown"))
+
+    raw = _a("raw_perception_event")
+    good = _a("embodiment_snapshot")
+    diag = _a("embodiment_proposal_diagnostic")
+    action_cap = _a("embodiment_snapshot", action_capable=True)
+    cands = build_embodiment_context_candidates([raw, good, diag, action_cap])
+    assert cands[2].ref_type == "diagnostic"
+    assert cands[1].metadata["context_eligible"] is True
+
+    pkt = build_context_packet_from_candidates(cands, "turn", "conv", "task", now=NOW)
+    assert any(i.ref_id == good["ref_id"] for i in pkt.included_embodiment_refs)
+    assert any(i.ref_id == diag["ref_id"] for i in pkt.included_diagnostic_refs)
+    assert pkt.pollution_risk == PollutionRisk.BLOCKED
+    assert any(r.ref_id == raw["ref_id"] for r in pkt.excluded_refs)
+    assert any("excluded:" in r for r in pkt.exclusion_reasons)
+    assert pkt.non_authoritative and pkt.decision_power == "none"
+
+    original = _a("embodiment_snapshot")
+    cloned = deepcopy(original)
+    _ = build_embodiment_context_candidates([original])
+    assert original == cloned
+
+    import sentientos.context_hygiene.embodiment_context as mod
+
+    txt = open(mod.__file__, encoding="utf-8").read()
+    for forbidden in [
+        "prompt_assembler",
+        "memory_manager",
+        "task_executor",
+        "task_admission",
+        "screen_awareness",
+        "mic_bridge",
+        "vision_tracker",
+        "multimodal_tracker",
+        "openai",
+        "requests",
+    ]:
+        assert forbidden not in txt


### PR DESCRIPTION
### Motivation
- Provide a Phase 63 pure adapter that converts already-sanitized embodiment/proposal/diagnostic artifacts into `ContextCandidate` records usable by the Phase 62 selector while deterministically blocking raw, privacy-sensitive, biometric/emotion-sensitive, raw-retention, and action-capable artifacts unless explicitly sanitized and allowed. 
- Preserve Phase 62B packet-level contamination semantics (first-class `PollutionRisk.BLOCKED`) so attempted-but-blocked embodiment candidates still surface in `excluded_refs` and influence packet risk.

### Description
- Add `sentientos/context_hygiene/embodiment_context.py` implementing enums (`EmbodimentContextSourceKind`, `EmbodimentPrivacyPosture`), an `EmbodimentContextEligibility` dataclass, classifiers, deterministic exclusion/explanation logic, sanitization checks, a candidate adapter `embodiment_artifact_to_context_candidate`, batch builder `build_embodiment_context_candidates`, and summary helpers. 
- Map eligible artifacts to `ContextCandidate` entries consumable by `selector.py`, with `embodiment_proposal_diagnostic` → `diagnostic` lane and other eligible summaries → `embodiment` lane, and include metadata fields required by selector semantics (provenance refs, scope, `already_sanitized_context_summary`, `pollution_risk`, etc.).
- Implement the Phase 63 eligibility rules (provenance & scope required, `decision_power` must be `none`, sanitation & explicit allow gates for privacy/biometric/raw-retention, action-capable gating, non-effect flags for handoff/bridge/fulfillment/validation artifacts, unknown kinds blocked). 
- Preserve architecture/boundary invariants: no runtime wiring into `prompt_assembler`, `memory_manager`, truth, embodiment runtime, action/retention/admission/execution; module is pure adapter/validation-only and exported from `sentientos.context_hygiene.__init__`. 
- Add docs `docs/architecture/phase63_embodiment_privacy_context_bridge_execplan.md` and update `docs/architecture/context_hygiene_spine.md` to record Phase 63 scope/non-goals and rules.

### Testing
- Ran `python -m scripts.run_tests -q tests/test_phase63_embodiment_context_eligibility.py` and the new Phase 63 tests passed. 
- Ran `python -m scripts.run_tests -q tests/test_phase62b_context_risk_contract_alignment.py tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and these selector/risk/packet contract suites passed. 
- Ran `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and architecture/boundary/import-purity checks passed. 
- Tests verify key behaviors: blocked raw/privacy/biometric/action-capable artifacts are excluded and contribute `PollutionRisk.BLOCKED` at packet level, eligible sanitized summaries are included in the appropriate lanes, excluded refs and exclusion reasons are recorded, and `ContextPacket` invariants (non-authoritative, `decision_power == "none"`, no memory/write/admit/execute flags) hold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f95c52aeac8320820dc9a8d5e65e9c)