### PR TITLE
[codex:docs] consolidate reviewer readiness proof path

### DIFF
--- a/docs/architecture/federated_improvement_candidate.md
+++ b/docs/architecture/federated_improvement_candidate.md
@@ -1,10 +1,12 @@
 # Federated Improvement Candidate Artifact
 
 The federated improvement candidate is a deterministic, metadata-first object for
-representing transmissible improvement evidence under local custody.  It lets a
-SentientOS node describe that a locally produced improvement candidate has source
-or lineage evidence, verification posture, test or rehearsal labels, risks, and
-local review requirements that another node may inspect.
+representing improvement evidence under local custody.  It lets a SentientOS node
+describe that a locally produced improvement candidate has source or lineage
+evidence, verification posture, test or rehearsal labels, risks, and local review
+requirements that another node may inspect.  The code-level
+`transmissible_evidence_only` flag means bounded metadata may be represented for
+review; it does not perform transport, sync, delivery, adoption, or execution.
 
 The artifact is intentionally not a federation transport, adoption engine,
 scheduler, prompt assembly path, provider invocation path, runtime authority

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -12,28 +12,30 @@ SentientOS is a deterministic governance-and-audit runtime for operator-directed
 - A repository with verification tooling that treats evidence artifacts, state transitions, and governance checks as first-class outputs.
 
 ### What it is not
-- Not autonomous authority: operators and local policy remain final authority.
-- Not implicit remote control: federation artifacts do not bypass local adoption gates.
-- Not a claim of self-executing provider invocation; prompt/provider boundaries are explicitly verified.
+- Not autonomous goal generation or autonomous authority: operators and local policy remain final authority.
+- Not forced federation adoption: federation artifacts do not bypass local adoption gates.
+- Not provider invocation and not prompt assembly; prompt/provider boundaries are explicitly verified.
+- Not remote execution, auto-update, or transport/sync by receipt alone.
 
 ## First reviewer path (short path)
 
 1. Read this document.
-2. Inspect control-plane and policy docs:
+2. Read the proof-oriented release-readiness index: `docs/architecture/reviewer_release_readiness_index.md`.
+3. Inspect control-plane and policy docs:
    - `docs/control_plane_authority_map.md`
    - `docs/STATE_MACHINE_PROPERTIES.md`
    - `docs/RELEASE_READINESS_MODEL.md`
-3. Inspect core verification scripts:
+4. Inspect core verification scripts:
    - `scripts/verify_audits.py`
    - `scripts/audit_immutability_verifier.py`
    - `scripts/verify_context_hygiene_prompt_boundaries.py`
-4. Inspect representative tests:
+5. Inspect representative tests:
    - `tests/test_verify_audits_cli.py`
    - `tests/test_federated_improvement_local_variant_artifact.py`
    - `tests/test_run_tests_bootstrap_airlock.py`
    - `tests/test_phase101_provider_invocation_denial_enforcement.py`
-5. Run the proof-map commands in this document and validate output artifacts under `glow/audits/`.
-6. Evaluate hard invariants below before considering any runtime or federation claim.
+6. Run the proof-map commands in this document and validate output artifacts under `glow/audits/`.
+7. Evaluate hard invariants below before considering any runtime or federation claim.
 
 ## Core control-plane model
 
@@ -117,9 +119,9 @@ Current runway terms are best interpreted as custody metadata stages:
 - **Custody runway:** tracked progression state for local evaluation.
 - **Local variant:** locally materialized evaluation variant for comparison.
 - **Lineage comparison:** provenance and divergence assessment.
-- **Dissemination receipt:** record that metadata/receipt was shared.
+- **Dissemination receipt:** record that metadata/receipt was cataloged for possible announcement, without transport or sync authority.
 
-These artifacts are **not** transport execution, **not** adoption, and **not** runtime authority by themselves.
+These artifacts are **not** transport execution, **not** transport/sync by receipt alone, **not** adoption, **not** merge/apply/install, **not** forced update, **not** provider invocation, **not** prompt assembly, and **not** runtime authority by themselves.
 
 ## Model/runtime loading posture
 
@@ -161,7 +163,7 @@ For broader internal language mapping, see `docs/PUBLIC_LANGUAGE_BRIDGE.md`.
 
 ## Recent hardening checks
 
-The current reviewer proof path covers these repaired areas:
+The current reviewer proof path is summarized in `docs/architecture/reviewer_release_readiness_index.md` and covers these repaired areas:
 - Control-plane admission, runtime closure, maintenance admission gating, and degradation boundaries.
 - Federation trust ledger startup recovery, event replay fallback, and probe prioritization ordering.
 - Chat/model lazy loading and local transformer `trust_remote_code` safe default behavior.
@@ -197,6 +199,10 @@ python scripts/verify_audits.py --strict
 
 # Immutability verifier
 python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json
+
+# Docs dependency check and docs build
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
 ```
 
 ## Internal language / cultural layer

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -1,0 +1,173 @@
+# Reviewer Release-Readiness Proof Index
+
+## What this index is
+
+This is a reviewer-facing map of the currently implemented proof surfaces for the
+recent SentientOS hardening and federation-improvement work. It is meant to help
+a technical reviewer move from the public overview to concrete tests, scripts,
+and custody artifacts without reconstructing context from scattered PRs.
+
+This index is not a release announcement, not a production-readiness claim, and
+not a promise of provider invocation, federation transport, automatic adoption,
+remote execution, or merge/apply/install behavior.
+
+## Current implemented proof surfaces
+
+### Control plane / authority admission
+
+`tests/test_control_plane_kernel.py` covers explicit authority admission,
+admission status visibility, and bounded process-local TTL idempotency. The
+current posture is explicit admission, not implicit runtime authority.
+
+### Maintenance degradation / fail-stop behavior
+
+`tests/test_sentientosd_runtime_closure.py` covers runtime closure behavior,
+maintenance forge/merge admission gating, and structured degradation when a
+maintenance tick fails. Denied maintenance admission does not run forge or merge
+ticks.
+
+### Federation trust ledger recovery
+
+`tests/test_trust_ledger.py` and `sentientos/tests/test_trust_ledger_recovery.py`
+cover trust ledger state loading, event replay fallback, and degraded handling
+for malformed state/events. Current recovery is startup recovery from local state
+or local events, not a cross-process mutation-locking guarantee.
+
+### Federation probe prioritization
+
+`tests/test_trust_ledger.py` covers deterministic prioritization of suspicious
+federation peers for probing. This is prioritization evidence only; it does not
+create transport, sync, or enforcement authority by itself.
+
+### Chat/model loading safety
+
+`tests/test_chat_service_lazy_loading.py`, `tests/test_local_model.py`, and
+`tests/integration/test_chat_mistral_runtime.py` cover lazy chat model loading and
+local transformer loading defaults. Importing chat service code does not load the
+model, and local custom model code execution defaults to `trust_remote_code=False`
+unless explicitly opted in.
+
+### Test runner bootstrap reliability
+
+`tests/test_run_tests_bootstrap_airlock.py` and
+`tests/test_integration_conftest_compat.py` cover the focused test-airlock path
+and integration marker compatibility. The focused proof suites should not require
+a broad runtime dependency install before collection.
+
+### Docs build reliability
+
+`tests/test_build_docs_tooling.py`, `python scripts/build_docs.py --check-deps`,
+and `python scripts/build_docs.py` cover explicit docs dependency declaration and
+building through the repository docs wrapper.
+
+### Provider invocation denial custody Phase 100-103
+
+The Phase 100-103 custody chain is metadata-only and release-blocking for real
+provider invocation:
+
+- `docs/architecture/phase100_provider_invocation_denial_closure_execplan.md`
+- `docs/architecture/phase101_provider_invocation_denial_enforcement_snapshot_execplan.md`
+- `docs/architecture/phase102_provider_invocation_denial_drift_review_execplan.md`
+- `docs/architecture/phase103_provider_invocation_denial_custody_checkpoint_execplan.md`
+- `tests/test_phase100_provider_invocation_denial_closure.py`
+- `tests/test_phase101_provider_invocation_denial_enforcement.py`
+- `tests/test_phase102_provider_invocation_denial_drift_review.py`
+- `tests/test_phase103_provider_invocation_denial_custody_checkpoint.py`
+
+These artifacts prove denial custody and drift review; they do not invoke a
+provider, assemble a prompt, export prompt text, construct provider clients, or
+open network/runtime authority.
+
+### Federated improvement custody runway
+
+The current implemented modules and tests are:
+
+- `sentientos/federation/improvement_candidate.py` / `tests/test_federated_improvement_candidate.py`
+- `sentientos/federation/improvement_intake_receipt.py` / `tests/test_federated_improvement_intake_receipt.py`
+- `sentientos/federation/improvement_custody_runway.py` / `tests/test_federated_improvement_custody_runway.py`
+- `sentientos/federation/improvement_local_variant_artifact.py` / `tests/test_federated_improvement_local_variant_artifact.py`
+- `sentientos/federation/improvement_lineage_comparison_receipt.py` / `tests/test_federated_improvement_lineage_comparison_receipt.py`
+- `sentientos/federation/improvement_dissemination_receipt.py` / `tests/test_federated_improvement_dissemination_receipt.py`
+
+These receipts and artifacts are custody/evidence/readiness surfaces only. They
+do not transport, sync, adopt, execute, merge, apply, install, force updates, or
+expand runtime authority.
+
+## Hard invariants currently proven
+
+- Authority is explicit and admitted.
+- Denied maintenance does not execute forge/merge ticks.
+- Maintenance failure emits one structured degradation signal.
+- Admission idempotency is bounded process-local TTL, not pretend-durable.
+- Trust ledger recovers from state or events and degrades on malformed input.
+- Suspicious federation peers are prioritized deterministically.
+- Chat service import does not load the model.
+- Local model custom code execution defaults false.
+- Focused tests do not require broad runtime dependency install.
+- Docs build dependencies are explicit.
+- Provider invocation remains release-blocked.
+- Federated improvement receipts do not transport, adopt, execute, merge, apply,
+  install, or force updates.
+
+## Proof commands
+
+Run from the repository root. Expected posture for each command is successful
+completion unless the local environment is missing an explicitly declared docs or
+test dependency, in which case the failure should be treated as a bootstrap issue
+and fixed through the documented wrapper path.
+
+```bash
+# Test-runner bootstrap and docs tooling smoke coverage.
+python -m scripts.run_tests -q tests/test_run_tests_bootstrap_airlock.py tests/test_build_docs_tooling.py
+
+# Control-plane admission and runtime closure / maintenance gating.
+python -m scripts.run_tests -q tests/test_control_plane_kernel.py tests/test_sentientosd_runtime_closure.py
+
+# Federation trust ledger recovery and probe prioritization.
+python -m scripts.run_tests -q tests/test_trust_ledger.py sentientos/tests/test_trust_ledger_recovery.py
+
+# Chat/model lazy loading and local model safety.
+python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py
+
+# Integration marker compatibility.
+python -m scripts.run_tests -q tests/test_integration_conftest_compat.py
+
+# Federated improvement custody/evidence runway.
+python -m scripts.run_tests -q tests/test_federated_improvement_candidate.py tests/test_federated_improvement_intake_receipt.py tests/test_federated_improvement_custody_runway.py tests/test_federated_improvement_local_variant_artifact.py tests/test_federated_improvement_lineage_comparison_receipt.py tests/test_federated_improvement_dissemination_receipt.py
+
+# Context hygiene / prompt-boundary verification.
+python scripts/verify_context_hygiene_prompt_boundaries.py
+
+# Audit chain verification.
+python scripts/verify_audits.py --strict
+
+# Immutable manifest verification.
+python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json
+
+# Docs dependency check and docs build.
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
+```
+
+## Deferred / explicitly not implemented
+
+- Real provider invocation.
+- Prompt assembly or prompt-text export for provider invocation.
+- Federation transport/sync for improvement receipts.
+- Automatic adoption.
+- Remote execution.
+- Merge/conflict-resolution engine.
+- Apply/install/update engine for federated improvement receipts.
+- Production execution from rehearsal/readiness receipts.
+- Durable cross-process admission idempotency.
+- Cross-process trust ledger mutation locking.
+
+## How to review
+
+1. Read `docs/architecture/public_technical_overview.md` first.
+2. Run the proof-map commands above from the repository root.
+3. Inspect `tests/test_control_plane_kernel.py` and `tests/test_sentientosd_runtime_closure.py`.
+4. Inspect `tests/test_trust_ledger.py` and `sentientos/tests/test_trust_ledger_recovery.py`.
+5. Inspect `tests/test_chat_service_lazy_loading.py`, `tests/test_local_model.py`, and `tests/integration/test_chat_mistral_runtime.py`.
+6. Inspect the federated improvement receipt tests listed in the custody runway section.
+7. Build docs with `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`.

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_OVERVIEW = "docs/architecture/public_technical_overview.md"
+READINESS_INDEX = "docs/architecture/reviewer_release_readiness_index.md"
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_readme_points_reviewers_to_public_technical_overview() -> None:
+    readme = _read("README.md")
+    assert PUBLIC_OVERVIEW in readme
+
+
+def test_public_overview_points_to_release_readiness_index() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    assert READINESS_INDEX in overview
+
+
+def test_release_readiness_index_keeps_key_proof_commands_current() -> None:
+    index = _read(READINESS_INDEX)
+    expected_commands = [
+        "python -m scripts.run_tests -q tests/test_control_plane_kernel.py tests/test_sentientosd_runtime_closure.py",
+        "python -m scripts.run_tests -q tests/test_trust_ledger.py sentientos/tests/test_trust_ledger_recovery.py",
+        "python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py",
+        "python -m scripts.run_tests -q tests/test_federated_improvement_candidate.py tests/test_federated_improvement_intake_receipt.py tests/test_federated_improvement_custody_runway.py tests/test_federated_improvement_local_variant_artifact.py tests/test_federated_improvement_lineage_comparison_receipt.py tests/test_federated_improvement_dissemination_receipt.py",
+        "python scripts/verify_context_hygiene_prompt_boundaries.py",
+        "python scripts/verify_audits.py --strict",
+        "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json",
+        "python scripts/build_docs.py --check-deps",
+        "python scripts/build_docs.py",
+    ]
+    for command in expected_commands:
+        assert command in index


### PR DESCRIPTION
### Motivation
- Provide a single reviewer-facing proof index and tighten public docs so a technical reviewer can start at `README -> public technical overview -> release-readiness index` and run focused proof commands without chasing scattered PRs.
- Ensure federated-improvement and provider-denial language cannot be misread as granting transport, adoption, execution, or provider-invocation authority.

### Description
- Added a new reviewer release-readiness proof index at `docs/architecture/reviewer_release_readiness_index.md` that maps implemented proof surfaces, hard invariants, proof commands, deferred work, and a 7-step reviewer path.
- Updated `docs/architecture/public_technical_overview.md` to point to the new readiness index, strengthen the “what this is not” language (explicitly listing non-goals such as provider invocation, prompt assembly, remote execution, transport/sync by receipt alone, auto-update, forced adoption), and include docs-build commands in the proof map.
- Clarified custody/evidence wording in `docs/architecture/federated_improvement_candidate.md` so the `transmissible_evidence_only` flag and candidate/dissemination artifacts are explicitly metadata/custody-only and not transport/adoption/execution surfaces.
- Added a small regression test `tests/test_reviewer_release_readiness_index.py` that asserts: `README` points to the public overview, the public overview points to the new readiness index, and the readiness index contains the key proof commands.
- No runtime codepaths, provider SDKs, prompt-assembly behavior, transport, adoption, merge/apply/install, or execution authority were added or changed.

### Testing
- Ran focused docs/tooling bootstrap smoke: `python -m scripts.run_tests -q tests/test_run_tests_bootstrap_airlock.py tests/test_build_docs_tooling.py` — passed.
- Verified the new docs-link test: `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` — passed.
- Ran the core proof-map suites: `python -m scripts.run_tests -q tests/test_control_plane_kernel.py tests/test_sentientosd_runtime_closure.py`, `python -m scripts.run_tests -q tests/test_trust_ledger.py sentientos/tests/test_trust_ledger_recovery.py`, `python -m scripts.run_tests -q tests/test_chat_service_lazy_loading.py tests/test_local_model.py tests/integration/test_chat_mistral_runtime.py`, `python -m scripts.run_tests -q tests/test_integration_conftest_compat.py`, and the federated-improvement suites — all passed (focused runs reported all tests passing for these targets).
- Ran context/hygiene and audit/immutability tools: `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python scripts/verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json` — all reported clean/pass results.
- Docs build: initial `python scripts/build_docs.py --check-deps` failed due to missing `mkdocs` (environment/bootstrap issue), then `python scripts/build_docs.py --bootstrap-docs` was executed to install the declared docs dependencies, after which `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` passed and the site was generated.

Files changed:
- Added: `docs/architecture/reviewer_release_readiness_index.md`
- Modified: `docs/architecture/public_technical_overview.md`
- Modified: `docs/architecture/federated_improvement_candidate.md`
- Added: `tests/test_reviewer_release_readiness_index.py`

Other notes:
- README was not changed; it still points reviewers to `docs/architecture/public_technical_overview.md`.
- Confirmed no new authority surfaces were introduced; the changes are documentation, wording clarifications, and a small docs-link test only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0517aef35c8320be029ee842ef2aaa)