### PR TITLE
[codex:control-plane] gate forge and merge ticks on maintenance admission

### DIFF
--- a/sentientosd.py
+++ b/sentientosd.py
@@ -182,12 +182,34 @@ def _run_maintenance_tick(
         ),
         execute=runtime_surfaces.monitor,
     )
-    kernel.set_phase(LifecyclePhase.RUNTIME, actor="sentientosd")
     # Sentinel runs after integrity guard so contract artifacts are trustworthy, before forge daemon so queued repairs execute same tick.
     if os.getenv("SENTIENTOS_SENTINEL_ENABLED", "0") == "1":
         contract_sentinel.tick()
-    forge_daemon.run_tick()
-    merge_train.tick()
+    feedback = runtime_surfaces.governance_feedback()
+    kernel.admit_and_execute(
+        ControlActionRequest(
+            action_kind="forge_tick",
+            authority_class=AuthorityClass.REPAIR,
+            actor="sentientosd",
+            target_subsystem="forge_daemon",
+            requested_phase=LifecyclePhase.MAINTENANCE,
+            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:forge_tick"},
+        ),
+        execute=forge_daemon.run_tick,
+    )
+    feedback = runtime_surfaces.governance_feedback()
+    kernel.admit_and_execute(
+        ControlActionRequest(
+            action_kind="merge_tick",
+            authority_class=AuthorityClass.REPAIR,
+            actor="sentientosd",
+            target_subsystem="forge_merge_train",
+            requested_phase=LifecyclePhase.MAINTENANCE,
+            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:merge_tick"},
+        ),
+        execute=merge_train.tick,
+    )
+    kernel.set_phase(LifecyclePhase.RUNTIME, actor="sentientosd")
 
     plan = runtime_surfaces.next_commit()
     if plan:

--- a/tests/test_sentientosd_runtime_closure.py
+++ b/tests/test_sentientosd_runtime_closure.py
@@ -246,8 +246,12 @@ def test_governor_denial_prevents_daemon_loop_side_effects(tmp_path: Path) -> No
     assert surfaces.cycle_calls == 0
     assert surfaces.guard_calls == 0
     assert surfaces.monitor_calls == 0
-    assert forge.calls == 1
-    assert merge.calls == 1
+    assert forge.calls == 0
+    assert merge.calls == 0
+
+    rows = [json.loads(line) for line in (tmp_path / "decisions.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("action_kind") == "forge_tick" and row.get("final_disposition") == "deny" for row in rows)
+    assert any(row.get("action_kind") == "merge_tick" and row.get("final_disposition") == "deny" for row in rows)
 
 
 def test_runtime_feedback_degradation_is_reused_for_later_maintenance_gating(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Close a maintenance-loop side-channel where `_run_maintenance_tick` called `forge_daemon.run_tick()` and `merge_train.tick()` unconditionally even when the runtime/governor denied admitted maintenance surfaces. 
- Ensure mutating maintenance work from the forge/merge paths is subject to the same control-plane admission checks and preserve fail-closed governance.

### Description
- Route `forge_daemon.run_tick()` through `ControlPlaneKernel.admit_and_execute(...)` with `action_kind="forge_tick"`, `authority_class=AuthorityClass.REPAIR`, and `requested_phase=LifecyclePhase.MAINTENANCE` before execution. 
- Route `merge_train.tick()` through `ControlPlaneKernel.admit_and_execute(...)` with `action_kind="merge_tick"`, `authority_class=AuthorityClass.REPAIR`, and `requested_phase=LifecyclePhase.MAINTENANCE` before execution. 
- Restore `kernel.set_phase(LifecyclePhase.RUNTIME, ...)` only after the admission-controlled forge/merge calls complete, and avoid `startup_symbol` mediation for these ticks to prevent startup-only gating. 
- Update `tests/test_sentientosd_runtime_closure.py` to assert that governor denial prevents forge/merge ticks from running and that explicit deny decisions for `forge_tick` and `merge_tick` are recorded.

### Testing
- Ran byte-compile with `python -m py_compile sentientosd.py tests/test_sentientosd_runtime_closure.py` and it succeeded. 
- Ran focused test suites with `python -m scripts.run_tests -q tests/test_sentientosd_runtime_closure.py tests/test_control_plane_kernel.py` and all tests passed. 
- Existing runtime-closure tests were adjusted to prove denied maintenance does not allow forge/merge side-effect ticks and to verify deny decisions are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03686b69d0832f9c37746db2b651b6)