### PR TITLE
[codex:context-hygiene] add prompt assembly dry-run envelope

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -87,3 +87,10 @@ Key assertions:
 - Does not contain prompt text or call LLM/web/retrieval/memory write paths.
 - Preserves packet-safe summaries, lane/ref summaries, and safety metadata summaries only.
 - Does not alter embodiment/action/retention runtime behavior.
+
+## Phase 68: Prompt Assembly Dry-Run Envelope
+- Adds a pure dry-run envelope sourced only from the Phase 67 handoff manifest.
+- Maps handoff status to dry-run readiness without assembling prompt text.
+- Carries manifest id/digest, packet id/scope, assembly constraints, section summaries, and safe admissible ref summaries only for ready/caveated manifests.
+- Withholds admissible refs for blocked, not-applicable, and invalid manifests while preserving block reasons, caveats, source-kind summary, safety-contract gap summary, and provenance summary.
+- Includes explicit no-runtime markers for no LLM calls, memory retrieval/writes, feedback, retention, work routing/execution/admission, or final prompt text.

--- a/docs/architecture/phase68_prompt_assembly_dry_run_envelope_execplan.md
+++ b/docs/architecture/phase68_prompt_assembly_dry_run_envelope_execplan.md
@@ -1,0 +1,51 @@
+# Phase 68: Prompt Assembly Dry-Run Envelope (Execution Plan)
+
+## Goal
+Define a pure, non-authoritative dry-run envelope sourced exclusively from the Phase 67 context prompt handoff manifest. The envelope previews prompt-assembly readiness without assembling prompt text, retrieving memory, calling an LLM, writing memory, admitting work, routing work, executing work, triggering feedback, or committing retention.
+
+## Source artifact
+Phase 68 consumes the existing Phase 67 `ContextPromptHandoffManifest` as its only source. It copies only manifest-safe identifiers, digest, packet scope, section summaries, admissible reference summaries, caveats, block reasons, source-kind counts, safety-contract gaps, provenance posture, and rationale.
+
+## Status mapping
+- `handoff_ready` → `dry_run_ready`
+- `handoff_ready_with_caveats` → `dry_run_ready_with_caveats`
+- `handoff_blocked` → `dry_run_blocked`
+- `handoff_not_applicable` → `dry_run_not_applicable`
+- `handoff_invalid_packet` → `dry_run_invalid_manifest`
+
+Unknown handoff status values fail closed as `dry_run_invalid_manifest`.
+
+## Admissible reference rules
+Admissible reference summaries are included only when the dry-run status is `dry_run_ready` or `dry_run_ready_with_caveats`. Blocked, not-applicable, and invalid manifests preserve block/caveat/provenance/safety summaries but withhold all admissible references.
+
+## Assembly constraints
+The envelope records constraints rather than prompt content:
+- source artifact is the Phase 67 handoff manifest;
+- the manifest id and digest remain visible;
+- output is pure, non-authoritative, non-executing, and manifest-only;
+- prompt assembly and final prompt text are explicitly absent;
+- admissible refs are available only for ready or caveated manifests.
+
+## No-runtime markers
+The envelope contains explicit no-runtime marker booleans:
+- `does_not_assemble_prompt`
+- `does_not_contain_final_prompt_text`
+- `does_not_call_llm`
+- `does_not_retrieve_memory`
+- `does_not_write_memory`
+- `does_not_trigger_feedback`
+- `does_not_commit_retention`
+- `does_not_execute_or_route_work`
+- `does_not_admit_work`
+
+## Digest rules
+The envelope digest is a deterministic SHA256 over stable envelope-safe fields with the digest field omitted. Changes in source manifest digest, status, caveats, block reasons, summaries, provenance, safety gaps, or admissible refs change the digest.
+
+## Non-goals
+- No prompt text generation or assembly.
+- No prompt assembler integration.
+- No memory manager, truth runtime, embodiment runtime, action, retention, routing, admission, execution, or orchestration behavior changes.
+- No authoritative decision surface.
+
+## Tests
+See `tests/test_phase68_prompt_assembly_dry_run_envelope.py`.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -98,6 +98,19 @@ __all__ = [
     "summarize_context_packet_lane_for_handoff",
     "summarize_context_packet_ref_for_handoff",
     "summarize_context_prompt_handoff_manifest",
+    "ContextPromptDryRunEnvelope",
+    "ContextPromptDryRunNoRuntimeMarkers",
+    "ContextPromptDryRunRefSummary",
+    "ContextPromptDryRunSectionSummary",
+    "ContextPromptDryRunStatus",
+    "build_context_prompt_dry_run_envelope",
+    "compute_context_prompt_dry_run_envelope_digest",
+    "dry_run_envelope_contains_no_prompt_text",
+    "dry_run_envelope_has_no_runtime_authority",
+    "map_handoff_status_to_prompt_dry_run_status",
+    "summarize_context_prompt_dry_run_envelope",
+    "summarize_handoff_lane_for_prompt_dry_run",
+    "summarize_handoff_ref_for_prompt_dry_run",
 ]
 
 from sentientos.context_hygiene.selector import (
@@ -176,4 +189,20 @@ from sentientos.context_hygiene.prompt_handoff_manifest import (
     summarize_context_packet_lane_for_handoff,
     summarize_context_packet_ref_for_handoff,
     summarize_context_prompt_handoff_manifest,
+)
+
+from sentientos.context_hygiene.prompt_dry_run_envelope import (
+    ContextPromptDryRunEnvelope,
+    ContextPromptDryRunNoRuntimeMarkers,
+    ContextPromptDryRunRefSummary,
+    ContextPromptDryRunSectionSummary,
+    ContextPromptDryRunStatus,
+    build_context_prompt_dry_run_envelope,
+    compute_context_prompt_dry_run_envelope_digest,
+    dry_run_envelope_contains_no_prompt_text,
+    dry_run_envelope_has_no_runtime_authority,
+    map_handoff_status_to_prompt_dry_run_status,
+    summarize_context_prompt_dry_run_envelope,
+    summarize_handoff_lane_for_prompt_dry_run,
+    summarize_handoff_ref_for_prompt_dry_run,
 )

--- a/sentientos/context_hygiene/prompt_dry_run_envelope.py
+++ b/sentientos/context_hygiene/prompt_dry_run_envelope.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+from typing import Any, Mapping
+
+from sentientos.context_hygiene.prompt_handoff_manifest import (
+    ContextPromptHandoffLaneSummary,
+    ContextPromptHandoffManifest,
+    ContextPromptHandoffRefSummary,
+    ContextPromptHandoffStatus,
+)
+
+
+class ContextPromptDryRunStatus:
+    DRY_RUN_READY = "dry_run_ready"
+    DRY_RUN_READY_WITH_CAVEATS = "dry_run_ready_with_caveats"
+    DRY_RUN_BLOCKED = "dry_run_blocked"
+    DRY_RUN_NOT_APPLICABLE = "dry_run_not_applicable"
+    DRY_RUN_INVALID_MANIFEST = "dry_run_invalid_manifest"
+
+
+@dataclass(frozen=True)
+class ContextPromptDryRunNoRuntimeMarkers:
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+@dataclass(frozen=True)
+class ContextPromptDryRunSectionSummary:
+    section_id: str
+    lane: str
+    ref_type: str
+    admissible_ref_count: int
+    highest_pollution_risk: str
+    provenance_complete: bool
+    source_kinds: tuple[str, ...]
+    caveats: tuple[str, ...]
+    blocked_or_unsafe_count: int
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ContextPromptDryRunRefSummary:
+    ref_id: str
+    ref_type: str
+    lane: str
+    scope_id: str
+    content_summary: str
+    provenance_refs: tuple[str, ...] = field(default_factory=tuple)
+    provenance_status: str = ""
+    pollution_risk: str = ""
+    freshness_status: str = ""
+    contradiction_status: str = ""
+    source_kind: str = ""
+    privacy_posture: str = ""
+    safety_metadata_summary: Mapping[str, Any] = field(default_factory=dict)
+    safety_contract_valid: bool | None = None
+    caveats: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ContextPromptDryRunEnvelope:
+    envelope_id: str
+    manifest_id: str
+    manifest_digest: str
+    packet_id: str
+    packet_scope: str
+    handoff_status: str
+    dry_run_status: str
+    assembly_constraints: Mapping[str, Any]
+    section_summaries: tuple[ContextPromptDryRunSectionSummary, ...]
+    admissible_ref_summaries: tuple[ContextPromptDryRunRefSummary, ...]
+    block_reasons: tuple[str, ...]
+    caveats: tuple[str, ...]
+    source_kind_summary: Mapping[str, int]
+    safety_contract_gap_summary: tuple[str, ...]
+    provenance_summary: str
+    rationale: str
+    no_runtime_markers: ContextPromptDryRunNoRuntimeMarkers = field(default_factory=ContextPromptDryRunNoRuntimeMarkers)
+    digest: str = ""
+
+
+_STATUS_MAP = {
+    ContextPromptHandoffStatus.HANDOFF_READY: ContextPromptDryRunStatus.DRY_RUN_READY,
+    ContextPromptHandoffStatus.HANDOFF_READY_WITH_CAVEATS: ContextPromptDryRunStatus.DRY_RUN_READY_WITH_CAVEATS,
+    ContextPromptHandoffStatus.HANDOFF_BLOCKED: ContextPromptDryRunStatus.DRY_RUN_BLOCKED,
+    ContextPromptHandoffStatus.HANDOFF_NOT_APPLICABLE: ContextPromptDryRunStatus.DRY_RUN_NOT_APPLICABLE,
+    ContextPromptHandoffStatus.HANDOFF_INVALID_PACKET: ContextPromptDryRunStatus.DRY_RUN_INVALID_MANIFEST,
+}
+
+_RUNTIME_MARKER_NAMES = tuple(ContextPromptDryRunNoRuntimeMarkers.__dataclass_fields__.keys())
+_ADMISSIBLE_STATUSES = {
+    ContextPromptDryRunStatus.DRY_RUN_READY,
+    ContextPromptDryRunStatus.DRY_RUN_READY_WITH_CAVEATS,
+}
+_FORBIDDEN_PAYLOAD_KEYS = frozenset({"raw_payload", "prompt_text", "final_prompt_text", "llm_params", "execution_handle"})
+
+
+def map_handoff_status_to_prompt_dry_run_status(handoff_status: str) -> str:
+    return _STATUS_MAP.get(handoff_status, ContextPromptDryRunStatus.DRY_RUN_INVALID_MANIFEST)
+
+
+def _clean_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(k): v for k, v in mapping.items() if str(k) not in _FORBIDDEN_PAYLOAD_KEYS}
+
+
+def summarize_handoff_lane_for_prompt_dry_run(lane: ContextPromptHandoffLaneSummary) -> ContextPromptDryRunSectionSummary:
+    return ContextPromptDryRunSectionSummary(
+        section_id=f"section:{lane.lane}",
+        lane=lane.lane,
+        ref_type=lane.ref_type,
+        admissible_ref_count=lane.count,
+        highest_pollution_risk=lane.highest_pollution_risk,
+        provenance_complete=lane.provenance_complete,
+        source_kinds=lane.source_kinds,
+        caveats=lane.caveats,
+        blocked_or_unsafe_count=lane.blocked_or_unsafe_count,
+        rationale=lane.rationale,
+    )
+
+
+def summarize_handoff_ref_for_prompt_dry_run(ref: ContextPromptHandoffRefSummary) -> ContextPromptDryRunRefSummary:
+    return ContextPromptDryRunRefSummary(
+        ref_id=ref.ref_id,
+        ref_type=ref.ref_type,
+        lane=ref.lane,
+        scope_id=ref.scope_id,
+        content_summary=ref.content_summary,
+        provenance_refs=ref.provenance_refs,
+        provenance_status=ref.provenance_status,
+        pollution_risk=ref.pollution_risk,
+        freshness_status=ref.freshness_status,
+        contradiction_status=ref.contradiction_status,
+        source_kind=ref.source_kind,
+        privacy_posture=ref.privacy_posture,
+        safety_metadata_summary=_clean_mapping(ref.safety_metadata_summary),
+        safety_contract_valid=ref.safety_contract_valid,
+        caveats=ref.caveats,
+    )
+
+
+def _assembly_constraints(manifest: ContextPromptHandoffManifest, dry_run_status: str) -> dict[str, Any]:
+    return {
+        "source_artifact": "phase67_context_prompt_handoff_manifest",
+        "source_manifest_id": manifest.manifest_id,
+        "source_manifest_digest": manifest.digest,
+        "dry_run_status": dry_run_status,
+        "pure": True,
+        "non_authoritative": True,
+        "non_executing": True,
+        "uses_handoff_manifest_only": True,
+        "does_not_assemble_prompt": True,
+        "does_not_contain_final_prompt_text": True,
+        "admissible_refs_available_only_when_ready_or_caveated": True,
+        "blocked_not_applicable_or_invalid_refs_are_withheld": True,
+    }
+
+
+def compute_context_prompt_dry_run_envelope_digest(envelope: ContextPromptDryRunEnvelope) -> str:
+    stable = asdict(envelope)
+    stable.pop("digest", None)
+    payload = json.dumps(stable, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def dry_run_envelope_has_no_runtime_authority(envelope: ContextPromptDryRunEnvelope) -> bool:
+    markers = envelope.no_runtime_markers
+    return all(bool(getattr(markers, name)) for name in _RUNTIME_MARKER_NAMES)
+
+
+def dry_run_envelope_contains_no_prompt_text(envelope: ContextPromptDryRunEnvelope) -> bool:
+    def walk(value: Any) -> bool:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                if str(key) in _FORBIDDEN_PAYLOAD_KEYS:
+                    return False
+                if not walk(child):
+                    return False
+        elif isinstance(value, (tuple, list)):
+            return all(walk(child) for child in value)
+        return True
+
+    return walk(asdict(envelope))
+
+
+def summarize_context_prompt_dry_run_envelope(envelope: ContextPromptDryRunEnvelope) -> dict[str, Any]:
+    return {
+        "envelope_id": envelope.envelope_id,
+        "manifest_id": envelope.manifest_id,
+        "manifest_digest": envelope.manifest_digest,
+        "packet_id": envelope.packet_id,
+        "packet_scope": envelope.packet_scope,
+        "handoff_status": envelope.handoff_status,
+        "dry_run_status": envelope.dry_run_status,
+        "admissible_ref_count": len(envelope.admissible_ref_summaries),
+        "digest": envelope.digest,
+    }
+
+
+def build_context_prompt_dry_run_envelope(manifest: ContextPromptHandoffManifest) -> ContextPromptDryRunEnvelope:
+    dry_run_status = map_handoff_status_to_prompt_dry_run_status(manifest.handoff_status)
+    ref_summaries: tuple[ContextPromptDryRunRefSummary, ...] = ()
+    if dry_run_status in _ADMISSIBLE_STATUSES:
+        ref_summaries = tuple(summarize_handoff_ref_for_prompt_dry_run(ref) for ref in manifest.included_ref_summaries)
+
+    envelope = ContextPromptDryRunEnvelope(
+        envelope_id=f"dry-run:{manifest.manifest_id}",
+        manifest_id=manifest.manifest_id,
+        manifest_digest=manifest.digest,
+        packet_id=manifest.packet_id,
+        packet_scope=manifest.packet_scope,
+        handoff_status=manifest.handoff_status,
+        dry_run_status=dry_run_status,
+        assembly_constraints=_assembly_constraints(manifest, dry_run_status),
+        section_summaries=tuple(summarize_handoff_lane_for_prompt_dry_run(lane) for lane in manifest.lane_summaries),
+        admissible_ref_summaries=ref_summaries,
+        block_reasons=manifest.block_reasons,
+        caveats=manifest.caveats,
+        source_kind_summary=dict(manifest.source_kind_summary),
+        safety_contract_gap_summary=manifest.safety_contract_gap_summary,
+        provenance_summary=manifest.provenance_summary,
+        rationale=manifest.rationale,
+        digest="",
+    )
+    return _replace_envelope(envelope, digest=compute_context_prompt_dry_run_envelope_digest(envelope))
+
+
+def _replace_envelope(envelope: ContextPromptDryRunEnvelope, **changes: Any) -> ContextPromptDryRunEnvelope:
+    data = asdict(envelope)
+    data.update(changes)
+    data["section_summaries"] = tuple(
+        ContextPromptDryRunSectionSummary(**item) if isinstance(item, dict) else item
+        for item in data["section_summaries"]
+    )
+    data["admissible_ref_summaries"] = tuple(
+        ContextPromptDryRunRefSummary(**item) if isinstance(item, dict) else item
+        for item in data["admissible_ref_summaries"]
+    )
+    if isinstance(data.get("no_runtime_markers"), dict):
+        data["no_runtime_markers"] = ContextPromptDryRunNoRuntimeMarkers(**data["no_runtime_markers"])
+    return ContextPromptDryRunEnvelope(**data)

--- a/tests/test_phase68_prompt_assembly_dry_run_envelope.py
+++ b/tests/test_phase68_prompt_assembly_dry_run_envelope.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from sentientos.context_hygiene.context_packet import ContextMode
+from sentientos.context_hygiene.prompt_dry_run_envelope import (
+    ContextPromptDryRunStatus,
+    build_context_prompt_dry_run_envelope,
+    compute_context_prompt_dry_run_envelope_digest,
+    dry_run_envelope_contains_no_prompt_text,
+    dry_run_envelope_has_no_runtime_authority,
+    map_handoff_status_to_prompt_dry_run_status,
+    summarize_context_prompt_dry_run_envelope,
+)
+from sentientos.context_hygiene.prompt_handoff_manifest import (
+    ContextPromptHandoffStatus,
+    build_context_prompt_handoff_manifest,
+)
+from sentientos.context_hygiene.prompt_preflight import (
+    PromptContextEligibility,
+    PromptContextEligibilityStatus,
+    evaluate_context_packet_prompt_eligibility,
+)
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+NOW = datetime.now(timezone.utc)
+
+
+def _cand(ref_id="r", ref_type="evidence", metadata=None, truth_ingress_status="allowed"):
+    return ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        provenance_refs=("p1",),
+        source_locator="src",
+        summary="packet-safe summary",
+        already_sanitized_context_summary=True,
+        truth_ingress_status=truth_ingress_status,
+        metadata=metadata or {},
+    )
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(
+        cands,
+        "turn",
+        "conv",
+        "task",
+        context_mode=ContextMode.RESPONSE,
+        now=NOW,
+    )
+
+
+def _handoff_for_metadata(metadata):
+    return build_context_prompt_handoff_manifest(_pkt([_cand("r", metadata=metadata)]))
+
+
+def test_phase68_status_mapping_is_exact_and_manifest_sourced():
+    assert map_handoff_status_to_prompt_dry_run_status(ContextPromptHandoffStatus.HANDOFF_READY) == ContextPromptDryRunStatus.DRY_RUN_READY
+    assert map_handoff_status_to_prompt_dry_run_status(ContextPromptHandoffStatus.HANDOFF_READY_WITH_CAVEATS) == ContextPromptDryRunStatus.DRY_RUN_READY_WITH_CAVEATS
+    assert map_handoff_status_to_prompt_dry_run_status(ContextPromptHandoffStatus.HANDOFF_BLOCKED) == ContextPromptDryRunStatus.DRY_RUN_BLOCKED
+    assert map_handoff_status_to_prompt_dry_run_status(ContextPromptHandoffStatus.HANDOFF_NOT_APPLICABLE) == ContextPromptDryRunStatus.DRY_RUN_NOT_APPLICABLE
+    assert map_handoff_status_to_prompt_dry_run_status(ContextPromptHandoffStatus.HANDOFF_INVALID_PACKET) == ContextPromptDryRunStatus.DRY_RUN_INVALID_MANIFEST
+
+    manifest = _handoff_for_metadata({"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"})
+    envelope = build_context_prompt_dry_run_envelope(manifest)
+    assert envelope.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_READY
+    assert envelope.manifest_id == manifest.manifest_id
+    assert envelope.manifest_digest == manifest.digest
+    assert envelope.packet_id == manifest.packet_id
+    assert envelope.packet_scope == manifest.packet_scope
+    assert envelope.assembly_constraints["source_artifact"] == "phase67_context_prompt_handoff_manifest"
+    assert envelope.assembly_constraints["uses_handoff_manifest_only"] is True
+    assert envelope.section_summaries
+    assert envelope.admissible_ref_summaries
+
+
+def test_phase68_ready_and_caveated_include_admissible_refs_only_from_manifest():
+    ready_manifest = _handoff_for_metadata({"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"})
+    ready = build_context_prompt_dry_run_envelope(ready_manifest)
+    assert ready.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_READY
+    assert tuple(r.ref_id for r in ready.admissible_ref_summaries) == tuple(r.ref_id for r in ready_manifest.included_ref_summaries)
+    assert ready.source_kind_summary == ready_manifest.source_kind_summary
+    assert ready.provenance_summary == ready_manifest.provenance_summary
+
+    caveated_manifest = _handoff_for_metadata({
+        "source_kind": "embodiment_snapshot",
+        "privacy_posture": "privacy_sensitive",
+        "sanitized_context_summary": True,
+        "allow_context_privacy_sensitive": True,
+        "non_authoritative": True,
+        "decision_power": "none",
+    })
+    caveated = build_context_prompt_dry_run_envelope(caveated_manifest)
+    assert caveated.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_READY_WITH_CAVEATS
+    assert caveated.caveats == caveated_manifest.caveats
+    assert caveated.admissible_ref_summaries
+
+
+def test_phase68_blocked_not_applicable_and_invalid_withhold_admissible_refs_and_preserve_reasons():
+    blocked_manifest = _handoff_for_metadata({"source_kind": "evidence", "pollution_risk": "blocked", "non_authoritative": True, "decision_power": "none"})
+    blocked = build_context_prompt_dry_run_envelope(blocked_manifest)
+    assert blocked.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_BLOCKED
+    assert blocked.admissible_ref_summaries == ()
+    assert blocked.block_reasons == blocked_manifest.block_reasons
+    assert blocked.safety_contract_gap_summary == blocked_manifest.safety_contract_gap_summary
+
+    empty_manifest = build_context_prompt_handoff_manifest(_pkt([]))
+    empty = build_context_prompt_dry_run_envelope(empty_manifest)
+    assert empty.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_NOT_APPLICABLE
+    assert empty.admissible_ref_summaries == ()
+
+    invalid_manifest = build_context_prompt_handoff_manifest(replace(_pkt([_cand("bad", metadata={"source_kind": "evidence", "non_authoritative": True, "decision_power": "none"})]), context_packet_id=""))
+    invalid = build_context_prompt_dry_run_envelope(invalid_manifest)
+    assert invalid.dry_run_status == ContextPromptDryRunStatus.DRY_RUN_INVALID_MANIFEST
+    assert invalid.admissible_ref_summaries == ()
+    assert invalid.block_reasons == invalid_manifest.block_reasons
+
+
+def test_phase68_deterministic_digest_changes_with_manifest_digest_and_caveats():
+    packet = _pkt([_cand("a", metadata={"source_kind": "evidence", "non_authoritative": True, "decision_power": "none"})])
+    manifest = build_context_prompt_handoff_manifest(packet)
+    envelope = build_context_prompt_dry_run_envelope(manifest)
+    assert envelope.digest == compute_context_prompt_dry_run_envelope_digest(replace(envelope, digest=""))
+    assert envelope.digest == build_context_prompt_dry_run_envelope(manifest).digest
+
+    pre = evaluate_context_packet_prompt_eligibility(packet)
+    caveated_pre = PromptContextEligibility(
+        eligibility_status=PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS,
+        prompt_eligible=True,
+        may_be_prompted_only_with_caveats=True,
+        caveats=("operator_review",),
+        packet_id=packet.context_packet_id,
+        included_ref_count=pre.included_ref_count,
+    )
+    caveated_manifest = build_context_prompt_handoff_manifest(packet, caveated_pre)
+    assert build_context_prompt_dry_run_envelope(caveated_manifest).digest != envelope.digest
+
+
+def test_phase68_no_runtime_markers_no_prompt_text_and_import_purity():
+    manifest = _handoff_for_metadata({
+        "source_kind": "evidence",
+        "privacy_posture": "public",
+        "non_authoritative": True,
+        "decision_power": "none",
+        "prompt_text": "must not pass through",
+        "raw_payload": "must not pass through",
+    })
+    envelope = build_context_prompt_dry_run_envelope(manifest)
+    markers = envelope.no_runtime_markers
+    assert markers.does_not_assemble_prompt is True
+    assert markers.does_not_contain_final_prompt_text is True
+    assert markers.does_not_call_llm is True
+    assert markers.does_not_retrieve_memory is True
+    assert markers.does_not_write_memory is True
+    assert markers.does_not_trigger_feedback is True
+    assert markers.does_not_commit_retention is True
+    assert markers.does_not_execute_or_route_work is True
+    assert markers.does_not_admit_work is True
+    assert dry_run_envelope_has_no_runtime_authority(envelope)
+    assert dry_run_envelope_contains_no_prompt_text(envelope)
+    assert summarize_context_prompt_dry_run_envelope(envelope)["manifest_digest"] == manifest.digest
+
+    import sentientos.context_hygiene.prompt_dry_run_envelope as mod
+
+    txt = open(mod.__file__, encoding="utf-8").read()
+    for forbidden in ["prompt_assembler", "memory_manager", "task_executor", "task_admission", "openai", "requests"]:
+        assert forbidden not in txt


### PR DESCRIPTION
### Motivation
- Implement Phase 68: a pure, non-authoritative prompt assembly dry-run envelope that previews prompt-assembly readiness without assembling prompt text or performing any runtime actions. 
- Source the envelope exclusively from the Phase 67 `ContextPromptHandoffManifest` and preserve manifest-safe identifiers, summaries, provenance, safety-gap and rationale metadata.

### Description
- Add `sentientos/context_hygiene/prompt_dry_run_envelope.py` which defines the dry-run dataclasses, status mapping, summarizers, deterministic SHA256 digest, assembly-constraint metadata, admissible-ref inclusion rules, and explicit no-runtime marker booleans. 
- Export the Phase 68 API from `sentientos/context_hygiene/__init__.py` (types and helpers such as `ContextPromptDryRunEnvelope`, `build_context_prompt_dry_run_envelope`, `compute_context_prompt_dry_run_envelope_digest`, `map_handoff_status_to_prompt_dry_run_status`, and related summarizers). 
- Add `tests/test_phase68_prompt_assembly_dry_run_envelope.py` covering status mapping, manifest-sourced fields, ready/caveated admissible-ref inclusion, blocked/not-applicable/invalid withholding (with preservation of block reasons/caveats/safety/provenance), deterministic digest behavior, no-runtime markers, no prompt-text leakage, and import-purity checks. 
- Add docs: `docs/architecture/phase68_prompt_assembly_dry_run_envelope_execplan.md` and update `docs/architecture/context_hygiene_spine.md` to record Phase 68 purpose and non-goals.

### Testing
- Ran `python -m scripts.run_tests -q tests/test_phase68_prompt_assembly_dry_run_envelope.py` and the new Phase 68 test passed. 
- Ran the Phase 61–67 regression set with `python -m scripts.run_tests -q tests/test_phase67_context_prompt_handoff_manifest.py tests/test_phase66_context_source_kind_safety_contracts.py tests/test_phase65_context_safety_metadata_preservation.py tests/test_phase64_context_prompt_preflight.py tests/test_phase63_embodiment_context_eligibility.py tests/test_phase62b_context_risk_contract_alignment.py tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and all tests passed. 
- Ran architecture and import-purity checks with `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and both passed. 
- Verified `git diff --check` and `python -m py_compile sentientos/context_hygiene/prompt_dry_run_envelope.py tests/test_phase68_prompt_assembly_dry_run_envelope.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa5c484c48832096a0b3ea378e4395)