### PR TITLE
[codex:docs] map SentientOS trajectory organs

### DIFF
--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -21,21 +21,22 @@ SentientOS is a deterministic governance-and-audit runtime for operator-directed
 
 1. Read this document.
 2. Read the proof-oriented release-readiness index: `docs/architecture/reviewer_release_readiness_index.md`.
-3. Inspect control-plane and policy docs:
+3. Read the whole-system trajectory and missing-organs map: `docs/architecture/sentientos_trajectory_and_missing_organs.md`.
+4. Inspect control-plane and policy docs:
    - `docs/control_plane_authority_map.md`
    - `docs/STATE_MACHINE_PROPERTIES.md`
    - `docs/RELEASE_READINESS_MODEL.md`
-4. Inspect core verification scripts:
+5. Inspect core verification scripts:
    - `scripts/verify_audits.py`
    - `scripts/audit_immutability_verifier.py`
    - `scripts/verify_context_hygiene_prompt_boundaries.py`
-5. Inspect representative tests:
+6. Inspect representative tests:
    - `tests/test_verify_audits_cli.py`
    - `tests/test_federated_improvement_local_variant_artifact.py`
    - `tests/test_run_tests_bootstrap_airlock.py`
    - `tests/test_phase101_provider_invocation_denial_enforcement.py`
-6. Run the proof-map commands in this document and validate output artifacts under `glow/audits/`.
-7. Evaluate hard invariants below before considering any runtime or federation claim.
+7. Run the proof-map commands in this document and validate output artifacts under `glow/audits/`.
+8. Evaluate hard invariants below before considering any runtime or federation claim.
 
 ## Core control-plane model
 

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -11,6 +11,10 @@ This index is not a release announcement, not a production-readiness claim, and
 not a promise of provider invocation, federation transport, automatic adoption,
 remote execution, or merge/apply/install behavior.
 
+For the broader user-space operating-substrate trajectory and the concrete
+missing subsystems still required, see
+`docs/architecture/sentientos_trajectory_and_missing_organs.md`.
+
 ## Current implemented proof surfaces
 
 ### Control plane / authority admission

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -1,0 +1,350 @@
+# SentientOS Trajectory and Missing Organs
+
+## What SentientOS is becoming
+
+SentientOS is becoming a user-space operating substrate for governed AI
+autonomy. It does not replace Windows, macOS, Linux, or any host kernel. It runs
+above the host OS and organizes installer/bootstrap flow, first boot,
+shell/dashboard affordances, local model runtime, memory/context/reflection,
+perception and embodiment telemetry, bounded GUI/browser interaction,
+hardware/driver awareness, audit/immutability checks, control-plane authority,
+governed self-amendment, and federation evidence custody.
+
+The practical trajectory is an AI operating layer with explicit admission and
+receipts. It should make local capabilities visible, propose bounded work from
+observations, gate sensitive action through governance, execute only admitted
+host effects, and leave enough audit evidence for an operator or reviewer to
+reconstruct what happened. Capabilities that are only implied by this trajectory
+are listed below as missing or deferred rather than claimed as implemented.
+
+## What already exists
+
+The repository already contains these major subsystem surfaces:
+
+| Area | Existing paths | Current status |
+| --- | --- | --- |
+| Installer/setup/bootstrap | `installer/setup_installer.py`, `setup_env.sh`, `scripts/install_locked.py`, `scripts/bootstrap_node.py`, `scripts/bootstrap_cathedral.py`, `sentientos/runtime/bootstrap.py`, `sentientos/node/__main__.py` | Offline/deterministic setup helpers, dependency/bootstrap paths, node bootstrap helpers, log creation, manifest artifact verification, and smoke-test hooks. |
+| Windows install path | `README.md`, `docs/WINDOWS_LOCAL_MODEL_SETUP.md`, `run_cathedral.bat`, `launch_sentientos.bat`, `Start-All.ps1`, `Stop-All.ps1`, `scripts/package_launcher.py` | Windows-oriented run and packaging documentation/scripts exist. This is a user-space Windows path, not a kernel or driver replacement. |
+| First boot wizard | `sentientos/first_boot.py`, `tests/test_first_boot.py` | First boot records approval, driver review, Codex mode/cadence, architect autonomy flag, federation peer settings, completion flag, ledger rows, and pulse events. |
+| Shell/dashboard/start menu/file explorer/Codex console | `sentientos/shell/__init__.py`, `sentientos/shell/cli.py`, `apps/dashboard/main.py`, `dashboard_ui/`, `scripts/streamlit_dashboard.py`, `scripts/launcher_gui.py` | Shell abstractions cover start menu, taskbar, sandboxed file explorer, install simulation, Codex expansion request files, event logging, and dashboard surfaces. |
+| Local model/chat runtime | `sentientos/local_model.py`, `sentientos/chat_service.py`, `model_bridge.py`, `tests/test_local_model.py`, `tests/test_chat_service_lazy_loading.py`, `tests/integration/test_chat_mistral_runtime.py` | Local model loading supports placeholder/null, echo, GGUF/llama.cpp, and local transformers backends with local-file defaults and safe fallback behavior. Chat service lazy loading is tested. |
+| Memory/context/reflection storage | `memory_manager.py`, `memory_governor.py`, `sentientos/memory/`, `sentientos/meta/reflection_loop.py`, `reflection_log_cli.py`, `api/actuator.py` | Memory append/read, reflection storage, memory pressure/governor, pulse views, and action-result reflection surfaces exist. Context hygiene lives under `sentientos/context_hygiene/`. |
+| Autonomy runtime composition | `sentientos/autonomy/runtime.py`, `sentientos/autonomy/state.py`, `sentientos/autonomy/rehearsal.py`, `sentientos/autonomy/curiosity_loop.py`, `sentientos/orchestrator.py`, `scripts/orchestrator_daemon.py` | Runtime/state/rehearsal and orchestrator pieces exist. They should be treated as governed composition surfaces, not blanket authority. |
+| ASR/TTS/screen OCR/perception | `mic_bridge.py`, `tts_bridge.py`, `tts_service.py`, `ocr_pipeline.py`, `ocr_utils.py`, `scripts/perception/screen_adapter.py`, `sentientos/perception_api.py` | Speech recognition, text-to-speech, OCR, screen observation normalization, and perception telemetry surfaces exist. Legacy perception paths are explicitly marked non-authoritative/proposal-oriented in several modules. |
+| GUI control shim | `ui_controller.py`, `input_controller.py`, `sentientos/innervation.py` | UI/key/mouse abstractions and panic/permission/policy checks exist. These are shims and should not be read as blanket host control. |
+| Browser automation | `sentientos/agents/browser_automator.py`, `sentientos/oracle_relay.py`, `browser_voice.py` | Browser automation can be configured with enable flags, domain allowlists, daily budgets, panic checks, audit logging, and council checks for posting. Oracle relay contains Playwright session machinery. |
+| Driver manager and hardware/device awareness | `sentientos/daemons/driver_manager.py`, `config/hardware_profile.json`, `gpu_autosetup.py`, `tests/test_first_boot.py` | Device probing/recommendation, candidate driver catalog, suggestions, whitelisted vendors, and veil-pending install requests exist. This is not blanket hardware control. |
+| Embodiment fusion/ingress/proposal/governance/fulfillment/avatar state | `sentientos/embodiment_fusion.py`, `sentientos/embodiment_ingress.py`, `sentientos/embodiment_proposals.py`, `sentientos/embodiment_proposal_review.py`, `sentientos/embodiment_governance_bridge.py`, `sentientos/embodiment_fulfillment.py`, `sentientos/embodiment/avatar_state.py`, `godot_avatar_demo/` | Embodiment snapshots, ingress gates, proposal records, review receipts, governance bridge candidates, fulfillment candidates/receipts, and avatar state/demo surfaces exist. Fulfillment receipts are currently non-authoritative evidence, not proof of side effects. |
+| Control-plane kernel and admission authority | `sentientos/control_plane_kernel.py`, `control_plane/`, `sentientos/runtime_governor.py`, `docs/control_plane_authority_map.md`, `tests/test_control_plane_kernel.py` | Phase-aware admission, authority classes, decisions, process-local dedupe, runtime governor delegation, and machine-readable decision rows exist. |
+| ArchitectDaemon / GenesisForge / Codex self-amendment arc | `architect_daemon.py`, `codex/autogenesis.py`, `sentientos/forge.py`, `sentientos/forge_cli/`, `sentientos/forge_queue.py`, `sentientos/protected_mutation_intent.py`, `tests/test_architect_daemon.py`, `tests/test_genesis_forge.py`, `tests/test_autogenesis_loop.py` | Gap scanning, lineage annotation, review symmetry, forge CLI/status/queue, and protected mutation intent surfaces exist. These are governed proposal/review paths, not unapproved self-modification. |
+| Audit/immutability/context-boundary verification | `scripts/verify_audits.py`, `verify_audits.py`, `audit_immutability.py`, `scripts/audit_immutability_verifier.py`, `scripts/verify_context_hygiene_prompt_boundaries.py`, `sentientos/context_hygiene/`, `docs/architecture/context_hygiene_spine.md` | Audit verification, immutability checks, prompt/context boundary scans, provider denial custody, and source-kind safety contracts exist. |
+| Federation improvement custody runway | `sentientos/federation/improvement_candidate.py`, `sentientos/federation/improvement_intake_receipt.py`, `sentientos/federation/improvement_custody_runway.py`, `sentientos/federation/improvement_local_variant_artifact.py`, `sentientos/federation/improvement_lineage_comparison_receipt.py`, `sentientos/federation/improvement_dissemination_receipt.py`, `docs/architecture/federated_improvement_custody_runway.md` | Federation improvement artifacts and receipts exist as evidence/readiness/custody surfaces only. They do not transport, adopt, apply, merge, install, or execute by themselves. |
+
+## What works in concert
+
+The intended whole-system loop is:
+
+1. Install or bootstrap the node and verify pinned/local artifacts.
+2. Run first boot, obtain required local approval, detect hardware, and configure
+   driver review, Codex/autonomy posture, and federation peer metadata.
+3. Run the local model/chat runtime or placeholder backend under local-file and
+   fallback rules.
+4. Observe local screen/audio/vision/feedback/browser context through perception
+   adapters and legacy shims.
+5. Store eligible memory, context, and reflection records only through the
+   applicable memory/context paths and gates.
+6. Fuse observations into embodiment snapshots and classify embodied pressure,
+   privacy posture, retention posture, and risk flags.
+7. Convert eligible pressure into proposal, governance bridge, and fulfillment
+   candidates.
+8. Gate sensitive candidates through the control plane, runtime governor,
+   council/review surfaces, and policy checks.
+9. Execute only host actions that have an admitted, explicit, local authority
+   path; where fulfillment is only a receipt artifact, do not treat it as a real
+   effect.
+10. Write audit, immutability, decision, and receipt evidence.
+11. Detect capability gaps from logs/tests/probes and draft governed amendments
+    through ArchitectDaemon, GenesisForge/autogenesis, or forge/Codex review
+    flows.
+12. Optionally share metadata/evidence through federation custody artifacts, with
+    local adoption remaining separate and non-automatic.
+
+## Capabilities the repo supports today
+
+Supported facts in the current repository state:
+
+- Install/bootstrap helpers exist for deterministic/offline setup, dependency
+  handling, node/bootstrap scripts, log creation, manifest artifact verification,
+  and smoke-test hooks.
+- A local model/chat path exists, including placeholder/null, echo, GGUF/llama.cpp,
+  and local transformers loading. Local transformers loading uses local files and
+  defaults custom model code execution off unless explicitly opted in.
+- Memory, context, and reflection storage surfaces exist through `memory_manager.py`,
+  `memory_governor.py`, `sentientos/memory/`, `sentientos/meta/reflection_loop.py`,
+  and action/reflection logging paths.
+- Perception and embodiment telemetry surfaces exist for audio, screen/OCR,
+  vision/multimodal/feedback/gaze-shaped observations, normalized perception
+  events, and embodiment snapshots.
+- A GUI control shim exists through `ui_controller.py` and `input_controller.py`,
+  including dummy and optional platform backends, logging, panic handling, and
+  permission/policy hooks.
+- Browser automation exists through `sentientos/agents/browser_automator.py` and
+  related relay/demo surfaces, with enable flags, allowlists, budgets, panic
+  checks, and audit hooks.
+- TTS, ASR, and screen OCR surfaces exist through `tts_bridge.py`, `tts_service.py`,
+  `mic_bridge.py`, `ocr_pipeline.py`, `ocr_utils.py`, and
+  `scripts/perception/screen_adapter.py`.
+- Hardware driver awareness exists through `sentientos/daemons/driver_manager.py`,
+  with device reports, recommendations, package lists, whitelisted vendors,
+  suggestions, and veil-protected install requests.
+- First-boot Codex/federation configuration exists through `sentientos/first_boot.py`.
+- Governed self-amendment exists as gap scanning, lineage, review, protected
+  mutation intent, forge queue/status/CLI, and tests. It is not automatic
+  unapproved self-modification.
+- Federation evidence custody exists for improvement candidate, intake, custody
+  runway, local variant, lineage comparison, and dissemination receipts.
+
+## Claims not yet supported
+
+The following claims are not supported by the current repository state and should
+not be made as implemented capabilities:
+
+- Direct fan/PWM control is deferred unless and until a concrete, tested module is
+  added. No direct fan/PWM controller is claimed here.
+- Blanket hardware control is not implemented. The driver manager recommends and
+  queues/records driver actions; it is not general host-device authority.
+- Host kernel replacement is not implemented and is outside the stated model.
+  SentientOS is a user-space layer above Windows/macOS/Linux.
+- Automatic remote execution is not implemented.
+- Forced federation adoption is not implemented.
+- Provider invocation is not implemented as an approved runtime capability.
+  Existing provider-denial and provider-readiness artifacts are custody/metadata
+  surfaces; legacy relay/demo code must not be interpreted as approved provider
+  transport authority.
+- Prompt assembly/export for provider invocation is not implemented as an
+  approved runtime capability. Prompt-related phase artifacts are dry-run,
+  boundary, denial, or metadata surfaces unless a future admitted implementation
+  says otherwise.
+- Autonomous unapproved self-modification is not implemented. The self-amendment
+  arc is proposal/review/governance oriented.
+- Production execution from readiness, rehearsal, receipt, or custody artifacts is
+  not implemented. Receipts can support review; they do not execute themselves.
+
+## Missing organs
+
+These are concrete subsystems required by the implied trajectory but not yet
+complete as canonical, production-ready organs:
+
+### 1. Host Resource Governor
+
+A canonical resource governor should collect CPU, RAM, GPU, disk, network,
+thermal, and fan telemetry first. Any future actions, including fan/PWM, CPU/GPU
+limits, network throttles, or process controls, must come later behind policy,
+hardware allowlists, receipts, and rollback behavior.
+
+Proof required:
+
+- Tests for telemetry parsing, missing-sensor handling, policy denial, and no-op
+  behavior when actions are disabled.
+- Audit receipt for every telemetry snapshot and every denied/deferred action.
+- Fail-closed behavior when sensor data is stale, contradictory, privileged, or
+  unavailable.
+- No implicit authority to change host resources.
+- Operator override and panic handling that stops future actions and marks state
+  degraded.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_host_resource_governor.py`.
+
+### 2. Privilege Broker
+
+A single canonical broker should mediate privileged host actions instead of each
+subsystem inventing its own escalation path. The broker should identify actor,
+authority class, requested effect, target, proof requirements, admission decision,
+and operator override state.
+
+Proof required:
+
+- Tests for allow/deny/defer/quarantine outcomes, unknown action denial, and
+  duplicate request handling.
+- Audit receipt for every request and decision.
+- Fail-closed behavior when policy, operator approval, or proof is missing.
+- No implicit authority from subsystem-local helper calls.
+- Operator override and panic handling with visible blocked/degraded state.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_privilege_broker.py`.
+
+### 3. Actuation Fulfillment Layer
+
+Approved candidates need a canonical layer that turns admitted proposals into
+real effects with receipts. This layer should distinguish candidate, admission,
+execution attempt, result, rollback, and audit receipt. It must not confuse a
+fulfillment candidate or receipt with proof that a side effect occurred.
+
+Proof required:
+
+- Tests for candidate-to-admission-to-effect lifecycle, denied candidates, dry-run
+  candidates, rollback paths, and idempotency.
+- Audit receipt for each attempted, skipped, denied, completed, and rolled-back
+  effect.
+- Fail-closed behavior when admission is missing or stale.
+- No implicit authority from proposal existence.
+- Operator override and panic handling before and during fulfillment.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_actuation_fulfillment_layer.py`.
+
+### 4. Hardware/Sensor Inventory Manifest
+
+A durable local manifest should inventory sensors, devices, power/thermal
+capabilities, available resource telemetry, driver posture, privacy class, and
+operator consent posture. It should be local-first and should not grant authority
+by itself.
+
+Proof required:
+
+- Tests for inventory creation, update, redaction, schema migration, and missing
+  hardware.
+- Audit receipt for inventory snapshots and schema changes.
+- Fail-closed behavior when a device capability is unknown or unverified.
+- No implicit authority to actuate hardware from inventory entries.
+- Operator override and panic handling that can mark devices disabled/degraded.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_hardware_sensor_inventory_manifest.py`.
+
+### 5. Runtime Supervisor
+
+A runtime supervisor should maintain a service registry, health status, restart
+policy, safe shutdown, panic shutdown, dependency order, and degraded state for
+SentientOS services. It should coordinate daemons without granting them new
+host authority.
+
+Proof required:
+
+- Tests for service registration, health transitions, bounded restarts, safe
+  shutdown, panic shutdown, and degraded dependencies.
+- Audit receipt for service lifecycle events and restart decisions.
+- Fail-closed behavior when restart budgets or health proofs fail.
+- No implicit authority for services to self-escalate.
+- Operator override and panic handling that stops or disables services.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_runtime_supervisor.py`.
+
+### 6. Capability Registry
+
+A machine-readable registry should state what the node can sense, remember,
+decide, act on, and federate. It should include capability provenance, status,
+policy owner, proof command, and whether the capability is read-only,
+proposal-only, dry-run, or effect-capable.
+
+Proof required:
+
+- Tests for registry schema, capability lookup, unsupported capability denial,
+  and drift detection against docs/tests.
+- Audit receipt for registry changes and capability posture changes.
+- Fail-closed behavior when a capability is absent or contradictory.
+- No implicit authority from capability names alone.
+- Operator override and panic handling that can mark capabilities blocked.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_capability_registry.py`.
+
+### 7. Local Model Authority Map
+
+A local model authority map should record each model's posture: escrowed local
+artifact, local custom-code setting, remote/provider posture, allowed tools,
+context access posture, and proof commands. It should make provider invocation
+and custom code posture explicit per model.
+
+Proof required:
+
+- Tests for model inventory, local-only defaults, custom-code opt-in, provider
+  denial, and missing artifact handling.
+- Audit receipt for model posture changes and load decisions.
+- Fail-closed behavior when artifact, checksum, or authority posture is unknown.
+- No implicit provider authority from model configuration.
+- Operator override and panic handling that disables model loads or tool access.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_local_model_authority_map.py`.
+
+### 8. World-State Board
+
+A live board should derive pending, degraded, approved, blocked, and fulfilled
+state from logs, decisions, receipts, and supervisor health. It should be a view
+of evidence, not a decision engine.
+
+Proof required:
+
+- Tests for state derivation from representative logs, contradiction handling,
+  stale data, and degraded views.
+- Audit receipt for board snapshots or exports.
+- Fail-closed behavior when source logs are missing or inconsistent.
+- No implicit authority to execute from board display state.
+- Operator override and panic handling shown clearly in the board.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_world_state_board.py`.
+
+### 9. Federation Transport Envelope
+
+A federation transport envelope should exchange metadata-only receipts and
+lineage evidence without adoption, execution, merge, apply, install, or remote
+control. It should preserve local review boundaries and make remote origin and
+trust posture explicit.
+
+Proof required:
+
+- Tests for envelope schema, signature/identity metadata, local rejection,
+  replay protection, and non-adoption.
+- Audit receipt for inbound/outbound metadata envelopes.
+- Fail-closed behavior when origin, schema, signature, or policy is invalid.
+- No implicit authority from receipt delivery.
+- Operator override and panic handling that disables transport.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_federation_transport_envelope.py`.
+
+### 10. External Reviewer Demo Script
+
+A safe reviewer demo should show one end-to-end path: install or bootstrap,
+observe, write memory/context, produce a proposal, gate it, audit it, and export
+proof. It should be deterministic, local, non-destructive, and explicit about
+which steps are simulated.
+
+Proof required:
+
+- Tests for the demo script in a temporary workspace with no real host side
+  effects.
+- Audit receipt for every demo step.
+- Fail-closed behavior on missing dependencies or unexpected host access.
+- No implicit authority outside the demo workspace.
+- Operator override and panic handling that aborts the demo safely.
+- Docs proof command, for example `python -m scripts.run_tests -q tests/test_external_reviewer_demo_script.py`.
+
+## Build order
+
+Recommended phased order:
+
+- **Phase A: Capability registry + whole-system map.** Establish one
+  machine-readable source for supported, proposal-only, dry-run, blocked, and
+  missing capabilities, and keep this document aligned with it.
+- **Phase B: Hardware/sensor inventory manifest.** Record durable local inventory
+  of devices, sensors, drivers, privacy posture, and resource telemetry
+  availability without granting control.
+- **Phase C: Host resource governor read-only telemetry.** Add read-only CPU,
+  RAM, GPU, disk, network, thermal, and fan telemetry. Fan/PWM remains deferred.
+- **Phase D: Privilege broker.** Route privileged host actions through one
+  auditable broker and deny unknown paths by default.
+- **Phase E: Actuation fulfillment layer.** Convert approved candidates into
+  real effects only through admitted, receipt-producing fulfillment.
+- **Phase F: Runtime supervisor.** Add registry, health, restart policy, safe
+  shutdown, panic shutdown, and degraded service state.
+- **Phase G: Federation transport envelope.** Exchange metadata-only custody
+  receipts with no adoption or execution.
+- **Phase H: Optional bounded host resource actions.** Consider fan/PWM or other
+  resource actions only after telemetry, policy, hardware allowlists, privilege
+  brokering, operator override, and rollback receipts exist.
+
+## Safety/proof requirements summary
+
+Every missing organ should satisfy the same baseline before being described as
+implemented:
+
+- Focused tests cover normal, denied, degraded, missing-dependency, and panic
+  paths.
+- Audit receipts exist for inputs, decisions, outputs, denials, and errors.
+- Fail-closed behavior is the default for missing policy, missing proof,
+  unavailable sensors, stale data, unknown capabilities, or invalid federation
+  metadata.
+- No implicit authority is inferred from observation, memory, proposal,
+  readiness, receipt, dashboard state, or federation delivery.
+- Operator override and panic handling are explicit, tested, logged, and visible
+  in state surfaces.
+- A docs proof command is listed for reviewers and can be run from the repository
+  root.

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.no_legacy_skip
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_OVERVIEW = "docs/architecture/public_technical_overview.md"
 READINESS_INDEX = "docs/architecture/reviewer_release_readiness_index.md"
+TRAJECTORY_DOC = "docs/architecture/sentientos_trajectory_and_missing_organs.md"
 
 
 def _read(relative: str) -> str:
@@ -40,3 +41,29 @@ def test_release_readiness_index_keeps_key_proof_commands_current() -> None:
     ]
     for command in expected_commands:
         assert command in index
+
+
+def test_navigation_links_to_trajectory_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    assert TRAJECTORY_DOC in overview
+    assert TRAJECTORY_DOC in index
+
+
+def test_trajectory_doc_clarifies_deferred_fan_pwm_and_missing_organs() -> None:
+    trajectory = _read(TRAJECTORY_DOC)
+    assert "Direct fan/PWM control is deferred" in trajectory
+    expected_organs = [
+        "Host Resource Governor",
+        "Privilege Broker",
+        "Actuation Fulfillment Layer",
+        "Hardware/Sensor Inventory Manifest",
+        "Runtime Supervisor",
+        "Capability Registry",
+        "Local Model Authority Map",
+        "World-State Board",
+        "Federation Transport Envelope",
+        "External Reviewer Demo Script",
+    ]
+    for organ in expected_organs:
+        assert organ in trajectory


### PR DESCRIPTION
### Motivation

- Provide a clear, plain-technical map of what SentientOS currently implements and what concrete subsystems are still required to realize its user-space operating-substrate trajectory for governed AI autonomy.

### Description

- Add `docs/architecture/sentientos_trajectory_and_missing_organs.md` documenting: what SentientOS is becoming; existing subsystems and repo paths; the end-to-end loop; supported capabilities today; claims explicitly not supported; a concrete list of missing organs with required proofs; recommended phased build order; and safety/proof requirements.  
- Link the new trajectory doc from `docs/architecture/public_technical_overview.md` and `docs/architecture/reviewer_release_readiness_index.md`.  
- Extend `tests/test_reviewer_release_readiness_index.py` with checks that the public overview and readiness index link to the new trajectory doc, that the doc states direct fan/PWM control is deferred, and that the named missing organs appear.

Files changed:
- Added: `docs/architecture/sentientos_trajectory_and_missing_organs.md`
- Modified: `docs/architecture/public_technical_overview.md`
- Modified: `docs/architecture/reviewer_release_readiness_index.md`
- Modified: `tests/test_reviewer_release_readiness_index.py`

### Testing

- Ran docs build dependency/bootstrap and full docs build: `python scripts/build_docs.py --bootstrap-docs`, `python scripts/build_docs.py --check-deps`, and `python scripts/build_docs.py` (succeeded after installing docs deps). (succeeded)
- Ran targeted tests: `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py -k trajectory` (both passed).
- Ran context-hygiene verifier: `python scripts/verify_context_hygiene_prompt_boundaries.py` (reported clean).
- Performed `git diff --check` (no issues found).

The PR updates documentation and adds a small regression test; no runtime host controls or actuation were implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a051c65bab483209e32df87b8736804)