### PR TITLE
[codex:chat] harden lazy model load and code execution defaults

### DIFF
--- a/sentientos/chat_service.py
+++ b/sentientos/chat_service.py
@@ -13,13 +13,22 @@ from .local_model import LocalModel
 
 LOGGER = logging.getLogger(__name__)
 APP = FastAPI(title="SentientOS Chat", version="1.0")
-_MODEL = LocalModel.autoload()
+_MODEL: LocalModel | None = None
 try:
     _CHANGE_NARRATOR = build_default_change_narrator()
 except Exception:  # pragma: no cover - defensive initialization
     LOGGER.exception("Unable to initialise change narrator")
     _CHANGE_NARRATOR = None
 
+
+
+
+def _get_model() -> LocalModel:
+    global _MODEL
+    if _MODEL is None:
+        _MODEL = LocalModel.autoload()
+        LOGGER.info("Chat model loaded: %s", _MODEL.describe())
+    return _MODEL
 
 class ChatRequest(BaseModel):
     message: str
@@ -37,7 +46,7 @@ class BootEvent(BaseModel):
 
 @APP.on_event("startup")
 async def _startup_event() -> None:
-    LOGGER.info("Chat interface ready using %s", _MODEL.describe())
+    LOGGER.info("Chat interface ready")
 
 
 @APP.post("/chat", response_model=ChatResponse)
@@ -49,7 +58,7 @@ async def chat_endpoint(request: ChatRequest) -> ChatResponse:
         summary = _CHANGE_NARRATOR.maybe_respond(message)
         if summary is not None:
             return ChatResponse(response=summary)
-    reply = _MODEL.generate(message)
+    reply = _get_model().generate(message)
     return ChatResponse(response=reply)
 
 

--- a/sentientos/local_model.py
+++ b/sentientos/local_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
@@ -13,6 +14,8 @@ from .storage import ensure_mounts, get_data_root
 LOGGER = logging.getLogger(__name__)
 
 _MODEL_META_NAME = "model.json"
+_ALLOW_MODEL_CODE_EXEC_ENV = "SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION"
+
 
 __all__ = ["LocalModel"]
 
@@ -110,7 +113,12 @@ class _TransformersBackend(_ModelBackend):
             raise ModelLoadError(f"Model path {model_location} does not exist")
 
         self._torch = torch
-        self._tokenizer = AutoTokenizer.from_pretrained(model_location, trust_remote_code=True, local_files_only=True)
+        trust_remote_code = _allow_model_code_execution(candidate, metadata)
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_location,
+            trust_remote_code=trust_remote_code,
+            local_files_only=True,
+        )
         device_map: Optional[str]
         torch_dtype: Optional[torch.dtype]
         if torch.cuda.is_available():
@@ -123,7 +131,7 @@ class _TransformersBackend(_ModelBackend):
             model_location,
             device_map=device_map,
             torch_dtype=torch_dtype,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             local_files_only=True,
         )
         self._generation = generation
@@ -159,6 +167,41 @@ class _TransformersBackend(_ModelBackend):
         if decoded.startswith(prompt):
             decoded = decoded[len(prompt) :]
         return decoded.strip() or ""
+
+
+def _allow_model_code_execution(candidate: ModelCandidate, metadata: Dict[str, Any]) -> bool:
+    allow_env = os.getenv(_ALLOW_MODEL_CODE_EXEC_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+    allow_option = bool(candidate.options.get("allow_model_code_execution"))
+    allow_metadata = bool(metadata.get("allow_model_code_execution"))
+    allow = allow_env or allow_option or allow_metadata
+    if allow:
+        manifest_hash = _candidate_manifest_hash(candidate)
+        if manifest_hash is not None:
+            LOGGER.warning(
+                "Model code execution enabled for %s with manifest hash %s",
+                candidate.display_name(),
+                manifest_hash,
+            )
+        else:
+            LOGGER.warning(
+                "Model code execution enabled for %s without escrow manifest hash",
+                candidate.display_name(),
+            )
+        return True
+    return False
+
+
+def _candidate_manifest_hash(candidate: ModelCandidate) -> Optional[str]:
+    if candidate.path is None:
+        return None
+    manifest_path = LocalModel._candidate_meta_path(candidate.path)
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = manifest_path.read_bytes()
+    except OSError:
+        return None
+    return hashlib.sha256(payload).hexdigest()
 
 
 class _LlamaCppBackend(_ModelBackend):

--- a/tests/test_chat_service_lazy_loading.py
+++ b/tests/test_chat_service_lazy_loading.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+def _reload_chat_service():
+    sys.modules.pop("sentientos.chat_service", None)
+    import sentientos.chat_service as chat_service
+
+    return importlib.reload(chat_service)
+
+
+def test_import_does_not_autoload_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "sentientos.local_model.LocalModel.autoload",
+        lambda: calls.append("autoload") or SimpleNamespace(describe=lambda: "fake", generate=lambda _: "ok"),
+    )
+
+    chat_service = _reload_chat_service()
+
+    assert calls == []
+    assert chat_service._MODEL is None
+
+
+def test_health_paths_do_not_load_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "sentientos.local_model.LocalModel.autoload",
+        lambda: calls.append("autoload") or SimpleNamespace(describe=lambda: "fake", generate=lambda _: "ok"),
+    )
+    chat_service = _reload_chat_service()
+    client = TestClient(chat_service.APP)
+
+    root = client.get("/")
+    boot = client.get("/boot-feed")
+
+    assert root.status_code == 200
+    assert boot.status_code == 200
+    assert calls == []
+
+
+def test_first_chat_request_lazy_loads_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    class FakeModel:
+        def describe(self) -> str:
+            return "fake"
+
+        def generate(self, prompt: str) -> str:
+            return f"reply:{prompt}"
+
+    monkeypatch.setattr("sentientos.local_model.LocalModel.autoload", lambda: calls.append("autoload") or FakeModel())
+    chat_service = _reload_chat_service()
+    client = TestClient(chat_service.APP)
+
+    resp = client.post("/chat", json={"message": "hello"})
+
+    assert resp.status_code == 200
+    assert resp.json()["response"] == "reply:hello"
+    assert calls == ["autoload"]
+
+
+def test_dependency_injection_model_without_autoload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "sentientos.local_model.LocalModel.autoload",
+        lambda: (_ for _ in ()).throw(AssertionError("autoload should not be called")),
+    )
+    chat_service = _reload_chat_service()
+
+    class FakeModel:
+        def describe(self) -> str:
+            return "fake"
+
+        def generate(self, prompt: str) -> str:
+            return f"injected:{prompt}"
+
+    chat_service._MODEL = FakeModel()
+    client = TestClient(chat_service.APP)
+
+    resp = client.post("/chat", json={"message": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["response"] == "injected:hello"

--- a/tests/test_local_model.py
+++ b/tests/test_local_model.py
@@ -152,3 +152,136 @@ def test_local_model_gguf_mistral_backend(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert "Mistral" in model.metadata.get("name", "")
     response = model.generate("Hello cathedral")
     assert "Mistral echoes" in response
+
+
+def test_transformers_backend_defaults_trust_remote_code_false(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    model_dir = _prepare_candidate(tmp_path, "hf-local")
+    config = {"candidates": [{"path": str(model_dir), "engine": "transformers", "name": "HF"}]}
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+    monkeypatch.delenv("SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION", raising=False)
+
+    calls: dict[str, object] = {}
+
+    class DummyTorch:
+        float16 = object()
+        float32 = object()
+        class cuda:
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_location: str, **kwargs: object):
+            calls["tokenizer"] = kwargs
+            return cls()
+
+    class DummyModel:
+        device = "cpu"
+
+        @classmethod
+        def from_pretrained(cls, model_location: str, **kwargs: object):
+            calls["model"] = kwargs
+            return cls()
+
+        def generate(self, **kwargs: object):
+            return [[1]]
+
+    class DummyTransformers:
+        AutoTokenizer = DummyTokenizer
+        AutoModelForCausalLM = DummyModel
+
+    monkeypatch.setattr("sentientos.local_model.optional_import", lambda name, feature=None: DummyTorch if name == "torch" else DummyTransformers)
+
+    LocalModel.autoload()
+
+    assert calls["tokenizer"]["trust_remote_code"] is False
+    assert calls["model"]["trust_remote_code"] is False
+    assert calls["tokenizer"]["local_files_only"] is True
+    assert calls["model"]["local_files_only"] is True
+
+
+def test_transformers_backend_opt_in_enables_trust_remote_code(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    model_dir = _prepare_candidate(tmp_path, "hf-local")
+    config = {"candidates": [{"path": str(model_dir), "engine": "transformers", "name": "HF"}]}
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+    monkeypatch.setenv("SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION", "1")
+
+    calls: dict[str, object] = {}
+
+    class DummyTorch:
+        float16 = object()
+        float32 = object()
+        class cuda:
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_location: str, **kwargs: object):
+            calls["tokenizer"] = kwargs
+            return cls()
+
+    class DummyModel:
+        device = "cpu"
+
+        @classmethod
+        def from_pretrained(cls, model_location: str, **kwargs: object):
+            calls["model"] = kwargs
+            return cls()
+
+        def generate(self, **kwargs: object):
+            return [[1]]
+
+    class DummyTransformers:
+        AutoTokenizer = DummyTokenizer
+        AutoModelForCausalLM = DummyModel
+
+    monkeypatch.setattr("sentientos.local_model.optional_import", lambda name, feature=None: DummyTorch if name == "torch" else DummyTransformers)
+
+    LocalModel.autoload()
+
+    assert calls["tokenizer"]["trust_remote_code"] is True
+    assert calls["model"]["trust_remote_code"] is True
+
+
+def test_transformers_custom_code_requirement_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    model_dir = _prepare_candidate(tmp_path, "hf-local")
+    config = {"candidates": [{"path": str(model_dir), "engine": "transformers", "name": "HF"}]}
+    config_path = _write_config(tmp_path, config)
+    monkeypatch.setenv("SENTIENTOS_DATA_DIR", str(data_root))
+    monkeypatch.setenv("SENTIENTOS_MODEL_CONFIG", str(config_path))
+    monkeypatch.delenv("SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION", raising=False)
+
+    class DummyTorch:
+        float16 = object()
+        float32 = object()
+        class cuda:
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_location: str, **kwargs: object):
+            if kwargs.get("trust_remote_code") is False:
+                raise ValueError("requires trust_remote_code=True")
+            return cls()
+
+    class DummyTransformers:
+        AutoTokenizer = DummyTokenizer
+        AutoModelForCausalLM = object
+
+    monkeypatch.setattr("sentientos.local_model.optional_import", lambda name, feature=None: DummyTorch if name == "torch" else DummyTransformers)
+
+    model = LocalModel.autoload()
+    assert model.metadata.get("engine") == "null"
+    assert any("requires trust_remote_code=True" in err for err in model.metadata.get("errors", []))


### PR DESCRIPTION
### Motivation
- Prevent heavyweight local model initialization at import-time so tooling, health checks, and CLI discovery can import `sentientos.chat_service` without triggering model loading.
- Reduce attack surface from automatic execution of model-provided Python by making `trust_remote_code` opt-in instead of enabled by default.
- Preserve existing API behavior for chat requests while ensuring fail-closed, diagnosable behavior when custom model code is required.

### Description
- Make model loading lazy in `sentientos/chat_service.py` by replacing the import-time `LocalModel.autoload()` with `_MODEL: LocalModel | None = None` and a one-time `_get_model()` loader used on first `/chat` inference. 
- Harden transformers backend in `sentientos/local_model.py` by defaulting `trust_remote_code=False`, preserving `local_files_only=True`, and consulting an explicit opt-in via `SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION`, candidate `allow_model_code_execution` option, or metadata `allow_model_code_execution` before enabling remote/custom model code execution. 
- Add manifest hashing (`sha256`) diagnostics for candidate metadata to log escrow/manifest posture when code execution is opted-in and record helpful warnings when manifest is missing. 
- Add tests and test updates: new `tests/test_chat_service_lazy_loading.py` for import/health/lazy-load behavior and expanded `tests/test_local_model.py` cases for transformers safety (defaults, opt-in, fail-closed); files changed: `sentientos/chat_service.py`, `sentientos/local_model.py`, `tests/test_chat_service_lazy_loading.py`, and `tests/test_local_model.py`.

### Testing
- Compiled modified modules and tests with `python -m py_compile sentientos/chat_service.py sentientos/local_model.py tests/test_chat_service_lazy_loading.py tests/test_local_model.py` which completed successfully. 
- Invoked the repository test harness with `python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py` but collection failed due to an environment/test-harness incompatibility (an internal pytest collection error caused by `tests/integration/conftest.py` mutating `item.keywords` under the pytest version installed). 
- Because of the harness issue, focused unit assertions are present in the new/updated tests but end-to-end CI execution was blocked and should be re-run in the project CI environment with the expected pytest version to validate the new tests. 
- All source edits are py-compile clean and tests are included to prove: `LocalModel.autoload()` is not invoked at import, first chat request lazily loads model, dependency injection works without autoload, transformers default to `trust_remote_code=False`, opt-in enables it, and custom-code-required models fail-closed when opt-in is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a039b96312c832fa6a6b9993628b03c)