### PR TITLE
[codex:federation] fix probe schedule prioritization order

### DIFF
--- a/sentientos/trust_ledger.py
+++ b/sentientos/trust_ledger.py
@@ -573,16 +573,21 @@ class FederationTrustLedger:
                 storm_active=storm_active,
             )
             peers = [self._snapshot_for(peer_id) for peer_id in sorted(set(peer_ids))]
+            # Highest-risk peers must sort first:
+            #   1) trust state risk class (incompatible > quarantined > degraded > watched > trusted)
+            #   2) divergence events (higher first)
+            #   3) epoch mismatch events (higher first)
+            #   4) digest mismatch events (higher first)
+            #   5) peer id (ascending) for deterministic tie-breaks.
             prioritized = sorted(
                 peers,
                 key=lambda item: (
-                    _TRUST_ORDER.get(item.trust_state, 9),
+                    -_TRUST_ORDER.get(item.trust_state, 9),
                     -item.divergence_events,
                     -item.epoch_mismatch_events,
                     -item.digest_mismatch_events,
                     item.peer_id,
                 ),
-                reverse=True,
             )
             selected = prioritized[:slots]
             pending: list[dict[str, object]] = []

--- a/tests/test_trust_ledger.py
+++ b/tests/test_trust_ledger.py
@@ -134,3 +134,71 @@ def test_artifacts_are_bounded_and_deterministic_rollup(monkeypatch, tmp_path) -
     assert event_path.exists()
     lines = event_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) <= 5
+
+
+def test_probe_schedule_prioritization_ordering(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("SENTIENTOS_GOVERNOR_ROOT", str(tmp_path / "governor"))
+    monkeypatch.setenv("SENTIENTOS_FEDERATION_ROOT", str(tmp_path / "federation"))
+    monkeypatch.setenv("SENTIENTOS_TRUST_PROBE_PLAN_LIMIT", "10")
+    reset_trust_ledger()
+    ledger = get_trust_ledger()
+
+    for _ in range(3):
+        ledger.record_probe("watch-high-div", status="fail", actor="test", reason="divergence")
+    for _ in range(1):
+        ledger.record_probe("watch-low-div", status="fail", actor="test", reason="divergence")
+
+    for _ in range(2):
+        ledger.record_governance_evaluation(
+            "epoch-high",
+            {"digest_status": "ok", "epoch_status": "unexpected", "quorum_satisfied": True, "denial_cause": "none"},
+            actor="test",
+        )
+    ledger.record_governance_evaluation(
+        "epoch-low",
+        {"digest_status": "ok", "epoch_status": "unexpected", "quorum_satisfied": True, "denial_cause": "none"},
+        actor="test",
+    )
+
+    ledger.record_governance_evaluation(
+        "digest-high",
+        {"digest_status": "incompatible", "epoch_status": "expected", "quorum_satisfied": True, "denial_cause": "none"},
+        actor="test",
+    )
+    ledger.record_governance_evaluation(
+        "digest-high",
+        {"digest_status": "incompatible", "epoch_status": "expected", "quorum_satisfied": True, "denial_cause": "none"},
+        actor="test",
+    )
+    ledger.record_governance_evaluation(
+        "digest-low",
+        {"digest_status": "incompatible", "epoch_status": "expected", "quorum_satisfied": True, "denial_cause": "none"},
+        actor="test",
+    )
+
+    for peer in ("alpha", "beta"):
+        ledger.record_probe(peer, status="ok", actor="test", reason="tie-break")
+
+    schedule = ledger.build_probe_schedule(
+        peer_ids=[
+            "watch-high-div",
+            "watch-low-div",
+            "epoch-high",
+            "epoch-low",
+            "digest-high",
+            "digest-low",
+            "alpha",
+            "beta",
+        ],
+        pressure_composite=0.2,
+        scheduling_window_open=True,
+        storm_active=False,
+    )
+    ordered = [entry["peer_id"] for entry in schedule["pending_actions"]]
+
+    assert ordered.index("watch-high-div") < ordered.index("watch-low-div")
+    assert ordered.index("epoch-high") < ordered.index("epoch-low")
+    assert ordered.index("digest-high") < ordered.index("digest-low")
+    assert ordered.index("digest-high") < ordered.index("watch-high-div")
+    assert ordered.index("watch-high-div") < ordered.index("alpha")
+    assert ordered.index("alpha") < ordered.index("beta")


### PR DESCRIPTION
### Motivation
- The probe scheduler previously mixed negative drift counters with `reverse=True`, which inverted the intended intra-trust-class priority and could schedule lower-divergence peers ahead of higher-divergence ones.  
- The intent is to ensure highest-risk/higher-divergence peers are probed first while preserving deterministic tie-breaking and the public API.

### Description
- Replace the `reverse=True` sort with an explicit descending sort key in `build_probe_schedule` so the key tuple is `(-_TRUST_ORDER.get(...), -divergence_events, -epoch_mismatch_events, -digest_mismatch_events, peer_id)` to make priority intent obvious and deterministic.  
- Add `test_probe_schedule_prioritization_ordering` to `tests/test_trust_ledger.py` to assert that within the same trust class higher divergence/epoch/digest counts sort before lower counts and that trust-class ordering and peer-id tie-breaks remain stable.  
- Files changed: `sentientos/trust_ledger.py` and `tests/test_trust_ledger.py`.

### Testing
- Ran `python -m py_compile sentientos/trust_ledger.py tests/test_trust_ledger.py` and it completed successfully.  
- Ran `python -m scripts.run_tests -q tests/test_trust_ledger.py` and the test suite completed successfully with the modified and existing trust-ledger tests passing.  
- The added test verifies intra-class divergence, epoch, and digest precedence and deterministic peer-id tie-break ordering without introducing any network/transport behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0361de08b0832f8367cb84cd57cb0e)