### PR TITLE
[codex:context-hygiene] add provider simulation result envelope

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -247,3 +247,18 @@ Provider/LLM/network calls remain forbidden. Credentials, provider clients, tran
 The receipt derives required mitigations from Phase 84 findings, warnings, constraints, warning status, and provider/network/credential/client forbidden markers. A receipt satisfies an envelope only when the envelope is ready or ready-with-warnings, the receipt is approved or approved-with-constraints, ids and digests match, the receipt is unexpired, required mitigations are accepted or addressed, no forbidden send override is attempted, all runtime/provider allowances remain false, and all non-sendable markers remain true.
 
 Phase 85 is a prerequisite to any future provider-call simulation contract or egress-review gate. It is not provider invocation and grants no runtime authority.
+
+## Phase 86 — Provider Simulation Result Envelope (No Network)
+
+Phase 86 adds `sentientos.context_hygiene.prompt_provider_simulation`, a pure provider simulation result envelope for Phase 84 provider dry-run requests after Phase 85 egress review approval. The artifact is fixed-stub/metadata-only and exists to record a deterministic provider-like boundary without provider invocation.
+
+The Phase 86 envelope preserves these boundaries:
+
+- provider/LLM/network calls remain forbidden;
+- credentials, provider clients, endpoints, auth/header material, SDK objects, sessions, transports, streams, and runtime handles remain forbidden;
+- semantic generation remains forbidden, and the simulated result stub must not answer, summarize, transform, or complete prompt content;
+- live `assemble_prompt(...)` behavior is untouched, and `prompt_assembler.py` remains outside this phase;
+- memory retrieval and memory writes remain forbidden;
+- embodiment runtime, tools, actions, retention, feedback, routing, admission, execution, fulfillment, and orchestration remain forbidden.
+
+Phase 86 is a prerequisite artifact for any future network-egress preflight or provider-call harness, but it does not authorize or implement those future paths. Provider simulation is not provider invocation.

--- a/docs/architecture/phase86_provider_simulation_result_envelope_execplan.md
+++ b/docs/architecture/phase86_provider_simulation_result_envelope_execplan.md
@@ -1,0 +1,77 @@
+# Phase 86 Provider Simulation Result Envelope Execplan
+
+## Goal
+
+Phase 86 adds a deterministic `ProviderSimulationResultEnvelope` for Phase 84 `ProviderDryRunRequestEnvelope` objects after Phase 85 provider dry-run egress review approval. The envelope is a provider-like response boundary artifact only: it records stable metadata, digest linkage, findings, constraints, warnings, and a fixed stub that proves no provider/model/network path ran.
+
+## Non-goals
+
+- No LLM call, provider send, provider SDK import, or network egress.
+- No semantic answer generation, prompt transformation, assistant-like completion, or model-computed output.
+- No credentials, endpoints, auth headers, provider clients, sessions, transports, streams, request IDs, or response handles.
+- No memory retrieval/write, retention commit, feedback trigger, tool/action execution, routing, admission, fulfillment, orchestration, or embodiment runtime effect.
+- No change to live `assemble_prompt(...)` behavior and no dependency on `prompt_assembler.py`.
+
+## Dependency chain: Phases 61 through 85
+
+Phase 86 sits after the context-hygiene spine that created packet schemas, truth-gated selection, contamination preservation, embodiment/privacy eligibility adapters, preflight gates, packet-local safety metadata, source-kind contracts, handoff/dry-run/constraint contracts, adapter/compliance/shadow preview contracts, materialization audit receipts, static guardrails, adversarial tests, policy decisions, operator review, synthetic/internal prompt candidates, display/egress receipts, model-call preflight/review receipts, Phase 84 non-sendable provider dry-run requests, and Phase 85 dry-run egress review receipts.
+
+The Phase 86 builder requires:
+
+1. a Phase 84 dry-run envelope in `provider_dry_run_ready` or `provider_dry_run_ready_with_warnings`, and
+2. a Phase 85 review receipt that satisfies the dry-run envelope and approves only a future provider simulation gate or future egress review gate.
+
+## Provider simulation is not provider invocation
+
+The simulation envelope represents a provider-like result shape without any provider execution. It preserves the invariant: **provider simulation is not provider invocation**. All explicit markers state that provider send, network egress, provider clients, credentials, semantic generation, tools, memory, retention, routing, admission, execution, and feedback remain forbidden.
+
+## Simulation modes and statuses
+
+Allowed metadata-only modes:
+
+- `simulation_mode_fixed_stub`
+- `simulation_mode_echo_metadata_only`
+- `simulation_mode_transport_shape_only`
+
+Forbidden modes include unknown, semantic-generation, live-provider, and network dry-run modes.
+
+Statuses are deterministic and compact:
+
+- `provider_simulation_ready`
+- `provider_simulation_ready_with_warnings`
+- `provider_simulation_blocked`
+- `provider_simulation_invalid_input`
+- `provider_simulation_review_missing`
+- `provider_simulation_dry_run_not_ready`
+- `provider_simulation_network_forbidden`
+- `provider_simulation_credentials_detected`
+- `provider_simulation_runtime_authority_detected`
+- `provider_simulation_semantic_generation_forbidden`
+
+## Fixed-stub and non-semantic behavior
+
+The simulated result stub is fixed and metadata-only. It includes the markers `PROVIDER SIMULATION RESULT`, `NO MODEL CALLED`, and `NO NETWORK EGRESS`, plus digest references and simulation mode. It does not include or transform the dry-run prompt, answer the user, summarize content, produce assistant-like text, expose chain-of-thought, or claim provider/model execution.
+
+## Payload shape rules
+
+The payload shape uses simulation-only labels such as `simulated_provider_stub`, `simulated_transport_metadata`, and `simulated_no_network_boundary`. Usage metadata is zero/`None` placeholder data. Digest references are preserved. Provider roles, generated message content, request IDs, completion IDs, endpoint fields, credential fields, auth/header fields, clients, sessions, streams, tool/function calls, raw payloads, and runtime handles remain forbidden.
+
+## No-network, provider-client, and credential rules
+
+The builder blocks unless dry-run and review gates are clean, simulation scope is internal only, no credential/network/provider-object/runtime markers are present, and all no-provider/no-network/no-runtime markers are true. Helper predicates expose proofs for no-network, not-model-output, no provider credentials, no runtime authority, and dry-run/review linkage preservation.
+
+## Digest behavior
+
+`simulation_digest` is deterministic over stable envelope-safe fields. It changes when dry-run digest, egress review digest, simulation mode, simulation scope, simulated stub, payload shape, findings, warnings, constraints, provider label, or model label changes. It excludes credentials, endpoints, provider client objects, transport handles, raw payloads, runtime handles, model/provider parameters, timestamps, and other nondeterministic/runtime-only data.
+
+## Guardrail behavior
+
+The Phase 75 prompt-boundary verifier now scans the Phase 86 module by default. It permits the Phase 86 `simulated_result_stub` field only in the provider simulation module and its test surface while continuing to reject prompt materialization fields, live prompt assembly, provider SDK imports, web/network clients, memory/action/retention/routing imports, `assemble_prompt(...)`, provider/network/runtime calls, raw payloads, credentials, endpoints, clients, sessions, headers/auth, and model/provider parameter fields.
+
+## Tests
+
+The Phase 86 test suite covers ready/warning/review-missing/rejected/expired/mismatched dry-run gates, blocked dry-run statuses, forbidden modes/scopes, credential/network/runtime markers, marker overrides, fixed-stub markers, non-semantic behavior, payload shape safety, helper strictness, deterministic digest changes, immutability of inputs, no runtime imports/calls, Phase 63-to-86 pass/fail chaining, Phase 62B/76 adversarial blocking, Phase 75 guardrails, and architecture/import-purity marker expectations.
+
+## Deferred work
+
+Future phases may add a network-egress preflight or provider-call harness. Phase 86 intentionally does not authorize, implement, or preview any live provider call path; it only creates a deterministic internal artifact that can be inspected before any future gate is designed.

--- a/scripts/verify_context_hygiene_prompt_boundaries.py
+++ b/scripts/verify_context_hygiene_prompt_boundaries.py
@@ -27,6 +27,7 @@ DEFAULT_SCAN_TARGETS: tuple[str, ...] = (
     "sentientos/context_hygiene/prompt_model_call_review.py",
     "sentientos/context_hygiene/prompt_provider_dry_run.py",
     "sentientos/context_hygiene/prompt_provider_dry_run_review.py",
+    "sentientos/context_hygiene/prompt_provider_simulation.py",
     "sentientos/context_hygiene/prompt_materialization_policy.py",
     "sentientos/context_hygiene/prompt_operator_review.py",
     "sentientos/context_hygiene/prompt_materialization_audit.py",
@@ -93,6 +94,8 @@ PROMPT_TEXT_ALLOWLIST_PATHS: frozenset[str] = frozenset(
         "tests/test_phase80_internal_no_llm_prompt_candidate_contract.py",
         "sentientos/context_hygiene/prompt_provider_dry_run.py",
         "tests/test_phase84_provider_dry_run_request_envelope.py",
+        "sentientos/context_hygiene/prompt_provider_simulation.py",
+        "tests/test_phase86_provider_simulation_result_envelope.py",
     }
 )
 
@@ -105,6 +108,9 @@ PROMPT_TEXT_ALLOWLIST_NAMES: frozenset[str] = frozenset(
         "internal_prompt_candidate",
         "InternalPromptCandidate",
         "dry_run_prompt_text",
+        "simulated_result_stub",
+        "dry_run_prompt_text_digest",
+        "dry_run_prompt_text_length",
     }
 )
 

--- a/sentientos/context_hygiene/__init__.py
+++ b/sentientos/context_hygiene/__init__.py
@@ -679,3 +679,24 @@ from sentientos.context_hygiene.prompt_provider_dry_run_review import (
     summarize_provider_dry_run_egress_review_receipt,
     validate_provider_dry_run_egress_review_receipt,
 )
+
+from sentientos.context_hygiene.prompt_provider_simulation import (
+    ProviderSimulationBoundary,
+    ProviderSimulationConstraint,
+    ProviderSimulationFinding,
+    ProviderSimulationMode,
+    ProviderSimulationResultEnvelope,
+    ProviderSimulationResultPayload,
+    ProviderSimulationScope,
+    ProviderSimulationStatus,
+    build_provider_simulation_result_envelope,
+    compute_provider_simulation_digest,
+    explain_provider_simulation_findings,
+    provider_simulation_has_no_provider_credentials,
+    provider_simulation_has_no_runtime_authority,
+    provider_simulation_is_no_network,
+    provider_simulation_is_not_model_output,
+    provider_simulation_preserves_dry_run_review,
+    summarize_provider_simulation_result_envelope,
+    validate_provider_simulation_result_envelope,
+)

--- a/sentientos/context_hygiene/prompt_provider_simulation.py
+++ b/sentientos/context_hygiene/prompt_provider_simulation.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass, replace
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from sentientos.context_hygiene.prompt_provider_dry_run import (
+    ProviderDryRunRequestEnvelope,
+    ProviderDryRunStatus,
+    compute_provider_dry_run_digest,
+    provider_dry_run_has_no_network_egress,
+    provider_dry_run_has_no_provider_credentials,
+    provider_dry_run_has_no_runtime_authority,
+    provider_dry_run_is_non_sendable,
+)
+from sentientos.context_hygiene.prompt_provider_dry_run_review import (
+    ProviderDryRunEgressReviewReceipt,
+    compute_provider_dry_run_egress_review_digest,
+    provider_dry_run_review_approves_future_egress_review_gate,
+    provider_dry_run_review_approves_future_simulation_gate,
+    provider_dry_run_review_satisfies_envelope,
+)
+
+
+class ProviderSimulationStatus:
+    PROVIDER_SIMULATION_READY = "provider_simulation_ready"
+    PROVIDER_SIMULATION_READY_WITH_WARNINGS = "provider_simulation_ready_with_warnings"
+    PROVIDER_SIMULATION_BLOCKED = "provider_simulation_blocked"
+    PROVIDER_SIMULATION_INVALID_INPUT = "provider_simulation_invalid_input"
+    PROVIDER_SIMULATION_REVIEW_MISSING = "provider_simulation_review_missing"
+    PROVIDER_SIMULATION_DRY_RUN_NOT_READY = "provider_simulation_dry_run_not_ready"
+    PROVIDER_SIMULATION_NETWORK_FORBIDDEN = "provider_simulation_network_forbidden"
+    PROVIDER_SIMULATION_CREDENTIALS_DETECTED = "provider_simulation_credentials_detected"
+    PROVIDER_SIMULATION_RUNTIME_AUTHORITY_DETECTED = "provider_simulation_runtime_authority_detected"
+    PROVIDER_SIMULATION_SEMANTIC_GENERATION_FORBIDDEN = "provider_simulation_semantic_generation_forbidden"
+
+
+class ProviderSimulationMode:
+    SIMULATION_MODE_FIXED_STUB = "simulation_mode_fixed_stub"
+    SIMULATION_MODE_ECHO_METADATA_ONLY = "simulation_mode_echo_metadata_only"
+    SIMULATION_MODE_TRANSPORT_SHAPE_ONLY = "simulation_mode_transport_shape_only"
+    SIMULATION_MODE_UNKNOWN_FORBIDDEN = "simulation_mode_unknown_forbidden"
+
+
+class ProviderSimulationScope:
+    INTERNAL_SIMULATION_ONLY = "internal_simulation_only"
+
+
+@dataclass(frozen=True)
+class ProviderSimulationFinding:
+    code: str
+    detail: str
+    severity: str = "blocker"
+
+
+@dataclass(frozen=True)
+class ProviderSimulationConstraint:
+    code: str
+    detail: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ProviderSimulationBoundary:
+    provider_simulation_only: bool = True
+    fixed_stub_or_metadata_only: bool = True
+    semantic_generation_forbidden: bool = True
+    provider_send_forbidden: bool = True
+    network_egress_forbidden: bool = True
+    credentials_forbidden: bool = True
+    provider_client_absent: bool = True
+    endpoint_absent: bool = True
+    api_key_absent: bool = True
+    tool_calls_forbidden: bool = True
+    memory_forbidden: bool = True
+    retention_forbidden: bool = True
+    action_execution_forbidden: bool = True
+    routing_forbidden: bool = True
+    does_not_call_llm: bool = True
+    does_not_send_to_provider: bool = True
+    does_not_make_network_calls: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+
+
+@dataclass(frozen=True)
+class ProviderSimulationResultPayload:
+    payload_kind: str = "non_sendable_provider_simulation_shape"
+    simulation_label: str = "simulated_no_network_boundary"
+    result_label: str = "simulated_provider_stub"
+    transport_label: str = "simulated_transport_metadata"
+    fixed_stub_label: str = "provider_simulation_fixed_stub"
+    digest_refs: Mapping[str, str] = field(default_factory=dict)
+    usage_placeholder: Mapping[str, int | None] = field(default_factory=lambda: {"input_units": 0, "output_units": 0, "total_units": 0, "provider_billed_units": None})
+    metadata_tags: tuple[str, ...] = field(default_factory=lambda: ("provider_simulation_only", "fixed_stub_or_metadata_only", "no_network_egress"))
+    provider_send_forbidden: bool = True
+    network_egress_forbidden: bool = True
+    provider_client_absent: bool = True
+    fixed_stub_or_metadata_only: bool = True
+
+
+@dataclass(frozen=True)
+class ProviderSimulationResultEnvelope:
+    simulation_id: str
+    simulation_status: str
+    simulation_mode: str
+    simulation_scope: str
+    simulation_reason: str
+    dry_run_id: str
+    dry_run_status: str
+    dry_run_digest: str
+    dry_run_prompt_text_digest: str
+    dry_run_prompt_text_length: int
+    egress_review_receipt_id: str
+    egress_review_status: str
+    egress_review_digest: str
+    provider_family_label: str
+    model_family_label: str
+    candidate_id: str
+    candidate_digest: str
+    preflight_id: str
+    preflight_digest: str
+    packet_id: str
+    packet_scope: str
+    simulated_payload_shape: ProviderSimulationResultPayload
+    simulated_result_stub: str
+    simulated_result_digest: str
+    findings: tuple[ProviderSimulationFinding, ...]
+    warnings: tuple[str, ...]
+    constraints: tuple[ProviderSimulationConstraint, ...]
+    rationale: str
+    simulation_digest: str
+    provider_simulation_only: bool = True
+    fixed_stub_or_metadata_only: bool = True
+    semantic_generation_forbidden: bool = True
+    provider_send_forbidden: bool = True
+    network_egress_forbidden: bool = True
+    credentials_forbidden: bool = True
+    provider_client_absent: bool = True
+    endpoint_absent: bool = True
+    api_key_absent: bool = True
+    tool_calls_forbidden: bool = True
+    memory_forbidden: bool = True
+    retention_forbidden: bool = True
+    action_execution_forbidden: bool = True
+    routing_forbidden: bool = True
+    does_not_call_llm: bool = True
+    does_not_send_to_provider: bool = True
+    does_not_make_network_calls: bool = True
+    does_not_retrieve_memory: bool = True
+    does_not_write_memory: bool = True
+    does_not_trigger_feedback: bool = True
+    does_not_commit_retention: bool = True
+    does_not_execute_or_route_work: bool = True
+    does_not_admit_work: bool = True
+    boundary: ProviderSimulationBoundary = field(default_factory=ProviderSimulationBoundary)
+
+
+_ALLOWED_MODES = frozenset(
+    {
+        ProviderSimulationMode.SIMULATION_MODE_FIXED_STUB,
+        ProviderSimulationMode.SIMULATION_MODE_ECHO_METADATA_ONLY,
+        ProviderSimulationMode.SIMULATION_MODE_TRANSPORT_SHAPE_ONLY,
+    }
+)
+_READY_DRY_RUN_STATUSES = frozenset(
+    {
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_READY,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_READY_WITH_WARNINGS,
+    }
+)
+_READY_SIMULATION_STATUSES = frozenset(
+    {
+        ProviderSimulationStatus.PROVIDER_SIMULATION_READY,
+        ProviderSimulationStatus.PROVIDER_SIMULATION_READY_WITH_WARNINGS,
+    }
+)
+_MARKER_FIELDS = tuple(ProviderSimulationBoundary.__dataclass_fields__.keys())
+_CREDENTIAL_MARKERS = ("api_key", "apikey", "secret", "credential", "token", "authorization", "bearer", "auth", "header")
+_NETWORK_MARKERS = ("endpoint", "url", "uri", "host", "base_url", "webhook", "http", "https")
+_PROVIDER_OBJECT_MARKERS = ("client", "session", "transport", "sdk", "connection")
+_RUNTIME_AUTHORITY_MARKERS = (
+    "tool_call",
+    "tool_schema",
+    "function_call",
+    "function_schema",
+    "memory_handle",
+    "action_handle",
+    "retention_handle",
+    "routing_handle",
+    "retrieval_handle",
+    "runtime_handle",
+    "execution_handle",
+    "runtime_authority",
+)
+_RAW_OR_PARAM_MARKERS = ("raw_payload", "provider_params", "model_params", "llm_params", "llm_parameters")
+_MODEL_OUTPUT_MARKERS = ("model_output", "assistant", "generated_content", "semantic_generation", "completion")
+_NO_MODEL_MARKER = "NO MODEL CALLED"
+_NO_NETWORK_MARKER = "NO NETWORK EGRESS"
+_STUB_PREFIX = "PROVIDER SIMULATION RESULT"
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return is_dataclass(value) and not isinstance(value, type)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if _is_dataclass_instance(value):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stable(value: Any) -> Any:
+    if _is_dataclass_instance(value):
+        return {str(key): _stable(item) for key, item in asdict(value).items()}
+    if isinstance(value, Mapping):
+        return {str(key): _stable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (tuple, list)):
+        return [_stable(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_stable(item) for item in value)
+    return value
+
+
+def _walk(value: Any) -> tuple[tuple[str, Any], ...]:
+    found: list[tuple[str, Any]] = []
+
+    def visit(child: Any) -> None:
+        if _is_dataclass_instance(child):
+            visit(asdict(child))
+        elif isinstance(child, Mapping):
+            for key, nested in child.items():
+                found.append((str(key), nested))
+                visit(nested)
+        elif isinstance(child, (tuple, list, set, frozenset)):
+            for nested in child:
+                visit(nested)
+
+    visit(value)
+    return tuple(found)
+
+
+def _truthy_forbidden(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip()) and value.strip().lower() not in {"false", "none", "null", "0"}
+    if isinstance(value, (tuple, list, set, frozenset, Mapping)):
+        return bool(value)
+    return bool(value)
+
+
+def _negative_or_simulation_label(text: str) -> bool:
+    return (
+        text.endswith("_absent")
+        or text.endswith("_forbidden")
+        or text.startswith("does_not_")
+        or text.startswith("no_")
+        or text.startswith("non_")
+        or text.startswith("simulated_")
+        or text in {"transport_label", "result_label", "simulation_label"}
+    )
+
+
+def _contains_marker(value: Any, markers: Sequence[str], *, keys_only: bool = False) -> bool:
+    for key, nested in _walk(value):
+        lowered_key = key.lower()
+        lowered_value = "" if keys_only else str(nested).lower()
+        for marker in markers:
+            if _negative_or_simulation_label(lowered_key):
+                continue
+            if marker == "auth" and ("authority" in lowered_key or (not keys_only and "authority" in lowered_value)):
+                continue
+            if marker in lowered_key or (not keys_only and marker in lowered_value):
+                if _truthy_forbidden(nested) or lowered_value:
+                    return True
+    if isinstance(value, str) and not keys_only:
+        lowered = value.lower()
+        return any(marker in lowered for marker in markers)
+    return False
+
+
+def _text_digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _finding(code: str, detail: str, severity: str = "blocker") -> ProviderSimulationFinding:
+    return ProviderSimulationFinding(code=code, detail=detail, severity=severity)
+
+
+def _base_constraints() -> tuple[ProviderSimulationConstraint, ...]:
+    return (
+        ProviderSimulationConstraint("provider_simulation_only", "artifact is a provider simulation result only"),
+        ProviderSimulationConstraint("fixed_stub_or_metadata_only", "result content is fixed-stub or metadata-only"),
+        ProviderSimulationConstraint("semantic_generation_forbidden", "semantic generation and assistant-like output are forbidden"),
+        ProviderSimulationConstraint("provider_send_forbidden", "provider/model egress remains forbidden"),
+        ProviderSimulationConstraint("network_egress_forbidden", "network egress, endpoints, clients, and credentials are forbidden"),
+        ProviderSimulationConstraint("runtime_authority_forbidden", "tools, memory, actions, retention, routing, and admission are forbidden"),
+    )
+
+
+def _stub(*, dry_run_id: str, dry_run_digest: str, review_digest: str, simulation_mode: str, fixed_stub_label: str) -> str:
+    return " | ".join(
+        (
+            f"{_STUB_PREFIX} - {_NO_MODEL_MARKER} - {_NO_NETWORK_MARKER}",
+            f"label={fixed_stub_label or 'provider_simulation_fixed_stub'}",
+            f"mode={simulation_mode}",
+            f"dry_run_id={dry_run_id}",
+            f"dry_run_digest={dry_run_digest}",
+            f"egress_review_digest={review_digest}",
+            "non_runtime=true",
+        )
+    )
+
+
+def _payload_shape(*, fixed_stub_label: str, simulation_status: str, dry_run_digest: str, review_digest: str, simulated_result_digest: str, provider_family_label: str, model_family_label: str) -> ProviderSimulationResultPayload:
+    return ProviderSimulationResultPayload(
+        fixed_stub_label=fixed_stub_label or "provider_simulation_fixed_stub",
+        digest_refs={
+            "dry_run_digest": dry_run_digest,
+            "egress_review_digest": review_digest,
+            "simulated_result_digest": simulated_result_digest,
+        },
+        metadata_tags=(
+            "provider_simulation_only",
+            "fixed_stub_or_metadata_only",
+            "no_network_egress",
+            "no_model_called",
+            f"status:{simulation_status}",
+            f"provider_label:{provider_family_label}",
+            f"model_label:{model_family_label}",
+        ),
+    )
+
+
+def _review_digest(review_receipt: Any | None) -> str:
+    data = _mapping(review_receipt)
+    if not data:
+        return ""
+    try:
+        computed = compute_provider_dry_run_egress_review_digest(review_receipt)  # type: ignore[arg-type]
+    except Exception:
+        computed = ""
+    return computed or str(data.get("review_digest", ""))
+
+
+def _dry_run_digest(envelope: Any) -> str:
+    data = _mapping(envelope)
+    if not data:
+        return ""
+    try:
+        computed = compute_provider_dry_run_digest(envelope)  # type: ignore[arg-type]
+    except Exception:
+        computed = ""
+    return computed or str(data.get("dry_run_digest", ""))
+
+
+def _clean_review(envelope: Any, review_receipt: Any | None) -> bool:
+    return bool(
+        review_receipt is not None
+        and provider_dry_run_review_satisfies_envelope(envelope, review_receipt)  # type: ignore[arg-type]
+        and (
+            provider_dry_run_review_approves_future_simulation_gate(review_receipt)  # type: ignore[arg-type]
+            or provider_dry_run_review_approves_future_egress_review_gate(review_receipt)  # type: ignore[arg-type]
+        )
+    )
+
+
+def _evaluate_findings(
+    *,
+    dry_run_envelope: Any,
+    egress_review_receipt: Any | None,
+    simulation_mode: str,
+    simulation_scope: str,
+    expected_dry_run_digest: str | None,
+    expected_review_digest: str | None,
+    simulated_payload_shape: ProviderSimulationResultPayload,
+    simulated_result_stub: str,
+    marker_values: Mapping[str, bool],
+) -> tuple[ProviderSimulationFinding, ...]:
+    findings: list[ProviderSimulationFinding] = []
+    dry_data = _mapping(dry_run_envelope)
+    review_data = _mapping(egress_review_receipt)
+    if not dry_data:
+        findings.append(_finding("dry_run_missing", "Phase 84 ProviderDryRunRequestEnvelope is required"))
+    if egress_review_receipt is None or not review_data:
+        findings.append(_finding("egress_review_missing", "Phase 85 ProviderDryRunEgressReviewReceipt is required"))
+    if simulation_mode not in _ALLOWED_MODES:
+        findings.append(_finding("simulation_mode_forbidden", "simulation mode must be fixed-stub, metadata-only, or transport-shape-only"))
+    if simulation_scope != ProviderSimulationScope.INTERNAL_SIMULATION_ONLY:
+        findings.append(_finding("simulation_scope_forbidden", "simulation scope must be internal simulation only"))
+    dry_status = str(dry_data.get("dry_run_status", ""))
+    if dry_data and dry_status not in _READY_DRY_RUN_STATUSES:
+        findings.append(_finding("dry_run_not_ready", f"dry-run status {dry_status!r} is not eligible for provider simulation"))
+    if dry_data and not provider_dry_run_is_non_sendable(dry_run_envelope):
+        findings.append(_finding("dry_run_send_forbidden_not_preserved", "dry-run envelope must remain non-sendable"))
+    if dry_data and not provider_dry_run_has_no_provider_credentials(dry_run_envelope):
+        findings.append(_finding("credentials_detected", "credential markers are present in dry-run metadata"))
+    if dry_data and not provider_dry_run_has_no_network_egress(dry_run_envelope):
+        findings.append(_finding("network_egress_detected", "network or endpoint markers are present in dry-run metadata"))
+    if dry_data and not provider_dry_run_has_no_runtime_authority(dry_run_envelope):
+        findings.append(_finding("runtime_authority_detected", "runtime authority markers are present in dry-run metadata"))
+    if dry_data and expected_dry_run_digest is not None and str(expected_dry_run_digest) != str(dry_data.get("dry_run_digest", "")):
+        findings.append(_finding("expected_dry_run_digest_mismatch", "expected dry-run digest does not match envelope"))
+    if review_data and expected_review_digest is not None and str(expected_review_digest) != str(review_data.get("review_digest", "")):
+        findings.append(_finding("expected_review_digest_mismatch", "expected review digest does not match receipt"))
+    if review_data and not _clean_review(dry_run_envelope, egress_review_receipt):
+        findings.append(_finding("egress_review_not_satisfied", "egress review does not approve a future simulation or egress-review gate for this dry-run"))
+    if _contains_marker((simulated_payload_shape,), _CREDENTIAL_MARKERS, keys_only=True):
+        findings.append(_finding("payload_credentials_detected", "simulated payload shape contains credential-like fields"))
+    if _contains_marker((simulated_payload_shape,), _NETWORK_MARKERS, keys_only=True):
+        findings.append(_finding("payload_network_detected", "simulated payload shape contains endpoint or network-like fields"))
+    if _contains_marker((simulated_payload_shape,), _PROVIDER_OBJECT_MARKERS, keys_only=True):
+        findings.append(_finding("payload_provider_object_detected", "simulated payload shape contains provider client/session/transport-like fields"))
+    if _contains_marker((simulated_payload_shape,), _RUNTIME_AUTHORITY_MARKERS + _RAW_OR_PARAM_MARKERS, keys_only=True):
+        findings.append(_finding("payload_runtime_authority_detected", "simulated payload shape contains runtime/raw/model parameter markers"))
+    if _contains_marker((simulated_payload_shape,), _MODEL_OUTPUT_MARKERS, keys_only=False):
+        findings.append(_finding("model_output_marker_detected", "simulated payload shape must not contain assistant/generated content markers"))
+    for marker in _MARKER_FIELDS:
+        if marker_values.get(marker) is not True:
+            code = "network_marker_false" if marker in {"network_egress_forbidden", "does_not_make_network_calls", "endpoint_absent"} else "required_marker_false"
+            findings.append(_finding(code, f"required provider simulation marker {marker} must be true"))
+    if _STUB_PREFIX not in simulated_result_stub or _NO_MODEL_MARKER not in simulated_result_stub or _NO_NETWORK_MARKER not in simulated_result_stub:
+        findings.append(_finding("fixed_stub_marker_missing", "simulated result stub must contain provider-simulation, no-model, and no-network markers"))
+    if _contains_marker(simulated_result_stub, _MODEL_OUTPUT_MARKERS, keys_only=False):
+        findings.append(_finding("semantic_generation_marker_detected", "simulated result stub must not contain model output markers"))
+    return tuple(findings)
+
+
+def _status_for_findings(findings: Sequence[ProviderSimulationFinding], warnings: Sequence[str], dry_run_status: str, review_present: bool) -> str:
+    codes = {finding.code for finding in findings}
+    if "dry_run_missing" in codes:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_INVALID_INPUT
+    if "egress_review_missing" in codes or not review_present:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_REVIEW_MISSING
+    if any("credentials" in code for code in codes) or dry_run_status == ProviderDryRunStatus.PROVIDER_DRY_RUN_CREDENTIALS_DETECTED:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_CREDENTIALS_DETECTED
+    if any("network" in code or "endpoint" in code for code in codes) or dry_run_status == ProviderDryRunStatus.PROVIDER_DRY_RUN_NETWORK_EGRESS_DETECTED:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_NETWORK_FORBIDDEN
+    if any("runtime" in code or "provider_object" in code for code in codes) or dry_run_status == ProviderDryRunStatus.PROVIDER_DRY_RUN_RUNTIME_AUTHORITY_DETECTED:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_RUNTIME_AUTHORITY_DETECTED
+    if "dry_run_not_ready" in codes:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_DRY_RUN_NOT_READY
+    if any("semantic" in code or "model_output" in code or "fixed_stub" in code for code in codes):
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_SEMANTIC_GENERATION_FORBIDDEN
+    if findings:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_BLOCKED
+    if warnings or dry_run_status == ProviderDryRunStatus.PROVIDER_DRY_RUN_READY_WITH_WARNINGS:
+        return ProviderSimulationStatus.PROVIDER_SIMULATION_READY_WITH_WARNINGS
+    return ProviderSimulationStatus.PROVIDER_SIMULATION_READY
+
+
+def compute_provider_simulation_digest(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> str:
+    data = dict(_mapping(envelope))
+    data.pop("simulation_digest", None)
+    data.pop("simulation_id", None)
+    payload = {
+        "simulation_status": data.get("simulation_status", ""),
+        "simulation_mode": data.get("simulation_mode", ""),
+        "simulation_scope": data.get("simulation_scope", ""),
+        "simulation_reason": data.get("simulation_reason", ""),
+        "dry_run_id": data.get("dry_run_id", ""),
+        "dry_run_status": data.get("dry_run_status", ""),
+        "dry_run_digest": data.get("dry_run_digest", ""),
+        "dry_run_prompt_text_digest": data.get("dry_run_prompt_text_digest", ""),
+        "dry_run_prompt_text_length": int(data.get("dry_run_prompt_text_length", 0) or 0),
+        "egress_review_receipt_id": data.get("egress_review_receipt_id", ""),
+        "egress_review_status": data.get("egress_review_status", ""),
+        "egress_review_digest": data.get("egress_review_digest", ""),
+        "provider_family_label": data.get("provider_family_label", ""),
+        "model_family_label": data.get("model_family_label", ""),
+        "candidate_id": data.get("candidate_id", ""),
+        "candidate_digest": data.get("candidate_digest", ""),
+        "preflight_id": data.get("preflight_id", ""),
+        "preflight_digest": data.get("preflight_digest", ""),
+        "packet_id": data.get("packet_id", ""),
+        "packet_scope": data.get("packet_scope", ""),
+        "simulated_payload_shape": _stable(data.get("simulated_payload_shape", {})),
+        "simulated_result_stub": data.get("simulated_result_stub", ""),
+        "simulated_result_digest": data.get("simulated_result_digest", ""),
+        "findings": _stable(data.get("findings", ())),
+        "warnings": _stable(data.get("warnings", ())),
+        "constraints": _stable(data.get("constraints", ())),
+        "rationale": data.get("rationale", ""),
+        "markers": {marker: bool(data.get(marker, False)) for marker in _MARKER_FIELDS},
+        "boundary": _stable(data.get("boundary", {})),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_provider_simulation_result_envelope(
+    dry_run_envelope: ProviderDryRunRequestEnvelope | Mapping[str, Any] | None,
+    egress_review_receipt: ProviderDryRunEgressReviewReceipt | Mapping[str, Any] | None,
+    *,
+    simulation_mode: str,
+    simulation_scope: str,
+    simulation_reason: str = "",
+    fixed_stub_label: str = "provider_simulation_fixed_stub",
+    expected_dry_run_digest: str | None = None,
+    expected_review_digest: str | None = None,
+    marker_overrides: Mapping[str, bool] | None = None,
+) -> ProviderSimulationResultEnvelope:
+    dry_data = _mapping(dry_run_envelope)
+    review_data = _mapping(egress_review_receipt)
+    dry_digest = str(dry_data.get("dry_run_digest", ""))
+    review_digest = str(review_data.get("review_digest", ""))
+    dry_run_text = str(dry_data.get("dry_run_prompt_text", ""))
+    stub = _stub(
+        dry_run_id=str(dry_data.get("dry_run_id", "")),
+        dry_run_digest=dry_digest,
+        review_digest=review_digest,
+        simulation_mode=str(simulation_mode),
+        fixed_stub_label=str(fixed_stub_label),
+    )
+    stub_digest = _text_digest(stub)
+    marker_values = {field_name: True for field_name in _MARKER_FIELDS}
+    if marker_overrides:
+        marker_values.update({str(key): bool(value) for key, value in marker_overrides.items() if str(key) in marker_values})
+    preliminary_payload = _payload_shape(
+        fixed_stub_label=str(fixed_stub_label),
+        simulation_status="pending",
+        dry_run_digest=dry_digest,
+        review_digest=review_digest,
+        simulated_result_digest=stub_digest,
+        provider_family_label=str(dry_data.get("provider_family_label", review_data.get("provider_family_label", ""))),
+        model_family_label=str(dry_data.get("model_family_label", review_data.get("model_family_label", ""))),
+    )
+    preliminary_findings = _evaluate_findings(
+        dry_run_envelope=dry_run_envelope,
+        egress_review_receipt=egress_review_receipt,
+        simulation_mode=str(simulation_mode),
+        simulation_scope=str(simulation_scope),
+        expected_dry_run_digest=expected_dry_run_digest,
+        expected_review_digest=expected_review_digest,
+        simulated_payload_shape=preliminary_payload,
+        simulated_result_stub=stub,
+        marker_values=marker_values,
+    )
+    warnings = tuple(str(item) for source in (dry_data, review_data) for item in (source.get("warnings", ()) or ()))
+    status = _status_for_findings(preliminary_findings, warnings, str(dry_data.get("dry_run_status", "")), bool(review_data))
+    payload = _payload_shape(
+        fixed_stub_label=str(fixed_stub_label),
+        simulation_status=status,
+        dry_run_digest=dry_digest,
+        review_digest=review_digest,
+        simulated_result_digest=stub_digest,
+        provider_family_label=str(dry_data.get("provider_family_label", review_data.get("provider_family_label", ""))),
+        model_family_label=str(dry_data.get("model_family_label", review_data.get("model_family_label", ""))),
+    )
+    findings = _evaluate_findings(
+        dry_run_envelope=dry_run_envelope,
+        egress_review_receipt=egress_review_receipt,
+        simulation_mode=str(simulation_mode),
+        simulation_scope=str(simulation_scope),
+        expected_dry_run_digest=expected_dry_run_digest,
+        expected_review_digest=expected_review_digest,
+        simulated_payload_shape=payload,
+        simulated_result_stub=stub,
+        marker_values=marker_values,
+    )
+    status = _status_for_findings(findings, warnings, str(dry_data.get("dry_run_status", "")), bool(review_data))
+    rationale = "; ".join(f"{finding.code}: {finding.detail}" for finding in findings[:4]) or "provider simulation result is fixed-stub/metadata-only; provider invocation and network egress remain forbidden"
+    boundary = ProviderSimulationBoundary(**marker_values)
+    envelope = ProviderSimulationResultEnvelope(
+        simulation_id="",
+        simulation_status=status,
+        simulation_mode=str(simulation_mode),
+        simulation_scope=str(simulation_scope),
+        simulation_reason=str(simulation_reason),
+        dry_run_id=str(dry_data.get("dry_run_id", "")),
+        dry_run_status=str(dry_data.get("dry_run_status", "")),
+        dry_run_digest=dry_digest,
+        dry_run_prompt_text_digest=_text_digest(dry_run_text),
+        dry_run_prompt_text_length=len(dry_run_text),
+        egress_review_receipt_id=str(review_data.get("review_receipt_id", "")),
+        egress_review_status=str(review_data.get("review_status", "")),
+        egress_review_digest=review_digest,
+        provider_family_label=str(dry_data.get("provider_family_label", review_data.get("provider_family_label", ""))),
+        model_family_label=str(dry_data.get("model_family_label", review_data.get("model_family_label", ""))),
+        candidate_id=str(dry_data.get("candidate_id", review_data.get("candidate_id", ""))),
+        candidate_digest=str(dry_data.get("candidate_digest", review_data.get("candidate_digest", ""))),
+        preflight_id=str(dry_data.get("preflight_id", review_data.get("preflight_id", ""))),
+        preflight_digest=str(dry_data.get("preflight_digest", review_data.get("preflight_digest", ""))),
+        packet_id=str(dry_data.get("packet_id", review_data.get("packet_id", ""))),
+        packet_scope=str(dry_data.get("packet_scope", review_data.get("packet_scope", ""))),
+        simulated_payload_shape=payload,
+        simulated_result_stub=stub,
+        simulated_result_digest=stub_digest,
+        findings=tuple(findings),
+        warnings=warnings,
+        constraints=_base_constraints(),
+        rationale=rationale[:1000],
+        simulation_digest="",
+        boundary=boundary,
+        **marker_values,
+    )
+    digest = compute_provider_simulation_digest(envelope)
+    return replace(envelope, simulation_id=f"provider-simulation:{envelope.dry_run_id or 'missing'}:{digest[:16]}", simulation_digest=digest)
+
+
+def validate_provider_simulation_result_envelope(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> tuple[ProviderSimulationFinding, ...]:
+    data = _mapping(envelope)
+    findings: list[ProviderSimulationFinding] = []
+    if not data:
+        return (_finding("simulation_malformed", "provider simulation envelope is malformed"),)
+    expected = compute_provider_simulation_digest(envelope)
+    if str(data.get("simulation_digest", "")) != expected:
+        findings.append(_finding("simulation_digest_mismatch", "simulation digest does not match envelope-safe fields"))
+    if str(data.get("simulation_status", "")) in _READY_SIMULATION_STATUSES and tuple(data.get("findings", ()) or ()): 
+        findings.append(_finding("ready_with_blocking_findings", "ready provider simulations must not contain findings"))
+    if not provider_simulation_is_no_network(envelope):
+        findings.append(_finding("no_network_proof_failed", "provider simulation no-network proof failed"))
+    if not provider_simulation_is_not_model_output(envelope):
+        findings.append(_finding("not_model_output_proof_failed", "provider simulation fixed-stub/non-semantic proof failed"))
+    if not provider_simulation_has_no_provider_credentials(envelope):
+        findings.append(_finding("credentials_detected", "provider simulation contains credential markers"))
+    if not provider_simulation_has_no_runtime_authority(envelope):
+        findings.append(_finding("runtime_authority_detected", "provider simulation contains runtime authority markers"))
+    return tuple(findings)
+
+
+def _finding_codes(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> set[str]:
+    return {str(_mapping(finding).get("code", "")) for finding in (_mapping(envelope).get("findings", ()) or ())}
+
+
+def provider_simulation_is_no_network(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> bool:
+    data = _mapping(envelope)
+    codes = _finding_codes(envelope)
+    return bool(
+        str(data.get("simulation_status", "")) in _READY_SIMULATION_STATUSES
+        and data.get("network_egress_forbidden") is True
+        and data.get("does_not_make_network_calls") is True
+        and data.get("endpoint_absent") is True
+        and data.get("provider_client_absent") is True
+        and data.get("api_key_absent") is True
+        and not any("network" in code or "endpoint" in code or "client" in code for code in codes)
+    )
+
+
+def provider_simulation_is_not_model_output(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> bool:
+    data = _mapping(envelope)
+    stub = str(data.get("simulated_result_stub", ""))
+    codes = _finding_codes(envelope)
+    return bool(
+        data.get("semantic_generation_forbidden") is True
+        and data.get("fixed_stub_or_metadata_only") is True
+        and data.get("does_not_call_llm") is True
+        and _STUB_PREFIX in stub
+        and _NO_MODEL_MARKER in stub
+        and _NO_NETWORK_MARKER in stub
+        and not any("model_output" in code or "assistant" in code or "generated" in code for code in codes)
+    )
+
+
+def provider_simulation_has_no_provider_credentials(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> bool:
+    data = _mapping(envelope)
+    return bool(
+        data.get("credentials_forbidden") is True
+        and data.get("api_key_absent") is True
+        and not _contains_marker((data.get("simulated_payload_shape", {}),), _CREDENTIAL_MARKERS, keys_only=True)
+    )
+
+
+def provider_simulation_has_no_runtime_authority(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> bool:
+    data = _mapping(envelope)
+    required = ("tool_calls_forbidden", "memory_forbidden", "retention_forbidden", "action_execution_forbidden", "routing_forbidden", "does_not_execute_or_route_work", "does_not_admit_work")
+    return bool(
+        all(data.get(marker) is True for marker in required)
+        and not _contains_marker((data.get("simulated_payload_shape", {}),), _RUNTIME_AUTHORITY_MARKERS + _RAW_OR_PARAM_MARKERS, keys_only=True)
+    )
+
+
+def provider_simulation_preserves_dry_run_review(
+    envelope: ProviderSimulationResultEnvelope | Mapping[str, Any],
+    dry_run_envelope: ProviderDryRunRequestEnvelope | Mapping[str, Any],
+    egress_review_receipt: ProviderDryRunEgressReviewReceipt | Mapping[str, Any],
+) -> bool:
+    data = _mapping(envelope)
+    dry_data = _mapping(dry_run_envelope)
+    review_data = _mapping(egress_review_receipt)
+    return bool(
+        data.get("dry_run_id") == dry_data.get("dry_run_id")
+        and data.get("dry_run_digest") == dry_data.get("dry_run_digest")
+        and data.get("egress_review_receipt_id") == review_data.get("review_receipt_id")
+        and data.get("egress_review_digest") == review_data.get("review_digest")
+    )
+
+
+def explain_provider_simulation_findings(envelope_or_findings: ProviderSimulationResultEnvelope | Mapping[str, Any] | Sequence[ProviderSimulationFinding]) -> tuple[str, ...]:
+    if isinstance(envelope_or_findings, Sequence) and not isinstance(envelope_or_findings, (str, bytes, Mapping)):
+        findings = envelope_or_findings
+    else:
+        findings = _mapping(envelope_or_findings).get("findings", ()) or ()
+    return tuple(f"{_mapping(item).get('severity', '')}:{_mapping(item).get('code', '')}:{_mapping(item).get('detail', '')}" for item in findings)
+
+
+def summarize_provider_simulation_result_envelope(envelope: ProviderSimulationResultEnvelope | Mapping[str, Any]) -> Mapping[str, Any]:
+    data = _mapping(envelope)
+    return {
+        "simulation_id": str(data.get("simulation_id", "")),
+        "simulation_status": str(data.get("simulation_status", "")),
+        "simulation_mode": str(data.get("simulation_mode", "")),
+        "simulation_scope": str(data.get("simulation_scope", "")),
+        "dry_run_id": str(data.get("dry_run_id", "")),
+        "dry_run_digest": str(data.get("dry_run_digest", "")),
+        "egress_review_receipt_id": str(data.get("egress_review_receipt_id", "")),
+        "egress_review_digest": str(data.get("egress_review_digest", "")),
+        "provider_family_label": str(data.get("provider_family_label", "")),
+        "model_family_label": str(data.get("model_family_label", "")),
+        "finding_count": len(data.get("findings", ()) or ()),
+        "warning_count": len(data.get("warnings", ()) or ()),
+        "simulation_digest": str(data.get("simulation_digest", "")),
+        "provider_simulation_only": bool(data.get("provider_simulation_only", False)),
+        "fixed_stub_or_metadata_only": bool(data.get("fixed_stub_or_metadata_only", False)),
+        "does_not_call_llm": bool(data.get("does_not_call_llm", False)),
+        "does_not_send_to_provider": bool(data.get("does_not_send_to_provider", False)),
+        "does_not_make_network_calls": bool(data.get("does_not_make_network_calls", False)),
+    }

--- a/sentientos/system_closure/architecture_boundary_manifest.json
+++ b/sentientos/system_closure/architecture_boundary_manifest.json
@@ -612,7 +612,13 @@
       "future_simulation_gate_review_only": true,
       "non_sendable_preserved": true,
       "provider_client_forbidden": true,
-      "does_not_make_network_calls": true
+      "does_not_make_network_calls": true,
+      "provider_simulation_only": true,
+      "fixed_stub_or_metadata_only": true,
+      "semantic_generation_forbidden": true,
+      "api_key_absent": true,
+      "endpoint_absent": true,
+      "no_semantic_generation": true
     }
   },
   "protected_sinks": {

--- a/tests/test_phase86_provider_simulation_result_envelope.py
+++ b/tests/test_phase86_provider_simulation_result_envelope.py
@@ -1,0 +1,341 @@
+"""Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, replace
+import importlib
+import sys
+import types
+
+# Keep privilege imports side-effect-safe under the repo's test ritual.
+tts_stub = types.ModuleType("tts_bridge")
+tts_stub.speak = lambda *args, **kwargs: None
+sys.modules.setdefault("tts_bridge", tts_stub)
+
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()
+require_lumos_approval()
+
+from sentientos.context_hygiene.prompt_provider_dry_run import (
+    ProviderDryRunStatus,
+    compute_provider_dry_run_digest,
+)
+from sentientos.context_hygiene.prompt_provider_dry_run_review import (
+    ProviderDryRunEgressReviewDecision,
+    ProviderDryRunEgressReviewScope,
+    compute_provider_dry_run_egress_review_digest,
+)
+from sentientos.context_hygiene.prompt_provider_simulation import (
+    ProviderSimulationFinding,
+    ProviderSimulationMode,
+    ProviderSimulationResultPayload,
+    ProviderSimulationScope,
+    ProviderSimulationStatus,
+    build_provider_simulation_result_envelope,
+    compute_provider_simulation_digest,
+    provider_simulation_has_no_provider_credentials,
+    provider_simulation_has_no_runtime_authority,
+    provider_simulation_is_no_network,
+    provider_simulation_is_not_model_output,
+    provider_simulation_preserves_dry_run_review,
+    summarize_provider_simulation_result_envelope,
+    validate_provider_simulation_result_envelope,
+)
+from scripts.verify_context_hygiene_prompt_boundaries import scan_context_hygiene_prompt_boundaries
+from tests.test_phase84_provider_dry_run_request_envelope import _chain, _envelope
+from tests.test_phase85_provider_dry_run_egress_review_receipt import _review
+
+READY = ProviderSimulationStatus.PROVIDER_SIMULATION_READY
+WARN = ProviderSimulationStatus.PROVIDER_SIMULATION_READY_WITH_WARNINGS
+BLOCKED = ProviderSimulationStatus.PROVIDER_SIMULATION_BLOCKED
+REVIEW_MISSING = ProviderSimulationStatus.PROVIDER_SIMULATION_REVIEW_MISSING
+DRY_NOT_READY = ProviderSimulationStatus.PROVIDER_SIMULATION_DRY_RUN_NOT_READY
+NETWORK = ProviderSimulationStatus.PROVIDER_SIMULATION_NETWORK_FORBIDDEN
+CREDS = ProviderSimulationStatus.PROVIDER_SIMULATION_CREDENTIALS_DETECTED
+RUNTIME = ProviderSimulationStatus.PROVIDER_SIMULATION_RUNTIME_AUTHORITY_DETECTED
+SEMANTIC = ProviderSimulationStatus.PROVIDER_SIMULATION_SEMANTIC_GENERATION_FORBIDDEN
+FIXED = ProviderSimulationMode.SIMULATION_MODE_FIXED_STUB
+META = ProviderSimulationMode.SIMULATION_MODE_ECHO_METADATA_ONLY
+SHAPE = ProviderSimulationMode.SIMULATION_MODE_TRANSPORT_SHAPE_ONLY
+SCOPE = ProviderSimulationScope.INTERNAL_SIMULATION_ONLY
+
+
+def _simulation(envelope=None, receipt=None, **overrides):
+    envelope = envelope or _envelope()
+    if receipt is ...:
+        receipt = None
+    elif receipt is None:
+        receipt = _review(envelope)
+    kwargs = {
+        "simulation_mode": FIXED,
+        "simulation_scope": SCOPE,
+        "simulation_reason": "phase86 deterministic provider simulation fixture",
+    }
+    kwargs.update(overrides)
+    return build_provider_simulation_result_envelope(envelope, receipt, **kwargs)
+
+
+def _with_dry_status(envelope, status: str):
+    changed = replace(envelope, dry_run_status=status)
+    return replace(changed, dry_run_digest=compute_provider_dry_run_digest(changed))
+
+
+def _with_dry_marker(envelope, **overrides):
+    changed = replace(envelope, **overrides)
+    return replace(changed, dry_run_digest=compute_provider_dry_run_digest(changed))
+
+
+def _with_review_digest(receipt, **overrides):
+    changed = replace(receipt, **overrides)
+    return replace(changed, review_digest=compute_provider_dry_run_egress_review_digest(changed))
+
+
+def _codes(envelope):
+    return {finding.code for finding in envelope.findings}
+
+
+def _bad_payload(key: str):
+    return ProviderSimulationResultPayload(digest_refs={key: "fixture"})
+
+
+def test_ready_dry_run_and_approved_review_fixed_stub_mode_produces_ready_summary_and_validation():
+    envelope = _envelope()
+    receipt = _review(envelope)
+    simulation = _simulation(envelope, receipt)
+    assert simulation.simulation_status == READY
+    assert simulation.simulation_mode == FIXED
+    assert simulation.simulation_scope == SCOPE
+    assert simulation.dry_run_id == envelope.dry_run_id
+    assert simulation.egress_review_receipt_id == receipt.review_receipt_id
+    assert provider_simulation_preserves_dry_run_review(simulation, envelope, receipt)
+    assert validate_provider_simulation_result_envelope(simulation) == ()
+    assert summarize_provider_simulation_result_envelope(simulation)["simulation_status"] == READY
+
+
+def test_ready_with_warnings_dry_run_or_review_produces_warning_status():
+    envelope = _with_dry_status(_envelope(extra_metadata={"warning_fixture": "metadata-only"}), ProviderDryRunStatus.PROVIDER_DRY_RUN_READY_WITH_WARNINGS)
+    receipt = _review(envelope)
+    simulation = _simulation(envelope, receipt)
+    assert simulation.simulation_status == WARN
+    assert simulation.dry_run_status == ProviderDryRunStatus.PROVIDER_DRY_RUN_READY_WITH_WARNINGS
+
+
+def test_missing_rejected_expired_or_mismatched_review_blocks_before_simulation():
+    envelope = _envelope()
+    assert _simulation(envelope, receipt=...).simulation_status == REVIEW_MISSING
+    rejected = _review(envelope, decision=ProviderDryRunEgressReviewDecision.REJECT_PROVIDER_DRY_RUN, accepted_mitigation_codes=())
+    assert _simulation(envelope, rejected).simulation_status == BLOCKED
+    expired = _review(envelope, expires_at="2026-05-09T00:00:00Z", evaluated_at="2026-05-09T00:00:00Z")
+    assert _simulation(envelope, expired).simulation_status == BLOCKED
+    mismatched = _with_review_digest(_review(envelope), dry_run_digest="digest:mismatch")
+    assert _simulation(envelope, mismatched).simulation_status == BLOCKED
+
+
+def test_dry_run_blocked_invalid_send_forbidden_credential_network_and_runtime_statuses_block():
+    base = _envelope()
+    expectations = {
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_BLOCKED: DRY_NOT_READY,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_INVALID_INPUT: DRY_NOT_READY,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_SEND_FORBIDDEN: DRY_NOT_READY,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_CREDENTIALS_DETECTED: CREDS,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_NETWORK_EGRESS_DETECTED: NETWORK,
+        ProviderDryRunStatus.PROVIDER_DRY_RUN_RUNTIME_AUTHORITY_DETECTED: RUNTIME,
+    }
+    for status, expected in expectations.items():
+        envelope = _with_dry_status(base, status)
+        simulation = _simulation(envelope, _review(envelope))
+        assert simulation.simulation_status == expected
+        assert "dry_run_not_ready" in _codes(simulation)
+
+
+def test_unknown_mode_and_live_or_network_scope_block():
+    assert _simulation(simulation_mode=ProviderSimulationMode.SIMULATION_MODE_UNKNOWN_FORBIDDEN).simulation_status == BLOCKED
+    assert _simulation(simulation_mode="semantic_generation_mode").simulation_status == SEMANTIC
+    assert _simulation(simulation_mode="live_provider_mode").simulation_status == BLOCKED
+    assert _simulation(simulation_mode="network_dry_run_mode").simulation_status == BLOCKED
+    for scope in ("live_provider_scope", "network_egress_scope", "external_provider_scope"):
+        assert _simulation(simulation_scope=scope).simulation_status == BLOCKED
+
+
+def test_forbidden_metadata_fields_in_dry_run_block_credentials_network_provider_object_and_runtime_authority():
+    bad_key = "api" + "_key"
+    net_field = "end" + "point"
+    secret_field = "auth" + "_header"
+    object_field = "provider" + "_client"
+    state_field = "request" + "_session"
+    transportish = "transport" + "_object"
+    toolish = "tool" + "_call"
+    functionish = "function" + "_schema"
+    memoryish = "memory" + "_handle"
+    actionish = "action" + "_handle"
+    retentionish = "retention" + "_handle"
+    routingish = "routing" + "_handle"
+    rawish = "raw" + "_payload"
+    runtimeish = "runtime" + "_authority"
+    llmish = "llm" + "_params"
+    provider_paramish = "provider" + "_params"
+    expectations = [
+        ({bad_key: "x"}, CREDS),
+        ({net_field: "x"}, NETWORK),
+        ({"service_url": "x"}, NETWORK),
+        ({secret_field: "x"}, CREDS),
+        ({"head" + "ers_fixture": "x"}, CREDS),
+        ({object_field: "x"}, CREDS),
+        ({state_field: "x"}, CREDS),
+        ({transportish: "x"}, CREDS),
+        ({toolish: "x"}, RUNTIME),
+        ({functionish: "x"}, RUNTIME),
+        ({memoryish: "x"}, RUNTIME),
+        ({actionish: "x"}, RUNTIME),
+        ({retentionish: "x"}, RUNTIME),
+        ({routingish: "x"}, RUNTIME),
+        ({rawish: "x"}, RUNTIME),
+        ({runtimeish: "x"}, RUNTIME),
+        ({llmish: "x"}, RUNTIME),
+        ({provider_paramish: "x"}, RUNTIME),
+    ]
+    for extra, expected in expectations:
+        envelope = _envelope(extra_metadata=extra)
+        simulation = _simulation(envelope, _review(envelope))
+        assert simulation.simulation_status == expected
+
+
+def test_marker_overrides_block_network_send_and_runtime_authority():
+    assert _simulation(marker_overrides={"provider_send_forbidden": False}).simulation_status == BLOCKED
+    assert _simulation(marker_overrides={"network_egress_forbidden": False}).simulation_status == NETWORK
+    assert _simulation(marker_overrides={"does_not_make_network_calls": False}).simulation_status == NETWORK
+    assert _simulation(marker_overrides={"tool_calls_forbidden": False}).simulation_status == BLOCKED
+
+
+def test_fixed_stub_contains_no_model_no_network_markers_and_does_not_transform_prompt():
+    envelope = _envelope()
+    simulation = _simulation(envelope)
+    assert "PROVIDER SIMULATION RESULT" in simulation.simulated_result_stub
+    assert "NO MODEL CALLED" in simulation.simulated_result_stub
+    assert "NO NETWORK EGRESS" in simulation.simulated_result_stub
+    assert envelope.dry_run_prompt_text not in simulation.simulated_result_stub
+    assert "internal no-llm candidate" not in simulation.simulated_result_stub.lower()
+    assert "answer" not in simulation.simulated_result_stub.lower()
+
+
+def test_payload_shape_uses_simulation_labels_and_no_provider_roles_or_forbidden_runtime_fields():
+    simulation = _simulation()
+    payload = asdict(simulation.simulated_payload_shape)
+    payload_text = repr(payload).lower()
+    assert payload["result_label"] == "simulated_provider_stub"
+    assert payload["transport_label"] == "simulated_transport_metadata"
+    assert payload["simulation_label"] == "simulated_no_network_boundary"
+    for forbidden in ("system", "developer", "assistant", "completion", "endpoint", "api_key", "auth", "headers", "session", "tool_calls", "function_call"):
+        assert forbidden not in payload_text
+    assert "client_absent" in payload_text
+
+
+def test_no_network_not_model_output_credentials_and_runtime_helpers_are_strict():
+    simulation = _simulation()
+    assert provider_simulation_is_no_network(simulation)
+    assert provider_simulation_is_not_model_output(simulation)
+    assert provider_simulation_has_no_provider_credentials(simulation)
+    assert provider_simulation_has_no_runtime_authority(simulation)
+    bad_cred = replace(simulation, simulated_payload_shape=_bad_payload("api" + "_key"), findings=(ProviderSimulationFinding("payload_credentials_detected", "x"),))
+    assert not provider_simulation_has_no_provider_credentials(bad_cred)
+    assert not provider_simulation_is_no_network(replace(simulation, findings=(ProviderSimulationFinding("network_egress_detected", "x"),)))
+    assert not provider_simulation_is_not_model_output(replace(simulation, simulated_result_stub="metadata only"))
+    bad_runtime = replace(simulation, simulated_payload_shape=_bad_payload("tool" + "_call"), findings=(ProviderSimulationFinding("payload_runtime_authority_detected", "x"),))
+    assert not provider_simulation_has_no_runtime_authority(bad_runtime)
+
+
+def test_digest_is_deterministic_and_changes_for_linkage_mode_label_payload_findings_and_stub_changes():
+    envelope = _envelope()
+    receipt = _review(envelope)
+    first = _simulation(envelope, receipt)
+    second = _simulation(envelope, receipt)
+    assert first.simulation_digest == second.simulation_digest
+    assert compute_provider_simulation_digest(first) == first.simulation_digest
+    dry_changed = _with_dry_marker(envelope, candidate_digest="digest:changed")
+    assert _simulation(dry_changed, _review(dry_changed)).simulation_digest != first.simulation_digest
+    review_changed = _with_review_digest(receipt, reviewer_ref="operator:changed")
+    assert _simulation(envelope, review_changed).simulation_digest != first.simulation_digest
+    assert _simulation(envelope, receipt, simulation_mode=META).simulation_digest != first.simulation_digest
+    assert _simulation(envelope, receipt, simulation_mode=SHAPE).simulation_digest != first.simulation_digest
+    label_changed = _with_dry_marker(envelope, provider_family_label="provider_family_local_label_only", model_family_label="model_family_chat_label_only")
+    assert _simulation(label_changed, _review(label_changed)).simulation_digest != first.simulation_digest
+    assert _simulation(envelope, receipt, fixed_stub_label="alternate_fixed_stub").simulation_digest != first.simulation_digest
+    payload_changed = replace(first, simulated_payload_shape=replace(first.simulated_payload_shape, fixed_stub_label="payload_changed"))
+    assert compute_provider_simulation_digest(payload_changed) != first.simulation_digest
+    finding_changed = replace(first, findings=(ProviderSimulationFinding("fixture", "changed"),))
+    assert compute_provider_simulation_digest(finding_changed) != first.simulation_digest
+
+
+def test_helpers_do_not_mutate_dry_run_or_review_and_do_not_import_runtime_surfaces(monkeypatch):
+    envelope = _envelope()
+    receipt = _review(envelope)
+    before_envelope = deepcopy(envelope)
+    before_receipt = deepcopy(receipt)
+    forbidden_modules = ("prompt_assembler", "memory_manager", "openai", "requests", "httpx")
+    for name in forbidden_modules:
+        sys.modules.pop(name, None)
+    simulation = _simulation(envelope, receipt)
+    assert envelope == before_envelope
+    assert receipt == before_receipt
+    assert simulation.simulation_status == READY
+    for name in forbidden_modules:
+        assert name not in sys.modules
+    module = importlib.import_module("sentientos.context_hygiene.prompt_provider_simulation")
+    assert not hasattr(module, "assemble_prompt")
+
+
+def test_phase63_to_phase86_chain_succeeds_only_when_all_gates_pass_and_blocked_attempted_candidate_blocks():
+    candidate, display, preflight, model_review = _chain()
+    envelope = _envelope(candidate=candidate, display_receipt=display, preflight=preflight, review_receipt=model_review)
+    receipt = _review(envelope)
+    assert _simulation(envelope, receipt).simulation_status == READY
+    blocked = _with_dry_status(envelope, ProviderDryRunStatus.PROVIDER_DRY_RUN_BLOCKED)
+    assert _simulation(blocked, _review(blocked)).simulation_status == DRY_NOT_READY
+
+
+def test_adversarial_provider_runtime_markers_remain_blocked():
+    envelope = _envelope(extra_metadata={"runtime" + "_handle": "x", "provider" + "_params": {"temperature": 1}})
+    simulation = _simulation(envelope, _review(envelope))
+    assert simulation.simulation_status == RUNTIME
+    assert "runtime_authority_detected" in _codes(simulation)
+
+
+def test_guardrail_allows_stub_only_in_provider_simulation_surfaces_and_rejects_forbidden_fields(tmp_path):
+    clean = scan_context_hygiene_prompt_boundaries([
+        "sentientos/context_hygiene/prompt_provider_simulation.py",
+        "tests/test_phase86_provider_simulation_result_envelope.py",
+    ])
+    assert clean.ok, clean.findings
+    bad = tmp_path / "bad_provider_simulation_fixture.py"
+    bad.write_text(
+        "api" + "_key = 'x'\n"
+        "end" + "point = 'x'\n"
+        "client = object()\n"
+        "session = object()\n"
+        "provider" + "_params = {}\n",
+        encoding="utf-8",
+    )
+    report = scan_context_hygiene_prompt_boundaries([bad])
+    assert not report.ok
+    codes = {finding.code for finding in report.findings}
+    assert "forbidden_materialization_assignment" in codes
+
+
+def test_architecture_and_import_purity_surface_has_expected_markers():
+    simulation = _simulation()
+    assert simulation.provider_simulation_only
+    assert simulation.fixed_stub_or_metadata_only
+    assert simulation.semantic_generation_forbidden
+    assert simulation.provider_send_forbidden
+    assert simulation.network_egress_forbidden
+    assert simulation.credentials_forbidden
+    assert simulation.provider_client_absent
+    assert simulation.does_not_call_llm
+    assert simulation.does_not_send_to_provider
+    assert simulation.does_not_make_network_calls
+    assert simulation.does_not_retrieve_memory
+    assert simulation.does_not_write_memory
+    assert simulation.does_not_commit_retention
+    assert simulation.does_not_execute_or_route_work
+    assert simulation.does_not_admit_work


### PR DESCRIPTION
### Motivation
- Provide a deterministic, no-network provider-like result artifact that records metadata and digest linkage for Phase 84 `ProviderDryRunRequestEnvelope` after Phase 85 approval without calling providers or performing semantic generation. 
- Preserve strict context-hygiene invariants (no provider SDKs, no network, no LLM, no memory/retention/action/runtime side effects) while enabling downstream inspection and gated design of future provider-call flows.

### Description
- Add a new Phase 86 module `sentientos/context_hygiene/prompt_provider_simulation.py` implementing frozen dataclasses (`ProviderSimulationResultEnvelope`, `ProviderSimulationResultPayload`, `ProviderSimulationBoundary`, `ProviderSimulationFinding`, `ProviderSimulationConstraint`), compact statuses and modes, deterministic digest computation, builder `build_provider_simulation_result_envelope(...)`, validator `validate_provider_simulation_result_envelope(...)`, and helper predicates such as `provider_simulation_is_no_network(...)` and `provider_simulation_is_not_model_output(...)` that prove the artifact is metadata-only and non-runtime. 
- Implement a fixed, deterministic stub text (contains `PROVIDER SIMULATION RESULT`, `NO MODEL CALLED`, `NO NETWORK EGRESS`) and simulation-only payload labels (`simulated_provider_stub`, `simulated_transport_metadata`, `simulated_no_network_boundary`) that explicitly exclude provider/client/credential/endpoint/runtime artifacts. 
- Export the Phase 86 API from `sentientos/context_hygiene/__init__.py` and update the Phase 75 static guardrail scanner `scripts/verify_context_hygiene_prompt_boundaries.py` to include the new module and narrowly allow `simulated_result_stub` and related metadata-only names in scan allowlists. 
- Add deterministic documentation `docs/architecture/phase86_provider_simulation_result_envelope_execplan.md` and update `docs/architecture/context_hygiene_spine.md` and the `sentientos/system_closure/architecture_boundary_manifest.json` classification to reflect the Phase 86 boundary markers. 
- Add comprehensive regression tests in `tests/test_phase86_provider_simulation_result_envelope.py` that cover gating logic, blocking conditions (credentials, network, runtime authority, missing/expired/mismatched reviews), allowed simulation modes, payload shape safety, digest determinism, immutability of inputs, guardrail scans, and prevention of runtime/provider imports or calls.

### Testing
- Ran the new Phase 86 unit tests with the repo-approved fallback: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 pytest -q tests/test_phase86_provider_simulation_result_envelope.py`, and the Phase 86 test suite passed under that fallback. 
- Verified cross-phase suites via the same fallback for the Phase 84/85 and context-hygiene suites: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 pytest -q tests/test_phase85_provider_dry_run_egress_review_receipt.py tests/test_phase84_provider_dry_run_request_envelope.py` and related context-hygiene tests; these passed under the fallback runner. 
- Ran architecture and import-purity checks with the fallback: `SENTIENTOS_ALLOW_NAKED_PYTEST=1 pytest -q tests/architecture/test_architecture_boundaries.py tests/integrity/test_import_purity.py`, and they passed. 
- Ran guardrail and verifier scripts directly: `python scripts/verify_context_hygiene_prompt_boundaries.py` and `python scripts/audit_immutability_verifier.py`, and both produced clean results for the updated targets. 
- Note on environment: attempts to run `python -m scripts.run_tests -q ...` in this container failed to provision some build deps (pandas/pkg_resources) and the runner airlock (missing `fastapi`), so we used the repo-approved `SENTIENTOS_ALLOW_NAKED_PYTEST=1` fallback and direct `pytest` for the new tests; results are documented above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff464e8d948320a3d9e8a6a6f94000)