### PR TITLE
[codex:context-hygiene] add prompt boundary CI guardrails

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -140,3 +140,13 @@ Phase 73 does not modify truth, embodiment, action, retention, routing, admissio
 - The receipt does not call LLMs, retrieve memory, write memory, or modify embodiment/action/retention runtime behavior.
 - The receipt preserves IDs, digests, statuses, caveats, warnings, violations, boundary markers, provenance/privacy/truth/safety summaries, source-kind/ref/section counts, and a deterministic receipt digest.
 - The receipt is the prerequisite gate for any future shadow text materializer; blocked, not-applicable, invalid, invalid-chain, and runtime-wiring statuses remain non-materializable.
+
+## Phase 75: Context Hygiene Prompt Boundary CI Guardrails
+- Adds static/CI guardrails for the context-hygiene prompt assembly boundary before any future prompt text materialization is allowed.
+- The guardrails inspect source text and AST only; they are not prompt materialization and do not assemble prompt text.
+- The guardrails enforce forbidden prompt-text fields, raw-payload/runtime-handle fields, forbidden runtime imports, forbidden runtime calls, and prompt-assembler bypass imports.
+- The guardrails do not call LLMs, provider SDKs, web clients, tools, browser controllers, or hardware adapters.
+- The guardrails do not retrieve memory, write memory, trigger feedback, commit retention, admit work, route work, execute work, or orchestrate runtime behavior.
+- The guardrails do not modify truth, embodiment, action, retention, routing, admission, execution, orchestration, or live `assemble_prompt(...)` behavior.
+- Phase 75 preserves the Phase 72-74 shadow-only allowlist while continuing to require no-runtime markers and no forbidden calls/imports inside those implementations.
+- These guardrails are prerequisite enforcement before any future synthetic materializer may be proposed.

--- a/docs/architecture/phase75_context_hygiene_prompt_boundary_guardrails_execplan.md
+++ b/docs/architecture/phase75_context_hygiene_prompt_boundary_guardrails_execplan.md
@@ -1,0 +1,101 @@
+# Phase 75 Context Hygiene Prompt Boundary Guardrails Execplan
+
+## Goal
+Phase 75 adds CI-friendly static guardrails that enforce the context-hygiene shadow prompt assembly boundary before any prompt text materialization is permitted. The guardrails fail on source/AST evidence of prompt materialization fields, forbidden runtime imports, forbidden runtime calls, or bypass paths around the Phase 61-74 contract chain.
+
+## Non-goals
+- Do not materialize prompt text.
+- Do not assemble final prompts.
+- Do not call LLMs, provider SDKs, tools, browser controllers, or hardware adapters.
+- Do not retrieve memory or write memory.
+- Do not trigger feedback, commit retention, admit work, route work, execute work, or orchestrate runtime behavior.
+- Do not change live `assemble_prompt(...)` behavior or any production prompt assembler call site.
+- Do not modify truth, embodiment, action, retention, routing, admission, execution, or orchestration runtime behavior.
+
+## Phase 61 through Phase 74 dependency chain
+1. Phase 61 created `ContextPacket` schema and receipts.
+2. Phase 62 added truth-gated context selection.
+3. Phase 62B made blocked risk first-class and preserved attempted-candidate contamination.
+4. Phase 63 added embodiment/privacy context eligibility adapters.
+5. Phase 64 added prompt preflight.
+6. Phase 65 preserved packet-local safety metadata.
+7. Phase 66 added source-kind safety contracts.
+8. Phase 67 added prompt handoff manifest.
+9. Phase 68 added prompt assembly dry-run envelope.
+10. Phase 69 added prompt assembly constraint verifier.
+11. Phase 70 added prompt assembly adapter contract.
+12. Phase 71 added prompt assembler compliance harness.
+13. Phase 72 added prompt assembler shadow adapter preview hook.
+14. Phase 73 added prompt assembler shadow blueprint contract.
+15. Phase 74 added prompt materialization audit receipt / attestation.
+
+Phase 75 enforces that future changes cannot bypass this chain by directly wiring context-hygiene payloads into prompt materialization or runtime authority surfaces.
+
+## Guardrails are not prompt materialization
+The guardrail script reads source text and parses Python AST only. It does not import `prompt_assembler.py`, does not import context-hygiene runtime helpers, and does not execute project runtime modules. Its outputs are boundary reports and findings, not prompt content.
+
+## Static scan targets
+The default scan target set is:
+- `prompt_assembler.py`
+- `sentientos/context_hygiene/prompt_materialization_audit.py`
+- `sentientos/context_hygiene/prompt_assembler_compliance.py`
+- `sentientos/context_hygiene/prompt_adapter_contract.py`
+- `sentientos/context_hygiene/prompt_constraint_verifier.py`
+- `sentientos/context_hygiene/prompt_dry_run_envelope.py`
+- `sentientos/context_hygiene/prompt_handoff_manifest.py`
+- `sentientos/context_hygiene/prompt_preflight.py`
+- `sentientos/context_hygiene/context_packet.py`
+- `sentientos/context_hygiene/safety_metadata.py`
+- `sentientos/context_hygiene/source_kind_contracts.py`
+- `sentientos/context_hygiene/selector.py`
+
+## Forbidden fields, imports, and calls
+The scanner fails on prompt-materialization and runtime-authority identifiers such as `final_prompt_text`, `assembled_prompt`, `prompt_text`, `raw_payload`, `execution_handle`, `action_handle`, `retention_handle`, and `retrieval_handle`, except for explicitly negative no-runtime marker names such as `does_not_contain_final_prompt_text` and `does_not_materialize_prompt_text`.
+
+It fails context-hygiene prompt-boundary modules that import runtime/provider surfaces such as `memory_manager`, `openai`, `requests`, `httpx`, browser/tool control modules, action/retention/routing/admission/execution surfaces, embodiment runtime adapters, or raw screen/audio/vision/multimodal adapters.
+
+It fails context-hygiene prompt-boundary modules that call `assemble_prompt(...)`, provider/LLM creation or generation methods, memory retrieval/write methods, retention commits, feedback triggers, action execution, work routing/admission/execution/orchestration, or browser/mouse/keyboard/tool control calls.
+
+## Shadow allowlist
+Phase 75 keeps a compact allowlist for intentional shadow-only names introduced in Phases 72-74:
+- `preview_context_hygiene_adapter_payload_for_prompt_assembly`
+- `build_context_hygiene_shadow_prompt_adapter_preview`
+- `build_context_hygiene_shadow_prompt_blueprint`
+- `build_shadow_prompt_blueprint_from_adapter_payload`
+- `PromptAssemblerShadowAdapterPreview`
+- `PromptAssemblerShadowBlueprint`
+- `PromptMaterializationAuditReceipt`
+- `audit_receipt_allows_shadow_materializer`
+
+These names are allowed by name only. Their implementations are still scanned for forbidden runtime imports, forbidden runtime calls, and forbidden prompt-text fields.
+
+## CLI behavior
+Run:
+
+```bash
+python scripts/verify_context_hygiene_prompt_boundaries.py
+```
+
+Expected behavior:
+- exits `0` when the default scan is clean;
+- exits nonzero when boundary findings exist;
+- prints compact human-readable findings by default;
+- supports `--json` for deterministic JSON output;
+- accepts optional paths to scan temporary fixtures or changed files.
+
+## Tests
+`tests/test_phase75_context_hygiene_prompt_boundary_guardrails.py` covers:
+- clean default scanning;
+- deterministic reports and summaries;
+- injected forbidden field/import/call fixtures;
+- negative marker allowlisting;
+- Phase 72-74 shadow-name allowlisting;
+- `prompt_assembler.py` shadow import boundary checks;
+- CLI success/failure behavior;
+- import-purity and no optional pyttsx3/eSpeak dependency expectations;
+- preservation of Phase 74 and architecture test surfaces.
+
+## Deferred work
+- Future phases may add a synthetic materializer only after these guardrails remain green and the materializer has a separate explicit boundary contract.
+- Future docs scans may add live-integration wording checks if drift appears in architecture documentation.
+- Future architecture manifests may classify this script as a dedicated static/CI boundary enforcement layer if the manifest grows per-script classifications.

--- a/scripts/verify_context_hygiene_prompt_boundaries.py
+++ b/scripts/verify_context_hygiene_prompt_boundaries.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Static guardrails for context-hygiene prompt assembly boundaries.
+
+This verifier reads source text and AST only. It intentionally does not import
+prompt_assembler.py, context-hygiene helpers, memory/runtime modules, provider
+SDKs, browser/tool controllers, or optional speech dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+import json
+from pathlib import Path
+import sys
+from typing import Iterable, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_SCAN_TARGETS: tuple[str, ...] = (
+    "prompt_assembler.py",
+    "sentientos/context_hygiene/prompt_materialization_audit.py",
+    "sentientos/context_hygiene/prompt_assembler_compliance.py",
+    "sentientos/context_hygiene/prompt_adapter_contract.py",
+    "sentientos/context_hygiene/prompt_constraint_verifier.py",
+    "sentientos/context_hygiene/prompt_dry_run_envelope.py",
+    "sentientos/context_hygiene/prompt_handoff_manifest.py",
+    "sentientos/context_hygiene/prompt_preflight.py",
+    "sentientos/context_hygiene/context_packet.py",
+    "sentientos/context_hygiene/safety_metadata.py",
+    "sentientos/context_hygiene/source_kind_contracts.py",
+    "sentientos/context_hygiene/selector.py",
+)
+
+FORBIDDEN_FIELD_PATTERNS: tuple[str, ...] = (
+    "final_prompt",
+    "final_prompt_text",
+    "assembled_prompt",
+    "prompt_text",
+    "rendered_prompt",
+    "materialized_prompt",
+    "system_prompt",
+    "developer_prompt",
+    "llm_params",
+    "llm_parameters",
+    "model_params",
+    "provider_params",
+    "raw_payload",
+    "raw_memory_payload",
+    "raw_screen_payload",
+    "raw_audio_payload",
+    "raw_vision_payload",
+    "raw_multimodal_payload",
+    "execution_handle",
+    "action_handle",
+    "retention_handle",
+    "retrieval_handle",
+    "browser_handle",
+    "mouse_handle",
+    "keyboard_handle",
+)
+
+NEGATIVE_MARKER_PREFIXES: tuple[str, ...] = (
+    "does_not_",
+    "no_",
+    "non_",
+    "not_",
+    "without_",
+    "must_not_",
+)
+
+SHADOW_ALLOWLIST_NAMES: frozenset[str] = frozenset(
+    {
+        "preview_context_hygiene_adapter_payload_for_prompt_assembly",
+        "build_context_hygiene_shadow_prompt_adapter_preview",
+        "build_context_hygiene_shadow_prompt_blueprint",
+        "build_shadow_prompt_blueprint_from_adapter_payload",
+        "PromptAssemblerShadowAdapterPreview",
+        "PromptAssemblerShadowBlueprint",
+        "PromptMaterializationAuditReceipt",
+        "audit_receipt_allows_shadow_materializer",
+    }
+)
+
+PROMPT_ASSEMBLER_ALLOWED_CONTEXT_HYGIENE_IMPORTS: frozenset[str] = frozenset(
+    {
+        "sentientos.context_hygiene.prompt_adapter_contract",
+        "sentientos.context_hygiene.prompt_assembler_compliance",
+    }
+)
+PROMPT_ASSEMBLER_FORBIDDEN_CONTEXT_HYGIENE_IMPORTS: tuple[str, ...] = (
+    "sentientos.context_hygiene.selector",
+    "sentientos.context_hygiene.prompt_preflight",
+    "sentientos.context_hygiene.prompt_handoff_manifest",
+    "sentientos.context_hygiene.prompt_dry_run_envelope",
+    "sentientos.context_hygiene.prompt_constraint_verifier",
+    "sentientos.context_hygiene.prompt_materialization_audit",
+    "sentientos.context_hygiene.context_packet",
+    "sentientos.context_hygiene.safety_metadata",
+    "sentientos.context_hygiene.source_kind_contracts",
+)
+
+FORBIDDEN_IMPORT_PATTERNS: tuple[str, ...] = (
+    "memory_manager",
+    "openai",
+    "requests",
+    "httpx",
+    "browser",
+    "pyautogui",
+    "mouse",
+    "keyboard",
+    "task_admission",
+    "task_executor",
+    "orchestrator",
+    "orchestration",
+    "router",
+    "routing",
+    "executor",
+    "execution",
+    "action_router",
+    "action_executor",
+    "action_dispatch",
+    "retention",
+    "feedback",
+    "screen_awareness",
+    "vision_tracker",
+    "mic_bridge",
+    "multimodal_tracker",
+    "embodiment_runtime",
+    "raw_screen",
+    "raw_audio",
+    "raw_vision",
+    "raw_multimodal",
+)
+
+FORBIDDEN_CALL_NAMES: tuple[str, ...] = (
+    "assemble_prompt",
+    "create",
+    "chat.completions.create",
+    "responses.create",
+    "complete",
+    "completion",
+    "retrieve_memory",
+    "retrieve_memories",
+    "search_memory",
+    "query_memory",
+    "write_memory",
+    "save_memory",
+    "append_memory",
+    "commit_retention",
+    "commit",
+    "trigger_feedback",
+    "execute_action",
+    "dispatch_action",
+    "route_task",
+    "route_work",
+    "admit_task",
+    "admit_work",
+    "execute_task",
+    "execute_work",
+    "orchestrate",
+    "browser",
+    "click",
+    "typewrite",
+    "press",
+)
+
+FORBIDDEN_PROVIDER_CALL_OWNERS: tuple[str, ...] = ("openai", "client", "provider", "llm", "model")
+FORBIDDEN_CONTEXT_PAYLOAD_TYPES: tuple[str, ...] = (
+    "ContextPacket",
+    "PromptAssemblyAdapterPayload",
+    "PromptAssemblerShadowBlueprint",
+    "PromptMaterializationAuditReceipt",
+)
+MATERIALIZER_FUNCTION_PREFIXES: tuple[str, ...] = ("materialize", "render", "assemble")
+
+
+class ContextHygienePromptBoundaryStatus(str, Enum):
+    BOUNDARY_CLEAN = "boundary_clean"
+    BOUNDARY_CLEAN_WITH_WARNINGS = "boundary_clean_with_warnings"
+    BOUNDARY_FAILED = "boundary_failed"
+    BOUNDARY_SCAN_ERROR = "boundary_scan_error"
+
+
+@dataclass(frozen=True, order=True)
+class ContextHygienePromptBoundaryFinding:
+    path: str
+    line: int
+    column: int
+    code: str
+    detail: str
+    severity: str = "blocker"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ContextHygienePromptBoundaryReport:
+    status: ContextHygienePromptBoundaryStatus
+    scanned_paths: tuple[str, ...]
+    findings: tuple[ContextHygienePromptBoundaryFinding, ...] = field(default_factory=tuple)
+    warnings: tuple[ContextHygienePromptBoundaryFinding, ...] = field(default_factory=tuple)
+    shadow_allowlist: tuple[str, ...] = field(default_factory=lambda: tuple(sorted(SHADOW_ALLOWLIST_NAMES)))
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {
+            ContextHygienePromptBoundaryStatus.BOUNDARY_CLEAN,
+            ContextHygienePromptBoundaryStatus.BOUNDARY_CLEAN_WITH_WARNINGS,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "scanned_paths": list(self.scanned_paths),
+            "findings": [finding.to_dict() for finding in self.findings],
+            "warnings": [warning.to_dict() for warning in self.warnings],
+            "shadow_allowlist": list(self.shadow_allowlist),
+        }
+
+
+def _display_path(path: Path, repo_root: Path = REPO_ROOT) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _module_name_from_import(node: ast.AST) -> tuple[str, ...]:
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        return tuple(module + (f".{alias.name}" if module else alias.name) for alias in node.names)
+    return ()
+
+
+def _name_is_negative_marker(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered.startswith(NEGATIVE_MARKER_PREFIXES)
+        or lowered.startswith(("forbidden_", "_forbidden_"))
+        or "_forbidden_" in lowered
+        or "_not_" in lowered
+        or "does_not" in lowered
+        or "must_not" in lowered
+        or "without" in lowered
+    )
+
+
+def _identifier_contains_forbidden_field(name: str) -> str | None:
+    lowered = name.lower()
+    if name in SHADOW_ALLOWLIST_NAMES or _name_is_negative_marker(name):
+        return None
+    for pattern in FORBIDDEN_FIELD_PATTERNS:
+        if pattern in lowered:
+            return pattern
+    return None
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _call_name(node.value)
+    return ""
+
+
+def _target_names(node: ast.AST) -> Iterable[tuple[str, int, int]]:
+    if isinstance(node, ast.Name):
+        yield node.id, node.lineno, node.col_offset
+    elif isinstance(node, ast.Attribute):
+        yield node.attr, node.lineno, node.col_offset
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for elt in node.elts:
+            yield from _target_names(elt)
+
+
+def _string_dict_keys(node: ast.AST) -> Iterable[tuple[str, int, int]]:
+    if isinstance(node, ast.Dict):
+        for key in node.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                yield key.value, key.lineno, key.col_offset
+
+
+def _annotation_mentions_context_payload(node: ast.AST | None) -> bool:
+    if node is None:
+        return False
+    return any(payload_type in ast.unparse(node) for payload_type in FORBIDDEN_CONTEXT_PAYLOAD_TYPES)
+
+
+def _is_prompt_assembler(path: Path) -> bool:
+    return path.name == "prompt_assembler.py"
+
+
+def _is_context_hygiene_module(path: Path) -> bool:
+    parts = path.as_posix().split("/")
+    return "sentientos" in parts and "context_hygiene" in parts
+
+
+def _finding(path: Path, line: int, col: int, code: str, detail: str, repo_root: Path) -> ContextHygienePromptBoundaryFinding:
+    return ContextHygienePromptBoundaryFinding(
+        path=_display_path(path, repo_root),
+        line=line,
+        column=col,
+        code=code,
+        detail=detail,
+    )
+
+
+def scan_file_for_prompt_boundary_violations(path: str | Path, *, repo_root: str | Path = REPO_ROOT) -> tuple[ContextHygienePromptBoundaryFinding, ...]:
+    """Scan one Python source file for prompt-boundary violations.
+
+    The scan is purely textual/AST-based; the target module is never imported.
+    """
+    root = Path(repo_root)
+    source_path = Path(path)
+    if not source_path.is_absolute():
+        source_path = root / source_path
+    findings: list[ContextHygienePromptBoundaryFinding] = []
+    try:
+        text = source_path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(source_path))
+    except Exception as exc:  # pragma: no cover - exact parse errors vary by Python.
+        return (_finding(source_path, 1, 0, "boundary_scan_error", f"could not parse source: {exc}", root),)
+
+    prompt_assembler = _is_prompt_assembler(source_path)
+    context_hygiene = _is_context_hygiene_module(source_path) or not prompt_assembler
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for module_name in _module_name_from_import(node):
+                lowered = module_name.lower()
+                if prompt_assembler and module_name.startswith("sentientos.context_hygiene"):
+                    base = module_name.rsplit(".", 1)[0]
+                    if any(module_name.startswith(forbidden) for forbidden in PROMPT_ASSEMBLER_FORBIDDEN_CONTEXT_HYGIENE_IMPORTS):
+                        findings.append(_finding(source_path, node.lineno, node.col_offset, "prompt_assembler_context_hygiene_bypass_import", f"prompt_assembler.py must not directly import {module_name}; use the Phase 70/71 shadow-only boundary", root))
+                    elif base not in PROMPT_ASSEMBLER_ALLOWED_CONTEXT_HYGIENE_IMPORTS and module_name not in PROMPT_ASSEMBLER_ALLOWED_CONTEXT_HYGIENE_IMPORTS:
+                        findings.append(_finding(source_path, node.lineno, node.col_offset, "prompt_assembler_unapproved_context_hygiene_import", f"prompt_assembler.py imports unapproved context hygiene surface {module_name}", root))
+                elif context_hygiene:
+                    for pattern in FORBIDDEN_IMPORT_PATTERNS:
+                        if pattern in lowered:
+                            findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_runtime_import", f"prompt-boundary code must not import runtime/provider surface {module_name}", root))
+                            break
+                    if lowered.startswith("prompt_assembler") or lowered.startswith("sentientos.prompt_assembler"):
+                        findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_prompt_assembler_import", f"context hygiene code must not import {module_name}", root))
+
+        if context_hygiene and isinstance(node, ast.AnnAssign):
+            for name, line, col in _target_names(node.target):
+                forbidden = _identifier_contains_forbidden_field(name)
+                if forbidden:
+                    findings.append(_finding(source_path, line, col, "forbidden_materialization_field", f"identifier {name!r} contains forbidden prompt/runtime field pattern {forbidden!r}", root))
+
+        if context_hygiene and isinstance(node, (ast.Assign, ast.AugAssign, ast.NamedExpr)):
+            targets: Sequence[ast.AST]
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AugAssign):
+                targets = (node.target,)
+            else:
+                targets = (node.target,)
+            for target in targets:
+                for name, line, col in _target_names(target):
+                    forbidden = _identifier_contains_forbidden_field(name)
+                    if forbidden:
+                        findings.append(_finding(source_path, line, col, "forbidden_materialization_assignment", f"assignment target {name!r} contains forbidden prompt/runtime field pattern {forbidden!r}", root))
+
+        if context_hygiene and isinstance(node, ast.Dict):
+            for name, line, col in _string_dict_keys(node):
+                forbidden = _identifier_contains_forbidden_field(name)
+                if forbidden:
+                    findings.append(_finding(source_path, line, col, "forbidden_materialization_mapping_key", f"mapping key {name!r} contains forbidden prompt/runtime field pattern {forbidden!r}", root))
+
+        if context_hygiene and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            lowered_name = node.name.lower()
+            if any(lowered_name.startswith(prefix) for prefix in MATERIALIZER_FUNCTION_PREFIXES):
+                annotations = [arg.annotation for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)] + [node.returns]
+                if any(_annotation_mentions_context_payload(annotation) for annotation in annotations):
+                    findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_context_payload_materializer", f"function {node.name!r} appears to materialize/render/assemble a context hygiene payload type", root))
+
+        if context_hygiene and isinstance(node, ast.Call):
+            call = _call_name(node.func)
+            lowered_call = call.lower()
+            if call == "assemble_prompt" or lowered_call.endswith(".assemble_prompt"):
+                findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_assemble_prompt_call", "context hygiene prompt-boundary code must not call assemble_prompt(...) directly", root))
+            elif any(lowered_call == forbidden or lowered_call.endswith(f".{forbidden}") for forbidden in FORBIDDEN_CALL_NAMES):
+                if lowered_call == "commit" and not any(owner in lowered_call for owner in ("retention", "memory")):
+                    continue
+                findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_runtime_call", f"forbidden runtime/provider call pattern {call!r}", root))
+            elif any(owner in lowered_call for owner in FORBIDDEN_PROVIDER_CALL_OWNERS) and any(verb in lowered_call for verb in ("create", "complete", "invoke", "generate", "send")):
+                findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_provider_call", f"forbidden LLM/provider call pattern {call!r}", root))
+            elif any(term in lowered_call for term in ("retrieve_memory", "write_memory", "save_memory", "search_memory", "commit_retention", "execute_action", "route_work", "admit_work")):
+                findings.append(_finding(source_path, node.lineno, node.col_offset, "forbidden_runtime_call", f"forbidden context side-effect call pattern {call!r}", root))
+
+    return tuple(sorted(findings))
+
+
+def scan_prompt_assembler_shadow_boundary(path: str | Path = "prompt_assembler.py", *, repo_root: str | Path = REPO_ROOT) -> tuple[ContextHygienePromptBoundaryFinding, ...]:
+    return scan_file_for_prompt_boundary_violations(path, repo_root=repo_root)
+
+
+def _resolve_scan_targets(paths: Sequence[str | Path] | None, repo_root: Path) -> tuple[Path, ...]:
+    selected = paths if paths else DEFAULT_SCAN_TARGETS
+    return tuple((Path(p) if Path(p).is_absolute() else repo_root / Path(p)) for p in selected)
+
+
+def scan_context_hygiene_prompt_boundaries(paths: Sequence[str | Path] | None = None, *, repo_root: str | Path = REPO_ROOT) -> ContextHygienePromptBoundaryReport:
+    root = Path(repo_root)
+    targets = _resolve_scan_targets(paths, root)
+    findings: list[ContextHygienePromptBoundaryFinding] = []
+    scanned: list[str] = []
+    for target in targets:
+        scanned.append(_display_path(target, root))
+        findings.extend(scan_file_for_prompt_boundary_violations(target, repo_root=root))
+    unique_findings = tuple(sorted({finding: None for finding in findings}.keys()))
+    status = (
+        ContextHygienePromptBoundaryStatus.BOUNDARY_FAILED
+        if unique_findings
+        else ContextHygienePromptBoundaryStatus.BOUNDARY_CLEAN
+    )
+    return ContextHygienePromptBoundaryReport(status=status, scanned_paths=tuple(scanned), findings=unique_findings)
+
+
+def summarize_context_hygiene_prompt_boundary_scan(report: ContextHygienePromptBoundaryReport) -> str:
+    lines = [
+        f"Context hygiene prompt boundary scan: {report.status.value}",
+        f"Scanned files: {len(report.scanned_paths)}",
+        f"Findings: {len(report.findings)}",
+    ]
+    for finding in report.findings:
+        lines.append(f"- {finding.path}:{finding.line}:{finding.column} [{finding.code}] {finding.detail}")
+    if not report.findings:
+        lines.append("No prompt materialization, forbidden runtime import/call, or context-hygiene bypass findings detected.")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify context-hygiene prompt boundary static guardrails.")
+    parser.add_argument("paths", nargs="*", help="Optional Python files to scan instead of the default Phase 75 target set.")
+    parser.add_argument("--json", action="store_true", help="Emit deterministic JSON report.")
+    args = parser.parse_args(argv)
+    report = scan_context_hygiene_prompt_boundaries(args.paths or None)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(summarize_context_hygiene_prompt_boundary_scan(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by CLI tests.
+    raise SystemExit(main())

--- a/tests/test_phase75_context_hygiene_prompt_boundary_guardrails.py
+++ b/tests/test_phase75_context_hygiene_prompt_boundary_guardrails.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import verify_context_hygiene_prompt_boundaries as guardrails
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_fixture(tmp_path: Path, source: str, name: str = "fixture.py") -> Path:
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _scan_source(tmp_path: Path, source: str, name: str = "fixture.py"):
+    return guardrails.scan_file_for_prompt_boundary_violations(_write_fixture(tmp_path, source, name), repo_root=tmp_path)
+
+
+def _codes(findings) -> set[str]:
+    return {finding.code for finding in findings}
+
+
+def test_default_scan_passes_on_current_repo() -> None:
+    report = guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    assert report.ok, guardrails.summarize_context_hygiene_prompt_boundary_scan(report)
+    assert not report.findings
+
+
+def test_default_scan_reports_clean_or_clean_with_warnings() -> None:
+    report = guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    assert report.status in {
+        guardrails.ContextHygienePromptBoundaryStatus.BOUNDARY_CLEAN,
+        guardrails.ContextHygienePromptBoundaryStatus.BOUNDARY_CLEAN_WITH_WARNINGS,
+    }
+
+
+@pytest.mark.parametrize("name", ["final_prompt_text", "assembled_prompt"])
+def test_forbidden_prompt_materialization_assignments_are_detected(tmp_path: Path, name: str) -> None:
+    findings = _scan_source(tmp_path, f"{name} = 'not allowed'\n")
+    assert "forbidden_materialization_assignment" in _codes(findings)
+
+
+def test_forbidden_prompt_text_field_is_detected(tmp_path: Path) -> None:
+    findings = _scan_source(tmp_path, "from dataclasses import dataclass\n@dataclass\nclass Bad:\n    prompt_text: str = ''\n")
+    assert "forbidden_materialization_field" in _codes(findings)
+
+
+@pytest.mark.parametrize("marker", ["does_not_contain_final_prompt_text", "does_not_materialize_prompt_text"])
+def test_negative_prompt_text_markers_are_allowed(tmp_path: Path, marker: str) -> None:
+    findings = _scan_source(tmp_path, f"{marker} = True\n")
+    assert not findings
+
+
+def test_raw_payload_field_is_detected(tmp_path: Path) -> None:
+    findings = _scan_source(tmp_path, "raw_payload = {'x': 'y'}\n")
+    assert "forbidden_materialization_assignment" in _codes(findings)
+
+
+@pytest.mark.parametrize("handle", ["execution_handle", "action_handle", "retention_handle", "retrieval_handle"])
+def test_forbidden_runtime_handle_fields_are_detected(tmp_path: Path, handle: str) -> None:
+    findings = _scan_source(tmp_path, f"{handle} = object()\n")
+    assert "forbidden_materialization_assignment" in _codes(findings)
+
+
+def test_forbidden_memory_manager_import_is_detected(tmp_path: Path) -> None:
+    findings = _scan_source(tmp_path, "import memory_manager\n")
+    assert "forbidden_runtime_import" in _codes(findings)
+
+
+@pytest.mark.parametrize("module", ["openai", "requests", "httpx"])
+def test_forbidden_provider_or_network_import_is_detected(tmp_path: Path, module: str) -> None:
+    findings = _scan_source(tmp_path, f"import {module}\n")
+    assert "forbidden_runtime_import" in _codes(findings)
+
+
+@pytest.mark.parametrize("module", ["action_router", "retention_commit", "task_admission", "task_executor", "work_routing"])
+def test_forbidden_action_retention_routing_import_is_detected(tmp_path: Path, module: str) -> None:
+    findings = _scan_source(tmp_path, f"import {module}\n")
+    assert "forbidden_runtime_import" in _codes(findings)
+
+
+def test_forbidden_assemble_prompt_call_is_detected(tmp_path: Path) -> None:
+    findings = _scan_source(tmp_path, "def f():\n    return assemble_prompt({})\n")
+    assert "forbidden_assemble_prompt_call" in _codes(findings)
+
+
+@pytest.mark.parametrize("call", ["openai.chat.completions.create", "client.responses.create", "llm.generate"])
+def test_forbidden_llm_provider_call_pattern_is_detected(tmp_path: Path, call: str) -> None:
+    findings = _scan_source(tmp_path, f"def f():\n    return {call}('x')\n")
+    assert _codes(findings) & {"forbidden_provider_call", "forbidden_runtime_call"}
+
+
+@pytest.mark.parametrize("call", ["retrieve_memory", "write_memory", "search_memory"])
+def test_forbidden_memory_retrieval_or_write_call_pattern_is_detected(tmp_path: Path, call: str) -> None:
+    findings = _scan_source(tmp_path, f"def f():\n    return {call}('x')\n")
+    assert "forbidden_runtime_call" in _codes(findings)
+
+
+@pytest.mark.parametrize("call", ["commit_retention", "execute_action", "route_work", "admit_work", "orchestrate"])
+def test_forbidden_retention_action_routing_call_pattern_is_detected(tmp_path: Path, call: str) -> None:
+    findings = _scan_source(tmp_path, f"def f():\n    return {call}('x')\n")
+    assert "forbidden_runtime_call" in _codes(findings)
+
+
+@pytest.mark.parametrize(
+    "allowed_name",
+    [
+        "preview_context_hygiene_adapter_payload_for_prompt_assembly",
+        "build_context_hygiene_shadow_prompt_adapter_preview",
+    ],
+)
+def test_phase72_shadow_preview_helper_names_are_not_flagged_by_name(tmp_path: Path, allowed_name: str) -> None:
+    findings = _scan_source(tmp_path, f"def {allowed_name}():\n    return None\n")
+    assert not findings
+
+
+@pytest.mark.parametrize(
+    "allowed_name",
+    ["build_context_hygiene_shadow_prompt_blueprint", "build_shadow_prompt_blueprint_from_adapter_payload", "PromptAssemblerShadowBlueprint"],
+)
+def test_phase73_shadow_blueprint_helper_names_are_not_flagged_by_name(tmp_path: Path, allowed_name: str) -> None:
+    source = f"class {allowed_name}:\n    pass\n" if allowed_name.startswith("Prompt") else f"def {allowed_name}():\n    return None\n"
+    findings = _scan_source(tmp_path, source)
+    assert not findings
+
+
+@pytest.mark.parametrize("allowed_name", ["PromptMaterializationAuditReceipt", "audit_receipt_allows_shadow_materializer"])
+def test_phase74_audit_receipt_names_are_not_flagged_by_name(tmp_path: Path, allowed_name: str) -> None:
+    source = f"class {allowed_name}:\n    pass\n" if allowed_name.startswith("Prompt") else f"def {allowed_name}():\n    return True\n"
+    findings = _scan_source(tmp_path, source)
+    assert not findings
+
+
+def test_prompt_assembler_scan_allows_intentional_phase72_73_shadow_hook_imports() -> None:
+    findings = guardrails.scan_prompt_assembler_shadow_boundary(REPO_ROOT / "prompt_assembler.py", repo_root=REPO_ROOT)
+    assert not findings
+
+
+def test_prompt_assembler_scan_flags_direct_context_hygiene_bypass_imports(tmp_path: Path) -> None:
+    path = _write_fixture(tmp_path, "from sentientos.context_hygiene.selector import select_context_candidates\n", "prompt_assembler.py")
+    findings = guardrails.scan_prompt_assembler_shadow_boundary(path, repo_root=tmp_path)
+    assert "prompt_assembler_context_hygiene_bypass_import" in _codes(findings)
+
+
+def test_script_cli_returns_zero_on_current_repo() -> None:
+    result = subprocess.run([sys.executable, "scripts/verify_context_hygiene_prompt_boundaries.py"], cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "boundary_clean" in result.stdout
+
+
+def test_script_cli_returns_nonzero_on_temporary_forbidden_materialization(tmp_path: Path) -> None:
+    bad = _write_fixture(tmp_path, "final_prompt_text = 'blocked'\n")
+    result = subprocess.run([sys.executable, str(REPO_ROOT / "scripts/verify_context_hygiene_prompt_boundaries.py"), str(bad)], cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    assert result.returncode != 0
+    assert "forbidden_materialization_assignment" in result.stdout
+
+
+def test_report_serialization_and_summary_are_deterministic() -> None:
+    first = guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    second = guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    assert json.dumps(first.to_dict(), sort_keys=True) == json.dumps(second.to_dict(), sort_keys=True)
+    assert guardrails.summarize_context_hygiene_prompt_boundary_scan(first) == guardrails.summarize_context_hygiene_prompt_boundary_scan(second)
+
+
+def test_scan_does_not_import_prompt_assembler() -> None:
+    sys.modules.pop("prompt_assembler", None)
+    guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    assert "prompt_assembler" not in sys.modules
+
+
+@pytest.mark.parametrize("module", ["memory_manager", "openai", "requests", "httpx", "pyttsx3"])
+def test_scan_does_not_import_memory_runtime_provider_or_speech_modules(module: str) -> None:
+    sys.modules.pop(module, None)
+    guardrails.scan_context_hygiene_prompt_boundaries(repo_root=REPO_ROOT)
+    assert module not in sys.modules
+
+
+def test_guardrail_script_is_import_pure() -> None:
+    code = "import importlib, logging; before=len(logging.getLogger().handlers); importlib.import_module('scripts.verify_context_hygiene_prompt_boundaries'); after=len(logging.getLogger().handlers); assert before == after == 0"
+    result = subprocess.run([sys.executable, "-c", code], cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_phase74_audit_receipt_test_file_remains_present() -> None:
+    assert (REPO_ROOT / "tests/test_phase74_prompt_materialization_audit_receipt.py").exists()
+
+
+def test_architecture_boundary_test_file_remains_present() -> None:
+    assert (REPO_ROOT / "tests/architecture/test_architecture_boundaries.py").exists()


### PR DESCRIPTION
### Motivation
- Enforce the Phase 72–74 shadow prompt-assembly boundary with static CI checks so future changes cannot accidentally materialize prompt text or wire runtime authority from context-hygiene modules. 
- Provide deterministic, import-safe guardrails that scan source text/AST only and therefore do not change runtime behavior or call any LLM/memory/action/retention surfaces. 
- Make violations (forbidden fields/imports/calls/bypass imports) fail CI early and document the Phase 75 intent for reviewers and integrators.

### Description
- Add a static verifier script `scripts/verify_context_hygiene_prompt_boundaries.py` that scans a default Phase 75 target set (including `prompt_assembler.py` and `sentientos/context_hygiene/*`) using AST/text only, emits deterministic reports, supports `--json`, and exits nonzero on failures. 
- Introduce `tests/test_phase75_context_hygiene_prompt_boundary_guardrails.py` with fixture-based violation injection and coverage of: forbidden-field detection, forbidden-import detection, forbidden-call detection, shadow-name allowlisting, prompt_assembler bypass import checks, CLI behavior, and import-purity expectations. 
- Add documentation `docs/architecture/phase75_context_hygiene_prompt_boundary_guardrails_execplan.md` and update `docs/architecture/context_hygiene_spine.md` to record Phase 75 role, non-goals, scan targets, forbidden identifiers/calls/imports, and the shadow allowlist. 
- Scanner behavior: fails on forbidden prompt/materialization fields and runtime-authority handles, flags forbidden runtime/provider imports (e.g., `memory_manager`, `openai`, `requests`, `httpx`, action/retention/routing surfaces, embodiment/raw-perception adapters), disallows calls that look like `assemble_prompt(...)`/LLM/provider create/generate calls/memory writes/retention/action/routing calls, and allows only an explicit compact shadow allowlist of Phase 72–74 names (name-only allowlist; implementations still scanned).

### Testing
- Ran the Phase 75 unit suite: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 python -m pytest -q tests/test_phase75_context_hygiene_prompt_boundary_guardrails.py` — all tests passed (dot-run 100%).
- Verified CLI and JSON output: `python scripts/verify_context_hygiene_prompt_boundaries.py` and `python scripts/verify_context_hygiene_prompt_boundaries.py --json` produced a clean `boundary_clean` report for the repository and deterministic JSON; exit status 0. 
- Ran existing Phase 61–74 tests under the naked-pytest fallback: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 python -m pytest -q tests/test_phase74_prompt_materialization_audit_receipt.py ... tests/test_phase61_context_packet_contract.py` — passed under the fallback runner; note: `scripts.run_tests` wrapper with full editable install path was blocked in this environment due to a missing test-airlock dependency (`fastapi`), so the repo-approved `SENTIENTOS_ALLOW_NAKED_PYTEST=1` fallback was used and results are reported. 
- Architecture and import-purity tests: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 python -m pytest -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py` — passed under the fallback. 
- Ran `python scripts/audit_immutability_verifier.py` — passed (non-blocking artifact-dependent check). 
- Notes and risk: `scripts.run_tests` in this environment could not perform an editable install (missing `fastapi` and build deps for some packages), so the fallback test execution was used and documented; runtime behavior and live `assemble_prompt(...)` were not modified by these changes. 
- Repo diff stat: 4 files changed (added script, test, execplan doc, and spine update), 766 insertions; commit id in this workspace: `f3e79eaddfb48d8d9ba361fa001d8b2b8a133d85`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fbae51f4448320972f151356228fe4)