### PR TITLE
[codex:test-runner] add focused test airlock bootstrap

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import os
 import subprocess
@@ -27,6 +28,15 @@ TEST_INFRA_IMPORTS = (
     ("sentientos", None),
 )
 INSTALL_EXTRAS = "[dev,test]"
+MINIMAL_TEST_AIRLOCK_DEPS = (
+    "pytest>=7,<8",
+    "pytest-cov",
+    "fastapi>=0.110,<1",
+    "starlette>=0.37,<1",
+    "httpx>=0.27,<1",
+)
+INSTALL_MODE_FULL = "full"
+INSTALL_MODE_TEST_AIRLOCK_MINIMAL = "test_airlock_minimal"
 BYPASS_ENV_VARS = (
     "SENTIENTOS_ALLOW_NAKED_PYTEST",
     "SENTIENTOS_ALLOW_NO_TESTS",
@@ -130,13 +140,74 @@ def _imports_ok() -> tuple[bool, str | None]:
     return True, None
 
 
-def _install_deps() -> bool:
+@dataclass(frozen=True)
+class BootstrapResult:
+    ok: bool
+    install_performed: bool
+    install_mode: str | None
+    attempted_modes: tuple[str, ...]
+    fallback_reason: str | None = None
+    failure_reason: str | None = None
+
+
+def _run_pip_install(args: list[str]) -> bool:
     proc = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-e", f".{INSTALL_EXTRAS}"],
+        [sys.executable, "-m", "pip", "install", *args],
         cwd=REPO_ROOT,
         check=False,
     )
+    if proc.returncode != 0:
+        print(f"run_tests dependency bootstrap failed: pip install {' '.join(args)} exited {proc.returncode}.")
     return proc.returncode == 0
+
+
+def _install_full_deps() -> bool:
+    return _run_pip_install(["-e", f".{INSTALL_EXTRAS}"])
+
+
+def _install_minimal_test_airlock_deps() -> bool:
+    if not _run_pip_install(["--no-deps", "-e", "."]):
+        return False
+    return _run_pip_install(list(MINIMAL_TEST_AIRLOCK_DEPS))
+
+
+def _bootstrap_missing_editable(run_intent: str) -> BootstrapResult:
+    if run_intent == "targeted":
+        ok = _install_minimal_test_airlock_deps()
+        return BootstrapResult(
+            ok=ok,
+            install_performed=True,
+            install_mode=INSTALL_MODE_TEST_AIRLOCK_MINIMAL if ok else None,
+            attempted_modes=(INSTALL_MODE_TEST_AIRLOCK_MINIMAL,),
+            failure_reason=None if ok else "minimal-test-airlock-install-failed",
+        )
+
+    if _install_full_deps():
+        return BootstrapResult(
+            ok=True,
+            install_performed=True,
+            install_mode=INSTALL_MODE_FULL,
+            attempted_modes=(INSTALL_MODE_FULL,),
+        )
+
+    fallback_reason = "full-install-failed"
+    if _install_minimal_test_airlock_deps():
+        return BootstrapResult(
+            ok=True,
+            install_performed=True,
+            install_mode=INSTALL_MODE_TEST_AIRLOCK_MINIMAL,
+            attempted_modes=(INSTALL_MODE_FULL, INSTALL_MODE_TEST_AIRLOCK_MINIMAL),
+            fallback_reason=fallback_reason,
+        )
+
+    return BootstrapResult(
+        ok=False,
+        install_performed=True,
+        install_mode=None,
+        attempted_modes=(INSTALL_MODE_FULL, INSTALL_MODE_TEST_AIRLOCK_MINIMAL),
+        fallback_reason=fallback_reason,
+        failure_reason="full-and-minimal-test-airlock-install-failed",
+    )
 
 
 def _emit_run_context(
@@ -146,15 +217,20 @@ def _emit_run_context(
     editable_ok: bool,
     repo_root: Path,
     bypass_env: str | None,
+    install_mode: str | None = None,
+    install_fallback_reason: str | None = None,
 ) -> None:
     joined_args = " ".join(pytest_args) if pytest_args else "(none)"
     context = [
         f"python={sys.executable}",
         f"install_performed={install_performed}",
         f"editable_ok={str(editable_ok).lower()}",
+        f"install_mode={install_mode or 'none'}",
         f"repo_root={repo_root}",
         f"pytest_args={joined_args}",
     ]
+    if install_fallback_reason:
+        context.append(f"install_fallback_reason={install_fallback_reason}")
     if bypass_env:
         context.append("bypass_env=SENTIENTOS_ALLOW_NAKED_PYTEST=1")
     print(
@@ -416,6 +492,9 @@ def _write_provenance(
     junitxml_path: Path | None,
     failure_report_path: Path | None,
     env: dict[str, str],
+    install_mode: str | None = None,
+    install_fallback_reason: str | None = None,
+    install_attempted_modes: list[str] | tuple[str, ...] | None = None,
 ) -> dict[str, object]:
     run_dir = repo_root / "glow" / "test_runs"
     provenance_dir = run_dir / "provenance"
@@ -439,6 +518,9 @@ def _write_provenance(
         "bypass_env": bypass_env,
         "allow_nonexecution": allow_nonexecution,
         "install_performed": install_performed,
+        "install_mode": install_mode or "none",
+        "install_attempted_modes": list(install_attempted_modes or ()),
+        "install_fallback_reason": install_fallback_reason,
         "pytest_args": list(pytest_args),
         "run_intent": run_intent,
         "selection_flags": list(selection_flags),
@@ -517,7 +599,10 @@ def _write_provenance(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Install SentientOS dev/test deps (if needed) and run pytest.",
+        description=(
+            "Install SentientOS test dependencies (if needed) and run pytest. "
+            "Focused selections use a minimal test-airlock bootstrap to avoid broad optional runtime deps."
+        ),
     )
     parser.add_argument(
         "pytest_args",
@@ -543,10 +628,17 @@ def main(argv: list[str] | None = None) -> int:
     if allow_nonexecution:
         run_intent = "exceptional"
     install_performed = False
+    install_mode: str | None = None
+    install_fallback_reason: str | None = None
+    install_attempted_modes: tuple[str, ...] = ()
     editable_status = get_editable_install_status(REPO_ROOT)
     if not editable_status.ok:
-        install_performed = True
-        if not _install_deps():
+        bootstrap_result = _bootstrap_missing_editable(run_intent)
+        install_performed = bootstrap_result.install_performed
+        install_mode = bootstrap_result.install_mode
+        install_fallback_reason = bootstrap_result.fallback_reason
+        install_attempted_modes = bootstrap_result.attempted_modes
+        if not bootstrap_result.ok:
             _write_provenance(
                 repo_root=REPO_ROOT,
                 install_performed=install_performed,
@@ -580,6 +672,9 @@ def main(argv: list[str] | None = None) -> int:
                 junitxml_path=None,
                 failure_report_path=None,
                 env=env,
+                install_mode=install_mode,
+                install_fallback_reason=bootstrap_result.failure_reason or install_fallback_reason,
+                install_attempted_modes=install_attempted_modes,
             )
             _emit_run_context(
                 install_performed,
@@ -587,6 +682,8 @@ def main(argv: list[str] | None = None) -> int:
                 editable_ok=editable_status.ok,
                 repo_root=REPO_ROOT,
                 bypass_env="1" if bypass_env else None,
+                install_mode=install_mode,
+                install_fallback_reason=bootstrap_result.failure_reason or install_fallback_reason,
             )
             print(PRECHECK_MESSAGE)
             return 1
@@ -627,6 +724,9 @@ def main(argv: list[str] | None = None) -> int:
             junitxml_path=None,
             failure_report_path=None,
             env=env,
+            install_mode=install_mode,
+            install_fallback_reason=install_fallback_reason,
+            install_attempted_modes=install_attempted_modes,
         )
         _emit_run_context(
             install_performed,
@@ -634,6 +734,8 @@ def main(argv: list[str] | None = None) -> int:
             editable_ok=editable_status.ok,
             repo_root=REPO_ROOT,
             bypass_env="1" if bypass_env else None,
+            install_mode=install_mode,
+            install_fallback_reason=install_fallback_reason,
         )
         if import_error:
             print(f"run_tests import airlock failed: {import_error}")
@@ -646,6 +748,8 @@ def main(argv: list[str] | None = None) -> int:
         editable_ok=editable_status.ok,
         repo_root=REPO_ROOT,
         bypass_env="1" if bypass_env else None,
+        install_mode=install_mode,
+        install_fallback_reason=install_fallback_reason,
     )
     if allow_nonexecution:
         print(
@@ -686,6 +790,9 @@ def main(argv: list[str] | None = None) -> int:
             junitxml_path=None,
             failure_report_path=None,
             env=env,
+            install_mode=install_mode,
+            install_fallback_reason=install_fallback_reason,
+            install_attempted_modes=install_attempted_modes,
         )
         print("CI proof requires executed tests. Collection/info modes are not admissible.")
         return 1
@@ -947,6 +1054,9 @@ def main(argv: list[str] | None = None) -> int:
         junitxml_path=junitxml_path if junitxml_path is not None and junitxml_path.exists() else None,
         failure_report_path=failure_report_path if failure_report_path is not None and failure_report_path.exists() else None,
         env=env,
+        install_mode=install_mode,
+        install_fallback_reason=install_fallback_reason,
+        install_attempted_modes=install_attempted_modes,
     )
     if failure_report_path is not None and failure_report_path.exists():
         try:

--- a/tests/test_run_tests_bootstrap_airlock.py
+++ b/tests/test_run_tests_bootstrap_airlock.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_tests
+from scripts.editable_install import EditableInstallStatus
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def _write_report(env: dict[str, str] | None, *, failed: int = 0, passed: int = 1) -> None:
+    assert env is not None
+    report_path = Path(env["SENTIENTOS_PYTEST_REPORT_PATH"])
+    report_path.write_text(
+        json.dumps(
+            {
+                "tests_collected": passed + failed,
+                "tests_selected": passed + failed,
+                "tests_executed": passed + failed,
+                "tests_passed": passed,
+                "tests_failed": failed,
+                "tests_skipped": 0,
+                "tests_xfailed": 0,
+                "tests_xpassed": 0,
+                "reporter_ok": True,
+                "reporter_error": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_targeted_missing_editable_uses_minimal_airlock_without_broad_deps(monkeypatch, tmp_path):
+    pip_commands: list[list[str]] = []
+    editable_statuses = iter(
+        [
+            EditableInstallStatus(False, "distribution-not-found"),
+            EditableInstallStatus(True, "direct-url"),
+        ]
+    )
+
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pip"]:
+            pip_commands.append(cmd)
+            return _Completed(0)
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pytest"]:
+            _write_report(env)
+            return _Completed(0)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "abc123\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests, "get_editable_install_status", lambda _root: next(editable_statuses)
+    )
+    monkeypatch.setattr(run_tests, "_imports_ok", lambda: (True, None))
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q", "tests/test_focused.py"])
+
+    assert code == 0
+    assert pip_commands == [
+        [run_tests.sys.executable, "-m", "pip", "install", "--no-deps", "-e", "."],
+        [run_tests.sys.executable, "-m", "pip", "install", *run_tests.MINIMAL_TEST_AIRLOCK_DEPS],
+    ]
+    assert all(f".{run_tests.INSTALL_EXTRAS}" not in part for command in pip_commands for part in command)
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["install_mode"] == run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL
+    assert payload["install_attempted_modes"] == [run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL]
+    assert payload["install_fallback_reason"] is None
+    assert payload["run_intent"] == "targeted"
+
+
+def test_default_full_install_failure_falls_back_to_minimal_airlock(monkeypatch, tmp_path):
+    pip_commands: list[list[str]] = []
+    editable_statuses = iter(
+        [
+            EditableInstallStatus(False, "distribution-not-found"),
+            EditableInstallStatus(True, "direct-url"),
+        ]
+    )
+
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pip"]:
+            pip_commands.append(cmd)
+            if cmd[-1] == f".{run_tests.INSTALL_EXTRAS}":
+                return _Completed(1)
+            return _Completed(0)
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pytest"]:
+            _write_report(env)
+            return _Completed(0)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "def456\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests, "get_editable_install_status", lambda _root: next(editable_statuses)
+    )
+    monkeypatch.setattr(run_tests, "_imports_ok", lambda: (True, None))
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q"])
+
+    assert code == 0
+    assert pip_commands[0] == [
+        run_tests.sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-e",
+        f".{run_tests.INSTALL_EXTRAS}",
+    ]
+    assert pip_commands[1:] == [
+        [run_tests.sys.executable, "-m", "pip", "install", "--no-deps", "-e", "."],
+        [run_tests.sys.executable, "-m", "pip", "install", *run_tests.MINIMAL_TEST_AIRLOCK_DEPS],
+    ]
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["install_mode"] == run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL
+    assert payload["install_fallback_reason"] == "full-install-failed"
+    assert payload["install_attempted_modes"] == [
+        run_tests.INSTALL_MODE_FULL,
+        run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL,
+    ]
+
+
+def test_airlock_imports_are_checked_after_minimal_bootstrap(monkeypatch, tmp_path):
+    editable_statuses = iter(
+        [
+            EditableInstallStatus(False, "distribution-not-found"),
+            EditableInstallStatus(True, "direct-url"),
+        ]
+    )
+    import_checks = 0
+
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pip"]:
+            return _Completed(0)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "fedcba\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    def fake_imports_ok():
+        nonlocal import_checks
+        import_checks += 1
+        return False, "fastapi import failed: missing"
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests, "get_editable_install_status", lambda _root: next(editable_statuses)
+    )
+    monkeypatch.setattr(run_tests, "_imports_ok", fake_imports_ok)
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q", "tests/test_focused.py"])
+
+    assert code == 1
+    assert import_checks == 1
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["exit_reason"] == "airlock-failed"
+    assert payload["install_mode"] == run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL
+
+
+def test_actual_pytest_failures_still_fail_as_pytest_failures(monkeypatch, tmp_path):
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pytest"]:
+            _write_report(env, failed=1, passed=0)
+            return _Completed(1)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "badbad\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests,
+        "get_editable_install_status",
+        lambda _root: EditableInstallStatus(True, "direct-url"),
+    )
+    monkeypatch.setattr(run_tests, "_imports_ok", lambda: (True, None))
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q", "tests/test_focused.py"])
+
+    assert code == 1
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["exit_reason"] == "pytest-failed"
+    assert payload["tests_failed"] == 1
+    assert payload["metrics_status"] == "ok"
+
+
+def test_bootstrap_failure_is_distinct_from_test_failure(monkeypatch, tmp_path):
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pip"]:
+            return _Completed(1)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "feed01\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests,
+        "get_editable_install_status",
+        lambda _root: EditableInstallStatus(False, "distribution-not-found"),
+    )
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q", "tests/test_focused.py"])
+
+    assert code == 1
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["exit_reason"] == "install-failed"
+    assert payload["metrics_status"] == "unavailable"
+    assert payload["tests_failed"] == 0
+    assert payload["install_fallback_reason"] == "minimal-test-airlock-install-failed"
+
+
+def test_naked_pytest_bypass_still_marks_run_exceptional(monkeypatch):
+    monkeypatch.setenv("SENTIENTOS_ALLOW_NAKED_PYTEST", "1")
+
+    run_intent, selection = run_tests._run_intent(
+        pytest_args=["-q", "tests/test_focused.py"],
+        bypass_envs=run_tests._active_bypass_envs({"SENTIENTOS_ALLOW_NAKED_PYTEST": "1"}),
+    )
+
+    assert run_intent == "exceptional"
+    assert selection == ["tests/test_focused.py"]


### PR DESCRIPTION
### Motivation
- Focused/targeted test runs were blocked by the runner attempting a full editable install `pip install -e .[dev,test]` which resolves broad runtime dependencies (pandas/audio/UI/ML/hardware) and can fail in constrained Python environments.  This is a bootstrap/test-harness problem, not a test assertion failure.

### Description
- Add a deterministic minimal test-airlock bootstrap path and constants (`MINIMAL_TEST_AIRLOCK_DEPS`, `INSTALL_MODE_*`) and implement pip helper `_run_pip_install` plus `_install_full_deps`, `_install_minimal_test_airlock_deps`, and `_bootstrap_missing_editable` to choose full vs minimal installs and fallback logic. (files changed: `scripts/run_tests.py`).
- Make targeted runs (`pytest` selection flags present) prefer the minimal airlock: `pip install --no-deps -e .` then install only required test infra (`pytest`, `pytest-cov`, `fastapi`, `starlette`, `httpx`).
- Preserve original editable-install validation and import-airlock checks, record install provenance fields (`install_mode`, `install_attempted_modes`, `install_fallback_reason`) and surface install mode/fallback in run context for diagnosability. (provenance and _emit_run_context updates in `scripts/run_tests.py`).
- Add focused unit tests that mock subprocess behavior to assert minimal bootstrap usage, fallback behavior, airlock import checks, separation of bootstrap vs pytest failures, and naked-pytest bypass intent (`tests/test_run_tests_bootstrap_airlock.py`).

### Testing
- Compiled changed modules: `python -m py_compile scripts/run_tests.py scripts/editable_install.py` (succeeded).
- Exercised harnessed runs via the runner: `python -m scripts.run_tests -q tests/test_run_tests_bootstrap_airlock.py` (new focused bootstrap tests executed under `scripts.run_tests` and passed in the modified harness).
- Verified a representative existing focused test run: `python -m scripts.run_tests -q tests/test_phase103_provider_invocation_denial_custody_checkpoint.py` (passed under the runner after changes).
- Observed behavior when invoking naked pytest directly: `python -m pytest -q tests/test_run_tests_bootstrap_airlock.py tests/test_run_tests_harness_normalization.py tests/test_run_tests_reporter_resilience.py` was blocked by `tests/conftest.py` editable-install airlock (expected outside `scripts.run_tests` and noted as such), demonstrating the runner is the correct entrypoint for bootstrap provisioning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022781db348320ae99f4db038cc66b)