### PR TITLE
[codex:context-hygiene] add prompt assembly adapter contract

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -103,3 +103,9 @@ Key assertions:
 - The verifier does not retrieve or write memory.
 - The verifier does not modify truth, embodiment, action, retention, routing, orchestration, admission, or execution runtime behavior.
 - Blocked, not-applicable, and invalid envelopes admit no candidate refs while preserving diagnostic caveats, constraints, and block posture for review.
+
+### Phase 70: Prompt Assembly Adapter Contract
+
+Phase 70 adds `sentientos.context_hygiene.prompt_adapter_contract` as a dry-wired adapter contract between the Phase 69 constraint verifier and any future prompt assembler. The adapter defines the future prompt-assembler-facing payload shape while remaining non-authoritative and preparation-only.
+
+The adapter does not modify `prompt_assembler.py`, does not assemble prompts, does not contain final prompt text, does not call LLMs, and does not retrieve or write memory. It also does not change truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior. Adapter refs are gated by Phase 69 verification status, and failed, not-applicable, invalid, or blocked material is withheld from adapter refs while warnings and violations remain visible.

--- a/docs/architecture/phase70_prompt_assembly_adapter_contract_execplan.md
+++ b/docs/architecture/phase70_prompt_assembly_adapter_contract_execplan.md
@@ -1,0 +1,94 @@
+# Phase 70 Prompt Assembly Adapter Contract Exec Plan
+
+## Goal
+
+Phase 70 adds a pure Prompt Assembly Adapter Contract that converts a Phase 69 verified `PromptAssemblyCandidatePlan` into a bounded adapter payload shape for a future prompt assembler. The adapter payload is non-authoritative, deterministic, and explicitly dry-wired.
+
+## Non-goals
+
+- No changes to `prompt_assembler.py`.
+- No prompt assembly and no final prompt text.
+- No LLM calls or LLM parameter transport.
+- No memory retrieval or memory writes.
+- No action, retention, feedback, routing, execution, orchestration, or admission behavior.
+- No source rehydration and no raw memory, screen, audio, vision, multimodal, browser, mouse, or keyboard payloads.
+
+## Dependency chain
+
+- Phase 61 created the `ContextPacket` schema and receipts.
+- Phase 62 added truth-gated context selection.
+- Phase 62B made `BLOCKED` first-class and preserved attempted-candidate contamination.
+- Phase 63 added embodiment/privacy context eligibility adapters.
+- Phase 64 added prompt preflight.
+- Phase 65 preserved packet-local safety metadata.
+- Phase 66 added per-source-kind safety contract completeness.
+- Phase 67 added the prompt handoff manifest.
+- Phase 68 added the prompt assembly dry-run envelope.
+- Phase 69 added the prompt assembly constraint verifier.
+- Phase 70 consumes Phase 69 verification plus the verified candidate plan and emits only an adapter contract payload.
+
+## Adapter is not prompt assembly
+
+The adapter contract is a preparation-only schema. It never concatenates summaries into final prompt prose, never emits system/developer/user prompt text, and never grants runtime authority. Its payload is safe input shape only; a future prompt assembler must still enforce its own prompt-generation logic and boundaries.
+
+## Adapter payload is not final prompt text
+
+The payload contains IDs, statuses, bounded summaries, constraints, notes, caveats, violations, warnings, sections, refs, and no-runtime markers. It does not contain `prompt_text`, `final_prompt_text`, `assembled_prompt`, raw payloads, hidden chain-of-thought, execution handles, retrieval handles, action handles, retention handles, or LLM parameters.
+
+## Adapter status mapping
+
+| Phase 69 verifier status | Phase 70 adapter status |
+| --- | --- |
+| `constraint_verified` | `adapter_ready` |
+| `constraint_verified_with_warnings` | `adapter_ready_with_warnings` |
+| `constraint_failed` | `adapter_blocked` |
+| `constraint_not_applicable` | `adapter_not_applicable` |
+| `constraint_invalid_envelope` | `adapter_invalid_verification` |
+| `constraint_invalid_candidate_plan` | `adapter_invalid_candidate_plan` |
+
+## Adapter ref and section rules
+
+Adapter refs are derived only from verified candidate-plan refs and may include ref identity, ref type, lane, content summary, provenance refs, source kind, privacy posture, pollution risk, caveats, and safety summary.
+
+Allowed section kinds are:
+
+- `adapter_context_refs`
+- `adapter_diagnostic_refs`
+- `adapter_evidence_refs`
+- `adapter_embodiment_refs`
+- `adapter_caveat_requirements`
+- `adapter_provenance_boundaries`
+- `adapter_privacy_boundaries`
+- `adapter_truth_boundaries`
+- `adapter_safety_boundaries`
+- `adapter_constraint_summary`
+
+Sections summarize contract boundaries only. They do not assemble prose and do not merge summaries into final prompt text.
+
+## Gating behavior
+
+- `constraint_verified` and `constraint_verified_with_warnings`: include adapter refs.
+- `constraint_failed`: include no adapter refs and preserve violations.
+- `constraint_not_applicable`: include no adapter refs.
+- `constraint_invalid_envelope` and `constraint_invalid_candidate_plan`: include no adapter refs and preserve violations.
+
+Failed, not-applicable, and invalid material is therefore never made to appear usable by the adapter layer.
+
+## Digest rules
+
+The adapter digest is a deterministic SHA-256 over stable adapter-safe fields. It changes when verification status, refs, warnings, violations, caveats, assembly constraints, or notes change. It excludes raw payloads, final prompt text, and runtime handles by construction because those fields are not part of the adapter payload contract.
+
+## Relationship to Phase 69 verifier
+
+Phase 70 does not re-verify source truth or re-run raw selection. It trusts the Phase 69 verification object as the gate and maps that verification into adapter readiness. Convenience builders may construct the Phase 68 envelope, default Phase 69 candidate plan, and Phase 69 verification from an envelope or packet, but they still stop at adapter payload construction.
+
+## Tests
+
+`tests/test_phase70_prompt_assembly_adapter_contract.py` covers status mapping, identity fields, constraints, sections, gated refs, caveats, provenance/privacy/truth/safety notes, warnings, violations, no-prompt/no-raw/no-authority helpers, digest determinism and sensitivity, envelope and packet builders, Phase 63-to-70 flow, Phase 62B blocked safety, input immutability, and import purity.
+
+## Deferred work
+
+- Runtime integration with any prompt assembler remains deferred.
+- Actual prompt text assembly remains deferred.
+- Additional downstream assembler validation remains deferred.
+- UI or operator presentation of adapter payloads remains deferred.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -129,6 +129,25 @@ __all__ = [
     "summarize_prompt_assembly_constraint_verification",
     "verify_prompt_assembly_candidate_plan",
     "verify_prompt_assembly_constraints",
+    "PromptAssemblyAdapterBoundary",
+    "PromptAssemblyAdapterConstraint",
+    "PromptAssemblyAdapterPayload",
+    "PromptAssemblyAdapterRef",
+    "PromptAssemblyAdapterSection",
+    "PromptAssemblyAdapterStatus",
+    "adapter_payload_contains_no_prompt_text",
+    "adapter_payload_contains_no_raw_payloads",
+    "adapter_payload_has_no_runtime_authority",
+    "adapter_payload_is_safe_for_future_prompt_assembler",
+    "build_prompt_assembly_adapter_payload",
+    "build_prompt_assembly_adapter_payload_from_envelope",
+    "build_prompt_assembly_adapter_payload_from_packet",
+    "compute_prompt_adapter_payload_digest",
+    "explain_prompt_adapter_block",
+    "map_prompt_verification_status_to_adapter_status",
+    "summarize_adapter_ref",
+    "summarize_prompt_adapter_payload",
+    "summarize_verified_candidate_plan_for_adapter",
 ]
 
 from sentientos.context_hygiene.selector import (
@@ -244,4 +263,27 @@ from sentientos.context_hygiene.prompt_constraint_verifier import (
     summarize_prompt_assembly_constraint_verification,
     verify_prompt_assembly_candidate_plan,
     verify_prompt_assembly_constraints,
+)
+
+
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterBoundary,
+    PromptAssemblyAdapterConstraint,
+    PromptAssemblyAdapterPayload,
+    PromptAssemblyAdapterRef,
+    PromptAssemblyAdapterSection,
+    PromptAssemblyAdapterStatus,
+    adapter_payload_contains_no_prompt_text,
+    adapter_payload_contains_no_raw_payloads,
+    adapter_payload_has_no_runtime_authority,
+    adapter_payload_is_safe_for_future_prompt_assembler,
+    build_prompt_assembly_adapter_payload,
+    build_prompt_assembly_adapter_payload_from_envelope,
+    build_prompt_assembly_adapter_payload_from_packet,
+    compute_prompt_adapter_payload_digest,
+    explain_prompt_adapter_block,
+    map_prompt_verification_status_to_adapter_status,
+    summarize_adapter_ref,
+    summarize_prompt_adapter_payload,
+    summarize_verified_candidate_plan_for_adapter,
 )

--- a/sentientos/context_hygiene/prompt_adapter_contract.py
+++ b/sentientos/context_hygiene/prompt_adapter_contract.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from sentientos.context_hygiene.context_packet import ContextPacket
+from sentientos.context_hygiene.prompt_constraint_verifier import (
+    PromptAssemblyCandidatePlan,
+    PromptAssemblyCandidateRef,
+    PromptAssemblyConstraintVerification,
+    PromptAssemblyConstraintVerificationStatus,
+    build_candidate_plan_from_dry_run_envelope,
+    verify_prompt_assembly_constraints,
+)
+from sentientos.context_hygiene.prompt_dry_run_envelope import ContextPromptDryRunEnvelope, build_context_prompt_dry_run_envelope
+from sentientos.context_hygiene.prompt_handoff_manifest import build_context_prompt_handoff_manifest
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibility
+
+
+class PromptAssemblyAdapterStatus:
+    ADAPTER_READY = "adapter_ready"
+    ADAPTER_READY_WITH_WARNINGS = "adapter_ready_with_warnings"
+    ADAPTER_BLOCKED = "adapter_blocked"
+    ADAPTER_NOT_APPLICABLE = "adapter_not_applicable"
+    ADAPTER_INVALID_VERIFICATION = "adapter_invalid_verification"
+    ADAPTER_INVALID_CANDIDATE_PLAN = "adapter_invalid_candidate_plan"
+
+
+@dataclass(frozen=True)
+class PromptAssemblyAdapterRef:
+    ref_id: str
+    ref_type: str
+    lane: str
+    content_summary: str
+    provenance_refs: tuple[str, ...] = field(default_factory=tuple)
+    source_kind: str = ""
+    privacy_posture: str = ""
+    pollution_risk: str = ""
+    caveats: tuple[str, ...] = field(default_factory=tuple)
+    safety_summary: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PromptAssemblyAdapterSection:
+    section_id: str
+    section_kind: str
+    ref_ids: tuple[str, ...] = field(default_factory=tuple)
+    summary: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PromptAssemblyAdapterBoundary:
+    non_authoritative: bool = True
+    adapter_contract_only: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+@dataclass(frozen=True)
+class PromptAssemblyAdapterConstraint:
+    name: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class PromptAssemblyAdapterPayload:
+    adapter_payload_id: str
+    candidate_plan_id: str
+    envelope_id: str
+    envelope_digest: str
+    packet_id: str
+    packet_scope: str
+    adapter_status: str
+    verification_status: str
+    verified: bool
+    warnings: tuple[Mapping[str, str], ...]
+    violations: tuple[Mapping[str, str], ...]
+    assembly_constraints: Mapping[str, Any]
+    adapter_sections: tuple[PromptAssemblyAdapterSection, ...]
+    adapter_refs: tuple[PromptAssemblyAdapterRef, ...]
+    preserved_caveats: tuple[str, ...]
+    provenance_notes: Mapping[str, Any]
+    privacy_notes: Mapping[str, Any]
+    truth_notes: Mapping[str, Any]
+    safety_notes: Mapping[str, Any]
+    non_authoritative: bool
+    rationale: str
+    boundary: PromptAssemblyAdapterBoundary = field(default_factory=PromptAssemblyAdapterBoundary)
+    adapter_contract_only: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+    digest: str = ""
+
+
+_STATUS_MAP = {
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED: PromptAssemblyAdapterStatus.ADAPTER_READY,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED_WITH_WARNINGS: PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_FAILED: PromptAssemblyAdapterStatus.ADAPTER_BLOCKED,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_NOT_APPLICABLE: PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_INVALID_ENVELOPE: PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_INVALID_CANDIDATE_PLAN: PromptAssemblyAdapterStatus.ADAPTER_INVALID_CANDIDATE_PLAN,
+}
+_READY_VERIFICATION_STATUSES = {
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED,
+    PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED_WITH_WARNINGS,
+}
+_ALLOWED_SECTION_KINDS = (
+    "adapter_context_refs",
+    "adapter_diagnostic_refs",
+    "adapter_evidence_refs",
+    "adapter_embodiment_refs",
+    "adapter_caveat_requirements",
+    "adapter_provenance_boundaries",
+    "adapter_privacy_boundaries",
+    "adapter_truth_boundaries",
+    "adapter_safety_boundaries",
+    "adapter_constraint_summary",
+)
+_FORBIDDEN_RAW_KEYS = frozenset(
+    {
+        "raw_payload",
+        "raw_memory_payload",
+        "screen_frame",
+        "mic_audio",
+        "audio_payload",
+        "vision_frame",
+        "multimodal_raw_data",
+        "browser_control_data",
+        "mouse_control_data",
+        "keyboard_control_data",
+        "hidden_chain_of_thought",
+        "chain_of_thought",
+    }
+)
+_FORBIDDEN_PROMPT_TEXT_KEYS = frozenset({"prompt_text", "final_prompt_text", "assembled_prompt", "system_prompt", "developer_prompt"})
+_RUNTIME_AUTHORITY_KEYS = frozenset(
+    {
+        "execution_handle",
+        "action_handle",
+        "retention_handle",
+        "retrieval_handle",
+        "memory_write",
+        "can_write_memory",
+        "write_memory",
+        "memory_write_capability",
+        "retention_commit",
+        "can_commit_retention",
+        "commit_retention",
+        "retention_commit_capability",
+        "feedback_trigger",
+        "can_trigger_feedback",
+        "trigger_feedback",
+        "feedback_trigger_capability",
+        "execute_action",
+        "action_execution",
+        "can_execute_action",
+        "action_execution_capability",
+        "route_work",
+        "admit_work",
+        "execute_work",
+        "can_route",
+        "can_admit",
+        "can_execute",
+        "llm_params",
+        "llm_parameters",
+    }
+)
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return is_dataclass(value) and not isinstance(value, type)
+
+
+def _stable(value: Any) -> Any:
+    if _is_dataclass_instance(value):
+        return {k: _stable(v) for k, v in asdict(value).items()}
+    if isinstance(value, Mapping):
+        return {str(k): _stable(v) for k, v in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, (tuple, list)):
+        return [_stable(v) for v in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_stable(v) for v in value)
+    return value
+
+
+def _walk(value: Any) -> Sequence[tuple[str, Any]]:
+    found: list[tuple[str, Any]] = []
+
+    def rec(child: Any) -> None:
+        if _is_dataclass_instance(child):
+            rec(asdict(child))
+        elif isinstance(child, Mapping):
+            for key, nested in child.items():
+                found.append((str(key), nested))
+                rec(nested)
+        elif isinstance(child, (tuple, list, set, frozenset)):
+            for nested in child:
+                rec(nested)
+
+    rec(value)
+    return tuple(found)
+
+
+def _issue_dict(issue: Any) -> Mapping[str, str]:
+    return {"code": str(issue.code), "detail": str(issue.detail), "ref_id": str(issue.ref_id)}
+
+
+def _candidate_refs(candidate_plan: PromptAssemblyCandidatePlan | Mapping[str, Any]) -> tuple[Any, ...]:
+    refs = candidate_plan.candidate_refs if isinstance(candidate_plan, PromptAssemblyCandidatePlan) else candidate_plan.get("candidate_refs", ())
+    return tuple(refs) if isinstance(refs, (tuple, list)) else ()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if _is_dataclass_instance(value):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def map_prompt_verification_status_to_adapter_status(status: str) -> str:
+    return _STATUS_MAP.get(status, PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION)
+
+
+def summarize_adapter_ref(ref: PromptAssemblyCandidateRef | Mapping[str, Any]) -> PromptAssemblyAdapterRef:
+    data = _mapping(ref)
+    safety_summary = data.get("safety_summary", {})
+    return PromptAssemblyAdapterRef(
+        ref_id=str(data.get("ref_id", "")),
+        ref_type=str(data.get("ref_type", "")),
+        lane=str(data.get("lane", "")),
+        content_summary=str(data.get("content_summary", "")),
+        provenance_refs=tuple(str(v) for v in data.get("provenance_refs", ())),
+        source_kind=str(data.get("source_kind", "")),
+        privacy_posture=str(data.get("privacy_posture", "")),
+        pollution_risk=str(data.get("pollution_risk", "")),
+        caveats=tuple(str(v) for v in data.get("caveats", ())),
+        safety_summary=dict(safety_summary) if isinstance(safety_summary, Mapping) else {},
+    )
+
+
+def _adapter_refs_allowed(verification: PromptAssemblyConstraintVerification) -> bool:
+    return verification.status in _READY_VERIFICATION_STATUSES
+
+
+def _section(section_kind: str, ref_ids: tuple[str, ...] = (), **summary: Any) -> PromptAssemblyAdapterSection:
+    return PromptAssemblyAdapterSection(section_id=f"section:{section_kind}", section_kind=section_kind, ref_ids=ref_ids, summary=summary)
+
+
+def _build_sections(candidate_plan: PromptAssemblyCandidatePlan | Mapping[str, Any], adapter_refs: tuple[PromptAssemblyAdapterRef, ...]) -> tuple[PromptAssemblyAdapterSection, ...]:
+    plan = _mapping(candidate_plan)
+    ref_ids = tuple(ref.ref_id for ref in adapter_refs)
+    sections: list[PromptAssemblyAdapterSection] = [
+        _section("adapter_context_refs", ref_ids, ref_count=len(adapter_refs)),
+        _section("adapter_diagnostic_refs", (), diagnostic_markers=plan.get("diagnostic_markers", {})),
+        _section("adapter_evidence_refs", tuple(ref.ref_id for ref in adapter_refs if ref.lane == "evidence" or ref.ref_type == "evidence")),
+        _section("adapter_embodiment_refs", tuple(ref.ref_id for ref in adapter_refs if ref.lane == "embodiment" or ref.ref_type == "embodiment")),
+        _section("adapter_caveat_requirements", (), preserved_caveats=tuple(plan.get("preserved_caveats", ()))),
+        _section("adapter_provenance_boundaries", ref_ids, provenance_notes=plan.get("provenance_notes", {})),
+        _section("adapter_privacy_boundaries", ref_ids, privacy_notes=plan.get("privacy_notes", {})),
+        _section("adapter_truth_boundaries", ref_ids, truth_notes=plan.get("truth_notes", {})),
+        _section("adapter_safety_boundaries", ref_ids, safety_notes=plan.get("safety_notes", {})),
+        _section("adapter_constraint_summary", (), assembly_constraints=plan.get("preserved_constraints", {})),
+    ]
+    return tuple(s for s in sections if s.section_kind in _ALLOWED_SECTION_KINDS)
+
+
+def summarize_verified_candidate_plan_for_adapter(
+    verification: PromptAssemblyConstraintVerification,
+    candidate_plan: PromptAssemblyCandidatePlan | Mapping[str, Any],
+) -> dict[str, Any]:
+    refs = tuple(summarize_adapter_ref(ref) for ref in _candidate_refs(candidate_plan)) if _adapter_refs_allowed(verification) else ()
+    plan = _mapping(candidate_plan)
+    return {
+        "plan_id": str(plan.get("plan_id", "")),
+        "envelope_id": str(plan.get("envelope_id", "")),
+        "packet_id": str(plan.get("packet_id", "")),
+        "adapter_ref_count": len(refs),
+        "adapter_status": map_prompt_verification_status_to_adapter_status(verification.status),
+        "verification_status": verification.status,
+    }
+
+
+def compute_prompt_adapter_payload_digest(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> str:
+    stable = _stable(payload)
+    if isinstance(stable, dict):
+        stable.pop("digest", None)
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _with_digest(payload: PromptAssemblyAdapterPayload) -> PromptAssemblyAdapterPayload:
+    data = asdict(payload)
+    data["digest"] = compute_prompt_adapter_payload_digest(payload)
+    data["adapter_sections"] = tuple(PromptAssemblyAdapterSection(**item) for item in data["adapter_sections"])
+    data["adapter_refs"] = tuple(PromptAssemblyAdapterRef(**item) for item in data["adapter_refs"])
+    data["boundary"] = PromptAssemblyAdapterBoundary(**data["boundary"])
+    return PromptAssemblyAdapterPayload(**data)
+
+
+def build_prompt_assembly_adapter_payload(
+    verification: PromptAssemblyConstraintVerification,
+    candidate_plan: PromptAssemblyCandidatePlan | Mapping[str, Any],
+) -> PromptAssemblyAdapterPayload:
+    plan = _mapping(candidate_plan)
+    adapter_status = map_prompt_verification_status_to_adapter_status(verification.status)
+    adapter_refs = tuple(summarize_adapter_ref(ref) for ref in _candidate_refs(candidate_plan)) if _adapter_refs_allowed(verification) else ()
+    payload = PromptAssemblyAdapterPayload(
+        adapter_payload_id=f"adapter-payload:{verification.plan_id or plan.get('plan_id', '')}",
+        candidate_plan_id=str(plan.get("plan_id", verification.plan_id)),
+        envelope_id=str(plan.get("envelope_id", verification.envelope_id)),
+        envelope_digest=str(plan.get("envelope_digest", "")),
+        packet_id=str(plan.get("packet_id", "")),
+        packet_scope=str(plan.get("packet_scope", "")),
+        adapter_status=adapter_status,
+        verification_status=verification.status,
+        verified=verification.status in _READY_VERIFICATION_STATUSES,
+        warnings=tuple(_issue_dict(w) for w in verification.warnings),
+        violations=tuple(_issue_dict(v) for v in verification.violations),
+        assembly_constraints=dict(plan.get("preserved_constraints", {})),
+        adapter_sections=(),
+        adapter_refs=adapter_refs,
+        preserved_caveats=tuple(plan.get("preserved_caveats", ())),
+        provenance_notes=dict(plan.get("provenance_notes", {})),
+        privacy_notes=dict(plan.get("privacy_notes", {})),
+        truth_notes=dict(plan.get("truth_notes", {})),
+        safety_notes=dict(plan.get("safety_notes", {})),
+        non_authoritative=bool(plan.get("non_authoritative", False)),
+        rationale=verification.rationale or adapter_status,
+    )
+    payload = _with_digest(
+        PromptAssemblyAdapterPayload(
+            **{**asdict(payload), "adapter_sections": _build_sections(candidate_plan, adapter_refs), "boundary": payload.boundary, "adapter_refs": adapter_refs}
+        )
+    )
+    return payload
+
+
+def build_prompt_assembly_adapter_payload_from_envelope(envelope: ContextPromptDryRunEnvelope) -> PromptAssemblyAdapterPayload:
+    candidate_plan = build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, candidate_plan)
+    return build_prompt_assembly_adapter_payload(verification, candidate_plan)
+
+
+def build_prompt_assembly_adapter_payload_from_packet(packet: ContextPacket, preflight: PromptContextEligibility | None = None) -> PromptAssemblyAdapterPayload:
+    manifest = build_context_prompt_handoff_manifest(packet, preflight)
+    envelope = build_context_prompt_dry_run_envelope(manifest)
+    return build_prompt_assembly_adapter_payload_from_envelope(envelope)
+
+
+def adapter_payload_contains_no_prompt_text(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    return not any(key in _FORBIDDEN_PROMPT_TEXT_KEYS for key, _ in _walk(payload))
+
+
+def adapter_payload_contains_no_raw_payloads(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    return not any(key in _FORBIDDEN_RAW_KEYS for key, _ in _walk(payload))
+
+
+def adapter_payload_has_no_runtime_authority(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    markers = _mapping(payload)
+    marker_names = tuple(PromptAssemblyAdapterBoundary.__dataclass_fields__.keys())
+    if any(markers.get(name) is not True for name in marker_names if name != "non_authoritative"):
+        return False
+    return not any(key in _RUNTIME_AUTHORITY_KEYS and bool(value) for key, value in _walk(payload))
+
+
+def adapter_payload_is_safe_for_future_prompt_assembler(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    return (
+        adapter_payload_contains_no_prompt_text(payload)
+        and adapter_payload_contains_no_raw_payloads(payload)
+        and adapter_payload_has_no_runtime_authority(payload)
+        and bool(_mapping(payload).get("adapter_contract_only", False))
+    )
+
+
+def explain_prompt_adapter_block(payload: PromptAssemblyAdapterPayload) -> tuple[str, ...]:
+    if payload.violations:
+        return tuple(f"{v['code']}:{v['ref_id']}:{v['detail']}" if v.get("ref_id") else f"{v['code']}:{v['detail']}" for v in payload.violations)
+    if payload.adapter_status not in {PromptAssemblyAdapterStatus.ADAPTER_READY, PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS}:
+        return (payload.adapter_status,)
+    return ()
+
+
+def summarize_prompt_adapter_payload(payload: PromptAssemblyAdapterPayload) -> dict[str, Any]:
+    return {
+        "adapter_payload_id": payload.adapter_payload_id,
+        "candidate_plan_id": payload.candidate_plan_id,
+        "envelope_id": payload.envelope_id,
+        "packet_id": payload.packet_id,
+        "adapter_status": payload.adapter_status,
+        "verification_status": payload.verification_status,
+        "adapter_ref_count": len(payload.adapter_refs),
+        "warning_count": len(payload.warnings),
+        "violation_count": len(payload.violations),
+        "digest": payload.digest,
+    }

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -559,7 +559,8 @@
       "no_llm_calls": true,
       "no_hardware_calls": true,
       "no_retention_side_effects": true,
-      "no_embodiment_runtime_effects": true
+      "no_embodiment_runtime_effects": true,
+      "adapter_contract_only": true
     }
   },
   "protected_sinks": {

--- a/tests/test_phase70_prompt_assembly_adapter_contract.py
+++ b/tests/test_phase70_prompt_assembly_adapter_contract.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sentientos.context_hygiene.context_packet import ContextMode
+from sentientos.context_hygiene.embodiment_context import build_embodiment_context_candidates
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterStatus,
+    adapter_payload_contains_no_prompt_text,
+    adapter_payload_contains_no_raw_payloads,
+    adapter_payload_has_no_runtime_authority,
+    adapter_payload_is_safe_for_future_prompt_assembler,
+    build_prompt_assembly_adapter_payload,
+    build_prompt_assembly_adapter_payload_from_envelope,
+    build_prompt_assembly_adapter_payload_from_packet,
+    compute_prompt_adapter_payload_digest,
+    explain_prompt_adapter_block,
+    map_prompt_verification_status_to_adapter_status,
+    summarize_prompt_adapter_payload,
+    summarize_verified_candidate_plan_for_adapter,
+)
+from sentientos.context_hygiene.prompt_constraint_verifier import (
+    PromptAssemblyCandidateRef,
+    PromptAssemblyConstraintVerificationStatus,
+    build_candidate_plan_from_dry_run_envelope,
+    verify_prompt_assembly_constraints,
+)
+from sentientos.context_hygiene.prompt_dry_run_envelope import build_context_prompt_dry_run_envelope
+from sentientos.context_hygiene.prompt_handoff_manifest import build_context_prompt_handoff_manifest
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibility, PromptContextEligibilityStatus, evaluate_context_packet_prompt_eligibility
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+NOW = datetime.now(timezone.utc)
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cand(ref_id="r", ref_type="evidence", metadata=None, truth_ingress_status="allowed", contradiction_status="unknown"):
+    return ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        provenance_refs=("prov:1",),
+        source_locator="src",
+        summary="packet-safe summary",
+        already_sanitized_context_summary=True,
+        truth_ingress_status=truth_ingress_status,
+        contradiction_status=contradiction_status,
+        metadata=metadata or {"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"},
+    )
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(cands, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+
+
+def _envelope_for(cands):
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt(cands)))
+
+
+def _ready_envelope():
+    return _envelope_for([_cand("ready")])
+
+
+def _caveated_envelope():
+    packet = _pkt([_cand("caveat")])
+    pre = evaluate_context_packet_prompt_eligibility(packet)
+    caveated = PromptContextEligibility(
+        eligibility_status=PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS,
+        prompt_eligible=True,
+        may_be_prompted_only_with_caveats=True,
+        caveats=("truth_caveat: operator review",),
+        packet_id=packet.context_packet_id,
+        included_ref_count=pre.included_ref_count,
+    )
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(packet, caveated))
+
+
+def _blocked_envelope():
+    return _envelope_for([_cand("blocked", metadata={"source_kind": "evidence", "pollution_risk": "blocked", "non_authoritative": True, "decision_power": "none"})])
+
+
+def _not_applicable_envelope():
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt([])))
+
+
+def _invalid_envelope():
+    packet = replace(_pkt([_cand("bad")]), context_packet_id="")
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(packet))
+
+
+def _payload(envelope=None, plan=None):
+    envelope = envelope or _ready_envelope()
+    plan = plan or build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, plan)
+    return build_prompt_assembly_adapter_payload(verification, plan), verification, plan
+
+
+def test_verified_candidate_plan_produces_adapter_ready_and_identity_fields():
+    envelope = _ready_envelope()
+    payload, verification, plan = _payload(envelope)
+    assert verification.status == PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_READY
+    assert payload.verified is True
+    assert payload.candidate_plan_id == plan.plan_id
+    assert payload.envelope_id == envelope.envelope_id
+    assert payload.envelope_digest == envelope.digest
+    assert payload.packet_id == envelope.packet_id
+    assert payload.packet_scope == envelope.packet_scope
+    assert summarize_verified_candidate_plan_for_adapter(verification, plan)["adapter_ref_count"] == 1
+
+
+def test_verified_with_warnings_maps_to_adapter_ready_with_warnings_and_preserves_warnings():
+    payload, verification, _ = _payload(_caveated_envelope())
+    assert verification.status == PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED_WITH_WARNINGS
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS
+    assert payload.warnings
+    assert payload.warnings[0]["code"] == "caveated_dry_run_envelope"
+
+
+def test_constraint_failed_maps_to_blocked_preserves_violations_and_withholds_refs():
+    envelope = _ready_envelope()
+    plan = replace(build_candidate_plan_from_dry_run_envelope(envelope), packet_id="wrong")
+    payload, verification, _ = _payload(envelope, plan)
+    assert verification.status == PromptAssemblyConstraintVerificationStatus.CONSTRAINT_FAILED
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_BLOCKED
+    assert payload.adapter_refs == ()
+    assert payload.violations[0]["code"] == "packet_identity_mismatch"
+    assert explain_prompt_adapter_block(payload)
+
+
+def test_not_applicable_invalid_envelope_and_invalid_candidate_plan_withhold_refs():
+    cases = [
+        (_not_applicable_envelope(), PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE, PromptAssemblyConstraintVerificationStatus.CONSTRAINT_NOT_APPLICABLE),
+        (_invalid_envelope(), PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION, PromptAssemblyConstraintVerificationStatus.CONSTRAINT_INVALID_ENVELOPE),
+    ]
+    for envelope, adapter_status, verifier_status in cases:
+        payload, verification, _ = _payload(envelope)
+        assert verification.status == verifier_status
+        assert payload.adapter_status == adapter_status
+        assert payload.adapter_refs == ()
+
+    envelope = _ready_envelope()
+    malformed = {"plan_id": "bad", "candidate_refs": "not refs"}
+    verification = verify_prompt_assembly_constraints(envelope, malformed)
+    payload = build_prompt_assembly_adapter_payload(verification, malformed)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_INVALID_CANDIDATE_PLAN
+    assert payload.adapter_refs == ()
+    assert payload.violations[0]["code"] == "invalid_candidate_plan"
+
+
+def test_blocked_envelope_is_not_applicable_safe_and_has_no_refs():
+    payload, verification, plan = _payload(_blocked_envelope())
+    assert plan.candidate_refs == ()
+    assert verification.status == PromptAssemblyConstraintVerificationStatus.CONSTRAINT_NOT_APPLICABLE
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE
+    assert payload.adapter_refs == ()
+
+
+def test_payload_includes_constraints_sections_refs_caveats_and_notes_when_allowed():
+    envelope = _caveated_envelope()
+    payload, _, plan = _payload(envelope)
+    assert payload.assembly_constraints == plan.preserved_constraints
+    assert payload.adapter_sections
+    assert {s.section_kind for s in payload.adapter_sections} >= {
+        "adapter_context_refs",
+        "adapter_caveat_requirements",
+        "adapter_provenance_boundaries",
+        "adapter_privacy_boundaries",
+        "adapter_truth_boundaries",
+        "adapter_safety_boundaries",
+        "adapter_constraint_summary",
+    }
+    assert payload.adapter_refs
+    assert payload.preserved_caveats == plan.preserved_caveats
+    assert payload.provenance_notes == plan.provenance_notes
+    assert payload.privacy_notes == plan.privacy_notes
+    assert payload.truth_notes == plan.truth_notes
+    assert payload.safety_notes == plan.safety_notes
+
+
+def test_payload_contains_no_final_prompt_text_raw_payloads_or_runtime_authority():
+    payload, _, _ = _payload()
+    assert payload.adapter_contract_only is True
+    assert payload.does_not_assemble_prompt is True
+    assert payload.does_not_contain_final_prompt_text is True
+    assert payload.does_not_call_llm is True
+    assert payload.does_not_retrieve_memory is True
+    assert payload.does_not_write_memory is True
+    assert payload.does_not_trigger_feedback is True
+    assert payload.does_not_commit_retention is True
+    assert payload.does_not_execute_or_route_work is True
+    assert payload.does_not_admit_work is True
+    assert adapter_payload_contains_no_prompt_text(payload)
+    assert adapter_payload_contains_no_raw_payloads(payload)
+    assert adapter_payload_has_no_runtime_authority(payload)
+    assert adapter_payload_is_safe_for_future_prompt_assembler(payload)
+
+
+def test_digest_is_deterministic_and_changes_with_refs_status_and_warnings_or_violations():
+    envelope = _ready_envelope()
+    payload, verification, plan = _payload(envelope)
+    assert payload.digest == compute_prompt_adapter_payload_digest(replace(payload, digest=""))
+    assert payload.digest == _payload(envelope)[0].digest
+
+    changed_ref = replace(plan.candidate_refs[0], content_summary="different adapter-safe summary")
+    changed_plan = replace(plan, candidate_refs=(changed_ref,))
+    changed_verification = verify_prompt_assembly_constraints(envelope, changed_plan)
+    assert build_prompt_assembly_adapter_payload(changed_verification, changed_plan).digest != payload.digest
+
+    failed_payload, _, _ = _payload(envelope, replace(plan, packet_id="wrong"))
+    assert failed_payload.digest != payload.digest
+
+    caveated_payload, _, _ = _payload(_caveated_envelope())
+    assert caveated_payload.digest != payload.digest
+
+
+def test_build_from_envelope_and_packet_paths_work():
+    envelope = _ready_envelope()
+    from_envelope = build_prompt_assembly_adapter_payload_from_envelope(envelope)
+    assert from_envelope.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_READY
+
+    packet = _pkt([_cand("packet-path")])
+    from_packet = build_prompt_assembly_adapter_payload_from_packet(packet)
+    assert from_packet.packet_id == packet.context_packet_id
+    assert from_packet.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_READY
+
+
+def test_phase63_to_phase70_pipeline_works_for_sanitized_embodiment_proposal():
+    proposals = build_embodiment_context_candidates(
+        [
+            {
+                "ref_id": "emb:1",
+                "source_kind": "embodiment_snapshot",
+                "packet_scope": "turn",
+                "conversation_scope_id": "conv",
+                "task_scope_id": "task",
+                "content_summary": "sanitized posture summary",
+                "sanitized_context_summary": True,
+                "privacy_posture": "low_risk",
+                "provenance_refs": ("sensor:summary",),
+                "non_authoritative": True,
+                "decision_power": "none",
+            }
+        ]
+    )
+    packet = build_context_packet_from_candidates(proposals, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+    payload = build_prompt_assembly_adapter_payload_from_packet(packet)
+    assert payload.adapter_status in {PromptAssemblyAdapterStatus.ADAPTER_READY, PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS}
+    assert payload.adapter_refs
+    assert payload.adapter_refs[0].source_kind == "embodiment_snapshot"
+
+
+def test_helpers_do_not_mutate_verification_or_candidate_plan():
+    envelope = _ready_envelope()
+    plan = build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, plan)
+    before_plan = deepcopy(asdict(plan))
+    before_verification = deepcopy(asdict(verification))
+    build_prompt_assembly_adapter_payload(verification, plan)
+    assert asdict(plan) == before_plan
+    assert asdict(verification) == before_verification
+
+
+def test_status_mapping_and_summary_are_compact():
+    assert map_prompt_verification_status_to_adapter_status(PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED) == PromptAssemblyAdapterStatus.ADAPTER_READY
+    assert map_prompt_verification_status_to_adapter_status(PromptAssemblyConstraintVerificationStatus.CONSTRAINT_VERIFIED_WITH_WARNINGS) == PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS
+    assert map_prompt_verification_status_to_adapter_status(PromptAssemblyConstraintVerificationStatus.CONSTRAINT_FAILED) == PromptAssemblyAdapterStatus.ADAPTER_BLOCKED
+    payload, _, _ = _payload()
+    summary = summarize_prompt_adapter_payload(payload)
+    assert summary["adapter_status"] == PromptAssemblyAdapterStatus.ADAPTER_READY
+    assert summary["adapter_ref_count"] == 1
+
+
+def test_adapter_module_imports_remain_pure():
+    path = ROOT / "sentientos/context_hygiene/prompt_adapter_contract.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.append(node.module or "")
+    forbidden = (
+        "prompt_assembler",
+        "memory_manager",
+        "task_admission",
+        "task_executor",
+        "retention",
+        "openai",
+        "requests",
+        "hardware",
+        "webbrowser",
+    )
+    for imp in imports:
+        assert not any(token in imp for token in forbidden), imp


### PR DESCRIPTION
### Motivation

- Provide Phase 70 dry-wired adapter contract that maps a Phase 69 `PromptAssemblyConstraintVerification` + `PromptAssemblyCandidatePlan` into a non-authoritative, prompt-assembler-facing payload shape without performing any prompt assembly or runtime actions. 
- Capture a deterministic, bounded, audit-safe input contract (IDs, constraints, notes, caveats, warnings, violations, sections, refs) that explicitly forbids final prompt text, raw payloads, runtime authority, LLM calls, memory I/O, action/retention/execution, or routing behaviors. 
- Make adapter refs gated by the Phase 69 verifier so failed/invalid/not-applicable material is withheld while preserving diagnostics for review. 

### Description

- Added `sentientos/context_hygiene/prompt_adapter_contract.py` implementing frozen dataclasses (`PromptAssemblyAdapterPayload`, `PromptAssemblyAdapterRef`, `PromptAssemblyAdapterSection`, `PromptAssemblyAdapterBoundary`, `PromptAssemblyAdapterConstraint`), status mapping, gated-ref summarization, section builders, deterministic digest computation, and safety predicates. 
- Implemented builders `build_prompt_assembly_adapter_payload`, `build_prompt_assembly_adapter_payload_from_envelope`, and `build_prompt_assembly_adapter_payload_from_packet` that stop at adapter construction and do not call the prompt assembler or any runtime modules. 
- Exported the adapter API from `sentientos.context_hygiene` and added docs `docs/architecture/phase70_prompt_assembly_adapter_contract_execplan.md` and a spine note to `docs/architecture/context_hygiene_spine.md`; added `adapter_contract_only` flag to the architecture manifest. 
- Added unit tests `tests/test_phase70_prompt_assembly_adapter_contract.py` covering status mappings, gating, identity fields, constraints/sections/refs, caveats/notes, warnings/violations, absence of prompt/raw/runtime authority, deterministic digest behavior, envelope/packet builders and Phase 63-to-70 flow, immutability, and import-purity. 

### Testing

- Ran the new Phase 70 test file: `python -m scripts.run_tests -q tests/test_phase70_prompt_assembly_adapter_contract.py`; initial run revealed a test shape mismatch which was corrected and the final run passed (`all tests in file: PASS`).
- Ran Phase 61–69 integration suite: `python -m scripts.run_tests -q tests/test_phase69_prompt_assembly_constraint_verifier.py tests/test_phase68_prompt_assembly_dry_run_envelope.py tests/test_phase67_context_prompt_handoff_manifest.py tests/test_phase66_context_source_kind_safety_contracts.py tests/test_phase65_context_safety_metadata_preservation.py tests/test_phase64_context_prompt_preflight.py tests/test_phase63_embodiment_context_eligibility.py tests/test_phase62b_context_risk_contract_alignment.py tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and the suite passed (all tests: PASS).
- Ran architecture and import-purity checks: `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and both passed (all tests: PASS).
- All automated test runs in this rollout completed successfully after a single test adjustment; no runtime or integration behavior was modified or executed by the adapter code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa6a435cbc8320939b5064abd5563b)