### PR TITLE
[codex:context-hygiene] add prompt assembler shadow adapter hook

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -117,3 +117,11 @@ Phase 71 adds `sentientos.context_hygiene.prompt_assembler_compliance` as a pure
 The compliance harness defines future prompt assembler rules: adapter payloads must be verified before use, only adapter refs may be consumed, failed/blocked/invalid/not-applicable payloads must not produce prompt material, and caveat/provenance/privacy/truth/safety boundaries must remain visible.
 
 Phase 71 does not modify `prompt_assembler.py`, does not wire adapter payloads into it, does not assemble prompts, does not call LLMs, does not retrieve or write memory, and does not modify embodiment, action, retention, truth, routing, admission, execution, or orchestration runtime behavior.
+
+### Phase 72: Prompt Assembler Shadow Adapter Hook
+
+Phase 72 adds the first controlled `prompt_assembler.py` context hygiene touch: a shadow-only adapter preview hook that validates a Phase 70 `PromptAssemblyAdapterPayload` through the Phase 71 compliance harness. The hook exists in `prompt_assembler.py` so the prompt assembler can recognize the adapter contract, but it is opt-in and test-invoked only in this phase.
+
+The hook is not used by runtime prompt assembly paths. It does not alter `assemble_prompt(...)`, does not change existing call sites, does not assemble prompt text, and does not concatenate adapter refs into final prompt material. Its output is a compact preview/receipt containing adapter/compliance status, metadata counts, caveats, notes-presence booleans, warnings, violations, constraints, rationale, and explicit non-runtime markers.
+
+Phase 72 does not call LLMs, does not retrieve memory, does not write memory, and does not modify truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior. Blocked, not-applicable, invalid, or runtime-wiring-detected adapter payloads remain prompt-materialization blocked and expose only preview status/metadata for audit.

--- a/docs/architecture/phase72_prompt_assembler_shadow_adapter_hook_execplan.md
+++ b/docs/architecture/phase72_prompt_assembler_shadow_adapter_hook_execplan.md
@@ -1,0 +1,72 @@
+# Phase 72 Prompt Assembler Shadow Adapter Hook Execution Plan
+
+## Goal
+Add the first controlled `prompt_assembler.py` touch for context hygiene: an explicitly invoked, shadow-only adapter preview hook that validates a Phase 70 `PromptAssemblyAdapterPayload` through the Phase 71 prompt assembler compliance harness and returns a compact non-runtime receipt.
+
+## Non-goals
+- Do not change live prompt assembly call behavior.
+- Do not assemble final prompt text or prompt fragments.
+- Do not wire context hygiene into normal runtime prompt assembly paths.
+- Do not call LLMs, retrieval, memory, truth runtime, embodiment runtime, action, retention, routing, admission, execution, or orchestration code.
+- Do not retrieve memory or write memory.
+- Do not treat adapter payloads as authoritative runtime input.
+
+## Dependency chain
+- Phase 61 created `ContextPacket` schema and receipts.
+- Phase 62 added truth-gated context selection.
+- Phase 62B made `BLOCKED` first-class and preserved attempted-candidate contamination.
+- Phase 63 added embodiment/privacy context eligibility adapters.
+- Phase 64 added prompt preflight.
+- Phase 65 preserved packet-local safety metadata.
+- Phase 66 added per-source-kind safety contract completeness.
+- Phase 67 added the prompt handoff manifest.
+- Phase 68 added the prompt assembly dry-run envelope.
+- Phase 69 added the prompt assembly constraint verifier.
+- Phase 70 added the prompt assembly adapter contract.
+- Phase 71 added the prompt assembler compliance harness.
+
+## First controlled `prompt_assembler.py` touch
+Phase 72 adds `PromptAssemblerShadowAdapterPreview` and `preview_context_hygiene_adapter_payload_for_prompt_assembly(...)` in `prompt_assembler.py`. The hook is opt-in, test-invoked, and not called by `assemble_prompt(...)` or any existing prompt assembly path.
+
+## Shadow hook is not live prompt assembly
+The hook calls only the Phase 71 compliance evaluator, summarizes adapter/compliance status, counts refs/sections, records caveats, notes-presence booleans, warnings, violations, constraints, and explicit non-runtime markers. It never concatenates adapter refs, never returns final prompt text, and never invokes existing prompt assembly functions.
+
+## Preview output shape
+The preview includes:
+- `preview_id`
+- `adapter_payload_id`
+- `adapter_status`
+- `compliance_status`
+- `may_future_assembler_consume`
+- `must_block_prompt_materialization`
+- `adapter_ref_count`
+- `section_count`
+- `preserved_caveats`
+- provenance/privacy/truth/safety notes-present booleans
+- metadata-only `violations` and `warnings`
+- compact `constraints`
+- compact `rationale`
+- explicit non-runtime markers including no prompt assembly, no final prompt text, no LLM calls, no memory retrieval/writes, no feedback/retention, and no execution/routing/admission.
+
+## Compliance relationship
+The hook maps Phase 71 statuses to shadow preview status labels in its rationale:
+
+| Phase 71 compliance status | Phase 72 shadow preview status |
+| --- | --- |
+| `compliance_ready_for_future_integration` | `shadow_preview_ready` |
+| `compliance_ready_with_warnings` | `shadow_preview_ready_with_warnings` |
+| `compliance_blocked` | `shadow_preview_blocked` |
+| `compliance_not_applicable` | `shadow_preview_not_applicable` |
+| `compliance_invalid_adapter_payload` | `shadow_preview_invalid_adapter_payload` |
+| `compliance_runtime_wiring_detected` | `shadow_preview_runtime_wiring_detected` |
+
+Ready and warning payloads expose metadata counts and boundary notes only. Blocked, not-applicable, invalid, and runtime-wiring-detected payloads report preview status while keeping prompt material blocked.
+
+## Existing behavior preservation
+`assemble_prompt(...)` signatures and call sites remain unchanged. The new hook is not invoked from live prompt assembly. Existing prompt assembly behavior continues to use the prior profile, memory, context window, emotion, and action-feedback behavior when callers explicitly call `assemble_prompt(...)`.
+
+## Tests
+Phase 72 tests cover ready, ready-with-warnings, blocked, not-applicable, invalid payloads, preview shape, metadata-only caveats/warnings/violations, note booleans, non-runtime markers, no final prompt text/raw payload fields, no runtime authority, no payload mutation, no live prompt assembly calls, representative existing prompt assembly behavior, static scan distinction between shadow hook and live runtime wiring, Phase 63-to-Phase 72 pipeline, Phase 62B blocked-candidate propagation, and import/boundary compatibility.
+
+## Deferred work
+A future phase may design a governed live integration path. That work remains deferred and must separately prove prompt materialization, runtime authority, memory access, retention, routing, and orchestration boundaries before any production wiring.

--- a/prompt_assembler.py
+++ b/prompt_assembler.py
@@ -4,7 +4,8 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 
 require_admin_banner()
 require_lumos_approval()
-from typing import List
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, List, Mapping
 import hashlib
 import json
 import logging
@@ -17,6 +18,131 @@ import memory_manager as mm
 import user_profile as up
 import emotion_memory as em
 import affective_context as ac
+from sentientos.context_hygiene.prompt_adapter_contract import PromptAssemblyAdapterPayload
+from sentientos.context_hygiene.prompt_assembler_compliance import (
+    PromptAssemblerComplianceStatus,
+    evaluate_prompt_assembler_adapter_compliance,
+)
+
+
+@dataclass(frozen=True)
+class PromptAssemblerShadowAdapterPreview:
+    preview_id: str
+    adapter_payload_id: str
+    adapter_status: str
+    compliance_status: str
+    may_future_assembler_consume: bool
+    must_block_prompt_materialization: bool
+    adapter_ref_count: int
+    section_count: int
+    preserved_caveats: tuple[str, ...]
+    provenance_notes_present: bool
+    privacy_notes_present: bool
+    truth_notes_present: bool
+    safety_notes_present: bool
+    violations: tuple[Mapping[str, str], ...]
+    warnings: tuple[Mapping[str, str], ...]
+    constraints: Mapping[str, Any]
+    rationale: str
+    shadow_hook_only: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+_CONTEXT_HYGIENE_SHADOW_PREVIEW_STATUS_MAP = {
+    PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION: "shadow_preview_ready",
+    PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS: "shadow_preview_ready_with_warnings",
+    PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED: "shadow_preview_blocked",
+    PromptAssemblerComplianceStatus.COMPLIANCE_NOT_APPLICABLE: "shadow_preview_not_applicable",
+    PromptAssemblerComplianceStatus.COMPLIANCE_INVALID_ADAPTER_PAYLOAD: "shadow_preview_invalid_adapter_payload",
+    PromptAssemblerComplianceStatus.COMPLIANCE_RUNTIME_WIRING_DETECTED: "shadow_preview_runtime_wiring_detected",
+}
+
+
+def _shadow_payload_mapping(payload: PromptAssemblyAdapterPayload | Mapping[str, Any]) -> Mapping[str, Any]:
+    if is_dataclass(payload) and not isinstance(payload, type):
+        return asdict(payload)
+    if isinstance(payload, Mapping):
+        return payload
+    return {}
+
+
+def _shadow_issue_metadata(*issue_groups: tuple[Any, ...]) -> tuple[Mapping[str, str], ...]:
+    compact: list[Mapping[str, str]] = []
+    for issues in issue_groups:
+        for issue in issues:
+            if is_dataclass(issue) and not isinstance(issue, type):
+                data = asdict(issue)
+            elif isinstance(issue, Mapping):
+                data = issue
+            else:
+                data = {"code": str(issue), "detail": ""}
+            compact.append(
+                {"code": str(data.get("code", "")), "detail": str(data.get("detail", ""))}
+            )
+    return tuple(compact)
+
+
+def preview_context_hygiene_adapter_payload_for_prompt_assembly(
+    payload: PromptAssemblyAdapterPayload | Mapping[str, Any],
+) -> PromptAssemblerShadowAdapterPreview:
+    """Validate a Phase 70 adapter payload through Phase 71 without assembling prompt text.
+
+    This shadow-only hook is opt-in and test-invoked. It emits metadata counts,
+    IDs, compliance status, caveats, notes-presence booleans, and issue summaries
+    only; it never calls the live prompt assembly path or any runtime authority.
+    """
+
+    report = evaluate_prompt_assembler_adapter_compliance(payload)
+    data = _shadow_payload_mapping(payload)
+    preview_status = _CONTEXT_HYGIENE_SHADOW_PREVIEW_STATUS_MAP.get(
+        report.compliance_status,
+        "shadow_preview_invalid_adapter_payload",
+    )
+    adapter_refs = (
+        tuple(data.get("adapter_refs", ()) or ())
+        if isinstance(data.get("adapter_refs", ()), (tuple, list))
+        else ()
+    )
+    adapter_sections = (
+        tuple(data.get("adapter_sections", ()) or ())
+        if isinstance(data.get("adapter_sections", ()), (tuple, list))
+        else ()
+    )
+    return PromptAssemblerShadowAdapterPreview(
+        preview_id=f"shadow-preview:{data.get('adapter_payload_id', 'unknown')}:{report.compliance_status}",
+        adapter_payload_id=str(data.get("adapter_payload_id", "")),
+        adapter_status=str(data.get("adapter_status", report.adapter_payload_status)),
+        compliance_status=report.compliance_status,
+        may_future_assembler_consume=report.may_future_assembler_consume,
+        must_block_prompt_materialization=report.must_block_prompt_materialization,
+        adapter_ref_count=len(adapter_refs) if report.may_future_assembler_consume else 0,
+        section_count=len(adapter_sections) if report.may_future_assembler_consume else 0,
+        preserved_caveats=tuple(str(caveat) for caveat in data.get("preserved_caveats", ()) or ()),
+        provenance_notes_present=bool(data.get("provenance_notes")),
+        privacy_notes_present=bool(data.get("privacy_notes")),
+        truth_notes_present=bool(data.get("truth_notes")),
+        safety_notes_present=bool(data.get("safety_notes")),
+        violations=_shadow_issue_metadata(tuple(data.get("violations", ()) or ()), report.gaps),
+        warnings=_shadow_issue_metadata(tuple(data.get("warnings", ()) or ()), report.warnings),
+        constraints=(
+            dict(data.get("assembly_constraints", {}))
+            if isinstance(data.get("assembly_constraints", {}), Mapping)
+            else {}
+        ),
+        rationale=f"{preview_status}: {report.rationale}; shadow hook does not materialize prompt text",
+    )
+
+
+build_context_hygiene_shadow_prompt_adapter_preview = preview_context_hygiene_adapter_payload_for_prompt_assembly
+
 
 SYSTEM_PROMPT = "You are Lumos, an emotionally present AI assistant."
 _ALLOW_UNSAFE_GRADIENT = os.getenv("SENTIENTOS_ALLOW_UNSAFE") == "1"

--- a/sentientos/context_hygiene/prompt_assembler_compliance.py
+++ b/sentientos/context_hygiene/prompt_assembler_compliance.py
@@ -99,8 +99,26 @@ _FORBIDDEN_BYPASS_IMPORTS = (
     "sentientos.context_hygiene.prompt_handoff_manifest",
     "sentientos.context_hygiene.prompt_dry_run_envelope",
     "sentientos.context_hygiene.prompt_constraint_verifier",
-    "sentientos.context_hygiene.prompt_adapter_contract",
     "sentientos.context_hygiene.context_packet",
+)
+_ALLOWED_SHADOW_HOOK_IMPORTS = frozenset(
+    {
+        "sentientos.context_hygiene.prompt_assembler_compliance",
+        "sentientos.context_hygiene.prompt_adapter_contract",
+    }
+)
+_SHADOW_HOOK_FUNCTION_NAMES = frozenset(
+    {
+        "preview_context_hygiene_adapter_payload_for_prompt_assembly",
+        "build_context_hygiene_shadow_prompt_adapter_preview",
+    }
+)
+_SHADOW_HOOK_ALLOWED_NAMES = frozenset(
+    {
+        "PromptAssemblyAdapterPayload",
+        "PromptAssemblerComplianceStatus",
+        "evaluate_prompt_assembler_adapter_compliance",
+    }
 )
 _CONTEXT_HYGIENE_HELPER_NAMES = (
     "ContextPacket",
@@ -264,27 +282,36 @@ def scan_prompt_assembler_static_findings(
     tree = ast.parse(source_text or "", filename=str(prompt_assembler_path))
     imports = _imports_from_tree(tree)
     names = _names_from_tree(tree)
-    imports_context_hygiene_adapter_modules = any("sentientos.context_hygiene" in imp for imp in imports)
+    function_names = frozenset(node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef))
+    shadow_hook_only = bool(function_names & _SHADOW_HOOK_FUNCTION_NAMES)
+    context_hygiene_imports = tuple(imp for imp in imports if "sentientos.context_hygiene" in imp)
+    non_shadow_context_hygiene_imports = tuple(imp for imp in context_hygiene_imports if imp not in _ALLOWED_SHADOW_HOOK_IMPORTS)
+    imports_context_hygiene_adapter_modules = bool(context_hygiene_imports)
     imports_prompt_adapter_contract = any("prompt_adapter_contract" in imp for imp in imports)
     uses_context_packet_directly = "ContextPacket" in names or "ContextPacket" in (source_text or "")
-    calls_context_hygiene_helpers = any(name in names for name in _CONTEXT_HYGIENE_HELPER_NAMES)
-    bypasses_adapter_contract = any(imp in _FORBIDDEN_BYPASS_IMPORTS for imp in imports) and not imports_prompt_adapter_contract
-    retrieves_memory_for_context_hygiene = "context_hygiene" in (source_text or "") and any("memory" in imp for imp in imports)
-    calls_llm_for_context_hygiene = "context_hygiene" in (source_text or "") and any(token in (source_text or "") for token in ("openai", "anthropic", "ChatCompletion", "llm"))
+    helper_names_used = set(names) & set(_CONTEXT_HYGIENE_HELPER_NAMES)
+    disallowed_helper_names_used = helper_names_used - (_SHADOW_HOOK_ALLOWED_NAMES if shadow_hook_only else frozenset())
+    calls_context_hygiene_helpers = bool(disallowed_helper_names_used)
+    bypasses_adapter_contract = any(imp in _FORBIDDEN_BYPASS_IMPORTS for imp in imports)
+    retrieves_memory_for_context_hygiene = bool(non_shadow_context_hygiene_imports) and any("memory" in imp for imp in imports)
+    provider_tokens = {"openai", "anthropic", "ChatCompletion"}
+    calls_llm_for_context_hygiene = bool(non_shadow_context_hygiene_imports) and any(token in (source_text or "") for token in provider_tokens)
     contains_phase70_adapter_payload_usage = "PromptAssemblyAdapterPayload" in names or "build_prompt_assembly_adapter_payload" in names
+    shadow_adapter_payload_usage_only = shadow_hook_only and contains_phase70_adapter_payload_usage and not non_shadow_context_hygiene_imports
     active_context_hygiene_runtime_wiring = any(
         (
-            imports_context_hygiene_adapter_modules,
-            imports_prompt_adapter_contract,
+            bool(non_shadow_context_hygiene_imports),
             uses_context_packet_directly,
             calls_context_hygiene_helpers,
-            contains_phase70_adapter_payload_usage,
+            contains_phase70_adapter_payload_usage and not shadow_adapter_payload_usage_only,
         )
     )
     forbidden_context_bypass_detected = any((bypasses_adapter_contract, retrieves_memory_for_context_hygiene, calls_llm_for_context_hygiene))
     return {
         "imports_context_hygiene_adapter_modules": imports_context_hygiene_adapter_modules,
         "imports_prompt_adapter_contract": imports_prompt_adapter_contract,
+        "context_hygiene_shadow_hook_only": shadow_hook_only and not active_context_hygiene_runtime_wiring and not forbidden_context_bypass_detected,
+        "non_shadow_context_hygiene_imports": non_shadow_context_hygiene_imports,
         "uses_context_packet_directly": uses_context_packet_directly,
         "calls_selector_preflight_manifest_envelope_verifier_or_adapter_helpers": calls_context_hygiene_helpers,
         "bypasses_adapter_contract_by_reading_context_hygiene_internals": bypasses_adapter_contract,

--- a/tests/test_phase71_prompt_assembler_compliance_harness.py
+++ b/tests/test_phase71_prompt_assembler_compliance_harness.py
@@ -251,9 +251,10 @@ def test_missing_packet_envelope_candidate_identifiers_are_blocked():
     assert {"packet_id_missing", "envelope_id_missing", "candidate_plan_id_missing"}.issubset(_codes(report))
 
 
-def test_static_prompt_assembler_scan_reports_no_active_context_hygiene_wiring_pre_integration():
+def test_static_prompt_assembler_scan_reports_shadow_hook_without_active_context_hygiene_runtime_wiring():
     findings = scan_prompt_assembler_static_findings(ROOT / "prompt_assembler.py")
     assert findings["inspection_mode"] == "source_text_ast_only_no_import"
+    assert findings["context_hygiene_shadow_hook_only"] is True
     assert findings["active_context_hygiene_runtime_wiring"] is False
     assert prompt_assembler_module_has_no_context_hygiene_runtime_wiring(ROOT / "prompt_assembler.py") is True
 

--- a/tests/test_phase72_prompt_assembler_shadow_adapter_hook.py
+++ b/tests/test_phase72_prompt_assembler_shadow_adapter_hook.py
@@ -1,0 +1,295 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+tts_stub = types.ModuleType("tts_bridge")
+tts_stub.speak = lambda *args, **kwargs: None
+sys.modules.setdefault("tts_bridge", tts_stub)
+
+import prompt_assembler as pa
+from sentientos.context_hygiene.context_packet import ContextMode
+from sentientos.context_hygiene.embodiment_context import build_embodiment_context_candidates
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterRef,
+    PromptAssemblyAdapterStatus,
+    build_prompt_assembly_adapter_payload,
+    build_prompt_assembly_adapter_payload_from_packet,
+)
+from sentientos.context_hygiene.prompt_assembler_compliance import (
+    PromptAssemblerComplianceStatus,
+    evaluate_prompt_assembler_adapter_compliance,
+    scan_prompt_assembler_static_findings,
+)
+from sentientos.context_hygiene.prompt_constraint_verifier import build_candidate_plan_from_dry_run_envelope, verify_prompt_assembly_constraints
+from sentientos.context_hygiene.prompt_dry_run_envelope import build_context_prompt_dry_run_envelope
+from sentientos.context_hygiene.prompt_handoff_manifest import build_context_prompt_handoff_manifest
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibility, PromptContextEligibilityStatus, evaluate_context_packet_prompt_eligibility
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+NOW = datetime.now(timezone.utc)
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cand(ref_id="r", ref_type="evidence", metadata=None, truth_ingress_status="allowed", contradiction_status="unknown"):
+    return ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        provenance_refs=("prov:1",),
+        source_locator="src",
+        summary="packet-safe summary",
+        already_sanitized_context_summary=True,
+        truth_ingress_status=truth_ingress_status,
+        contradiction_status=contradiction_status,
+        metadata=metadata or {"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"},
+    )
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(cands, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+
+
+def _envelope_for(cands):
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt(cands)))
+
+
+def _ready_envelope():
+    return _envelope_for([_cand("ready")])
+
+
+def _caveated_envelope():
+    packet = _pkt([_cand("caveat")])
+    pre = evaluate_context_packet_prompt_eligibility(packet)
+    caveated = PromptContextEligibility(
+        eligibility_status=PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS,
+        prompt_eligible=True,
+        may_be_prompted_only_with_caveats=True,
+        caveats=("truth_caveat: operator review",),
+        packet_id=packet.context_packet_id,
+        included_ref_count=pre.included_ref_count,
+    )
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(packet, caveated))
+
+
+def _not_applicable_envelope():
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt([])))
+
+
+def _payload(envelope=None, plan=None):
+    envelope = envelope or _ready_envelope()
+    plan = plan or build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, plan)
+    return build_prompt_assembly_adapter_payload(verification, plan), verification, plan
+
+
+def _blocked_payload():
+    envelope = _ready_envelope()
+    bad_plan = replace(build_candidate_plan_from_dry_run_envelope(envelope), packet_id="wrong")
+    return _payload(envelope, bad_plan)[0]
+
+
+def _invalid_payload():
+    envelope = _ready_envelope()
+    malformed = {"plan_id": "bad", "candidate_refs": "not refs"}
+    verification = verify_prompt_assembly_constraints(envelope, malformed)
+    return build_prompt_assembly_adapter_payload(verification, malformed)
+
+
+def _preview(payload):
+    return pa.preview_context_hygiene_adapter_payload_for_prompt_assembly(payload)
+
+
+def _mutated(payload, **changes):
+    data = asdict(payload) if not isinstance(payload, dict) else dict(payload)
+    data.update(changes)
+    if "adapter_refs" in data:
+        data["adapter_refs"] = tuple(PromptAssemblyAdapterRef(**r) if isinstance(r, dict) else r for r in data["adapter_refs"])
+    return data
+
+
+def test_shadow_hook_maps_all_phase71_compliance_statuses_to_preview_statuses():
+    ready, _, _ = _payload()
+    ready_preview = _preview(ready)
+    assert ready_preview.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION
+    assert ready_preview.rationale.startswith("shadow_preview_ready:")
+
+    warned, _, _ = _payload(_caveated_envelope())
+    warning_preview = _preview(warned)
+    assert warning_preview.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS
+    assert warning_preview.rationale.startswith("shadow_preview_ready_with_warnings:")
+
+    blocked_preview = _preview(_blocked_payload())
+    assert blocked_preview.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_BLOCKED
+    assert blocked_preview.rationale.startswith("shadow_preview_blocked:")
+
+    not_applicable, _, _ = _payload(_not_applicable_envelope())
+    not_applicable_preview = _preview(not_applicable)
+    assert not_applicable.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE
+    assert not_applicable_preview.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_NOT_APPLICABLE
+    assert not_applicable_preview.rationale.startswith("shadow_preview_not_applicable:")
+
+    invalid_preview = _preview(_invalid_payload())
+    assert invalid_preview.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_INVALID_ADAPTER_PAYLOAD
+    assert invalid_preview.rationale.startswith("shadow_preview_invalid_adapter_payload:")
+
+
+def test_shadow_preview_shape_exposes_only_metadata_counts_notes_and_boundaries():
+    payload, _, _ = _payload(_caveated_envelope())
+    preview = _preview(payload)
+    report = evaluate_prompt_assembler_adapter_compliance(payload, prompt_assembler_path=ROOT / "prompt_assembler.py")
+
+    assert preview.adapter_payload_id == payload.adapter_payload_id
+    assert preview.adapter_status == payload.adapter_status
+    assert preview.compliance_status == report.compliance_status
+    assert preview.may_future_assembler_consume is True
+    assert preview.must_block_prompt_materialization is False
+    assert preview.adapter_ref_count == len(payload.adapter_refs)
+    assert preview.section_count == len(payload.adapter_sections)
+    assert preview.preserved_caveats == payload.preserved_caveats
+    assert preview.provenance_notes_present is True
+    assert preview.privacy_notes_present is True
+    assert preview.truth_notes_present is True
+    assert preview.safety_notes_present is True
+    assert preview.shadow_hook_only is True
+    for marker in (
+        "does_not_assemble_prompt",
+        "does_not_contain_final_prompt_text",
+        "does_not_call_llm",
+        "does_not_retrieve_memory",
+        "does_not_write_memory",
+        "does_not_trigger_feedback",
+        "does_not_commit_retention",
+        "does_not_execute_or_route_work",
+        "does_not_admit_work",
+    ):
+        assert getattr(preview, marker) is True
+
+
+def test_shadow_preview_preserves_warnings_violations_as_metadata_only_and_contains_no_prompt_text_or_raw_payloads():
+    ready, _, _ = _payload()
+    blocked = _blocked_payload()
+    forbidden = _mutated(ready, prompt_text="forbidden final prompt text", raw_payload={"secret": "payload"})
+    preview = _preview(forbidden)
+    blocked_preview = _preview(blocked)
+    preview_data = asdict(preview)
+    serialized = repr(preview_data)
+
+    assert any(item["code"] == "prompt_text_present" for item in preview.violations)
+    assert any(item["code"] == "raw_payload_present" for item in preview.violations)
+    assert blocked_preview.must_block_prompt_materialization is True
+    assert blocked_preview.adapter_ref_count == 0
+    assert blocked_preview.section_count == 0
+    assert "forbidden final prompt text" not in serialized
+    assert "packet-safe summary" not in serialized
+    assert "content_summary" not in serialized
+    assert "adapter_refs" not in serialized
+    assert "final_prompt_text" not in preview_data
+    assert "prompt_text" not in preview_data
+    assert "raw_payload" not in preview_data
+
+
+def test_shadow_hook_has_no_runtime_authority_and_does_not_mutate_payload_or_live_prompt_paths(monkeypatch):
+    payload, _, _ = _payload()
+    before = deepcopy(asdict(payload))
+
+    monkeypatch.setattr(pa, "assemble_prompt", lambda *args, **kwargs: pytest.fail("live prompt assembly called"))
+    monkeypatch.setattr(pa.mm, "get_context", lambda *args, **kwargs: pytest.fail("memory retrieval called"))
+    monkeypatch.setattr(pa.em, "average_emotion", lambda *args, **kwargs: pytest.fail("emotion runtime called"))
+    monkeypatch.setattr(pa.cw, "get_context", lambda *args, **kwargs: pytest.fail("context window runtime called"))
+    monkeypatch.setattr(pa.actuator, "recent_logs", lambda *args, **kwargs: pytest.fail("action feedback runtime called"))
+    monkeypatch.setattr(pa.ac, "capture_affective_context", lambda *args, **kwargs: pytest.fail("feedback capture called"))
+    monkeypatch.setattr(pa.ac, "register_context", lambda *args, **kwargs: pytest.fail("feedback register called"))
+
+    preview = _preview(payload)
+    assert asdict(payload) == before
+    assert preview.does_not_call_llm is True
+    assert preview.does_not_retrieve_memory is True
+    assert preview.does_not_write_memory is True
+    assert preview.does_not_execute_or_route_work is True
+    assert preview.does_not_admit_work is True
+
+
+def test_existing_prompt_assembler_behavior_is_representatively_unchanged(monkeypatch):
+    monkeypatch.setattr(pa.up, "format_profile", lambda: "name: Allen")
+    monkeypatch.setattr(pa.mm, "get_context", lambda _query, k=6: [{"plan": "alpha"}, {"plan": "beta"}])
+    monkeypatch.setattr(pa.em, "average_emotion", lambda: {})
+    monkeypatch.setattr(pa.cw, "get_context", lambda: (["msg-1"], "summary"))
+    monkeypatch.setattr(pa.actuator, "recent_logs", lambda *args, **kwargs: [])
+    monkeypatch.setattr(pa.ac, "capture_affective_context", lambda *args, **kwargs: {"captured": True})
+    monkeypatch.setattr(pa.ac, "register_context", lambda *args, **kwargs: None)
+
+    prompt = pa.assemble_prompt("reflect", ["hi"], k=2)
+    assert "SYSTEM:" in prompt
+    assert "USER PROFILE:\nname: Allen" in prompt
+    assert "RELEVANT MEMORIES:\n- alpha\n- beta" in prompt
+    assert "RECENT DIALOGUE:\nhi" in prompt
+    assert "SUMMARY:\nsummary" in prompt
+    assert "USER:\nreflect" in prompt
+    assert "affect" not in prompt
+
+
+def test_static_scan_detects_intentional_shadow_hook_without_live_runtime_wiring_or_bypass():
+    findings = scan_prompt_assembler_static_findings(ROOT / "prompt_assembler.py")
+    assert findings["context_hygiene_shadow_hook_only"] is True
+    assert findings["imports_context_hygiene_adapter_modules"] is True
+    assert findings["active_context_hygiene_runtime_wiring"] is False
+    assert findings["forbidden_context_bypass_detected"] is False
+    assert findings["non_shadow_context_hygiene_imports"] == ()
+
+
+def test_phase63_to_phase72_shadow_hook_pipeline_works_for_sanitized_embodiment_proposal():
+    proposals = build_embodiment_context_candidates(
+        [
+            {
+                "ref_id": "emb:1",
+                "source_kind": "embodiment_snapshot",
+                "packet_scope": "turn",
+                "conversation_scope_id": "conv",
+                "task_scope_id": "task",
+                "content_summary": "sanitized posture summary",
+                "sanitized_context_summary": True,
+                "privacy_posture": "low_risk",
+                "provenance_refs": ("sensor:summary",),
+                "non_authoritative": True,
+                "decision_power": "none",
+            }
+        ]
+    )
+    packet = build_context_packet_from_candidates(proposals, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+    payload = build_prompt_assembly_adapter_payload_from_packet(packet)
+    preview = _preview(payload)
+    assert payload.adapter_refs
+    assert preview.compliance_status in {
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION,
+        PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS,
+    }
+    assert preview.adapter_ref_count == len(payload.adapter_refs)
+    assert "sanitized posture summary" not in repr(asdict(preview))
+
+
+def test_phase62b_blocked_attempted_candidate_shadow_hook_blocks_materialization():
+    payload, _, _ = _payload(
+        _envelope_for(
+            [_cand("blocked", metadata={"source_kind": "evidence", "pollution_risk": "blocked", "non_authoritative": True, "decision_power": "none"})]
+        )
+    )
+    preview = _preview(payload)
+    assert payload.adapter_status in {PromptAssemblyAdapterStatus.ADAPTER_BLOCKED, PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE}
+    assert preview.may_future_assembler_consume is False
+    assert preview.must_block_prompt_materialization is True
+    assert preview.adapter_ref_count == 0
+    assert preview.section_count == 0


### PR DESCRIPTION
### Motivation
- Add an opt-in, shadow-only adapter preview hook in `prompt_assembler.py` so the prompt assembler can recognize and validate Phase 70 `PromptAssemblyAdapterPayload` through the Phase 71 compliance harness without changing live prompt assembly behavior or producing final prompt text.

### Description
- Introduced `PromptAssemblerShadowAdapterPreview` and `preview_context_hygiene_adapter_payload_for_prompt_assembly(...)` (alias `build_context_hygiene_shadow_prompt_adapter_preview`) in `prompt_assembler.py` to call the Phase 71 compliance evaluator and emit a compact, frozen preview/receipt containing IDs, counts, caveats, note-presence booleans, constraints, warnings/violations, and explicit non-runtime markers, while never assembling final prompt text or invoking runtime systems.
- Added a Phase-71→Phase-72 preview status mapping and logic to withhold adapter refs/sections when materialization must be blocked; the hook never mutates the payload or global prompt assembler state and does not call LLM/retrieval/memory/action/retention/orchestration code.
- Updated `sentientos/context_hygiene/prompt_assembler_compliance.py` static scanner to recognize the intentional shadow hook (allowing a narrow set of imports for that test-only path) while still flagging any non-shadow runtime wiring or forbidden bypass imports.
- Added `tests/test_phase72_prompt_assembler_shadow_adapter_hook.py`, tweaked `tests/test_phase71_prompt_assembler_compliance_harness.py` to assert the shadow-hook-aware scan, and added documentation `docs/architecture/phase72_prompt_assembler_shadow_adapter_hook_execplan.md` plus a brief Phase 72 note in `docs/architecture/context_hygiene_spine.md`.

### Testing
- Ran `python -m scripts.run_tests -q tests/test_phase72_prompt_assembler_shadow_adapter_hook.py` and the Phase 72 test suite passed successfully after adding a localized `tts_bridge` stub to avoid host TTS installation issues.
- Ran the Phase 71..Phase 61 compliance/adapter/verifier/dry-run/handoff/preflight pipeline tests with `python -m scripts.run_tests -q` and those phase suites passed, including the static-scan assertions that distinguish the shadow hook from forbidden runtime wiring.
- Ran architecture and import-purity checks `python -m scripts.run_tests -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` and they passed for the modified files and the allowed shadow-hook import pattern.
- Verified `python scripts/audit_immutability_verifier.py` passed for repository immutability checks in this environment; noted `verify_audits` was not present here.
- Noted and documented that initial collection of some existing prompt-assembler integration tests failed in this environment due to import-time `pyttsx3`/eSpeak dependency, which is a pre-existing environmental requirement and was worked around in the Phase 72 test by stubbing `tts_bridge`; the hook itself was exercised without invoking live TTS, memory retrieval, LLMs, or runtime action paths.
- Ran `mypy scripts/ sentientos/` and observed pre-existing, repository-wide type issues unrelated to this change; these are outside the scope of this Phase 72 opt-in shadow hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fae628b95c8320812a48c1a11aa295)