### PR TITLE
[codex:test-harness] repair integration pytest marker compatibility

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -997,7 +997,14 @@ def main(argv: list[str] | None = None) -> int:
     if pytest_exit_code == 5:
         exit_reason = "no-tests-collected"
     elif pytest_exit_code != 0:
-        if metrics_status in {"unavailable", "partial"}:
+        if (
+            metrics_status == "ok"
+            and isinstance(tests_executed, int)
+            and tests_executed == 0
+            and pytest_exit_code in {2, 3, 4}
+        ):
+            exit_reason = "pytest-collection-failed"
+        elif metrics_status in {"unavailable", "partial"}:
             exit_reason = "bootstrap-metrics-failed"
         else:
             exit_reason = "pytest-failed"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     for item in items:
         if 'tests/integration' in str(item.fspath):
-            # Remove skip markers added by parent conftest
-            item.keywords.pop('skip', None)
-            item.own_markers = [m for m in item.own_markers if m.name != 'skip']
+            # Remove skip markers added by parent conftest without mutating
+            # pytest's keywords mapping, which is intentionally not deletable.
+            item.own_markers = [marker for marker in item.own_markers if marker.name != 'skip']

--- a/tests/test_integration_conftest_compat.py
+++ b/tests/test_integration_conftest_compat.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_CONFTEST = REPO_ROOT / "tests" / "integration" / "conftest.py"
+
+
+def _load_integration_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "sentientos_integration_conftest_under_test",
+        INTEGRATION_CONFTEST,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_integration_conftest_does_not_mutate_item_keywords_directly() -> None:
+    tree = ast.parse(INTEGRATION_CONFTEST.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "keywords"
+                and node.func.attr in {"pop", "popitem", "clear", "update", "setdefault"}
+            )
+        if isinstance(node, (ast.Delete, ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            targets = []
+            if isinstance(node, ast.Delete):
+                targets = list(node.targets)
+            elif isinstance(node, ast.Assign):
+                targets = list(node.targets)
+            else:
+                targets = [node.target]
+            for target in targets:
+                assert not (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Attribute)
+                    and target.value.attr == "keywords"
+                )
+
+
+def test_integration_skip_override_uses_marker_metadata_without_keywords_access() -> None:
+    integration_conftest = _load_integration_conftest()
+
+    class IntegrationItem:
+        fspath = Path("tests/integration/test_chat_mistral_runtime.py")
+        own_markers = [SimpleNamespace(name="skip"), SimpleNamespace(name="legacy")]
+
+        @property
+        def keywords(self):  # pragma: no cover - the assertion is the behavior under test.
+            raise AssertionError("integration conftest must not mutate or inspect item.keywords")
+
+    item = IntegrationItem()
+
+    integration_conftest.pytest_collection_modifyitems(SimpleNamespace(), [item])
+
+    assert [marker.name for marker in item.own_markers] == ["legacy"]
+
+
+def test_integration_skip_override_leaves_non_integration_items_unchanged() -> None:
+    integration_conftest = _load_integration_conftest()
+    skip_marker = SimpleNamespace(name="skip")
+    unit_item = SimpleNamespace(
+        fspath=Path("tests/test_chat_service_lazy_loading.py"),
+        own_markers=[skip_marker],
+    )
+
+    integration_conftest.pytest_collection_modifyitems(SimpleNamespace(), [unit_item])
+
+    assert unit_item.own_markers == [skip_marker]

--- a/tests/test_run_tests_bootstrap_airlock.py
+++ b/tests/test_run_tests_bootstrap_airlock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -17,15 +18,23 @@ class _Completed:
         self.stdout = stdout
 
 
-def _write_report(env: dict[str, str] | None, *, failed: int = 0, passed: int = 1) -> None:
+def _write_report(
+    env: dict[str, str] | None,
+    *,
+    failed: int = 0,
+    passed: int = 1,
+    collected: int | None = None,
+    selected: int | None = None,
+    executed: int | None = None,
+) -> None:
     assert env is not None
     report_path = Path(env["SENTIENTOS_PYTEST_REPORT_PATH"])
     report_path.write_text(
         json.dumps(
             {
-                "tests_collected": passed + failed,
-                "tests_selected": passed + failed,
-                "tests_executed": passed + failed,
+                "tests_collected": collected if collected is not None else passed + failed,
+                "tests_selected": selected if selected is not None else passed + failed,
+                "tests_executed": executed if executed is not None else passed + failed,
                 "tests_passed": passed,
                 "tests_failed": failed,
                 "tests_skipped": 0,
@@ -37,6 +46,24 @@ def _write_report(env: dict[str, str] | None, *, failed: int = 0, passed: int = 
         ),
         encoding="utf-8",
     )
+
+
+def test_minimal_airlock_pytest_constraint_matches_project_declaration() -> None:
+    pyproject = tomllib.loads((run_tests.REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project_pytest_specs = {
+        dep
+        for dep in pyproject["project"]["dependencies"]
+        if dep.startswith("pytest") and not dep.startswith("pytest-")
+    }
+    test_extra_pytest_specs = {
+        dep
+        for dep in pyproject["project"]["optional-dependencies"]["test"]
+        if dep.startswith("pytest") and not dep.startswith("pytest-")
+    }
+
+    assert project_pytest_specs == {"pytest>=7,<8"}
+    assert test_extra_pytest_specs == project_pytest_specs
+    assert set(run_tests.MINIMAL_TEST_AIRLOCK_DEPS) >= project_pytest_specs
 
 
 def test_targeted_missing_editable_uses_minimal_airlock_without_broad_deps(monkeypatch, tmp_path):
@@ -259,3 +286,35 @@ def test_naked_pytest_bypass_still_marks_run_exceptional(monkeypatch):
 
     assert run_intent == "exceptional"
     assert selection == ["tests/test_focused.py"]
+
+
+def test_collection_failure_is_distinct_from_test_failure(monkeypatch, tmp_path):
+    def fake_run(cmd, cwd=None, env=None, capture_output=False, text=False, check=False):
+        if cmd[:3] == [run_tests.sys.executable, "-m", "pytest"]:
+            _write_report(env, passed=0, failed=0, collected=3, selected=3, executed=0)
+            return _Completed(2)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return _Completed(0, "c011ec7\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(run_tests, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        run_tests,
+        "get_editable_install_status",
+        lambda _root: EditableInstallStatus(True, "direct-url"),
+    )
+    monkeypatch.setattr(run_tests, "_imports_ok", lambda: (True, None))
+    monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+    code = run_tests.main(["-q", "tests/test_focused.py"])
+
+    assert code == 2
+    payload = json.loads(
+        (tmp_path / "glow" / "test_runs" / "test_run_provenance.json").read_text(encoding="utf-8")
+    )
+    assert payload["exit_reason"] == "pytest-collection-failed"
+    assert payload["exit_reason"] != "pytest-failed"
+    assert payload["pytest_exit_code"] == 2
+    assert payload["tests_executed"] == 0
+    assert payload["tests_failed"] == 0
+    assert payload["metrics_status"] == "ok"


### PR DESCRIPTION
### Motivation
- Pytest collection was blocked by `tests/integration/conftest.py` calling `item.keywords.pop('skip', ...)`, which raises on the pytest `keywords` mapping and prevented collection under the runner-installed pytest; the test harness must avoid mutating pytest internals. 
- The test runner's minimal airlock must remain deterministic and aligned with the project's declared pytest constraint (`pytest>=7,<8`), and collection failures must be reported separately from test assertion failures.

### Description
- Update `tests/integration/conftest.py` to stop mutating `item.keywords` and instead filter `item.own_markers` to remove parent-added `skip` markers: use `item.own_markers = [marker for marker in item.own_markers if marker.name != 'skip']`.
- Make the runner preserve collection-vs-test-failure provenance by adding a distinct `pytest-collection-failed` exit reason in `scripts/run_tests.py` when `metrics_status == "ok"`, `tests_executed == 0`, and `pytest_exit_code` is a collection-level code (`2,3,4`).
- Add `tests/test_integration_conftest_compat.py` to assert the integration conftest no longer mutates `item.keywords`, removes skip markers via `own_markers`, and leaves non-integration items unchanged.
- Extend `tests/test_run_tests_bootstrap_airlock.py` to (a) verify the minimal airlock pytest constraint matches the project declaration and (b) add a focused test proving a collection failure produces the `pytest-collection-failed` exit reason and remains distinct from `pytest-failed`.

### Testing
- Ran `python -m py_compile tests/integration/conftest.py scripts/run_tests.py` and compilation succeeded.
- Ran `python -m scripts.run_tests -q tests/test_integration_conftest_compat.py tests/test_run_tests_bootstrap_airlock.py` and both test modules passed (dot output, reporter xmls generated). 
- Ran `python -m scripts.run_tests -q tests/test_run_tests_bootstrap_airlock.py` and `python -m scripts.run_tests -q tests/test_integration_conftest_compat.py` individually and both passed.
- Ran the original command `python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py`; collection now proceeds to execution, but two existing assertion failures remain in the product hardening tests: `test_transformers_custom_code_requirement_fails_closed` and `test_chat_endpoint_uses_mistral_backend` (these failures are unrelated to the collection blocker and reflect test/model hardening behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03f3f8726483209a8f4a1f956a4fcc)