### PR TITLE
[codex:context-hygiene] add prompt assembler shadow blueprint contract

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -125,3 +125,11 @@ Phase 72 adds the first controlled `prompt_assembler.py` context hygiene touch: 
 The hook is not used by runtime prompt assembly paths. It does not alter `assemble_prompt(...)`, does not change existing call sites, does not assemble prompt text, and does not concatenate adapter refs into final prompt material. Its output is a compact preview/receipt containing adapter/compliance status, metadata counts, caveats, notes-presence booleans, warnings, violations, constraints, rationale, and explicit non-runtime markers.
 
 Phase 72 does not call LLMs, does not retrieve memory, does not write memory, and does not modify truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior. Blocked, not-applicable, invalid, or runtime-wiring-detected adapter payloads remain prompt-materialization blocked and expose only preview status/metadata for audit.
+
+### Phase 73: Prompt Assembler Shadow Blueprint Contract
+
+Phase 73 adds a second controlled `prompt_assembler.py` context hygiene touch: a shadow-only blueprint helper that converts a Phase 70 `PromptAssemblyAdapterPayload`, after Phase 72 shadow preview and Phase 71 compliance, into a structured future prompt-layout blueprint. The blueprint groups compliant adapter refs into blueprint sections and records caveat, provenance, privacy, truth, safety, constraint, status, and digest metadata.
+
+The blueprint is test-invoked only and is not live prompt assembly. It does not assemble prompt text, does not concatenate adapter refs into prompt prose, does not call LLMs, does not retrieve memory, and does not write memory. Blocked, not-applicable, invalid, or runtime-wiring-detected payloads produce no blueprint refs and keep prompt materialization blocked.
+
+Phase 73 does not modify truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior. It does not alter existing `assemble_prompt(...)` behavior or any existing call site.

--- a/docs/architecture/phase73_prompt_assembler_shadow_blueprint_contract_execplan.md
+++ b/docs/architecture/phase73_prompt_assembler_shadow_blueprint_contract_execplan.md
@@ -1,0 +1,101 @@
+# Phase 73: Prompt Assembler Shadow Blueprint Contract Exec Plan
+
+## Goal
+Add an opt-in, test-invoked shadow-only blueprint contract in `prompt_assembler.py` that accepts a Phase 70 `PromptAssemblyAdapterPayload`, runs it through the Phase 72 shadow preview/compliance path, and emits a structured future prompt-layout blueprint.
+
+The blueprint proves how compliant adapter refs could be grouped and ordered later without producing prompt text or gaining runtime authority.
+
+## Non-goals
+- No final prompt text assembly.
+- No concatenation of adapter refs or summaries into prompt prose.
+- No LLM calls.
+- No memory retrieval or memory writes.
+- No feedback, retention, action, routing, admission, execution, orchestration, truth, or embodiment runtime changes.
+- No change to `assemble_prompt(...)` behavior or existing call sites.
+
+## Dependency chain
+Phase 73 depends on the context hygiene spine:
+
+1. **Phase 61**: `ContextPacket` schema and receipts.
+2. **Phase 62**: truth-gated context selection.
+3. **Phase 62B**: first-class `blocked` pollution risk and attempted-candidate contamination preservation.
+4. **Phase 63**: embodiment/privacy eligibility adapters.
+5. **Phase 64**: prompt preflight.
+6. **Phase 65**: packet-local safety metadata preservation.
+7. **Phase 66**: per-source-kind safety contract completeness.
+8. **Phase 67**: prompt handoff manifest.
+9. **Phase 68**: prompt assembly dry-run envelope.
+10. **Phase 69**: prompt assembly constraint verifier.
+11. **Phase 70**: prompt assembly adapter contract.
+12. **Phase 71**: prompt assembler compliance harness.
+13. **Phase 72**: opt-in shadow prompt assembler adapter preview hook.
+
+## Shadow blueprint is not prompt assembly
+The Phase 73 blueprint is a contract artifact only. It carries section descriptors, blueprint-safe ref summaries, caveat requirements, boundary-note requirements, constraints, status mapping, and a deterministic digest. It deliberately omits final prompt text, prompt fragments, raw payloads, raw memory, multimodal raw data, executable handles, retrieval handles, retention handles, action handles, LLM parameters, and browser/mouse/keyboard control data.
+
+## Blueprint output shape
+The blueprint includes:
+
+- `blueprint_id`
+- `adapter_payload_id`
+- `adapter_status`
+- `preview_status`
+- `blueprint_status`
+- `compliance_status`
+- `may_future_assembler_consume`
+- `must_block_prompt_materialization`
+- `adapter_ref_count`
+- `blueprint_ref_count`
+- `section_count`
+- `blueprint_sections`
+- `blueprint_refs`
+- `preserved_caveats`
+- `warnings`
+- `violations`
+- `assembly_constraints`
+- provenance/privacy/truth/safety note-presence booleans
+- compact rationale
+- deterministic digest
+- explicit non-runtime markers
+
+## Section/ref summary rules
+Blueprint sections are derived only from Phase 70 adapter sections. Adapter section kinds map to blueprint section kinds:
+
+- `adapter_context_refs` → `blueprint_context_refs`
+- `adapter_diagnostic_refs` → `blueprint_diagnostic_refs`
+- `adapter_evidence_refs` → `blueprint_evidence_refs`
+- `adapter_embodiment_refs` → `blueprint_embodiment_refs`
+- `adapter_caveat_requirements` → `blueprint_caveat_requirements`
+- `adapter_provenance_boundaries` → `blueprint_provenance_boundaries`
+- `adapter_privacy_boundaries` → `blueprint_privacy_boundaries`
+- `adapter_truth_boundaries` → `blueprint_truth_boundaries`
+- `adapter_safety_boundaries` → `blueprint_safety_boundaries`
+- `adapter_constraint_summary` → `blueprint_constraint_summary`
+
+Blueprint refs are derived only from Phase 70 adapter refs and include only metadata-safe fields: ref id, ref type, lane, source kind, privacy posture, pollution risk, provenance ref count, caveat count, and safety-summary presence.
+
+## Digest behavior
+The digest is deterministic over stable blueprint-safe fields. It changes when adapter payload id, blueprint status, section/ref summaries, caveats, warnings, violations, constraints, or note-presence booleans change. It excludes raw payloads, final prompt text, runtime handles, LLM parameters, and nondeterministic timestamps.
+
+## Compliance/preview relationship
+The builder first calls the Phase 72 preview hook. Preview statuses map to blueprint statuses:
+
+- `shadow_preview_ready` → `shadow_blueprint_ready`
+- `shadow_preview_ready_with_warnings` → `shadow_blueprint_ready_with_warnings`
+- `shadow_preview_blocked` → `shadow_blueprint_blocked`
+- `shadow_preview_not_applicable` → `shadow_blueprint_not_applicable`
+- `shadow_preview_invalid_adapter_payload` → `shadow_blueprint_invalid_adapter_payload`
+- `shadow_preview_runtime_wiring_detected` → `shadow_blueprint_runtime_wiring_detected`
+
+Ready and ready-with-warnings previews may expose blueprint refs and sections. Blocked, not-applicable, invalid, or runtime-wiring-detected previews expose no blueprint refs or sections and keep prompt materialization blocked.
+
+## Existing behavior preservation
+The Phase 73 helper is explicitly invoked by tests only. It does not alter public prompt assembler signatures, does not call `assemble_prompt(...)`, and does not change existing prompt assembly call sites or live behavior.
+
+## Tests
+`tests/test_phase73_prompt_assembler_shadow_blueprint_contract.py` covers status mapping, output shape, no-prompt/no-raw/no-runtime markers, section/ref metadata rules, blocked gating, deterministic digest behavior, mutation safety, runtime-call isolation, representative `assemble_prompt(...)` preservation, static scan compatibility, a Phase 63→73 pipeline, and a Phase 62B blocked attempted-candidate path.
+
+## Deferred work
+- Real prompt materialization remains deferred.
+- Runtime integration remains deferred.
+- Any future assembler must re-check compliance, preserve caveats/boundaries, and keep blocked refs non-materialized.

--- a/prompt_assembler.py
+++ b/prompt_assembler.py
@@ -56,6 +56,89 @@ class PromptAssemblerShadowAdapterPreview:
     does_not_admit_work: bool = True
 
 
+
+
+@dataclass(frozen=True)
+class PromptAssemblerShadowBlueprintRef:
+    ref_id: str
+    ref_type: str
+    lane: str
+    source_kind: str
+    privacy_posture: str
+    pollution_risk: str
+    provenance_ref_count: int
+    caveat_count: int
+    safety_summary_present: bool
+
+
+@dataclass(frozen=True)
+class PromptAssemblerShadowBlueprintSection:
+    section_id: str
+    section_kind: str
+    source_section_kind: str
+    ref_ids: tuple[str, ...]
+    ref_count: int
+    caveats: tuple[str, ...]
+    required_boundary_notes: tuple[str, ...]
+    provenance_required: bool
+    privacy_boundary_required: bool
+    truth_boundary_required: bool
+    safety_boundary_required: bool
+    rationale: str
+
+
+@dataclass(frozen=True)
+class PromptAssemblerShadowBlueprintBoundary:
+    shadow_blueprint_only: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+@dataclass(frozen=True)
+class PromptAssemblerShadowBlueprint:
+    blueprint_id: str
+    adapter_payload_id: str
+    adapter_status: str
+    preview_status: str
+    blueprint_status: str
+    compliance_status: str
+    may_future_assembler_consume: bool
+    must_block_prompt_materialization: bool
+    adapter_ref_count: int
+    blueprint_ref_count: int
+    section_count: int
+    blueprint_sections: tuple[PromptAssemblerShadowBlueprintSection, ...]
+    blueprint_refs: tuple[PromptAssemblerShadowBlueprintRef, ...]
+    preserved_caveats: tuple[str, ...]
+    warnings: tuple[Mapping[str, str], ...]
+    violations: tuple[Mapping[str, str], ...]
+    assembly_constraints: Mapping[str, Any]
+    provenance_notes_present: bool
+    privacy_notes_present: bool
+    truth_notes_present: bool
+    safety_notes_present: bool
+    rationale: str
+    digest: str
+    boundary: PromptAssemblerShadowBlueprintBoundary = PromptAssemblerShadowBlueprintBoundary()
+    shadow_blueprint_only: bool = True
+    does_not_assemble_prompt: bool = True
+    does_not_contain_final_prompt_text: bool = True
+    does_not_call_llm: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
 _CONTEXT_HYGIENE_SHADOW_PREVIEW_STATUS_MAP = {
     PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION: "shadow_preview_ready",
     PromptAssemblerComplianceStatus.COMPLIANCE_READY_WITH_WARNINGS: "shadow_preview_ready_with_warnings",
@@ -142,6 +225,204 @@ def preview_context_hygiene_adapter_payload_for_prompt_assembly(
 
 
 build_context_hygiene_shadow_prompt_adapter_preview = preview_context_hygiene_adapter_payload_for_prompt_assembly
+
+_CONTEXT_HYGIENE_SHADOW_BLUEPRINT_STATUS_MAP = {
+    "shadow_preview_ready": "shadow_blueprint_ready",
+    "shadow_preview_ready_with_warnings": "shadow_blueprint_ready_with_warnings",
+    "shadow_preview_blocked": "shadow_blueprint_blocked",
+    "shadow_preview_not_applicable": "shadow_blueprint_not_applicable",
+    "shadow_preview_invalid_adapter_payload": "shadow_blueprint_invalid_adapter_payload",
+    "shadow_preview_runtime_wiring_detected": "shadow_blueprint_runtime_wiring_detected",
+}
+
+_CONTEXT_HYGIENE_BLUEPRINT_SECTION_KIND_MAP = {
+    "adapter_context_refs": "blueprint_context_refs",
+    "adapter_diagnostic_refs": "blueprint_diagnostic_refs",
+    "adapter_evidence_refs": "blueprint_evidence_refs",
+    "adapter_embodiment_refs": "blueprint_embodiment_refs",
+    "adapter_caveat_requirements": "blueprint_caveat_requirements",
+    "adapter_provenance_boundaries": "blueprint_provenance_boundaries",
+    "adapter_privacy_boundaries": "blueprint_privacy_boundaries",
+    "adapter_truth_boundaries": "blueprint_truth_boundaries",
+    "adapter_safety_boundaries": "blueprint_safety_boundaries",
+    "adapter_constraint_summary": "blueprint_constraint_summary",
+}
+
+
+def _shadow_digest_safe(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {k: _shadow_digest_safe(v) for k, v in asdict(value).items() if k != "digest"}
+    if isinstance(value, Mapping):
+        return {str(k): _shadow_digest_safe(v) for k, v in sorted(value.items(), key=lambda item: str(item[0])) if str(k) != "digest"}
+    if isinstance(value, (tuple, list)):
+        return [_shadow_digest_safe(v) for v in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_shadow_digest_safe(v) for v in value)
+    return value
+
+
+def _compute_shadow_blueprint_digest(fields: Mapping[str, Any]) -> str:
+    encoded = json.dumps(_shadow_digest_safe(fields), sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _blueprint_ref(ref: Any) -> PromptAssemblerShadowBlueprintRef:
+    data = _shadow_payload_mapping(ref)
+    provenance_refs = data.get("provenance_refs", ())
+    caveats = data.get("caveats", ())
+    safety_summary = data.get("safety_summary", {})
+    return PromptAssemblerShadowBlueprintRef(
+        ref_id=str(data.get("ref_id", "")),
+        ref_type=str(data.get("ref_type", "")),
+        lane=str(data.get("lane", "")),
+        source_kind=str(data.get("source_kind", "")),
+        privacy_posture=str(data.get("privacy_posture", "")),
+        pollution_risk=str(data.get("pollution_risk", "")),
+        provenance_ref_count=len(tuple(provenance_refs or ())) if isinstance(provenance_refs, (tuple, list)) else 0,
+        caveat_count=len(tuple(caveats or ())) if isinstance(caveats, (tuple, list)) else 0,
+        safety_summary_present=bool(safety_summary),
+    )
+
+
+def _blueprint_section(
+    section: Any,
+    *,
+    payload_caveats: tuple[str, ...],
+    provenance_notes_present: bool,
+    privacy_notes_present: bool,
+    truth_notes_present: bool,
+    safety_notes_present: bool,
+) -> PromptAssemblerShadowBlueprintSection | None:
+    data = _shadow_payload_mapping(section)
+    source_kind = str(data.get("section_kind", ""))
+    section_kind = _CONTEXT_HYGIENE_BLUEPRINT_SECTION_KIND_MAP.get(source_kind)
+    if section_kind is None:
+        return None
+    ref_ids = tuple(str(ref_id) for ref_id in data.get("ref_ids", ()) or ()) if isinstance(data.get("ref_ids", ()), (tuple, list)) else ()
+    required_notes: list[str] = []
+    provenance_required = section_kind == "blueprint_provenance_boundaries" and provenance_notes_present
+    privacy_required = section_kind == "blueprint_privacy_boundaries" and privacy_notes_present
+    truth_required = section_kind == "blueprint_truth_boundaries" and truth_notes_present
+    safety_required = section_kind == "blueprint_safety_boundaries" and safety_notes_present
+    if provenance_required:
+        required_notes.append("provenance_notes")
+    if privacy_required:
+        required_notes.append("privacy_notes")
+    if truth_required:
+        required_notes.append("truth_notes")
+    if safety_required:
+        required_notes.append("safety_notes")
+    section_caveats = payload_caveats if section_kind == "blueprint_caveat_requirements" else ()
+    return PromptAssemblerShadowBlueprintSection(
+        section_id=f"blueprint:{data.get('section_id', source_kind)}",
+        section_kind=section_kind,
+        source_section_kind=source_kind,
+        ref_ids=ref_ids,
+        ref_count=len(ref_ids),
+        caveats=section_caveats,
+        required_boundary_notes=tuple(required_notes),
+        provenance_required=provenance_required,
+        privacy_boundary_required=privacy_required,
+        truth_boundary_required=truth_required,
+        safety_boundary_required=safety_required,
+        rationale=f"{section_kind} derived from {source_kind} metadata only",
+    )
+
+
+def build_context_hygiene_shadow_prompt_blueprint(
+    payload: PromptAssemblyAdapterPayload | Mapping[str, Any],
+) -> PromptAssemblerShadowBlueprint:
+    """Build a Phase 73 shadow-only future prompt-layout blueprint from adapter metadata.
+
+    The blueprint is a structured section/ref contract only. It calls the Phase 72
+    shadow preview/compliance path, never calls assemble_prompt, never performs
+    memory retrieval/writes, and never materializes final prompt text.
+    """
+
+    preview = preview_context_hygiene_adapter_payload_for_prompt_assembly(payload)
+    data = _shadow_payload_mapping(payload)
+    preview_status = preview.rationale.split(":", 1)[0]
+    blueprint_status = _CONTEXT_HYGIENE_SHADOW_BLUEPRINT_STATUS_MAP.get(
+        preview_status, "shadow_blueprint_invalid_adapter_payload"
+    )
+    may_consume = preview.may_future_assembler_consume and blueprint_status in {
+        "shadow_blueprint_ready",
+        "shadow_blueprint_ready_with_warnings",
+    }
+    preserved_caveats = tuple(preview.preserved_caveats)
+    adapter_refs = tuple(data.get("adapter_refs", ()) or ()) if isinstance(data.get("adapter_refs", ()), (tuple, list)) else ()
+    adapter_sections = tuple(data.get("adapter_sections", ()) or ()) if isinstance(data.get("adapter_sections", ()), (tuple, list)) else ()
+    blueprint_refs = tuple(_blueprint_ref(ref) for ref in adapter_refs) if may_consume else ()
+    blueprint_sections = (
+        tuple(
+            section
+            for section in (
+                _blueprint_section(
+                    adapter_section,
+                    payload_caveats=preserved_caveats,
+                    provenance_notes_present=preview.provenance_notes_present,
+                    privacy_notes_present=preview.privacy_notes_present,
+                    truth_notes_present=preview.truth_notes_present,
+                    safety_notes_present=preview.safety_notes_present,
+                )
+                for adapter_section in adapter_sections
+            )
+            if section is not None
+        )
+        if may_consume
+        else ()
+    )
+    blueprint_id = f"shadow-blueprint:{preview.adapter_payload_id or 'unknown'}:{blueprint_status}"
+    digest_fields = {
+        "blueprint_id": blueprint_id,
+        "adapter_payload_id": preview.adapter_payload_id,
+        "adapter_status": preview.adapter_status,
+        "preview_status": preview_status,
+        "blueprint_status": blueprint_status,
+        "compliance_status": preview.compliance_status,
+        "may_future_assembler_consume": may_consume,
+        "must_block_prompt_materialization": (not may_consume) or preview.must_block_prompt_materialization,
+        "adapter_ref_count": preview.adapter_ref_count,
+        "blueprint_refs": blueprint_refs,
+        "blueprint_sections": blueprint_sections,
+        "preserved_caveats": preserved_caveats,
+        "warnings": preview.warnings,
+        "violations": preview.violations,
+        "assembly_constraints": preview.constraints,
+        "provenance_notes_present": preview.provenance_notes_present,
+        "privacy_notes_present": preview.privacy_notes_present,
+        "truth_notes_present": preview.truth_notes_present,
+        "safety_notes_present": preview.safety_notes_present,
+    }
+    digest = _compute_shadow_blueprint_digest(digest_fields)
+    return PromptAssemblerShadowBlueprint(
+        blueprint_id=blueprint_id,
+        adapter_payload_id=preview.adapter_payload_id,
+        adapter_status=preview.adapter_status,
+        preview_status=preview_status,
+        blueprint_status=blueprint_status,
+        compliance_status=preview.compliance_status,
+        may_future_assembler_consume=may_consume,
+        must_block_prompt_materialization=(not may_consume) or preview.must_block_prompt_materialization,
+        adapter_ref_count=preview.adapter_ref_count,
+        blueprint_ref_count=len(blueprint_refs),
+        section_count=len(blueprint_sections),
+        blueprint_sections=blueprint_sections,
+        blueprint_refs=blueprint_refs,
+        preserved_caveats=preserved_caveats,
+        warnings=preview.warnings,
+        violations=preview.violations,
+        assembly_constraints=preview.constraints,
+        provenance_notes_present=preview.provenance_notes_present,
+        privacy_notes_present=preview.privacy_notes_present,
+        truth_notes_present=preview.truth_notes_present,
+        safety_notes_present=preview.safety_notes_present,
+        rationale=f"{blueprint_status}: layout metadata only after {preview_status}; no prompt materialization",
+        digest=digest,
+    )
+
+
+build_shadow_prompt_blueprint_from_adapter_payload = build_context_hygiene_shadow_prompt_blueprint
 
 
 SYSTEM_PROMPT = "You are Lumos, an emotionally present AI assistant."

--- a/sentientos/context_hygiene/prompt_assembler_compliance.py
+++ b/sentientos/context_hygiene/prompt_assembler_compliance.py
@@ -111,6 +111,8 @@ _SHADOW_HOOK_FUNCTION_NAMES = frozenset(
     {
         "preview_context_hygiene_adapter_payload_for_prompt_assembly",
         "build_context_hygiene_shadow_prompt_adapter_preview",
+        "build_context_hygiene_shadow_prompt_blueprint",
+        "build_shadow_prompt_blueprint_from_adapter_payload",
     }
 )
 _SHADOW_HOOK_ALLOWED_NAMES = frozenset(

--- a/tests/test_phase73_prompt_assembler_shadow_blueprint_contract.py
+++ b/tests/test_phase73_prompt_assembler_shadow_blueprint_contract.py
@@ -1,0 +1,345 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+tts_stub = types.ModuleType("tts_bridge")
+tts_stub.speak = lambda *args, **kwargs: None
+sys.modules.setdefault("tts_bridge", tts_stub)
+
+import prompt_assembler as pa
+from sentientos.context_hygiene.context_packet import ContextMode
+from sentientos.context_hygiene.embodiment_context import build_embodiment_context_candidates
+from sentientos.context_hygiene.prompt_adapter_contract import (
+    PromptAssemblyAdapterRef,
+    PromptAssemblyAdapterStatus,
+    build_prompt_assembly_adapter_payload,
+    build_prompt_assembly_adapter_payload_from_packet,
+)
+from sentientos.context_hygiene.prompt_assembler_compliance import (
+    PromptAssemblerComplianceStatus,
+    scan_prompt_assembler_static_findings,
+)
+from sentientos.context_hygiene.prompt_constraint_verifier import build_candidate_plan_from_dry_run_envelope, verify_prompt_assembly_constraints
+from sentientos.context_hygiene.prompt_dry_run_envelope import build_context_prompt_dry_run_envelope
+from sentientos.context_hygiene.prompt_handoff_manifest import build_context_prompt_handoff_manifest
+from sentientos.context_hygiene.prompt_preflight import PromptContextEligibility, PromptContextEligibilityStatus, evaluate_context_packet_prompt_eligibility
+from sentientos.context_hygiene.selector import ContextCandidate, build_context_packet_from_candidates
+
+NOW = datetime.now(timezone.utc)
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cand(ref_id="r", ref_type="evidence", metadata=None, truth_ingress_status="allowed", contradiction_status="unknown"):
+    return ContextCandidate(
+        ref_id=ref_id,
+        ref_type=ref_type,
+        packet_scope="turn",
+        conversation_scope_id="conv",
+        task_scope_id="task",
+        provenance_refs=("prov:1",),
+        source_locator="src",
+        summary="packet-safe summary",
+        already_sanitized_context_summary=True,
+        truth_ingress_status=truth_ingress_status,
+        contradiction_status=contradiction_status,
+        metadata=metadata or {"source_kind": "evidence", "privacy_posture": "public", "non_authoritative": True, "decision_power": "none"},
+    )
+
+
+def _pkt(cands):
+    return build_context_packet_from_candidates(cands, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+
+
+def _envelope_for(cands):
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt(cands)))
+
+
+def _ready_envelope():
+    return _envelope_for([_cand("ready")])
+
+
+def _caveated_envelope():
+    packet = _pkt([_cand("caveat")])
+    pre = evaluate_context_packet_prompt_eligibility(packet)
+    caveated = PromptContextEligibility(
+        eligibility_status=PromptContextEligibilityStatus.PROMPT_ELIGIBLE_WITH_CAVEATS,
+        prompt_eligible=True,
+        may_be_prompted_only_with_caveats=True,
+        caveats=("truth_caveat: operator review",),
+        packet_id=packet.context_packet_id,
+        included_ref_count=pre.included_ref_count,
+    )
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(packet, caveated))
+
+
+def _not_applicable_envelope():
+    return build_context_prompt_dry_run_envelope(build_context_prompt_handoff_manifest(_pkt([])))
+
+
+def _payload(envelope=None, plan=None):
+    envelope = envelope or _ready_envelope()
+    plan = plan or build_candidate_plan_from_dry_run_envelope(envelope)
+    verification = verify_prompt_assembly_constraints(envelope, plan)
+    return build_prompt_assembly_adapter_payload(verification, plan), verification, plan
+
+
+def _blocked_payload():
+    envelope = _ready_envelope()
+    bad_plan = replace(build_candidate_plan_from_dry_run_envelope(envelope), packet_id="wrong")
+    return _payload(envelope, bad_plan)[0]
+
+
+def _invalid_payload():
+    envelope = _ready_envelope()
+    malformed = {"plan_id": "bad", "candidate_refs": "not refs"}
+    verification = verify_prompt_assembly_constraints(envelope, malformed)
+    return build_prompt_assembly_adapter_payload(verification, malformed)
+
+
+def _blueprint(payload):
+    return pa.build_context_hygiene_shadow_prompt_blueprint(payload)
+
+
+def _mutated(payload, **changes):
+    data = asdict(payload) if not isinstance(payload, dict) else dict(payload)
+    data.update(changes)
+    if "adapter_refs" in data:
+        data["adapter_refs"] = tuple(PromptAssemblyAdapterRef(**r) if isinstance(r, dict) else r for r in data["adapter_refs"])
+    return data
+
+
+def test_shadow_blueprint_maps_ready_warning_blocked_not_applicable_and_invalid_statuses():
+    ready = _blueprint(_payload()[0])
+    assert ready.blueprint_status == "shadow_blueprint_ready"
+    assert ready.preview_status == "shadow_preview_ready"
+    assert ready.compliance_status == PromptAssemblerComplianceStatus.COMPLIANCE_READY_FOR_FUTURE_INTEGRATION
+
+    warned = _blueprint(_payload(_caveated_envelope())[0])
+    assert warned.blueprint_status == "shadow_blueprint_ready_with_warnings"
+    assert warned.preview_status == "shadow_preview_ready_with_warnings"
+
+    blocked = _blueprint(_blocked_payload())
+    assert blocked.blueprint_status == "shadow_blueprint_blocked"
+    assert blocked.blueprint_refs == ()
+    assert blocked.blueprint_ref_count == 0
+
+    not_applicable = _blueprint(_payload(_not_applicable_envelope())[0])
+    assert not_applicable.adapter_status == PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE
+    assert not_applicable.blueprint_status == "shadow_blueprint_not_applicable"
+    assert not_applicable.blueprint_refs == ()
+
+    invalid = _blueprint(_invalid_payload())
+    assert invalid.blueprint_status == "shadow_blueprint_invalid_adapter_payload"
+    assert invalid.blueprint_refs == ()
+
+
+def test_shadow_blueprint_output_shape_preserves_metadata_without_prompt_materialization():
+    payload, _, _ = _payload(_caveated_envelope())
+    blueprint = _blueprint(payload)
+    data = asdict(blueprint)
+    serialized = repr(data)
+
+    assert blueprint.blueprint_id.startswith(f"shadow-blueprint:{payload.adapter_payload_id}:")
+    assert blueprint.adapter_payload_id == payload.adapter_payload_id
+    assert blueprint.adapter_status == payload.adapter_status
+    assert blueprint.preview_status == "shadow_preview_ready_with_warnings"
+    assert blueprint.may_future_assembler_consume is True
+    assert blueprint.must_block_prompt_materialization is False
+    assert blueprint.adapter_ref_count == len(payload.adapter_refs)
+    assert blueprint.blueprint_ref_count == len(payload.adapter_refs)
+    assert blueprint.section_count == len(payload.adapter_sections)
+    assert blueprint.blueprint_sections
+    assert blueprint.blueprint_refs
+    assert blueprint.preserved_caveats == payload.preserved_caveats
+    assert blueprint.warnings
+    assert blueprint.assembly_constraints == payload.assembly_constraints
+    assert blueprint.provenance_notes_present is True
+    assert blueprint.privacy_notes_present is True
+    assert blueprint.truth_notes_present is True
+    assert blueprint.safety_notes_present is True
+    assert blueprint.shadow_blueprint_only is True
+    assert blueprint.boundary.shadow_blueprint_only is True
+    for marker in (
+        "does_not_assemble_prompt",
+        "does_not_contain_final_prompt_text",
+        "does_not_call_llm",
+        "does_not_retrieve_memory",
+        "does_not_write_memory",
+        "does_not_trigger_feedback",
+        "does_not_commit_retention",
+        "does_not_execute_or_route_work",
+        "does_not_admit_work",
+    ):
+        assert getattr(blueprint, marker) is True
+        assert getattr(blueprint.boundary, marker) is True
+
+    assert "packet-safe summary" not in serialized
+    assert "content_summary" not in serialized
+    assert "final_prompt_text" not in data
+    assert "prompt_text" not in data
+    assert "raw_payload" not in data
+    assert "llm_params" not in serialized
+    assert "retrieval_handle" not in serialized
+    assert "action_handle" not in serialized
+    assert "retention_handle" not in serialized
+
+
+def test_shadow_blueprint_section_and_ref_summaries_are_adapter_derived_metadata_only():
+    payload, _, _ = _payload(_caveated_envelope())
+    blueprint = _blueprint(payload)
+    section_kinds = {section.section_kind for section in blueprint.blueprint_sections}
+    assert section_kinds == {
+        "blueprint_context_refs",
+        "blueprint_diagnostic_refs",
+        "blueprint_evidence_refs",
+        "blueprint_embodiment_refs",
+        "blueprint_caveat_requirements",
+        "blueprint_provenance_boundaries",
+        "blueprint_privacy_boundaries",
+        "blueprint_truth_boundaries",
+        "blueprint_safety_boundaries",
+        "blueprint_constraint_summary",
+    }
+    assert all(section.source_section_kind.startswith("adapter_") for section in blueprint.blueprint_sections)
+    assert any(section.caveats == payload.preserved_caveats for section in blueprint.blueprint_sections)
+    assert any(section.provenance_required for section in blueprint.blueprint_sections)
+    assert any(section.privacy_boundary_required for section in blueprint.blueprint_sections)
+    assert any(section.truth_boundary_required for section in blueprint.blueprint_sections)
+    assert any(section.safety_boundary_required for section in blueprint.blueprint_sections)
+    ref = blueprint.blueprint_refs[0]
+    assert ref.ref_id == payload.adapter_refs[0].ref_id
+    assert ref.ref_type == payload.adapter_refs[0].ref_type
+    assert ref.source_kind == payload.adapter_refs[0].source_kind
+    assert ref.provenance_ref_count == len(payload.adapter_refs[0].provenance_refs)
+    assert ref.caveat_count == len(payload.adapter_refs[0].caveats)
+    assert ref.safety_summary_present is bool(payload.adapter_refs[0].safety_summary)
+
+
+def test_shadow_blueprint_blocks_materialization_and_refs_for_non_consumable_payloads():
+    for payload in (_blocked_payload(), _payload(_not_applicable_envelope())[0], _invalid_payload()):
+        blueprint = _blueprint(payload)
+        assert blueprint.may_future_assembler_consume is False
+        assert blueprint.must_block_prompt_materialization is True
+        assert blueprint.blueprint_refs == ()
+        assert blueprint.blueprint_ref_count == 0
+        assert blueprint.blueprint_sections == ()
+        assert blueprint.section_count == 0
+
+
+def test_shadow_blueprint_digest_is_deterministic_and_changes_for_contract_fields():
+    payload, _, _ = _payload(_caveated_envelope())
+    first = _blueprint(payload)
+    second = _blueprint(payload)
+    assert first.digest == second.digest
+
+    ref_changed = replace(payload.adapter_refs[0], ref_id="changed")
+    changed_ref_payload = replace(payload, adapter_refs=(ref_changed,))
+    assert _blueprint(changed_ref_payload).digest != first.digest
+
+    warning_changed = _mutated(payload, warnings=({"code": "new_warning", "detail": "metadata only"},))
+    assert _blueprint(warning_changed).digest != first.digest
+
+    caveat_changed = replace(payload, preserved_caveats=("new caveat",))
+    assert _blueprint(caveat_changed).digest != first.digest
+
+
+def test_shadow_blueprint_does_not_mutate_payload_or_call_live_runtime_paths(monkeypatch):
+    payload, _, _ = _payload()
+    before = deepcopy(asdict(payload))
+
+    monkeypatch.setattr(pa, "assemble_prompt", lambda *args, **kwargs: pytest.fail("live prompt assembly called"))
+    monkeypatch.setattr(pa.mm, "get_context", lambda *args, **kwargs: pytest.fail("memory retrieval called"))
+    monkeypatch.setattr(pa.em, "average_emotion", lambda *args, **kwargs: pytest.fail("emotion runtime called"))
+    monkeypatch.setattr(pa.cw, "get_context", lambda *args, **kwargs: pytest.fail("context window runtime called"))
+    monkeypatch.setattr(pa.actuator, "recent_logs", lambda *args, **kwargs: pytest.fail("action feedback runtime called"))
+    monkeypatch.setattr(pa.ac, "capture_affective_context", lambda *args, **kwargs: pytest.fail("feedback capture called"))
+    monkeypatch.setattr(pa.ac, "register_context", lambda *args, **kwargs: pytest.fail("feedback register called"))
+
+    blueprint = _blueprint(payload)
+    assert asdict(payload) == before
+    assert blueprint.does_not_call_llm is True
+    assert blueprint.does_not_retrieve_memory is True
+    assert blueprint.does_not_write_memory is True
+    assert blueprint.does_not_execute_or_route_work is True
+    assert blueprint.does_not_admit_work is True
+
+
+def test_existing_prompt_assembler_behavior_is_representatively_unchanged(monkeypatch):
+    monkeypatch.setattr(pa.up, "format_profile", lambda: "name: Allen")
+    monkeypatch.setattr(pa.mm, "get_context", lambda _query, k=6: [{"plan": "alpha"}, {"plan": "beta"}])
+    monkeypatch.setattr(pa.em, "average_emotion", lambda: {})
+    monkeypatch.setattr(pa.cw, "get_context", lambda: (["msg-1"], "summary"))
+    monkeypatch.setattr(pa.actuator, "recent_logs", lambda *args, **kwargs: [])
+    monkeypatch.setattr(pa.ac, "capture_affective_context", lambda *args, **kwargs: {"captured": True})
+    monkeypatch.setattr(pa.ac, "register_context", lambda *args, **kwargs: None)
+
+    prompt = pa.assemble_prompt("reflect", ["hi"], k=2)
+    assert "SYSTEM:" in prompt
+    assert "USER PROFILE:\nname: Allen" in prompt
+    assert "RELEVANT MEMORIES:\n- alpha\n- beta" in prompt
+    assert "RECENT DIALOGUE:\nhi" in prompt
+    assert "SUMMARY:\nsummary" in prompt
+    assert "USER:\nreflect" in prompt
+    assert "affect" not in prompt
+
+
+def test_static_scan_allows_shadow_preview_and_blueprint_without_live_runtime_wiring_or_bypass():
+    findings = scan_prompt_assembler_static_findings(ROOT / "prompt_assembler.py")
+    assert findings["context_hygiene_shadow_hook_only"] is True
+    assert findings["imports_context_hygiene_adapter_modules"] is True
+    assert findings["active_context_hygiene_runtime_wiring"] is False
+    assert findings["forbidden_context_bypass_detected"] is False
+    assert findings["non_shadow_context_hygiene_imports"] == ()
+
+
+def test_phase63_to_phase73_shadow_blueprint_pipeline_works_for_sanitized_embodiment_proposal():
+    proposals = build_embodiment_context_candidates(
+        [
+            {
+                "ref_id": "emb:1",
+                "source_kind": "embodiment_snapshot",
+                "packet_scope": "turn",
+                "conversation_scope_id": "conv",
+                "task_scope_id": "task",
+                "content_summary": "sanitized posture summary",
+                "sanitized_context_summary": True,
+                "privacy_posture": "low_risk",
+                "provenance_refs": ("sensor:summary",),
+                "non_authoritative": True,
+                "decision_power": "none",
+            }
+        ]
+    )
+    packet = build_context_packet_from_candidates(proposals, "turn", "conv", "task", context_mode=ContextMode.RESPONSE, now=NOW)
+    payload = build_prompt_assembly_adapter_payload_from_packet(packet)
+    blueprint = _blueprint(payload)
+    assert payload.adapter_refs
+    assert blueprint.blueprint_status in {"shadow_blueprint_ready", "shadow_blueprint_ready_with_warnings"}
+    assert blueprint.blueprint_ref_count == len(payload.adapter_refs)
+    assert "sanitized posture summary" not in repr(asdict(blueprint))
+
+
+def test_phase62b_blocked_attempted_candidate_shadow_blueprint_blocks_materialization():
+    payload, _, _ = _payload(
+        _envelope_for(
+            [_cand("blocked", metadata={"source_kind": "evidence", "pollution_risk": "blocked", "non_authoritative": True, "decision_power": "none"})]
+        )
+    )
+    blueprint = _blueprint(payload)
+    assert payload.adapter_status in {PromptAssemblyAdapterStatus.ADAPTER_BLOCKED, PromptAssemblyAdapterStatus.ADAPTER_NOT_APPLICABLE}
+    assert blueprint.may_future_assembler_consume is False
+    assert blueprint.must_block_prompt_materialization is True
+    assert blueprint.blueprint_ref_count == 0
+    assert blueprint.section_count == 0


### PR DESCRIPTION
### Motivation
- Provide a shadow-only Phase 73 blueprint that demonstrates how a Phase 70 `PromptAssemblyAdapterPayload` (after Phase 72 preview/compliance) would be organized for a future prompt assembler without producing final prompt text or gaining runtime authority.
- Preserve and surface adapter metadata (sections, refs, caveats, provenance/privacy/truth/safety notes, constraints, warnings/violations) while enforcing non-runtime/no-assembly invariants. 
- Ensure static analysis distinguishes intentional, test-invoked shadow helpers from forbidden live context-hygiene wiring. 

### Description
- Added small, explicit dataclasses and a builder in `prompt_assembler.py`: `PromptAssemblerShadowBlueprint`, `PromptAssemblerShadowBlueprintSection`, `PromptAssemblerShadowBlueprintRef`, `PromptAssemblerShadowBlueprintBoundary`, and the helper `build_context_hygiene_shadow_prompt_blueprint` (alias `build_shadow_prompt_blueprint_from_adapter_payload`) which calls the Phase 72 preview hook and never assembles prompts or calls runtime services. 
- Implemented preview→blueprint status mapping and section/ref derivation rules that only use Phase 70 adapter `adapter_sections`/`adapter_refs`, preserve caveats/notes/constraints, gate refs to ready statuses, and emit explicit non-runtime markers; added deterministic digest computation over stable blueprint-safe fields. 
- Minor compliance allowlist update in `sentientos/context_hygiene/prompt_assembler_compliance.py` to register the new shadow helper function names, plus docs and tests: added `docs/architecture/phase73_prompt_assembler_shadow_blueprint_contract_execplan.md`, updated `docs/architecture/context_hygiene_spine.md`, and added `tests/test_phase73_prompt_assembler_shadow_blueprint_contract.py`. 

### Testing
- Ran `python -m scripts.run_tests -q tests/test_phase73_prompt_assembler_shadow_blueprint_contract.py` and the Phase 73 test suite passed. 
- Executed the Phase 61..72 compatibility suite `python -m scripts.run_tests -q tests/test_phase72_prompt_assembler_shadow_adapter_hook.py ... tests/test_phase61_context_packet_contract.py` and `tests/architecture/test_architecture_boundaries.py` plus `tests/integrity/test_import_purity.py`, all of which passed in this environment. 
- Ran `python scripts/audit_immutability_verifier.py` and static scan helpers which reported the shadow preview/blueprint helpers as allowed and no forbidden runtime wiring or bypass was detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69faf4af4df88320956023ded5e0aaef)