### PR TITLE
[codex:context-hygiene] add prompt assembler compliance harness

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -109,3 +109,11 @@ Key assertions:
 Phase 70 adds `sentientos.context_hygiene.prompt_adapter_contract` as a dry-wired adapter contract between the Phase 69 constraint verifier and any future prompt assembler. The adapter defines the future prompt-assembler-facing payload shape while remaining non-authoritative and preparation-only.
 
 The adapter does not modify `prompt_assembler.py`, does not assemble prompts, does not contain final prompt text, does not call LLMs, and does not retrieve or write memory. It also does not change truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior. Adapter refs are gated by Phase 69 verification status, and failed, not-applicable, invalid, or blocked material is withheld from adapter refs while warnings and violations remain visible.
+
+### Phase 71: Prompt Assembler Compliance Harness
+
+Phase 71 adds `sentientos.context_hygiene.prompt_assembler_compliance` as a pure compliance harness for future prompt assembler integration requirements. It evaluates Phase 70 adapter payload readiness, records gaps/warnings/non-runtime markers, and statically scans `prompt_assembler.py` using source text/AST inspection only.
+
+The compliance harness defines future prompt assembler rules: adapter payloads must be verified before use, only adapter refs may be consumed, failed/blocked/invalid/not-applicable payloads must not produce prompt material, and caveat/provenance/privacy/truth/safety boundaries must remain visible.
+
+Phase 71 does not modify `prompt_assembler.py`, does not wire adapter payloads into it, does not assemble prompts, does not call LLMs, does not retrieve or write memory, and does not modify embodiment, action, retention, truth, routing, admission, execution, or orchestration runtime behavior.

--- a/docs/architecture/phase71_prompt_assembler_compliance_harness_execplan.md
+++ b/docs/architecture/phase71_prompt_assembler_compliance_harness_execplan.md
@@ -1,0 +1,89 @@
+# Phase 71 Prompt Assembler Compliance Harness Exec Plan
+
+## Goal
+
+Add a pure compliance harness that defines and tests the prompt-assembler-side rules a future context hygiene integration must satisfy before any prompt assembler wiring is introduced.
+
+## Non-goals
+
+- Do not modify `prompt_assembler.py`.
+- Do not wire Phase 70 adapter payloads into `prompt_assembler.py`.
+- Do not assemble prompts from context hygiene packets, manifests, envelopes, candidate plans, or adapter payloads.
+- Do not call an LLM, web client, provider SDK, retrieval path, or memory path.
+- Do not retrieve memory or write memory.
+- Do not modify truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior.
+
+## Dependency chain
+
+- Phase 61 created `ContextPacket` schema and receipts.
+- Phase 62 added truth-gated context selection.
+- Phase 62B made `blocked` first-class and preserved attempted-candidate contamination.
+- Phase 63 added embodiment/privacy context eligibility adapters.
+- Phase 64 added prompt preflight.
+- Phase 65 preserved packet-local safety metadata.
+- Phase 66 added per-source-kind safety contract completeness.
+- Phase 67 added a prompt handoff manifest.
+- Phase 68 added a prompt assembly dry-run envelope.
+- Phase 69 added a prompt assembly constraint verifier.
+- Phase 70 added a prompt assembly adapter contract.
+- Phase 71 adds a compliance harness for future prompt assembler integration requirements only.
+
+## Compliance harness is not prompt assembly
+
+The harness evaluates `PromptAssemblyAdapterPayload` contract readiness and statically scans `prompt_assembler.py` source text for context hygiene wiring or bypass patterns. It emits compliance reports and future integration rules. It does not produce prompt text, does not call a model, and does not grant runtime authority.
+
+## Adapter compliance rules
+
+Future prompt assembler consumption is allowed only when all blocking rules pass:
+
+1. Adapter status is `adapter_ready` or `adapter_ready_with_warnings`.
+2. `adapter_blocked`, `adapter_not_applicable`, `adapter_invalid_verification`, and `adapter_invalid_candidate_plan` block prompt materialization.
+3. No final prompt text is present.
+4. No raw payloads are present.
+5. No runtime authority is present.
+6. `non_authoritative` posture is preserved.
+7. Caveat fields are preserved or reported as warnings when absent.
+8. Provenance notes are preserved or reported as warnings when absent.
+9. Privacy notes are preserved or reported as warnings when absent.
+10. Truth notes are preserved or reported as warnings when absent.
+11. Safety notes are preserved or reported as warnings when absent.
+12. Adapter refs are present only when status allows consumption.
+13. Adapter refs are absent when status blocks consumption.
+14. No-runtime guards cover LLM calls, memory retrieval/write, execution/routing/admission, retention commit, and feedback triggers.
+15. Digest is present.
+16. Packet, envelope, and candidate identifiers are present.
+
+## Static prompt assembler scan behavior
+
+The scan is source-text/AST-only. It does not import or execute `prompt_assembler.py`. It reports whether the current prompt assembler source imports context hygiene adapter modules, imports `prompt_adapter_contract`, uses `ContextPacket`, calls selector/preflight/manifest/envelope/verifier/adapter helpers, bypasses the adapter contract by reading context hygiene internals, retrieves memory for context hygiene purposes, calls LLM/provider APIs for context hygiene purposes, or contains Phase 70 adapter payload usage.
+
+Pre-integration absence of context hygiene wiring is expected and is not a failure. Forbidden context bypass or unexpected active wiring is reportable.
+
+## Future integration contract
+
+A future prompt assembler integration must:
+
+- accept only `PromptAssemblyAdapterPayload`;
+- reject adapter statuses other than `adapter_ready` and `adapter_ready_with_warnings`;
+- consume only `adapter_refs`;
+- preserve caveats/provenance/privacy/truth/safety notes;
+- never include raw payloads;
+- never treat adapter payload as authoritative;
+- not retrieve bypass context;
+- not bypass the Phase 69 verifier;
+- not bypass the Phase 68 envelope;
+- not bypass the Phase 64 preflight;
+- not bypass the Phase 62 selector;
+- not make blocked refs prompt-visible;
+- emit or record a compliance outcome before materialization in a future phase.
+
+## Tests
+
+`tests/test_phase71_prompt_assembler_compliance_harness.py` covers ready, warned, blocked, not-applicable, invalid-verification, and invalid-candidate-plan adapter statuses; prompt text/raw payload/runtime authority failures; boundary-note warnings; adapter ref status alignment; digest and identity requirements; static prompt assembler scanning; non-runtime report markers; import purity; Phase 63-to-71 pass-through; and Phase 62B blocked candidate materialization blocking.
+
+## Deferred work
+
+- Actual `prompt_assembler.py` integration remains deferred.
+- Prompt materialization from adapter refs remains deferred.
+- Compliance outcome persistence, if desired, remains deferred to the future integration phase.
+- LLM/provider execution remains outside this harness.

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -148,6 +148,22 @@ __all__ = [
     "summarize_adapter_ref",
     "summarize_prompt_adapter_payload",
     "summarize_verified_candidate_plan_for_adapter",
+    "PromptAssemblerComplianceGap",
+    "PromptAssemblerComplianceReport",
+    "PromptAssemblerComplianceRequirement",
+    "PromptAssemblerComplianceStatus",
+    "PromptAssemblerFutureIntegrationRule",
+    "adapter_payload_blocks_prompt_materialization",
+    "adapter_payload_may_be_consumed_by_future_assembler",
+    "adapter_payload_satisfies_compliance_prerequisites",
+    "build_prompt_assembler_compliance_requirements",
+    "evaluate_prompt_assembler_adapter_compliance",
+    "explain_prompt_assembler_compliance_gaps",
+    "prompt_assembler_module_has_no_context_hygiene_runtime_wiring",
+    "prompt_assembler_module_has_no_forbidden_context_bypass",
+    "scan_prompt_assembler_static_findings",
+    "summarize_future_prompt_assembler_integration_contract",
+    "summarize_prompt_assembler_compliance_report",
 ]
 
 from sentientos.context_hygiene.selector import (
@@ -286,4 +302,23 @@ from sentientos.context_hygiene.prompt_adapter_contract import (
     summarize_adapter_ref,
     summarize_prompt_adapter_payload,
     summarize_verified_candidate_plan_for_adapter,
+)
+
+from sentientos.context_hygiene.prompt_assembler_compliance import (
+    PromptAssemblerComplianceGap,
+    PromptAssemblerComplianceReport,
+    PromptAssemblerComplianceRequirement,
+    PromptAssemblerComplianceStatus,
+    PromptAssemblerFutureIntegrationRule,
+    adapter_payload_blocks_prompt_materialization,
+    adapter_payload_may_be_consumed_by_future_assembler,
+    adapter_payload_satisfies_compliance_prerequisites,
+    build_prompt_assembler_compliance_requirements,
+    evaluate_prompt_assembler_adapter_compliance,
+    explain_prompt_assembler_compliance_gaps,
+    prompt_assembler_module_has_no_context_hygiene_runtime_wiring,
+    prompt_assembler_module_has_no_forbidden_context_bypass,
+    scan_prompt_assembler_static_findings,
+    summarize_future_prompt_assembler_integration_contract,
+    summarize_prompt_assembler_compliance_report,
 )

--- a/sentientos/context_hygiene/prompt_assembler_compliance.py
+++ b/sentientos/context_hygiene/prompt_assembler_compliance.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import asdict, dataclass, field, is_dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterPayload,
+    PromptAssemblyAdapterStatus,
+    adapter_payload_contains_no_prompt_text,
+    adapter_payload_contains_no_raw_payloads,
+    adapter_payload_has_no_runtime_authority,
+)
+
+
+class PromptAssemblerComplianceStatus:
+    COMPLIANCE_READY_FOR_FUTURE_INTEGRATION = "compliance_ready_for_future_integration"
+    COMPLIANCE_READY_WITH_WARNINGS = "compliance_ready_with_warnings"
+    COMPLIANCE_BLOCKED = "compliance_blocked"
+    COMPLIANCE_NOT_APPLICABLE = "compliance_not_applicable"
+    COMPLIANCE_INVALID_ADAPTER_PAYLOAD = "compliance_invalid_adapter_payload"
+    COMPLIANCE_RUNTIME_WIRING_DETECTED = "compliance_runtime_wiring_detected"
+
+
+@dataclass(frozen=True)
+class PromptAssemblerComplianceRequirement:
+    requirement_id: str
+    summary: str
+    severity: str = "must"
+
+
+@dataclass(frozen=True)
+class PromptAssemblerFutureIntegrationRule:
+    rule_id: str
+    must_clause: str
+
+
+@dataclass(frozen=True)
+class PromptAssemblerComplianceGap:
+    code: str
+    detail: str
+    severity: str = "blocker"
+
+
+@dataclass(frozen=True)
+class PromptAssemblerComplianceReport:
+    compliance_status: str
+    adapter_payload_status: str
+    may_future_assembler_consume: bool
+    must_block_prompt_materialization: bool
+    gaps: tuple[PromptAssemblerComplianceGap, ...] = field(default_factory=tuple)
+    warnings: tuple[PromptAssemblerComplianceGap, ...] = field(default_factory=tuple)
+    requirements: tuple[PromptAssemblerComplianceRequirement, ...] = field(default_factory=tuple)
+    prompt_assembler_static_findings: Mapping[str, Any] = field(default_factory=dict)
+    no_runtime_wiring_detected: bool = True
+    no_forbidden_context_bypass_detected: bool = True
+    rationale: str = ""
+    compliance_harness_only: bool = True
+    does_not_modify_prompt_assembler: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+_READY_STATUSES = {
+    PromptAssemblyAdapterStatus.ADAPTER_READY,
+    PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS,
+}
+_BLOCKING_STATUSES = {
+    PromptAssemblyAdapterStatus.ADAPTER_BLOCKED,
+    PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE,
+    PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION,
+    PromptAssemblyAdapterStatus.ADAPTER_INVALID_CANDIDATE_PLAN,
+}
+_INVALID_STATUSES = {
+    PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION,
+    PromptAssemblyAdapterStatus.ADAPTER_INVALID_CANDIDATE_PLAN,
+}
+_REQUIRED_IDENTIFIER_FIELDS = ("adapter_payload_id", "candidate_plan_id", "envelope_id", "envelope_digest", "packet_id")
+_REQUIRED_NOTE_FIELDS = ("provenance_notes", "privacy_notes", "truth_notes", "safety_notes")
+_REQUIRED_NO_RUNTIME_MARKERS = (
+    "does_not_call_llm",
+    "does_not_retrieve_memory",
+    "does_not_write_memory",
+    "does_not_trigger_feedback",
+    "does_not_commit_retention",
+    "does_not_execute_or_route_work",
+    "does_not_admit_work",
+)
+_FORBIDDEN_BYPASS_IMPORTS = (
+    "sentientos.context_hygiene.selector",
+    "sentientos.context_hygiene.prompt_preflight",
+    "sentientos.context_hygiene.prompt_handoff_manifest",
+    "sentientos.context_hygiene.prompt_dry_run_envelope",
+    "sentientos.context_hygiene.prompt_constraint_verifier",
+    "sentientos.context_hygiene.prompt_adapter_contract",
+    "sentientos.context_hygiene.context_packet",
+)
+_CONTEXT_HYGIENE_HELPER_NAMES = (
+    "ContextPacket",
+    "ContextCandidate",
+    "PromptAssemblyAdapterPayload",
+    "build_context_packet_from_candidates",
+    "select_context_candidates",
+    "evaluate_context_packet_prompt_eligibility",
+    "build_context_prompt_handoff_manifest",
+    "build_context_prompt_dry_run_envelope",
+    "verify_prompt_assembly_constraints",
+    "build_prompt_assembly_adapter_payload",
+)
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return is_dataclass(value) and not isinstance(value, type)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if _is_dataclass_instance(value):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _walk(value: Any) -> Sequence[tuple[str, Any]]:
+    found: list[tuple[str, Any]] = []
+
+    def rec(child: Any) -> None:
+        if _is_dataclass_instance(child):
+            rec(asdict(child))
+        elif isinstance(child, Mapping):
+            for key, nested in child.items():
+                found.append((str(key), nested))
+                rec(nested)
+        elif isinstance(child, (tuple, list, set, frozenset)):
+            for nested in child:
+                rec(nested)
+
+    rec(value)
+    return tuple(found)
+
+
+def build_prompt_assembler_compliance_requirements() -> tuple[PromptAssemblerComplianceRequirement, ...]:
+    return (
+        PromptAssemblerComplianceRequirement("adapter_status_ready", "future assembler may consume only adapter_ready or adapter_ready_with_warnings payloads"),
+        PromptAssemblerComplianceRequirement("blocked_statuses_withhold_material", "blocked, not-applicable, and invalid adapter payloads must not materialize prompt content"),
+        PromptAssemblerComplianceRequirement("adapter_refs_only", "future assembler may consume adapter_refs only and must never consume raw payloads"),
+        PromptAssemblerComplianceRequirement("no_prompt_text", "adapter payload must not contain final prompt text or prompt fragments"),
+        PromptAssemblerComplianceRequirement("no_runtime_authority", "adapter payload must carry no LLM, memory, routing, admission, execution, feedback, or retention authority"),
+        PromptAssemblerComplianceRequirement("non_authoritative", "adapter payload posture must remain non-authoritative"),
+        PromptAssemblerComplianceRequirement("boundaries_preserved", "caveats, provenance, privacy, truth, and safety boundaries must be preserved"),
+        PromptAssemblerComplianceRequirement("digest_and_ids_present", "adapter digest and packet, envelope, and candidate identifiers must be present"),
+        PromptAssemblerComplianceRequirement("static_no_runtime_wiring", "pre-integration prompt_assembler.py must not contain context hygiene runtime wiring or bypasses"),
+    )
+
+
+def _gap(code: str, detail: str, severity: str = "blocker") -> PromptAssemblerComplianceGap:
+    return PromptAssemblerComplianceGap(code=code, detail=detail, severity=severity)
+
+
+def _constraints_include_no_runtime_guards(data: Mapping[str, Any]) -> bool:
+    constraints = data.get("assembly_constraints", {})
+    constraint_map = dict(constraints) if isinstance(constraints, Mapping) else {}
+    return all(data.get(name) is True or constraint_map.get(name) is True for name in _REQUIRED_NO_RUNTIME_MARKERS)
+
+
+def _adapter_payload_status(data: Mapping[str, Any]) -> str:
+    return str(data.get("adapter_status", ""))
+
+
+def adapter_payload_may_be_consumed_by_future_assembler(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    data = _mapping(payload)
+    return _adapter_payload_status(data) in _READY_STATUSES and adapter_payload_satisfies_compliance_prerequisites(payload)
+
+
+def adapter_payload_blocks_prompt_materialization(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    data = _mapping(payload)
+    status = _adapter_payload_status(data)
+    if status in _BLOCKING_STATUSES:
+        return True
+    return not adapter_payload_satisfies_compliance_prerequisites(payload)
+
+
+def adapter_payload_satisfies_compliance_prerequisites(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> bool:
+    report = evaluate_prompt_assembler_adapter_compliance(payload, prompt_assembler_source="")
+    return not report.gaps and report.compliance_status in {
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION,
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS,
+    }
+
+
+def _evaluate_payload(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> tuple[list[PromptAssemblerComplianceGap], list[PromptAssemblerComplianceGap]]:
+    data = _mapping(payload)
+    gaps: list[PromptAssemblerComplianceGap] = []
+    warnings: list[PromptAssemblerComplianceGap] = []
+    status = _adapter_payload_status(data)
+
+    if not data:
+        return [_gap("invalid_payload_shape", "adapter payload must be a PromptAssemblyAdapterPayload or mapping")], warnings
+    if status not in _READY_STATUSES | _BLOCKING_STATUSES:
+        gaps.append(_gap("unknown_adapter_status", "adapter payload status is not recognized"))
+
+    if not adapter_payload_contains_no_prompt_text(payload):
+        gaps.append(_gap("prompt_text_present", "adapter payload contains prompt_text or final prompt text"))
+    if not adapter_payload_contains_no_raw_payloads(payload):
+        gaps.append(_gap("raw_payload_present", "adapter payload contains raw payload material"))
+    if not adapter_payload_has_no_runtime_authority(payload):
+        gaps.append(_gap("runtime_authority_present", "adapter payload contains runtime authority or missing non-effect markers"))
+
+    if data.get("non_authoritative") is not True:
+        gaps.append(_gap("non_authoritative_missing", "adapter payload must preserve non_authoritative posture"))
+    if data.get("adapter_contract_only") is not True:
+        gaps.append(_gap("adapter_contract_only_missing", "adapter payload must remain adapter-contract-only"))
+    if not data.get("digest"):
+        gaps.append(_gap("digest_missing", "adapter payload digest is required"))
+    for field_name in _REQUIRED_IDENTIFIER_FIELDS:
+        if not data.get(field_name):
+            gaps.append(_gap(f"{field_name}_missing", f"adapter payload requires {field_name}"))
+
+    refs = tuple(data.get("adapter_refs", ()) or ())
+    if status in _READY_STATUSES and not refs:
+        gaps.append(_gap("adapter_refs_missing_for_ready_status", "ready adapter payloads must expose adapter refs for future assembler consumption"))
+    if status in _BLOCKING_STATUSES and refs:
+        gaps.append(_gap("adapter_refs_present_for_blocked_status", "blocking adapter statuses must withhold adapter refs"))
+
+    if not _constraints_include_no_runtime_guards(data):
+        gaps.append(_gap("no_runtime_constraints_missing", "adapter constraints must include no LLM, memory, feedback, retention, execution, routing, and admission guards"))
+
+    if status in _READY_STATUSES and "preserved_caveats" not in data:
+        warnings.append(_gap("caveats_missing", "preserved_caveats should be present even when upstream had none", "warning"))
+    for field_name in _REQUIRED_NOTE_FIELDS:
+        if field_name not in data or data.get(field_name) in (None, ""):
+            warnings.append(_gap(f"{field_name}_missing", f"{field_name} should be preserved when upstream supplied it", "warning"))
+
+    return gaps, warnings
+
+
+def _imports_from_tree(tree: ast.AST) -> tuple[str, ...]:
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.append(node.module or "")
+    return tuple(imports)
+
+
+def _names_from_tree(tree: ast.AST) -> tuple[str, ...]:
+    return tuple(node.id for node in ast.walk(tree) if isinstance(node, ast.Name))
+
+
+def scan_prompt_assembler_static_findings(
+    prompt_assembler_path: str | Path = "prompt_assembler.py", *, source_text: str | None = None
+) -> dict[str, Any]:
+    if source_text is None:
+        path = Path(prompt_assembler_path)
+        source_text = path.read_text(encoding="utf-8") if path.exists() else ""
+    tree = ast.parse(source_text or "", filename=str(prompt_assembler_path))
+    imports = _imports_from_tree(tree)
+    names = _names_from_tree(tree)
+    imports_context_hygiene_adapter_modules = any("sentientos.context_hygiene" in imp for imp in imports)
+    imports_prompt_adapter_contract = any("prompt_adapter_contract" in imp for imp in imports)
+    uses_context_packet_directly = "ContextPacket" in names or "ContextPacket" in (source_text or "")
+    calls_context_hygiene_helpers = any(name in names for name in _CONTEXT_HYGIENE_HELPER_NAMES)
+    bypasses_adapter_contract = any(imp in _FORBIDDEN_BYPASS_IMPORTS for imp in imports) and not imports_prompt_adapter_contract
+    retrieves_memory_for_context_hygiene = "context_hygiene" in (source_text or "") and any("memory" in imp for imp in imports)
+    calls_llm_for_context_hygiene = "context_hygiene" in (source_text or "") and any(token in (source_text or "") for token in ("openai", "anthropic", "ChatCompletion", "llm"))
+    contains_phase70_adapter_payload_usage = "PromptAssemblyAdapterPayload" in names or "build_prompt_assembly_adapter_payload" in names
+    active_context_hygiene_runtime_wiring = any(
+        (
+            imports_context_hygiene_adapter_modules,
+            imports_prompt_adapter_contract,
+            uses_context_packet_directly,
+            calls_context_hygiene_helpers,
+            contains_phase70_adapter_payload_usage,
+        )
+    )
+    forbidden_context_bypass_detected = any((bypasses_adapter_contract, retrieves_memory_for_context_hygiene, calls_llm_for_context_hygiene))
+    return {
+        "imports_context_hygiene_adapter_modules": imports_context_hygiene_adapter_modules,
+        "imports_prompt_adapter_contract": imports_prompt_adapter_contract,
+        "uses_context_packet_directly": uses_context_packet_directly,
+        "calls_selector_preflight_manifest_envelope_verifier_or_adapter_helpers": calls_context_hygiene_helpers,
+        "bypasses_adapter_contract_by_reading_context_hygiene_internals": bypasses_adapter_contract,
+        "retrieves_memory_directly_for_context_hygiene_purposes": retrieves_memory_for_context_hygiene,
+        "calls_llm_provider_apis_for_context_hygiene_purposes": calls_llm_for_context_hygiene,
+        "contains_phase70_adapter_payload_usage": contains_phase70_adapter_payload_usage,
+        "active_context_hygiene_runtime_wiring": active_context_hygiene_runtime_wiring,
+        "forbidden_context_bypass_detected": forbidden_context_bypass_detected,
+        "inspection_mode": "source_text_ast_only_no_import",
+    }
+
+
+def prompt_assembler_module_has_no_context_hygiene_runtime_wiring(prompt_assembler_path: str | Path = "prompt_assembler.py") -> bool:
+    return not scan_prompt_assembler_static_findings(prompt_assembler_path)["active_context_hygiene_runtime_wiring"]
+
+
+def prompt_assembler_module_has_no_forbidden_context_bypass(prompt_assembler_path: str | Path = "prompt_assembler.py") -> bool:
+    return not scan_prompt_assembler_static_findings(prompt_assembler_path)["forbidden_context_bypass_detected"]
+
+
+def evaluate_prompt_assembler_adapter_compliance(
+    payload: PromptAssemblyAdapterPayload | Mapping[str, Any],
+    *,
+    prompt_assembler_path: str | Path = "prompt_assembler.py",
+    prompt_assembler_source: str | None = None,
+) -> PromptAssemblerComplianceReport:
+    data = _mapping(payload)
+    payload_status = _adapter_payload_status(data)
+    gaps, warnings = _evaluate_payload(payload)
+    findings = scan_prompt_assembler_static_findings(prompt_assembler_path, source_text=prompt_assembler_source)
+    no_runtime_wiring = not findings["active_context_hygiene_runtime_wiring"]
+    no_bypass = not findings["forbidden_context_bypass_detected"]
+    if not no_bypass:
+        gaps.append(_gap("forbidden_context_bypass_detected", "prompt_assembler.py appears to bypass context hygiene adapter contract"))
+    if findings["active_context_hygiene_runtime_wiring"]:
+        gaps.append(_gap("context_hygiene_runtime_wiring_detected", "prompt_assembler.py contains active context hygiene wiring"))
+
+    if not no_bypass or findings["active_context_hygiene_runtime_wiring"]:
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_RUNTIME_WIRING_DETECTED
+    elif payload_status in _INVALID_STATUSES or any(g.code.startswith("invalid") for g in gaps):
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_INVALID_ADAPTER_PAYLOAD
+    elif payload_status == PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE and not gaps:
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_NOT_APPLICABLE
+    elif payload_status in _BLOCKING_STATUSES or gaps:
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    elif payload_status == PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS or warnings or data.get("warnings"):
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    else:
+        status = PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION
+
+    may_consume = status in {
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION,
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS,
+    }
+    must_block = not may_consume
+    rationale = "future assembler may consume adapter_refs only" if may_consume else "prompt materialization must be blocked before future assembler consumption"
+    return PromptAssemblerComplianceReport(
+        compliance_status=status,
+        adapter_payload_status=payload_status,
+        may_future_assembler_consume=may_consume,
+        must_block_prompt_materialization=must_block,
+        gaps=tuple(gaps),
+        warnings=tuple(warnings),
+        requirements=build_prompt_assembler_compliance_requirements(),
+        prompt_assembler_static_findings=findings,
+        no_runtime_wiring_detected=no_runtime_wiring,
+        no_forbidden_context_bypass_detected=no_bypass,
+        rationale=rationale,
+    )
+
+
+def explain_prompt_assembler_compliance_gaps(report: PromptAssemblerComplianceReport) -> tuple[str, ...]:
+    return tuple(f"{gap.severity}:{gap.code}:{gap.detail}" for gap in report.gaps)
+
+
+def summarize_prompt_assembler_compliance_report(report: PromptAssemblerComplianceReport) -> dict[str, Any]:
+    return {
+        "compliance_status": report.compliance_status,
+        "adapter_payload_status": report.adapter_payload_status,
+        "may_future_assembler_consume": report.may_future_assembler_consume,
+        "must_block_prompt_materialization": report.must_block_prompt_materialization,
+        "gap_count": len(report.gaps),
+        "warning_count": len(report.warnings),
+        "no_runtime_wiring_detected": report.no_runtime_wiring_detected,
+        "no_forbidden_context_bypass_detected": report.no_forbidden_context_bypass_detected,
+        "rationale": report.rationale,
+        "compliance_harness_only": report.compliance_harness_only,
+    }
+
+
+def summarize_future_prompt_assembler_integration_contract() -> tuple[PromptAssemblerFutureIntegrationRule, ...]:
+    return (
+        PromptAssemblerFutureIntegrationRule("accept_only_adapter_payload", "MUST accept only PromptAssemblyAdapterPayload"),
+        PromptAssemblerFutureIntegrationRule("reject_non_ready_statuses", "MUST reject adapter statuses other than adapter_ready / adapter_ready_with_warnings"),
+        PromptAssemblerFutureIntegrationRule("consume_only_adapter_refs", "MUST consume only adapter_refs"),
+        PromptAssemblerFutureIntegrationRule("preserve_boundary_notes", "MUST preserve caveats/provenance/privacy/truth/safety notes"),
+        PromptAssemblerFutureIntegrationRule("no_raw_payloads", "MUST never include raw payloads"),
+        PromptAssemblerFutureIntegrationRule("non_authoritative", "MUST never treat adapter payload as authoritative"),
+        PromptAssemblerFutureIntegrationRule("no_bypass_context", "MUST not retrieve bypass context"),
+        PromptAssemblerFutureIntegrationRule("no_bypass_phase69", "MUST not bypass Phase 69 verifier"),
+        PromptAssemblerFutureIntegrationRule("no_bypass_phase68", "MUST not bypass Phase 68 envelope"),
+        PromptAssemblerFutureIntegrationRule("no_bypass_phase64", "MUST not bypass Phase 64 preflight"),
+        PromptAssemblerFutureIntegrationRule("no_bypass_phase62", "MUST not bypass Phase 62 selector"),
+        PromptAssemblerFutureIntegrationRule("blocked_refs_not_visible", "MUST not make blocked refs prompt-visible"),
+        PromptAssemblerFutureIntegrationRule("record_compliance_before_materialization", "MUST emit/record compliance outcome before materialization in a future phase"),
+    )

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -560,7 +560,9 @@
       "no_hardware_calls": true,
       "no_retention_side_effects": true,
       "no_embodiment_runtime_effects": true,
-      "adapter_contract_only": true
+      "adapter_contract_only": true,
+      "compliance_harness_only": true,
+      "does_not_modify_prompt_assembler": true
     }
   },
   "protected_sinks": {

--- a/tests/test_phase71_prompt_assembler_compliance_harness.py
+++ b/tests/test_phase71_prompt_assembler_compliance_harness.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sentientos.context_hygiene.context_packet import ContextMode
+from sentientos.context_hygiene.embodiment_context import build_embodiment_context_candidates
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterPayload,
+    PromptAssemblyAdapterRef,
+    PromptAssemblyAdapterStatus,
+    build_prompt_assembly_adapter_payload,
+    build_prompt_assembly_adapter_payload_from_packet,
+)
+from sentientos.context_hygiene.prompt_assembler_compliance import (
+    PromptAssemblerComplianceStatus,
+    adapter_payload_blocks_prompt_materialization,
+    adapter_payload_may_be_consumed_by_future_assembler,
+    evaluate_prompt_assembler_adapter_compliance,
+    prompt_assembler_module_has_no_context_hygiene_runtime_wiring,
+    prompt_assembler_module_has_no_forbidden_context_bypass,
+    scan_prompt_assembler_static_findings,
+    summarize_future_prompt_assembler_integration_contract,
+    summarize_prompt_assembler_compliance_report,
+)
+from sentientos.context_hygiene.prompt_constraint_verifier import (
+    PromptAssemblyConstraintVerificationStatus,
+    build_candidate_plan_from_dry_run_envelope,
+    verify_prompt_assembly_constraints,
+)
+from sentientos.context_hygiene.prompt_dry_run_envelope import build_context_prompt_dry_run_envelope
+from sentientos.context_hygiene.prompt_handoff_manifest import build_context_prompt_handoff_manifest
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibility, PromptContextEligibilityStatus, evaluate_context_packet_prompt_eligibility
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+NOW = datetime.now(timezone.utc)
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cand(ref_id="r", ref_type="evidence", metadata=None, truth_ingress_status="allowed", contradiction_status="unknown"):
+    return ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        provenance_refs=("prov:1",),
+        source_locator="src",
+        summary="packet-safe summary",
+        already_sanitized_context_summary=True,
+        truth_ingress_status=truth_ingress_status,
+        contradiction_status=contradiction_status,
+        metadata=metadata or {"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"},
+    )
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(cands, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+
+
+def _envelope_for(cands):
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt(cands)))
+
+
+def _ready_envelope():
+    return _envelope_for([_cand("ready")])
+
+
+def _caveated_envelope():
+    packet = _pkt([_cand("caveat")])
+    pre = evaluate_context_packet_prompt_eligibility(packet)
+    caveated = PromptContextEligibility(
+        eligibility_status=PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS,
+        prompt_eligible=True,
+        may_be_prompted_only_with_caveats=True,
+        caveats=("truth_caveat: operator review",),
+        packet_id=packet.context_packet_id,
+        included_ref_count=pre.included_ref_count,
+    )
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(packet, caveated))
+
+
+def _not_applicable_envelope():
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt([])))
+
+
+def _payload(envelope=None, plan=None):
+    envelope = envelope or _ready_envelope()
+    plan = plan or build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, plan)
+    return build_prompt_assembly_adapter_payload(verification, plan), verification, plan
+
+
+def _report(payload):
+    return evaluate_prompt_assembler_adapter_compliance(payload, prompt_assembler_path=ROOT / "prompt_assembler.py")
+
+
+def _mutated(payload, **changes):
+    data = asdict(payload) if not isinstance(payload, dict) else dict(payload)
+    data.update(changes)
+    if "adapter_refs" in data:
+        data["adapter_refs"] = tuple(PromptAssemblyAdapterRef(**r) if isinstance(r, dict) else r for r in data["adapter_refs"])
+    return data
+
+
+def _codes(report):
+    return {gap.code for gap in report.gaps}
+
+
+def test_ready_adapter_payload_yields_compliance_ready_for_future_integration():
+    payload, _, _ = _payload()
+    report = _report(payload)
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION
+    assert report.may_future_assembler_consume is True
+    assert report.must_block_prompt_materialization is False
+    assert adapter_payload_may_be_consumed_by_future_assembler(payload)
+
+
+def test_ready_with_warnings_adapter_payload_yields_compliance_ready_with_warnings():
+    payload, _, _ = _payload(_caveated_envelope())
+    report = _report(payload)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_READY_WITH_WARNINGS
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    assert report.may_future_assembler_consume is True
+
+
+def test_blocked_adapter_payload_yields_compliance_blocked_and_blocks_materialization():
+    envelope = _ready_envelope()
+    plan = replace(build_candidate_plan_from_dry_run_envelope(envelope), packet_id="wrong")
+    payload, _, _ = _payload(envelope, plan)
+    report = _report(payload)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_BLOCKED
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert report.must_block_prompt_materialization is True
+    assert adapter_payload_blocks_prompt_materialization(payload)
+
+
+def test_not_applicable_adapter_payload_yields_compliance_not_applicable():
+    payload, _, _ = _payload(_not_applicable_envelope())
+    report = _report(payload)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_NOT_APPLICABLE
+    assert report.must_block_prompt_materialization is True
+
+
+def test_invalid_verification_adapter_payload_yields_invalid_adapter_payload():
+    invalid_packet = replace(_pkt([_cand("bad")]), context_packet_id="")
+    envelope = build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(invalid_packet))
+    payload, _, _ = _payload(envelope)
+    report = _report(payload)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_INVALID_VERIFICATION
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_INVALID_ADAPTER_PAYLOAD
+
+
+def test_invalid_candidate_plan_adapter_payload_yields_invalid_adapter_payload():
+    envelope = _ready_envelope()
+    malformed = {"plan_id": "bad", "candidate_refs": "not refs"}
+    verification = verify_prompt_assembly_constraints(envelope, malformed)
+    payload = build_prompt_assembly_adapter_payload(verification, malformed)
+    report = _report(payload)
+    assert payload.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_INVALID_CANDIDATE_PLAN
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_INVALID_ADAPTER_PAYLOAD
+
+
+def test_adapter_payload_with_prompt_text_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, prompt_text="forbidden final prompt"))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "prompt_text_present" in _codes(report)
+
+
+def test_adapter_payload_with_raw_payload_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, raw_payload={"unsafe": True}))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "raw_payload_present" in _codes(report)
+
+
+def test_adapter_payload_with_runtime_authority_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, can_write_memory=True))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "runtime_authority_present" in _codes(report)
+
+
+def test_adapter_payload_missing_non_authoritative_posture_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, non_authoritative=False))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "non_authoritative_missing" in _codes(report)
+
+
+def test_adapter_payload_missing_caveats_when_expected_is_warned():
+    payload, _, _ = _payload()
+    data = _mutated(payload)
+    data.pop("preserved_caveats")
+    report = _report(data)
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    assert {w.code for w in report.warnings} >= {"caveats_missing"}
+
+
+def test_adapter_payload_missing_provenance_notes_is_warned():
+    payload, _, _ = _payload()
+    data = _mutated(payload)
+    data.pop("provenance_notes")
+    report = _report(data)
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    assert "provenance_notes_missing" in {w.code for w in report.warnings}
+
+
+def test_adapter_payload_missing_privacy_truth_safety_notes_is_warned():
+    payload, _, _ = _payload()
+    data = _mutated(payload)
+    data.pop("privacy_notes")
+    data.pop("truth_notes")
+    data.pop("safety_notes")
+    report = _report(data)
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    assert {"privacy_notes_missing", "truth_notes_missing", "safety_notes_missing"}.issubset({w.code for w in report.warnings})
+
+
+def test_adapter_refs_present_for_blocked_status_is_blocked():
+    ready, _, _ = _payload()
+    blocked, _, _ = _payload(_ready_envelope(), replace(build_candidate_plan_from_dry_run_envelope(_ready_envelope()), packet_id="wrong"))
+    report = _report(_mutated(blocked, adapter_refs=ready.adapter_refs))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "adapter_refs_present_for_blocked_status" in _codes(report)
+
+
+def test_adapter_refs_absent_for_ready_status_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, adapter_refs=()))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "adapter_refs_missing_for_ready_status" in _codes(report)
+
+
+def test_missing_digest_is_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, digest=""))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert "digest_missing" in _codes(report)
+
+
+def test_missing_packet_envelope_candidate_identifiers_are_blocked():
+    payload, _, _ = _payload()
+    report = _report(_mutated(payload, packet_id="", envelope_id="", candidate_plan_id=""))
+    assert report.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert {"packet_id_missing", "envelope_id_missing", "candidate_plan_id_missing"}.issubset(_codes(report))
+
+
+def test_static_prompt_assembler_scan_reports_no_active_context_hygiene_wiring_pre_integration():
+    findings = scan_prompt_assembler_static_findings(ROOT / "prompt_assembler.py")
+    assert findings["inspection_mode"] == "source_text_ast_only_no_import"
+    assert findings["active_context_hygiene_runtime_wiring"] is False
+    assert prompt_assembler_module_has_no_context_hygiene_runtime_wiring(ROOT / "prompt_assembler.py") is True
+
+
+def test_static_prompt_assembler_scan_reports_no_forbidden_context_bypass():
+    findings = scan_prompt_assembler_static_findings(ROOT / "prompt_assembler.py")
+    assert findings["forbidden_context_bypass_detected"] is False
+    assert prompt_assembler_module_has_no_forbidden_context_bypass(ROOT / "prompt_assembler.py") is True
+
+
+def test_static_prompt_assembler_scan_uses_source_text_ast_only_without_importing_side_effects():
+    source = "raise RuntimeError('import side effect')\nfrom sentientos.context_hygiene.prompt_adapter_contract import PromptAssemblyAdapterPayload\n"
+    findings = scan_prompt_assembler_static_findings(source_text=source)
+    assert findings["inspection_mode"] == "source_text_ast_only_no_import"
+    assert findings["imports_prompt_adapter_contract"] is True
+
+
+def test_future_integration_contract_includes_all_required_must_clauses():
+    clauses = "\n".join(rule.must_clause for rule in summarize_future_prompt_assembler_integration_contract())
+    for phrase in (
+        "MUST accept only PromptAssemblyAdapterPayload",
+        "MUST reject adapter statuses other than adapter_ready / adapter_ready_with_warnings",
+        "MUST consume only adapter_refs",
+        "MUST preserve caveats/provenance/privacy/truth/safety notes",
+        "MUST never include raw payloads",
+        "MUST never treat adapter payload as authoritative",
+        "MUST not retrieve bypass context",
+        "MUST not bypass Phase 69 verifier",
+        "MUST not bypass Phase 68 envelope",
+        "MUST not bypass Phase 64 preflight",
+        "MUST not bypass Phase 62 selector",
+        "MUST not make blocked refs prompt-visible",
+        "MUST emit/record compliance outcome before materialization in a future phase",
+    ):
+        assert phrase in clauses
+
+
+def test_report_includes_explicit_non_runtime_markers():
+    payload, _, _ = _payload()
+    report = _report(payload)
+    summary = summarize_prompt_assembler_compliance_report(report)
+    assert summary["compliance_harness_only"] is True
+    for marker in (
+        "compliance_harness_only",
+        "does_not_modify_prompt_assembler",
+        "does_not_assemble_prompt",
+        "does_not_call_llm",
+        "does_not_retrieve_memory",
+        "does_not_write_memory",
+        "does_not_trigger_feedback",
+        "does_not_commit_retention",
+        "does_not_execute_or_route_work",
+        "does_not_admit_work",
+    ):
+        assert getattr(report, marker) is True
+
+
+def test_compliance_helper_does_not_mutate_adapter_payload():
+    payload, _, _ = _payload()
+    before = deepcopy(asdict(payload))
+    _report(payload)
+    assert asdict(payload) == before
+
+
+def test_compliance_helper_imports_remain_pure():
+    path = ROOT / "sentientos/context_hygiene/prompt_assembler_compliance.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.append(node.module or "")
+    forbidden = (
+        "prompt_assembler",
+        "memory_manager",
+        "task_admission",
+        "task_executor",
+        "retention",
+        "embodiment_ingress",
+        "embodiment_proposals",
+        "hardware",
+        "openai",
+        "requests",
+        "webbrowser",
+    )
+    for imp in imports:
+        assert not any(token in imp for token in forbidden), imp
+
+
+def test_phase63_to_adapter_to_compliance_pipeline_works_for_sanitized_embodiment_proposal():
+    proposals = build_embodiment_context_candidates(
+        [
+            {
+                "ref_id": "emb:1",
+                "source_kind": "embodiment_snapshot",
+                "packet_scope": "turn",
+                "conversation_scope_id": "conv",
+                "task_scope_id": "task",
+                "content_summary": "sanitized posture summary",
+                "sanitized_context_summary": True,
+                "privacy_posture": "low_risk",
+                "provenance_refs": ("sensor:summary",),
+                "non_authoritative": True,
+                "decision_power": "none",
+            }
+        ]
+    )
+    packet = build_context_packet_from_candidates(proposals, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+    payload = build_prompt_assembly_adapter_payload_from_packet(packet)
+    report = _report(payload)
+    assert payload.adapter_refs
+    assert report.compliance_status in {
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION,
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS,
+    }
+
+
+def test_phase62b_blocked_attempted_candidate_adapter_compliance_blocks_materialization():
+    payload, _, _ = _payload(_envelope_for([_cand("blocked", metadata={"source_kind": "evidence", "pollution_risk": "blocked", "non_authoritative": True, "decision_power": "none"})]))
+    report = _report(payload)
+    assert payload.adapter_status in {PromptAssemblyAdapterStatus.ADAPTER_BLOCKED, PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE}
+    assert report.must_block_prompt_materialization is True
+    assert report.may_future_assembler_consume is False


### PR DESCRIPTION
### Motivation

- Define a pure compliance harness for Phase 71 that states and verifies the requirements any future prompt assembler integration must satisfy without performing any integration work.
- Ensure adapter payloads are validated and that blocked/invalid/not-applicable payloads cannot produce prompt material, while preserving caveats/provenance/privacy/truth/safety boundaries. 
- Provide static, source-text/AST-only checks that `prompt_assembler.py` contains no pre-integration wiring or forbidden bypasses.

### Description

- Add `sentientos/context_hygiene/prompt_assembler_compliance.py` implementing frozen dataclasses for reports/gaps/requirements, deterministic compliance statuses, adapter compliance evaluators, static AST-based `prompt_assembler.py` scan helpers, and a future integration contract summary helper. 
- Export the new compliance APIs from `sentientos/context_hygiene/__init__.py` so other modules/tests can consume the harness without changing runtime wiring. 
- Add tests in `tests/test_phase71_prompt_assembler_compliance_harness.py` covering adapter statuses, blocking/warning rules, forbidden prompt/raw/runtime markers, identifier/digest requirements, adapter-ref alignment, static scan behavior, import-purity, Phase 63->70->71 pipeline, and Phase 62B blocked candidate handling. 
- Add documentation `docs/architecture/phase71_prompt_assembler_compliance_harness_execplan.md` and update `docs/architecture/context_hygiene_spine.md` and `sentientos/system_closure/architecture_boundary_manifest.json` to record the harness role and preserve architecture boundaries (non-authoritative, no runtime effects, does not modify `prompt_assembler.py`).

### Testing

- Ran `python -m scripts.run_tests -q tests/test_phase71_prompt_assembler_compliance_harness.py` and all tests passed (`26 passed`).
- Ran the Phase 61..70 contract/test suite via `python -m scripts.run_tests -q tests/test_phase70_prompt_assembly_adapter_contract.py tests/test_phase69_prompt_assembly_constraint_verifier.py tests/test_phase68_prompt_assembly_dry_run_envelope.py tests/test_phase67_context_prompt_handoff_manifest.py tests/test_phase66_context_source_kind_safety_contracts.py tests/test_phase65_context_safety_metadata_preservation.py tests/test_phase64_context_prompt_preflight.py tests/test_phase63_embodiment_context_eligibility.py tests/test_phase62b_context_risk_contract_alignment.py tests/test_phase62_context_truth_selector.py tests/test_phase61_context_packet_contract.py` and they passed (`59 passed`).
- Ran architecture/integrity checks `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed (`69 passed`).
- Static scan tests assert the harness inspects `prompt_assembler.py` by AST only and reports no active context-hygiene runtime wiring or forbidden bypasses in the current pre-integration code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa6d5eb2f48320b08d4cb7559c945b)