### PR TITLE
[codex:test-runner] guard minimal test airlock bootstrap

### DIFF
--- a/docs/architecture/minimal_test_airlock_bootstrap_custody_note.md
+++ b/docs/architecture/minimal_test_airlock_bootstrap_custody_note.md
@@ -1,0 +1,55 @@
+# Minimal test-airlock bootstrap custody note
+
+## Scope
+
+This note documents the bounded bootstrap behavior for `python -m scripts.run_tests`
+when a developer runs a focused or targeted test selection. It is a test-harness
+custody note only: it is not a context-hygiene provider phase, provider
+invocation path, prompt-assembly path, or runtime authority expansion.
+
+## Custody rule
+
+Focused invariant tests must remain decoupled from broad runtime dependency
+installation. When `scripts.run_tests` detects a targeted run and the repository
+is not already available as a test-capable editable install, it enters the
+minimal test-airlock bootstrap instead of installing the broad development and
+test extras first.
+
+The targeted minimal bootstrap is intentionally bounded to:
+
+```bash
+python -m pip install --no-deps -e .
+python -m pip install pytest>=7,<8 pytest-cov fastapi>=0.110,<1 starlette>=0.37,<1 httpx>=0.27,<1
+```
+
+Those packages are the airlock dependencies required for the runner, reporter,
+and focused FastAPI/Starlette/httpx tests. Broad runtime dependencies must not
+be prerequisites for focused invariant tests.
+
+## Default and exceptional paths
+
+Default, unselected runs may still attempt the full editable development/test
+install first:
+
+```bash
+python -m pip install -e .[dev,test]
+```
+
+If that full install fails, the runner may fall back to the same minimal
+test-airlock bootstrap, and provenance must record both attempted modes plus the
+`full-install-failed` fallback reason.
+
+Direct or naked `pytest` remains exceptional. Local debugging can opt into that
+path only through the explicit bypass environment already guarded by the test
+harness; the canonical path remains `python -m scripts.run_tests`.
+
+## Provenance separation
+
+Bootstrap failure and pytest failure must stay distinct in provenance:
+
+- dependency bootstrap failure records `exit_reason=install-failed` before
+  pytest is invoked;
+- import-airlock failure records `exit_reason=airlock-failed` before pytest is
+  invoked;
+- assertion or collection failures after pytest starts remain pytest outcomes,
+  such as `exit_reason=pytest-failed` when the reporter payload is complete.

--- a/tests/test_run_tests_bootstrap_airlock.py
+++ b/tests/test_run_tests_bootstrap_airlock.py
@@ -73,6 +73,15 @@ def test_targeted_missing_editable_uses_minimal_airlock_without_broad_deps(monke
         [run_tests.sys.executable, "-m", "pip", "install", "--no-deps", "-e", "."],
         [run_tests.sys.executable, "-m", "pip", "install", *run_tests.MINIMAL_TEST_AIRLOCK_DEPS],
     ]
+    assert pip_commands[0][-3:] == ["--no-deps", "-e", "."]
+    assert set(pip_commands[1][4:]) == set(run_tests.MINIMAL_TEST_AIRLOCK_DEPS)
+    assert {
+        "pytest>=7,<8",
+        "pytest-cov",
+        "fastapi>=0.110,<1",
+        "starlette>=0.37,<1",
+        "httpx>=0.27,<1",
+    } <= set(pip_commands[1])
     assert all(f".{run_tests.INSTALL_EXTRAS}" not in part for command in pip_commands for part in command)
     payload = json.loads(
         (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
@@ -204,6 +213,8 @@ def test_actual_pytest_failures_still_fail_as_pytest_failures(monkeypatch, tmp_p
     assert payload["exit_reason"] == "pytest-failed"
     assert payload["tests_failed"] == 1
     assert payload["metrics_status"] == "ok"
+    assert payload["install_mode"] == "none"
+    assert payload["install_fallback_reason"] is None
 
 
 def test_bootstrap_failure_is_distinct_from_test_failure(monkeypatch, tmp_path):
@@ -229,8 +240,12 @@ def test_bootstrap_failure_is_distinct_from_test_failure(monkeypatch, tmp_path):
         (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
     )
     assert payload["exit_reason"] == "install-failed"
+    assert payload["exit_reason"] != "pytest-failed"
     assert payload["metrics_status"] == "unavailable"
+    assert "pytest_exit_code" not in payload
     assert payload["tests_failed"] == 0
+    assert payload["install_mode"] == "none"
+    assert payload["install_attempted_modes"] == [run_tests.INSTALL_MODE_TEST_AIRLOCK_MINIMAL]
     assert payload["install_fallback_reason"] == "minimal-test-airlock-install-failed"
 
 


### PR DESCRIPTION
### Motivation
- Preserve a bounded “test-airlock” bootstrap for focused/targeted test selections so invariant tests remain decoupled from broad optional runtime dependencies.
- Make provenance and failure-classification explicit so bootstrap/import failures remain distinct from pytest assertion/collection failures.

### Description
- Add a custody note `docs/architecture/minimal_test_airlock_bootstrap_custody_note.md` documenting why targeted runs use a minimal bootstrap, the exact minimal commands, the allowed fallback behaviour, and provenance separation.
- Strengthen regression checks in `tests/test_run_tests_bootstrap_airlock.py` to assert the minimal bootstrap uses `--no-deps -e .`, that the second pip invocation contains the `MINIMAL_TEST_AIRLOCK_DEPS` set (`pytest`, `pytest-cov`, `fastapi`, `starlette`, `httpx`), and that targeted runs do not invoke `.[dev,test]` first.
- Add provenance guards in tests so: pytest failures remain classified as `pytest-failed` with no install fallback metadata, while bootstrap/install failures are recorded as `install-failed` (and do not include a `pytest_exit_code`).
- Runner implementation unchanged (this is docs + tests only); no modifications to `scripts/run_tests.py` were made.

### Testing
- Verified Python file syntax with `python -m py_compile scripts/run_tests.py scripts/editable_install.py` (succeeded).
- Executed focused regression suite with `python -m scripts.run_tests -q tests/test_run_tests_bootstrap_airlock.py` (completed; tests passed under the minimal bootstrap path).
- Executed phase custody checkpoint with `python -m scripts.run_tests -q tests/test_phase103_provider_invocation_denial_custody_checkpoint.py` (completed; tests passed).
- Exact files changed: `docs/architecture/minimal_test_airlock_bootstrap_custody_note.md`, `tests/test_run_tests_bootstrap_airlock.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a023d243ef88320ab1099425aed8fb4)