### PR TITLE
[codex:docs] repair docs build dependency bootstrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ test = [
     "starlette>=0.37,<1",
     "httpx>=0.27,<1",
 ]
+docs = [
+    "mkdocs>=1.6,<2",
+    "watchdog>=2,<3",
+]
 dev = [
     "mypy==1.*",
     "types-requests",

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -4,16 +4,61 @@ from sentientos.privilege import require_admin_banner, require_lumos_approval
 require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
 require_lumos_approval()
 import argparse
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+DOCS_DEPENDENCY_IMPORTS = ("mkdocs",)
+DOCS_PIP_REQUIREMENTS = ("mkdocs>=1.6,<2", "watchdog>=2,<3")
+DOCS_BOOTSTRAP_COMMAND = "python scripts/build_docs.py --bootstrap-docs"
+DOCS_EXTRA_INSTALL_COMMAND = "pip install -e .[docs]"
+DOCS_DEPENDENCY_MESSAGE = (
+    "Docs build dependencies missing. Run: "
+    f"{DOCS_BOOTSTRAP_COMMAND} (minimal), or {DOCS_EXTRA_INSTALL_COMMAND}"
+)
+
+
+def missing_docs_dependencies() -> list[str]:
+    """Return docs build dependency imports unavailable in this environment."""
+
+    return [name for name in DOCS_DEPENDENCY_IMPORTS if importlib.util.find_spec(name) is None]
+
+
+def _emit_missing_dependency_message(missing: list[str]) -> None:
+    joined = ", ".join(missing)
+    print(
+        "ENVIRONMENT/BOOTSTRAP ERROR: "
+        f"{DOCS_DEPENDENCY_MESSAGE}\nMissing Python import(s): {joined}",
+        file=sys.stderr,
+    )
+
+
+def bootstrap_docs_dependencies() -> bool:
+    """Install only the minimal docs build toolchain for this environment."""
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", *DOCS_PIP_REQUIREMENTS],
+        check=False,
+    )
+    return result.returncode == 0
+
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build documentation")
     parser.add_argument("--deploy", action="store_true", help="Deploy to GitHub Pages")
+    parser.add_argument(
+        "--check-deps",
+        action="store_true",
+        help="check docs build dependencies and mkdocs.yml without building",
+    )
+    parser.add_argument(
+        "--bootstrap-docs",
+        action="store_true",
+        help="install the minimal docs dependency set before building",
+    )
     args = parser.parse_args(argv)
 
     config = Path("mkdocs.yml")
@@ -21,9 +66,26 @@ def main(argv: list[str] | None = None) -> int:
         print("mkdocs.yml not found", file=sys.stderr)
         return 1
 
-    cmd = ["mkdocs", "build", "--clean"]
+    missing = missing_docs_dependencies()
+    if missing and args.bootstrap_docs:
+        if not bootstrap_docs_dependencies():
+            print(
+                "ENVIRONMENT/BOOTSTRAP ERROR: Docs dependency bootstrap failed. "
+                f"Tried: pip install {' '.join(DOCS_PIP_REQUIREMENTS)}",
+                file=sys.stderr,
+            )
+            return 2
+        missing = missing_docs_dependencies()
+    if missing:
+        _emit_missing_dependency_message(missing)
+        return 2
+    if args.check_deps:
+        print("Docs build dependencies available.")
+        return 0
+
+    cmd = [sys.executable, "-m", "mkdocs", "build", "--clean"]
     if args.deploy:
-        cmd = ["mkdocs", "gh-deploy", "--force"]
+        cmd = [sys.executable, "-m", "mkdocs", "gh-deploy", "--force"]
     result = subprocess.run(cmd, capture_output=True, text=True)
     sys.stdout.write(result.stdout)
     if result.returncode != 0:

--- a/tests/test_build_docs_tooling.py
+++ b/tests/test_build_docs_tooling.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from scripts import build_docs
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_docs_extra_declares_mkdocs() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    docs_deps = pyproject["project"]["optional-dependencies"]["docs"]
+
+    assert any(dep.startswith("mkdocs") for dep in docs_deps)
+    assert set(build_docs.DOCS_PIP_REQUIREMENTS) <= set(docs_deps)
+    assert not any(dep.startswith("mkdocs") for dep in pyproject["project"]["dependencies"])
+
+
+def test_missing_docs_dependency_fails_actionably(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "mkdocs.yml").write_text("site_name: Test\n", encoding="utf-8")
+    monkeypatch.setattr(build_docs.importlib.util, "find_spec", lambda name: None)
+
+    code = build_docs.main(["--check-deps"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "ENVIRONMENT/BOOTSTRAP ERROR" in captured.err
+    assert "Docs build dependencies missing. Run:" in captured.err
+    assert "python scripts/build_docs.py --bootstrap-docs" in captured.err
+    assert "pip install -e .[docs]" in captured.err
+    assert "Missing Python import(s): mkdocs" in captured.err
+
+
+def test_build_docs_uses_current_python_mkdocs_module(monkeypatch, tmp_path, capsys) -> None:
+    commands: list[list[str]] = []
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    (site_dir / "index.html").write_text("<h1>ok</h1>", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "mkdocs.yml").write_text("site_name: Test\n", encoding="utf-8")
+    monkeypatch.setattr(build_docs, "missing_docs_dependencies", lambda: [])
+
+    def fake_run(cmd, capture_output=False, text=False):
+        commands.append(cmd)
+        return _Completed(0, "mkdocs ok\n")
+
+    monkeypatch.setattr(build_docs.subprocess, "run", fake_run)
+
+    code = build_docs.main([])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert commands == [[sys.executable, "-m", "mkdocs", "build", "--clean"]]
+    assert "mkdocs ok" in captured.out
+    assert "Generated 1 pages:" in captured.out
+
+
+def test_bootstrap_docs_installs_minimal_docs_requirements(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, check=False):
+        commands.append(cmd)
+        return _Completed(0)
+
+    monkeypatch.setattr(build_docs.subprocess, "run", fake_run)
+
+    assert build_docs.bootstrap_docs_dependencies() is True
+    assert commands == [
+        [sys.executable, "-m", "pip", "install", *build_docs.DOCS_PIP_REQUIREMENTS]
+    ]


### PR DESCRIPTION
### Motivation
- Make `python scripts/build_docs.py` reliably detect or deterministically bootstrap the small docs toolchain and fail with a clear actionable environment classification instead of an unstructured missing-`mkdocs` failure. 
- Avoid promoting `mkdocs` to broad runtime deps while giving maintainers a minimal, testable docs-install pathway.

### Description
- Add a focused `docs` optional dependency extra in `pyproject.toml` containing `mkdocs>=1.6,<2` and `watchdog>=2,<3` so docs tooling is declared but not promoted to runtime dependencies. 
- Update `scripts/build_docs.py` to check for missing docs imports, emit an `ENVIRONMENT/BOOTSTRAP ERROR` with clear guidance, provide `--check-deps` and `--bootstrap-docs` flags, implement a minimal `bootstrap_docs_dependencies()` installer that runs `python -m pip install <minimal-requirements>`, and invoke MkDocs via `python -m mkdocs` to use the current Python environment. 
- Add `tests/test_build_docs_tooling.py` with focused assertions for docs extra declaration, actionable missing-dependency classification, deterministic `mkdocs` invocation, and the minimal bootstrap command. 
- Files changed: `pyproject.toml`, `scripts/build_docs.py`, and `tests/test_build_docs_tooling.py`.

### Testing
- Compiled the script with `python -m py_compile scripts/build_docs.py` which succeeded. 
- Ran the new tooling tests with `python -m scripts.run_tests -q tests/test_build_docs_tooling.py` and the repository bootstrap tests with `python -m scripts.run_tests -q tests/test_build_docs_tooling.py tests/test_run_tests_bootstrap_airlock.py`, both of which passed. 
- Verified `python scripts/verify_context_hygiene_prompt_boundaries.py` completed with clean results. 
- Validated behavior of the script: `python scripts/build_docs.py --check-deps` returns a classified exit (2) and prints the `ENVIRONMENT/BOOTSTRAP ERROR` when imports are missing, and `python scripts/build_docs.py --bootstrap-docs` installs the minimal docs toolchain and allows a subsequent `python scripts/build_docs.py` run to build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a050c11ab4083209cdbf57ad85ac060)