### PR TITLE
[codex:host-embodiment] add Phase 3 host resource policy & proposal receipts

### DIFF
--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -99,7 +99,7 @@ The longer doctrine remains:
 
 Phase 1 covers observe/model and proposal candidate summaries only. It never
 fulfills an action. The next read-only discovery pass is documented in
-`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`.
+`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`; Phase 3 policy receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`.
 
 ## Relationship to existing organs
 

--- a/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
+++ b/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
@@ -64,3 +64,8 @@ Phase 2 must not perform:
 - prompt assembly/export;
 - federation transport, sync, adoption, merge, apply, install, execution, or remote execution;
 - uncontrolled runtime authority expansion.
+
+
+## Next phase
+
+Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`.

--- a/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
+++ b/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
@@ -1,0 +1,94 @@
+# Host Embodiment Substrate Phase 3: Policy Receipts
+
+Phase 3 converts read-only host resource pressure reports into deterministic,
+auditable, proposal-only policy decisions and proposal receipts. It is the
+`propose` rung of the authority ladder and nothing more.
+
+`observe → model → propose → rehearse → authorize → fulfill → audit → rollback`
+
+Phase 3 consumes the Phase 1/2 pipeline:
+
+`collector results → HostResourceTelemetrySnapshot → HostResourcePressureReport → HostResourcePolicyDecision → HostResourceProposalReceipt(s)`
+
+## Core boundary
+
+Pressure is not action. A CPU, memory, GPU, disk, thermal, fan, service, or
+incomplete telemetry label may justify a policy proposal receipt, but the receipt
+is not an effect. Proposal receipts are not effects. They do not execute, do not
+mutate the host, do not authorize fulfillment, and do not bypass the control
+plane.
+
+A policy decision is not authorization. It records that a deterministic policy
+rule classified a pressure report and selected proposal kinds for review,
+diagnostics, rehearsal, or a future broker queue. It does not grant privilege,
+control devices, alter power profiles, restart services, clean disks, kill
+processes, install packages, install drivers, call providers, assemble prompts,
+perform network egress, sync federation state, or execute remotely.
+
+## Implemented surfaces
+
+`sentientos/host_resource_policy.py` defines immutable metadata records for:
+
+- `HostResourcePolicyRule`
+- `HostResourcePolicyDecision`
+- `HostResourceProposalReceipt`
+- `HostResourcePolicyValidationResult`
+
+The module also exposes deterministic helpers for default rules, policy
+evaluation, proposal receipt construction, validation, summaries, and digests.
+The summaries intentionally expose ids, statuses, counts, labels, booleans, and
+digests rather than raw host-sensitive telemetry.
+
+## Proposal mapping
+
+- CPU pressure can record `inspect_cpu_pressure_candidate`,
+  `reduce_model_load_candidate`, and `defer_heavy_task_candidate`.
+- Memory pressure can record `inspect_memory_pressure_candidate` and
+  `defer_heavy_task_candidate`.
+- GPU pressure can record `inspect_gpu_pressure_candidate`,
+  `reduce_model_load_candidate`, and `defer_heavy_task_candidate`.
+- Disk pressure can record `inspect_disk_pressure_candidate` and a blocked
+  `future_cleanup_policy_candidate`.
+- Thermal pressure can record `inspect_thermal_state_candidate` and a blocked
+  `future_cooling_policy_candidate`.
+- Fan RPM/PWM observations are diagnostics/monitoring only unless paired with
+  thermal pressure. PWM presence is not control authority.
+- Service degradation can record `inspect_service_health_candidate`, not a
+  restart.
+- Incomplete telemetry can record diagnostics/operator-review proposals only.
+- Unknown or contradictory reports block proposal readiness.
+
+## Future-only candidates
+
+Future cooling, power, service, and cleanup candidates remain future-only. Phase 3 names the future Privilege Broker and Actuation Fulfillment Layer without implementing either organ. They
+are explicit handoff material for a later Privilege Broker and Actuation
+Fulfillment Layer after separate authorization exists. A future fulfillment path
+must still provide control-plane admission, operator or policy approval, audit
+receipt, rollback receipt, panic handling, and hardware/policy allowlists as
+appropriate.
+
+Thermal pressure can justify inspection/proposal, not fan control. PWM presence
+is not control authority. Service degradation can justify review/proposal, not
+restart. Disk pressure can justify inspection/proposal, not cleanup.
+
+## Explicit non-effects
+
+Every Phase 3 proposal receipt records that it is proposal-only, does not
+execute, does not mutate host state, is not authorized for fulfillment, requires
+a future Privilege Broker, requires control-plane admission, requires operator or
+policy approval, requires an audit receipt, and requires a rollback receipt.
+
+Blocked action labels include host mutation, fan/PWM writes, thermal actuation,
+process kill, service restart, package install, driver install, provider
+invocation, network egress, prompt assembly, federation transport/sync/adoption,
+and remote execution.
+
+## Proof commands
+
+```bash
+python -m scripts.run_tests -q tests/test_host_resource_policy.py tests/test_host_resource_governor.py tests/test_capability_registry.py
+python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py
+python scripts/verify_context_hygiene_prompt_boundaries.py
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
+```

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -215,4 +215,4 @@ Internal and legacy cultural documentation remains available and is not removed 
 
 ## Host embodiment substrate
 
-See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` for Phase 1 metadata-only host embodiment and Phase 2 read-only discovery.
+See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` for Phase 1 metadata-only host embodiment and Phase 2 read-only discovery.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -185,3 +185,8 @@ python scripts/build_docs.py
 5. Inspect `tests/test_chat_service_lazy_loading.py`, `tests/test_local_model.py`, and `tests/integration/test_chat_mistral_runtime.py`.
 6. Inspect the federated improvement receipt tests listed in the custody runway section.
 7. Build docs with `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`.
+
+
+## Host Embodiment Phase 3 policy receipts
+
+See `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. Proposal receipts are not effects. A policy decision is not authorization. PWM presence is not control authority. Phase 3 names the future Privilege Broker and Actuation Fulfillment Layer and keeps them future/deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -18,7 +18,7 @@ reconstruct what happened. Capabilities that are only implied by this trajectory
 are listed below as missing or deferred rather than claimed as implemented.
 
 Host Embodiment Substrate Phase 1 is the first observe/model substrate for this
-path; see `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`. It adds a
+path; see `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. It adds a
 Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold while keeping Privilege Broker and Actuation
 Fulfillment Layer requirements ahead of any future host actuation. Direct
@@ -355,3 +355,8 @@ implemented:
   in state surfaces.
 - A docs proof command is listed for reviewers and can be run from the repository
   root.
+
+
+### Host Embodiment Phase 3 policy receipts
+
+Phase 3 is documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. It converts pressure reports into proposal receipts only: proposal receipts are not effects, policy decisions are not authorization, PWM presence is not control authority, and future cooling/power/service/cleanup candidates require the future Privilege Broker and Actuation Fulfillment Layer.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -29,6 +29,8 @@ CAPABILITY_CATEGORIES = frozenset(
         "hardware_driver_awareness",
         "hardware_sensor_inventory",
         "host_resource_telemetry",
+        "host_resource_policy",
+        "host_resource_proposal_receipts",
         "control_plane_admission",
         "audit_immutability",
         "self_amendment",
@@ -119,7 +121,7 @@ class CapabilityRecord:
 @dataclass(frozen=True)
 class CapabilityRegistry:
     registry_id: str
-    schema_version: str = "host-embodiment-substrate-phase1.v1"
+    schema_version: str = "host-embodiment-substrate-phase3.v1"
     records: tuple[CapabilityRecord, ...] = ()
     metadata_only: bool = True
     no_runtime_authority_expansion: bool = True
@@ -205,18 +207,22 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("browser_host_interaction", "browser_host_interaction", "implemented", "gated_host_interaction", source_paths=("sentientos/agents/browser_automator.py", "sentientos/oracle_relay.py", "browser_voice.py"), implemented_surfaces=("enable flags, allowlists, budgets, audit logging",), forbidden_implications=("network egress authority beyond configured browser automation",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
         _record("hardware_driver_awareness", "hardware_driver_awareness", "partial", "proposal_only", source_paths=("sentientos/daemons/driver_manager.py", "config/hardware_profile.json"), proof_tests=("tests/test_first_boot.py",), implemented_surfaces=("device reports, driver recommendations, veil-pending requests",), deferred_surfaces=("driver installation",), forbidden_implications=("package or driver install",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("hardware_sensor_inventory", "hardware_sensor_inventory", "scaffolded", "observation", source_paths=("sentientos/host_inventory.py",), proof_tests=("tests/test_host_inventory.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_inventory.py",), implemented_surfaces=("metadata manifest from supplied observations",), deferred_surfaces=("privileged sensor probing", "fan/PWM control"), forbidden_implications=("inventory grants authority")),
-        _record("host_resource_telemetry", "host_resource_telemetry", "scaffolded", "proposal_only", source_paths=("sentientos/host_resource_governor.py",), proof_tests=("tests/test_host_resource_governor.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_resource_governor.py",), implemented_surfaces=("read-only pressure classification from supplied telemetry",), deferred_surfaces=("cooling action", "process killing", "service restart", "power profile changes"), forbidden_implications=("telemetry is actuation")),
-        _record("direct_fan_pwm_thermal_control", "host_resource_telemetry", "blocked", "none", source_paths=("sentientos/host_resource_governor.py", "sentientos/host_inventory.py"), proof_tests=("tests/test_host_resource_governor.py", "tests/test_host_inventory.py"), deferred_surfaces=("fan/PWM writes", "direct thermal actuation"), forbidden_implications=("fan/PWM/thermal control is implemented"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("host_resource_telemetry", "host_resource_telemetry", "partial", "proposal_only", source_paths=("sentientos/host_resource_governor.py",), proof_tests=("tests/test_host_resource_governor.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_resource_governor.py",), implemented_surfaces=("read-only pressure classification from supplied telemetry",), deferred_surfaces=("cooling action", "process killing", "service restart", "power profile changes"), forbidden_implications=("telemetry is actuation")),
+        _record("host_resource_policy", "host_resource_policy", "implemented", "proposal_only", source_paths=("sentientos/host_resource_policy.py", "sentientos/host_resource_governor.py"), proof_tests=("tests/test_host_resource_policy.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_resource_policy.py",), implemented_surfaces=("deterministic metadata-only policy decisions from pressure reports",), deferred_surfaces=("Privilege Broker authorization", "Actuation Fulfillment Layer effects", "cooling action", "service restart", "power profile changes"), forbidden_implications=("policy decision is authorization", "pressure report executes host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("host_resource_proposal_receipts", "host_resource_proposal_receipts", "implemented", "proposal_only", source_paths=("sentientos/host_resource_policy.py",), proof_tests=("tests/test_host_resource_policy.py",), proof_commands=("python -m scripts.run_tests -q tests/test_host_resource_policy.py",), implemented_surfaces=("deterministic proposal-only resource policy receipts",), deferred_surfaces=("Privilege Broker", "Actuation Fulfillment Layer", "host mutation fulfillment", "fan/PWM writes", "thermal actuation"), forbidden_implications=("proposal receipts are effects", "proposal receipt grants privileged host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("direct_fan_pwm_thermal_control", "host_resource_telemetry", "blocked", "none", source_paths=("sentientos/host_resource_governor.py", "sentientos/host_inventory.py", "sentientos/host_resource_policy.py"), proof_tests=("tests/test_host_resource_governor.py", "tests/test_host_inventory.py", "tests/test_host_resource_policy.py"), deferred_surfaces=("fan/PWM writes", "direct thermal actuation"), forbidden_implications=("fan/PWM/thermal control is implemented"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("blanket_hardware_control", "hardware_driver_awareness", "blocked", "none", deferred_surfaces=("stem-to-stern host actuation",), forbidden_implications=("blanket hardware control exists"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("control_plane_admission", "control_plane_admission", "implemented", "proposal_only", source_paths=("sentientos/control_plane_kernel.py", "control_plane/", "sentientos/runtime_governor.py"), proof_tests=("tests/test_control_plane_kernel.py", "tests/test_sentientosd_runtime_closure.py"), implemented_surfaces=("admission receipts and runtime gating",), forbidden_implications=("admission alone performs effects",)),
+        _record("privilege_broker", "control_plane_admission", "deferred", "none", deferred_surfaces=("canonical privileged host action mediation", "cooling authorization", "service restart authorization", "cleanup authorization"), forbidden_implications=("privilege broker is implemented by Phase 3",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("actuation_fulfillment", "control_plane_admission", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "rollback execution", "host mutation effects"), forbidden_implications=("proposal receipt is actuation fulfillment",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
         _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase3", records=records)
 
 
 
@@ -282,6 +288,53 @@ def update_registry_from_host_resource_report(registry: CapabilityRegistry, repo
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase2.v1")
+
+
+def update_registry_from_host_resource_policy(registry: CapabilityRegistry, decision: Any, receipts: Sequence[Any] = ()) -> CapabilityRegistry:
+    """Reflect Phase 3 host resource policy receipts without granting effects."""
+
+    records: list[CapabilityRecord] = []
+    has_decision = bool(getattr(decision, "decision_id", ""))
+    has_receipts = bool(receipts)
+    source_paths = ("sentientos/host_resource_policy.py", "sentientos/host_resource_governor.py")
+    for record in registry.records:
+        if record.capability_id == "host_resource_policy":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_decision else "partial",
+                    authority_level="proposal_only",
+                    source_paths=tuple(sorted(set(record.source_paths + source_paths))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_resource_policy.py",)))),
+                    proof_commands=tuple(sorted(set(record.proof_commands + ("python -m scripts.run_tests -q tests/test_host_resource_policy.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("pressure-to-policy proposal decision receipts",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("Privilege Broker", "Actuation Fulfillment Layer", "host mutation",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("policy decision is authorization", "policy receipt performs effects",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "host_resource_proposal_receipts":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_receipts else "scaffolded",
+                    authority_level="proposal_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/host_resource_policy.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_resource_policy.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("deterministic proposal receipts from policy decisions",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("proposal receipts are effects", "proposal receipt authorizes fulfillment",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"privilege_broker", "actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase3.v1")
 
 
 def _canonical_json(value: Any) -> str:

--- a/sentientos/host_resource_governor.py
+++ b/sentientos/host_resource_governor.py
@@ -448,3 +448,23 @@ def validate_host_resource_pressure_report(
         if not all(required):
             findings.append(prefix + ":candidate_claims_execution_or_missing_future_gate")
     return HostResourceGovernorValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def evaluate_host_resource_policy_from_telemetry(
+    snapshot: HostResourceTelemetrySnapshot,
+    *,
+    host_id: str | None = None,
+    node_id: str | None = None,
+    thermal_pressure_c: float = 85.0,
+) -> tuple[Any, tuple[Any, ...]]:
+    """Evaluate Phase 3 policy receipts from supplied read-only telemetry.
+
+    The returned decision and receipts are proposal-only metadata. This helper
+    does not authorize or fulfill host action.
+    """
+
+    from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy
+
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=thermal_pressure_c)
+    decision = evaluate_host_resource_policy(report, host_id=host_id, node_id=node_id)
+    return decision, build_host_resource_proposal_receipts(decision)

--- a/sentientos/host_resource_policy.py
+++ b/sentientos/host_resource_policy.py
@@ -1,0 +1,507 @@
+"""Proposal-only host resource policy receipts for SentientOS Phase 3.
+
+This module turns read-only host resource pressure reports into deterministic,
+metadata-only policy decisions and proposal receipts. It never performs host
+mutation, fan/PWM writes, thermal actuation, process control, service restart,
+package or driver installation, provider invocation, network activity, prompt
+assembly, federation transport, or remote execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Mapping, Sequence
+
+from sentientos.host_resource_governor import HostResourcePressureReport, host_resource_report_digest
+
+HOST_RESOURCE_POLICY_STATUSES = frozenset(
+    {
+        "host_resource_policy_nominal",
+        "host_resource_policy_monitor",
+        "host_resource_policy_proposal_ready",
+        "host_resource_policy_operator_review_required",
+        "host_resource_policy_blocked",
+        "host_resource_policy_incomplete",
+        "host_resource_policy_contradicted",
+    }
+)
+HOST_RESOURCE_PROPOSAL_STATUSES = frozenset(
+    {
+        "host_resource_proposal_recorded",
+        "host_resource_proposal_recorded_with_warnings",
+        "host_resource_proposal_blocked",
+        "host_resource_proposal_incomplete",
+        "host_resource_proposal_contradicted",
+    }
+)
+HOST_RESOURCE_PROPOSAL_KINDS = frozenset(
+    {
+        "reduce_model_load_candidate",
+        "defer_heavy_task_candidate",
+        "request_operator_review_candidate",
+        "inspect_thermal_state_candidate",
+        "inspect_disk_pressure_candidate",
+        "inspect_memory_pressure_candidate",
+        "inspect_cpu_pressure_candidate",
+        "inspect_gpu_pressure_candidate",
+        "inspect_service_health_candidate",
+        "future_cooling_policy_candidate",
+        "future_power_policy_candidate",
+        "future_cleanup_policy_candidate",
+    }
+)
+HOST_RESOURCE_POLICY_SCOPES = frozenset(
+    {
+        "local_observation_only",
+        "operator_review_queue",
+        "future_privilege_broker_queue",
+        "diagnostics_only",
+        "rehearsal_candidate_only",
+    }
+)
+
+FUTURE_ACTION_GATES = (
+    "future_privilege_broker_required",
+    "future_control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+)
+BLOCKED_HOST_ACTIONS = (
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport_sync_adoption",
+    "remote_execution",
+)
+
+_LABEL_TO_KINDS: Mapping[str, tuple[str, ...]] = {
+    "cpu_pressure": ("inspect_cpu_pressure_candidate", "reduce_model_load_candidate", "defer_heavy_task_candidate"),
+    "memory_pressure": ("inspect_memory_pressure_candidate", "defer_heavy_task_candidate"),
+    "gpu_pressure": ("inspect_gpu_pressure_candidate", "reduce_model_load_candidate", "defer_heavy_task_candidate"),
+    "disk_pressure": ("inspect_disk_pressure_candidate", "future_cleanup_policy_candidate"),
+    "thermal_pressure": ("inspect_thermal_state_candidate", "future_cooling_policy_candidate"),
+    "battery_pressure": ("future_power_policy_candidate", "request_operator_review_candidate"),
+    "service_degraded": ("inspect_service_health_candidate",),
+    "telemetry_incomplete": ("request_operator_review_candidate",),
+    "sensor_unavailable": ("request_operator_review_candidate",),
+    "fan_signal_present": (),
+    "network_pressure": ("request_operator_review_candidate",),
+}
+
+
+@dataclass(frozen=True)
+class HostResourcePolicyRule:
+    rule_id: str
+    pressure_labels: tuple[str, ...]
+    proposal_kinds: tuple[str, ...]
+    proposal_scope: str
+    reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...] = ()
+    risk_codes: tuple[str, ...] = ()
+    blocked_proposal_kinds: tuple[str, ...] = ()
+    required_future_gates: tuple[str, ...] = FUTURE_ACTION_GATES
+    metadata_only: bool = True
+    proposal_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourcePolicyDecision:
+    decision_id: str
+    report_id: str
+    report_digest: str
+    host_id: str | None = None
+    node_id: str | None = None
+    observed_pressure_labels: tuple[str, ...] = ()
+    selected_policy_rules: tuple[str, ...] = ()
+    proposal_kinds: tuple[str, ...] = ()
+    blocked_proposal_kinds: tuple[str, ...] = ()
+    warning_codes: tuple[str, ...] = ()
+    risk_codes: tuple[str, ...] = ()
+    required_future_gates: tuple[str, ...] = FUTURE_ACTION_GATES
+    status: str = "host_resource_policy_monitor"
+    reason_codes: tuple[str, ...] = ()
+    metadata_only: bool = True
+    proposal_only: bool = True
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourceProposalReceipt:
+    receipt_id: str
+    decision_id: str
+    report_id: str
+    report_digest: str
+    proposal_kind: str
+    proposal_status: str
+    proposal_scope: str
+    pressure_labels: tuple[str, ...]
+    evidence_summary: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    proposal_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    not_authorized_for_fulfillment: bool = True
+    requires_privilege_broker_for_future_action: bool = True
+    requires_control_plane_admission_for_future_action: bool = True
+    requires_operator_or_policy_approval_for_future_action: bool = True
+    requires_audit_receipt_for_future_action: bool = True
+    requires_rollback_receipt_for_future_action: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostResourcePolicyValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _tuple_str(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def build_default_host_resource_policy_rules() -> tuple[HostResourcePolicyRule, ...]:
+    return (
+        HostResourcePolicyRule("nominal_monitor", ("nominal",), (), "local_observation_only", ("nominal_monitor_only",)),
+        HostResourcePolicyRule("cpu_pressure_policy", ("cpu_pressure",), _LABEL_TO_KINDS["cpu_pressure"], "operator_review_queue", ("cpu_pressure_observed",)),
+        HostResourcePolicyRule("memory_pressure_policy", ("memory_pressure",), _LABEL_TO_KINDS["memory_pressure"], "operator_review_queue", ("memory_pressure_observed",)),
+        HostResourcePolicyRule("gpu_pressure_policy", ("gpu_pressure",), _LABEL_TO_KINDS["gpu_pressure"], "operator_review_queue", ("gpu_pressure_observed",)),
+        HostResourcePolicyRule("disk_pressure_policy", ("disk_pressure",), _LABEL_TO_KINDS["disk_pressure"], "future_privilege_broker_queue", ("disk_pressure_observed",), blocked_proposal_kinds=("future_cleanup_policy_candidate",)),
+        HostResourcePolicyRule("thermal_pressure_policy", ("thermal_pressure",), _LABEL_TO_KINDS["thermal_pressure"], "future_privilege_broker_queue", ("thermal_pressure_observed",), warning_codes=("thermal_pressure_is_not_cooling_authorization",), risk_codes=("future_cooling_requires_privileged_gates",), blocked_proposal_kinds=("future_cooling_policy_candidate",)),
+        HostResourcePolicyRule("fan_signal_diagnostics_policy", ("fan_signal_present",), (), "diagnostics_only", ("fan_signal_is_telemetry_only",), warning_codes=("pwm_presence_is_not_control_authority",)),
+        HostResourcePolicyRule("service_degraded_policy", ("service_degraded",), _LABEL_TO_KINDS["service_degraded"], "operator_review_queue", ("service_degraded_observed",), blocked_proposal_kinds=("service_restart",)),
+        HostResourcePolicyRule("incomplete_telemetry_policy", ("telemetry_incomplete", "sensor_unavailable"), ("request_operator_review_candidate",), "diagnostics_only", ("telemetry_incomplete_or_sensor_unavailable",), warning_codes=("incomplete_telemetry_blocks_automatic_readiness",)),
+        HostResourcePolicyRule("unknown_contradiction_policy", ("unknown",), (), "diagnostics_only", ("unknown_or_contradictory_pressure_report",), warning_codes=("proposal_readiness_blocked",)),
+    )
+
+
+def evaluate_host_resource_policy(
+    report: HostResourcePressureReport,
+    *,
+    host_id: str | None = None,
+    node_id: str | None = None,
+    rules: Sequence[HostResourcePolicyRule] | None = None,
+) -> HostResourcePolicyDecision:
+    labels = tuple(sorted(str(label) for label in report.pressure_labels))
+    report_digest = host_resource_report_digest(report)
+    rule_set = tuple(rules or build_default_host_resource_policy_rules())
+    selected: list[HostResourcePolicyRule] = []
+    proposal_kinds: set[str] = set()
+    blocked_kinds: set[str] = set()
+    warnings: set[str] = set()
+    risks: set[str] = set()
+    reasons: set[str] = set()
+
+    for rule in rule_set:
+        if set(rule.pressure_labels).intersection(labels):
+            selected.append(rule)
+            proposal_kinds.update(rule.proposal_kinds)
+            blocked_kinds.update(rule.blocked_proposal_kinds)
+            warnings.update(rule.warning_codes)
+            risks.update(rule.risk_codes)
+            reasons.update(rule.reason_codes)
+
+    candidate_kinds = {candidate.kind for candidate in report.proposal_candidates}
+    for label in labels:
+        proposal_kinds.update(_LABEL_TO_KINDS.get(label, ()))
+    proposal_kinds.update(kind for kind in candidate_kinds if kind in HOST_RESOURCE_PROPOSAL_KINDS)
+
+    unknown_candidate_kinds = sorted(kind for kind in candidate_kinds if kind not in HOST_RESOURCE_PROPOSAL_KINDS)
+    if unknown_candidate_kinds:
+        warnings.add("unknown_candidate_kind_observed")
+        blocked_kinds.update(unknown_candidate_kinds)
+
+    if "nominal" in labels and len(labels) > 1:
+        status = "host_resource_policy_contradicted"
+        reasons.add("nominal_with_pressure_labels")
+    elif "unknown" in labels:
+        status = "host_resource_policy_blocked"
+        reasons.add("unknown_pressure_label_blocks_proposal_readiness")
+    elif "telemetry_incomplete" in labels or "sensor_unavailable" in labels:
+        status = "host_resource_policy_incomplete"
+        reasons.add("incomplete_telemetry_requires_review")
+        proposal_kinds.add("request_operator_review_candidate")
+    elif labels == ("nominal",):
+        status = "host_resource_policy_nominal"
+        reasons.add("nominal_monitor_only")
+    elif labels == ("fan_signal_present",) or set(labels).issubset({"fan_signal_present"}):
+        status = "host_resource_policy_monitor"
+        reasons.add("fan_pwm_observation_is_diagnostics_only")
+        warnings.add("pwm_presence_is_not_control_authority")
+    elif proposal_kinds:
+        status = "host_resource_policy_proposal_ready"
+        reasons.add("pressure_report_mapped_to_proposal_receipts")
+    else:
+        status = "host_resource_policy_operator_review_required"
+        reasons.add("no_deterministic_policy_mapping")
+        proposal_kinds.add("request_operator_review_candidate")
+
+    if "service_degraded" in labels:
+        blocked_kinds.add("service_restart")
+    if "fan_signal_present" in labels:
+        warnings.add("fan_pwm_signal_is_observation_only")
+    if "thermal_pressure" in labels:
+        blocked_kinds.add("future_cooling_policy_candidate")
+    if "disk_pressure" in labels:
+        blocked_kinds.add("future_cleanup_policy_candidate")
+
+    material = {
+        "report_id": report.report_id,
+        "report_digest": report_digest,
+        "host_id": host_id,
+        "node_id": node_id,
+        "labels": labels,
+        "rules": sorted(rule.rule_id for rule in selected),
+        "proposal_kinds": sorted(proposal_kinds),
+        "blocked_proposal_kinds": sorted(blocked_kinds),
+        "status": status,
+        "reasons": sorted(reasons),
+    }
+    decision_id = _digest_payload("hrpd_", material)
+    return HostResourcePolicyDecision(
+        decision_id=decision_id,
+        report_id=report.report_id,
+        report_digest=report_digest,
+        host_id=host_id,
+        node_id=node_id,
+        observed_pressure_labels=labels,
+        selected_policy_rules=tuple(sorted(rule.rule_id for rule in selected)),
+        proposal_kinds=tuple(sorted(proposal_kinds)),
+        blocked_proposal_kinds=tuple(sorted(blocked_kinds)),
+        warning_codes=tuple(sorted(warnings)),
+        risk_codes=tuple(sorted(risks)),
+        required_future_gates=FUTURE_ACTION_GATES,
+        status=status,
+        reason_codes=tuple(sorted(reasons)),
+    )
+
+
+def _proposal_scope(proposal_kind: str, decision: HostResourcePolicyDecision) -> str:
+    if decision.status in {"host_resource_policy_blocked", "host_resource_policy_contradicted"}:
+        return "diagnostics_only"
+    if proposal_kind.startswith("future_"):
+        return "future_privilege_broker_queue"
+    if proposal_kind.startswith("inspect_"):
+        return "diagnostics_only"
+    if proposal_kind == "request_operator_review_candidate":
+        return "operator_review_queue"
+    return "rehearsal_candidate_only"
+
+
+def build_host_resource_proposal_receipts(
+    decision: HostResourcePolicyDecision,
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> tuple[HostResourceProposalReceipt, ...]:
+    receipts: list[HostResourceProposalReceipt] = []
+    for proposal_kind in decision.proposal_kinds:
+        if decision.status == "host_resource_policy_contradicted":
+            proposal_status = "host_resource_proposal_contradicted"
+        elif decision.status == "host_resource_policy_blocked" or proposal_kind in decision.blocked_proposal_kinds:
+            proposal_status = "host_resource_proposal_blocked"
+        elif decision.status == "host_resource_policy_incomplete":
+            proposal_status = "host_resource_proposal_incomplete"
+        elif decision.warning_codes:
+            proposal_status = "host_resource_proposal_recorded_with_warnings"
+        else:
+            proposal_status = "host_resource_proposal_recorded"
+        scope = _proposal_scope(proposal_kind, decision)
+        evidence = (
+            f"decision_status:{decision.status}",
+            f"pressure_label_count:{len(decision.observed_pressure_labels)}",
+            "pressure_is_not_action",
+            "policy_decision_is_not_authorization",
+        )
+        material = {
+            "decision_id": decision.decision_id,
+            "report_id": decision.report_id,
+            "report_digest": decision.report_digest,
+            "proposal_kind": proposal_kind,
+            "proposal_status": proposal_status,
+            "proposal_scope": scope,
+            "pressure_labels": decision.observed_pressure_labels,
+            "created_at": created_at,
+            "required_future_gates": decision.required_future_gates,
+            "blocked_actions": BLOCKED_HOST_ACTIONS,
+            "warning_codes": decision.warning_codes,
+            "risk_codes": decision.risk_codes,
+        }
+        receipt_id = _digest_payload("hrpr_", material)
+        provisional = HostResourceProposalReceipt(
+            receipt_id=receipt_id,
+            decision_id=decision.decision_id,
+            report_id=decision.report_id,
+            report_digest=decision.report_digest,
+            proposal_kind=proposal_kind,
+            proposal_status=proposal_status,
+            proposal_scope=scope,
+            pressure_labels=decision.observed_pressure_labels,
+            evidence_summary=evidence,
+            required_future_gates=decision.required_future_gates,
+            blocked_actions=BLOCKED_HOST_ACTIONS,
+            warning_codes=decision.warning_codes,
+            risk_codes=decision.risk_codes,
+            created_at=created_at,
+        )
+        receipts.append(replace(provisional, digest=host_resource_proposal_receipt_digest(provisional)))
+    return tuple(sorted(receipts, key=lambda receipt: receipt.receipt_id))
+
+
+def host_resource_policy_decision_digest(decision: HostResourcePolicyDecision) -> str:
+    return hashlib.sha256(_canonical_json(decision.to_dict()).encode("utf-8")).hexdigest()
+
+
+def host_resource_proposal_receipt_digest(receipt: HostResourceProposalReceipt) -> str:
+    payload = receipt.to_dict()
+    payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def summarize_host_resource_policy_decision(decision: HostResourcePolicyDecision) -> dict[str, Any]:
+    return {
+        "decision_id": decision.decision_id,
+        "report_id": decision.report_id,
+        "report_digest": decision.report_digest,
+        "status": decision.status,
+        "pressure_labels": decision.observed_pressure_labels,
+        "selected_policy_rule_count": len(decision.selected_policy_rules),
+        "proposal_kind_count": len(decision.proposal_kinds),
+        "blocked_proposal_kind_count": len(decision.blocked_proposal_kinds),
+        "warning_count": len(decision.warning_codes),
+        "risk_count": len(decision.risk_codes),
+        "metadata_only": decision.metadata_only,
+        "proposal_only": decision.proposal_only,
+        "host_mutation_performed": decision.host_mutation_performed,
+        "fan_pwm_write_performed": decision.fan_pwm_write_performed,
+        "thermal_actuation_performed": decision.thermal_actuation_performed,
+        "network_performed": decision.network_performed,
+        "digest": host_resource_policy_decision_digest(decision),
+    }
+
+
+def summarize_host_resource_proposal_receipt(receipt: HostResourceProposalReceipt) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt.receipt_id,
+        "decision_id": receipt.decision_id,
+        "report_id": receipt.report_id,
+        "proposal_kind": receipt.proposal_kind,
+        "proposal_status": receipt.proposal_status,
+        "proposal_scope": receipt.proposal_scope,
+        "pressure_labels": receipt.pressure_labels,
+        "future_gate_count": len(receipt.required_future_gates),
+        "blocked_action_count": len(receipt.blocked_actions),
+        "warning_count": len(receipt.warning_codes),
+        "risk_count": len(receipt.risk_codes),
+        "proposal_only": receipt.proposal_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "not_authorized_for_fulfillment": receipt.not_authorized_for_fulfillment,
+        "digest": receipt.digest,
+    }
+
+
+def validate_host_resource_policy_decision(decision: HostResourcePolicyDecision) -> HostResourcePolicyValidationResult:
+    findings: list[str] = []
+    if not decision.decision_id:
+        findings.append("missing_decision_id")
+    if not decision.report_id:
+        findings.append("missing_report_id")
+    if decision.status not in HOST_RESOURCE_POLICY_STATUSES:
+        findings.append("unknown_policy_status")
+    for kind in decision.proposal_kinds:
+        if kind not in HOST_RESOURCE_PROPOSAL_KINDS:
+            findings.append(f"unknown_proposal_kind:{kind}")
+    if not decision.metadata_only or not decision.proposal_only:
+        findings.append("decision_not_metadata_proposal_only")
+    forbidden_flags = {
+        "host_mutation_performed": decision.host_mutation_performed,
+        "fan_pwm_write_performed": decision.fan_pwm_write_performed,
+        "thermal_actuation_performed": decision.thermal_actuation_performed,
+        "process_kill_performed": decision.process_kill_performed,
+        "service_restart_performed": decision.service_restart_performed,
+        "package_install_performed": decision.package_install_performed,
+        "driver_install_performed": decision.driver_install_performed,
+        "provider_invocation_performed": decision.provider_invocation_performed,
+        "network_performed": decision.network_performed,
+        "prompt_assembly_performed": decision.prompt_assembly_performed,
+    }
+    for flag, value in forbidden_flags.items():
+        if value:
+            findings.append(f"forbidden_decision_flag:{flag}")
+    return HostResourcePolicyValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_host_resource_proposal_receipt(receipt: HostResourceProposalReceipt) -> HostResourcePolicyValidationResult:
+    findings: list[str] = []
+    if not receipt.receipt_id:
+        findings.append("missing_receipt_id")
+    if not receipt.decision_id:
+        findings.append("missing_decision_id")
+    if receipt.proposal_kind not in HOST_RESOURCE_PROPOSAL_KINDS:
+        findings.append("unknown_proposal_kind")
+    if receipt.proposal_status not in HOST_RESOURCE_PROPOSAL_STATUSES:
+        findings.append("unknown_proposal_status")
+    if receipt.proposal_scope not in HOST_RESOURCE_POLICY_SCOPES:
+        findings.append("unknown_proposal_scope")
+    if receipt.digest and receipt.digest != host_resource_proposal_receipt_digest(receipt):
+        findings.append("receipt_digest_mismatch")
+    required_true = {
+        "proposal_only": receipt.proposal_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "not_authorized_for_fulfillment": receipt.not_authorized_for_fulfillment,
+        "requires_privilege_broker_for_future_action": receipt.requires_privilege_broker_for_future_action,
+        "requires_control_plane_admission_for_future_action": receipt.requires_control_plane_admission_for_future_action,
+        "requires_operator_or_policy_approval_for_future_action": receipt.requires_operator_or_policy_approval_for_future_action,
+        "requires_audit_receipt_for_future_action": receipt.requires_audit_receipt_for_future_action,
+        "requires_rollback_receipt_for_future_action": receipt.requires_rollback_receipt_for_future_action,
+    }
+    for flag, value in required_true.items():
+        if not value:
+            findings.append(f"receipt_claims_execution_or_authority:{flag}")
+    missing_gates = [gate for gate in FUTURE_ACTION_GATES if gate not in receipt.required_future_gates]
+    if missing_gates:
+        findings.append("receipt_missing_future_gates")
+    missing_blocks = [action for action in BLOCKED_HOST_ACTIONS if action not in receipt.blocked_actions]
+    if missing_blocks:
+        findings.append("receipt_missing_blocked_actions")
+    return HostResourcePolicyValidationResult(ok=not findings, findings=tuple(findings))

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -31,7 +31,7 @@ def test_summary_shape_is_metadata_only_and_digest_changes_on_metadata() -> None
     assert summary["metadata_only"] is True
     assert summary["no_runtime_authority_expansion"] is True
     assert "direct_fan_pwm_thermal_control" in summary["capability_ids"]
-    changed = replace_capability_record(registry, "host_resource_telemetry", status="partial")
+    changed = replace_capability_record(registry, "host_resource_telemetry", status="implemented")
     assert capability_registry_digest(changed) != summary["digest"]
 
 
@@ -163,4 +163,26 @@ def test_registry_updates_from_collector_backed_inventory_and_resource_report_wi
     assert records["host_resource_telemetry"].authority_level == "proposal_only"
     assert records["host_resource_telemetry"].host_actuation_performed is False
     assert records["direct_fan_pwm_thermal_control"].status in {"blocked", "deferred"}
+    assert validate_capability_registry(registry).ok
+
+
+def test_phase3_policy_registry_records_are_proposal_only_and_defer_privileged_organs() -> None:
+    from sentientos.capability_registry import update_registry_from_host_resource_policy
+    from sentientos.host_resource_governor import build_host_resource_telemetry_snapshot, evaluate_host_resource_pressure
+    from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy
+
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id="s", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    report = evaluate_host_resource_pressure(snapshot)
+    decision = evaluate_host_resource_policy(report)
+    receipts = build_host_resource_proposal_receipts(decision)
+    registry = update_registry_from_host_resource_policy(build_default_capability_registry(), decision, receipts)
+    records = registry.by_id()
+    assert records["host_resource_policy"].status == "implemented"
+    assert records["host_resource_policy"].authority_level == "proposal_only"
+    assert records["host_resource_policy"].host_actuation_performed is False
+    assert records["host_resource_proposal_receipts"].status == "implemented"
+    assert records["host_resource_proposal_receipts"].authority_level == "proposal_only"
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+    assert records["privilege_broker"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "deferred"
     assert validate_capability_registry(registry).ok

--- a/tests/test_host_resource_policy.py
+++ b/tests/test_host_resource_policy.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.capability_registry import build_default_capability_registry, update_registry_from_host_resource_policy, validate_capability_registry
+from sentientos.host_collectors import collect_fan_pwm_observation, collect_thermal_sensor_observation
+from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, build_host_resource_telemetry_snapshot, evaluate_host_resource_policy_from_telemetry, evaluate_host_resource_pressure
+from sentientos.host_resource_policy import (
+    build_host_resource_proposal_receipts,
+    evaluate_host_resource_policy,
+    host_resource_policy_decision_digest,
+    host_resource_proposal_receipt_digest,
+    summarize_host_resource_policy_decision,
+    summarize_host_resource_proposal_receipt,
+    validate_host_resource_policy_decision,
+    validate_host_resource_proposal_receipt,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _decision(**kwargs):
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id="snap-policy", observed_at="2026-01-01T00:00:00+00:00", **kwargs)
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    decision = evaluate_host_resource_policy(report, host_id="host", node_id="node")
+    receipts = build_host_resource_proposal_receipts(decision)
+    return snapshot, report, decision, receipts
+
+
+def _kinds(receipts):
+    return {receipt.proposal_kind for receipt in receipts}
+
+
+def test_nominal_pressure_report_produces_nominal_monitor_and_no_executable_receipt() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert decision.status == "host_resource_policy_nominal"
+    assert decision.proposal_kinds == ()
+    assert receipts == ()
+    assert validate_host_resource_policy_decision(decision).ok
+
+
+def test_cpu_pressure_produces_reduce_and_defer_proposal_receipts() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert decision.status == "host_resource_policy_proposal_ready"
+    assert {"inspect_cpu_pressure_candidate", "reduce_model_load_candidate", "defer_heavy_task_candidate"}.issubset(_kinds(receipts))
+    assert all(receipt.does_not_execute and receipt.does_not_mutate_host for receipt in receipts)
+
+
+def test_memory_gpu_disk_pressure_map_to_inspect_and_future_candidates() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=10, ram_utilization_percent=95, gpu_utilization_percent=95, disk_utilization_percent=95)
+    kinds = _kinds(receipts)
+    assert "inspect_memory_pressure_candidate" in kinds
+    assert "defer_heavy_task_candidate" in kinds
+    assert "inspect_gpu_pressure_candidate" in kinds
+    assert "inspect_disk_pressure_candidate" in kinds
+    assert "future_cleanup_policy_candidate" in kinds
+    cleanup = [receipt for receipt in receipts if receipt.proposal_kind == "future_cleanup_policy_candidate"][0]
+    assert cleanup.proposal_status == "host_resource_proposal_blocked"
+    assert validate_host_resource_policy_decision(decision).ok
+
+
+def test_thermal_pressure_produces_inspect_and_future_cooling_non_executing_receipts() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, thermal_zone_temperatures_c={"cpu": 90})
+    kinds = _kinds(receipts)
+    assert {"inspect_thermal_state_candidate", "future_cooling_policy_candidate"}.issubset(kinds)
+    cooling = [receipt for receipt in receipts if receipt.proposal_kind == "future_cooling_policy_candidate"][0]
+    assert cooling.proposal_status == "host_resource_proposal_blocked"
+    assert cooling.does_not_execute is True
+    assert cooling.not_authorized_for_fulfillment is True
+    assert "future_privilege_broker_required" in cooling.required_future_gates
+    assert "fan_pwm_write" in cooling.blocked_actions
+    assert "thermal_actuation" in cooling.blocked_actions
+
+
+def test_fan_rpm_and_pwm_observation_alone_remains_diagnostics_not_control() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, fan_rpm_observations={"fan0": 1200}, model_runtime_pressure_labels=("pwm_signal_observed_not_control_authority",))
+    assert decision.status == "host_resource_policy_monitor"
+    assert decision.proposal_kinds == ()
+    assert receipts == ()
+    assert "pwm_presence_is_not_control_authority" in decision.warning_codes
+    assert decision.fan_pwm_write_performed is False
+
+
+def test_service_degraded_creates_inspect_service_health_not_restart() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, service_health_labels=("daemon_degraded",))
+    assert "inspect_service_health_candidate" in _kinds(receipts)
+    assert "service_restart" in decision.blocked_proposal_kinds
+    assert all("service_restart" in receipt.blocked_actions for receipt in receipts)
+
+
+def test_incomplete_telemetry_produces_diagnostics_operator_review_only() -> None:
+    _, _, decision, receipts = _decision(unavailable_sensor_labels=("cpu",))
+    assert decision.status == "host_resource_policy_incomplete"
+    assert _kinds(receipts) == {"request_operator_review_candidate"}
+    assert receipts[0].proposal_status == "host_resource_proposal_incomplete"
+    assert receipts[0].proposal_scope in {"diagnostics_only", "operator_review_queue"}
+
+
+def test_unknown_and_contradictory_reports_block_proposal_readiness() -> None:
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id="snap", cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30)
+    report = evaluate_host_resource_pressure(snapshot)
+    unknown_decision = evaluate_host_resource_policy(replace(report, pressure_labels=("unknown",)))
+    assert unknown_decision.status == "host_resource_policy_blocked"
+    contradicted = evaluate_host_resource_policy(replace(report, pressure_labels=("nominal", "cpu_pressure")))
+    assert contradicted.status == "host_resource_policy_contradicted"
+
+
+def test_receipts_and_decision_digests_are_deterministic_and_change_on_metadata() -> None:
+    _, _, first_decision, first_receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    _, _, second_decision, second_receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert host_resource_policy_decision_digest(first_decision) == host_resource_policy_decision_digest(second_decision)
+    assert [receipt.digest for receipt in first_receipts] == [receipt.digest for receipt in second_receipts]
+    changed = replace(first_decision, reason_codes=first_decision.reason_codes + ("extra_reason",))
+    assert host_resource_policy_decision_digest(changed) != host_resource_policy_decision_digest(first_decision)
+    changed_receipt = replace(first_receipts[0], warning_codes=first_receipts[0].warning_codes + ("extra_warning",), digest="")
+    assert host_resource_proposal_receipt_digest(changed_receipt) != first_receipts[0].digest
+
+
+def test_summaries_are_metadata_only_and_do_not_include_raw_sensitive_evidence() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    decision_summary = summarize_host_resource_policy_decision(decision)
+    receipt_summary = summarize_host_resource_proposal_receipt(receipts[0])
+    assert set(decision_summary) == {"decision_id", "report_id", "report_digest", "status", "pressure_labels", "selected_policy_rule_count", "proposal_kind_count", "blocked_proposal_kind_count", "warning_count", "risk_count", "metadata_only", "proposal_only", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "network_performed", "digest"}
+    assert set(receipt_summary) == {"receipt_id", "decision_id", "report_id", "proposal_kind", "proposal_status", "proposal_scope", "pressure_labels", "future_gate_count", "blocked_action_count", "warning_count", "risk_count", "proposal_only", "does_not_execute", "does_not_mutate_host", "not_authorized_for_fulfillment", "digest"}
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "host_mutation_performed",
+        "fan_pwm_write_performed",
+        "thermal_actuation_performed",
+        "process_kill_performed",
+        "service_restart_performed",
+        "package_install_performed",
+        "driver_install_performed",
+        "provider_invocation_performed",
+        "network_performed",
+        "prompt_assembly_performed",
+    ],
+)
+def test_validation_rejects_policy_decision_forbidden_flags(field: str) -> None:
+    _, _, decision, _ = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    bad = replace(decision, **{field: True})
+    result = validate_host_resource_policy_decision(bad)
+    assert not result.ok
+    assert f"forbidden_decision_flag:{field}" in result.findings
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "proposal_only",
+        "does_not_execute",
+        "does_not_mutate_host",
+        "not_authorized_for_fulfillment",
+        "requires_privilege_broker_for_future_action",
+        "requires_control_plane_admission_for_future_action",
+        "requires_operator_or_policy_approval_for_future_action",
+        "requires_audit_receipt_for_future_action",
+        "requires_rollback_receipt_for_future_action",
+    ],
+)
+def test_validation_rejects_proposal_receipt_claiming_execution_or_authorization(field: str) -> None:
+    _, _, _, receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    bad = replace(receipts[0], **{field: False})
+    result = validate_host_resource_proposal_receipt(bad)
+    assert not result.ok
+    assert any("receipt_claims_execution_or_authority" in finding for finding in result.findings)
+
+
+def test_fake_collectors_to_policy_receipts_integration_thermal_pwm_proposal_only() -> None:
+    tree = {"/thermal": ("thermal_zone0",), "/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "pwm1")}
+    files = {"/thermal/thermal_zone0/temp": "90000\n", "/thermal/thermal_zone0/type": "cpu\n", "/hwmon/hwmon0/fan1_input": "1400\n", "/hwmon/hwmon0/pwm1": "128\n"}
+    results = (
+        collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/empty", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+        collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+    )
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id="collector-snap")
+    decision, receipts = evaluate_host_resource_policy_from_telemetry(snapshot, host_id="host", node_id="node", thermal_pressure_c=85)
+    assert "future_cooling_policy_candidate" in _kinds(receipts)
+    assert "pwm_presence_is_not_control_authority" in decision.warning_codes
+    assert all(validate_host_resource_proposal_receipt(receipt).ok for receipt in receipts)
+    assert all(receipt.does_not_execute and receipt.does_not_mutate_host for receipt in receipts)
+
+
+def test_capability_registry_reflects_policy_proposal_only_and_deferred_fulfillment() -> None:
+    _, _, decision, receipts = _decision(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    registry = update_registry_from_host_resource_policy(build_default_capability_registry(), decision, receipts)
+    records = registry.by_id()
+    assert records["host_resource_policy"].status == "implemented"
+    assert records["host_resource_policy"].authority_level == "proposal_only"
+    assert records["host_resource_proposal_receipts"].authority_level == "proposal_only"
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+    assert records["privilege_broker"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "deferred"
+    assert all(record.host_actuation_performed is False for record in records.values() if "host_resource" in record.capability_id or record.capability_id in {"direct_fan_pwm_thermal_control", "privilege_broker", "actuation_fulfillment"})
+    assert validate_capability_registry(registry).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -118,3 +118,27 @@ def test_phase2_doc_preserves_read_only_discovery_boundaries() -> None:
     assert "PWM presence is not control authority" in phase2
     assert "Privilege Broker" in phase2
     assert "Actuation Fulfillment Layer" in phase2
+
+HOST_EMBODIMENT_PHASE3 = "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md"
+
+
+def test_navigation_links_to_host_embodiment_phase3_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase1 = _read(HOST_EMBODIMENT_PHASE1)
+    phase2 = _read(HOST_EMBODIMENT_PHASE2)
+    trajectory = _read(TRAJECTORY_DOC)
+    assert HOST_EMBODIMENT_PHASE3 in overview
+    assert HOST_EMBODIMENT_PHASE3 in index
+    assert HOST_EMBODIMENT_PHASE3 in phase1
+    assert HOST_EMBODIMENT_PHASE3 in phase2
+    assert HOST_EMBODIMENT_PHASE3 in trajectory
+
+
+def test_phase3_doc_preserves_proposal_receipt_boundaries() -> None:
+    phase3 = _read(HOST_EMBODIMENT_PHASE3)
+    assert "Proposal receipts are not effects" in phase3
+    assert "policy decision is not authorization" in phase3
+    assert "PWM presence is not control authority" in phase3
+    assert "Privilege Broker" in phase3
+    assert "Actuation Fulfillment Layer" in phase3


### PR DESCRIPTION
### Motivation

- Add Phase 3 (propose-only) layer that converts Phase 1/2 read-only telemetry/pressure reports into deterministic, auditable, metadata-only policy decisions and proposal receipts. 
- Preserve strict observe → model → propose boundary so no host mutation or side-effect can occur in this phase. 
- Produce deterministic receipts and digests that later Privilege Broker / Actuation Fulfillment layers can consume (still deferred). 

### Description

- New policy module `sentientos/host_resource_policy.py` implementing frozen dataclasses `HostResourcePolicyRule`, `HostResourcePolicyDecision`, `HostResourceProposalReceipt`, and `HostResourcePolicyValidationResult`, deterministic digest/summarize/validate helpers, default mapping rules and blocked-action/future-gate semantics. 
- Integration helper `evaluate_host_resource_policy_from_telemetry(...)` added to `sentientos/host_resource_governor.py` to produce policy decisions and proposal receipts from a telemetry snapshot while keeping the pipeline read-only and non-mutating. 
- Capability registry extended in `sentientos/capability_registry.py` to add `host_resource_policy` and `host_resource_proposal_receipts` capability records, plus `update_registry_from_host_resource_policy(...)` to reflect Phase 3 outputs while keeping `privilege_broker` and `actuation_fulfillment` deferred and `direct_fan_pwm_thermal_control` blocked. 
- Documentation and tests added/updated: `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` plus links from Phase 1/2/trajectory/overview/index, and tests `tests/test_host_resource_policy.py` with supporting updates to `tests/test_capability_registry.py` and `tests/test_reviewer_release_readiness_index.py` to cover Phase 3 behavior and registry reflection. 

Files changed/added (high level): `sentientos/host_resource_policy.py` (new), `sentientos/host_resource_governor.py` (integration helper), `sentintos/capability_registry.py` (additions + update function), docs under `docs/architecture/*` (phase3 doc + links), tests: `tests/test_host_resource_policy.py` (new) and small updates to existing tests. All changes are additive and preserve the no-actuation guarantee.

### Testing

- Python static compile checks: `python -m py_compile sentientos/host_resource_policy.py sentientos/host_resource_governor.py sentientos/capability_registry.py tests/test_host_resource_policy.py tests/test_host_resource_governor.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` (succeeded).
- Unit test suites run: `python -m scripts.run_tests -q tests/test_host_resource_policy.py tests/test_host_resource_governor.py tests/test_capability_registry.py` (all tests passed).
- Integration/coverage tests run: `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` (all passed).
- Control-plane smoke tests: `python -m scripts.run_tests -q tests/test_control_plane_kernel.py tests/test_sentientosd_runtime_closure.py` (passed).
- Docs: ran `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` (docs built successfully after bootstrapping missing docs deps). 
- Context-hygiene and forbidden-scan: `python scripts/verify_context_hygiene_prompt_boundaries.py` (no findings) and an execution-time scan for forbidden side-effect tokens (`rg` pattern in the rollout) matched only validation/doc/marker strings and not active implementations, i.e., no forbidden operations were introduced. 

All automated tests listed above passed on the final run and the docs build completed (initial docs bootstrap step was required to provision `mkdocs` in the environment). The change remains strictly metadata-only and proposal-only with explicit validation rejecting any claims of execution or host mutation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0527fe704c83209e1ff1a56d397ff9)