### PR TITLE
[codex:maintenance] harden maintenance degradation boundary

### DIFF
--- a/sentientosd.py
+++ b/sentientosd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import signal
@@ -119,6 +120,51 @@ class RuntimeMaintenanceSurfaces:
         self._feedback["degraded"] = degraded
 
 
+def _maintenance_degradation_signal(
+    *,
+    tick_id: str,
+    surface: str,
+    correlation_id: str,
+    phase_before: Any,
+    phase_at_failure: Any,
+    exc: BaseException,
+) -> dict[str, Any]:
+    return {
+        "event_type": "runtime_maintenance_degradation",
+        "schema": "runtime_maintenance_degradation:v1",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tick_id": tick_id,
+        "correlation_id": correlation_id,
+        "phase": LifecyclePhase.MAINTENANCE.value,
+        "phase_before": getattr(phase_before, "value", str(phase_before)),
+        "phase_at_failure": getattr(phase_at_failure, "value", str(phase_at_failure)),
+        "surface": surface,
+        "actor": "sentientosd",
+        "severity": "blocking",
+        "disposition": "fail_stop_degraded",
+        "stopped_active_cycle": True,
+        "retry_attempted": False,
+        "follow_up_enqueued": False,
+        "reinterpreted_as_goal": False,
+        "failure_type": type(exc).__name__,
+        "failure_message": str(exc),
+    }
+
+
+def _record_maintenance_degradation(*, kernel: Any, signal: dict[str, Any]) -> None:
+    logging.getLogger("sentientos.degradation").error(json.dumps(signal, sort_keys=True))
+    append = getattr(kernel, "_append", None)
+    if callable(append):
+        try:
+            append(signal)
+        except Exception:
+            LOGGER.warning(
+                "Failed to append runtime maintenance degradation signal",
+                extra={"correlation_id": signal.get("correlation_id"), "surface": signal.get("surface")},
+                exc_info=True,
+            )
+
+
 def _run_maintenance_tick(
     *,
     kernel: Any,
@@ -128,94 +174,137 @@ def _run_maintenance_tick(
     merge_train: ForgeMergeTrain,
 ) -> None:
     LOGGER.debug("SentientOS daemon tick")
-    kernel.set_phase(LifecyclePhase.MAINTENANCE, actor="sentientosd")
+    phase_before = getattr(kernel, "phase", LifecyclePhase.RUNTIME)
     tick_id = datetime.now(timezone.utc).isoformat()
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="expand",
-            authority_class=AuthorityClass.PROPOSAL_EVALUATION,
-            actor="sentientosd",
-            target_subsystem="genesis_forge",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            startup_symbol="GenesisForge",
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:expand"},
-        ),
-        execute=runtime_surfaces.expand,
-    )
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="cycle",
-            authority_class=AuthorityClass.SPEC_AMENDMENT,
-            actor="sentientosd",
-            target_subsystem="spec_amender",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            startup_symbol="SpecAmender",
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:cycle"},
-        ),
-        execute=runtime_surfaces.cycle,
-    )
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="guard",
-            authority_class=AuthorityClass.PROPOSAL_EVALUATION,
-            actor="sentientosd",
-            target_subsystem="integrity_daemon",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            startup_symbol="IntegrityDaemon",
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:guard"},
-        ),
-        execute=runtime_surfaces.guard,
-    )
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="monitor",
-            authority_class=AuthorityClass.REPAIR,
-            actor="sentientosd",
-            target_subsystem="codex_healer",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            startup_symbol="CodexHealer",
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:monitor"},
-        ),
-        execute=runtime_surfaces.monitor,
-    )
-    # Sentinel runs after integrity guard so contract artifacts are trustworthy, before forge daemon so queued repairs execute same tick.
-    if os.getenv("SENTIENTOS_SENTINEL_ENABLED", "0") == "1":
-        contract_sentinel.tick()
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="forge_tick",
-            authority_class=AuthorityClass.REPAIR,
-            actor="sentientosd",
-            target_subsystem="forge_daemon",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:forge_tick"},
-        ),
-        execute=forge_daemon.run_tick,
-    )
-    feedback = runtime_surfaces.governance_feedback()
-    kernel.admit_and_execute(
-        ControlActionRequest(
-            action_kind="merge_tick",
-            authority_class=AuthorityClass.REPAIR,
-            actor="sentientosd",
-            target_subsystem="forge_merge_train",
-            requested_phase=LifecyclePhase.MAINTENANCE,
-            metadata={"runtime_feedback": feedback, "correlation_id": f"{tick_id}:merge_tick"},
-        ),
-        execute=merge_train.tick,
-    )
-    kernel.set_phase(LifecyclePhase.RUNTIME, actor="sentientosd")
+    current_surface = "maintenance_start"
+    current_correlation_id = f"{tick_id}:{current_surface}"
 
-    plan = runtime_surfaces.next_commit()
-    if plan:
-        LOGGER.info("Codex amendment ready for commit: %s", plan.message)
-        if git_commit_push(plan.message):
-            runtime_surfaces.mark_committed(plan)
+    try:
+        kernel.set_phase(LifecyclePhase.MAINTENANCE, actor="sentientosd")
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "expand"
+        current_correlation_id = f"{tick_id}:expand"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="expand",
+                authority_class=AuthorityClass.PROPOSAL_EVALUATION,
+                actor="sentientosd",
+                target_subsystem="genesis_forge",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                startup_symbol="GenesisForge",
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=runtime_surfaces.expand,
+        )
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "cycle"
+        current_correlation_id = f"{tick_id}:cycle"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="cycle",
+                authority_class=AuthorityClass.SPEC_AMENDMENT,
+                actor="sentientosd",
+                target_subsystem="spec_amender",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                startup_symbol="SpecAmender",
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=runtime_surfaces.cycle,
+        )
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "guard"
+        current_correlation_id = f"{tick_id}:guard"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="guard",
+                authority_class=AuthorityClass.PROPOSAL_EVALUATION,
+                actor="sentientosd",
+                target_subsystem="integrity_daemon",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                startup_symbol="IntegrityDaemon",
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=runtime_surfaces.guard,
+        )
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "monitor"
+        current_correlation_id = f"{tick_id}:monitor"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="monitor",
+                authority_class=AuthorityClass.REPAIR,
+                actor="sentientosd",
+                target_subsystem="codex_healer",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                startup_symbol="CodexHealer",
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=runtime_surfaces.monitor,
+        )
+        # Sentinel runs after integrity guard so contract artifacts are trustworthy, before forge daemon so queued repairs execute same tick.
+        if os.getenv("SENTIENTOS_SENTINEL_ENABLED", "0") == "1":
+            current_surface = "sentinel_tick"
+            current_correlation_id = f"{tick_id}:sentinel_tick"
+            contract_sentinel.tick()
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "forge_tick"
+        current_correlation_id = f"{tick_id}:forge_tick"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="forge_tick",
+                authority_class=AuthorityClass.REPAIR,
+                actor="sentientosd",
+                target_subsystem="forge_daemon",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=forge_daemon.run_tick,
+        )
+        feedback = runtime_surfaces.governance_feedback()
+        current_surface = "merge_tick"
+        current_correlation_id = f"{tick_id}:merge_tick"
+        kernel.admit_and_execute(
+            ControlActionRequest(
+                action_kind="merge_tick",
+                authority_class=AuthorityClass.REPAIR,
+                actor="sentientosd",
+                target_subsystem="forge_merge_train",
+                requested_phase=LifecyclePhase.MAINTENANCE,
+                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+            ),
+            execute=merge_train.tick,
+        )
+        kernel.set_phase(LifecyclePhase.RUNTIME, actor="sentientosd")
+
+        current_surface = "commit_plan"
+        current_correlation_id = f"{tick_id}:commit_plan"
+        plan = runtime_surfaces.next_commit()
+        if plan:
+            LOGGER.info("Codex amendment ready for commit: %s", plan.message)
+            if git_commit_push(plan.message):
+                runtime_surfaces.mark_committed(plan)
+    except Exception as exc:
+        signal = _maintenance_degradation_signal(
+            tick_id=tick_id,
+            surface=current_surface,
+            correlation_id=current_correlation_id,
+            phase_before=phase_before,
+            phase_at_failure=getattr(kernel, "phase", "unknown"),
+            exc=exc,
+        )
+        _record_maintenance_degradation(kernel=kernel, signal=signal)
+        safe_phase = phase_before if isinstance(phase_before, LifecyclePhase) else LifecyclePhase.RUNTIME
+        if safe_phase == LifecyclePhase.MAINTENANCE:
+            safe_phase = LifecyclePhase.RUNTIME
+        try:
+            kernel.set_phase(safe_phase, actor="sentientosd")
+        except Exception:
+            LOGGER.warning(
+                "Failed to restore runtime phase after maintenance degradation",
+                extra={"correlation_id": current_correlation_id, "surface": current_surface},
+                exc_info=True,
+            )
+        return
 
 
 async def run_loop(shutdown_event: asyncio.Event, interval_seconds: int = 60) -> None:

--- a/tests/test_sentientosd_runtime_closure.py
+++ b/tests/test_sentientosd_runtime_closure.py
@@ -254,6 +254,209 @@ def test_governor_denial_prevents_daemon_loop_side_effects(tmp_path: Path) -> No
     assert any(row.get("action_kind") == "merge_tick" and row.get("final_disposition") == "deny" for row in rows)
 
 
+class _FailingRuntimeSurfaceSpy(_RuntimeSurfaceSpy):
+    def __init__(self, *, fail_surface: str) -> None:
+        super().__init__()
+        self.fail_surface = fail_surface
+        self.next_commit_calls = 0
+        self.mark_committed_calls = 0
+
+    def expand(self) -> list[object]:
+        self.expand_calls += 1
+        if self.fail_surface == "expand":
+            raise RuntimeError("boom-expand")
+        return []
+
+    def cycle(self) -> dict[str, object]:
+        self.cycle_calls += 1
+        if self.fail_surface == "cycle":
+            raise RuntimeError("boom-cycle")
+        return {}
+
+    def guard(self) -> dict[str, object]:
+        self.guard_calls += 1
+        if self.fail_surface == "guard":
+            raise RuntimeError("boom-guard")
+        return {}
+
+    def monitor(self) -> list[dict[str, object]]:
+        self.monitor_calls += 1
+        if self.fail_surface == "monitor":
+            raise RuntimeError("boom-monitor")
+        return []
+
+    def next_commit(self):
+        self.next_commit_calls += 1
+        if self.fail_surface == "commit_plan":
+            raise RuntimeError("boom-commit-plan")
+        return None
+
+    def mark_committed(self, _plan) -> None:
+        self.mark_committed_calls += 1
+        raise AssertionError("mark_committed should not run during degradation tests")
+
+
+class _FailingForgeDaemonStub(_ForgeDaemonStub):
+    def run_tick(self) -> None:
+        self.calls += 1
+        raise RuntimeError("boom-forge")
+
+
+class _FailingMergeTrainStub(_MergeTrainStub):
+    def tick(self) -> None:
+        self.calls += 1
+        raise RuntimeError("boom-merge")
+
+
+def _decision_rows(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _maintenance_degradations(path: Path) -> list[dict[str, object]]:
+    return [row for row in _decision_rows(path) if row.get("event_type") == "runtime_maintenance_degradation"]
+
+
+@pytest.mark.parametrize(
+    ("fail_surface", "expected_counts"),
+    [
+        ("expand", {"expand": 1, "cycle": 0, "guard": 0, "monitor": 0, "forge": 0, "merge": 0, "next_commit": 0}),
+        ("cycle", {"expand": 1, "cycle": 1, "guard": 0, "monitor": 0, "forge": 0, "merge": 0, "next_commit": 0}),
+        ("guard", {"expand": 1, "cycle": 1, "guard": 1, "monitor": 0, "forge": 0, "merge": 0, "next_commit": 0}),
+        ("monitor", {"expand": 1, "cycle": 1, "guard": 1, "monitor": 1, "forge": 0, "merge": 0, "next_commit": 0}),
+    ],
+)
+def test_maintenance_tick_failure_surfaces_fail_stop_once_and_restore_runtime(
+    tmp_path: Path,
+    fail_surface: str,
+    expected_counts: dict[str, int],
+) -> None:
+    decisions_path = tmp_path / "decisions.jsonl"
+    kernel = ControlPlaneKernel(
+        runtime_governor=_GovernorStub(allow=True),  # type: ignore[arg-type]
+        decisions_path=decisions_path,
+    )
+    surfaces = _FailingRuntimeSurfaceSpy(fail_surface=fail_surface)
+    forge = _ForgeDaemonStub()
+    merge = _MergeTrainStub()
+
+    _run_maintenance_tick(
+        kernel=kernel,
+        runtime_surfaces=surfaces,  # type: ignore[arg-type]
+        contract_sentinel=_SentinelStub(),  # type: ignore[arg-type]
+        forge_daemon=forge,  # type: ignore[arg-type]
+        merge_train=merge,  # type: ignore[arg-type]
+    )
+
+    assert surfaces.expand_calls == expected_counts["expand"]
+    assert surfaces.cycle_calls == expected_counts["cycle"]
+    assert surfaces.guard_calls == expected_counts["guard"]
+    assert surfaces.monitor_calls == expected_counts["monitor"]
+    assert forge.calls == expected_counts["forge"]
+    assert merge.calls == expected_counts["merge"]
+    assert surfaces.next_commit_calls == expected_counts["next_commit"]
+    assert surfaces.mark_committed_calls == 0
+    assert kernel.phase == LifecyclePhase.RUNTIME
+
+    degradations = _maintenance_degradations(decisions_path)
+    assert len(degradations) == 1
+    degradation = degradations[0]
+    assert degradation == {
+        **degradation,
+        "event_type": "runtime_maintenance_degradation",
+        "schema": "runtime_maintenance_degradation:v1",
+        "surface": fail_surface,
+        "actor": "sentientosd",
+        "severity": "blocking",
+        "disposition": "fail_stop_degraded",
+        "stopped_active_cycle": True,
+        "retry_attempted": False,
+        "follow_up_enqueued": False,
+        "reinterpreted_as_goal": False,
+        "failure_type": "RuntimeError",
+        "failure_message": f"boom-{fail_surface}",
+        "phase": "maintenance",
+        "phase_before": "runtime",
+        "phase_at_failure": "maintenance",
+    }
+    assert degradation["correlation_id"] == f"{degradation['tick_id']}:{fail_surface}"
+
+
+@pytest.mark.parametrize(
+    ("fail_surface", "forge_factory", "merge_factory", "expected_forge", "expected_merge"),
+    [
+        ("forge_tick", _FailingForgeDaemonStub, _MergeTrainStub, 1, 0),
+        ("merge_tick", _ForgeDaemonStub, _FailingMergeTrainStub, 1, 1),
+    ],
+)
+def test_maintenance_tick_forge_merge_failure_fail_stop_once_and_no_retry(
+    tmp_path: Path,
+    fail_surface: str,
+    forge_factory,
+    merge_factory,
+    expected_forge: int,
+    expected_merge: int,
+) -> None:
+    decisions_path = tmp_path / "decisions.jsonl"
+    kernel = ControlPlaneKernel(
+        runtime_governor=_GovernorStub(allow=True),  # type: ignore[arg-type]
+        decisions_path=decisions_path,
+    )
+    surfaces = _FailingRuntimeSurfaceSpy(fail_surface="none")
+    forge = forge_factory()
+    merge = merge_factory()
+
+    _run_maintenance_tick(
+        kernel=kernel,
+        runtime_surfaces=surfaces,  # type: ignore[arg-type]
+        contract_sentinel=_SentinelStub(),  # type: ignore[arg-type]
+        forge_daemon=forge,  # type: ignore[arg-type]
+        merge_train=merge,  # type: ignore[arg-type]
+    )
+
+    assert (surfaces.expand_calls, surfaces.cycle_calls, surfaces.guard_calls, surfaces.monitor_calls) == (1, 1, 1, 1)
+    assert forge.calls == expected_forge
+    assert merge.calls == expected_merge
+    assert surfaces.next_commit_calls == 0
+    assert surfaces.mark_committed_calls == 0
+    assert kernel.phase == LifecyclePhase.RUNTIME
+
+    degradations = _maintenance_degradations(decisions_path)
+    assert len(degradations) == 1
+    assert degradations[0]["surface"] == fail_surface
+    assert degradations[0]["retry_attempted"] is False
+    assert degradations[0]["follow_up_enqueued"] is False
+    assert degradations[0]["reinterpreted_as_goal"] is False
+
+
+def test_maintenance_tick_commit_plan_failure_degrades_without_new_action(tmp_path: Path) -> None:
+    decisions_path = tmp_path / "decisions.jsonl"
+    kernel = ControlPlaneKernel(
+        runtime_governor=_GovernorStub(allow=True),  # type: ignore[arg-type]
+        decisions_path=decisions_path,
+    )
+    surfaces = _FailingRuntimeSurfaceSpy(fail_surface="commit_plan")
+    forge = _ForgeDaemonStub()
+    merge = _MergeTrainStub()
+
+    _run_maintenance_tick(
+        kernel=kernel,
+        runtime_surfaces=surfaces,  # type: ignore[arg-type]
+        contract_sentinel=_SentinelStub(),  # type: ignore[arg-type]
+        forge_daemon=forge,  # type: ignore[arg-type]
+        merge_train=merge,  # type: ignore[arg-type]
+    )
+
+    assert (surfaces.expand_calls, surfaces.cycle_calls, surfaces.guard_calls, surfaces.monitor_calls) == (1, 1, 1, 1)
+    assert forge.calls == 1
+    assert merge.calls == 1
+    assert surfaces.next_commit_calls == 1
+    assert surfaces.mark_committed_calls == 0
+    assert kernel.phase == LifecyclePhase.RUNTIME
+    degradations = _maintenance_degradations(decisions_path)
+    assert len(degradations) == 1
+    assert degradations[0]["surface"] == "commit_plan"
+    assert degradations[0]["phase_at_failure"] == "runtime"
+
 def test_runtime_feedback_degradation_is_reused_for_later_maintenance_gating(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("SENTIENTOS_GOVERNOR_ROOT", str(tmp_path / "governor"))
     monkeypatch.setenv("SENTIENTOS_REPO_ROOT", str(tmp_path))


### PR DESCRIPTION
### Motivation
- Ensure the maintenance tick has an explicit top-level fail-stop boundary so any maintenance-surface failure halts the active maintenance cycle and is recorded exactly once. 
- Emit a deterministic, structured degradation signal observable in existing logs and the control-plane decision ledger so failures are auditable and not reinterpreted or retried. 
- Restore a safe runtime phase after failure and preserve existing denial/happy-path behavior.

### Description
- Added a deterministic maintenance degradation helper `_maintenance_degradation_signal` and a recorder `_record_maintenance_degradation` that logs to `sentientos.degradation` and appends to the kernel decision path when available. (added `import json`).
- Wrapped the full `_run_maintenance_tick` sequence in a top-level `try/except`, tracking `current_surface` and `correlation_id` so the exact failing surface is recorded, later surfaces are not executed, and the function returns immediately on failure. 
- On exception, emit a single `runtime_maintenance_degradation:v1` payload with phase/phase_before/phase_at_failure, surface, correlation_id, severity/disposition flags, and exception details; coerce the runtime phase back to a safe state and restore it via `kernel.set_phase`. 
- Kept happy-path admission and denial semantics unchanged; preserved existing `admit_and_execute` ordering, sentinel gating, forge/merge handling, and commit-plan behavior. 
- Files changed: `sentientosd.py` (core changes + new helpers) and `tests/test_sentientosd_runtime_closure.py` (new focused degradation tests).

### Testing
- Compiled modified modules with `python -m py_compile sentientosd.py tests/test_sentientosd_runtime_closure.py` (succeeded).
- Ran focused test suites with `python -m scripts.run_tests -q tests/test_sentientosd_runtime_closure.py tests/test_control_plane_kernel.py` (passed).
- Ran `python -m scripts.run_tests -q tests/test_failure_degradation.py` which completed (the file exercised degradation harness and reported tests, some tests were intentionally skipped per existing harness); overall test runs succeeded.
- New tests assert: single degradation record emitted on failure for `expand`, `cycle`, `guard`, `monitor`, `forge_tick`, `merge_tick`, and `commit_plan`; later surfaces do not run after the failure point; no retry/follow-up/new-goal is created; runtime phase is restored to `runtime`; and existing happy/deny paths remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03fa99f1488320870d3bc8e7b9748e)