### PR TITLE
[codex:context-hygiene] add source-kind safety contract matrix

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -72,3 +72,10 @@ Key assertions:
 - Packets remain auditable without raw-source rehydration.
 - Preserved metadata is non-raw and non-authoritative; no prompt assembly/LLM/retrieval/memory-write/runtime action behavior is added.
 - This closes the Phase 64 metadata-loss blind spot between selector and prompt preflight.
+
+
+## Phase 66: Source-kind safety contract matrix
+- Safety metadata must be source-kind complete for contract-required kinds.
+- Explicit `unknown` source kind fails closed where contracted safety metadata is required.
+- Contracts validate evidence metadata only (non-authoritative) and do not grant authority.
+- No prompt assembly, LLM calls, retrieval, memory writes, or runtime embodiment/action/retention behavior changes are introduced in this phase.

--- a/docs/architecture/phase66_context_source_kind_safety_contract_matrix_execplan.md
+++ b/docs/architecture/phase66_context_source_kind_safety_contract_matrix_execplan.md
@@ -1,0 +1,31 @@
+# Phase 66: Context Source-Kind Safety Contract Matrix
+
+## Goal
+Define deterministic per-source-kind safety metadata contracts and enforce them in selector, packet validation, and prompt preflight.
+
+## Non-goals
+No prompt assembly changes, no runtime action/memory/retention/embodiment/truth behavior changes, no retrieval/LLM/web/hardware calls.
+
+## Dependency chain
+Phase 61 packet schema → 62 truth-gated selection → 62B blocked pollution tracking → 63 embodiment eligibility adapters → 64 prompt preflight → 65 safety metadata preservation → **66 source-kind completeness contracts**.
+
+## Contract matrix
+Implemented in `sentientos/context_hygiene/source_kind_contracts.py` with fail-closed rules for raw/unknown kinds and required-field policies for embodiment/validation/diagnostic kinds.
+
+## Fail-closed behavior
+- `raw_perception_event` and legacy raw modality kinds are prompt-ineligible.
+- `unknown` source kind is contract-invalid.
+
+## Legacy compatibility
+Refs without `source_kind` remain backward compatible unless they explicitly opt into a source-kind contract.
+
+## Enforcement
+- Selector excludes candidates with source-kind contract gaps.
+- Packet validation rejects included refs violating source-kind contract.
+- Prompt preflight returns schema violation for source-kind contract gaps.
+
+## Tests
+See `tests/test_phase66_context_source_kind_safety_contracts.py` plus updated phase 64/65 coverage.
+
+## Deferred
+Potential finer taxonomy for evidence/truth/research contracts.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -76,6 +76,14 @@ __all__ = [
     "safety_metadata_has_authority_block",
     "safety_metadata_has_privacy_block",
     "safety_metadata_has_raw_source_block",
+    "ContextSourceKindSafetyContract",
+    "context_source_kind_requires_safety_metadata",
+    "explain_context_safety_contract_gap",
+    "get_context_source_kind_safety_contract",
+    "source_kind_contract_allows_prompt_preflight",
+    "source_kind_contract_has_required_non_effect_guards",
+    "summarize_source_kind_contract_matrix",
+    "validate_context_safety_metadata_against_source_kind",
 ]
 
 from sentientos.context_hygiene.selector import (
@@ -127,4 +135,14 @@ from sentientos.context_hygiene.safety_metadata import (
     safety_metadata_has_authority_block,
     safety_metadata_has_privacy_block,
     safety_metadata_has_raw_source_block,
+)
+from sentientos.context_hygiene.source_kind_contracts import (
+    ContextSourceKindSafetyContract,
+    context_source_kind_requires_safety_metadata,
+    explain_context_safety_contract_gap,
+    get_context_source_kind_safety_contract,
+    source_kind_contract_allows_prompt_preflight,
+    source_kind_contract_has_required_non_effect_guards,
+    summarize_source_kind_contract_matrix,
+    validate_context_safety_metadata_against_source_kind,
 )

--- a/sentientos/context_hygiene/context_packet.py
+++ b/sentientos/context_hygiene/context_packet.py
@@ -11,6 +11,9 @@ from sentientos.context_hygiene.safety_metadata import (
     safety_metadata_has_authority_block,
     safety_metadata_has_raw_source_block,
 )
+from sentientos.context_hygiene.source_kind_contracts import (
+    validate_context_safety_metadata_against_source_kind,
+)
 
 
 class ContextAssemblyStatus(str, Enum):
@@ -145,6 +148,12 @@ def validate_context_packet(packet: ContextPacket) -> list[str]:
             errors.append(f"included ref without provenance: {item.ref_id}")
             continue
         safety_meta = item.provenance.get(CONTEXT_SAFETY_METADATA_KEY, {})
+        if safety_meta:
+            valid, reasons = validate_context_safety_metadata_against_source_kind(safety_meta)
+            if not valid:
+                errors.append(
+                    f"included ref violates source-kind safety contract: {item.ref_id} ({'; '.join(reasons)})"
+                )
         if safety_meta and safety_metadata_has_raw_source_block(safety_meta):
             errors.append(f"included ref contains raw-source safety metadata: {item.ref_id}")
         if safety_meta and safety_metadata_has_action_authority(safety_meta):

--- a/sentientos/context_hygiene/prompt_preflight.py
+++ b/sentientos/context_hygiene/prompt_preflight.py
@@ -13,6 +13,10 @@ from sentientos.context_hygiene.context_packet import (
     validate_context_packet,
 )
 from sentientos.context_hygiene.safety_metadata import CONTEXT_SAFETY_METADATA_KEY
+from sentientos.context_hygiene.source_kind_contracts import (
+    source_kind_contract_allows_prompt_preflight,
+    validate_context_safety_metadata_against_source_kind,
+)
 
 
 class PromptContextEligibilityStatus(str, Enum):
@@ -115,6 +119,17 @@ def packet_has_prompt_blocking_privacy_gap(packet: ContextPacket) -> bool:
     return False
 
 
+def packet_has_prompt_blocking_source_kind_contract_gap(packet: ContextPacket) -> bool:
+    for i in _all_included(packet):
+        safety_meta = i.provenance.get(CONTEXT_SAFETY_METADATA_KEY, {})
+        if not safety_meta:
+            continue
+        valid, _ = validate_context_safety_metadata_against_source_kind(safety_meta)
+        if not valid or not source_kind_contract_allows_prompt_preflight(safety_meta):
+            return True
+    return False
+
+
 def packet_has_prompt_blocking_action_gap(packet: ContextPacket) -> bool:
     flags = ["can_write_memory", "can_trigger_feedback", "can_commit_retention", "action_capable", "can_admit", "can_route", "can_approve", "can_execute", "can_fulfill", "can_trigger_work"]
     guard_flags = ["validation_is_not_memory_write", "validation_is_not_action_trigger", "validation_is_not_retention_commit", "handoff_is_not_fulfillment", "bridge_is_not_admission", "fulfillment_candidate_is_not_effect", "fulfillment_receipt_is_not_effect", "receipt_does_not_prove_side_effect"]
@@ -153,6 +168,9 @@ def evaluate_context_packet_prompt_eligibility(packet: ContextPacket) -> PromptC
     elif packet_has_prompt_blocking_privacy_gap(packet):
         block_reasons.append("privacy/sanitization gap")
         status = PromptContextEligibilityStatus.PROMPT_INELIGIBLE_PRIVACY_GAP
+    elif packet_has_prompt_blocking_source_kind_contract_gap(packet):
+        block_reasons.append("source-kind safety contract gap")
+        status = PromptContextEligibilityStatus.PROMPT_INELIGIBLE_SCHEMA_VIOLATION
     elif packet_has_prompt_blocking_action_gap(packet):
         block_reasons.append("action-capable gap")
         status = PromptContextEligibilityStatus.PROMPT_INELIGIBLE_ACTION_GAP

--- a/sentientos/context_hygiene/safety_metadata.py
+++ b/sentientos/context_hygiene/safety_metadata.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from sentientos.context_hygiene.source_kind_contracts import explain_context_safety_contract_gap, validate_context_safety_metadata_against_source_kind
+
 
 CONTEXT_SAFETY_METADATA_KEY = "context_safety_metadata"
 
@@ -45,6 +47,9 @@ _ALLOWED_KEYS = frozenset(
         "allow_context_privacy_sensitive",
         "allow_context_biometric_or_emotion",
         "allow_context_raw_retention",
+        "source_kind_contract_valid",
+        "missing_required_safety_fields",
+        "source_kind_contract_gap_reasons",
     }
 )
 
@@ -60,6 +65,11 @@ def normalize_context_safety_metadata(metadata: Mapping[str, Any]) -> dict[str, 
         out["safety_flags"] = [str(out["safety_flags"])]
     if out:
         out["preflight_relevant_metadata_present"] = True
+        valid, reasons = validate_context_safety_metadata_against_source_kind(out)
+        out["source_kind_contract_valid"] = valid
+        if reasons:
+            out["missing_required_safety_fields"] = [r for r in reasons if r.startswith("missing required") or "requires " in r]
+            out["source_kind_contract_gap_reasons"] = list(reasons)
     return out
 
 
@@ -86,7 +96,7 @@ def explain_missing_context_safety_metadata(ref_type: str, metadata: Mapping[str
     source_kind = str(metadata.get("source_kind", "")).strip().lower()
     if source_kind == "unknown":
         return f"unknown safety metadata source_kind for {ref_type}"
-    return None
+    return explain_context_safety_contract_gap(metadata)
 
 
 def safety_metadata_has_action_authority(metadata: Mapping[str, Any]) -> bool:

--- a/sentientos/context_hygiene/selector.py
+++ b/sentientos/context_hygiene/selector.py
@@ -29,6 +29,7 @@ from sentientos.context_hygiene.safety_metadata import (
     explain_missing_context_safety_metadata,
     extract_context_safety_metadata,
 )
+from sentientos.context_hygiene.source_kind_contracts import context_source_kind_requires_safety_metadata
 
 
 @dataclass(frozen=True)
@@ -101,9 +102,11 @@ def explain_candidate_exclusion(candidate: ContextCandidate, packet_scope: str, 
     if candidate.ref_type == "embodiment" and not candidate.already_sanitized_context_summary:
         return "excluded: embodiment candidate not sanitized (Phase 63)"
     safety_meta = extract_context_safety_metadata(candidate)
-    missing_safety = explain_missing_context_safety_metadata(candidate.ref_type, safety_meta)
-    if missing_safety:
-        return f"excluded: {missing_safety}"
+    source_kind = str(safety_meta.get("source_kind", "")).strip().lower()
+    if source_kind and context_source_kind_requires_safety_metadata(source_kind):
+        missing_safety = explain_missing_context_safety_metadata(candidate.ref_type, safety_meta)
+        if missing_safety:
+            return f"excluded: source-kind safety contract gap ({missing_safety})"
     return None
 
 

--- a/sentientos/context_hygiene/source_kind_contracts.py
+++ b/sentientos/context_hygiene/source_kind_contracts.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+NON_EFFECT_GUARD_FLAGS = (
+    "validation_is_not_memory_write",
+    "validation_is_not_action_trigger",
+    "validation_is_not_retention_commit",
+    "handoff_is_not_fulfillment",
+    "bridge_is_not_admission",
+    "fulfillment_candidate_is_not_effect",
+    "fulfillment_receipt_is_not_effect",
+    "receipt_does_not_prove_side_effect",
+)
+
+CAPABILITY_FLAGS = (
+    "action_capable",
+    "memory_write_capable",
+    "feedback_trigger_capable",
+    "retention_commit_capable",
+    "admit_work_capable",
+    "route_work_capable",
+    "approve_work_capable",
+    "execute_work_capable",
+    "fulfill_work_capable",
+)
+
+
+@dataclass(frozen=True)
+class ContextSourceKindSafetyContract:
+    source_kind: str
+    required_fields: tuple[str, ...] = ()
+    optional_fields: tuple[str, ...] = ()
+    forbidden_fields: tuple[str, ...] = ()
+    requires_scope: bool = False
+    requires_provenance: bool = False
+    requires_sanitized_summary: bool = False
+    requires_privacy_posture: bool = False
+    requires_non_authoritative: bool = True
+    requires_decision_power_none: bool = True
+    requires_context_eligible: bool = False
+    requires_non_effect_guard_flags: tuple[str, ...] = ()
+    allows_prompt_preflight: bool = True
+    fail_closed_if_missing: bool = False
+    rationale: str = ""
+
+
+_CONTRACTS = {
+    "unknown": ContextSourceKindSafetyContract("unknown", required_fields=("source_kind",), allows_prompt_preflight=False, fail_closed_if_missing=True),
+    "raw_perception_event": ContextSourceKindSafetyContract("raw_perception_event", required_fields=("source_kind",), forbidden_fields=("sanitized_context_summary",), allows_prompt_preflight=False, fail_closed_if_missing=True),
+    **{k: ContextSourceKindSafetyContract(k, required_fields=("source_kind",), allows_prompt_preflight=False, fail_closed_if_missing=True) for k in (
+        "legacy_screen_artifact", "legacy_audio_artifact", "legacy_vision_artifact", "legacy_multimodal_artifact", "legacy_feedback_artifact")},
+    "embodiment_snapshot": ContextSourceKindSafetyContract("embodiment_snapshot", required_fields=("source_kind", "sanitized_context_summary", "privacy_posture", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_sanitized_summary=True, requires_privacy_posture=True),
+    "embodiment_ingress_receipt": ContextSourceKindSafetyContract("embodiment_ingress_receipt", required_fields=("source_kind", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True),
+    "embodiment_proposal": ContextSourceKindSafetyContract("embodiment_proposal", required_fields=("source_kind", "privacy_posture", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_privacy_posture=True),
+    "embodiment_proposal_diagnostic": ContextSourceKindSafetyContract("embodiment_proposal_diagnostic", required_fields=("source_kind", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True),
+    "embodiment_review_receipt": ContextSourceKindSafetyContract("embodiment_review_receipt", required_fields=("source_kind", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True),
+    "embodiment_handoff_candidate": ContextSourceKindSafetyContract("embodiment_handoff_candidate", required_fields=("source_kind", "handoff_is_not_fulfillment", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("handoff_is_not_fulfillment",)),
+    "embodiment_governance_bridge_candidate": ContextSourceKindSafetyContract("embodiment_governance_bridge_candidate", required_fields=("source_kind", "bridge_is_not_admission", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("bridge_is_not_admission",)),
+    "embodiment_fulfillment_candidate": ContextSourceKindSafetyContract("embodiment_fulfillment_candidate", required_fields=("source_kind", "fulfillment_candidate_is_not_effect", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("fulfillment_candidate_is_not_effect",)),
+    "embodiment_fulfillment_receipt": ContextSourceKindSafetyContract("embodiment_fulfillment_receipt", required_fields=("source_kind", "fulfillment_receipt_is_not_effect", "receipt_does_not_prove_side_effect", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("fulfillment_receipt_is_not_effect", "receipt_does_not_prove_side_effect")),
+    "memory_ingress_validation": ContextSourceKindSafetyContract("memory_ingress_validation", required_fields=("source_kind", "validation_is_not_memory_write", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("validation_is_not_memory_write",)),
+    "action_ingress_validation": ContextSourceKindSafetyContract("action_ingress_validation", required_fields=("source_kind", "validation_is_not_action_trigger", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("validation_is_not_action_trigger",)),
+    "retention_ingress_validation": ContextSourceKindSafetyContract("retention_ingress_validation", required_fields=("source_kind", "validation_is_not_retention_commit", "non_authoritative", "decision_power"), requires_scope=True, requires_provenance=True, requires_non_effect_guard_flags=("validation_is_not_retention_commit",)),
+    "diagnostic": ContextSourceKindSafetyContract("diagnostic", required_fields=("source_kind", "non_authoritative", "decision_power"), requires_provenance=True),
+    "evidence": ContextSourceKindSafetyContract("evidence", required_fields=("source_kind",), requires_provenance=True, fail_closed_if_missing=False),
+    "truth": ContextSourceKindSafetyContract("truth", required_fields=("source_kind",), requires_provenance=True, fail_closed_if_missing=False),
+    "research": ContextSourceKindSafetyContract("research", required_fields=("source_kind",), requires_provenance=True, fail_closed_if_missing=False),
+}
+
+
+def get_context_source_kind_safety_contract(source_kind: str | None) -> ContextSourceKindSafetyContract:
+    return _CONTRACTS.get(str(source_kind or "").strip().lower(), _CONTRACTS["unknown"])
+
+
+def context_source_kind_requires_safety_metadata(source_kind: str | None) -> bool:
+    k = str(source_kind or "").strip().lower()
+    return bool(k and k in _CONTRACTS and k not in {"evidence", "truth", "research"})
+
+
+def validate_context_safety_metadata_against_source_kind(metadata: Mapping[str, Any]) -> tuple[bool, tuple[str, ...]]:
+    m = dict(metadata)
+    kind = str(m.get("source_kind", "")).strip().lower()
+    if not kind:
+        return True, tuple()
+    c = get_context_source_kind_safety_contract(kind)
+    reasons: list[str] = []
+    if kind == "unknown": reasons.append("source_kind unknown")
+    for f in c.required_fields:
+        if f not in m: reasons.append(f"missing required field: {f}")
+    if c.requires_sanitized_summary and not bool(m.get("sanitized_context_summary", False)): reasons.append("missing required field: sanitized_context_summary")
+    if c.requires_privacy_posture and not m.get("privacy_posture"): reasons.append("missing required field: privacy_posture")
+    if c.requires_non_authoritative and not bool(m.get("non_authoritative", False)): reasons.append("non_authoritative must be true")
+    if c.requires_decision_power_none and str(m.get("decision_power", "none")) != "none": reasons.append("decision_power must be none")
+    if kind == "embodiment_ingress_receipt" and not (bool(m.get("context_eligible")) or bool(m.get("sanitized_context_summary"))): reasons.append("requires context_eligible or sanitized_context_summary")
+    if kind == "embodiment_proposal" and not (bool(m.get("context_eligible")) or bool(m.get("sanitized_context_summary"))): reasons.append("requires context_eligible or sanitized_context_summary")
+    if kind == "raw_perception_event" and m.get("raw_perception") is False: reasons.append("raw_perception_event requires raw_perception=true when present")
+    for guard in c.requires_non_effect_guard_flags:
+        if not bool(m.get(guard, False)): reasons.append(f"missing required guard flag: {guard}")
+    if kind == "diagnostic" or kind.startswith("embodiment_"):
+        for cap in CAPABILITY_FLAGS:
+            if bool(m.get(cap, False)): reasons.append(f"forbidden capability flag: {cap}")
+    return not reasons, tuple(reasons)
+
+
+def explain_context_safety_contract_gap(metadata: Mapping[str, Any]) -> str | None:
+    valid, reasons = validate_context_safety_metadata_against_source_kind(metadata)
+    return None if valid else "; ".join(reasons)
+
+
+def source_kind_contract_allows_prompt_preflight(metadata: Mapping[str, Any]) -> bool:
+    return get_context_source_kind_safety_contract(metadata.get("source_kind")).allows_prompt_preflight
+
+
+def source_kind_contract_has_required_non_effect_guards(metadata: Mapping[str, Any]) -> bool:
+    c = get_context_source_kind_safety_contract(metadata.get("source_kind"))
+    return all(bool(metadata.get(flag, False)) for flag in c.requires_non_effect_guard_flags)
+
+
+def summarize_source_kind_contract_matrix() -> dict[str, dict[str, Any]]:
+    return {k: {"required_fields": list(v.required_fields), "allows_prompt_preflight": v.allows_prompt_preflight, "fail_closed_if_missing": v.fail_closed_if_missing} for k, v in _CONTRACTS.items()}

--- a/tests/test_phase64_context_prompt_preflight.py
+++ b/tests/test_phase64_context_prompt_preflight.py
@@ -42,11 +42,11 @@ def test_phase64_prompt_preflight_contract_and_purity():
     r = evaluate_context_packet_prompt_eligibility(clean)
     assert r.eligibility_status == PromptContextEligibilityStatus.PROMPT_ELIGIBLE
 
-    high_priv = replace(_pkt([_cand("p", metadata={"source_kind": "embodiment_snapshot", "privacy_posture": "privacy_sensitive", "sanitized_context_summary": True, "allow_context_privacy_sensitive": True})]), pollution_risk=PollutionRisk.HIGH)
+    high_priv = replace(_pkt([_cand("p", metadata={"source_kind": "embodiment_snapshot", "privacy_posture": "privacy_sensitive", "sanitized_context_summary": True, "allow_context_privacy_sensitive": True, "non_authoritative": True, "decision_power": "none"})]), pollution_risk=PollutionRisk.HIGH)
     assert evaluate_context_packet_prompt_eligibility(high_priv).eligibility_status == PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS
 
     for posture, allow in [("biometric_or_emotion_sensitive", "allow_context_biometric_or_emotion"), ("raw_retention_sensitive", "allow_context_raw_retention")]:
-        pkt = replace(_pkt([_cand("x" + posture, metadata={"source_kind": "embodiment_snapshot", "privacy_posture": posture, "sanitized_context_summary": True, allow: True})]), pollution_risk=PollutionRisk.HIGH)
+        pkt = replace(_pkt([_cand("x" + posture, metadata={"source_kind": "embodiment_snapshot", "privacy_posture": posture, "sanitized_context_summary": True, allow: True, "non_authoritative": True, "decision_power": "none"})]), pollution_risk=PollutionRisk.HIGH)
         assert evaluate_context_packet_prompt_eligibility(pkt).eligibility_status == PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS
 
     assert evaluate_context_packet_prompt_eligibility(replace(clean, pollution_risk=PollutionRisk.BLOCKED)).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_BLOCKED_RISK

--- a/tests/test_phase65_context_safety_metadata_preservation.py
+++ b/tests/test_phase65_context_safety_metadata_preservation.py
@@ -73,12 +73,12 @@ def test_phase65_preservation_and_preflight_contract():
     assert evaluate_context_packet_prompt_eligibility(act).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_SCHEMA_VIOLATION
 
     privacy_gap = replace(pkt, included_embodiment_refs=(ContextPacketItem("p", "embodiment", attach_context_safety_metadata_to_packet_ref({"provenance_refs": ["p"]}, {"source_kind": "embodiment_snapshot", "privacy_posture": "privacy_sensitive", "sanitized_context_summary": False})),))
-    assert evaluate_context_packet_prompt_eligibility(privacy_gap).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_PRIVACY_GAP
+    assert evaluate_context_packet_prompt_eligibility(privacy_gap).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_SCHEMA_VIOLATION
 
     auth_gap = replace(pkt, included_embodiment_refs=(ContextPacketItem("u", "embodiment", attach_context_safety_metadata_to_packet_ref({"provenance_refs": ["p"]}, {"source_kind": "embodiment_snapshot", "non_authoritative": False})),))
     assert evaluate_context_packet_prompt_eligibility(auth_gap).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_SCHEMA_VIOLATION
 
-    caveat = replace(pkt, pollution_risk=PollutionRisk.HIGH, included_embodiment_refs=(ContextPacketItem("c", "embodiment", attach_context_safety_metadata_to_packet_ref({"provenance_refs": ["p"]}, {"source_kind": "embodiment_snapshot", "privacy_posture": "privacy_sensitive", "sanitized_context_summary": True, "allow_context_privacy_sensitive": True})),))
+    caveat = replace(pkt, pollution_risk=PollutionRisk.HIGH, included_embodiment_refs=(ContextPacketItem("c", "embodiment", attach_context_safety_metadata_to_packet_ref({"provenance_refs": ["p"]}, {"source_kind": "embodiment_snapshot", "privacy_posture": "privacy_sensitive", "sanitized_context_summary": True, "allow_context_privacy_sensitive": True, "non_authoritative": True, "decision_power": "none"})),))
     assert evaluate_context_packet_prompt_eligibility(caveat).eligibility_status == PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS
 
     clean = _pkt([_cand("cl", metadata={})])

--- a/tests/test_phase66_context_source_kind_safety_contracts.py
+++ b/tests/test_phase66_context_source_kind_safety_contracts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from sentientos.context_hygiene.context_packet import ContextMode, ContextPacketItem, validate_context_packet
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibilityStatus, evaluate_context_packet_prompt_eligibility
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+from sentientos.context_hygiene.source_kind_contracts import (
+    get_context_source_kind_safety_contract,
+    summarize_source_kind_contract_matrix,
+    validate_context_safety_metadata_against_source_kind,
+)
+
+NOW = datetime.now(timezone.utc)
+
+
+def _cand(ref_id="c", ref_type="embodiment", metadata=None):
+    return ContextCandidate(ref_id=ref_id, ref_type=ref_type, packet_scope="turn", conversation_scope_id="conv", task_scope_id="task", provenance_refs=("p1",), source_locator="loc", summary="s", already_sanitized_context_summary=True, truth_ingress_status="allowed", metadata=metadata or {})
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(cands, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+
+
+def test_phase66_contract_matrix_basics_and_unknown_fail_closed():
+    matrix = summarize_source_kind_contract_matrix()
+    for k in ["raw_perception_event", "embodiment_snapshot", "embodiment_proposal", "unknown", "diagnostic", "evidence", "truth", "research"]:
+        assert k in matrix
+        assert get_context_source_kind_safety_contract(k).source_kind == k
+    ok, reasons = validate_context_safety_metadata_against_source_kind({"source_kind": "unknown"})
+    assert not ok and reasons
+
+
+def test_phase66_selector_packet_preflight_contract_enforcement():
+    bad = _cand("bad", metadata={"source_kind": "embodiment_snapshot", "non_authoritative": True, "decision_power": "none"})
+    pkt = _pkt([bad])
+    assert not pkt.included_embodiment_refs
+
+    good_meta = {"source_kind": "embodiment_snapshot", "sanitized_context_summary": True, "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"}
+    good = _cand("good", metadata=good_meta)
+    pkt2 = _pkt([good])
+    assert pkt2.included_embodiment_refs
+    assert validate_context_packet(pkt2) == []
+    assert evaluate_context_packet_prompt_eligibility(pkt2).eligibility_status == PromptContextEligibilityStatus.PROMPT_ELIGIBLE
+
+    legacy = _pkt([_cand("legacy", ref_type="claim", metadata={})])
+    assert legacy.included_claim_refs
+
+    unknown = replace(pkt2, included_embodiment_refs=(ContextPacketItem("u", "embodiment", {"provenance_refs": ["p"], "context_safety_metadata": {"source_kind": "unknown"}}),))
+    assert any("source-kind safety contract" in e for e in validate_context_packet(unknown))
+    assert evaluate_context_packet_prompt_eligibility(unknown).eligibility_status == PromptContextEligibilityStatus.PROMPT_INELIGIBLE_SCHEMA_VIOLATION
+
+
+def test_phase66_no_forbidden_runtime_imports():
+    import sentientos.context_hygiene.source_kind_contracts as mod
+
+    txt = open(mod.__file__, encoding="utf-8").read()
+    for forbidden in ["prompt_assembler", "memory_manager", "task_executor", "task_admission", "openai", "requests"]:
+        assert forbidden not in txt


### PR DESCRIPTION
### Motivation
- Formalize deterministic per-source-kind safety metadata contracts so preserved `context_safety_metadata` from Phase 65 can be judged complete or incomplete for prompt eligibility. 
- Fail-closed for raw/unknown/contract-required kinds to prevent sanitized-but-incomplete metadata from enabling prompt eligibility. 
- Preserve backward compatibility for legacy/simple low-risk refs that do not claim a contract-required `source_kind`. 

### Description
- Add `sentientos/context_hygiene/source_kind_contracts.py` implementing `ContextSourceKindSafetyContract` and pure helpers such as `get_context_source_kind_safety_contract`, `validate_context_safety_metadata_against_source_kind`, `explain_context_safety_contract_gap`, and `summarize_source_kind_contract_matrix`. 
- Integrate validation without runtime side-effects by: (1) annotating normalized safety metadata in `sentientos/context_hygiene/safety_metadata.py`, (2) excluding candidates in `sentientos/context_hygiene/selector.py` when a contract-required `source_kind` is incomplete, (3) validating included refs in `sentientos/context_hygiene/context_packet.py`, and (4) adding contract-gap checks to `sentientos/context_hygiene/prompt_preflight.py`. 
- Export new helpers through the `sentientos.context_hygiene` package API and add conservative contract entries for Phase 63/65 kinds (raw/legacy modalities, embodiment families, ingress validations, diagnostic/evidence/truth/research, unknown). 
- Add tests (`tests/test_phase66_context_source_kind_safety_contracts.py`) and update Phase 64/65 tests and docs (`docs/architecture/phase66_context_source_kind_safety_contract_matrix_execplan.md`, `docs/architecture/context_hygiene_spine.md`) to reflect source-kind completeness semantics. 

### Testing
- Ran the new contract test suite with `python -m scripts.run_tests -q tests/test_phase66_context_source_kind_safety_contracts.py` and it passed. 
- Ran the Phase 61–65 and related preflight/selector tests with `python -m scripts.run_tests -q tests/test_phase65_context_safety_metadata_preservation.py tests/test_phase64_context_prompt_preflight.py tests/test_phase63_embodiment_context_eligibility.py tests/test_phase62b_context_risk_contract_alignment.py tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and all passed. 
- Verified architecture/import purity with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and both passed. 
- All added helpers are pure and do not import prompt assembly, memory manager, embodiment runtime, action/retention/runtime execution, web, or LLM modules per boundary requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f987005dc48320b4117b49fb7951c9)