### PR TITLE
[codex:host-embodiment] add read-only host discovery

### DIFF
--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -98,7 +98,8 @@ The longer doctrine remains:
 `observe → model → propose → rehearse → authorize → fulfill → audit → rollback`
 
 Phase 1 covers observe/model and proposal candidate summaries only. It never
-fulfills an action.
+fulfills an action. The next read-only discovery pass is documented in
+`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`.
 
 ## Relationship to existing organs
 

--- a/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
+++ b/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
@@ -1,0 +1,66 @@
+# Host Embodiment Substrate Phase 2: Read-Only Discovery
+
+## Purpose
+
+Phase 2 extends [Host Embodiment Substrate Phase 1](docs/architecture/host_embodiment_substrate_phase1.md) from supplied metadata to safe local body discovery. SentientOS can now collect read-only observations and feed them into the Capability Registry, Hardware/Sensor Inventory Manifest, and Host Resource Governor without changing the host.
+
+The authority ladder remains:
+
+`observe → model → propose → rehearse → authorize → fulfill → audit → rollback`
+
+Phase 2 is only `observe → model → propose`.
+
+## Safe observations collected
+
+`sentientos/host_collectors.py` provides narrow collectors for:
+
+- platform and architecture labels from the standard library;
+- disk capacity/free space through `shutil.disk_usage` or an injected test provider;
+- memory totals when safely available through standard-library OS metadata, otherwise unavailable/partial findings;
+- CPU count and load averages where available, while leaving utilization unavailable when it cannot be computed safely;
+- process count from numeric `/proc` entries when available, without reading command lines;
+- local network interface names/link-address presence from read-only filesystem labels, without connectivity tests;
+- service-manager platform labels, without service status mutation or restart;
+- Linux thermal sensor values from injected or read-only `/sys/class/thermal` and `/sys/class/hwmon` readers;
+- Linux fan RPM and PWM-signal presence from injected or read-only `/sys/class/hwmon` readers.
+
+Every collector result records telemetry-only posture, warning/risk notes, privacy notes, and explicit false flags for host mutation, network use, and privileged action.
+
+## Graceful degradation
+
+Some platforms do not expose exact RAM, process, network, thermal, fan, PWM, or service-manager details through safe standard-library or read-only filesystem surfaces. Phase 2 records these as `partial`, `unavailable`, or `error` findings. It does not invent values and it does not call privileged tools such as `sensors-detect`, `pwmconfig`, or `fancontrol`.
+
+## Thermal, fan, and PWM remain telemetry-only
+
+Thermal zones and fan RPM are observations. PWM file presence is represented as `pwm_signal_observed=True`, `control_available=False`, `control_deferred=True`, `requires_future_allowlist=True`, and `requires_privilege_broker=True`.
+
+PWM presence is not control authority. A visible `pwm*` file may indicate a possible controller surface, but Phase 2 does not prove hardware safety, operator policy, rollback behavior, panic handling, or privilege-broker admission. Therefore direct fan/PWM writes remain forbidden/deferred and direct thermal actuation remains forbidden/deferred.
+
+## Integration flow
+
+Collector results feed inventory through `build_host_inventory_from_collector_results(...)` and optional live collection through `collect_host_inventory_manifest(...)`. The manifest populates OS/platform, architecture, CPU, RAM, disk, network interface, thermal zone, fan/PWM, service-manager, warning, risk, and unsupported/deferred labels while preserving metadata-only validation.
+
+Collector results feed resource pressure through `build_host_resource_telemetry_from_collector_results(...)` and optional evaluation through `evaluate_current_host_resource_pressure(...)`. The Host Resource Governor maps safe observations into telemetry snapshots and proposal-only pressure reports. Thermal pressure and fan-signal labels may produce inspection/future-policy candidates, but candidates do not execute and do not mutate the host.
+
+Collector-backed inventory and resource reports can update the Capability Registry with observation/proposal-only status through `update_registry_from_host_inventory(...)` and `update_registry_from_host_resource_report(...)`. Direct fan/PWM/thermal control remains blocked.
+
+## Future preparation
+
+Phase 2 prepares future Privilege Broker and Actuation Fulfillment Layer work by making the local body visible before any action path exists. Future host control must still add policy, hardware allowlists, admission receipts, operator authorization, panic stop, audit receipts, rollback receipts, and tested fulfillment modules.
+
+## Explicitly forbidden in Phase 2
+
+Phase 2 must not perform:
+
+- host mutation;
+- direct fan/PWM writes;
+- direct thermal actuation or cooling action;
+- process killing;
+- service restart;
+- package installation;
+- driver installation;
+- network egress or connectivity tests;
+- provider invocation;
+- prompt assembly/export;
+- federation transport, sync, adoption, merge, apply, install, execution, or remote execution;
+- uncontrolled runtime authority expansion.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -215,4 +215,4 @@ Internal and legacy cultural documentation remains available and is not removed 
 
 ## Host embodiment substrate
 
-See `docs/architecture/host_embodiment_substrate_phase1.md` for Phase 1 metadata-only host embodiment.
+See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` for Phase 1 metadata-only host embodiment and Phase 2 read-only discovery.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -16,7 +16,7 @@ missing subsystems still required, see
 `docs/architecture/sentientos_trajectory_and_missing_organs.md`.
 
 Host Embodiment Substrate Phase 1 is covered by
-`docs/architecture/host_embodiment_substrate_phase1.md`. It adds the
+`docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`. It adds the
 Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold. Privilege Broker and Actuation Fulfillment Layer
 remain future gates for any host action; direct fan/PWM control remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -18,7 +18,7 @@ reconstruct what happened. Capabilities that are only implied by this trajectory
 are listed below as missing or deferred rather than claimed as implemented.
 
 Host Embodiment Substrate Phase 1 is the first observe/model substrate for this
-path; see `docs/architecture/host_embodiment_substrate_phase1.md`. It adds a
+path; see `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`. It adds a
 Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold while keeping Privilege Broker and Actuation
 Fulfillment Layer requirements ahead of any future host actuation. Direct

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -219,6 +219,71 @@ def build_default_capability_registry() -> CapabilityRegistry:
     return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase1", records=records)
 
 
+
+def update_registry_from_host_inventory(registry: CapabilityRegistry, manifest: Any) -> CapabilityRegistry:
+    """Reflect collector-backed hardware inventory without granting control."""
+
+    records: list[CapabilityRecord] = []
+    source_paths = ("sentientos/host_collectors.py", "sentientos/host_inventory.py")
+    has_collector_source = any(str(label).startswith("collector:") for label in getattr(manifest, "source_labels", ()))
+    sensor_count = len(getattr(manifest, "sensors", ()) or ())
+    device_count = len(getattr(manifest, "devices", ()) or ())
+    status = "implemented" if has_collector_source and (sensor_count or device_count) else "partial"
+    for record in registry.records:
+        if record.capability_id == "hardware_sensor_inventory":
+            records.append(
+                replace(
+                    record,
+                    status=status,
+                    authority_level="observation",
+                    source_paths=tuple(sorted(set(record.source_paths + source_paths))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_collectors.py", "tests/test_host_inventory.py")))),
+                    proof_commands=tuple(sorted(set(record.proof_commands + ("python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("collector-backed read-only local host inventory",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("direct fan/PWM control", "direct thermal actuation",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("pwm presence is control authority", "inventory grants host actuation",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "direct_fan_pwm_thermal_control":
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase2.v1")
+
+
+def update_registry_from_host_resource_report(registry: CapabilityRegistry, report: Any) -> CapabilityRegistry:
+    """Reflect collector-backed host resource telemetry as observe/model/propose only."""
+
+    records: list[CapabilityRecord] = []
+    has_labels = bool(getattr(report, "pressure_labels", ()) or getattr(report, "findings", ()))
+    status = "implemented" if has_labels else "partial"
+    source_paths = ("sentientos/host_collectors.py", "sentientos/host_resource_governor.py")
+    for record in registry.records:
+        if record.capability_id == "host_resource_telemetry":
+            records.append(
+                replace(
+                    record,
+                    status=status,
+                    authority_level="proposal_only",
+                    source_paths=tuple(sorted(set(record.source_paths + source_paths))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_collectors.py", "tests/test_host_resource_governor.py")))),
+                    proof_commands=tuple(sorted(set(record.proof_commands + ("python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_resource_governor.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("collector-backed read-only resource pressure telemetry",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("cooling fulfillment", "process killing", "service restart", "power profile mutation",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("telemetry candidates execute host actions",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "direct_fan_pwm_thermal_control":
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase2.v1")
+
+
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 

--- a/sentientos/host_collectors.py
+++ b/sentientos/host_collectors.py
@@ -1,0 +1,418 @@
+"""Read-only host observation collectors for Host Embodiment Phase 2.
+
+Collectors in this module observe local metadata only. They do not mutate host
+state, open network connections, invoke providers, assemble prompts, install
+packages or drivers, kill processes, restart services, or write fan/PWM/thermal
+controls.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import platform
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+COLLECTOR_STATUSES = frozenset({"available", "partial", "unavailable", "error"})
+FORBIDDEN_COLLECTOR_MARKERS = frozenset(
+    {
+        "host_mutation_performed",
+        "network_performed",
+        "privileged_action_performed",
+        "fan_pwm_write_marker",
+        "thermal_write_marker",
+        "process_kill_marker",
+        "service_restart_marker",
+        "package_install_marker",
+        "driver_install_marker",
+        "provider_invocation_marker",
+        "prompt_assembly_marker",
+        "federation_transport_marker",
+        "remote_execution_marker",
+    }
+)
+
+DiskUsageProvider = Callable[[str], Any]
+MemoryProvider = Callable[[], Mapping[str, Any] | None]
+DirectoryLister = Callable[[str], Sequence[str]]
+TextReader = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class HostCollectorObservation:
+    label: str
+    value: Any
+    unit: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostCollectorFinding:
+    code: str
+    severity: str = "info"
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostCollectorResult:
+    collector_id: str
+    status: str
+    observed_at: str
+    source: str
+    values: Mapping[str, Any] = field(default_factory=dict)
+    observations: tuple[HostCollectorObservation, ...] = ()
+    findings: tuple[HostCollectorFinding, ...] = ()
+    warnings: tuple[str, ...] = ()
+    risks: tuple[str, ...] = ()
+    privacy_notes: tuple[str, ...] = ()
+    telemetry_only: bool = True
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    privileged_action_performed: bool = False
+    forbidden_markers: Mapping[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostCollectorValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _tuple_str(values: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(value) for value in (values or ()))
+
+
+def _finding(code: str, severity: str = "info", detail: str = "") -> HostCollectorFinding:
+    return HostCollectorFinding(code=code, severity=severity, detail=detail)
+
+
+def _result(
+    collector_id: str,
+    status: str,
+    *,
+    observed_at: str | None = None,
+    source: str,
+    values: Mapping[str, Any] | None = None,
+    observations: Sequence[HostCollectorObservation] | None = None,
+    findings: Sequence[HostCollectorFinding] | None = None,
+    warnings: Sequence[str] | None = None,
+    risks: Sequence[str] | None = None,
+    privacy_notes: Sequence[str] | None = None,
+    forbidden_markers: Mapping[str, bool] | None = None,
+) -> HostCollectorResult:
+    return HostCollectorResult(
+        collector_id=collector_id,
+        status=status if status in COLLECTOR_STATUSES else "error",
+        observed_at=observed_at or _now_iso(),
+        source=source,
+        values=dict(values or {}),
+        observations=tuple(observations or ()),
+        findings=tuple(findings or ()),
+        warnings=_tuple_str(warnings),
+        risks=_tuple_str(risks),
+        privacy_notes=_tuple_str(privacy_notes),
+        forbidden_markers=dict(forbidden_markers or {}),
+    )
+
+
+def _safe_read(path: str, text_reader: TextReader | None = None) -> str | None:
+    try:
+        if text_reader is not None:
+            return text_reader(path)
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return None
+
+
+def _safe_list(path: str, directory_lister: DirectoryLister | None = None) -> tuple[str, ...]:
+    try:
+        if directory_lister is not None:
+            return tuple(str(item) for item in directory_lister(path))
+        return tuple(sorted(item.name for item in Path(path).iterdir()))
+    except OSError:
+        return ()
+
+
+def _to_float(raw: str | None, *, scale: float = 1.0) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return float(str(raw).strip()) / scale
+    except (TypeError, ValueError):
+        return None
+
+
+def _disk_usage_dict(usage: Any) -> dict[str, int]:
+    return {"total_bytes": int(usage.total), "used_bytes": int(usage.used), "free_bytes": int(usage.free)}
+
+
+def collect_platform_observation(*, observed_at: str | None = None) -> HostCollectorResult:
+    values = {
+        "os_family": (platform.system() or "unknown").lower(),
+        "os_release": platform.release() or "unknown",
+        "platform": platform.platform(aliased=True, terse=True) or "unknown",
+        "architecture": platform.machine() or "unknown",
+        "python_implementation": platform.python_implementation() or "unknown",
+        "cpu_count": os.cpu_count(),
+    }
+    return _result(
+        "platform",
+        "available",
+        observed_at=observed_at,
+        source="standard_library:platform,os",
+        values=values,
+        privacy_notes=("Platform metadata may identify OS family and architecture but does not inspect files or network.",),
+    )
+
+
+def collect_disk_observation(
+    *,
+    path: str = ".",
+    disk_provider: DiskUsageProvider | None = None,
+    observed_at: str | None = None,
+) -> HostCollectorResult:
+    try:
+        usage = (disk_provider or shutil.disk_usage)(path)
+        values = _disk_usage_dict(usage)
+        total = values["total_bytes"]
+        values["used_percent"] = round((values["used_bytes"] / total) * 100, 6) if total else None
+        values["path_label"] = path
+        return _result("disk", "available", observed_at=observed_at, source="standard_library:shutil.disk_usage", values=values)
+    except (OSError, AttributeError, TypeError, ValueError) as exc:
+        return _result("disk", "error", observed_at=observed_at, source="standard_library:shutil.disk_usage", findings=(_finding("disk_unavailable", "warning", str(exc)),), warnings=("disk_usage_unavailable",))
+
+
+def collect_memory_observation(*, memory_provider: MemoryProvider | None = None, observed_at: str | None = None) -> HostCollectorResult:
+    try:
+        supplied = dict(memory_provider() or {}) if memory_provider is not None else {}
+    except Exception as exc:  # deterministic tests may inject failing providers
+        return _result("memory", "error", observed_at=observed_at, source="injected_memory_provider", findings=(_finding("memory_provider_error", "warning", str(exc)),), warnings=("memory_unavailable",))
+    values: dict[str, Any] = dict(supplied)
+    if not values:
+        if hasattr(os, "sysconf"):
+            try:
+                page_size = int(os.sysconf("SC_PAGE_SIZE"))
+                page_count = int(os.sysconf("SC_PHYS_PAGES"))
+                values["total_bytes"] = page_size * page_count
+                values["usage_unavailable"] = True
+            except (OSError, ValueError, AttributeError):
+                values = {}
+    if not values:
+        return _result("memory", "unavailable", observed_at=observed_at, source="standard_library:os.sysconf", findings=(_finding("memory_details_unavailable", "info", "Exact RAM details unavailable via safe standard library path."),), warnings=("sensor_unavailable:memory",))
+    status = "partial" if values.get("usage_unavailable") or "used_percent" not in values else "available"
+    findings = () if status == "available" else (_finding("memory_usage_unavailable", "info", "Total RAM observed but utilization was not computed."),)
+    return _result("memory", status, observed_at=observed_at, source="standard_library:os.sysconf", values=values, findings=findings)
+
+
+def collect_cpu_observation(*, observed_at: str | None = None) -> HostCollectorResult:
+    values: dict[str, Any] = {"cpu_count": os.cpu_count(), "processor": platform.processor() or "unknown", "utilization_percent": None}
+    findings = [_finding("cpu_utilization_unavailable", "info", "Standard library does not provide instantaneous CPU utilization without sampling or optional dependencies.")]
+    try:
+        load1, load5, load15 = os.getloadavg()
+        values.update({"load_average_1m": load1, "load_average_5m": load5, "load_average_15m": load15})
+        status = "partial"
+    except (OSError, AttributeError):
+        status = "partial" if values["cpu_count"] is not None else "unavailable"
+        findings.append(_finding("load_average_unavailable", "info", "Load average unavailable on this platform."))
+    return _result("cpu", status, observed_at=observed_at, source="standard_library:os,platform", values=values, findings=findings)
+
+
+def collect_process_observation(
+    *,
+    proc_path: str = "/proc",
+    directory_lister: DirectoryLister | None = None,
+    observed_at: str | None = None,
+) -> HostCollectorResult:
+    entries = _safe_list(proc_path, directory_lister)
+    if not entries:
+        return _result("process", "unavailable", observed_at=observed_at, source="read_only:/proc directory names", findings=(_finding("process_count_unavailable", "info", "Process count unavailable without privileged or platform-specific probing."),), warnings=("sensor_unavailable:process_count",), privacy_notes=("No process command lines are inspected.",))
+    count = sum(1 for entry in entries if str(entry).isdigit())
+    status = "available" if count else "unavailable"
+    return _result("process", status, observed_at=observed_at, source="read_only:/proc directory names", values={"process_count": count}, privacy_notes=("Only numeric process directory names are counted; command lines are not read.",))
+
+
+def collect_network_interface_observation(
+    *,
+    interface_path: str = "/sys/class/net",
+    directory_lister: DirectoryLister | None = None,
+    text_reader: TextReader | None = None,
+    observed_at: str | None = None,
+) -> HostCollectorResult:
+    names = _safe_list(interface_path, directory_lister)
+    if not names:
+        return _result("network_interfaces", "unavailable", observed_at=observed_at, source="read_only:/sys/class/net", findings=(_finding("network_interfaces_unavailable", "info", "Interface names unavailable via safe local filesystem observation."),), warnings=("sensor_unavailable:network_interfaces",), privacy_notes=("No connectivity check or network call is performed.",))
+    interfaces: list[dict[str, Any]] = []
+    for name in sorted(names):
+        address = _safe_read(f"{interface_path}/{name}/address", text_reader)
+        interfaces.append({"name": str(name), "address_observed": bool(address), "address": str(address).strip() if address else None})
+    return _result("network_interfaces", "available", observed_at=observed_at, source="read_only:/sys/class/net", values={"interfaces": interfaces, "connectivity_checked": False}, privacy_notes=("Interface names and local link addresses may be identifying; no connectivity check is performed.",))
+
+
+def collect_service_manager_observation(*, observed_at: str | None = None) -> HostCollectorResult:
+    system = (platform.system() or "unknown").lower()
+    label = "unknown"
+    if system == "linux":
+        if Path("/run/systemd/system").exists():
+            label = "systemd_present_marker"
+        elif Path("/sbin/openrc").exists() or Path("/run/openrc").exists():
+            label = "openrc_present_marker"
+        else:
+            label = "linux_service_manager_unidentified"
+    elif system == "darwin":
+        label = "launchd_platform_label"
+    elif system == "windows":
+        label = "windows_service_control_manager_platform_label"
+    status = "partial" if label.endswith("unidentified") or label == "unknown" else "available"
+    return _result("service_manager", status, observed_at=observed_at, source="read_only:platform/filesystem labels", values={"service_manager_label": label, "live_services_queried": False, "restart_performed": False}, warnings=("service_health_not_queried",) if status == "partial" else ())
+
+
+def collect_thermal_sensor_observation(
+    *,
+    thermal_path: str = "/sys/class/thermal",
+    hwmon_path: str = "/sys/class/hwmon",
+    directory_lister: DirectoryLister | None = None,
+    text_reader: TextReader | None = None,
+    observed_at: str | None = None,
+) -> HostCollectorResult:
+    zones: list[dict[str, Any]] = []
+    findings: list[HostCollectorFinding] = []
+    for entry in _safe_list(thermal_path, directory_lister):
+        if not fnmatch.fnmatch(str(entry), "thermal_zone*"):
+            continue
+        base = f"{thermal_path}/{entry}"
+        raw_temp = _safe_read(f"{base}/temp", text_reader)
+        temp_c = _to_float(raw_temp, scale=1000.0)
+        label = (_safe_read(f"{base}/type", text_reader) or str(entry)).strip()
+        if raw_temp is not None and temp_c is None:
+            findings.append(_finding("malformed_thermal_value", "warning", str(entry)))
+        elif temp_c is not None:
+            zones.append({"id": str(entry), "label": label, "temperature_c": temp_c, "control_available": False, "telemetry_only": True})
+    for hwmon in _safe_list(hwmon_path, directory_lister):
+        base = f"{hwmon_path}/{hwmon}"
+        for child in _safe_list(base, directory_lister):
+            if fnmatch.fnmatch(str(child), "temp*_input"):
+                raw_temp = _safe_read(f"{base}/{child}", text_reader)
+                temp_c = _to_float(raw_temp, scale=1000.0)
+                if raw_temp is not None and temp_c is None:
+                    findings.append(_finding("malformed_thermal_value", "warning", f"{hwmon}/{child}"))
+                elif temp_c is not None:
+                    zones.append({"id": f"{hwmon}/{child}", "label": f"{hwmon}:{child}", "temperature_c": temp_c, "control_available": False, "telemetry_only": True})
+    if not zones:
+        status = "partial" if findings else "unavailable"
+        warnings = ("sensor_unavailable:thermal",) if not findings else ("thermal_values_malformed",)
+    else:
+        status = "partial" if findings else "available"
+        warnings = ("thermal_values_malformed",) if findings else ()
+    return _result("thermal_sensors", status, observed_at=observed_at, source="read_only:/sys/class/thermal,/sys/class/hwmon", values={"zones": zones, "control_available": False, "thermal_actuation_deferred": True}, findings=findings, warnings=warnings)
+
+
+def collect_fan_pwm_observation(
+    *,
+    hwmon_path: str = "/sys/class/hwmon",
+    directory_lister: DirectoryLister | None = None,
+    text_reader: TextReader | None = None,
+    observed_at: str | None = None,
+) -> HostCollectorResult:
+    fans: list[dict[str, Any]] = []
+    pwm_signals: list[dict[str, Any]] = []
+    findings: list[HostCollectorFinding] = []
+    for hwmon in _safe_list(hwmon_path, directory_lister):
+        base = f"{hwmon_path}/{hwmon}"
+        for child in _safe_list(base, directory_lister):
+            child_text = str(child)
+            if fnmatch.fnmatch(child_text, "fan*_input"):
+                raw = _safe_read(f"{base}/{child_text}", text_reader)
+                rpm = _to_float(raw)
+                if raw is not None and rpm is None:
+                    findings.append(_finding("malformed_fan_rpm_value", "warning", f"{hwmon}/{child_text}"))
+                elif rpm is not None:
+                    fans.append({"id": f"{hwmon}/{child_text}", "rpm": rpm, "telemetry_only": True, "control_available": False})
+            elif fnmatch.fnmatch(child_text, "pwm*") and "enable" not in child_text:
+                pwm_signals.append({"id": f"{hwmon}/{child_text}", "pwm_signal_observed": True, "possible_controller_observed": True, "control_available": False, "control_deferred": True, "requires_future_allowlist": True, "requires_privilege_broker": True, "telemetry_only": True})
+    values = {
+        "fans": fans,
+        "pwm_signals": pwm_signals,
+        "pwm_signal_observed": bool(pwm_signals),
+        "control_available": False,
+        "control_deferred": True,
+        "requires_future_allowlist": True,
+        "requires_privilege_broker": True,
+        "telemetry_only": True,
+    }
+    if not fans and not pwm_signals:
+        status = "partial" if findings else "unavailable"
+        warnings = ("sensor_unavailable:fan_pwm",) if not findings else ("fan_pwm_values_malformed",)
+    else:
+        status = "partial" if findings else "available"
+        warnings = ("fan_pwm_values_malformed",) if findings else ()
+    return _result("fan_pwm", status, observed_at=observed_at, source="read_only:/sys/class/hwmon", values=values, findings=findings, warnings=warnings, risks=("pwm_presence_is_not_control_authority",) if pwm_signals else ())
+
+
+def collect_basic_host_observations(*, observed_at: str | None = None) -> tuple[HostCollectorResult, ...]:
+    """Run the safe standard-library/read-only filesystem collector subset."""
+
+    stamp = observed_at or _now_iso()
+    return (
+        collect_platform_observation(observed_at=stamp),
+        collect_disk_observation(observed_at=stamp),
+        collect_memory_observation(observed_at=stamp),
+        collect_cpu_observation(observed_at=stamp),
+        collect_process_observation(observed_at=stamp),
+        collect_network_interface_observation(observed_at=stamp),
+        collect_service_manager_observation(observed_at=stamp),
+        collect_thermal_sensor_observation(observed_at=stamp),
+        collect_fan_pwm_observation(observed_at=stamp),
+    )
+
+
+def validate_host_collector_result(result: HostCollectorResult) -> HostCollectorValidationResult:
+    findings: list[str] = []
+    if not result.collector_id:
+        findings.append("missing_collector_id")
+    if result.status not in COLLECTOR_STATUSES:
+        findings.append("unknown_status")
+    if not result.observed_at:
+        findings.append("missing_observed_at")
+    if not result.source:
+        findings.append("missing_source")
+    if not result.telemetry_only:
+        findings.append("collector_not_telemetry_only")
+    if result.host_mutation_performed:
+        findings.append("host_mutation_performed")
+    if result.network_performed:
+        findings.append("network_performed")
+    if result.privileged_action_performed:
+        findings.append("privileged_action_performed")
+    for key, value in result.forbidden_markers.items():
+        if key in FORBIDDEN_COLLECTOR_MARKERS and bool(value):
+            findings.append(f"forbidden_marker:{key}")
+    text = repr(result.to_dict()).lower()
+    marker_terms = {
+        "fan_pwm_write_marker": "fan_pwm_write_marker",
+        "thermal_write_marker": "thermal_write_marker",
+        "process_kill_marker": "process_kill_marker",
+        "service_restart_marker": "service_restart_marker",
+        "package_install_marker": "package_install_marker",
+        "driver_install_marker": "driver_install_marker",
+    }
+    for term, code in marker_terms.items():
+        if term in text and not result.forbidden_markers.get(term, False):
+            findings.append(f"forbidden_marker_text:{code}")
+    return HostCollectorValidationResult(ok=not findings, findings=tuple(findings))

--- a/sentientos/host_inventory.py
+++ b/sentientos/host_inventory.py
@@ -224,6 +224,130 @@ def collect_basic_host_inventory(*, manifest_id: str = "basic-host-inventory", n
     )
 
 
+
+def build_host_inventory_from_collector_results(
+    results: Sequence[Any],
+    *,
+    manifest_id: str = "collector-backed-host-inventory",
+    node_id: str = "local-node",
+    host_id: str | None = None,
+) -> HostInventoryManifest:
+    """Build a metadata-only inventory manifest from Phase 2 collectors.
+
+    Collector results are read-only observations. They populate inventory summary
+    fields but never grant device control or privileged host action.
+    """
+
+    from sentientos.host_collectors import HostCollectorResult, validate_host_collector_result
+
+    by_id: dict[str, HostCollectorResult] = {str(result.collector_id): result for result in results if isinstance(result, HostCollectorResult)}
+    source_labels: list[str] = []
+    warnings: list[str] = []
+    deferred: list[str] = []
+    devices: list[HostInventoryDevice] = []
+    sensors: list[HostInventorySensor] = []
+    observed_values = [result.observed_at for result in by_id.values() if result.observed_at]
+    observed_at = min(observed_values) if observed_values else _now_iso()
+
+    for result in by_id.values():
+        source_labels.append(f"collector:{result.collector_id}:{result.source}")
+        warnings.extend(result.warnings)
+        warnings.extend(f"collector_validation:{finding}" for finding in validate_host_collector_result(result).findings)
+        if result.status in {"unavailable", "partial", "error"}:
+            deferred.append(f"{result.collector_id}_{result.status}")
+        warnings.extend(f"{result.collector_id}:{finding.code}" for finding in result.findings)
+        warnings.extend(f"risk:{risk}" for risk in result.risks)
+
+    platform_values = dict(by_id.get("platform").values) if by_id.get("platform") else {}
+    cpu_values = dict(by_id.get("cpu").values) if by_id.get("cpu") else {}
+    memory_values = dict(by_id.get("memory").values) if by_id.get("memory") else {}
+    disk_values = dict(by_id.get("disk").values) if by_id.get("disk") else {}
+    network_values = dict(by_id.get("network_interfaces").values) if by_id.get("network_interfaces") else {}
+    service_values = dict(by_id.get("service_manager").values) if by_id.get("service_manager") else {}
+    thermal_values = dict(by_id.get("thermal_sensors").values) if by_id.get("thermal_sensors") else {}
+    fan_values = dict(by_id.get("fan_pwm").values) if by_id.get("fan_pwm") else {}
+
+    if platform_values:
+        devices.append(HostInventoryDevice(device_id="host-platform", kind="other", label="Host platform", summary=platform_values, status=by_id["platform"].status, source_label="collector:platform"))
+    if cpu_values or platform_values.get("cpu_count") is not None:
+        merged_cpu = {**({"cpu_count": platform_values.get("cpu_count")} if platform_values.get("cpu_count") is not None else {}), **cpu_values}
+        devices.append(HostInventoryDevice(device_id="cpu-summary", kind="cpu", label="CPU summary", summary=merged_cpu, status=by_id.get("cpu").status if by_id.get("cpu") else "partial", source_label="collector:cpu"))
+    if memory_values:
+        devices.append(HostInventoryDevice(device_id="ram-summary", kind="ram", label="RAM summary", summary=memory_values, status=by_id["memory"].status, source_label="collector:memory"))
+    if disk_values:
+        devices.append(HostInventoryDevice(device_id="disk-summary", kind="disk", label="Disk summary", summary=disk_values, status=by_id["disk"].status, source_label="collector:disk"))
+    if network_values:
+        devices.append(HostInventoryDevice(device_id="network-interfaces", kind="network", label="Network interfaces", summary=network_values, status=by_id["network_interfaces"].status, source_label="collector:network_interfaces"))
+    if service_values:
+        devices.append(HostInventoryDevice(device_id="service-manager", kind="service_manager", label="Service manager", summary=service_values, status=by_id["service_manager"].status, source_label="collector:service_manager"))
+
+    zones = tuple(thermal_values.get("zones") or ())
+    for index, zone in enumerate(zones):
+        if isinstance(zone, Mapping):
+            sensors.append(HostInventorySensor(sensor_id=f"thermal-{index}", kind="temperature", label=str(zone.get("label") or zone.get("id") or f"thermal-{index}"), status="observed", observed_value=zone.get("temperature_c"), unit="C", source_label="collector:thermal_sensors", control_available=False, metadata_only=True))
+    fans = tuple(fan_values.get("fans") or ())
+    for index, fan in enumerate(fans):
+        if isinstance(fan, Mapping):
+            sensors.append(HostInventorySensor(sensor_id=f"fan-rpm-{index}", kind="fan_rpm", label=str(fan.get("id") or f"fan-rpm-{index}"), status="observed", observed_value=fan.get("rpm"), unit="rpm", source_label="collector:fan_pwm", control_available=False, metadata_only=True))
+
+    fan_summary = {
+        **fan_values,
+        "status": by_id.get("fan_pwm").status if by_id.get("fan_pwm") else "unavailable",
+        "telemetry_only": True,
+        "pwm_signal_observed": bool(fan_values.get("pwm_signal_observed", False)),
+        "control_available": False,
+        "control_deferred": True,
+        "requires_future_allowlist": True,
+        "requires_privilege_broker": True,
+    }
+    if fan_summary["pwm_signal_observed"]:
+        deferred.extend(("fan_pwm_control_deferred", "pwm_presence_not_control_authority", "requires_future_allowlist", "requires_privilege_broker"))
+
+    thermal_summary = {**thermal_values, "telemetry_only": True, "control_available": False, "thermal_actuation_deferred": True}
+    if zones:
+        deferred.append("thermal_actuation_deferred")
+
+    return build_host_inventory_manifest(
+        manifest_id=manifest_id,
+        node_id=node_id,
+        host_id=host_id,
+        os_family=str(platform_values.get("os_family") or "unknown"),
+        os_release=str(platform_values.get("os_release") or "unknown"),
+        architecture=str(platform_values.get("architecture") or "unknown"),
+        cpu_summary={**cpu_values, **({"cpu_count": platform_values.get("cpu_count")} if platform_values.get("cpu_count") is not None and "cpu_count" not in cpu_values else {})},
+        ram_summary=memory_values,
+        disk_summary=disk_values,
+        network_interface_summary=network_values,
+        thermal_zone_summary=thermal_summary,
+        fan_pwm_controller_summary=fan_summary,
+        service_manager_summary=service_values,
+        devices=devices,
+        sensors=sensors,
+        observed_at=observed_at,
+        source_labels=tuple(sorted(set(source_labels))),
+        unsupported_deferred_labels=tuple(sorted(set(deferred))),
+        warning_risk_codes=tuple(sorted(set(warnings))),
+    )
+
+
+def collect_host_inventory_manifest(
+    *,
+    manifest_id: str = "collector-backed-host-inventory",
+    node_id: str = "local-node",
+    host_id: str | None = None,
+) -> HostInventoryManifest:
+    """Collect read-only Phase 2 host observations and build a manifest."""
+
+    from sentientos.host_collectors import collect_basic_host_observations
+
+    return build_host_inventory_from_collector_results(
+        collect_basic_host_observations(),
+        manifest_id=manifest_id,
+        node_id=node_id,
+        host_id=host_id,
+    )
+
+
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
 

--- a/sentientos/host_resource_governor.py
+++ b/sentientos/host_resource_governor.py
@@ -252,6 +252,109 @@ def evaluate_host_resource_pressure(
     )
 
 
+
+def build_host_resource_telemetry_from_collector_results(
+    results: Sequence[Any],
+    *,
+    snapshot_id: str = "collector-backed-host-resource-telemetry",
+) -> HostResourceTelemetrySnapshot:
+    """Build read-only resource telemetry from Phase 2 collector results."""
+
+    from sentientos.host_collectors import HostCollectorResult, validate_host_collector_result
+
+    by_id: dict[str, HostCollectorResult] = {str(result.collector_id): result for result in results if isinstance(result, HostCollectorResult)}
+    unavailable: list[str] = []
+    service_labels: list[str] = []
+    model_labels: list[str] = []
+    forbidden_markers: dict[str, bool] = {}
+    observed_values = [result.observed_at for result in by_id.values() if result.observed_at]
+    observed_at = min(observed_values) if observed_values else None
+
+    for result in by_id.values():
+        if result.status in {"unavailable", "partial", "error"}:
+            unavailable.append(result.collector_id)
+        for finding in validate_host_collector_result(result).findings:
+            unavailable.append(f"collector_validation:{finding}")
+        for warning in result.warnings:
+            if "sensor_unavailable" in warning:
+                unavailable.append(warning)
+        for key, value in result.forbidden_markers.items():
+            if value:
+                forbidden_markers[key] = True
+
+    cpu_values = dict(by_id.get("cpu").values) if by_id.get("cpu") else {}
+    memory_values = dict(by_id.get("memory").values) if by_id.get("memory") else {}
+    disk_values = dict(by_id.get("disk").values) if by_id.get("disk") else {}
+    process_values = dict(by_id.get("process").values) if by_id.get("process") else {}
+    thermal_values = dict(by_id.get("thermal_sensors").values) if by_id.get("thermal_sensors") else {}
+    fan_values = dict(by_id.get("fan_pwm").values) if by_id.get("fan_pwm") else {}
+    service_values = dict(by_id.get("service_manager").values) if by_id.get("service_manager") else {}
+
+    cpu_utilization_percent = cpu_values.get("utilization_percent")
+    if cpu_utilization_percent is None and any(key in cpu_values for key in ("load_average_1m", "load_average_5m", "load_average_15m")):
+        model_labels.append("cpu_load_average_observed_utilization_unavailable")
+
+    ram_utilization_percent = memory_values.get("used_percent") or memory_values.get("utilization_percent")
+    disk_utilization_percent = disk_values.get("used_percent")
+    disk_free_bytes = disk_values.get("free_bytes")
+    process_count = process_values.get("process_count")
+
+    thermal_zone_temperatures_c: dict[str, float] = {}
+    for index, zone in enumerate(tuple(thermal_values.get("zones") or ())):
+        if isinstance(zone, Mapping) and zone.get("temperature_c") is not None:
+            try:
+                thermal_zone_temperatures_c[str(zone.get("id") or zone.get("label") or index)] = float(zone["temperature_c"])
+            except (TypeError, ValueError):
+                unavailable.append("thermal_temperature_malformed")
+
+    fan_rpm_observations: dict[str, float] = {}
+    for index, fan in enumerate(tuple(fan_values.get("fans") or ())):
+        if isinstance(fan, Mapping) and fan.get("rpm") is not None:
+            try:
+                fan_rpm_observations[str(fan.get("id") or index)] = float(fan["rpm"])
+            except (TypeError, ValueError):
+                unavailable.append("fan_rpm_malformed")
+    if fan_values.get("pwm_signal_observed"):
+        model_labels.append("pwm_signal_observed_not_control_authority")
+
+    if service_values:
+        service_labels.append(str(service_values.get("service_manager_label") or "service_manager_observed"))
+        if not service_values.get("live_services_queried", False):
+            unavailable.append("service_health_not_queried")
+
+    return build_host_resource_telemetry_snapshot(
+        snapshot_id=snapshot_id,
+        cpu_utilization_percent=float(cpu_utilization_percent) if cpu_utilization_percent is not None else None,
+        ram_utilization_percent=float(ram_utilization_percent) if ram_utilization_percent is not None else None,
+        disk_utilization_percent=float(disk_utilization_percent) if disk_utilization_percent is not None else None,
+        disk_free_bytes=int(disk_free_bytes) if disk_free_bytes is not None else None,
+        process_count=int(process_count) if process_count is not None else None,
+        thermal_zone_temperatures_c=thermal_zone_temperatures_c,
+        fan_rpm_observations=fan_rpm_observations,
+        model_runtime_pressure_labels=tuple(sorted(set(model_labels))),
+        service_health_labels=tuple(sorted(set(service_labels))),
+        unavailable_sensor_labels=tuple(sorted(set(unavailable))),
+        observed_at=observed_at,
+        forbidden_markers=forbidden_markers,
+    )
+
+
+def evaluate_current_host_resource_pressure(
+    results: Sequence[Any] | None = None,
+    *,
+    snapshot_id: str = "collector-backed-host-resource-telemetry",
+    thermal_pressure_c: float = 85.0,
+) -> tuple[HostResourceTelemetrySnapshot, HostResourcePressureReport]:
+    """Collect or consume read-only telemetry and evaluate proposal-only pressure."""
+
+    if results is None:
+        from sentientos.host_collectors import collect_basic_host_observations
+
+        results = collect_basic_host_observations()
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id=snapshot_id)
+    return snapshot, evaluate_host_resource_pressure(snapshot, thermal_pressure_c=thermal_pressure_c)
+
+
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
 

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -142,3 +142,25 @@ def test_validation_rejects_federation_evidence_as_transport() -> None:
     result = validate_capability_registry(CapabilityRegistry(registry_id="bad", records=(bad,)))
     assert not result.ok
     assert any("federation_evidence" in finding for finding in result.findings)
+
+
+def test_registry_updates_from_collector_backed_inventory_and_resource_report_without_control() -> None:
+    from sentientos.capability_registry import update_registry_from_host_inventory, update_registry_from_host_resource_report
+    from sentientos.host_collectors import collect_fan_pwm_observation
+    from sentientos.host_inventory import build_host_inventory_from_collector_results
+    from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, evaluate_host_resource_pressure
+
+    tree = {"/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "pwm1")}
+    files = {"/hwmon/hwmon0/fan1_input": "1000\n", "/hwmon/hwmon0/pwm1": "1\n"}
+    results = (collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),)
+    manifest = build_host_inventory_from_collector_results(results, manifest_id="m", node_id="n")
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id="s")
+    report = evaluate_host_resource_pressure(snapshot)
+    registry = update_registry_from_host_resource_report(update_registry_from_host_inventory(build_default_capability_registry(), manifest), report)
+    records = registry.by_id()
+    assert records["hardware_sensor_inventory"].status in {"implemented", "partial"}
+    assert records["host_resource_telemetry"].status in {"implemented", "partial"}
+    assert records["host_resource_telemetry"].authority_level == "proposal_only"
+    assert records["host_resource_telemetry"].host_actuation_performed is False
+    assert records["direct_fan_pwm_thermal_control"].status in {"blocked", "deferred"}
+    assert validate_capability_registry(registry).ok

--- a/tests/test_host_collectors.py
+++ b/tests/test_host_collectors.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from sentientos.host_collectors import (
+    HostCollectorResult,
+    collect_cpu_observation,
+    collect_disk_observation,
+    collect_fan_pwm_observation,
+    collect_memory_observation,
+    collect_network_interface_observation,
+    collect_platform_observation,
+    collect_thermal_sensor_observation,
+    validate_host_collector_result,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+STAMP = "2026-01-01T00:00:00+00:00"
+
+
+def test_platform_collector_is_telemetry_only_and_non_mutating() -> None:
+    result = collect_platform_observation(observed_at=STAMP)
+    assert result.telemetry_only is True
+    assert result.host_mutation_performed is False
+    assert result.network_performed is False
+    assert result.privileged_action_performed is False
+    assert validate_host_collector_result(result).ok
+
+
+def test_disk_collector_uses_supplied_disk_provider() -> None:
+    result = collect_disk_observation(path="/fake", disk_provider=lambda path: SimpleNamespace(total=100, used=25, free=75), observed_at=STAMP)
+    assert result.status == "available"
+    assert result.values["used_percent"] == 25
+    assert result.values["path_label"] == "/fake"
+    assert validate_host_collector_result(result).ok
+
+
+def test_memory_collector_degrades_when_details_missing() -> None:
+    result = collect_memory_observation(memory_provider=lambda: None, observed_at=STAMP)
+    assert result.status in {"partial", "unavailable"}
+    assert result.telemetry_only is True
+    assert validate_host_collector_result(result).ok
+
+
+def test_cpu_collector_reports_partial_when_utilization_unavailable() -> None:
+    result = collect_cpu_observation(observed_at=STAMP)
+    assert result.status in {"partial", "unavailable"}
+    assert result.values.get("utilization_percent") is None
+    assert any(finding.code == "cpu_utilization_unavailable" for finding in result.findings)
+
+
+def test_network_collector_reads_interfaces_without_connectivity_check() -> None:
+    def lister(path: str) -> tuple[str, ...]:
+        assert path == "/sys/class/net"
+        return ("lo", "eth0")
+
+    def reader(path: str) -> str:
+        return "00:00:00:00:00:00\n"
+
+    result = collect_network_interface_observation(directory_lister=lister, text_reader=reader, observed_at=STAMP)
+    assert result.status == "available"
+    assert result.values["connectivity_checked"] is False
+    assert result.network_performed is False
+    assert [item["name"] for item in result.values["interfaces"]] == ["eth0", "lo"]
+
+
+def test_thermal_collector_reads_injected_fake_sysfs_and_malformed_values() -> None:
+    tree = {
+        "/thermal": ("thermal_zone0", "thermal_zone1"),
+        "/hwmon": ("hwmon0",),
+        "/hwmon/hwmon0": ("temp1_input", "temp2_input"),
+    }
+    files = {
+        "/thermal/thermal_zone0/temp": "42000\n",
+        "/thermal/thermal_zone0/type": "x86_pkg_temp\n",
+        "/thermal/thermal_zone1/temp": "not-a-number\n",
+        "/thermal/thermal_zone1/type": "bad\n",
+        "/hwmon/hwmon0/temp1_input": "44000\n",
+        "/hwmon/hwmon0/temp2_input": "bad\n",
+    }
+    result = collect_thermal_sensor_observation(
+        thermal_path="/thermal",
+        hwmon_path="/hwmon",
+        directory_lister=lambda path: tree.get(path, ()),
+        text_reader=lambda path: files[path],
+        observed_at=STAMP,
+    )
+    assert result.status == "partial"
+    assert [zone["temperature_c"] for zone in result.values["zones"]] == [42.0, 44.0]
+    assert any(finding.code == "malformed_thermal_value" for finding in result.findings)
+    assert result.values["control_available"] is False
+
+
+def test_fan_pwm_collector_treats_pwm_presence_as_telemetry_not_control() -> None:
+    tree = {"/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "fan2_input", "pwm1")}
+    files = {"/hwmon/hwmon0/fan1_input": "1200\n", "/hwmon/hwmon0/fan2_input": "bad\n", "/hwmon/hwmon0/pwm1": "255\n"}
+    result = collect_fan_pwm_observation(
+        hwmon_path="/hwmon",
+        directory_lister=lambda path: tree.get(path, ()),
+        text_reader=lambda path: files[path],
+        observed_at=STAMP,
+    )
+    assert result.status == "partial"
+    assert result.values["pwm_signal_observed"] is True
+    assert result.values["control_available"] is False
+    assert result.values["control_deferred"] is True
+    assert result.values["requires_future_allowlist"] is True
+    assert result.values["requires_privilege_broker"] is True
+    assert result.values["fans"][0]["rpm"] == 1200
+    assert any(finding.code == "malformed_fan_rpm_value" for finding in result.findings)
+    assert validate_host_collector_result(result).ok
+
+
+@pytest.mark.parametrize(
+    ("field", "finding"),
+    [
+        ("host_mutation_performed", "host_mutation_performed"),
+        ("network_performed", "network_performed"),
+        ("privileged_action_performed", "privileged_action_performed"),
+    ],
+)
+def test_validation_rejects_forbidden_action_flags(field: str, finding: str) -> None:
+    result = HostCollectorResult(collector_id="bad", status="available", observed_at=STAMP, source="test")
+    bad = replace(result, **{field: True})
+    validation = validate_host_collector_result(bad)
+    assert not validation.ok
+    assert finding in validation.findings
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "fan_pwm_write_marker",
+        "thermal_write_marker",
+        "process_kill_marker",
+        "service_restart_marker",
+        "package_install_marker",
+        "driver_install_marker",
+    ],
+)
+def test_validation_rejects_forbidden_markers(marker: str) -> None:
+    result = HostCollectorResult(collector_id="bad", status="available", observed_at=STAMP, source="test", forbidden_markers={marker: True})
+    validation = validate_host_collector_result(result)
+    assert not validation.ok
+    assert f"forbidden_marker:{marker}" in validation.findings

--- a/tests/test_host_inventory.py
+++ b/tests/test_host_inventory.py
@@ -125,3 +125,59 @@ def test_fan_pwm_control_claim_requires_backend_metadata_and_privileged_devices_
     assert "fan_pwm_control_claimed_without_backend_metadata" in result.findings
     assert any("privileged_action_claimed" in finding for finding in result.findings)
     assert any("control_claimed" in finding for finding in result.findings)
+
+
+def test_build_inventory_from_collector_results_maps_read_only_discovery() -> None:
+    from sentientos.host_collectors import (
+        collect_disk_observation,
+        collect_fan_pwm_observation,
+        collect_network_interface_observation,
+        collect_platform_observation,
+        collect_thermal_sensor_observation,
+    )
+    from sentientos.host_inventory import build_host_inventory_from_collector_results
+
+    tree = {"/thermal": ("thermal_zone0",), "/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "pwm1")}
+    files = {
+        "/thermal/thermal_zone0/temp": "86000\n",
+        "/thermal/thermal_zone0/type": "cpu\n",
+        "/hwmon/hwmon0/fan1_input": "1300\n",
+        "/hwmon/hwmon0/pwm1": "200\n",
+    }
+    results = (
+        collect_platform_observation(observed_at="2026-01-01T00:00:00+00:00"),
+        collect_disk_observation(disk_provider=lambda path: type("D", (), {"total": 100, "used": 50, "free": 50})(), observed_at="2026-01-01T00:00:00+00:00"),
+        collect_network_interface_observation(directory_lister=lambda path: ("lo",), text_reader=lambda path: "00\n", observed_at="2026-01-01T00:00:00+00:00"),
+        collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/empty", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+        collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+    )
+    manifest = build_host_inventory_from_collector_results(results, manifest_id="m", node_id="n")
+    assert validate_host_inventory_manifest(manifest).ok
+    assert manifest.disk_summary["free_bytes"] == 50
+    assert manifest.thermal_zone_summary["zones"][0]["temperature_c"] == 86
+    assert manifest.fan_pwm_controller_summary["pwm_signal_observed"] is True
+    assert manifest.fan_pwm_controller_summary["control_available"] is False
+    assert manifest.fan_pwm_controller_summary["control_deferred"] is True
+    assert manifest.fan_pwm_controller_summary["requires_future_allowlist"] is True
+    assert manifest.fan_pwm_controller_summary["requires_privilege_broker"] is True
+    assert "pwm_presence_not_control_authority" in manifest.unsupported_deferred_labels
+    assert host_inventory_digest(manifest) == host_inventory_digest(build_host_inventory_from_collector_results(results, manifest_id="m", node_id="n"))
+
+
+def test_collector_unavailable_inventory_adds_warning_deferred_labels_and_rejects_authority_claims() -> None:
+    from sentientos.host_collectors import HostCollectorResult
+    from sentientos.host_inventory import build_host_inventory_from_collector_results
+
+    result = HostCollectorResult(
+        collector_id="fan_pwm",
+        status="unavailable",
+        observed_at="2026-01-01T00:00:00+00:00",
+        source="test",
+        warnings=("sensor_unavailable:fan_pwm",),
+    )
+    manifest = build_host_inventory_from_collector_results((result,), manifest_id="m", node_id="n")
+    assert validate_host_inventory_manifest(manifest).ok
+    assert "fan_pwm_unavailable" in manifest.unsupported_deferred_labels
+    assert "sensor_unavailable:fan_pwm" in manifest.warning_risk_codes
+    bad = replace(manifest, fan_pwm_controller_summary={**manifest.fan_pwm_controller_summary, "control_available": True})
+    assert not validate_host_inventory_manifest(bad).ok

--- a/tests/test_host_resource_governor.py
+++ b/tests/test_host_resource_governor.py
@@ -139,3 +139,40 @@ def test_deterministic_digest_and_metadata_summary() -> None:
     assert summary["no_host_actuation"] is True
     assert summary["no_fan_pwm_writes"] is True
     assert validate_host_resource_pressure_report(first_report, first_snapshot).ok
+
+
+def test_build_resource_telemetry_from_collectors_classifies_thermal_and_fan_telemetry_only() -> None:
+    from sentientos.host_collectors import collect_fan_pwm_observation, collect_thermal_sensor_observation
+    from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results
+
+    tree = {"/thermal": ("thermal_zone0",), "/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "pwm1")}
+    files = {"/thermal/thermal_zone0/temp": "90000\n", "/thermal/thermal_zone0/type": "cpu\n", "/hwmon/hwmon0/fan1_input": "1400\n", "/hwmon/hwmon0/pwm1": "128\n"}
+    results = (
+        collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/empty", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+        collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+    )
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id="s")
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    assert snapshot.thermal_zone_temperatures_c["thermal_zone0"] == 90
+    assert snapshot.fan_rpm_observations["hwmon0/fan1_input"] == 1400
+    assert "pwm_signal_observed_not_control_authority" in snapshot.model_runtime_pressure_labels
+    assert "thermal_pressure" in report.pressure_labels
+    assert "fan_signal_present" in report.pressure_labels
+    assert all(candidate.does_not_mutate_host for candidate in report.proposal_candidates)
+    assert validate_host_resource_pressure_report(report, snapshot).ok
+
+
+def test_incomplete_collector_data_yields_unavailable_findings_and_digest_is_deterministic() -> None:
+    from sentientos.host_collectors import HostCollectorResult
+    from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results
+
+    result = HostCollectorResult(collector_id="memory", status="unavailable", observed_at="2026-01-01T00:00:00+00:00", source="test", warnings=("sensor_unavailable:memory",))
+    snapshot = build_host_resource_telemetry_from_collector_results((result,), snapshot_id="s")
+    report = evaluate_host_resource_pressure(snapshot)
+    assert "telemetry_incomplete" in report.pressure_labels
+    assert "sensor_unavailable" in report.pressure_labels
+    assert any("sensor_unavailable" in finding for finding in report.findings)
+    assert host_resource_report_digest(report) == host_resource_report_digest(evaluate_host_resource_pressure(build_host_resource_telemetry_from_collector_results((result,), snapshot_id="s")))
+    bad_snapshot = replace(snapshot, forbidden_markers={"actuation_claimed": True})
+    bad_report = evaluate_host_resource_pressure(bad_snapshot)
+    assert not validate_host_resource_pressure_report(bad_report, bad_snapshot).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -11,6 +11,7 @@ PUBLIC_OVERVIEW = "docs/architecture/public_technical_overview.md"
 READINESS_INDEX = "docs/architecture/reviewer_release_readiness_index.md"
 TRAJECTORY_DOC = "docs/architecture/sentientos_trajectory_and_missing_organs.md"
 HOST_EMBODIMENT_PHASE1 = "docs/architecture/host_embodiment_substrate_phase1.md"
+HOST_EMBODIMENT_PHASE2 = "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md"
 
 
 def _read(relative: str) -> str:
@@ -97,3 +98,23 @@ def test_host_embodiment_docs_preserve_phase1_boundaries() -> None:
         "Actuation Fulfillment Layer",
     ]:
         assert term in combined
+
+
+
+def test_navigation_links_to_host_embodiment_phase2_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase1 = _read(HOST_EMBODIMENT_PHASE1)
+    trajectory = _read(TRAJECTORY_DOC)
+    assert HOST_EMBODIMENT_PHASE2 in overview
+    assert HOST_EMBODIMENT_PHASE2 in index
+    assert HOST_EMBODIMENT_PHASE2 in phase1
+    assert HOST_EMBODIMENT_PHASE2 in trajectory
+
+
+def test_phase2_doc_preserves_read_only_discovery_boundaries() -> None:
+    phase2 = _read(HOST_EMBODIMENT_PHASE2)
+    assert "direct fan/PWM writes remain forbidden/deferred" in phase2
+    assert "PWM presence is not control authority" in phase2
+    assert "Privilege Broker" in phase2
+    assert "Actuation Fulfillment Layer" in phase2


### PR DESCRIPTION
### Motivation

- Provide Phase 2 of Host Embodiment Substrate: read-only local body discovery so SentientOS can observe and model the host without any actuation authority. 
- Populate the Capability Registry, Hardware/Sensor Inventory Manifest, and Host Resource Governor from safe, read-only observations while preserving metadata-only/proposal-only guarantees.
- Keep the authority ladder intact (`observe → model → propose` only) and explicitly forbid any host mutation, fan/PWM writes, thermal actuation, process kills, service restarts, package/driver installs, network egress, provider invocation, prompt assembly/export, or remote execution.

### Description

- Added a new read-only collectors module `sentientos/host_collectors.py` that defines immutable dataclasses `HostCollectorObservation`, `HostCollectorFinding`, `HostCollectorResult`, and `HostCollectorValidationResult`, and safe collectors for platform, disk, memory, CPU, process count, network interfaces, service-manager labels, thermal sensors, fan/PWM observations, and an aggregate `collect_basic_host_observations(...)`; all collectors default to `telemetry_only=True` and explicit false safety flags. 
- Integrated collectors into inventory: added `build_host_inventory_from_collector_results(...)` and `collect_host_inventory_manifest(...)` in `sentientos/host_inventory.py` to map collector results into `HostInventoryManifest` devices/sensors and to represent PWM presence as telemetry-only (`pwm_signal_observed=True`, `control_available=False`, `control_deferred=True`, `requires_future_allowlist=True`, `requires_privilege_broker=True`).
- Integrated collectors into resource governor: added `build_host_resource_telemetry_from_collector_results(...)` and `evaluate_current_host_resource_pressure(...)` in `sentientos/host_resource_governor.py` to create `HostResourceTelemetrySnapshot` from collectors and to evaluate proposal-only pressure reports (thermal, CPU, memory, disk, fan signals) with no-actuation guarantees.
- Capability registry hooks: added `update_registry_from_host_inventory(...)` and `update_registry_from_host_resource_report(...)` in `sentientos/capability_registry.py` to reflect collector-backed observation/proposal surfaces while keeping direct fan/PWM/thermal control blocked and `host_actuation_performed=False`.
- Documentation and tests: added `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and wired it into the Phase 1, public overview, trajectory, and reviewer readiness index; added `tests/test_host_collectors.py` and extended/updated tests in `tests/test_host_inventory.py`, `tests/test_host_resource_governor.py`, and `tests/test_capability_registry.py` to validate collector behavior, injection-based sysfs/fake providers, telemetry-only posture, malformed-value resiliency, forbidden-marker validation, inventory/resource mapping, and registry integration.

### Testing

- Ran `python -m py_compile` on modified modules and new tests; compilation succeeded (no syntax errors).
- Ran unit test suites: `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_capability_registry.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py`; all targeted tests passed.
- Ran docs build flow: `python scripts/build_docs.py --check-deps` initially reported missing docs deps, then `python scripts/build_docs.py --bootstrap-docs` and `python scripts/build_docs.py` completed and generated docs pages; docs-check completed after bootstrapping.
- Ran context-hygiene check: `python scripts/verify_context_hygiene_prompt_boundaries.py` returned clean (no forbidden prompt/materialization findings).
- Ran additional proof tests: `python -m scripts.run_tests -q tests/test_control_plane_kernel.py tests/test_sentientosd_runtime_closure.py` completed successfully; `git diff --check` and a forbidden-pattern scan (`rg -n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0523c15b388320b22624a002858456)