### PR TITLE
[codex:model] harden local chat model tests

### DIFF
--- a/sentientos/local_model.py
+++ b/sentientos/local_model.py
@@ -114,11 +114,18 @@ class _TransformersBackend(_ModelBackend):
 
         self._torch = torch
         trust_remote_code = _allow_model_code_execution(candidate, metadata)
-        self._tokenizer = AutoTokenizer.from_pretrained(
-            model_location,
-            trust_remote_code=trust_remote_code,
-            local_files_only=True,
-        )
+        try:
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                model_location,
+                trust_remote_code=trust_remote_code,
+                local_files_only=True,
+            )
+        except Exception as exc:
+            raise _model_load_error_for_transformers_exception(
+                exc,
+                trust_remote_code=trust_remote_code,
+                phase="tokenizer",
+            ) from exc
         device_map: Optional[str]
         torch_dtype: Optional[torch.dtype]
         if torch.cuda.is_available():
@@ -127,13 +134,20 @@ class _TransformersBackend(_ModelBackend):
         else:
             device_map = None
             torch_dtype = torch.float32
-        self._model = AutoModelForCausalLM.from_pretrained(
-            model_location,
-            device_map=device_map,
-            torch_dtype=torch_dtype,
-            trust_remote_code=trust_remote_code,
-            local_files_only=True,
-        )
+        try:
+            self._model = AutoModelForCausalLM.from_pretrained(
+                model_location,
+                device_map=device_map,
+                torch_dtype=torch_dtype,
+                trust_remote_code=trust_remote_code,
+                local_files_only=True,
+            )
+        except Exception as exc:
+            raise _model_load_error_for_transformers_exception(
+                exc,
+                trust_remote_code=trust_remote_code,
+                phase="model",
+            ) from exc
         self._generation = generation
         self._max_context_tokens = max_context_tokens
 
@@ -167,6 +181,32 @@ class _TransformersBackend(_ModelBackend):
         if decoded.startswith(prompt):
             decoded = decoded[len(prompt) :]
         return decoded.strip() or ""
+
+
+def _model_load_error_for_transformers_exception(
+    exc: Exception,
+    *,
+    trust_remote_code: bool,
+    phase: str,
+) -> ModelLoadError:
+    message = str(exc) or exc.__class__.__name__
+    if not trust_remote_code and _requires_custom_model_code(message):
+        return ModelLoadError(
+            "transformers model requires custom code but explicit opt-in is absent; "
+            "refusing to enable trust_remote_code=True. "
+            f"Set {_ALLOW_MODEL_CODE_EXEC_ENV}=1 only for audited local weights. "
+            f"Original {phase} loader error: {message}"
+        )
+    return ModelLoadError(f"transformers {phase} loader failed: {message}")
+
+
+def _requires_custom_model_code(message: str) -> bool:
+    normalized = message.lower().replace("-", "_")
+    return (
+        "trust_remote_code" in normalized
+        or "custom code" in normalized
+        or "remote code" in normalized
+    )
 
 
 def _allow_model_code_execution(candidate: ModelCandidate, metadata: Dict[str, Any]) -> bool:

--- a/tests/integration/test_chat_mistral_runtime.py
+++ b/tests/integration/test_chat_mistral_runtime.py
@@ -1,5 +1,4 @@
 import importlib
-import importlib
 import sys
 import types
 from pathlib import Path
@@ -8,6 +7,8 @@ import pytest
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
+
+from sentientos.optional_deps import reset_optional_dependency_state
 
 
 def _prepare_mistral(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -37,6 +38,7 @@ def test_chat_endpoint_uses_mistral_backend(monkeypatch: pytest.MonkeyPatch, tmp
             return {"choices": [{"text": f"Mistral test reply: {prompt}"}]}
 
     monkeypatch.setitem(sys.modules, "llama_cpp", types.SimpleNamespace(Llama=DummyLlama))
+    reset_optional_dependency_state()
 
     sys.modules.pop("sentientos.chat_service", None)
     chat_service = importlib.import_module("sentientos.chat_service")

--- a/tests/test_local_model.py
+++ b/tests/test_local_model.py
@@ -284,4 +284,7 @@ def test_transformers_custom_code_requirement_fails_closed(monkeypatch: pytest.M
 
     model = LocalModel.autoload()
     assert model.metadata.get("engine") == "null"
-    assert any("requires trust_remote_code=True" in err for err in model.metadata.get("errors", []))
+    errors = model.metadata.get("errors", [])
+    assert any("requires custom code" in err for err in errors)
+    assert any("explicit opt-in is absent" in err for err in errors)
+    assert any("refusing to enable trust_remote_code=True" in err for err in errors)


### PR DESCRIPTION
### Motivation
- Prevent silent or non-deterministic transformer loader failures from bypassing the fail-closed safety behavior when `trust_remote_code` is not opted-in.
- Keep chat service lazy-loading intact while making integration tests deterministic when tests inject fake backends.
- Provide clearer diagnostics when a transformer model requires custom/remote code so operators can opt-in deliberately via `SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION`.

### Description
- Wrap `transformers` tokenizer and model `from_pretrained` calls in `sentientos/local_model.py` with try/except and convert exceptions into deterministic `ModelLoadError` diagnostics via a new helper `_model_load_error_for_transformers_exception` that detects "requires custom code" cases and preserves the `trust_remote_code` policy.
- Add `_requires_custom_model_code(...)` to classify loader messages that indicate a custom/remote-code requirement and produce an explicit fail-closed message recommending `SENTIENTOS_ALLOW_MODEL_CODE_EXECUTION` opt-in for audited local weights.
- Update `tests/test_local_model.py` to assert the new, explicit fail-closed diagnostic text instead of matching the previous brittle substring.
- Reset the optional-dependency import cache in `tests/integration/test_chat_mistral_runtime.py` after injecting the fake `llama_cpp` module by calling `reset_optional_dependency_state()` so the integration chat endpoint deterministically picks the test fake backend without reintroducing import-time autoload.

### Testing
- Ran `python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py` and all tests in that set passed.
- Ran `python -m scripts.run_tests -q tests/test_integration_conftest_compat.py tests/test_run_tests_bootstrap_airlock.py` and the suite passed.
- Ran `python -m py_compile sentientos/chat_service.py sentientos/local_model.py tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py` and compilation succeeded.

Files changed: `sentientos/local_model.py`, `tests/test_local_model.py`, `tests/integration/test_chat_mistral_runtime.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03f6092924832085a7f6e16a73c1e6)