### PR TITLE
[codex:host-embodiment] add phase 1 substrate metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,25 @@ unless explicitly marked **sealed** or **deprecated**.
 - Avoid modifying any file listed in `AGENTS.md` unless creating logs or
   updating the index.
 
+### Codex Project Law
+- Use `python -m scripts.run_tests` for tests; direct naked `pytest` is exceptional.
+- Do not modify `prompt_assembler.py` unless explicitly asked.
+- Do not add provider invocation, prompt export, provider SDKs, network egress,
+  or runtime provider authority unless explicitly asked.
+- Do not add direct host actuation unless the task explicitly requests it and
+  includes control-plane admission, audit, rollback, panic, and operator
+  authority requirements.
+- Do not implement direct fan/PWM/thermal writes unless explicitly requested;
+  Phase 1 host resource work is read-only telemetry.
+- Preserve local operator authority and fail closed on ambiguity around
+  privileged host action.
+- Federation evidence is not adoption, transport, sync, merge, apply, install,
+  or execution. Receipts/readiness/proposals are not effects.
+- Update public docs and proof maps when behavior changes.
+- Run docs build and prompt-boundary checks when docs or context-hygiene docs
+  are touched.
+
+
 ### Procedure-Required Actions
 - Any invocation of `bless`, `animate`, or `reflect` must write a corresponding
   entry to `/logs/privileges/`.

--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -1,0 +1,126 @@
+# Host Embodiment Substrate Phase 1
+
+## Why this exists
+
+Host Embodiment Substrate Phase 1 creates the first concrete organ for the long
+trajectory where SentientOS can eventually understand and govern the local
+computer from stem to stern. The phase is intentionally limited to
+observe/model/propose posture. It adds metadata surfaces that make capability,
+hardware/sensor inventory, and resource pressure visible without granting unsafe
+host authority.
+
+This phase follows the build order named in
+`docs/architecture/sentientos_trajectory_and_missing_organs.md`: Capability
+Registry, Hardware/Sensor Inventory Manifest, Host Resource Governor read-only
+telemetry, then later Privilege Broker, Actuation Fulfillment Layer, Runtime
+Supervisor, and Federation Transport Envelope. It does not skip ahead to host
+mutation.
+
+## Implemented now
+
+### Capability Registry
+
+`sentientos/capability_registry.py` defines a machine-readable registry of what
+the current node says it can sense, remember, decide, propose, act on, and
+federate. The registry is metadata-only. It records implemented, partial,
+scaffolded, deferred, blocked, and unknown surfaces with authority levels,
+source paths, proof tests, proof commands, deferred surfaces, and forbidden
+implications.
+
+The default registry honestly marks GUI/browser host interaction as implemented
+but gated, hardware driver awareness as partial, host resource telemetry as
+scaffolded, federation evidence custody as implemented, provider invocation as
+blocked, and federation transport/sync/adoption as blocked or deferred. Direct
+fan/PWM/thermal control and blanket hardware control are blocked/deferred, not
+implemented.
+
+### Hardware/Sensor Inventory Manifest
+
+`sentientos/host_inventory.py` represents the local machine body as supplied
+metadata: node/host labels, OS family/release/architecture, CPU/GPU/RAM/disk,
+network, battery/power, thermal zones, fan/PWM controllers, audio, camera,
+display, input, service manager, privilege model, devices, sensors, source
+labels, unsupported/deferred labels, and warning/risk codes.
+
+Fan/PWM appears only as inventory and telemetry posture. If no fan/PWM sensors
+are supplied, the manifest records `unknown_unavailable_deferred` and
+`fan_pwm_control_deferred`; that is not a validation failure and never grants
+control.
+
+### Host Resource Governor
+
+`sentientos/host_resource_governor.py` classifies supplied telemetry into labels
+such as nominal, CPU pressure, memory pressure, GPU pressure, disk pressure,
+thermal pressure, fan signal present, battery pressure, service degraded,
+telemetry incomplete, and sensor unavailable. It can emit proposal-only
+candidate summaries for future governance, such as reducing model load,
+deferring heavy work, requesting operator review, inspecting thermal state,
+inspecting disk pressure, inspecting service health, or drafting a future cooling
+policy.
+
+Every proposal candidate explicitly states that it is proposal-only, does not
+execute, does not mutate the host, and would require a future Privilege Broker,
+control-plane admission, operator or policy approval, audit receipt, and rollback
+receipt before any future action.
+
+## Deferred and forbidden in Phase 1
+
+Phase 1 does not implement:
+
+- direct fan/PWM writes;
+- direct thermal actuation or cooling action;
+- power profile changes;
+- process killing;
+- service restart;
+- package installation;
+- driver installation or modification;
+- host configuration writes;
+- provider invocation, prompt export, provider SDK authority, or network egress;
+- federation transport, sync, adoption, merge, apply, install, execution, or
+  remote execution;
+- production execution from readiness/proposal artifacts;
+- unapproved self-modification.
+
+direct fan/PWM control remains deferred because safe host-resource action needs
+more than telemetry. It requires policy, hardware allowlists, a Privilege Broker,
+operator override, panic handling, control-plane admission, fulfillment receipts,
+audit receipts, and rollback receipts. Thermal control is likewise deferred
+until a later phase proves the complete authority and recovery chain.
+
+## Future ladder
+
+Every new class of host control must pass through this ladder:
+
+`telemetry → proposal → privilege broker → fulfillment → audit → rollback`
+
+The longer doctrine remains:
+
+`observe → model → propose → rehearse → authorize → fulfill → audit → rollback`
+
+Phase 1 covers observe/model and proposal candidate summaries only. It never
+fulfills an action.
+
+## Relationship to existing organs
+
+- GUI/browser control remains bounded and gated through existing shims and audit
+  posture; registry entries do not convert it into blanket host control.
+- `sentientos/daemons/driver_manager.py` remains hardware/driver awareness and
+  recommendation posture; Phase 1 does not install drivers.
+- The embodiment pipeline (`embodiment_fusion`, `embodiment_ingress`,
+  `embodiment_proposals`, `embodiment_governance_bridge`, and
+  `embodiment_fulfillment`) remains evidence, proposal, review, bridge, and
+  non-authoritative fulfillment-candidate posture; receipts are not effects.
+- `sentientos/control_plane_kernel.py` remains the admission surface for governed
+  work; Phase 1 does not add a bypass around it.
+- The autonomy runtime and future Runtime Supervisor remain composition and
+  health/safe-shutdown concerns, not uncontrolled authority expansion.
+
+## Proof commands
+
+```bash
+python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_host_inventory.py tests/test_host_resource_governor.py
+python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py
+python scripts/verify_context_hygiene_prompt_boundaries.py
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
+```

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -212,3 +212,7 @@ Internal and legacy cultural documentation remains available and is not removed 
 - `docs/PUBLIC_LANGUAGE_BRIDGE.md`
 - `docs/enter_cathedral.md`
 - `AGENTS.md` (repository governance ledger)
+
+## Host embodiment substrate
+
+See `docs/architecture/host_embodiment_substrate_phase1.md` for Phase 1 metadata-only host embodiment.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -15,6 +15,12 @@ For the broader user-space operating-substrate trajectory and the concrete
 missing subsystems still required, see
 `docs/architecture/sentientos_trajectory_and_missing_organs.md`.
 
+Host Embodiment Substrate Phase 1 is covered by
+`docs/architecture/host_embodiment_substrate_phase1.md`. It adds the
+Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
+Resource Governor scaffold. Privilege Broker and Actuation Fulfillment Layer
+remain future gates for any host action; direct fan/PWM control remains deferred.
+
 ## Current implemented proof surfaces
 
 ### Control plane / authority admission
@@ -138,6 +144,10 @@ python -m scripts.run_tests -q tests/test_integration_conftest_compat.py
 
 # Federated improvement custody/evidence runway.
 python -m scripts.run_tests -q tests/test_federated_improvement_candidate.py tests/test_federated_improvement_intake_receipt.py tests/test_federated_improvement_custody_runway.py tests/test_federated_improvement_local_variant_artifact.py tests/test_federated_improvement_lineage_comparison_receipt.py tests/test_federated_improvement_dissemination_receipt.py
+
+
+# Host embodiment substrate Phase 1 metadata-only proof.
+python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_host_inventory.py tests/test_host_resource_governor.py
 
 # Context hygiene / prompt-boundary verification.
 python scripts/verify_context_hygiene_prompt_boundaries.py

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -17,6 +17,13 @@ host effects, and leave enough audit evidence for an operator or reviewer to
 reconstruct what happened. Capabilities that are only implied by this trajectory
 are listed below as missing or deferred rather than claimed as implemented.
 
+Host Embodiment Substrate Phase 1 is the first observe/model substrate for this
+path; see `docs/architecture/host_embodiment_substrate_phase1.md`. It adds a
+Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
+Resource Governor scaffold while keeping Privilege Broker and Actuation
+Fulfillment Layer requirements ahead of any future host actuation. Direct
+fan/PWM control remains deferred.
+
 ## What already exists
 
 The repository already contains these major subsystem surfaces:

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -1,12 +1,58 @@
-"""In-memory capability registry for session-scoped disablement."""
+"""Metadata-only capability registry for SentientOS host embodiment.
+
+The registry describes current and deferred capability surfaces. It never probes
+hardware, opens network connections, assembles prompts, invokes providers, or
+changes runtime authority.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import json
-from typing import Mapping
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Mapping, Sequence
 
+CAPABILITY_CATEGORIES = frozenset(
+    {
+        "install_bootstrap",
+        "first_boot_configuration",
+        "local_model_chat",
+        "memory_context_reflection",
+        "perception_audio",
+        "perception_screen",
+        "perception_vision",
+        "embodiment_fusion",
+        "embodiment_governance",
+        "avatar_state",
+        "gui_host_interaction",
+        "browser_host_interaction",
+        "hardware_driver_awareness",
+        "hardware_sensor_inventory",
+        "host_resource_telemetry",
+        "control_plane_admission",
+        "audit_immutability",
+        "self_amendment",
+        "federation_evidence",
+        "docs_proof",
+    }
+)
+CAPABILITY_STATUSES = frozenset({"implemented", "partial", "scaffolded", "deferred", "blocked", "unknown"})
+AUTHORITY_LEVELS = frozenset(
+    {
+        "none",
+        "observation",
+        "proposal_only",
+        "gated_host_interaction",
+        "privileged_host_action",
+        "federation_evidence",
+        "self_amendment",
+    }
+)
+_SAFE_PROVIDER_NETWORK_STATUSES = frozenset({"blocked", "deferred"})
 
+# Backward-compatible session-scoped disablement registry used by diagnostics.
+# This legacy API is intentionally local in-memory metadata; it does not grant,
+# execute, or expand host authority.
 _DISABLED_CAPABILITIES: dict[str, str] = {}
 
 
@@ -43,11 +89,220 @@ def capability_snapshot_hash() -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-__all__ = [
-    "disable_capability",
-    "is_capability_disabled",
-    "disabled_capability_reason",
-    "disabled_capabilities",
-    "reset_capability_registry",
-    "capability_snapshot_hash",
-]
+@dataclass(frozen=True)
+class CapabilityRecord:
+    capability_id: str
+    category: str
+    status: str
+    authority_level: str = "none"
+    source_paths: tuple[str, ...] = ()
+    proof_tests: tuple[str, ...] = ()
+    proof_commands: tuple[str, ...] = ()
+    implemented_surfaces: tuple[str, ...] = ()
+    deferred_surfaces: tuple[str, ...] = ()
+    forbidden_implications: tuple[str, ...] = ()
+    requires_control_plane_admission: bool = False
+    requires_operator_approval: bool = False
+    requires_panic_stop: bool = False
+    requires_audit_receipt: bool = False
+    requires_rollback_receipt: bool = False
+    network_required: bool = False
+    provider_required: bool = False
+    prompt_assembly_required: bool = False
+    host_actuation_performed: bool = False
+    metadata_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CapabilityRegistry:
+    registry_id: str
+    schema_version: str = "host-embodiment-substrate-phase1.v1"
+    records: tuple[CapabilityRecord, ...] = ()
+    metadata_only: bool = True
+    no_runtime_authority_expansion: bool = True
+
+    def by_id(self) -> dict[str, CapabilityRecord]:
+        return {record.capability_id: record for record in self.records}
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CapabilityValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _record(
+    capability_id: str,
+    category: str,
+    status: str,
+    authority_level: str = "none",
+    *,
+    source_paths: Sequence[str] = (),
+    proof_tests: Sequence[str] = (),
+    proof_commands: Sequence[str] = (),
+    implemented_surfaces: Sequence[str] = (),
+    deferred_surfaces: Sequence[str] = (),
+    forbidden_implications: Sequence[str] = (),
+    requires_control_plane_admission: bool = False,
+    requires_operator_approval: bool = False,
+    requires_panic_stop: bool = False,
+    requires_audit_receipt: bool = False,
+    requires_rollback_receipt: bool = False,
+    network_required: bool = False,
+    provider_required: bool = False,
+    prompt_assembly_required: bool = False,
+    host_actuation_performed: bool = False,
+) -> CapabilityRecord:
+    return CapabilityRecord(
+        capability_id=capability_id,
+        category=category,
+        status=status,
+        authority_level=authority_level,
+        source_paths=_tuple(source_paths),
+        proof_tests=_tuple(proof_tests),
+        proof_commands=_tuple(proof_commands),
+        implemented_surfaces=_tuple(implemented_surfaces),
+        deferred_surfaces=_tuple(deferred_surfaces),
+        forbidden_implications=_tuple(forbidden_implications),
+        requires_control_plane_admission=requires_control_plane_admission,
+        requires_operator_approval=requires_operator_approval,
+        requires_panic_stop=requires_panic_stop,
+        requires_audit_receipt=requires_audit_receipt,
+        requires_rollback_receipt=requires_rollback_receipt,
+        network_required=network_required,
+        provider_required=provider_required,
+        prompt_assembly_required=prompt_assembly_required,
+        host_actuation_performed=host_actuation_performed,
+        metadata_only=True,
+    )
+
+
+def build_default_capability_registry() -> CapabilityRegistry:
+    """Return the deterministic Phase 1 capability map."""
+
+    records = (
+        _record("install_bootstrap", "install_bootstrap", "implemented", "observation", source_paths=("installer/setup_installer.py", "installer/dry_run.py", "scripts/package_launcher.py"), implemented_surfaces=("offline/dry-run setup metadata",), forbidden_implications=("package installation without operator action",)),
+        _record("first_boot_configuration", "first_boot_configuration", "implemented", "observation", source_paths=("sentientos/first_boot.py",), proof_tests=("tests/test_first_boot.py",), implemented_surfaces=("operator approvals and first-boot ledger rows",)),
+        _record("local_model_chat", "local_model_chat", "partial", "observation", source_paths=("sentientos/local_model.py", "sentientos/chat_service.py", "model_bridge.py"), proof_tests=("tests/test_local_model.py", "tests/test_chat_service_lazy_loading.py"), implemented_surfaces=("local-file/echo/null model paths",), deferred_surfaces=("provider invocation",), forbidden_implications=("runtime provider authority",)),
+        _record("memory_context_reflection", "memory_context_reflection", "implemented", "observation", source_paths=("memory_manager.py", "memory_governor.py", "sentientos/memory/", "sentientos/meta/reflection_loop.py"), implemented_surfaces=("memory/reflection storage and pressure summaries",), forbidden_implications=("host mutation",)),
+        _record("perception_audio", "perception_audio", "partial", "observation", source_paths=("mic_bridge.py", "tts_bridge.py", "tts_service.py"), implemented_surfaces=("audio ingress/egress adapters",), forbidden_implications=("privileged device control",)),
+        _record("perception_screen", "perception_screen", "partial", "observation", source_paths=("ocr_pipeline.py", "ocr_utils.py", "scripts/perception/screen_adapter.py"), implemented_surfaces=("screen OCR and normalized screen observations",), forbidden_implications=("desktop control",)),
+        _record("perception_vision", "perception_vision", "partial", "observation", source_paths=("sentientos/perception_api.py",), implemented_surfaces=("vision/perception telemetry APIs",), forbidden_implications=("camera authority expansion",)),
+        _record("embodiment_fusion", "embodiment_fusion", "implemented", "proposal_only", source_paths=("sentientos/embodiment_fusion.py", "sentientos/embodiment_ingress.py", "sentientos/embodiment_proposals.py"), implemented_surfaces=("event fusion, ingress receipts, proposal handoffs",), forbidden_implications=("proposal is not effect",)),
+        _record("embodiment_governance", "embodiment_governance", "implemented", "proposal_only", source_paths=("sentientos/embodiment_governance_bridge.py", "sentientos/embodiment_fulfillment.py"), implemented_surfaces=("governance bridge and non-authoritative fulfillment candidates",), forbidden_implications=("fulfillment candidate is not side-effect proof",)),
+        _record("avatar_state", "avatar_state", "implemented", "observation", source_paths=("avatar_state.py", "sentientos/embodiment/avatar_state.py"), implemented_surfaces=("avatar state metadata",)),
+        _record("gui_host_interaction", "gui_host_interaction", "implemented", "gated_host_interaction", source_paths=("sentientos/actuators/gui_control.py", "ui_controller.py", "input_controller.py", "sentientos/innervation.py"), implemented_surfaces=("permission/panic/policy gated UI shims",), forbidden_implications=("blanket host control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("browser_host_interaction", "browser_host_interaction", "implemented", "gated_host_interaction", source_paths=("sentientos/agents/browser_automator.py", "sentientos/oracle_relay.py", "browser_voice.py"), implemented_surfaces=("enable flags, allowlists, budgets, audit logging",), forbidden_implications=("network egress authority beyond configured browser automation",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("hardware_driver_awareness", "hardware_driver_awareness", "partial", "proposal_only", source_paths=("sentientos/daemons/driver_manager.py", "config/hardware_profile.json"), proof_tests=("tests/test_first_boot.py",), implemented_surfaces=("device reports, driver recommendations, veil-pending requests",), deferred_surfaces=("driver installation",), forbidden_implications=("package or driver install",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("hardware_sensor_inventory", "hardware_sensor_inventory", "scaffolded", "observation", source_paths=("sentientos/host_inventory.py",), proof_tests=("tests/test_host_inventory.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_inventory.py",), implemented_surfaces=("metadata manifest from supplied observations",), deferred_surfaces=("privileged sensor probing", "fan/PWM control"), forbidden_implications=("inventory grants authority")),
+        _record("host_resource_telemetry", "host_resource_telemetry", "scaffolded", "proposal_only", source_paths=("sentientos/host_resource_governor.py",), proof_tests=("tests/test_host_resource_governor.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_resource_governor.py",), implemented_surfaces=("read-only pressure classification from supplied telemetry",), deferred_surfaces=("cooling action", "process killing", "service restart", "power profile changes"), forbidden_implications=("telemetry is actuation")),
+        _record("direct_fan_pwm_thermal_control", "host_resource_telemetry", "blocked", "none", source_paths=("sentientos/host_resource_governor.py", "sentientos/host_inventory.py"), proof_tests=("tests/test_host_resource_governor.py", "tests/test_host_inventory.py"), deferred_surfaces=("fan/PWM writes", "direct thermal actuation"), forbidden_implications=("fan/PWM/thermal control is implemented"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("blanket_hardware_control", "hardware_driver_awareness", "blocked", "none", deferred_surfaces=("stem-to-stern host actuation",), forbidden_implications=("blanket hardware control exists"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("control_plane_admission", "control_plane_admission", "implemented", "proposal_only", source_paths=("sentientos/control_plane_kernel.py", "control_plane/", "sentientos/runtime_governor.py"), proof_tests=("tests/test_control_plane_kernel.py", "tests/test_sentientosd_runtime_closure.py"), implemented_surfaces=("admission receipts and runtime gating",), forbidden_implications=("admission alone performs effects",)),
+        _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
+        _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
+        _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
+        _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+    )
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase1", records=records)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def capability_registry_digest(registry: CapabilityRegistry) -> str:
+    return hashlib.sha256(_canonical_json(registry.to_dict()).encode("utf-8")).hexdigest()
+
+
+def summarize_capability_registry(registry: CapabilityRegistry) -> dict[str, Any]:
+    by_status: dict[str, int] = {}
+    by_authority: dict[str, int] = {}
+    for record in registry.records:
+        by_status[record.status] = by_status.get(record.status, 0) + 1
+        by_authority[record.authority_level] = by_authority.get(record.authority_level, 0) + 1
+    return {
+        "registry_id": registry.registry_id,
+        "schema_version": registry.schema_version,
+        "record_count": len(registry.records),
+        "records_by_status": dict(sorted(by_status.items())),
+        "records_by_authority_level": dict(sorted(by_authority.items())),
+        "capability_ids": tuple(sorted(record.capability_id for record in registry.records)),
+        "metadata_only": registry.metadata_only,
+        "no_runtime_authority_expansion": registry.no_runtime_authority_expansion,
+        "digest": capability_registry_digest(registry),
+    }
+
+
+def validate_capability_registry(registry: CapabilityRegistry) -> CapabilityValidationResult:
+    findings: list[str] = []
+    if not registry.registry_id:
+        findings.append("missing_registry_id")
+    if not registry.metadata_only:
+        findings.append("registry_not_metadata_only")
+    seen: set[str] = set()
+    for record in registry.records:
+        prefix = f"capability:{record.capability_id or '<missing>'}:"
+        if not record.capability_id:
+            findings.append(prefix + "missing_id")
+        if record.capability_id in seen:
+            findings.append(prefix + "duplicate_id")
+        seen.add(record.capability_id)
+        if not record.category:
+            findings.append(prefix + "missing_category")
+        elif record.category not in CAPABILITY_CATEGORIES:
+            findings.append(prefix + "unknown_category")
+        if not record.status:
+            findings.append(prefix + "missing_status")
+        elif record.status not in CAPABILITY_STATUSES:
+            findings.append(prefix + "unknown_status")
+        if record.authority_level not in AUTHORITY_LEVELS:
+            findings.append(prefix + "unknown_authority_level")
+        if not record.metadata_only:
+            findings.append(prefix + "not_metadata_only")
+        forbidden_text = " ".join(record.forbidden_implications).lower()
+        if record.status == "implemented" and forbidden_text and any(term in forbidden_text for term in ("implemented", "exists", "authority")) and record.host_actuation_performed:
+            findings.append(prefix + "implemented_claims_forbidden_implication")
+        if (record.provider_required or record.network_required or record.prompt_assembly_required) and record.status not in _SAFE_PROVIDER_NETWORK_STATUSES:
+            findings.append(prefix + "provider_network_prompt_authority_not_blocked_or_deferred")
+        record_text = _canonical_json(record.to_dict()).lower()
+        fan_pwm = "fan" in record_text or "pwm" in record_text or "thermal" in record_text
+        if record.status == "implemented" and fan_pwm and record.host_actuation_performed:
+            if not record.source_paths or not record.proof_tests:
+                findings.append(prefix + "implemented_fan_pwm_actuation_missing_source_or_proof")
+        if record.host_actuation_performed:
+            if record.authority_level != "privileged_host_action":
+                findings.append(prefix + "host_actuation_without_privileged_authority_level")
+            required = (
+                record.requires_control_plane_admission,
+                record.requires_operator_approval,
+                record.requires_panic_stop,
+                record.requires_audit_receipt,
+                record.requires_rollback_receipt,
+            )
+            if not all(required):
+                findings.append(prefix + "host_actuation_missing_admission_operator_panic_audit_or_rollback")
+        if record.category == "federation_evidence" and record.status == "implemented":
+            implemented_text = " ".join(record.implemented_surfaces).lower()
+            if any(term in implemented_text for term in ("transport", "sync", "adoption", "adopt", "merge", "apply", "install", "execution", "execute")):
+                findings.append(prefix + "federation_evidence_claims_transport_or_adoption")
+    return CapabilityValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def replace_capability_record(registry: CapabilityRegistry, capability_id: str, **changes: Any) -> CapabilityRegistry:
+    """Test helper for deterministic mutations without changing metadata behavior."""
+
+    records = tuple(replace(record, **changes) if record.capability_id == capability_id else record for record in registry.records)
+    return replace(registry, records=records)

--- a/sentientos/host_inventory.py
+++ b/sentientos/host_inventory.py
@@ -1,0 +1,327 @@
+"""Read-only host inventory manifest for SentientOS Phase 1.
+
+The manifest is a supplied-observation body map. It does not probe privileged
+hardware, mutate host state, invoke providers, assemble prompts, or grant action
+authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+KNOWN_OS_FAMILIES = frozenset({"linux", "windows", "darwin", "macos", "freebsd", "openbsd", "netbsd", "unknown"})
+DEVICE_KINDS = frozenset({"cpu", "gpu", "ram", "disk", "network", "battery", "power", "thermal", "fan_pwm", "audio", "camera", "display", "input", "service_manager", "privilege_model", "other"})
+SENSOR_KINDS = frozenset({"temperature", "fan_rpm", "battery_percent", "power_state", "utilization", "capacity", "presence", "unknown"})
+CONTROL_CLAIM_KEYS = frozenset({"control_available", "fan_pwm_control_available", "privileged_action_available", "host_actuation_available", "provider_authority", "network_authority", "prompt_authority"})
+
+
+@dataclass(frozen=True)
+class HostInventoryDevice:
+    device_id: str
+    kind: str
+    label: str
+    summary: Mapping[str, Any] = field(default_factory=dict)
+    status: str = "unknown"
+    source_label: str = "supplied"
+    control_available: bool = False
+    privileged_action_available: bool = False
+    metadata_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostInventorySensor:
+    sensor_id: str
+    kind: str
+    label: str
+    status: str = "unknown"
+    observed_value: Any | None = None
+    unit: str | None = None
+    source_label: str = "supplied"
+    control_available: bool = False
+    metadata_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostInventoryManifest:
+    manifest_id: str
+    node_id: str
+    host_id: str
+    os_family: str
+    os_release: str = "unknown"
+    architecture: str = "unknown"
+    cpu_summary: Mapping[str, Any] = field(default_factory=dict)
+    gpu_summary: Mapping[str, Any] = field(default_factory=dict)
+    ram_summary: Mapping[str, Any] = field(default_factory=dict)
+    disk_summary: Mapping[str, Any] = field(default_factory=dict)
+    network_interface_summary: Mapping[str, Any] = field(default_factory=dict)
+    battery_power_summary: Mapping[str, Any] = field(default_factory=dict)
+    thermal_zone_summary: Mapping[str, Any] = field(default_factory=dict)
+    fan_pwm_controller_summary: Mapping[str, Any] = field(default_factory=dict)
+    audio_device_summary: Mapping[str, Any] = field(default_factory=dict)
+    camera_display_input_summary: Mapping[str, Any] = field(default_factory=dict)
+    service_manager_summary: Mapping[str, Any] = field(default_factory=dict)
+    privilege_model_summary: Mapping[str, Any] = field(default_factory=dict)
+    devices: tuple[HostInventoryDevice, ...] = ()
+    sensors: tuple[HostInventorySensor, ...] = ()
+    observed_at: str = "unknown"
+    source_labels: tuple[str, ...] = ()
+    unsupported_deferred_labels: tuple[str, ...] = ()
+    warning_risk_codes: tuple[str, ...] = ()
+    metadata_only: bool = True
+    no_host_actuation: bool = True
+    no_provider_network_prompt_authority: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostInventoryValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    return dict(value or {})
+
+
+def _tuple_str(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _device_from_mapping(value: HostInventoryDevice | Mapping[str, Any]) -> HostInventoryDevice:
+    if isinstance(value, HostInventoryDevice):
+        return value
+    if not isinstance(value, Mapping):
+        return HostInventoryDevice(device_id="", kind="other", label="malformed", status="malformed")
+    return HostInventoryDevice(
+        device_id=str(value.get("device_id") or value.get("id") or ""),
+        kind=str(value.get("kind") or "other"),
+        label=str(value.get("label") or value.get("name") or ""),
+        summary=_mapping(value.get("summary") if isinstance(value.get("summary"), Mapping) else {}),
+        status=str(value.get("status") or "unknown"),
+        source_label=str(value.get("source_label") or "supplied"),
+        control_available=bool(value.get("control_available", False)),
+        privileged_action_available=bool(value.get("privileged_action_available", False)),
+        metadata_only=bool(value.get("metadata_only", True)),
+    )
+
+
+def _sensor_from_mapping(value: HostInventorySensor | Mapping[str, Any]) -> HostInventorySensor:
+    if isinstance(value, HostInventorySensor):
+        return value
+    if not isinstance(value, Mapping):
+        return HostInventorySensor(sensor_id="", kind="unknown", label="malformed", status="malformed")
+    return HostInventorySensor(
+        sensor_id=str(value.get("sensor_id") or value.get("id") or ""),
+        kind=str(value.get("kind") or "unknown"),
+        label=str(value.get("label") or value.get("name") or ""),
+        status=str(value.get("status") or "unknown"),
+        observed_value=value.get("observed_value", value.get("value")),
+        unit=str(value.get("unit")) if value.get("unit") is not None else None,
+        source_label=str(value.get("source_label") or "supplied"),
+        control_available=bool(value.get("control_available", False)),
+        metadata_only=bool(value.get("metadata_only", True)),
+    )
+
+
+def build_host_inventory_manifest(
+    *,
+    manifest_id: str,
+    node_id: str,
+    host_id: str | None = None,
+    os_family: str = "unknown",
+    os_release: str = "unknown",
+    architecture: str = "unknown",
+    cpu_summary: Mapping[str, Any] | None = None,
+    gpu_summary: Mapping[str, Any] | None = None,
+    ram_summary: Mapping[str, Any] | None = None,
+    disk_summary: Mapping[str, Any] | None = None,
+    network_interface_summary: Mapping[str, Any] | None = None,
+    battery_power_summary: Mapping[str, Any] | None = None,
+    thermal_zone_summary: Mapping[str, Any] | None = None,
+    fan_pwm_controller_summary: Mapping[str, Any] | None = None,
+    audio_device_summary: Mapping[str, Any] | None = None,
+    camera_display_input_summary: Mapping[str, Any] | None = None,
+    service_manager_summary: Mapping[str, Any] | None = None,
+    privilege_model_summary: Mapping[str, Any] | None = None,
+    devices: Sequence[HostInventoryDevice | Mapping[str, Any]] | None = None,
+    sensors: Sequence[HostInventorySensor | Mapping[str, Any]] | None = None,
+    observed_at: str | None = None,
+    source_labels: Sequence[str] | None = None,
+    unsupported_deferred_labels: Sequence[str] | None = None,
+    warning_risk_codes: Sequence[str] | None = None,
+) -> HostInventoryManifest:
+    fan_summary = _mapping(fan_pwm_controller_summary)
+    deferred = list(unsupported_deferred_labels or ())
+    if not fan_summary:
+        fan_summary = {"status": "unknown_unavailable_deferred", "control_available": False, "telemetry_only": True}
+        deferred.append("fan_pwm_control_deferred")
+    else:
+        fan_summary.setdefault("telemetry_only", True)
+        fan_summary.setdefault("control_available", False)
+    return HostInventoryManifest(
+        manifest_id=manifest_id,
+        node_id=node_id,
+        host_id=host_id or node_id,
+        os_family=os_family.lower() if os_family else "unknown",
+        os_release=os_release,
+        architecture=architecture,
+        cpu_summary=_mapping(cpu_summary),
+        gpu_summary=_mapping(gpu_summary),
+        ram_summary=_mapping(ram_summary),
+        disk_summary=_mapping(disk_summary),
+        network_interface_summary=_mapping(network_interface_summary),
+        battery_power_summary=_mapping(battery_power_summary),
+        thermal_zone_summary=_mapping(thermal_zone_summary),
+        fan_pwm_controller_summary=fan_summary,
+        audio_device_summary=_mapping(audio_device_summary),
+        camera_display_input_summary=_mapping(camera_display_input_summary),
+        service_manager_summary=_mapping(service_manager_summary),
+        privilege_model_summary=_mapping(privilege_model_summary),
+        devices=tuple(_device_from_mapping(item) for item in (devices or ())),
+        sensors=tuple(_sensor_from_mapping(item) for item in (sensors or ())),
+        observed_at=observed_at or _now_iso(),
+        source_labels=_tuple_str(source_labels),
+        unsupported_deferred_labels=tuple(sorted(set(str(item) for item in deferred))),
+        warning_risk_codes=_tuple_str(warning_risk_codes),
+    )
+
+
+def collect_basic_host_inventory(*, manifest_id: str = "basic-host-inventory", node_id: str = "local-node") -> HostInventoryManifest:
+    """Best-effort standard-library inventory; read-only and non-privileged."""
+
+    disk = shutil.disk_usage(os.getcwd())
+    return build_host_inventory_manifest(
+        manifest_id=manifest_id,
+        node_id=node_id,
+        os_family=(platform.system() or "unknown").lower(),
+        os_release=platform.release() or "unknown",
+        architecture=platform.machine() or "unknown",
+        cpu_summary={"processor": platform.processor() or "unknown", "cpu_count": os.cpu_count()},
+        disk_summary={"cwd_total_bytes": disk.total, "cwd_free_bytes": disk.free},
+        service_manager_summary={"status": "not_probed", "read_only": True},
+        privilege_model_summary={"status": "not_probed", "read_only": True},
+        source_labels=("standard_library_platform_os_shutil",),
+        warning_risk_codes=("best_effort_read_only_inventory",),
+    )
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def host_inventory_digest(manifest: HostInventoryManifest) -> str:
+    return hashlib.sha256(_canonical_json(manifest.to_dict()).encode("utf-8")).hexdigest()
+
+
+def summarize_host_inventory_manifest(manifest: HostInventoryManifest) -> dict[str, Any]:
+    return {
+        "manifest_id": manifest.manifest_id,
+        "node_id": manifest.node_id,
+        "host_id": manifest.host_id,
+        "os_family": manifest.os_family,
+        "architecture": manifest.architecture,
+        "device_count": len(manifest.devices),
+        "sensor_count": len(manifest.sensors),
+        "fan_pwm_status": manifest.fan_pwm_controller_summary.get("status", "unknown"),
+        "fan_pwm_telemetry_only": bool(manifest.fan_pwm_controller_summary.get("telemetry_only", True)),
+        "metadata_only": manifest.metadata_only,
+        "no_host_actuation": manifest.no_host_actuation,
+        "no_provider_network_prompt_authority": manifest.no_provider_network_prompt_authority,
+        "unsupported_deferred_labels": manifest.unsupported_deferred_labels,
+        "warning_risk_codes": manifest.warning_risk_codes,
+        "digest": host_inventory_digest(manifest),
+    }
+
+
+def _check_non_negative_mapping(prefix: str, mapping: Mapping[str, Any], findings: list[str]) -> None:
+    for key, value in mapping.items():
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value < 0:
+            findings.append(f"{prefix}:{key}:negative_value")
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and "percent" in str(key).lower() and not 0 <= float(value) <= 100:
+            findings.append(f"{prefix}:{key}:percent_out_of_range")
+        if str(key) in CONTROL_CLAIM_KEYS and bool(value):
+            findings.append(f"{prefix}:{key}:authority_claim_forbidden")
+
+
+def validate_host_inventory_manifest(manifest: HostInventoryManifest) -> HostInventoryValidationResult:
+    findings: list[str] = []
+    if not manifest.manifest_id:
+        findings.append("missing_manifest_id")
+    if not manifest.node_id:
+        findings.append("missing_node_id")
+    if not manifest.host_id:
+        findings.append("missing_host_id")
+    if manifest.os_family not in KNOWN_OS_FAMILIES:
+        findings.append("unknown_os_family")
+    if not manifest.metadata_only:
+        findings.append("manifest_not_metadata_only")
+    if not manifest.no_host_actuation:
+        findings.append("host_actuation_claimed")
+    if not manifest.no_provider_network_prompt_authority:
+        findings.append("provider_network_prompt_authority_claimed")
+    summary_maps = {
+        "cpu_summary": manifest.cpu_summary,
+        "gpu_summary": manifest.gpu_summary,
+        "ram_summary": manifest.ram_summary,
+        "disk_summary": manifest.disk_summary,
+        "network_interface_summary": manifest.network_interface_summary,
+        "battery_power_summary": manifest.battery_power_summary,
+        "thermal_zone_summary": manifest.thermal_zone_summary,
+        "fan_pwm_controller_summary": manifest.fan_pwm_controller_summary,
+        "audio_device_summary": manifest.audio_device_summary,
+        "camera_display_input_summary": manifest.camera_display_input_summary,
+        "service_manager_summary": manifest.service_manager_summary,
+        "privilege_model_summary": manifest.privilege_model_summary,
+    }
+    for name, mapping in summary_maps.items():
+        if not isinstance(mapping, Mapping):
+            findings.append(f"{name}:malformed_mapping")
+            continue
+        _check_non_negative_mapping(name, mapping, findings)
+    if bool(manifest.fan_pwm_controller_summary.get("control_available", False)) and not manifest.fan_pwm_controller_summary.get("backend_metadata"):
+        findings.append("fan_pwm_control_claimed_without_backend_metadata")
+    for device in manifest.devices:
+        prefix = f"device:{device.device_id or '<missing>'}"
+        if not device.device_id or not device.label:
+            findings.append(prefix + ":malformed_device")
+        if device.kind not in DEVICE_KINDS:
+            findings.append(prefix + ":unknown_device_kind")
+        if not device.metadata_only:
+            findings.append(prefix + ":not_metadata_only")
+        if device.control_available or device.privileged_action_available:
+            findings.append(prefix + ":privileged_action_claimed")
+        _check_non_negative_mapping(prefix + ":summary", device.summary, findings)
+    for sensor in manifest.sensors:
+        prefix = f"sensor:{sensor.sensor_id or '<missing>'}"
+        if not sensor.sensor_id or not sensor.label:
+            findings.append(prefix + ":malformed_sensor")
+        if sensor.kind not in SENSOR_KINDS:
+            findings.append(prefix + ":unknown_sensor_kind")
+        if not sensor.metadata_only:
+            findings.append(prefix + ":not_metadata_only")
+        if sensor.control_available:
+            findings.append(prefix + ":control_claimed")
+        if isinstance(sensor.observed_value, (int, float)) and not isinstance(sensor.observed_value, bool) and sensor.observed_value < 0 and sensor.kind in {"fan_rpm", "battery_percent", "utilization", "capacity"}:
+            findings.append(prefix + ":negative_observed_value")
+        if sensor.kind == "battery_percent" and isinstance(sensor.observed_value, (int, float)) and not 0 <= float(sensor.observed_value) <= 100:
+            findings.append(prefix + ":percent_out_of_range")
+    return HostInventoryValidationResult(ok=not findings, findings=tuple(findings))

--- a/sentientos/host_resource_governor.py
+++ b/sentientos/host_resource_governor.py
@@ -1,0 +1,347 @@
+"""Read-only host resource pressure governor scaffold for SentientOS Phase 1.
+
+This module classifies supplied telemetry and emits proposal-only candidate
+summaries for later governance. It never cools hardware, changes power profiles,
+kills processes, restarts services, installs packages, modifies drivers, opens
+network authority, invokes providers, assembles prompts, or mutates host state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Sequence
+
+PRESSURE_LABELS = frozenset(
+    {
+        "nominal",
+        "cpu_pressure",
+        "memory_pressure",
+        "gpu_pressure",
+        "disk_pressure",
+        "network_pressure",
+        "thermal_pressure",
+        "fan_signal_present",
+        "battery_pressure",
+        "service_degraded",
+        "telemetry_incomplete",
+        "sensor_unavailable",
+        "unknown",
+    }
+)
+CANDIDATE_KINDS = frozenset(
+    {
+        "reduce_model_load_candidate",
+        "defer_heavy_task_candidate",
+        "request_operator_review_candidate",
+        "inspect_thermal_state_candidate",
+        "inspect_disk_pressure_candidate",
+        "inspect_service_health_candidate",
+        "future_cooling_policy_candidate",
+    }
+)
+FORBIDDEN_MARKER_KEYS = frozenset(
+    {
+        "actuation_claimed",
+        "host_mutation_claimed",
+        "fan_pwm_write_marker",
+        "thermal_write_marker",
+        "process_kill_marker",
+        "service_restart_marker",
+        "package_install_marker",
+        "driver_install_marker",
+        "provider_invocation_marker",
+        "network_egress_marker",
+        "prompt_assembly_marker",
+    }
+)
+
+
+@dataclass(frozen=True)
+class HostResourceTelemetrySnapshot:
+    snapshot_id: str
+    cpu_utilization_percent: float | None = None
+    ram_utilization_percent: float | None = None
+    gpu_utilization_percent: float | None = None
+    vram_utilization_percent: float | None = None
+    disk_utilization_percent: float | None = None
+    disk_free_bytes: int | None = None
+    network_rx_bytes_per_second: float | None = None
+    network_tx_bytes_per_second: float | None = None
+    process_count: int | None = None
+    thermal_zone_temperatures_c: Mapping[str, float] = field(default_factory=dict)
+    fan_rpm_observations: Mapping[str, float] = field(default_factory=dict)
+    battery_percent: float | None = None
+    battery_charging: bool | None = None
+    power_profile_label: str | None = None
+    model_runtime_pressure_labels: tuple[str, ...] = ()
+    service_health_labels: tuple[str, ...] = ()
+    unavailable_sensor_labels: tuple[str, ...] = ()
+    observed_at: str | None = None
+    forbidden_markers: Mapping[str, bool] = field(default_factory=dict)
+    metadata_only: bool = True
+    no_host_actuation: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourceProposalCandidate:
+    candidate_id: str
+    kind: str
+    reason_labels: tuple[str, ...]
+    summary: str
+    proposal_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    requires_privilege_broker_for_future_action: bool = True
+    requires_control_plane_admission_for_future_action: bool = True
+    requires_operator_or_policy_approval_for_future_action: bool = True
+    requires_audit_receipt_for_future_action: bool = True
+    requires_rollback_receipt_for_future_action: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourcePressureReport:
+    report_id: str
+    snapshot_id: str
+    pressure_labels: tuple[str, ...]
+    findings: tuple[str, ...]
+    proposal_candidates: tuple[HostResourceProposalCandidate, ...]
+    metadata_only: bool = True
+    observe_model_propose_only: bool = True
+    no_host_actuation: bool = True
+    no_fan_pwm_writes: bool = True
+    no_process_kill_restart_install: bool = True
+    no_provider_network_prompt_authority: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourceGovernorValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _tuple_str(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def build_host_resource_telemetry_snapshot(
+    *,
+    snapshot_id: str,
+    cpu_utilization_percent: float | None = None,
+    ram_utilization_percent: float | None = None,
+    gpu_utilization_percent: float | None = None,
+    vram_utilization_percent: float | None = None,
+    disk_utilization_percent: float | None = None,
+    disk_free_bytes: int | None = None,
+    network_rx_bytes_per_second: float | None = None,
+    network_tx_bytes_per_second: float | None = None,
+    process_count: int | None = None,
+    thermal_zone_temperatures_c: Mapping[str, float] | None = None,
+    fan_rpm_observations: Mapping[str, float] | None = None,
+    battery_percent: float | None = None,
+    battery_charging: bool | None = None,
+    power_profile_label: str | None = None,
+    model_runtime_pressure_labels: Sequence[str] | None = None,
+    service_health_labels: Sequence[str] | None = None,
+    unavailable_sensor_labels: Sequence[str] | None = None,
+    observed_at: str | None = None,
+    forbidden_markers: Mapping[str, bool] | None = None,
+) -> HostResourceTelemetrySnapshot:
+    return HostResourceTelemetrySnapshot(
+        snapshot_id=snapshot_id,
+        cpu_utilization_percent=cpu_utilization_percent,
+        ram_utilization_percent=ram_utilization_percent,
+        gpu_utilization_percent=gpu_utilization_percent,
+        vram_utilization_percent=vram_utilization_percent,
+        disk_utilization_percent=disk_utilization_percent,
+        disk_free_bytes=disk_free_bytes,
+        network_rx_bytes_per_second=network_rx_bytes_per_second,
+        network_tx_bytes_per_second=network_tx_bytes_per_second,
+        process_count=process_count,
+        thermal_zone_temperatures_c=dict(thermal_zone_temperatures_c or {}),
+        fan_rpm_observations=dict(fan_rpm_observations or {}),
+        battery_percent=battery_percent,
+        battery_charging=battery_charging,
+        power_profile_label=power_profile_label,
+        model_runtime_pressure_labels=_tuple_str(model_runtime_pressure_labels),
+        service_health_labels=_tuple_str(service_health_labels),
+        unavailable_sensor_labels=_tuple_str(unavailable_sensor_labels),
+        observed_at=observed_at,
+        forbidden_markers=dict(forbidden_markers or {}),
+    )
+
+
+def _candidate(snapshot_id: str, kind: str, reason_labels: Sequence[str], summary: str) -> HostResourceProposalCandidate:
+    material = {"snapshot_id": snapshot_id, "kind": kind, "reason_labels": sorted(str(label) for label in reason_labels), "summary": summary}
+    candidate_id = "hrc_" + hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return HostResourceProposalCandidate(candidate_id=candidate_id, kind=kind, reason_labels=tuple(material["reason_labels"]), summary=summary)
+
+
+def evaluate_host_resource_pressure(
+    snapshot: HostResourceTelemetrySnapshot,
+    *,
+    cpu_pressure_percent: float = 90.0,
+    ram_pressure_percent: float = 90.0,
+    gpu_pressure_percent: float = 90.0,
+    disk_pressure_percent: float = 90.0,
+    thermal_pressure_c: float = 85.0,
+    battery_low_percent: float = 15.0,
+    network_pressure_bytes_per_second: float | None = None,
+) -> HostResourcePressureReport:
+    labels: set[str] = set()
+    findings: list[str] = []
+    candidates: list[HostResourceProposalCandidate] = []
+    if snapshot.cpu_utilization_percent is None and snapshot.ram_utilization_percent is None and snapshot.disk_utilization_percent is None:
+        labels.add("telemetry_incomplete")
+        findings.append("core_cpu_ram_disk_telemetry_incomplete")
+    if snapshot.unavailable_sensor_labels:
+        labels.add("sensor_unavailable")
+        findings.append("sensor_unavailable:" + ",".join(sorted(snapshot.unavailable_sensor_labels)))
+    if snapshot.cpu_utilization_percent is not None and snapshot.cpu_utilization_percent >= cpu_pressure_percent:
+        labels.add("cpu_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "reduce_model_load_candidate", ("cpu_pressure",), "CPU pressure observed; future governance may reduce model load."))
+    if snapshot.ram_utilization_percent is not None and snapshot.ram_utilization_percent >= ram_pressure_percent:
+        labels.add("memory_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "defer_heavy_task_candidate", ("memory_pressure",), "Memory pressure observed; future governance may defer heavy work."))
+    if (snapshot.gpu_utilization_percent is not None and snapshot.gpu_utilization_percent >= gpu_pressure_percent) or (snapshot.vram_utilization_percent is not None and snapshot.vram_utilization_percent >= gpu_pressure_percent):
+        labels.add("gpu_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "reduce_model_load_candidate", ("gpu_pressure",), "GPU/VRAM pressure observed; future governance may reduce model load."))
+    if snapshot.disk_utilization_percent is not None and snapshot.disk_utilization_percent >= disk_pressure_percent:
+        labels.add("disk_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "inspect_disk_pressure_candidate", ("disk_pressure",), "Disk pressure observed; future governance may inspect storage posture."))
+    if network_pressure_bytes_per_second is not None:
+        rx = snapshot.network_rx_bytes_per_second or 0.0
+        tx = snapshot.network_tx_bytes_per_second or 0.0
+        if rx >= network_pressure_bytes_per_second or tx >= network_pressure_bytes_per_second:
+            labels.add("network_pressure")
+            candidates.append(_candidate(snapshot.snapshot_id, "request_operator_review_candidate", ("network_pressure",), "Network pressure observed; future governance may request operator review."))
+    hot_zones = [zone for zone, temp in snapshot.thermal_zone_temperatures_c.items() if temp >= thermal_pressure_c]
+    if hot_zones:
+        labels.add("thermal_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "inspect_thermal_state_candidate", ("thermal_pressure",), "Thermal pressure observed; inspect-only candidate, not cooling action."))
+        candidates.append(_candidate(snapshot.snapshot_id, "future_cooling_policy_candidate", ("thermal_pressure", "future_only"), "Future cooling policy candidate only; no fan/PWM or thermal writes are performed."))
+    if snapshot.fan_rpm_observations:
+        labels.add("fan_signal_present")
+        findings.append("fan_rpm_observation_is_telemetry_only")
+    if snapshot.battery_percent is not None and snapshot.battery_percent <= battery_low_percent and snapshot.battery_charging is not True:
+        labels.add("battery_pressure")
+        candidates.append(_candidate(snapshot.snapshot_id, "request_operator_review_candidate", ("battery_pressure",), "Battery pressure observed; future governance may ask operator to review."))
+    degraded = [label for label in snapshot.service_health_labels if "degraded" in label or "failed" in label or "unhealthy" in label]
+    if degraded:
+        labels.add("service_degraded")
+        candidates.append(_candidate(snapshot.snapshot_id, "inspect_service_health_candidate", ("service_degraded",), "Service degradation label observed; inspect-only candidate."))
+    if not labels:
+        labels.add("nominal")
+    report_id = "hrr_" + hashlib.sha256(json.dumps({"snapshot_id": snapshot.snapshot_id, "labels": sorted(labels), "findings": sorted(findings)}, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:24]
+    return HostResourcePressureReport(
+        report_id=report_id,
+        snapshot_id=snapshot.snapshot_id,
+        pressure_labels=tuple(sorted(labels)),
+        findings=tuple(sorted(findings)),
+        proposal_candidates=tuple(sorted(candidates, key=lambda candidate: candidate.candidate_id)),
+    )
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def host_resource_report_digest(report: HostResourcePressureReport) -> str:
+    return hashlib.sha256(_canonical_json(report.to_dict()).encode("utf-8")).hexdigest()
+
+
+def summarize_host_resource_pressure(report: HostResourcePressureReport) -> dict[str, Any]:
+    return {
+        "report_id": report.report_id,
+        "snapshot_id": report.snapshot_id,
+        "pressure_labels": report.pressure_labels,
+        "finding_count": len(report.findings),
+        "proposal_candidate_count": len(report.proposal_candidates),
+        "candidate_kinds": tuple(sorted(candidate.kind for candidate in report.proposal_candidates)),
+        "metadata_only": report.metadata_only,
+        "observe_model_propose_only": report.observe_model_propose_only,
+        "no_host_actuation": report.no_host_actuation,
+        "no_fan_pwm_writes": report.no_fan_pwm_writes,
+        "no_process_kill_restart_install": report.no_process_kill_restart_install,
+        "no_provider_network_prompt_authority": report.no_provider_network_prompt_authority,
+        "digest": host_resource_report_digest(report),
+    }
+
+
+def validate_host_resource_pressure_report(
+    report: HostResourcePressureReport,
+    snapshot: HostResourceTelemetrySnapshot,
+    *,
+    min_temperature_c: float = -100.0,
+    max_temperature_c: float = 150.0,
+) -> HostResourceGovernorValidationResult:
+    findings: list[str] = []
+    if not snapshot.snapshot_id:
+        findings.append("missing_snapshot_id")
+    if report.snapshot_id != snapshot.snapshot_id:
+        findings.append("report_snapshot_mismatch")
+    percentage_fields = {
+        "cpu_utilization_percent": snapshot.cpu_utilization_percent,
+        "ram_utilization_percent": snapshot.ram_utilization_percent,
+        "gpu_utilization_percent": snapshot.gpu_utilization_percent,
+        "vram_utilization_percent": snapshot.vram_utilization_percent,
+        "disk_utilization_percent": snapshot.disk_utilization_percent,
+        "battery_percent": snapshot.battery_percent,
+    }
+    for name, value in percentage_fields.items():
+        if value is not None and not 0 <= float(value) <= 100:
+            findings.append(f"{name}:percent_out_of_range")
+    rate_fields = {
+        "disk_free_bytes": snapshot.disk_free_bytes,
+        "network_rx_bytes_per_second": snapshot.network_rx_bytes_per_second,
+        "network_tx_bytes_per_second": snapshot.network_tx_bytes_per_second,
+        "process_count": snapshot.process_count,
+    }
+    for name, value in rate_fields.items():
+        if value is not None and float(value) < 0:
+            findings.append(f"{name}:negative_value")
+    for zone, temp in snapshot.thermal_zone_temperatures_c.items():
+        if float(temp) < min_temperature_c or float(temp) > max_temperature_c:
+            findings.append(f"thermal_zone:{zone}:temperature_out_of_range")
+    for label, rpm in snapshot.fan_rpm_observations.items():
+        if float(rpm) < 0:
+            findings.append(f"fan_rpm:{label}:negative_value")
+    for key, value in snapshot.forbidden_markers.items():
+        if key in FORBIDDEN_MARKER_KEYS and bool(value):
+            findings.append(f"forbidden_marker:{key}")
+    for label in report.pressure_labels:
+        if label not in PRESSURE_LABELS:
+            findings.append(f"unknown_pressure_label:{label}")
+    if not report.metadata_only:
+        findings.append("report_not_metadata_only")
+    if not report.observe_model_propose_only or not report.no_host_actuation or not report.no_fan_pwm_writes or not report.no_process_kill_restart_install or not report.no_provider_network_prompt_authority:
+        findings.append("report_claims_forbidden_authority")
+    for candidate in report.proposal_candidates:
+        prefix = f"candidate:{candidate.candidate_id or '<missing>'}"
+        if not candidate.candidate_id:
+            findings.append(prefix + ":missing_id")
+        if candidate.kind not in CANDIDATE_KINDS:
+            findings.append(prefix + ":unknown_kind")
+        required = (
+            candidate.proposal_only,
+            candidate.does_not_execute,
+            candidate.does_not_mutate_host,
+            candidate.requires_privilege_broker_for_future_action,
+            candidate.requires_control_plane_admission_for_future_action,
+            candidate.requires_operator_or_policy_approval_for_future_action,
+            candidate.requires_audit_receipt_for_future_action,
+            candidate.requires_rollback_receipt_for_future_action,
+        )
+        if not all(required):
+            findings.append(prefix + ":candidate_claims_execution_or_missing_future_gate")
+    return HostResourceGovernorValidationResult(ok=not findings, findings=tuple(findings))

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.capability_registry import (
+    CapabilityRecord,
+    CapabilityRegistry,
+    build_default_capability_registry,
+    capability_registry_digest,
+    replace_capability_record,
+    summarize_capability_registry,
+    validate_capability_registry,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def test_default_registry_builds_deterministically_and_validates() -> None:
+    first = build_default_capability_registry()
+    second = build_default_capability_registry()
+    assert capability_registry_digest(first) == capability_registry_digest(second)
+    assert validate_capability_registry(first).ok
+    assert first.metadata_only is True
+
+
+def test_summary_shape_is_metadata_only_and_digest_changes_on_metadata() -> None:
+    registry = build_default_capability_registry()
+    summary = summarize_capability_registry(registry)
+    assert summary["metadata_only"] is True
+    assert summary["no_runtime_authority_expansion"] is True
+    assert "direct_fan_pwm_thermal_control" in summary["capability_ids"]
+    changed = replace_capability_record(registry, "host_resource_telemetry", status="partial")
+    assert capability_registry_digest(changed) != summary["digest"]
+
+
+def test_direct_fan_pwm_is_deferred_or_blocked_not_implemented() -> None:
+    record = build_default_capability_registry().by_id()["direct_fan_pwm_thermal_control"]
+    assert record.status in {"blocked", "deferred"}
+    assert record.host_actuation_performed is False
+    assert "fan/PWM writes" in record.deferred_surfaces
+
+
+def test_hardware_driver_awareness_references_driver_manager() -> None:
+    record = build_default_capability_registry().by_id()["hardware_driver_awareness"]
+    assert record.status in {"implemented", "partial"}
+    assert "sentientos/daemons/driver_manager.py" in record.source_paths
+    assert "driver installation" in record.deferred_surfaces
+
+
+def test_gui_and_browser_interaction_implemented_but_gated() -> None:
+    records = build_default_capability_registry().by_id()
+    for capability_id in ("gui_host_interaction", "browser_host_interaction"):
+        record = records[capability_id]
+        assert record.status == "implemented"
+        assert record.authority_level == "gated_host_interaction"
+        assert record.requires_control_plane_admission is True
+        assert record.requires_operator_approval is True
+        assert record.requires_panic_stop is True
+        assert record.requires_audit_receipt is True
+        assert record.host_actuation_performed is False
+
+
+def test_federation_evidence_is_implemented_but_not_transport_adoption_or_sync() -> None:
+    records = build_default_capability_registry().by_id()
+    evidence = records["federation_evidence_custody"]
+    transport = records["federation_transport_sync_adoption"]
+    assert evidence.status == "implemented"
+    assert evidence.authority_level == "federation_evidence"
+    assert {"transport", "sync", "adoption"}.issubset(set(evidence.deferred_surfaces))
+    assert transport.status in {"blocked", "deferred"}
+
+
+def test_provider_invocation_remains_blocked_or_deferred() -> None:
+    record = build_default_capability_registry().by_id()["provider_invocation"]
+    assert record.status in {"blocked", "deferred"}
+    assert record.provider_required is False
+    assert record.network_required is False
+    assert record.prompt_assembly_required is False
+    assert "provider invocation" in record.deferred_surfaces
+
+
+def test_validation_rejects_unsupported_implemented_host_actuation_without_requirements() -> None:
+    registry = CapabilityRegistry(
+        registry_id="bad",
+        records=(
+            CapabilityRecord(
+                capability_id="bad_actuation",
+                category="host_resource_telemetry",
+                status="implemented",
+                authority_level="observation",
+                host_actuation_performed=True,
+            ),
+        ),
+    )
+    result = validate_capability_registry(registry)
+    assert not result.ok
+    assert any("host_actuation" in finding for finding in result.findings)
+
+
+def test_validation_rejects_fan_pwm_implemented_claim_without_source_or_proof() -> None:
+    registry = CapabilityRegistry(
+        registry_id="bad",
+        records=(
+            CapabilityRecord(
+                capability_id="bad_fan",
+                category="host_resource_telemetry",
+                status="implemented",
+                authority_level="privileged_host_action",
+                implemented_surfaces=("fan/PWM actuation",),
+                host_actuation_performed=True,
+                requires_control_plane_admission=True,
+                requires_operator_approval=True,
+                requires_panic_stop=True,
+                requires_audit_receipt=True,
+                requires_rollback_receipt=True,
+            ),
+        ),
+    )
+    result = validate_capability_registry(registry)
+    assert not result.ok
+    assert any("fan_pwm" in finding for finding in result.findings)
+
+
+def test_validation_rejects_provider_network_prompt_authority_claims() -> None:
+    base = build_default_capability_registry().by_id()["local_model_chat"]
+    bad = replace(base, provider_required=True)
+    result = validate_capability_registry(CapabilityRegistry(registry_id="bad", records=(bad,)))
+    assert not result.ok
+    assert any("provider_network_prompt" in finding for finding in result.findings)
+
+
+def test_validation_rejects_federation_evidence_as_transport() -> None:
+    bad = CapabilityRecord(
+        capability_id="bad_federation",
+        category="federation_evidence",
+        status="implemented",
+        authority_level="federation_evidence",
+        implemented_surfaces=("transport and adoption",),
+    )
+    result = validate_capability_registry(CapabilityRegistry(registry_id="bad", records=(bad,)))
+    assert not result.ok
+    assert any("federation_evidence" in finding for finding in result.findings)

--- a/tests/test_host_inventory.py
+++ b/tests/test_host_inventory.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.host_inventory import (
+    HostInventoryDevice,
+    HostInventoryManifest,
+    HostInventorySensor,
+    build_host_inventory_manifest,
+    host_inventory_digest,
+    summarize_host_inventory_manifest,
+    validate_host_inventory_manifest,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _clean_manifest() -> HostInventoryManifest:
+    return build_host_inventory_manifest(
+        manifest_id="manifest-1",
+        node_id="node-1",
+        host_id="host-1",
+        os_family="linux",
+        os_release="6.x",
+        architecture="x86_64",
+        cpu_summary={"model": "test cpu", "cores": 8},
+        gpu_summary={"devices": ["test gpu"]},
+        ram_summary={"total_bytes": 16_000_000_000, "used_percent": 50},
+        disk_summary={"total_bytes": 100_000_000_000, "free_bytes": 50_000_000_000, "used_percent": 50},
+        network_interface_summary={"interfaces": ["lo", "eth0"]},
+        battery_power_summary={"battery_percent": 80, "charging": True},
+        thermal_zone_summary={"zones": ["cpu"], "max_c": 55},
+        fan_pwm_controller_summary={"status": "rpm_observable", "telemetry_only": True, "control_available": False},
+        audio_device_summary={"devices": ["default"]},
+        camera_display_input_summary={"camera_count": 1, "display_count": 1, "input_count": 2},
+        service_manager_summary={"kind": "systemd", "read_only": True},
+        privilege_model_summary={"user": "non-root", "read_only": True},
+        devices=(
+            {"device_id": "cpu0", "kind": "cpu", "label": "CPU", "summary": {"cores": 8}, "status": "observed"},
+            {"device_id": "gpu0", "kind": "gpu", "label": "GPU", "summary": {"memory_bytes": 8_000_000_000}, "status": "observed"},
+        ),
+        sensors=(
+            {"sensor_id": "temp0", "kind": "temperature", "label": "CPU temp", "observed_value": 55, "unit": "C", "status": "observed"},
+            {"sensor_id": "fan0", "kind": "fan_rpm", "label": "Fan RPM", "observed_value": 1200, "unit": "rpm", "status": "observed"},
+        ),
+        observed_at="2026-01-01T00:00:00+00:00",
+        source_labels=("test",),
+    )
+
+
+def test_clean_manifest_with_supplied_metadata_validates() -> None:
+    manifest = _clean_manifest()
+    assert validate_host_inventory_manifest(manifest).ok
+    summary = summarize_host_inventory_manifest(manifest)
+    assert summary["metadata_only"] is True
+    assert summary["no_host_actuation"] is True
+    assert summary["device_count"] == 2
+    assert summary["sensor_count"] == 2
+
+
+def test_missing_unknown_fan_pwm_is_unavailable_deferred_not_control() -> None:
+    manifest = build_host_inventory_manifest(manifest_id="manifest-2", node_id="node-1", os_family="linux", observed_at="t")
+    assert validate_host_inventory_manifest(manifest).ok
+    assert manifest.fan_pwm_controller_summary["status"] == "unknown_unavailable_deferred"
+    assert manifest.fan_pwm_controller_summary["control_available"] is False
+    assert "fan_pwm_control_deferred" in manifest.unsupported_deferred_labels
+
+
+def test_negative_ram_disk_and_percent_values_fail_closed() -> None:
+    manifest = build_host_inventory_manifest(
+        manifest_id="bad",
+        node_id="node",
+        os_family="linux",
+        ram_summary={"total_bytes": -1, "used_percent": 101},
+        disk_summary={"free_bytes": -2},
+        observed_at="t",
+    )
+    result = validate_host_inventory_manifest(manifest)
+    assert not result.ok
+    assert any("negative_value" in finding for finding in result.findings)
+    assert any("percent_out_of_range" in finding for finding in result.findings)
+
+
+def test_malformed_device_and_sensor_entries_fail_closed() -> None:
+    manifest = build_host_inventory_manifest(
+        manifest_id="bad",
+        node_id="node",
+        os_family="linux",
+        devices=({"device_id": "", "kind": "warp", "label": ""},),
+        sensors=({"sensor_id": "", "kind": "warp", "label": ""},),
+        observed_at="t",
+    )
+    result = validate_host_inventory_manifest(manifest)
+    assert not result.ok
+    assert any("malformed_device" in finding for finding in result.findings)
+    assert any("unknown_sensor_kind" in finding for finding in result.findings)
+
+
+def test_digest_is_deterministic_and_changes_on_metadata() -> None:
+    first = _clean_manifest()
+    second = _clean_manifest()
+    assert host_inventory_digest(first) == host_inventory_digest(second)
+    changed = replace(first, architecture="arm64")
+    assert host_inventory_digest(changed) != host_inventory_digest(first)
+
+
+def test_no_host_actuation_flags_allowed() -> None:
+    manifest = replace(_clean_manifest(), no_host_actuation=False)
+    result = validate_host_inventory_manifest(manifest)
+    assert not result.ok
+    assert "host_actuation_claimed" in result.findings
+
+
+def test_fan_pwm_control_claim_requires_backend_metadata_and_privileged_devices_rejected() -> None:
+    manifest = replace(
+        _clean_manifest(),
+        fan_pwm_controller_summary={"status": "claimed", "control_available": True},
+        devices=(HostInventoryDevice(device_id="fanctl", kind="fan_pwm", label="Fan controller", control_available=True),),
+        sensors=(HostInventorySensor(sensor_id="fan", kind="fan_rpm", label="Fan", control_available=True),),
+    )
+    result = validate_host_inventory_manifest(manifest)
+    assert not result.ok
+    assert "fan_pwm_control_claimed_without_backend_metadata" in result.findings
+    assert any("privileged_action_claimed" in finding for finding in result.findings)
+    assert any("control_claimed" in finding for finding in result.findings)

--- a/tests/test_host_resource_governor.py
+++ b/tests/test_host_resource_governor.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.host_resource_governor import (
+    HostResourceProposalCandidate,
+    build_host_resource_telemetry_snapshot,
+    evaluate_host_resource_pressure,
+    host_resource_report_digest,
+    summarize_host_resource_pressure,
+    validate_host_resource_pressure_report,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _report(**kwargs):
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id="snap-1", observed_at="t", **kwargs)
+    report = evaluate_host_resource_pressure(snapshot)
+    return snapshot, report
+
+
+def test_nominal_telemetry_produces_nominal_report() -> None:
+    snapshot, report = _report(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert report.pressure_labels == ("nominal",)
+    assert not report.proposal_candidates
+    assert validate_host_resource_pressure_report(report, snapshot).ok
+
+
+def test_pressure_classification_for_cpu_memory_gpu_disk_and_thermal() -> None:
+    snapshot, report = _report(
+        cpu_utilization_percent=95,
+        ram_utilization_percent=91,
+        gpu_utilization_percent=92,
+        disk_utilization_percent=93,
+        thermal_zone_temperatures_c={"cpu": 90},
+    )
+    assert {"cpu_pressure", "memory_pressure", "gpu_pressure", "disk_pressure", "thermal_pressure"}.issubset(set(report.pressure_labels))
+    assert validate_host_resource_pressure_report(report, snapshot).ok
+
+
+def test_fan_rpm_observation_is_telemetry_only() -> None:
+    snapshot, report = _report(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, fan_rpm_observations={"fan0": 1200})
+    assert "fan_signal_present" in report.pressure_labels
+    assert "fan_rpm_observation_is_telemetry_only" in report.findings
+    assert report.no_fan_pwm_writes is True
+    assert validate_host_resource_pressure_report(report, snapshot).ok
+
+
+def test_incomplete_telemetry_and_unavailable_sensors_are_findings() -> None:
+    snapshot, report = _report(unavailable_sensor_labels=("gpu", "fan_pwm"))
+    assert "telemetry_incomplete" in report.pressure_labels
+    assert "sensor_unavailable" in report.pressure_labels
+    assert any("sensor_unavailable" in finding for finding in report.findings)
+
+
+def test_proposal_candidates_are_proposal_only_and_non_mutating() -> None:
+    snapshot, report = _report(cpu_utilization_percent=99, ram_utilization_percent=95, disk_utilization_percent=95)
+    assert report.proposal_candidates
+    for candidate in report.proposal_candidates:
+        assert candidate.proposal_only is True
+        assert candidate.does_not_execute is True
+        assert candidate.does_not_mutate_host is True
+        assert candidate.requires_privilege_broker_for_future_action is True
+        assert candidate.requires_control_plane_admission_for_future_action is True
+        assert candidate.requires_operator_or_policy_approval_for_future_action is True
+        assert candidate.requires_audit_receipt_for_future_action is True
+        assert candidate.requires_rollback_receipt_for_future_action is True
+    assert validate_host_resource_pressure_report(report, snapshot).ok
+
+
+def test_invalid_percentages_fail_closed() -> None:
+    snapshot, report = _report(cpu_utilization_percent=101, ram_utilization_percent=-1, disk_utilization_percent=10)
+    result = validate_host_resource_pressure_report(report, snapshot)
+    assert not result.ok
+    assert any("percent_out_of_range" in finding for finding in result.findings)
+
+
+def test_negative_rates_and_counts_fail_closed() -> None:
+    snapshot, report = _report(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, disk_free_bytes=-1, network_rx_bytes_per_second=-1, process_count=-1)
+    result = validate_host_resource_pressure_report(report, snapshot)
+    assert not result.ok
+    assert any("negative_value" in finding for finding in result.findings)
+
+
+def test_fan_pwm_write_marker_fails_closed() -> None:
+    snapshot, report = _report(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, forbidden_markers={"fan_pwm_write_marker": True})
+    result = validate_host_resource_pressure_report(report, snapshot)
+    assert not result.ok
+    assert "forbidden_marker:fan_pwm_write_marker" in result.findings
+
+
+def test_process_kill_restart_install_markers_fail_closed() -> None:
+    snapshot, report = _report(
+        cpu_utilization_percent=10,
+        ram_utilization_percent=20,
+        disk_utilization_percent=30,
+        forbidden_markers={"process_kill_marker": True, "service_restart_marker": True, "package_install_marker": True},
+    )
+    result = validate_host_resource_pressure_report(report, snapshot)
+    assert not result.ok
+    assert "forbidden_marker:process_kill_marker" in result.findings
+    assert "forbidden_marker:service_restart_marker" in result.findings
+    assert "forbidden_marker:package_install_marker" in result.findings
+
+
+def test_provider_network_prompt_markers_fail_closed() -> None:
+    snapshot, report = _report(
+        cpu_utilization_percent=10,
+        ram_utilization_percent=20,
+        disk_utilization_percent=30,
+        forbidden_markers={"provider_invocation_marker": True, "network_egress_marker": True, "prompt_assembly_marker": True},
+    )
+    result = validate_host_resource_pressure_report(report, snapshot)
+    assert not result.ok
+    assert "forbidden_marker:provider_invocation_marker" in result.findings
+    assert "forbidden_marker:network_egress_marker" in result.findings
+    assert "forbidden_marker:prompt_assembly_marker" in result.findings
+
+
+def test_candidate_execution_or_host_mutation_claim_fails_closed() -> None:
+    snapshot, report = _report(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    bad_candidate = replace(report.proposal_candidates[0], does_not_execute=False)
+    bad_report = replace(report, proposal_candidates=(bad_candidate,))
+    result = validate_host_resource_pressure_report(bad_report, snapshot)
+    assert not result.ok
+    assert any("candidate_claims_execution" in finding for finding in result.findings)
+
+
+def test_deterministic_digest_and_metadata_summary() -> None:
+    first_snapshot, first_report = _report(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    second_snapshot, second_report = _report(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert host_resource_report_digest(first_report) == host_resource_report_digest(second_report)
+    summary = summarize_host_resource_pressure(first_report)
+    assert summary["metadata_only"] is True
+    assert summary["observe_model_propose_only"] is True
+    assert summary["no_host_actuation"] is True
+    assert summary["no_fan_pwm_writes"] is True
+    assert validate_host_resource_pressure_report(first_report, first_snapshot).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_OVERVIEW = "docs/architecture/public_technical_overview.md"
 READINESS_INDEX = "docs/architecture/reviewer_release_readiness_index.md"
 TRAJECTORY_DOC = "docs/architecture/sentientos_trajectory_and_missing_organs.md"
+HOST_EMBODIMENT_PHASE1 = "docs/architecture/host_embodiment_substrate_phase1.md"
 
 
 def _read(relative: str) -> str:
@@ -50,6 +51,15 @@ def test_navigation_links_to_trajectory_doc() -> None:
     assert TRAJECTORY_DOC in index
 
 
+def test_navigation_links_to_host_embodiment_phase1_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    trajectory = _read(TRAJECTORY_DOC)
+    assert HOST_EMBODIMENT_PHASE1 in overview
+    assert HOST_EMBODIMENT_PHASE1 in index
+    assert HOST_EMBODIMENT_PHASE1 in trajectory
+
+
 def test_trajectory_doc_clarifies_deferred_fan_pwm_and_missing_organs() -> None:
     trajectory = _read(TRAJECTORY_DOC)
     assert "Direct fan/PWM control is deferred" in trajectory
@@ -67,3 +77,23 @@ def test_trajectory_doc_clarifies_deferred_fan_pwm_and_missing_organs() -> None:
     ]
     for organ in expected_organs:
         assert organ in trajectory
+
+
+def test_host_embodiment_docs_preserve_phase1_boundaries() -> None:
+    combined = "\n".join(
+        [
+            _read(HOST_EMBODIMENT_PHASE1),
+            _read(PUBLIC_OVERVIEW),
+            _read(READINESS_INDEX),
+            _read(TRAJECTORY_DOC),
+        ]
+    )
+    assert "direct fan/PWM control remains deferred" in combined
+    for term in [
+        "Capability Registry",
+        "Hardware/Sensor Inventory Manifest",
+        "Host Resource Governor",
+        "Privilege Broker",
+        "Actuation Fulfillment Layer",
+    ]:
+        assert term in combined


### PR DESCRIPTION
### Motivation

- Provide a safe, metadata-only Phase 1 substrate so SentientOS can observe and model host state without gaining unsafe host actuation authority. 
- Make node capabilities, hardware/sensor inventory, and read-only telemetry/governor surfaces machine-readable and verifiable to support later privilege/fulfillment organs.

### Description

- Add concise Codex repo law to `AGENTS.md` defining test runner, prompt/provider/network, and host-actuation boundaries and fail-closed guidance. 
- New metadata-only Capability Registry at `sentientos/capability_registry.py` with `CapabilityRecord`, `CapabilityRegistry`, deterministic summarization/digest, validation rules, and a deterministic `build_default_capability_registry()` marking implemented/partial/scaffolded/deferred/blocked surfaces per Phase 1 policy. A legacy, in-memory disablement API is preserved for diagnostics. 
- New Hardware/Sensor Inventory Manifest at `sentientos/host_inventory.py` with frozen dataclasses (`HostInventoryManifest`, `HostInventoryDevice`, `HostInventorySensor`), builders including a safe `collect_basic_host_inventory()`, deterministic digest/summary helpers, and validation that fails-closed on malformed or privileged claims while treating missing fan/PWM as `unknown_unavailable_deferred`. 
- New read-only Host Resource Governor scaffold at `sentientos/host_resource_governor.py` providing `HostResourceTelemetrySnapshot`, `HostResourcePressureReport`, `HostResourceProposalCandidate`, helpers to evaluate pressure (`evaluate_host_resource_pressure`), deterministic digests/summaries, and validation that rejects forbidden actuation markers and enforces proposal-only, non-mutating candidate semantics. 
- Documentation: `docs/architecture/host_embodiment_substrate_phase1.md` explaining scope, what is implemented, deferred/forbidden behaviors (explicitly listing fan/PWM, thermal control, process kills, installs, provider/network/prompt authority, etc.), and the future ladder (telemetry→proposal→privilege broker→fulfillment→audit→rollback). Updated `public_technical_overview.md`, `reviewer_release_readiness_index.md`, and `sentientos_trajectory_and_missing_organs.md` to link Phase 1 doc. 
- Tests: Added `tests/test_capability_registry.py`, `tests/test_host_inventory.py`, `tests/test_host_resource_governor.py`, and extended `tests/test_reviewer_release_readiness_index.py` to assert doc links and Phase 1 boundary language.

### Testing

- Compiled new modules and tests (`python -m py_compile sentientos/capability_registry.py sentientos/host_inventory.py sentientos/host_resource_governor.py tests/test_capability_registry.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_reviewer_release_readiness_index.py`) and fixed non-Python doc note. The compile step succeeded for the Python files. 
- Ran focused unit suites: `python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_host_inventory.py tests/test_host_resource_governor.py`, which passed. 
- Ran docs/regression checks: `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py`, which initially failed due to missing docs bootstrap; after `python scripts/build_docs.py --bootstrap-docs` and subsequent docs build, the tests passed. 
- Ran `python scripts/verify_context_hygiene_prompt_boundaries.py` (passed) and `python scripts/build_docs.py` (bootstrap then full build; passed). 
- Ran additional compatibility checks including `tests/test_control_plane_kernel.py` and `tests/test_sentientosd_runtime_closure.py` (passed) and `tests/test_cli_import_recovery.py` against preserved legacy disablement API (passed with expected skips). 
- Searched new modules for forbidden imports/side-effect markers (grep for sockets/requests/subprocess/prompt_assembler/fan.*write/etc.) and confirmed only metadata/validation markers and no host-actuation calls. 

Files changed (summary)
- Updated: `AGENTS.md`, `docs/architecture/public_technical_overview.md`, `docs/architecture/reviewer_release_readiness_index.md`, `docs/architecture/sentientos_trajectory_and_missing_organs.md`, `tests/test_reviewer_release_readiness_index.py`.
- Added: `sentientos/capability_registry.py`, `sentientos/host_inventory.py`, `sentientos/host_resource_governor.py`, `docs/architecture/host_embodiment_substrate_phase1.md`, `tests/test_capability_registry.py`, `tests/test_host_inventory.py`, `tests/test_host_resource_governor.py`.

Notes / safety assurances
- No module performs network calls, provider invocation, prompt assembly/export, driver/package installs, process kills, service restarts, fan/PWM writes, thermal writes, or other host-mutation actions. All actuation or privileged claims are either blocked/deferred in the registry and manifest or cause validation failures. 
- Proposal candidates emitted by the governor are explicitly `proposal_only`, `does_not_execute`, and require future privilege-broker/control-plane/operator/audit/rollback gates before any effect. 

If you want, I can: provide a brief ADR summarizing these design choices, add a lightweight CLI view for summaries/digests, or open a follow-up PR to begin the Privilege Broker Phase 2 scaffolding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a051fd62040832088e63f106e44efda)