### PR TITLE
[codex:federation] add improvement intake receipt

### DIFF
--- a/docs/architecture/federated_improvement_intake_receipt.md
+++ b/docs/architecture/federated_improvement_intake_receipt.md
@@ -1,0 +1,27 @@
+# Federated Improvement Intake Receipt
+
+A receiving-node federated improvement intake receipt is a deterministic,
+metadata-only custody artifact for `FederatedImprovementCandidate` evidence. It
+answers whether a candidate that arrived at a node is eligible for local
+inspection, local rehearsal, local adaptation, rejection, or a separate local
+governance review queue.
+
+The receipt is deliberately not an adoption artifact. It does not install,
+apply, execute, merge, route, schedule, transport, prompt, export, call a
+provider, or expand runtime authority. It records only node IDs, candidate IDs,
+digests, compact statuses and decisions, gate code labels, verification labels,
+booleans, and lineage references by ID or digest.
+
+Local custody is preserved because the producing node's candidate remains
+external evidence and the receiving node records only an intake classification.
+Any later adoption must occur through the receiving node's own governance,
+audit, immutability, compatibility, and canonical control-plane gates. A remote
+candidate cannot force an update, bypass a local gate, grant remote authority,
+or carry endpoint, client, secret, prompt-text, raw patch, or executable payload
+material inside the receipt.
+
+Fail-closed intake statuses distinguish incomplete metadata, contradicted
+metadata, local-review holds, explicit rejection, ready-for-inspection,
+ready-for-rehearsal, and ready-with-conditions outcomes. Decisions remain
+bounded to inspect-only, rehearse-locally, adapt-locally, reject-candidate,
+hold-for-operator-review, or queue-for-local-governance-review.

--- a/sentientos/federation/__init__.py
+++ b/sentientos/federation/__init__.py
@@ -19,6 +19,25 @@ from .improvement_candidate import (
     summarize_federated_improvement_candidate,
     validate_federated_improvement_candidate,
 )
+from .improvement_intake_receipt import (
+    FederatedImprovementIntakeDecision,
+    FederatedImprovementIntakeReceipt,
+    FederatedImprovementIntakeStatus,
+    FederatedImprovementIntakeValidation,
+    INTAKE_DECISIONS,
+    INTAKE_STATUSES,
+    build_federated_improvement_intake_receipt,
+    compute_federated_improvement_intake_receipt_digest,
+    explain_federated_improvement_intake_receipt,
+    federated_improvement_intake_receipt_allows_adaptation,
+    federated_improvement_intake_receipt_allows_inspection,
+    federated_improvement_intake_receipt_allows_rehearsal,
+    federated_improvement_intake_receipt_has_no_remote_authority,
+    federated_improvement_intake_receipt_is_metadata_only,
+    federated_improvement_intake_receipt_preserves_local_custody,
+    summarize_federated_improvement_intake_receipt,
+    validate_federated_improvement_intake_receipt,
+)
 from .consensus_sentinel import FederationConsensusSentinel
 from .concord_daemon import ConcordDaemon, PeerSnapshot
 from .config import PeerConfig, FederationConfig, load_federation_config
@@ -104,4 +123,21 @@ __all__ = [
     "federated_improvement_candidate_ready_for_receipt_inspection",
     "summarize_federated_improvement_candidate",
     "validate_federated_improvement_candidate",
+    "FederatedImprovementIntakeDecision",
+    "FederatedImprovementIntakeReceipt",
+    "FederatedImprovementIntakeStatus",
+    "FederatedImprovementIntakeValidation",
+    "INTAKE_DECISIONS",
+    "INTAKE_STATUSES",
+    "build_federated_improvement_intake_receipt",
+    "compute_federated_improvement_intake_receipt_digest",
+    "explain_federated_improvement_intake_receipt",
+    "federated_improvement_intake_receipt_allows_adaptation",
+    "federated_improvement_intake_receipt_allows_inspection",
+    "federated_improvement_intake_receipt_allows_rehearsal",
+    "federated_improvement_intake_receipt_has_no_remote_authority",
+    "federated_improvement_intake_receipt_is_metadata_only",
+    "federated_improvement_intake_receipt_preserves_local_custody",
+    "summarize_federated_improvement_intake_receipt",
+    "validate_federated_improvement_intake_receipt",
 ]

--- a/sentientos/federation/improvement_intake_receipt.py
+++ b/sentientos/federation/improvement_intake_receipt.py
@@ -1,0 +1,690 @@
+"""Receiving-node intake receipts for federated improvement candidates.
+
+The receipt in this module is metadata-only and intake-only.  It classifies a
+received :class:`FederatedImprovementCandidate` for local inspection,
+rehearsal, adaptation, rejection, or separate local governance review without
+installing, applying, executing, merging, routing, scheduling, adopting,
+exporting, prompting, or granting runtime authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, fields, is_dataclass
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from .improvement_candidate import (
+    CANDIDATE_KINDS,
+    FederatedImprovementCandidate,
+    FederatedImprovementCandidateStatus,
+    CandidateTestEvidence,
+    compute_federated_improvement_candidate_digest,
+    validate_federated_improvement_candidate,
+)
+
+
+class FederatedImprovementIntakeStatus:
+    FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_INSPECTION = (
+        "federated_improvement_intake_ready_for_inspection"
+    )
+    FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL = (
+        "federated_improvement_intake_ready_for_rehearsal"
+    )
+    FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS = (
+        "federated_improvement_intake_ready_with_conditions"
+    )
+    FEDERATED_IMPROVEMENT_INTAKE_HOLD_FOR_LOCAL_REVIEW = (
+        "federated_improvement_intake_hold_for_local_review"
+    )
+    FEDERATED_IMPROVEMENT_INTAKE_REJECTED = "federated_improvement_intake_rejected"
+    FEDERATED_IMPROVEMENT_INTAKE_INCOMPLETE = "federated_improvement_intake_incomplete"
+    FEDERATED_IMPROVEMENT_INTAKE_CONTRADICTED = "federated_improvement_intake_contradicted"
+
+
+class FederatedImprovementIntakeDecision:
+    INSPECT_ONLY = "inspect_only"
+    REHEARSE_LOCALLY = "rehearse_locally"
+    ADAPT_LOCALLY = "adapt_locally"
+    REJECT_CANDIDATE = "reject_candidate"
+    HOLD_FOR_OPERATOR_REVIEW = "hold_for_operator_review"
+    QUEUE_FOR_LOCAL_GOVERNANCE_REVIEW = "queue_for_local_governance_review"
+
+
+INTAKE_STATUSES = (
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_INSPECTION,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_HOLD_FOR_LOCAL_REVIEW,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_REJECTED,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_INCOMPLETE,
+    FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_CONTRADICTED,
+)
+
+INTAKE_DECISIONS = (
+    FederatedImprovementIntakeDecision.INSPECT_ONLY,
+    FederatedImprovementIntakeDecision.REHEARSE_LOCALLY,
+    FederatedImprovementIntakeDecision.ADAPT_LOCALLY,
+    FederatedImprovementIntakeDecision.REJECT_CANDIDATE,
+    FederatedImprovementIntakeDecision.HOLD_FOR_OPERATOR_REVIEW,
+    FederatedImprovementIntakeDecision.QUEUE_FOR_LOCAL_GOVERNANCE_REVIEW,
+)
+
+_READY_CANDIDATE_STATUSES = frozenset(
+    {
+        FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY,
+        FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_READY_WITH_CONDITIONS,
+    }
+)
+_HOLD_OR_REJECT_DECISIONS = frozenset(
+    {
+        FederatedImprovementIntakeDecision.REJECT_CANDIDATE,
+        FederatedImprovementIntakeDecision.HOLD_FOR_OPERATOR_REVIEW,
+        FederatedImprovementIntakeDecision.QUEUE_FOR_LOCAL_GOVERNANCE_REVIEW,
+    }
+)
+_COMPATIBLE_LOCAL_POSTURES = frozenset(
+    {"compatible", "compatible_with_conditions", "local_review_required"}
+)
+_INCOMPATIBLE_LOCAL_POSTURES = frozenset(
+    {"incompatible", "contradicted", "forced_adoption_required"}
+)
+_FORBIDDEN_ADOPTION_MARKERS = (
+    "adopt_on_receipt",
+    "auto_adopt",
+    "auto-adopt",
+    "autoadopt",
+    "auto_update",
+    "auto-update",
+    "forced_update",
+    "forced_adoption",
+    "install_on_receipt",
+    "apply_on_receipt",
+    "merge_on_receipt",
+    "execute_on_receipt",
+    "remote_execution",
+    "remote-execution",
+    "remote_execute",
+    "schedule_on_receipt",
+    "route_on_receipt",
+)
+_PROVIDER_NETWORK_EXPORT_RUNTIME_PROMPT_MARKERS = (
+    "provider",
+    "llm_call",
+    "model_call",
+    "network",
+    "http://",
+    "https://",
+    "socket",
+    "webhook",
+    "export_payload",
+    "runtime_handle",
+    "runtime_authority",
+    "tool_call",
+    "function_call",
+    "memory_handle",
+    "routing_handle",
+    "execution_handle",
+    "prompt_text",
+    "system_prompt",
+    "assembled_prompt",
+    "raw_prompt",
+)
+_SECRET_ENDPOINT_CLIENT_MARKERS = (
+    "api_key",
+    "apikey",
+    "secret",
+    "credential",
+    "authorization",
+    "bearer",
+    "access_token",
+    "refresh_token",
+    "endpoint",
+    "base_url",
+    "client_handle",
+    "provider_client",
+    "sdk_client",
+    "session_handle",
+)
+_LOCAL_GOVERNANCE_BYPASS_MARKERS = (
+    "bypass_governance",
+    "governance_bypass",
+    "skip_review",
+    "skip_local_review",
+    "bypass_review_gate",
+    "ignore_review_gate",
+    "canonical_gate_bypass",
+    "control_plane_bypass",
+)
+_RAW_PAYLOAD_MARKERS = (
+    "diff --git",
+    "patch_body",
+    "raw_patch",
+    "executable_payload",
+    "script_body",
+    "code_payload",
+)
+
+
+@dataclass(frozen=True)
+class FederatedImprovementIntakeValidation:
+    status: str
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class FederatedImprovementIntakeReceipt:
+    receiving_node_id: str
+    producing_node_id: str
+    source_candidate_id: str
+    candidate_digest: str
+    expected_candidate_digest: str
+    candidate_kind: str
+    candidate_status: str
+    candidate_compatibility_posture: str
+    candidate_audit_verification_status: str
+    candidate_immutable_verification_status: str
+    local_compatibility_posture: str
+    local_policy_posture: str
+    required_local_review_gates: tuple[str, ...] = field(default_factory=tuple)
+    accepted_gate_codes: tuple[str, ...] = field(default_factory=tuple)
+    rejected_gate_codes: tuple[str, ...] = field(default_factory=tuple)
+    pending_gate_codes: tuple[str, ...] = field(default_factory=tuple)
+    local_rehearsal_required: bool = False
+    local_adaptation_required: bool = False
+    rejection_reason_codes: tuple[str, ...] = field(default_factory=tuple)
+    warning_codes: tuple[str, ...] = field(default_factory=tuple)
+    lineage_refs: tuple[str, ...] = field(default_factory=tuple)
+    intake_decision: str = FederatedImprovementIntakeDecision.INSPECT_ONLY
+    metadata_only: bool = True
+    intake_only: bool = True
+    local_custody_preserved: bool = True
+    candidate_not_adopted: bool = True
+    candidate_not_executed: bool = True
+    no_remote_authority: bool = True
+    no_forced_update: bool = True
+    no_provider_network_export_prompt_runtime_authority: bool = True
+    no_secret_endpoint_client_material: bool = True
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return is_dataclass(value) and not isinstance(value, type)
+
+
+def _stable(value: Any) -> Any:
+    if _is_dataclass_instance(value):
+        return {str(key): _stable(item) for key, item in asdict(value).items()}
+    if isinstance(value, Mapping):
+        return {str(key): _stable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (tuple, list)):
+        return [_stable(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_stable(item) for item in value)
+    return value
+
+
+def _walk_values(value: Any) -> tuple[str, ...]:
+    found: list[str] = []
+
+    def visit(child: Any) -> None:
+        if _is_dataclass_instance(child):
+            visit(asdict(child))
+        elif isinstance(child, Mapping):
+            for nested in child.values():
+                visit(nested)
+        elif isinstance(child, (tuple, list, set, frozenset)):
+            for nested in child:
+                visit(nested)
+        elif isinstance(child, str):
+            found.append(child)
+
+    visit(value)
+    return tuple(found)
+
+
+def _contains_marker(value: Any, markers: Sequence[str]) -> bool:
+    lowered = tuple(item.lower() for item in _walk_values(value))
+    return any(marker in item for marker in markers for item in lowered)
+
+
+def _tuple_of_strings(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, (tuple, list, set, frozenset)):
+        return tuple(str(item) for item in value if str(item))
+    return (str(value),) if str(value) else ()
+
+
+def _coerce_test_evidence(value: Any) -> tuple[CandidateTestEvidence, ...]:
+    evidence: list[CandidateTestEvidence] = []
+    for item in value or ():
+        if isinstance(item, CandidateTestEvidence):
+            evidence.append(item)
+        elif isinstance(item, Mapping):
+            evidence.append(
+                CandidateTestEvidence(
+                    command_label=str(item.get("command_label", "")),
+                    result_label=str(item.get("result_label", "")),
+                )
+            )
+    return tuple(evidence)
+
+
+def _candidate_from_mapping(mapping: Mapping[str, Any]) -> FederatedImprovementCandidate | None:
+    candidate_fields = {item.name for item in fields(FederatedImprovementCandidate)}
+    if not any(key in mapping for key in ("producing_node_id", "local_candidate_id", "candidate_kind")):
+        return None
+    values = {key: mapping[key] for key in candidate_fields if key in mapping}
+    values["test_evidence"] = _coerce_test_evidence(values.get("test_evidence", ()))
+    for tuple_key in (
+        "rehearsal_artifact_refs",
+        "required_local_review_gates",
+        "adoption_constraints",
+        "known_risk_codes",
+        "lineage_refs",
+    ):
+        values[tuple_key] = _tuple_of_strings(values.get(tuple_key, ()))
+    for required in ("producing_node_id", "local_candidate_id", "candidate_kind"):
+        values.setdefault(required, "")
+    try:
+        return FederatedImprovementCandidate(**values)
+    except TypeError:
+        return None
+
+
+def _candidate_metadata(candidate: FederatedImprovementCandidate | Mapping[str, Any] | None) -> dict[str, Any]:
+    if candidate is None:
+        return {}
+    if isinstance(candidate, FederatedImprovementCandidate):
+        validation = validate_federated_improvement_candidate(candidate)
+        return {
+            "candidate": candidate,
+            "producing_node_id": candidate.producing_node_id,
+            "source_candidate_id": candidate.local_candidate_id,
+            "candidate_kind": candidate.candidate_kind,
+            "candidate_digest": compute_federated_improvement_candidate_digest(candidate),
+            "candidate_status": validation.status,
+            "candidate_compatibility_posture": candidate.federation_compatibility_posture,
+            "candidate_audit_verification_status": candidate.audit_verification_status,
+            "candidate_immutable_verification_status": candidate.immutable_verification_status,
+            "required_local_review_gates": candidate.required_local_review_gates,
+            "lineage_refs": candidate.lineage_refs,
+            "candidate_blockers": validation.blockers,
+            "candidate_warnings": validation.warnings,
+        }
+    if not isinstance(candidate, Mapping):
+        return {}
+    coerced = _candidate_from_mapping(candidate)
+    if coerced is not None:
+        metadata = _candidate_metadata(coerced)
+        metadata["candidate_digest"] = str(candidate.get("candidate_digest") or metadata["candidate_digest"])
+        metadata["candidate_status"] = str(candidate.get("candidate_status") or metadata["candidate_status"])
+        return metadata
+    return {
+        "producing_node_id": str(candidate.get("producing_node_id", "")),
+        "source_candidate_id": str(candidate.get("source_candidate_id", candidate.get("local_candidate_id", ""))),
+        "candidate_kind": str(candidate.get("candidate_kind", "")),
+        "candidate_digest": str(candidate.get("candidate_digest", "")),
+        "candidate_status": str(candidate.get("candidate_status", "")),
+        "candidate_compatibility_posture": str(
+            candidate.get("candidate_compatibility_posture", candidate.get("federation_compatibility_posture", ""))
+        ),
+        "candidate_audit_verification_status": str(candidate.get("candidate_audit_verification_status", "")),
+        "candidate_immutable_verification_status": str(candidate.get("candidate_immutable_verification_status", "")),
+        "required_local_review_gates": _tuple_of_strings(candidate.get("required_local_review_gates", ())),
+        "lineage_refs": _tuple_of_strings(candidate.get("lineage_refs", ())),
+        "candidate_blockers": _tuple_of_strings(candidate.get("candidate_blockers", ())),
+        "candidate_warnings": _tuple_of_strings(candidate.get("candidate_warnings", ())),
+        "raw_mapping": candidate,
+    }
+
+
+def build_federated_improvement_intake_receipt(
+    *,
+    receiving_node_id: str,
+    candidate: FederatedImprovementCandidate | Mapping[str, Any] | None,
+    intake_decision: str = FederatedImprovementIntakeDecision.INSPECT_ONLY,
+    expected_candidate_digest: str = "",
+    local_compatibility_posture: str = "local_review_required",
+    local_policy_posture: str = "local_governance_required",
+    accepted_gate_codes: Sequence[str] = (),
+    rejected_gate_codes: Sequence[str] = (),
+    pending_gate_codes: Sequence[str] = (),
+    local_rehearsal_required: bool = False,
+    local_adaptation_required: bool = False,
+    rejection_reason_codes: Sequence[str] = (),
+    warning_codes: Sequence[str] = (),
+) -> FederatedImprovementIntakeReceipt:
+    metadata = _candidate_metadata(candidate)
+    candidate_digest = str(metadata.get("candidate_digest", ""))
+    expected_digest = expected_candidate_digest or candidate_digest
+    candidate_rejections = _tuple_of_strings(metadata.get("candidate_blockers", ()))
+    candidate_warnings = _tuple_of_strings(metadata.get("candidate_warnings", ()))
+    return FederatedImprovementIntakeReceipt(
+        receiving_node_id=receiving_node_id,
+        producing_node_id=str(metadata.get("producing_node_id", "")),
+        source_candidate_id=str(metadata.get("source_candidate_id", "")),
+        candidate_digest=candidate_digest,
+        expected_candidate_digest=expected_digest,
+        candidate_kind=str(metadata.get("candidate_kind", "")),
+        candidate_status=str(metadata.get("candidate_status", "")),
+        candidate_compatibility_posture=str(metadata.get("candidate_compatibility_posture", "")),
+        candidate_audit_verification_status=str(metadata.get("candidate_audit_verification_status", "")),
+        candidate_immutable_verification_status=str(metadata.get("candidate_immutable_verification_status", "")),
+        local_compatibility_posture=local_compatibility_posture,
+        local_policy_posture=local_policy_posture,
+        required_local_review_gates=_tuple_of_strings(metadata.get("required_local_review_gates", ())),
+        accepted_gate_codes=_tuple_of_strings(accepted_gate_codes),
+        rejected_gate_codes=_tuple_of_strings(rejected_gate_codes),
+        pending_gate_codes=_tuple_of_strings(pending_gate_codes),
+        local_rehearsal_required=local_rehearsal_required,
+        local_adaptation_required=local_adaptation_required,
+        rejection_reason_codes=tuple(dict.fromkeys((*candidate_rejections, *_tuple_of_strings(rejection_reason_codes)))),
+        warning_codes=tuple(dict.fromkeys((*candidate_warnings, *_tuple_of_strings(warning_codes)))),
+        lineage_refs=_tuple_of_strings(metadata.get("lineage_refs", ())),
+        intake_decision=intake_decision,
+    )
+
+
+def compute_federated_improvement_intake_receipt_digest(receipt: FederatedImprovementIntakeReceipt) -> str:
+    payload = _stable(receipt)
+    serialised = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(serialised).hexdigest()
+
+
+def validate_federated_improvement_intake_receipt(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> FederatedImprovementIntakeValidation:
+    blockers: list[str] = []
+    warnings: list[str] = list(receipt.warning_codes)
+
+    if not receipt.receiving_node_id:
+        blockers.append("missing_receiving_node_id")
+    if not receipt.producing_node_id or not receipt.source_candidate_id or not receipt.candidate_kind:
+        blockers.append("missing_candidate_metadata")
+    if receipt.candidate_kind and receipt.candidate_kind not in CANDIDATE_KINDS:
+        blockers.append("unknown_candidate_kind")
+    if not receipt.candidate_digest or not receipt.expected_candidate_digest:
+        blockers.append("missing_candidate_digest")
+    elif receipt.candidate_digest != receipt.expected_candidate_digest:
+        blockers.append("candidate_digest_mismatch")
+    if not receipt.candidate_status:
+        blockers.append("missing_candidate_status")
+    elif receipt.candidate_status == FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_CONTRADICTED:
+        blockers.append("candidate_contradicted_status")
+    elif receipt.candidate_status == FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_INCOMPLETE:
+        blockers.append("candidate_validation_failure")
+    elif receipt.candidate_status == FederatedImprovementCandidateStatus.FEDERATED_IMPROVEMENT_CANDIDATE_BLOCKED:
+        if receipt.intake_decision not in _HOLD_OR_REJECT_DECISIONS:
+            blockers.append("blocked_candidate_requires_reject_or_hold")
+        else:
+            warnings.append("blocked_candidate_held_or_rejected")
+    elif receipt.candidate_status not in _READY_CANDIDATE_STATUSES:
+        blockers.append("candidate_validation_failure")
+
+    if receipt.candidate_compatibility_posture in _INCOMPATIBLE_LOCAL_POSTURES:
+        blockers.append("incompatible_federation_posture")
+    if receipt.local_compatibility_posture in _INCOMPATIBLE_LOCAL_POSTURES:
+        blockers.append("incompatible_local_posture")
+    elif receipt.local_compatibility_posture not in _COMPATIBLE_LOCAL_POSTURES:
+        warnings.append("local_compatibility_unknown")
+
+    reviewed_gates = set(receipt.accepted_gate_codes) | set(receipt.rejected_gate_codes) | set(receipt.pending_gate_codes)
+    missing_gates = tuple(gate for gate in receipt.required_local_review_gates if gate not in reviewed_gates)
+    if missing_gates:
+        blockers.append("missing_required_local_review_gates")
+    if receipt.rejected_gate_codes and receipt.intake_decision != FederatedImprovementIntakeDecision.REJECT_CANDIDATE:
+        blockers.append("rejected_gate_requires_reject_decision")
+    if receipt.pending_gate_codes and receipt.intake_decision not in _HOLD_OR_REJECT_DECISIONS:
+        blockers.append("pending_gate_requires_local_review_hold")
+    if receipt.intake_decision not in INTAKE_DECISIONS:
+        blockers.append("unknown_intake_decision")
+
+    invariant_checks = {
+        "metadata_only_false": receipt.metadata_only,
+        "intake_only_false": receipt.intake_only,
+        "local_custody_not_preserved": receipt.local_custody_preserved,
+        "candidate_adopted_marker": receipt.candidate_not_adopted,
+        "candidate_executed_marker": receipt.candidate_not_executed,
+        "remote_authority_present": receipt.no_remote_authority,
+        "forced_update_present": receipt.no_forced_update,
+        "provider_network_export_prompt_runtime_authority_present": (
+            receipt.no_provider_network_export_prompt_runtime_authority
+        ),
+        "secret_endpoint_client_material_present": receipt.no_secret_endpoint_client_material,
+    }
+    for code, allowed in invariant_checks.items():
+        if not allowed:
+            blockers.append(code)
+
+    if _contains_marker(receipt, _FORBIDDEN_ADOPTION_MARKERS):
+        blockers.append("forbidden_adoption_apply_install_merge_execute_marker")
+    if _contains_marker(receipt, _PROVIDER_NETWORK_EXPORT_RUNTIME_PROMPT_MARKERS):
+        blockers.append("provider_network_export_runtime_prompt_marker")
+    if _contains_marker(receipt, _SECRET_ENDPOINT_CLIENT_MARKERS):
+        blockers.append("secret_endpoint_client_marker")
+    if _contains_marker(receipt, _LOCAL_GOVERNANCE_BYPASS_MARKERS):
+        blockers.append("local_governance_bypass_marker")
+    if _contains_marker(receipt, _RAW_PAYLOAD_MARKERS):
+        blockers.append("raw_patch_or_executable_payload_marker")
+
+    unique_blockers = tuple(dict.fromkeys(blockers))
+    unique_warnings = tuple(dict.fromkeys(warnings))
+    return FederatedImprovementIntakeValidation(
+        status=_derive_intake_status(receipt, unique_blockers, unique_warnings),
+        blockers=unique_blockers,
+        warnings=unique_warnings,
+    )
+
+
+def _derive_intake_status(
+    receipt: FederatedImprovementIntakeReceipt,
+    blockers: tuple[str, ...],
+    warnings: tuple[str, ...],
+) -> str:
+    incomplete_codes = {
+        "missing_receiving_node_id",
+        "missing_candidate_metadata",
+        "missing_candidate_digest",
+        "missing_candidate_status",
+        "unknown_candidate_kind",
+    }
+    contradiction_codes = {
+        "candidate_digest_mismatch",
+        "candidate_contradicted_status",
+        "incompatible_federation_posture",
+        "incompatible_local_posture",
+        "local_governance_bypass_marker",
+        "forbidden_adoption_apply_install_merge_execute_marker",
+        "provider_network_export_runtime_prompt_marker",
+        "secret_endpoint_client_marker",
+        "raw_patch_or_executable_payload_marker",
+        "metadata_only_false",
+        "intake_only_false",
+        "local_custody_not_preserved",
+        "candidate_adopted_marker",
+        "candidate_executed_marker",
+        "remote_authority_present",
+        "forced_update_present",
+        "provider_network_export_prompt_runtime_authority_present",
+        "secret_endpoint_client_material_present",
+    }
+    if any(code in blockers for code in contradiction_codes):
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_CONTRADICTED
+    if any(code in blockers for code in incomplete_codes):
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_INCOMPLETE
+    if receipt.intake_decision == FederatedImprovementIntakeDecision.REJECT_CANDIDATE:
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_REJECTED
+    if blockers or receipt.intake_decision in {
+        FederatedImprovementIntakeDecision.HOLD_FOR_OPERATOR_REVIEW,
+        FederatedImprovementIntakeDecision.QUEUE_FOR_LOCAL_GOVERNANCE_REVIEW,
+    }:
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_HOLD_FOR_LOCAL_REVIEW
+    if receipt.intake_decision == FederatedImprovementIntakeDecision.REHEARSE_LOCALLY:
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL
+    if warnings or receipt.local_adaptation_required or receipt.local_rehearsal_required:
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS
+    if receipt.intake_decision == FederatedImprovementIntakeDecision.ADAPT_LOCALLY:
+        return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS
+    return FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_INSPECTION
+
+
+def summarize_federated_improvement_intake_receipt(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> dict[str, object]:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return {
+        "receiving_node_id": receipt.receiving_node_id,
+        "producing_node_id": receipt.producing_node_id,
+        "source_candidate_id": receipt.source_candidate_id,
+        "candidate_digest": receipt.candidate_digest,
+        "expected_candidate_digest": receipt.expected_candidate_digest,
+        "receipt_digest": compute_federated_improvement_intake_receipt_digest(receipt),
+        "candidate_kind": receipt.candidate_kind,
+        "candidate_status": receipt.candidate_status,
+        "intake_status": validation.status,
+        "intake_decision": receipt.intake_decision,
+        "candidate_compatibility_posture": receipt.candidate_compatibility_posture,
+        "local_compatibility_posture": receipt.local_compatibility_posture,
+        "local_policy_posture": receipt.local_policy_posture,
+        "required_local_review_gate_count": len(receipt.required_local_review_gates),
+        "accepted_gate_count": len(receipt.accepted_gate_codes),
+        "rejected_gate_count": len(receipt.rejected_gate_codes),
+        "pending_gate_count": len(receipt.pending_gate_codes),
+        "local_rehearsal_required": receipt.local_rehearsal_required,
+        "local_adaptation_required": receipt.local_adaptation_required,
+        "rejection_reason_count": len(receipt.rejection_reason_codes),
+        "warning_count": len(validation.warnings),
+        "lineage_ref_count": len(receipt.lineage_refs),
+        "metadata_only": receipt.metadata_only,
+        "intake_only": receipt.intake_only,
+        "local_custody_preserved": receipt.local_custody_preserved,
+        "candidate_not_adopted": receipt.candidate_not_adopted,
+        "candidate_not_executed": receipt.candidate_not_executed,
+        "no_remote_authority": receipt.no_remote_authority,
+        "no_forced_update": receipt.no_forced_update,
+        "no_provider_network_export_prompt_runtime_authority": (
+            receipt.no_provider_network_export_prompt_runtime_authority
+        ),
+        "no_secret_endpoint_client_material": receipt.no_secret_endpoint_client_material,
+        "blocker_count": len(validation.blockers),
+    }
+
+
+def explain_federated_improvement_intake_receipt(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> tuple[str, ...]:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    explanation = [
+        f"status:{validation.status}",
+        f"decision:{receipt.intake_decision}",
+        f"candidate_digest:{receipt.candidate_digest}",
+        f"receipt_digest:{compute_federated_improvement_intake_receipt_digest(receipt)}",
+        "custody:receiving_node_local_custody_preserved",
+        "scope:intake_only_no_adoption_no_execution_no_forced_update",
+        "authority:no_remote_authority_no_provider_network_export_prompt_runtime_authority",
+    ]
+    explanation.extend(f"blocker:{code}" for code in validation.blockers)
+    explanation.extend(f"warning:{code}" for code in validation.warnings)
+    return tuple(explanation)
+
+
+def federated_improvement_intake_receipt_is_metadata_only(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return receipt.metadata_only and "raw_patch_or_executable_payload_marker" not in validation.blockers
+
+
+def federated_improvement_intake_receipt_preserves_local_custody(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return (
+        receipt.intake_only
+        and receipt.local_custody_preserved
+        and receipt.candidate_not_adopted
+        and receipt.candidate_not_executed
+        and validation.status
+        not in {
+            FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_CONTRADICTED,
+            FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_INCOMPLETE,
+        }
+    )
+
+
+def federated_improvement_intake_receipt_has_no_remote_authority(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return (
+        receipt.no_remote_authority
+        and receipt.no_forced_update
+        and receipt.no_provider_network_export_prompt_runtime_authority
+        and receipt.no_secret_endpoint_client_material
+        and not any(
+            code in validation.blockers
+            for code in (
+                "forbidden_adoption_apply_install_merge_execute_marker",
+                "provider_network_export_runtime_prompt_marker",
+                "secret_endpoint_client_marker",
+                "local_governance_bypass_marker",
+                "remote_authority_present",
+                "forced_update_present",
+            )
+        )
+    )
+
+
+def federated_improvement_intake_receipt_allows_inspection(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return validation.status in {
+        FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_INSPECTION,
+        FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL,
+        FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS,
+        FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_HOLD_FOR_LOCAL_REVIEW,
+    }
+
+
+def federated_improvement_intake_receipt_allows_rehearsal(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return validation.status == FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL
+
+
+def federated_improvement_intake_receipt_allows_adaptation(
+    receipt: FederatedImprovementIntakeReceipt,
+) -> bool:
+    validation = validate_federated_improvement_intake_receipt(receipt)
+    return (
+        receipt.intake_decision == FederatedImprovementIntakeDecision.ADAPT_LOCALLY
+        and validation.status
+        == FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS
+    )
+
+
+__all__ = [
+    "FederatedImprovementIntakeDecision",
+    "FederatedImprovementIntakeReceipt",
+    "FederatedImprovementIntakeStatus",
+    "FederatedImprovementIntakeValidation",
+    "INTAKE_DECISIONS",
+    "INTAKE_STATUSES",
+    "build_federated_improvement_intake_receipt",
+    "compute_federated_improvement_intake_receipt_digest",
+    "explain_federated_improvement_intake_receipt",
+    "federated_improvement_intake_receipt_allows_adaptation",
+    "federated_improvement_intake_receipt_allows_inspection",
+    "federated_improvement_intake_receipt_allows_rehearsal",
+    "federated_improvement_intake_receipt_has_no_remote_authority",
+    "federated_improvement_intake_receipt_is_metadata_only",
+    "federated_improvement_intake_receipt_preserves_local_custody",
+    "summarize_federated_improvement_intake_receipt",
+    "validate_federated_improvement_intake_receipt",
+]

--- a/tests/test_federated_improvement_intake_receipt.py
+++ b/tests/test_federated_improvement_intake_receipt.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.federation.improvement_candidate import (
+    CandidateTestEvidence,
+    FederatedImprovementCandidate,
+    FederatedImprovementCandidateKind,
+    compute_federated_improvement_candidate_digest,
+)
+from sentientos.federation.improvement_intake_receipt import (
+    INTAKE_DECISIONS,
+    INTAKE_STATUSES,
+    FederatedImprovementIntakeDecision,
+    FederatedImprovementIntakeStatus,
+    build_federated_improvement_intake_receipt,
+    compute_federated_improvement_intake_receipt_digest,
+    explain_federated_improvement_intake_receipt,
+    federated_improvement_intake_receipt_allows_adaptation,
+    federated_improvement_intake_receipt_allows_inspection,
+    federated_improvement_intake_receipt_allows_rehearsal,
+    federated_improvement_intake_receipt_has_no_remote_authority,
+    federated_improvement_intake_receipt_is_metadata_only,
+    federated_improvement_intake_receipt_preserves_local_custody,
+    summarize_federated_improvement_intake_receipt,
+    validate_federated_improvement_intake_receipt,
+)
+
+INSPECT = FederatedImprovementIntakeDecision.INSPECT_ONLY
+REHEARSE = FederatedImprovementIntakeDecision.REHEARSE_LOCALLY
+ADAPT = FederatedImprovementIntakeDecision.ADAPT_LOCALLY
+REJECT = FederatedImprovementIntakeDecision.REJECT_CANDIDATE
+HOLD = FederatedImprovementIntakeDecision.HOLD_FOR_OPERATOR_REVIEW
+QUEUE = FederatedImprovementIntakeDecision.QUEUE_FOR_LOCAL_GOVERNANCE_REVIEW
+READY_INSPECTION = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_INSPECTION
+READY_REHEARSAL = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_FOR_REHEARSAL
+READY_CONDITIONS = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_READY_WITH_CONDITIONS
+HOLD_REVIEW = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_HOLD_FOR_LOCAL_REVIEW
+REJECTED = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_REJECTED
+INCOMPLETE = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_INCOMPLETE
+CONTRADICTED = FederatedImprovementIntakeStatus.FEDERATED_IMPROVEMENT_INTAKE_CONTRADICTED
+
+
+def _candidate(**kwargs: object) -> FederatedImprovementCandidate:
+    base = FederatedImprovementCandidate(
+        producing_node_id="node-alpha",
+        local_candidate_id="candidate-001",
+        candidate_kind=FederatedImprovementCandidateKind.FEDERATION_PROTOCOL_IMPROVEMENT,
+        source_amendment_or_proposal_id="proposal-17",
+        source_commit_ref_digest="sha256:abc123",
+        rationale_digest_or_label="rationale_digest_001",
+        test_evidence=(CandidateTestEvidence("py_compile_candidate_module", "passed"),),
+        rehearsal_artifact_refs=("rehearsal_digest_001",),
+        audit_verification_status="verified",
+        immutable_verification_status="verified",
+        federation_compatibility_posture="compatible",
+        lineage_refs=("lineage_digest_001",),
+    )
+    return replace(base, **kwargs)
+
+
+def _receipt(**kwargs: object):
+    values = {
+        "receiving_node_id": "node-local",
+        "candidate": _candidate(),
+        "intake_decision": INSPECT,
+        "local_compatibility_posture": "compatible",
+        "local_policy_posture": "local_policy_allows_intake",
+    }
+    values.update(kwargs)
+    return build_federated_improvement_intake_receipt(**values)
+
+
+def test_clean_ready_for_inspection_intake() -> None:
+    receipt = _receipt()
+    validation = validate_federated_improvement_intake_receipt(receipt)
+
+    assert validation.status == READY_INSPECTION
+    assert validation.blockers == ()
+    assert federated_improvement_intake_receipt_is_metadata_only(receipt)
+    assert federated_improvement_intake_receipt_preserves_local_custody(receipt)
+    assert federated_improvement_intake_receipt_has_no_remote_authority(receipt)
+    assert federated_improvement_intake_receipt_allows_inspection(receipt)
+    assert "scope:intake_only_no_adoption_no_execution_no_forced_update" in explain_federated_improvement_intake_receipt(receipt)
+
+
+def test_ready_for_rehearsal_intake() -> None:
+    receipt = _receipt(intake_decision=REHEARSE, local_rehearsal_required=True)
+
+    assert validate_federated_improvement_intake_receipt(receipt).status == READY_REHEARSAL
+    assert federated_improvement_intake_receipt_allows_rehearsal(receipt)
+
+
+def test_ready_with_conditions_intake() -> None:
+    candidate = _candidate(federation_compatibility_posture="compatible_with_conditions")
+    receipt = _receipt(candidate=candidate, intake_decision=ADAPT, local_adaptation_required=True)
+
+    assert validate_federated_improvement_intake_receipt(receipt).status == READY_CONDITIONS
+    assert federated_improvement_intake_receipt_allows_adaptation(receipt)
+
+
+def test_hold_for_local_review_intake() -> None:
+    candidate = _candidate(required_local_review_gates=("council_review_gate",))
+    receipt = _receipt(candidate=candidate, intake_decision=QUEUE, pending_gate_codes=("council_review_gate",))
+
+    assert validate_federated_improvement_intake_receipt(receipt).status == HOLD_REVIEW
+
+
+def test_rejected_intake() -> None:
+    receipt = _receipt(intake_decision=REJECT, rejection_reason_codes=("operator_rejected",))
+
+    assert validate_federated_improvement_intake_receipt(receipt).status == REJECTED
+
+
+def test_incomplete_intake_from_missing_receiving_node_id() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(receiving_node_id=""))
+
+    assert validation.status == INCOMPLETE
+    assert "missing_receiving_node_id" in validation.blockers
+
+
+def test_incomplete_intake_from_missing_candidate_metadata() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(candidate=None))
+
+    assert validation.status == INCOMPLETE
+    assert "missing_candidate_metadata" in validation.blockers
+
+
+def test_contradiction_from_candidate_digest_mismatch() -> None:
+    receipt = _receipt(expected_candidate_digest="sha256:not-the-candidate")
+    validation = validate_federated_improvement_intake_receipt(receipt)
+
+    assert validation.status == CONTRADICTED
+    assert "candidate_digest_mismatch" in validation.blockers
+
+
+def test_contradiction_from_candidate_contradicted_status() -> None:
+    receipt = _receipt(candidate=_candidate(adoption_constraints=("execute_on_receipt",)))
+    validation = validate_federated_improvement_intake_receipt(receipt)
+
+    assert validation.status == CONTRADICTED
+    assert "candidate_contradicted_status" in validation.blockers
+
+
+def test_blocked_candidate_can_only_be_rejected_or_held() -> None:
+    blocked = _candidate(audit_verification_status="failed")
+    inspect_validation = validate_federated_improvement_intake_receipt(_receipt(candidate=blocked))
+    reject_validation = validate_federated_improvement_intake_receipt(_receipt(candidate=blocked, intake_decision=REJECT))
+    hold_validation = validate_federated_improvement_intake_receipt(_receipt(candidate=blocked, intake_decision=HOLD))
+
+    assert inspect_validation.status == HOLD_REVIEW
+    assert "blocked_candidate_requires_reject_or_hold" in inspect_validation.blockers
+    assert reject_validation.status == REJECTED
+    assert hold_validation.status == HOLD_REVIEW
+
+
+def test_incompatible_federation_posture_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(
+        _receipt(candidate=_candidate(federation_compatibility_posture="incompatible"))
+    )
+
+    assert validation.status == CONTRADICTED
+    assert "candidate_contradicted_status" in validation.blockers
+
+
+def test_missing_required_local_review_gates_fails_closed() -> None:
+    candidate = _candidate(required_local_review_gates=("council_review_gate",))
+    validation = validate_federated_improvement_intake_receipt(_receipt(candidate=candidate))
+
+    assert validation.status == HOLD_REVIEW
+    assert "missing_required_local_review_gates" in validation.blockers
+
+
+def test_local_governance_bypass_marker_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(pending_gate_codes=("bypass_governance",)))
+
+    assert validation.status == CONTRADICTED
+    assert "local_governance_bypass_marker" in validation.blockers
+
+
+def test_adoption_apply_install_merge_execute_marker_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(rejection_reason_codes=("apply_on_receipt",)))
+
+    assert validation.status == CONTRADICTED
+    assert "forbidden_adoption_apply_install_merge_execute_marker" in validation.blockers
+
+
+def test_provider_network_export_runtime_prompt_marker_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(warning_codes=("runtime_handle",)))
+
+    assert validation.status == CONTRADICTED
+    assert "provider_network_export_runtime_prompt_marker" in validation.blockers
+
+
+def test_secret_endpoint_client_marker_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(warning_codes=("client_handle",)))
+
+    assert validation.status == CONTRADICTED
+    assert "secret_endpoint_client_marker" in validation.blockers
+
+
+def test_raw_patch_or_executable_payload_marker_fails_closed() -> None:
+    validation = validate_federated_improvement_intake_receipt(_receipt(warning_codes=("raw_patch",)))
+
+    assert validation.status == CONTRADICTED
+    assert "raw_patch_or_executable_payload_marker" in validation.blockers
+
+
+def test_mapping_candidate_metadata_is_consumed_without_payload() -> None:
+    candidate = _candidate()
+    mapping = {
+        "producing_node_id": candidate.producing_node_id,
+        "local_candidate_id": candidate.local_candidate_id,
+        "candidate_kind": candidate.candidate_kind,
+        "source_amendment_or_proposal_id": candidate.source_amendment_or_proposal_id,
+        "source_commit_ref_digest": candidate.source_commit_ref_digest,
+        "test_evidence": ({"command_label": "py_compile_candidate_module", "result_label": "passed"},),
+        "audit_verification_status": "verified",
+        "immutable_verification_status": "verified",
+        "federation_compatibility_posture": "compatible",
+        "lineage_refs": ("lineage_digest_001",),
+    }
+    receipt = _receipt(candidate=mapping)
+
+    assert validate_federated_improvement_intake_receipt(receipt).status == READY_INSPECTION
+    assert receipt.candidate_digest == compute_federated_improvement_candidate_digest(
+        _candidate(rationale_digest_or_label="", rehearsal_artifact_refs=())
+    )
+
+
+def test_deterministic_digest_behavior() -> None:
+    first = _receipt()
+    equivalent = _receipt()
+    changed = _receipt(local_policy_posture="local_policy_requires_review")
+
+    assert compute_federated_improvement_intake_receipt_digest(first) == compute_federated_improvement_intake_receipt_digest(equivalent)
+    assert compute_federated_improvement_intake_receipt_digest(first) != compute_federated_improvement_intake_receipt_digest(changed)
+
+
+def test_summary_shape_contains_only_ids_digests_statuses_counts_booleans_and_labels() -> None:
+    summary = summarize_federated_improvement_intake_receipt(_receipt())
+
+    forbidden_keys = {
+        "patch_body",
+        "raw_patch",
+        "prompt_text",
+        "endpoint",
+        "client_handle",
+        "runtime_handle",
+        "executable_payload",
+    }
+    assert forbidden_keys.isdisjoint(summary)
+    assert set(summary) == {
+        "receiving_node_id",
+        "producing_node_id",
+        "source_candidate_id",
+        "candidate_digest",
+        "expected_candidate_digest",
+        "receipt_digest",
+        "candidate_kind",
+        "candidate_status",
+        "intake_status",
+        "intake_decision",
+        "candidate_compatibility_posture",
+        "local_compatibility_posture",
+        "local_policy_posture",
+        "required_local_review_gate_count",
+        "accepted_gate_count",
+        "rejected_gate_count",
+        "pending_gate_count",
+        "local_rehearsal_required",
+        "local_adaptation_required",
+        "rejection_reason_count",
+        "warning_count",
+        "lineage_ref_count",
+        "metadata_only",
+        "intake_only",
+        "local_custody_preserved",
+        "candidate_not_adopted",
+        "candidate_not_executed",
+        "no_remote_authority",
+        "no_forced_update",
+        "no_provider_network_export_prompt_runtime_authority",
+        "no_secret_endpoint_client_material",
+        "blocker_count",
+    }
+    assert all(not isinstance(value, (dict, list, tuple)) for value in summary.values())
+
+
+def test_predicate_helpers_remain_conservative() -> None:
+    clean = _receipt()
+    contradicted = _receipt(rejection_reason_codes=("execute_on_receipt",))
+    incomplete = _receipt(receiving_node_id="")
+
+    assert federated_improvement_intake_receipt_allows_inspection(clean)
+    assert not federated_improvement_intake_receipt_has_no_remote_authority(contradicted)
+    assert not federated_improvement_intake_receipt_preserves_local_custody(incomplete)
+    assert federated_improvement_intake_receipt_is_metadata_only(incomplete)
+
+
+def test_statuses_and_decisions_are_compact_and_complete() -> None:
+    assert READY_INSPECTION in INTAKE_STATUSES
+    assert READY_REHEARSAL in INTAKE_STATUSES
+    assert READY_CONDITIONS in INTAKE_STATUSES
+    assert HOLD_REVIEW in INTAKE_STATUSES
+    assert REJECTED in INTAKE_STATUSES
+    assert INCOMPLETE in INTAKE_STATUSES
+    assert CONTRADICTED in INTAKE_STATUSES
+    assert INSPECT in INTAKE_DECISIONS
+    assert REHEARSE in INTAKE_DECISIONS
+    assert ADAPT in INTAKE_DECISIONS
+    assert REJECT in INTAKE_DECISIONS
+    assert HOLD in INTAKE_DECISIONS
+    assert QUEUE in INTAKE_DECISIONS
+
+
+def test_package_init_exports_receipt_api() -> None:
+    module = importlib.import_module("sentientos.federation")
+
+    assert module.FederatedImprovementIntakeReceipt
+    assert module.build_federated_improvement_intake_receipt is build_federated_improvement_intake_receipt
+
+
+def test_no_prompt_assembler_modification() -> None:
+    result = subprocess.run(
+        ["git", "diff", "--quiet", "--", "prompt_assembler.py"],
+        check=False,
+        cwd=".",
+    )
+
+    assert result.returncode == 0
+
+
+def test_no_runtime_provider_network_export_authority_imports() -> None:
+    before = set(sys.modules)
+    module = importlib.import_module("sentientos.federation.improvement_intake_receipt")
+    imported = set(sys.modules) - before
+
+    assert module.FederatedImprovementIntakeReceipt
+    forbidden_modules = {
+        "openai",
+        "requests",
+        "httpx",
+        "socket",
+        "prompt_assembler",
+        "memory_manager",
+        "sentientos.runtime.shell",
+    }
+    assert forbidden_modules.isdisjoint(imported)


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only receiving-node intake artifact to answer whether an incoming `FederatedImprovementCandidate` is eligible for local inspection, rehearsal, adaptation, rejection, or separate local governance review. 
- Preserve receiving-node local custody and explicitly forbid adoption, execution, forced updates, provider/network/export/runtime authority, secrets, or raw/executable payloads inside the receipt. 
- Enforce fail-closed validation for missing metadata, digest mismatches, contradicted/blocked candidates, incompatible postures, governance-bypass markers, and other forbidden markers.

### Description

- Added a new metadata-only intake artifact and helpers in `sentientos/federation/improvement_intake_receipt.py`, including the frozen dataclass `FederatedImprovementIntakeReceipt`, compact intake statuses (`federated_improvement_intake_*`) and decisions (`inspect_only`, `rehearse_locally`, `adapt_locally`, `reject_candidate`, `hold_for_operator_review`, `queue_for_local_governance_review`), deterministic digest, `build_federated_improvement_intake_receipt`, `validate_federated_improvement_intake_receipt`, `compute_federated_improvement_intake_receipt_digest`, `summarize_federated_improvement_intake_receipt`, `explain_federated_improvement_intake_receipt`, and conservative predicate helpers. 
- The builder consumes either a `FederatedImprovementCandidate` or a metadata-safe mapping and records only metadata evidence (ids, digests, kinds, statuses, posture labels, gate codes, booleans, lineage refs, rejection/warning codes), never raw patch bodies, prompts, endpoints, secrets, or runtime handles. 
- Validation is fail-closed for missing receiving node id, missing/invalid candidate metadata, digest mismatch, contradicted candidate status, blocked-candidate rules (must be held or rejected), incompatible federation/local posture, missing required local review gates, governance-bypass markers, adoption/install/apply/merge/execute/provider/network/export/runtime/prompt markers, secret/endpoint/client markers, and raw/executable payload markers. 
- Exported the intake API from `sentientos.federation` by updating `sentientos/federation/__init__.py`. 
- Added focused unit tests in `tests/test_federated_improvement_intake_receipt.py` covering ready-for-inspection, rehearsal, ready-with-conditions, hold-for-review, rejection, incomplete cases, contradictions, blocked-candidate behavior, forbidden markers, deterministic digest and summary shape, conservative predicate behavior, package export, and forbidden imports. 
- Added a short architecture note `docs/architecture/federated_improvement_intake_receipt.md` clarifying that intake is local-custody preservation and not adoption or authority expansion.

### Testing

- Ran byte-compile: `python -m py_compile sentientos/federation/improvement_intake_receipt.py sentientos/federation/__init__.py tests/test_federated_improvement_intake_receipt.py` (succeeded). 
- Ran intake receipt tests: `python -m scripts.run_tests -q tests/test_federated_improvement_intake_receipt.py` (all tests passed). 
- Ran candidate tests: `python -m scripts.run_tests -q tests/test_federated_improvement_candidate.py` (all tests passed). 
- Ran a small selection of federation/governance lightweight suites to ensure no regressions; those runs completed with expected pass/skip behavior for environment-conditional tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02c09d465c83208e68b3837f5352ec)