### PR TITLE
[codex:federation] add improvement candidate evidence artifact

### DIFF
--- a/docs/architecture/federated_improvement_candidate.md
+++ b/docs/architecture/federated_improvement_candidate.md
@@ -1,0 +1,25 @@
+# Federated Improvement Candidate Artifact
+
+The federated improvement candidate is a deterministic, metadata-first object for
+representing transmissible improvement evidence under local custody.  It lets a
+SentientOS node describe that a locally produced improvement candidate has source
+or lineage evidence, verification posture, test or rehearsal labels, risks, and
+local review requirements that another node may inspect.
+
+The artifact is intentionally not a federation transport, adoption engine,
+scheduler, prompt assembly path, provider invocation path, runtime authority
+surface, or remote execution mechanism.  Receipt of the object does not install,
+apply, execute, merge, route, schedule, or adopt anything.  Receiving nodes remain
+free to inspect, rehearse, adapt, reject, or separately adopt under their own
+local governance gates.
+
+Only identifiers, digests, compact labels, statuses, counts, booleans, and coded
+warnings are represented.  Raw patch bodies, secrets, prompt text, endpoint data,
+client handles, runtime handles, executable payloads, and provider/network/export
+runtime material are forbidden and fail closed.
+
+The validation policy fails closed when required local identity, candidate id,
+source or lineage evidence, audit verification, immutable verification, and test
+or rehearsal evidence are missing or failed.  It also treats auto-adoption,
+forced update, remote execution, federation compatibility contradictions, and
+local governance bypass markers as contradictions rather than usable evidence.

--- a/sentientos/federation/__init__.py
+++ b/sentientos/federation/__init__.py
@@ -2,6 +2,23 @@
 
 from .identity import NodeId
 from .federation_digest import FederationDigest
+from .improvement_candidate import (
+    CandidateTestEvidence,
+    CandidateValidation,
+    CANDIDATE_KINDS,
+    CANDIDATE_STATUSES,
+    FederatedImprovementCandidate,
+    FederatedImprovementCandidateKind,
+    FederatedImprovementCandidateStatus,
+    compute_federated_improvement_candidate_digest,
+    explain_federated_improvement_candidate,
+    federated_improvement_candidate_has_no_remote_authority,
+    federated_improvement_candidate_is_metadata_only,
+    federated_improvement_candidate_is_transmissible_evidence_only,
+    federated_improvement_candidate_ready_for_receipt_inspection,
+    summarize_federated_improvement_candidate,
+    validate_federated_improvement_candidate,
+)
 from .consensus_sentinel import FederationConsensusSentinel
 from .concord_daemon import ConcordDaemon, PeerSnapshot
 from .config import PeerConfig, FederationConfig, load_federation_config
@@ -72,4 +89,19 @@ __all__ = [
     "FederationConsensusSentinel",
     "ConcordDaemon",
     "PeerSnapshot",
+    "CandidateTestEvidence",
+    "CandidateValidation",
+    "CANDIDATE_KINDS",
+    "CANDIDATE_STATUSES",
+    "FederatedImprovementCandidate",
+    "FederatedImprovementCandidateKind",
+    "FederatedImprovementCandidateStatus",
+    "compute_federated_improvement_candidate_digest",
+    "explain_federated_improvement_candidate",
+    "federated_improvement_candidate_has_no_remote_authority",
+    "federated_improvement_candidate_is_metadata_only",
+    "federated_improvement_candidate_is_transmissible_evidence_only",
+    "federated_improvement_candidate_ready_for_receipt_inspection",
+    "summarize_federated_improvement_candidate",
+    "validate_federated_improvement_candidate",
 ]

--- a/sentientos/federation/improvement_candidate.py
+++ b/sentientos/federation/improvement_candidate.py
@@ -1,0 +1,474 @@
+"""Metadata-only federated improvement candidate evidence.
+
+This module defines a bounded artifact for sharing local improvement evidence
+between SentientOS nodes.  It never installs, applies, executes, merges,
+routes, schedules, adopts, exports, prompts, or grants runtime authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+
+class FederatedImprovementCandidateStatus:
+    FEDERATED_IMPROVEMENT_CANDIDATE_READY = "federated_improvement_candidate_ready"
+    FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS = (
+        "federated_improvement_candidate_ready_with_conditions"
+    )
+    FEDERATED_IMPROVEMENT_CANDIDATE_BLOCKED = "federated_improvement_candidate_blocked"
+    FEDERATED_IMPROVEMENT_CANDIDATE_INCOMPLETE = "federated_improvement_candidate_incomplete"
+    FEDERATED_IMPROVEMENT_CANDIDATE_CONTRADICTED = "federated_improvement_candidate_contradicted"
+
+
+class FederatedImprovementCandidateKind:
+    MEMORY_DISTILLATION_IMPROVEMENT = "memory_distillation_improvement"
+    CONTEXT_SELECTION_IMPROVEMENT = "context_selection_improvement"
+    EMBODIMENT_GUARD_IMPROVEMENT = "embodiment_guard_improvement"
+    AUDIT_INTEGRITY_IMPROVEMENT = "audit_integrity_improvement"
+    INSTALLER_BOOTSTRAP_IMPROVEMENT = "installer_bootstrap_improvement"
+    FEDERATION_PROTOCOL_IMPROVEMENT = "federation_protocol_improvement"
+    GENESIS_FORGE_SCAFFOLD_IMPROVEMENT = "genesis_forge_scaffold_improvement"
+    CODEX_REPAIR_IMPROVEMENT = "codex_repair_improvement"
+    POLICY_GATE_IMPROVEMENT = "policy_gate_improvement"
+    DOCUMENTATION_OR_DEMO_IMPROVEMENT = "documentation_or_demo_improvement"
+
+
+CANDIDATE_STATUSES = (
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY,
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS,
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_BLOCKED,
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_INCOMPLETE,
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_CONTRADICTED,
+)
+
+CANDIDATE_KINDS = (
+    FederatedImprovementCandidateKind.MEMORY_DISTILLATION_IMPROVEMENT,
+    FederatedImprovementCandidateKind.CONTEXT_SELECTION_IMPROVEMENT,
+    FederatedImprovementCandidateKind.EMBODIMENT_GUARD_IMPROVEMENT,
+    FederatedImprovementCandidateKind.AUDIT_INTEGRITY_IMPROVEMENT,
+    FederatedImprovementCandidateKind.INSTALLER_BOOTSTRAP_IMPROVEMENT,
+    FederatedImprovementCandidateKind.FEDERATION_PROTOCOL_IMPROVEMENT,
+    FederatedImprovementCandidateKind.GENESIS_FORGE_SCAFFOLD_IMPROVEMENT,
+    FederatedImprovementCandidateKind.CODEX_REPAIR_IMPROVEMENT,
+    FederatedImprovementCandidateKind.POLICY_GATE_IMPROVEMENT,
+    FederatedImprovementCandidateKind.DOCUMENTATION_OR_DEMO_IMPROVEMENT,
+)
+
+_READY_VERIFICATION = frozenset({"verified", "passed", "ok", "not_required_with_reason"})
+_FAILED_VERIFICATION = frozenset({"failed", "failure", "invalid", "contradicted"})
+_COMPATIBLE_POSTURES = frozenset({"compatible", "compatible_with_conditions", "local_review_required"})
+_CONTRADICTED_COMPATIBILITY = frozenset({"incompatible", "contradicted", "forced_adoption_required"})
+_PASSING_TEST_RESULTS = frozenset({"passed", "ok", "warning", "not_required_with_reason"})
+_FORBIDDEN_ADOPTION_MARKERS = (
+    "adopt_on_receipt",
+    "auto_adopt",
+    "auto-adopt",
+    "autoadopt",
+    "auto_update",
+    "auto-update",
+    "forced_update",
+    "forced_adoption",
+    "install_on_receipt",
+    "apply_on_receipt",
+    "merge_on_receipt",
+    "execute_on_receipt",
+    "remote_execution",
+    "remote-execution",
+    "remote_execute",
+    "schedule_on_receipt",
+    "route_on_receipt",
+)
+_PROVIDER_NETWORK_EXPORT_RUNTIME_PROMPT_MARKERS = (
+    "provider",
+    "llm_call",
+    "model_call",
+    "network",
+    "http://",
+    "https://",
+    "socket",
+    "webhook",
+    "export_payload",
+    "runtime_handle",
+    "runtime_authority",
+    "tool_call",
+    "function_call",
+    "memory_handle",
+    "routing_handle",
+    "execution_handle",
+    "prompt_text",
+    "system_prompt",
+    "assembled_prompt",
+    "raw_prompt",
+)
+_SECRET_ENDPOINT_CLIENT_MARKERS = (
+    "api_key",
+    "apikey",
+    "secret",
+    "credential",
+    "authorization",
+    "bearer",
+    "access_token",
+    "refresh_token",
+    "endpoint",
+    "base_url",
+    "client_handle",
+    "provider_client",
+    "sdk_client",
+    "session_handle",
+)
+_LOCAL_GOVERNANCE_BYPASS_MARKERS = (
+    "bypass_governance",
+    "governance_bypass",
+    "skip_review",
+    "skip_local_review",
+    "bypass_review_gate",
+    "ignore_review_gate",
+    "canonical_gate_bypass",
+    "control_plane_bypass",
+)
+_RAW_PAYLOAD_MARKERS = (
+    "diff --git",
+    "patch_body",
+    "raw_patch",
+    "executable_payload",
+    "script_body",
+    "code_payload",
+)
+
+
+@dataclass(frozen=True)
+class CandidateTestEvidence:
+    command_label: str
+    result_label: str
+
+
+@dataclass(frozen=True)
+class CandidateValidation:
+    status: str
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class FederatedImprovementCandidate:
+    producing_node_id: str
+    local_candidate_id: str
+    candidate_kind: str
+    source_amendment_or_proposal_id: str = ""
+    source_commit_ref_digest: str = ""
+    rationale_digest_or_label: str = ""
+    test_evidence: tuple[CandidateTestEvidence, ...] = field(default_factory=tuple)
+    rehearsal_artifact_refs: tuple[str, ...] = field(default_factory=tuple)
+    audit_verification_status: str = "unknown"
+    immutable_verification_status: str = "unknown"
+    federation_compatibility_posture: str = "local_review_required"
+    required_local_review_gates: tuple[str, ...] = field(default_factory=tuple)
+    adoption_constraints: tuple[str, ...] = field(default_factory=tuple)
+    known_risk_codes: tuple[str, ...] = field(default_factory=tuple)
+    lineage_refs: tuple[str, ...] = field(default_factory=tuple)
+    require_audit_verification: bool = True
+    require_immutable_verification: bool = True
+    require_test_or_rehearsal_evidence: bool = True
+    metadata_only: bool = True
+    locally_produced: bool = True
+    transmissible_evidence_only: bool = True
+    not_adopted_by_default: bool = True
+    not_executable_by_receipt: bool = True
+    no_remote_authority: bool = True
+    no_forced_update: bool = True
+    no_provider_network_export_prompt_runtime_authority: bool = True
+    no_secret_endpoint_client_material: bool = True
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return is_dataclass(value) and not isinstance(value, type)
+
+
+def _stable(value: Any) -> Any:
+    if _is_dataclass_instance(value):
+        return {str(key): _stable(item) for key, item in asdict(value).items()}
+    if isinstance(value, Mapping):
+        return {str(key): _stable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (tuple, list)):
+        return [_stable(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_stable(item) for item in value)
+    return value
+
+
+def _walk_values(value: Any) -> tuple[str, ...]:
+    found: list[str] = []
+
+    def visit(child: Any) -> None:
+        if _is_dataclass_instance(child):
+            visit(asdict(child))
+        elif isinstance(child, Mapping):
+            for nested in child.values():
+                visit(nested)
+        elif isinstance(child, (tuple, list, set, frozenset)):
+            for nested in child:
+                visit(nested)
+        elif isinstance(child, str):
+            found.append(child)
+        else:
+            return
+
+    visit(value)
+    return tuple(found)
+
+
+def _contains_marker(candidate: FederatedImprovementCandidate, markers: Sequence[str]) -> bool:
+    lowered = tuple(item.lower() for item in _walk_values(candidate))
+    return any(marker in item for marker in markers for item in lowered)
+
+
+def _has_source_or_lineage(candidate: FederatedImprovementCandidate) -> bool:
+    return bool(
+        candidate.source_amendment_or_proposal_id
+        or candidate.source_commit_ref_digest
+        or candidate.lineage_refs
+    )
+
+
+def _has_test_or_rehearsal_evidence(candidate: FederatedImprovementCandidate) -> bool:
+    return bool(candidate.test_evidence or candidate.rehearsal_artifact_refs)
+
+
+def _tests_are_not_failed(candidate: FederatedImprovementCandidate) -> bool:
+    return all(evidence.result_label in _PASSING_TEST_RESULTS for evidence in candidate.test_evidence)
+
+
+def compute_federated_improvement_candidate_digest(candidate: FederatedImprovementCandidate) -> str:
+    payload = _stable(candidate)
+    serialised = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(serialised).hexdigest()
+
+
+def validate_federated_improvement_candidate(candidate: FederatedImprovementCandidate) -> CandidateValidation:
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    if not candidate.producing_node_id:
+        blockers.append("missing_producing_node_id")
+    if not candidate.local_candidate_id:
+        blockers.append("missing_local_candidate_id")
+    if candidate.candidate_kind not in CANDIDATE_KINDS:
+        blockers.append("unknown_candidate_kind")
+    if not _has_source_or_lineage(candidate):
+        blockers.append("missing_lineage_or_source_evidence")
+    if candidate.require_audit_verification and candidate.audit_verification_status not in _READY_VERIFICATION:
+        blockers.append("audit_verification_not_satisfied")
+    if candidate.audit_verification_status in _FAILED_VERIFICATION:
+        blockers.append("audit_verification_failed")
+    if candidate.require_immutable_verification and candidate.immutable_verification_status not in _READY_VERIFICATION:
+        blockers.append("immutable_verification_not_satisfied")
+    if candidate.immutable_verification_status in _FAILED_VERIFICATION:
+        blockers.append("immutable_verification_failed")
+    if candidate.require_test_or_rehearsal_evidence and not _has_test_or_rehearsal_evidence(candidate):
+        blockers.append("missing_test_or_rehearsal_evidence")
+    if not _tests_are_not_failed(candidate):
+        blockers.append("test_evidence_failed")
+    if candidate.federation_compatibility_posture in _CONTRADICTED_COMPATIBILITY:
+        blockers.append("federation_compatibility_contradiction")
+    elif candidate.federation_compatibility_posture not in _COMPATIBLE_POSTURES:
+        warnings.append("federation_compatibility_unknown")
+
+    invariant_checks = {
+        "metadata_only_false": candidate.metadata_only,
+        "locally_produced_false": candidate.locally_produced,
+        "transmissible_evidence_only_false": candidate.transmissible_evidence_only,
+        "not_adopted_by_default_false": candidate.not_adopted_by_default,
+        "not_executable_by_receipt_false": candidate.not_executable_by_receipt,
+        "remote_authority_present": candidate.no_remote_authority,
+        "forced_update_present": candidate.no_forced_update,
+        "provider_network_export_prompt_runtime_authority_present": (
+            candidate.no_provider_network_export_prompt_runtime_authority
+        ),
+        "secret_endpoint_client_material_present": candidate.no_secret_endpoint_client_material,
+    }
+    for code, allowed in invariant_checks.items():
+        if not allowed:
+            blockers.append(code)
+
+    if _contains_marker(candidate, _FORBIDDEN_ADOPTION_MARKERS):
+        blockers.append("forbidden_adoption_or_remote_execution_marker")
+    if _contains_marker(candidate, _PROVIDER_NETWORK_EXPORT_RUNTIME_PROMPT_MARKERS):
+        blockers.append("provider_network_export_runtime_prompt_marker")
+    if _contains_marker(candidate, _SECRET_ENDPOINT_CLIENT_MARKERS):
+        blockers.append("secret_endpoint_client_marker")
+    if _contains_marker(candidate, _LOCAL_GOVERNANCE_BYPASS_MARKERS):
+        blockers.append("local_governance_gate_bypass_marker")
+    if _contains_marker(candidate, _RAW_PAYLOAD_MARKERS):
+        blockers.append("raw_or_executable_payload_marker")
+
+    unique_blockers = tuple(dict.fromkeys(blockers))
+    unique_warnings = tuple(dict.fromkeys(warnings))
+    return CandidateValidation(
+        status=_derive_status(candidate, unique_blockers, unique_warnings),
+        blockers=unique_blockers,
+        warnings=unique_warnings,
+    )
+
+
+def _derive_status(
+    candidate: FederatedImprovementCandidate,
+    blockers: tuple[str, ...],
+    warnings: tuple[str, ...],
+) -> str:
+    contradiction_codes = (
+        "forbidden_adoption_or_remote_execution_marker",
+        "provider_network_export_runtime_prompt_marker",
+        "secret_endpoint_client_marker",
+        "federation_compatibility_contradiction",
+        "local_governance_gate_bypass_marker",
+        "raw_or_executable_payload_marker",
+        "metadata_only_false",
+        "locally_produced_false",
+        "transmissible_evidence_only_false",
+        "not_adopted_by_default_false",
+        "not_executable_by_receipt_false",
+        "remote_authority_present",
+        "forced_update_present",
+        "provider_network_export_prompt_runtime_authority_present",
+        "secret_endpoint_client_material_present",
+    )
+    incomplete_codes = (
+        "missing_producing_node_id",
+        "missing_local_candidate_id",
+        "missing_lineage_or_source_evidence",
+        "missing_test_or_rehearsal_evidence",
+        "unknown_candidate_kind",
+    )
+    if any(code in blockers for code in contradiction_codes):
+        return FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_CONTRADICTED
+    if any(code in blockers for code in incomplete_codes):
+        return FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_INCOMPLETE
+    if blockers:
+        return FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_BLOCKED
+    if warnings or candidate.required_local_review_gates or candidate.adoption_constraints:
+        return FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS
+    return FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY
+
+
+def summarize_federated_improvement_candidate(candidate: FederatedImprovementCandidate) -> dict[str, object]:
+    validation = validate_federated_improvement_candidate(candidate)
+    return {
+        "producing_node_id": candidate.producing_node_id,
+        "local_candidate_id": candidate.local_candidate_id,
+        "candidate_kind": candidate.candidate_kind,
+        "status": validation.status,
+        "digest": compute_federated_improvement_candidate_digest(candidate),
+        "source_amendment_or_proposal_id": candidate.source_amendment_or_proposal_id,
+        "source_commit_ref_digest": candidate.source_commit_ref_digest,
+        "rationale_digest_or_label": candidate.rationale_digest_or_label,
+        "test_evidence_count": len(candidate.test_evidence),
+        "test_result_labels": tuple(evidence.result_label for evidence in candidate.test_evidence),
+        "rehearsal_artifact_ref_count": len(candidate.rehearsal_artifact_refs),
+        "audit_verification_status": candidate.audit_verification_status,
+        "immutable_verification_status": candidate.immutable_verification_status,
+        "federation_compatibility_posture": candidate.federation_compatibility_posture,
+        "required_local_review_gate_count": len(candidate.required_local_review_gates),
+        "adoption_constraint_count": len(candidate.adoption_constraints),
+        "known_risk_code_count": len(candidate.known_risk_codes),
+        "lineage_ref_count": len(candidate.lineage_refs),
+        "metadata_only": candidate.metadata_only,
+        "locally_produced": candidate.locally_produced,
+        "transmissible_evidence_only": candidate.transmissible_evidence_only,
+        "not_adopted_by_default": candidate.not_adopted_by_default,
+        "not_executable_by_receipt": candidate.not_executable_by_receipt,
+        "no_remote_authority": candidate.no_remote_authority,
+        "no_forced_update": candidate.no_forced_update,
+        "no_provider_network_export_prompt_runtime_authority": (
+            candidate.no_provider_network_export_prompt_runtime_authority
+        ),
+        "no_secret_endpoint_client_material": candidate.no_secret_endpoint_client_material,
+        "blocker_count": len(validation.blockers),
+        "warning_count": len(validation.warnings),
+    }
+
+
+def explain_federated_improvement_candidate(candidate: FederatedImprovementCandidate) -> tuple[str, ...]:
+    validation = validate_federated_improvement_candidate(candidate)
+    explanation = [
+        f"status:{validation.status}",
+        f"candidate_kind:{candidate.candidate_kind}",
+        f"digest:{compute_federated_improvement_candidate_digest(candidate)}",
+        "custody:local_production_required",
+        "receipt:inspection_rehearsal_adaptation_rejection_or_separate_local_adoption_only",
+        "authority:no_install_no_apply_no_execute_no_merge_no_route_no_schedule_no_remote_authority",
+    ]
+    explanation.extend(f"blocker:{code}" for code in validation.blockers)
+    explanation.extend(f"warning:{code}" for code in validation.warnings)
+    return tuple(explanation)
+
+
+def federated_improvement_candidate_is_metadata_only(candidate: FederatedImprovementCandidate) -> bool:
+    validation = validate_federated_improvement_candidate(candidate)
+    return candidate.metadata_only and "raw_or_executable_payload_marker" not in validation.blockers
+
+
+def federated_improvement_candidate_is_transmissible_evidence_only(
+    candidate: FederatedImprovementCandidate,
+) -> bool:
+    validation = validate_federated_improvement_candidate(candidate)
+    return (
+        candidate.transmissible_evidence_only
+        and candidate.not_adopted_by_default
+        and candidate.not_executable_by_receipt
+        and validation.status
+        in {
+            FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY,
+            FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS,
+        }
+    )
+
+
+def federated_improvement_candidate_has_no_remote_authority(candidate: FederatedImprovementCandidate) -> bool:
+    validation = validate_federated_improvement_candidate(candidate)
+    return (
+        candidate.no_remote_authority
+        and candidate.no_forced_update
+        and candidate.no_provider_network_export_prompt_runtime_authority
+        and candidate.no_secret_endpoint_client_material
+        and not any(
+            code in validation.blockers
+            for code in (
+                "forbidden_adoption_or_remote_execution_marker",
+                "provider_network_export_runtime_prompt_marker",
+                "secret_endpoint_client_marker",
+                "local_governance_gate_bypass_marker",
+            )
+        )
+    )
+
+
+def federated_improvement_candidate_ready_for_receipt_inspection(
+    candidate: FederatedImprovementCandidate,
+) -> bool:
+    validation = validate_federated_improvement_candidate(candidate)
+    return validation.status in {
+        FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY,
+        FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS,
+    }
+
+
+__all__ = [
+    "CandidateTestEvidence",
+    "CandidateValidation",
+    "CANDIDATE_KINDS",
+    "CANDIDATE_STATUSES",
+    "FederatedImprovementCandidate",
+    "FederatedImprovementCandidateKind",
+    "FederatedImprovementCandidateStatus",
+    "compute_federated_improvement_candidate_digest",
+    "explain_federated_improvement_candidate",
+    "federated_improvement_candidate_has_no_remote_authority",
+    "federated_improvement_candidate_is_metadata_only",
+    "federated_improvement_candidate_is_transmissible_evidence_only",
+    "federated_improvement_candidate_ready_for_receipt_inspection",
+    "summarize_federated_improvement_candidate",
+    "validate_federated_improvement_candidate",
+]

--- a/tests/test_federated_improvement_candidate.py
+++ b/tests/test_federated_improvement_candidate.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.federation.improvement_candidate import (
+    CANDIDATE_KINDS,
+    CANDIDATE_STATUSES,
+    CandidateTestEvidence,
+    FederatedImprovementCandidate,
+    FederatedImprovementCandidateKind,
+    FederatedImprovementCandidateStatus,
+    compute_federated_improvement_candidate_digest,
+    explain_federated_improvement_candidate,
+    federated_improvement_candidate_has_no_remote_authority,
+    federated_improvement_candidate_is_metadata_only,
+    federated_improvement_candidate_is_transmissible_evidence_only,
+    federated_improvement_candidate_ready_for_receipt_inspection,
+    summarize_federated_improvement_candidate,
+    validate_federated_improvement_candidate,
+)
+
+READY = FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY
+READY_WITH_CONDITIONS = (
+    FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS
+)
+BLOCKED = FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_BLOCKED
+INCOMPLETE = FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_INCOMPLETE
+CONTRADICTED = FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_CONTRADICTED
+
+
+def _candidate(**kwargs: object) -> FederatedImprovementCandidate:
+    base = FederatedImprovementCandidate(
+        producing_node_id="node-alpha",
+        local_candidate_id="candidate-001",
+        candidate_kind=FederatedImprovementCandidateKind.FEDERATION_PROTOCOL_IMPROVEMENT,
+        source_amendment_or_proposal_id="proposal-17",
+        source_commit_ref_digest="sha256:abc123",
+        rationale_digest_or_label="rationale_digest_001",
+        test_evidence=(CandidateTestEvidence("py_compile_candidate_module", "passed"),),
+        rehearsal_artifact_refs=("rehearsal_digest_001",),
+        audit_verification_status="verified",
+        immutable_verification_status="verified",
+        federation_compatibility_posture="compatible",
+        lineage_refs=("lineage_digest_001",),
+    )
+    return replace(base, **kwargs)
+
+
+def test_clean_metadata_only_candidate_is_ready() -> None:
+    candidate = _candidate()
+    validation = validate_federated_improvement_candidate(candidate)
+
+    assert validation.status == READY
+    assert validation.blockers == ()
+    assert federated_improvement_candidate_is_metadata_only(candidate)
+    assert federated_improvement_candidate_is_transmissible_evidence_only(candidate)
+    assert federated_improvement_candidate_has_no_remote_authority(candidate)
+    assert federated_improvement_candidate_ready_for_receipt_inspection(candidate)
+    assert "receipt:inspection_rehearsal_adaptation_rejection_or_separate_local_adoption_only" in explain_federated_improvement_candidate(candidate)
+
+
+def test_ready_with_conditions_candidate() -> None:
+    candidate = _candidate(
+        required_local_review_gates=("council_review_gate",),
+        adoption_constraints=("local_adoption_requires_separate_vote",),
+        federation_compatibility_posture="compatible_with_conditions",
+    )
+
+    validation = validate_federated_improvement_candidate(candidate)
+
+    assert validation.status == READY_WITH_CONDITIONS
+    assert validation.blockers == ()
+    assert federated_improvement_candidate_is_transmissible_evidence_only(candidate)
+
+
+def test_blocked_candidate_from_failed_audit_verification() -> None:
+    validation = validate_federated_improvement_candidate(_candidate(audit_verification_status="failed"))
+
+    assert validation.status == BLOCKED
+    assert "audit_verification_failed" in validation.blockers
+
+
+def test_blocked_candidate_from_failed_immutable_verification() -> None:
+    validation = validate_federated_improvement_candidate(_candidate(immutable_verification_status="failed"))
+
+    assert validation.status == BLOCKED
+    assert "immutable_verification_failed" in validation.blockers
+
+
+def test_incomplete_candidate_from_missing_node_candidate_or_source_evidence() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(
+            producing_node_id="",
+            local_candidate_id="",
+            source_amendment_or_proposal_id="",
+            source_commit_ref_digest="",
+            lineage_refs=(),
+        )
+    )
+
+    assert validation.status == INCOMPLETE
+    assert "missing_producing_node_id" in validation.blockers
+    assert "missing_local_candidate_id" in validation.blockers
+    assert "missing_lineage_or_source_evidence" in validation.blockers
+
+
+def test_incomplete_candidate_from_missing_test_or_rehearsal_evidence_when_required() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(test_evidence=(), rehearsal_artifact_refs=())
+    )
+
+    assert validation.status == INCOMPLETE
+    assert "missing_test_or_rehearsal_evidence" in validation.blockers
+
+
+def test_contradiction_from_auto_adoption_or_remote_execution_markers() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(adoption_constraints=("adopt_on_receipt", "remote_execution"))
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "forbidden_adoption_or_remote_execution_marker" in validation.blockers
+    assert not federated_improvement_candidate_is_transmissible_evidence_only(_candidate(adoption_constraints=("auto_update",)))
+
+
+def test_contradiction_from_provider_network_export_runtime_prompt_markers() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(known_risk_codes=("provider_client_requested", "network_handle", "prompt_text"))
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "provider_network_export_runtime_prompt_marker" in validation.blockers
+
+
+def test_contradiction_from_secret_endpoint_client_material() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(known_risk_codes=("api_key_present", "endpoint_present", "client_handle_present"))
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "secret_endpoint_client_marker" in validation.blockers
+
+
+def test_federation_compatibility_contradiction() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(federation_compatibility_posture="incompatible")
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "federation_compatibility_contradiction" in validation.blockers
+
+
+def test_local_governance_bypass_marker() -> None:
+    validation = validate_federated_improvement_candidate(
+        _candidate(required_local_review_gates=("bypass_governance",))
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "local_governance_gate_bypass_marker" in validation.blockers
+
+
+def test_deterministic_digest_behavior() -> None:
+    first = _candidate()
+    equivalent = _candidate()
+    changed = _candidate(local_candidate_id="candidate-002")
+
+    assert compute_federated_improvement_candidate_digest(first) == compute_federated_improvement_candidate_digest(equivalent)
+    assert compute_federated_improvement_candidate_digest(first) != compute_federated_improvement_candidate_digest(changed)
+
+
+def test_summary_shape_contains_only_metadata_labels_counts_booleans_and_statuses() -> None:
+    summary = summarize_federated_improvement_candidate(_candidate())
+
+    forbidden_keys = {
+        "patch_body",
+        "raw_patch",
+        "prompt_text",
+        "endpoint",
+        "client_handle",
+        "runtime_handle",
+        "executable_payload",
+    }
+    assert forbidden_keys.isdisjoint(summary)
+    assert set(summary) == {
+        "producing_node_id",
+        "local_candidate_id",
+        "candidate_kind",
+        "status",
+        "digest",
+        "source_amendment_or_proposal_id",
+        "source_commit_ref_digest",
+        "rationale_digest_or_label",
+        "test_evidence_count",
+        "test_result_labels",
+        "rehearsal_artifact_ref_count",
+        "audit_verification_status",
+        "immutable_verification_status",
+        "federation_compatibility_posture",
+        "required_local_review_gate_count",
+        "adoption_constraint_count",
+        "known_risk_code_count",
+        "lineage_ref_count",
+        "metadata_only",
+        "locally_produced",
+        "transmissible_evidence_only",
+        "not_adopted_by_default",
+        "not_executable_by_receipt",
+        "no_remote_authority",
+        "no_forced_update",
+        "no_provider_network_export_prompt_runtime_authority",
+        "no_secret_endpoint_client_material",
+        "blocker_count",
+        "warning_count",
+    }
+    assert all(not isinstance(value, dict) for value in summary.values())
+
+
+def test_predicate_helpers_remain_conservative() -> None:
+    contradicted = _candidate(adoption_constraints=("execute_on_receipt",))
+    incomplete = _candidate(producing_node_id="")
+
+    assert not federated_improvement_candidate_is_transmissible_evidence_only(contradicted)
+    assert not federated_improvement_candidate_has_no_remote_authority(contradicted)
+    assert not federated_improvement_candidate_ready_for_receipt_inspection(incomplete)
+    assert federated_improvement_candidate_is_metadata_only(incomplete)
+
+
+def test_statuses_and_kinds_are_compact_and_complete() -> None:
+    assert READY in CANDIDATE_STATUSES
+    assert READY_WITH_CONDITIONS in CANDIDATE_STATUSES
+    assert BLOCKED in CANDIDATE_STATUSES
+    assert INCOMPLETE in CANDIDATE_STATUSES
+    assert CONTRADICTED in CANDIDATE_STATUSES
+    assert FederatedImprovementCandidateKind.MEMORY_DISTILLATION_IMPROVEMENT in CANDIDATE_KINDS
+    assert FederatedImprovementCandidateKind.CODEX_REPAIR_IMPROVEMENT in CANDIDATE_KINDS
+    assert FederatedImprovementCandidateKind.DOCUMENTATION_OR_DEMO_IMPROVEMENT in CANDIDATE_KINDS
+
+
+def test_no_prompt_assembler_modification() -> None:
+    result = subprocess.run(
+        ["git", "diff", "--quiet", "--", "prompt_assembler.py"],
+        check=False,
+        cwd=".",
+    )
+
+    assert result.returncode == 0
+
+
+def test_no_runtime_provider_network_export_authority_imports() -> None:
+    before = set(sys.modules)
+    module = importlib.import_module("sentientos.federation.improvement_candidate")
+    imported = set(sys.modules) - before
+
+    assert module.FederatedImprovementCandidate is FederatedImprovementCandidate
+    forbidden_modules = {
+        "openai",
+        "requests",
+        "httpx",
+        "socket",
+        "prompt_assembler",
+        "memory_manager",
+        "sentientos.runtime.shell",
+    }
+    assert forbidden_modules.isdisjoint(imported)


### PR DESCRIPTION
### Motivation
- Make accepted local improvements explicitly representable as deterministic, metadata-first, transmissible evidence that other nodes may inspect, rehearse, adapt, reject, or adopt under their own governance without granting remote authority or executable payloads. 
- Provide a narrow, bounded artifact in the federation surface that uses existing governance/audit/lineage vocabulary and fails closed on any marker that would imply auto-adoption, execution, secrets, or provider/runtime authority.

### Description
- Added `sentientos/federation/improvement_candidate.py` which defines a frozen dataclass `FederatedImprovementCandidate` plus `CandidateTestEvidence` and `CandidateValidation`, deterministic digesting via `compute_federated_improvement_candidate_digest`, validation via `validate_federated_improvement_candidate`, a compact `summarize_federated_improvement_candidate`, an `explain_federated_improvement_candidate`, and conservative predicate helpers. 
- Introduced compact statuses (`federated_improvement_candidate_ready`, `federated_improvement_candidate_ready_with_conditions`, `federated_improvement_candidate_blocked`, `federated_improvement_candidate_incomplete`, `federated_improvement_candidate_contradicted`) and candidate kinds (`memory_distillation_improvement`, `context_selection_improvement`, `embodiment_guard_improvement`, `audit_integrity_improvement`, `installer_bootstrap_improvement`, `federation_protocol_improvement`, `genesis_forge_scaffold_improvement`, `codex_repair_improvement`, `policy_gate_improvement`, `documentation_or_demo_improvement`).
- Metadata-only evidence fields are supported (producing node id, local candidate id, `source_amendment_or_proposal_id`, `source_commit_ref_digest`, `rationale_digest_or_label`, test command/result labels, rehearsal artifact refs, `audit_verification_status`, `immutable_verification_status`, `federation_compatibility_posture`, `required_local_review_gates`, `adoption_constraints`, `known_risk_codes`, `lineage_refs`, plus boolean invariants proving metadata/local/evidence/no-authority posture). 
- Exported the new API from `sentientos.federation` and added a short architecture note `docs/architecture/federated_improvement_candidate.md` describing the artifact as ‘‘transmissible improvement evidence under local custody’’ and explicitly forbidding install/apply/execute/merge/route/schedule/remote-authority behaviors.

### Testing
- Ran static compile checks: `python -m py_compile sentientos/federation/improvement_candidate.py sentientos/federation/__init__.py tests/test_federated_improvement_candidate.py` and they passed. 
- Ran focused unit tests: `python -m scripts.run_tests -q tests/test_federated_improvement_candidate.py` which executed the added test suite and passed (all tests for this file succeeded). 
- Ran a lightweight set of federation/governance/audit tests for integration sanity: `python -m scripts.run_tests -q tests/test_federation_delta.py tests/test_federation_passive_replay.py tests/test_federation_non_dependence_invariant.py tests/test_governance_drift_check.py tests/test_audit_immutability.py tests/test_concord_daemon.py` and they completed successfully (existing tests remained green or showed expected skips). 
- Tests cover: clean metadata-only candidate, ready-with-conditions, blocked (failed audit/immutable verification), incomplete (missing node/candidate/source evidence), contradictions from auto-adoption/provider/network/runtime/prompt/secret/endpoint/client markers, federation compatibility contradiction, local governance bypass marker, deterministic digest behavior, summary shape (metadata-only), and conservative predicate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a028dd05b0083209c49e825ce8d79d7)