### PR TITLE
[codex:control-plane] bound admission dedupe cache

### DIFF
--- a/sentientos/control_plane_kernel.py
+++ b/sentientos/control_plane_kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections import OrderedDict
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -107,11 +108,31 @@ class ControlActionDecision:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class AdmissionDedupeStatus:
+    """Inspectable process-local admission idempotency cache status."""
+
+    key_shape: str
+    ttl_seconds: float
+    max_entries: int
+    current_entries: int
+    expires_at_by_key: dict[tuple[str, str], float]
+
+
+@dataclass(frozen=True, slots=True)
+class _AdmissionHistoryEntry:
+    first_seen: float
+    expires_at: float
+
+
 class ControlPlaneKernel:
     """Phase-aware control-plane admission broker.
 
     This layer orchestrates existing governors/guards and records a machine-readable
-    decision row for every sensitive action request.
+    decision row for every sensitive action request. Admission idempotency is
+    intentionally process-local: allowed admissions reserve ``(phase, correlation_id)``
+    for a bounded TTL so accidental duplicate execution is deferred without making a
+    reused correlation ID sticky for the full process lifetime.
     """
 
     def __init__(
@@ -120,17 +141,39 @@ class ControlPlaneKernel:
         runtime_governor: RuntimeGovernor | None = None,
         decisions_path: Path | None = None,
         phase: LifecyclePhase = LifecyclePhase.RUNTIME,
+        admission_dedupe_ttl_seconds: float = 3600.0,
+        admission_dedupe_max_entries: int = 4096,
+        clock: Callable[[], float] | None = None,
     ) -> None:
+        if admission_dedupe_ttl_seconds <= 0:
+            raise ValueError("admission_dedupe_ttl_seconds must be positive")
+        if admission_dedupe_max_entries < 1:
+            raise ValueError("admission_dedupe_max_entries must be at least 1")
         self._phase = phase
         self._runtime_governor = runtime_governor or get_runtime_governor()
         root = Path(os.getenv("SENTIENTOS_CONTROL_KERNEL_ROOT", "glow/control_plane"))
         self._decisions_path = decisions_path or (root / "kernel_decisions.jsonl")
         self._decisions_path.parent.mkdir(parents=True, exist_ok=True)
-        self._admission_history: set[tuple[str, str]] = set()
+        self._admission_dedupe_ttl_seconds = float(admission_dedupe_ttl_seconds)
+        self._admission_dedupe_max_entries = int(admission_dedupe_max_entries)
+        self._clock = clock or (lambda: datetime.now(timezone.utc).timestamp())
+        self._admission_history: OrderedDict[tuple[str, str], _AdmissionHistoryEntry] = OrderedDict()
 
     @property
     def phase(self) -> LifecyclePhase:
         return self._phase
+
+    def admission_dedupe_status(self) -> AdmissionDedupeStatus:
+        """Return deterministic status for the bounded process-local dedupe cache."""
+
+        self._expire_admission_history(self._now())
+        return AdmissionDedupeStatus(
+            key_shape="(current_phase.value, correlation_id)",
+            ttl_seconds=self._admission_dedupe_ttl_seconds,
+            max_entries=self._admission_dedupe_max_entries,
+            current_entries=len(self._admission_history),
+            expires_at_by_key={key: entry.expires_at for key, entry in self._admission_history.items()},
+        )
 
     def set_phase(self, phase: LifecyclePhase, *, actor: str = "control_plane_kernel") -> None:
         self._phase = phase
@@ -156,10 +199,19 @@ class ControlPlaneKernel:
             or f"{request.actor}:{request.action_kind}:{request.target_subsystem}"
         )
         dedupe_key = (self._phase.value, correlation_id)
-        if dedupe_key in self._admission_history:
+        now = self._now()
+        duplicate_entry = self._get_active_admission_history_entry(dedupe_key, now)
+        if duplicate_entry is not None:
             reasons.append("duplicate_admission_context")
+            delegated["admission_dedupe"] = {
+                "key_shape": "(current_phase.value, correlation_id)",
+                "phase": dedupe_key[0],
+                "correlation_id": dedupe_key[1],
+                "first_seen": duplicate_entry.first_seen,
+                "expires_at": duplicate_entry.expires_at,
+                "scope": "process_local",
+            }
             return self._finalize(request, AdmissionOutcome.DEFER, reasons, delegated, correlation_id=correlation_id)
-        self._admission_history.add(dedupe_key)
 
         phase_reason, phase_outcome = self._evaluate_phase(request)
         if phase_reason:
@@ -244,8 +296,70 @@ class ControlPlaneKernel:
                 advisory_denial=denial if denial not in {"", "none"} else None,
             )
 
+        admission_entry = self._reserve_admission_history_entry(dedupe_key, now)
+        if admission_entry is None:
+            reasons.append("admission_dedupe_cache_full")
+            delegated["admission_dedupe"] = {
+                "key_shape": "(current_phase.value, correlation_id)",
+                "phase": dedupe_key[0],
+                "correlation_id": dedupe_key[1],
+                "ttl_seconds": self._admission_dedupe_ttl_seconds,
+                "max_entries": self._admission_dedupe_max_entries,
+                "current_entries": len(self._admission_history),
+                "scope": "process_local",
+            }
+            return self._finalize(request, AdmissionOutcome.DEFER, reasons, delegated, correlation_id=correlation_id)
+        delegated["admission_dedupe"] = {
+            "key_shape": "(current_phase.value, correlation_id)",
+            "phase": dedupe_key[0],
+            "correlation_id": dedupe_key[1],
+            "first_seen": admission_entry.first_seen,
+            "expires_at": admission_entry.expires_at,
+            "ttl_seconds": self._admission_dedupe_ttl_seconds,
+            "max_entries": self._admission_dedupe_max_entries,
+            "scope": "process_local",
+        }
         reasons.append("admitted")
         return self._finalize(request, AdmissionOutcome.ALLOW, reasons, delegated, correlation_id=correlation_id)
+
+    def _now(self) -> float:
+        return float(self._clock())
+
+    def _get_active_admission_history_entry(
+        self,
+        key: tuple[str, str],
+        now: float,
+    ) -> _AdmissionHistoryEntry | None:
+        self._expire_admission_history(now)
+        entry = self._admission_history.get(key)
+        if entry is None:
+            return None
+        self._admission_history.move_to_end(key)
+        return entry
+
+    def _reserve_admission_history_entry(
+        self,
+        key: tuple[str, str],
+        now: float,
+    ) -> _AdmissionHistoryEntry | None:
+        self._expire_admission_history(now)
+        if key in self._admission_history:
+            entry = self._admission_history[key]
+            self._admission_history.move_to_end(key)
+            return entry
+        if len(self._admission_history) >= self._admission_dedupe_max_entries:
+            return None
+        entry = _AdmissionHistoryEntry(
+            first_seen=now,
+            expires_at=now + self._admission_dedupe_ttl_seconds,
+        )
+        self._admission_history[key] = entry
+        return entry
+
+    def _expire_admission_history(self, now: float) -> None:
+        expired_keys = [key for key, entry in self._admission_history.items() if entry.expires_at <= now]
+        for key in expired_keys:
+            self._admission_history.pop(key, None)
 
     @staticmethod
     def _authority_rule_for_federated_control(

--- a/tests/test_control_plane_kernel.py
+++ b/tests/test_control_plane_kernel.py
@@ -57,6 +57,37 @@ class ExplodingRuntimeGovernor:
         raise RuntimeError("boom")
 
 
+@dataclass
+class CountingRuntimeGovernor(FakeRuntimeGovernor):
+    calls: int = 0
+
+    def admit_action(self, action_type: str, actor: str, correlation_id: str, metadata=None) -> GovernorDecision:
+        self.calls += 1
+        return super().admit_action(action_type, actor, correlation_id, metadata=metadata)
+
+
+class MutableClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _restart_request(correlation_id: str, *, phase: LifecyclePhase = LifecyclePhase.RUNTIME) -> ControlActionRequest:
+    return ControlActionRequest(
+        action_kind="restart_daemon",
+        authority_class=AuthorityClass.DAEMON_RESTART,
+        actor="healer",
+        target_subsystem="daemon-x",
+        requested_phase=phase,
+        metadata={"correlation_id": correlation_id, "subject": "daemon-x"},
+    )
+
+
 def test_legal_bootstrap_action_allowed(tmp_path):
     kernel = ControlPlaneKernel(runtime_governor=FakeRuntimeGovernor(), decisions_path=tmp_path / "decisions.jsonl")
     kernel.set_phase(LifecyclePhase.BOOTSTRAP)
@@ -400,6 +431,143 @@ def test_duplicate_admission_attempt_in_same_phase_is_deferred(tmp_path):
     assert first.outcome == AdmissionOutcome.ALLOW
     assert second.outcome == AdmissionOutcome.DEFER
     assert "duplicate_admission_context" in second.reason_codes
+
+
+
+
+def test_duplicate_admission_dedupe_status_is_explicit_and_no_duplicate_execution(tmp_path):
+    clock = MutableClock(100.0)
+    governor = CountingRuntimeGovernor()
+    kernel = ControlPlaneKernel(
+        runtime_governor=governor,
+        decisions_path=tmp_path / "decisions.jsonl",
+        admission_dedupe_ttl_seconds=30.0,
+        clock=clock,
+    )
+    executions = {"count": 0}
+
+    def _execute() -> str:
+        executions["count"] += 1
+        return "executed"
+
+    first, result = kernel.admit_and_execute(_restart_request("dup-exec-1"), execute=_execute)
+    second, duplicate_result = kernel.admit_and_execute(_restart_request("dup-exec-1"), execute=_execute)
+
+    assert first.outcome == AdmissionOutcome.ALLOW
+    assert result == "executed"
+    assert second.outcome == AdmissionOutcome.DEFER
+    assert duplicate_result is None
+    assert "duplicate_admission_context" in second.reason_codes
+    assert second.delegated_outcomes["admission_dedupe"]["key_shape"] == "(current_phase.value, correlation_id)"
+    assert second.delegated_outcomes["admission_dedupe"]["scope"] == "process_local"
+    assert executions["count"] == 1
+    assert governor.calls == 1
+
+
+def test_dedupe_key_is_phase_and_correlation_id_not_action_shape(tmp_path):
+    clock = MutableClock(200.0)
+    kernel = ControlPlaneKernel(
+        runtime_governor=FakeRuntimeGovernor(),
+        decisions_path=tmp_path / "decisions.jsonl",
+        admission_dedupe_ttl_seconds=60.0,
+        clock=clock,
+    )
+
+    first = kernel.admit(_restart_request("shared-corr", phase=LifecyclePhase.RUNTIME))
+    other_correlation = kernel.admit(_restart_request("other-corr", phase=LifecyclePhase.RUNTIME))
+    kernel.set_phase(LifecyclePhase.MAINTENANCE)
+    other_phase = kernel.admit(_restart_request("shared-corr", phase=LifecyclePhase.MAINTENANCE))
+
+    assert first.outcome == AdmissionOutcome.ALLOW
+    assert other_correlation.outcome == AdmissionOutcome.ALLOW
+    assert other_phase.outcome == AdmissionOutcome.ALLOW
+    assert kernel.admission_dedupe_status().expires_at_by_key.keys() == {
+        (LifecyclePhase.RUNTIME.value, "shared-corr"),
+        (LifecyclePhase.RUNTIME.value, "other-corr"),
+        (LifecyclePhase.MAINTENANCE.value, "shared-corr"),
+    }
+
+
+def test_dedupe_entries_expire_and_allow_correlation_reuse(tmp_path):
+    clock = MutableClock(300.0)
+    kernel = ControlPlaneKernel(
+        runtime_governor=FakeRuntimeGovernor(),
+        decisions_path=tmp_path / "decisions.jsonl",
+        admission_dedupe_ttl_seconds=10.0,
+        clock=clock,
+    )
+
+    first = kernel.admit(_restart_request("ttl-corr"))
+    duplicate = kernel.admit(_restart_request("ttl-corr"))
+    clock.advance(10.0)
+    after_expiry = kernel.admit(_restart_request("ttl-corr"))
+
+    assert first.outcome == AdmissionOutcome.ALLOW
+    assert duplicate.outcome == AdmissionOutcome.DEFER
+    assert "duplicate_admission_context" in duplicate.reason_codes
+    assert after_expiry.outcome == AdmissionOutcome.ALLOW
+    status = kernel.admission_dedupe_status()
+    assert status.current_entries == 1
+    assert status.expires_at_by_key == {(LifecyclePhase.RUNTIME.value, "ttl-corr"): 320.0}
+
+
+def test_dedupe_cache_is_bounded_without_evicting_live_keys(tmp_path):
+    clock = MutableClock(400.0)
+    kernel = ControlPlaneKernel(
+        runtime_governor=FakeRuntimeGovernor(),
+        decisions_path=tmp_path / "decisions.jsonl",
+        admission_dedupe_ttl_seconds=100.0,
+        admission_dedupe_max_entries=2,
+        clock=clock,
+    )
+
+    first = kernel.admit(_restart_request("bounded-1"))
+    second = kernel.admit(_restart_request("bounded-2"))
+    over_capacity = kernel.admit(_restart_request("bounded-3"))
+    duplicate_first = kernel.admit(_restart_request("bounded-1"))
+
+    assert first.outcome == AdmissionOutcome.ALLOW
+    assert second.outcome == AdmissionOutcome.ALLOW
+    assert over_capacity.outcome == AdmissionOutcome.DEFER
+    assert "admission_dedupe_cache_full" in over_capacity.reason_codes
+    assert over_capacity.delegated_outcomes["admission_dedupe"]["current_entries"] == 2
+    assert duplicate_first.outcome == AdmissionOutcome.DEFER
+    assert "duplicate_admission_context" in duplicate_first.reason_codes
+    assert kernel.admission_dedupe_status().current_entries == 2
+
+
+def test_dedupe_cache_compacts_expired_entries_before_capacity_check(tmp_path):
+    clock = MutableClock(500.0)
+    kernel = ControlPlaneKernel(
+        runtime_governor=FakeRuntimeGovernor(),
+        decisions_path=tmp_path / "decisions.jsonl",
+        admission_dedupe_ttl_seconds=5.0,
+        admission_dedupe_max_entries=1,
+        clock=clock,
+    )
+
+    assert kernel.admit(_restart_request("old-corr")).outcome == AdmissionOutcome.ALLOW
+    clock.advance(5.0)
+    assert kernel.admit(_restart_request("new-corr")).outcome == AdmissionOutcome.ALLOW
+
+    status = kernel.admission_dedupe_status()
+    assert status.current_entries == 1
+    assert status.expires_at_by_key == {(LifecyclePhase.RUNTIME.value, "new-corr"): 510.0}
+
+
+def test_governor_denial_is_not_converted_to_duplicate_deferral(tmp_path):
+    governor = FakeRuntimeGovernor(allow=False, reason="operator_lockout")
+    kernel = ControlPlaneKernel(runtime_governor=governor, decisions_path=tmp_path / "decisions.jsonl")
+
+    first = kernel.admit(_restart_request("deny-corr"))
+    second = kernel.admit(_restart_request("deny-corr"))
+
+    assert first.outcome == AdmissionOutcome.DENY
+    assert second.outcome == AdmissionOutcome.DENY
+    assert "runtime_governor:operator_lockout" in first.reason_codes
+    assert "runtime_governor:operator_lockout" in second.reason_codes
+    assert "duplicate_admission_context" not in second.reason_codes
+    assert kernel.admission_dedupe_status().current_entries == 0
 
 
 def test_proof_budget_delegate_unavailable_is_deferred(monkeypatch: pytest.MonkeyPatch, tmp_path):


### PR DESCRIPTION
### Motivation

- Make `ControlPlaneKernel` admission dedupe/idempotency explicit, bounded, deterministic, and testable to avoid the previous unbounded, process-lifetime sticky, and non-expiring in-memory behavior. 
- Preserve existing duplicate-safety semantics (no duplicate execution inside the dedupe window) while preventing unbounded growth and making behavior inspectable for tests and operators.

### Description

- Replace the unbounded `_admission_history` set with a process-local bounded `OrderedDict` cache of keys `(current_phase.value, correlation_id)` storing `first_seen` and `expires_at`, and expire entries deterministically before lookups. 
- Add configurable TTL (`admission_dedupe_ttl_seconds`, default `3600.0`), max entries (`admission_dedupe_max_entries`, default `4096`), and an injectable `clock` for deterministic tests. 
- Expose `admission_dedupe_status()` and `AdmissionDedupeStatus` so operators/tests can inspect key shape, TTL, max size, current entries, and per-key expiry times; duplicates now return `AdmissionOutcome.DEFER` with `duplicate_admission_context` plus `admission_dedupe` metadata. 
- On capacity, the kernel defers new admissions with explicit `admission_dedupe_cache_full` (no eviction of live keys), and the dedupe cache remains process-local (no restart persistence) to keep the change minimal and auditable.

### Testing

- Static/compile checks: `python -m py_compile sentientos/control_plane_kernel.py tests/test_control_plane_kernel.py` completed successfully. 
- Unit tests: `python -m scripts.run_tests -q tests/test_control_plane_kernel.py` passed and includes new focused tests for duplicate deferral/no-duplicate-execution, key-shape, expiry/reuse, bounded-capacity behavior, expired compaction, and governor-denial interaction. 
- Integration closure: `python -m scripts.run_tests -q tests/test_sentientosd_runtime_closure.py` passed to ensure no regressions in related runtime closure tests.

Files changed: `sentientos/control_plane_kernel.py`, `tests/test_control_plane_kernel.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04051d7f3083208d6d134851e1063e)