### PR TITLE
[codex:host-embodiment] add privilege broker eligibility layer

### DIFF
--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -91,15 +91,15 @@ until a later phase proves the complete authority and recovery chain.
 
 Every new class of host control must pass through this ladder:
 
-`telemetry → proposal → privilege broker → fulfillment → audit → rollback`
+`telemetry → proposal → privilege broker eligibility → rehearse → authorize → fulfillment → audit → rollback`
 
 The longer doctrine remains:
 
-`observe → model → propose → rehearse → authorize → fulfill → audit → rollback`
+`observe → model → propose → broker eligibility → rehearse → authorize → fulfill → audit → rollback`
 
 Phase 1 covers observe/model and proposal candidate summaries only. It never
 fulfills an action. The next read-only discovery pass is documented in
-`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`; Phase 3 policy receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`.
+`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`; Phase 3 policy receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`.
 
 ## Relationship to existing organs
 

--- a/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
+++ b/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
@@ -68,4 +68,4 @@ Phase 2 must not perform:
 
 ## Next phase
 
-Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`.
+Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`.

--- a/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
+++ b/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
@@ -92,3 +92,5 @@ python scripts/verify_context_hygiene_prompt_boundaries.py
 python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 ```
+
+Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Eligibility is not authorization, and broker receipts are not fulfillment.

--- a/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
+++ b/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
@@ -1,0 +1,158 @@
+# Host Embodiment Substrate Phase 4: Privilege Broker Eligibility Layer
+
+Phase 4 adds the Privilege Broker eligibility layer for host embodiment. It
+consumes Phase 3 host-resource proposal receipts and classifies whether each
+receipt is eligible, conditionally eligible, blocked, incomplete, or
+contradicted for future privileged-action consideration.
+
+Phase 4 is not actuation. Eligibility is not authorization. A broker review
+receipt is not fulfillment; broker review receipt is not fulfillment. The broker only records metadata about future gates
+and missing prerequisites.
+
+## Authority ladder
+
+The host-embodiment ladder remains:
+
+`observe → model → propose → broker eligibility → rehearse → authorize → fulfill → audit → rollback`
+
+Phase 4 covers only `broker eligibility`. It does not skip to rehearsal,
+authorization, fulfillment, audit, or rollback.
+
+## What Phase 4 evaluates
+
+`sentientos/privilege_broker.py` evaluates proposal receipts from
+`sentientos/host_resource_policy.py` and produces two metadata-only artifacts:
+
+1. `PrivilegeBrokerEligibilityDecision` — the broker classification for a source
+   proposal receipt.
+2. `PrivilegeBrokerReviewReceipt` — a deterministic review receipt recording the
+   broker classification and future gates.
+
+The intended non-mutating pipeline is:
+
+`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → privilege broker eligibility decision → privilege broker review receipt`
+
+Each broker decision records the source proposal kind, source receipt digest,
+proposal status, proposal scope, pressure labels, privilege domain, eligibility
+status, reason/warning/risk codes, required future gates, blocked actions, and
+missing prerequisites.
+
+## Eligibility is not authorization
+
+A `privilege_broker_eligible_for_future_review` or
+`privilege_broker_eligible_with_conditions` decision means only that a later
+privileged-action request could be considered after all required gates are
+present. It does not authorize host action and does not grant fulfillment.
+
+Every eligibility decision preserves explicit non-effect flags:
+
+- `metadata_only=True`
+- `eligibility_only=True`
+- `authorization_granted=False`
+- `fulfillment_granted=False`
+- `host_mutation_performed=False`
+- `fan_pwm_write_performed=False`
+- `thermal_actuation_performed=False`
+- `process_kill_performed=False`
+- `service_restart_performed=False`
+- `package_install_performed=False`
+- `driver_install_performed=False`
+- `provider_invocation_performed=False`
+- `network_performed=False`
+- `prompt_assembly_performed=False`
+
+## Broker receipt is not fulfillment
+
+A `PrivilegeBrokerReviewReceipt` is a ledgerable review artifact only. It records
+that review happened and which future gates remain required. It does not execute,
+mutate, authorize fulfillment, or satisfy the future Actuation Fulfillment Layer.
+
+Every broker receipt preserves explicit non-effect flags:
+
+- `review_only=True`
+- `eligibility_only=True`
+- `does_not_execute=True`
+- `does_not_mutate_host=True`
+- `does_not_authorize_fulfillment=True`
+- `requires_control_plane_admission_for_future_action=True`
+- `requires_operator_or_policy_approval_for_future_action=True`
+- `requires_audit_receipt_for_future_action=True`
+- `requires_rollback_receipt_for_future_action=True`
+- `requires_actuation_fulfillment_layer_for_future_action=True`
+
+## Proposal kind mapping
+
+| Proposal kind | Privilege domain | Broker posture |
+| --- | --- | --- |
+| `inspect_cpu_pressure_candidate` | `resource_pressure_review` | Eligible for future review when source receipt is valid and non-effect. |
+| `inspect_memory_pressure_candidate` | `resource_pressure_review` | Eligible for future review when source receipt is valid and non-effect. |
+| `inspect_disk_pressure_candidate` | `disk_safety_review` | Eligible for future review when source receipt is valid and non-effect. |
+| `inspect_thermal_state_candidate` | `thermal_safety_review` | Eligible for future review only; no cooling authority. |
+| `inspect_service_health_candidate` | `service_health_review` | Eligible for review only; service restart remains blocked/deferred. |
+| `future_cooling_policy_candidate` | `future_cooling_policy_review` | Blocked if the Phase 3 receipt is blocked; otherwise eligible only with conditions. Never direct fulfillment. |
+| `future_power_policy_candidate` | `future_power_policy_review` | Eligible only with conditions; no power-profile mutation. |
+| `future_cleanup_policy_candidate` | `future_cleanup_policy_review` | Blocked if the Phase 3 receipt is blocked; otherwise eligible only with conditions. No cleanup mutation. |
+| `request_operator_review_candidate` | `operator_review` | Eligible for operator review when source receipt is valid and non-effect. |
+| `reduce_model_load_candidate` / `defer_heavy_task_candidate` | `resource_pressure_review` | Review/rehearsal candidate only; no fulfillment is granted. |
+
+## Future gates by privileged class
+
+Future cooling policy candidates require all of the following before any later
+action could even be considered: hardware allowlist, OS backend declaration,
+bounds policy, cooldown policy, panic stop, control-plane admission,
+operator/policy approval, audit receipt, rollback receipt, rehearsal, and the
+future Actuation Fulfillment Layer.
+
+Future power policy candidates require OS backend declaration, bounds policy,
+operator/policy approval, control-plane admission, audit receipt, rollback
+receipt, rehearsal, and the future Actuation Fulfillment Layer.
+
+Future cleanup policy candidates require dry-run/rehearsal, file/path scope
+declaration, operator/policy approval, audit receipt, rollback receipt, and the
+future Actuation Fulfillment Layer.
+
+Service health review candidates keep `service_restart` in blocked actions.
+Thermal and fan/PWM observations keep `fan_pwm_write` and `thermal_actuation` in
+blocked actions when cooling is discussed.
+
+## Explicitly forbidden in Phase 4
+
+The Privilege Broker cannot:
+
+- mutate host state;
+- write fan/PWM controls;
+- perform thermal actuation;
+- change power profiles;
+- kill processes;
+- restart services;
+- install packages or drivers;
+- perform network calls or remote execution;
+- invoke providers;
+- assemble or export prompts;
+- transport, sync, adopt, merge, apply, install, or execute federation evidence.
+
+direct fan/PWM/thermal control remains blocked/deferred. Future
+cooling/power/cleanup/service actions remain blocked behind future gates. The
+future Actuation Fulfillment Layer is still required before effects can occur.
+
+## Contradiction and incompleteness rules
+
+Source proposal receipts that are blocked, incomplete, or contradicted do not
+become eligible. They remain broker-blocked, broker-incomplete, or
+broker-contradicted.
+
+Any source receipt that claims execution, host mutation, fulfillment
+authorization, missing future gates, or missing blocked-action evidence is
+rejected as blocked or contradicted by the broker. This preserves the core
+principle: a proposal receipt is not an effect, a policy decision is not
+authorization, and a privilege broker eligibility decision is not fulfillment.
+
+## Proof commands
+
+```bash
+python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py
+python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
+python scripts/verify_context_hygiene_prompt_boundaries.py
+```

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -215,4 +215,9 @@ Internal and legacy cultural documentation remains available and is not removed 
 
 ## Host embodiment substrate
 
-See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` for Phase 1 metadata-only host embodiment and Phase 2 read-only discovery.
+See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` and `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` for Host Embodiment Substrate phases 1 through 4.
+
+
+### Host Embodiment Phase 4 Privilege Broker
+
+See `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Phase 4 evaluates proposal receipts for future privileged-action eligibility only. Eligibility is not authorization, a broker receipt is not fulfillment, fan/PWM/thermal control remains blocked/deferred, and the future Actuation Fulfillment Layer is still required before any effect can occur.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -19,7 +19,7 @@ Host Embodiment Substrate Phase 1 is covered by
 `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`. It adds the
 Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold. Privilege Broker and Actuation Fulfillment Layer
-remain future gates for any host action; direct fan/PWM control remains deferred.
+remain future gates for any host action; direct fan/PWM control remains deferred. Phase 4 broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` and still does not authorize or fulfill host action.
 
 ## Current implemented proof surfaces
 
@@ -190,3 +190,14 @@ python scripts/build_docs.py
 ## Host Embodiment Phase 3 policy receipts
 
 See `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. Proposal receipts are not effects. A policy decision is not authorization. PWM presence is not control authority. Phase 3 names the future Privilege Broker and Actuation Fulfillment Layer and keeps them future/deferred.
+
+
+## Host Embodiment Phase 4 privilege broker eligibility
+
+See `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Eligibility is not authorization. A broker receipt is not fulfillment. Fan/PWM/thermal control remains blocked/deferred. Future cooling, power, cleanup, and service actions remain behind future gates, including control-plane admission, operator/policy approval, audit, rollback, rehearsal, panic/hardware/backend/bounds gates where applicable, and the future Actuation Fulfillment Layer.
+
+Proof command:
+
+```bash
+python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py
+```

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -18,7 +18,7 @@ reconstruct what happened. Capabilities that are only implied by this trajectory
 are listed below as missing or deferred rather than claimed as implemented.
 
 Host Embodiment Substrate Phase 1 is the first observe/model substrate for this
-path; see `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. It adds a
+path; see `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` and `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. It adds a
 Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold while keeping Privilege Broker and Actuation
 Fulfillment Layer requirements ahead of any future host actuation. Direct
@@ -360,3 +360,8 @@ implemented:
 ### Host Embodiment Phase 3 policy receipts
 
 Phase 3 is documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`. It converts pressure reports into proposal receipts only: proposal receipts are not effects, policy decisions are not authorization, PWM presence is not control authority, and future cooling/power/service/cleanup candidates require the future Privilege Broker and Actuation Fulfillment Layer.
+
+
+### Host Embodiment Phase 4 privilege broker eligibility
+
+Phase 4 is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. It classifies proposal receipts for future privileged-action eligibility only. Eligibility is not authorization, a broker receipt is not fulfillment, and direct fan/PWM/thermal control, service restart, power mutation, cleanup mutation, package/driver install, provider invocation, network egress, prompt assembly, federation transport/sync/adoption, and remote execution remain blocked behind future gates and the future Actuation Fulfillment Layer.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -31,6 +31,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "host_resource_telemetry",
         "host_resource_policy",
         "host_resource_proposal_receipts",
+        "privilege_broker",
         "control_plane_admission",
         "audit_immutability",
         "self_amendment",
@@ -44,6 +45,7 @@ AUTHORITY_LEVELS = frozenset(
         "none",
         "observation",
         "proposal_only",
+        "eligibility_only",
         "gated_host_interaction",
         "privileged_host_action",
         "federation_evidence",
@@ -121,7 +123,7 @@ class CapabilityRecord:
 @dataclass(frozen=True)
 class CapabilityRegistry:
     registry_id: str
-    schema_version: str = "host-embodiment-substrate-phase3.v1"
+    schema_version: str = "host-embodiment-substrate-phase4.v1"
     records: tuple[CapabilityRecord, ...] = ()
     metadata_only: bool = True
     no_runtime_authority_expansion: bool = True
@@ -213,16 +215,16 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("direct_fan_pwm_thermal_control", "host_resource_telemetry", "blocked", "none", source_paths=("sentientos/host_resource_governor.py", "sentientos/host_inventory.py", "sentientos/host_resource_policy.py"), proof_tests=("tests/test_host_resource_governor.py", "tests/test_host_inventory.py", "tests/test_host_resource_policy.py"), deferred_surfaces=("fan/PWM writes", "direct thermal actuation"), forbidden_implications=("fan/PWM/thermal control is implemented"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("blanket_hardware_control", "hardware_driver_awareness", "blocked", "none", deferred_surfaces=("stem-to-stern host actuation",), forbidden_implications=("blanket hardware control exists"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("control_plane_admission", "control_plane_admission", "implemented", "proposal_only", source_paths=("sentientos/control_plane_kernel.py", "control_plane/", "sentientos/runtime_governor.py"), proof_tests=("tests/test_control_plane_kernel.py", "tests/test_sentientosd_runtime_closure.py"), implemented_surfaces=("admission receipts and runtime gating",), forbidden_implications=("admission alone performs effects",)),
-        _record("privilege_broker", "control_plane_admission", "deferred", "none", deferred_surfaces=("canonical privileged host action mediation", "cooling authorization", "service restart authorization", "cleanup authorization"), forbidden_implications=("privilege broker is implemented by Phase 3",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("actuation_fulfillment", "control_plane_admission", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "rollback execution", "host mutation effects"), forbidden_implications=("proposal receipt is actuation fulfillment",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("privilege_broker", "privilege_broker", "implemented", "eligibility_only", source_paths=("sentientos/privilege_broker.py", "sentientos/host_resource_policy.py"), proof_tests=("tests/test_privilege_broker.py",), proof_commands=("python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py",), implemented_surfaces=("eligibility-only classification of proposal receipts", "deterministic broker review receipts"), deferred_surfaces=("authorization", "Actuation Fulfillment Layer", "cooling fulfillment", "service restart fulfillment", "cleanup fulfillment", "power policy mutation"), forbidden_implications=("privilege broker eligibility is authorization", "broker review receipt is fulfillment", "privilege broker performs host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("actuation_fulfillment", "control_plane_admission", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "rollback execution", "host mutation effects", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("proposal receipt is actuation fulfillment", "privilege broker receipt is actuation fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
         _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase3", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase4", records=records)
 
 
 
@@ -330,7 +332,9 @@ def update_registry_from_host_resource_policy(registry: CapabilityRegistry, deci
             )
         elif record.capability_id in {"direct_fan_pwm_thermal_control"}:
             records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
-        elif record.capability_id in {"privilege_broker", "actuation_fulfillment"}:
+        elif record.capability_id == "privilege_broker":
+            records.append(record)
+        elif record.capability_id == "actuation_fulfillment":
             records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
         else:
             records.append(record)
@@ -424,3 +428,34 @@ def replace_capability_record(registry: CapabilityRegistry, capability_id: str, 
 
     records = tuple(replace(record, **changes) if record.capability_id == capability_id else record for record in registry.records)
     return replace(registry, records=records)
+
+
+def update_registry_from_privilege_broker_decision(registry: CapabilityRegistry, decision: Any, review_receipts: Sequence[Any] = ()) -> CapabilityRegistry:
+    """Reflect Phase 4 broker eligibility without claiming fulfillment."""
+
+    records: list[CapabilityRecord] = []
+    has_decision = bool(getattr(decision, "decision_id", ""))
+    has_receipts = bool(review_receipts)
+    for record in registry.records:
+        if record.capability_id == "privilege_broker":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_decision else "scaffolded",
+                    authority_level="eligibility_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/privilege_broker.py", "sentientos/host_resource_policy.py")))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_privilege_broker.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("proposal receipt eligibility classification", "non-effect broker review receipts" if has_receipts else "broker eligibility scaffold")))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("Actuation Fulfillment Layer", "authorization", "host mutation", "fan/PWM writes", "thermal actuation", "service restart", "cleanup mutation", "power profile mutation")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("eligibility decision is authorization", "broker receipt is fulfillment")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "actuation_fulfillment":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id == "direct_fan_pwm_thermal_control":
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase4.v1")

--- a/sentientos/host_resource_policy.py
+++ b/sentientos/host_resource_policy.py
@@ -505,3 +505,20 @@ def validate_host_resource_proposal_receipt(receipt: HostResourceProposalReceipt
     if missing_blocks:
         findings.append("receipt_missing_blocked_actions")
     return HostResourcePolicyValidationResult(ok=not findings, findings=tuple(findings))
+
+def evaluate_privilege_broker_for_host_resource_receipts(
+    receipts: Sequence[HostResourceProposalReceipt],
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
+    """Evaluate Phase 4 broker eligibility for Phase 3 proposal receipts.
+
+    The returned broker decisions and review receipts are metadata-only and
+    eligibility-only. They do not authorize, fulfill, or mutate host state.
+    """
+
+    from sentientos.privilege_broker import build_privilege_broker_review_receipt, evaluate_privilege_broker_eligibility
+
+    decisions = tuple(evaluate_privilege_broker_eligibility(receipt) for receipt in receipts)
+    review_receipts = tuple(build_privilege_broker_review_receipt(decision, created_at=created_at) for decision in decisions)
+    return decisions, review_receipts

--- a/sentientos/privilege_broker.py
+++ b/sentientos/privilege_broker.py
@@ -1,0 +1,571 @@
+"""Eligibility-only Privilege Broker for SentientOS host embodiment Phase 4.
+
+This module classifies proposal receipts for future privileged-action review. It
+is metadata-only: it never admits, authorizes, fulfills, executes, mutates host
+state, writes fan/PWM controls, changes thermal or power settings, kills
+processes, restarts services, installs packages or drivers, performs network
+activity, invokes providers, or assembles prompts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+from sentientos.host_resource_policy import (
+    BLOCKED_HOST_ACTIONS,
+    FUTURE_ACTION_GATES,
+    HOST_RESOURCE_PROPOSAL_STATUSES,
+    host_resource_proposal_receipt_digest,
+    validate_host_resource_proposal_receipt,
+)
+
+PRIVILEGE_BROKER_ELIGIBILITY_STATUSES = frozenset(
+    {
+        "privilege_broker_eligible_for_future_review",
+        "privilege_broker_eligible_with_conditions",
+        "privilege_broker_blocked",
+        "privilege_broker_incomplete",
+        "privilege_broker_contradicted",
+    }
+)
+PRIVILEGE_BROKER_REVIEW_STATUSES = frozenset(
+    {
+        "privilege_broker_receipt_recorded",
+        "privilege_broker_receipt_recorded_with_warnings",
+        "privilege_broker_receipt_blocked",
+        "privilege_broker_receipt_incomplete",
+        "privilege_broker_receipt_contradicted",
+    }
+)
+PRIVILEGE_DOMAINS = frozenset(
+    {
+        "diagnostics_only",
+        "operator_review",
+        "resource_pressure_review",
+        "service_health_review",
+        "thermal_safety_review",
+        "disk_safety_review",
+        "future_power_policy_review",
+        "future_cooling_policy_review",
+        "future_cleanup_policy_review",
+        "future_actuation_fulfillment_review",
+    }
+)
+REQUIRED_FUTURE_GATES = (
+    "control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "panic_stop_required",
+    "hardware_allowlist_required",
+    "os_backend_declaration_required",
+    "bounds_policy_required",
+    "cooldown_policy_required",
+    "rehearsal_required",
+    "fulfillment_layer_required",
+)
+BASE_FUTURE_GATES = (
+    "control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+)
+REHEARSAL_FULFILLMENT_GATES = BASE_FUTURE_GATES + ("rehearsal_required", "fulfillment_layer_required")
+COOLING_POLICY_GATES = (
+    "hardware_allowlist_required",
+    "os_backend_declaration_required",
+    "bounds_policy_required",
+    "cooldown_policy_required",
+    "panic_stop_required",
+    "control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "rehearsal_required",
+    "fulfillment_layer_required",
+)
+POWER_POLICY_GATES = (
+    "os_backend_declaration_required",
+    "bounds_policy_required",
+    "operator_or_policy_approval_required",
+    "control_plane_admission_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "rehearsal_required",
+    "fulfillment_layer_required",
+)
+CLEANUP_POLICY_GATES = (
+    "rehearsal_required",
+    "file_path_scope_declaration_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "fulfillment_layer_required",
+)
+SERVICE_HEALTH_GATES = BASE_FUTURE_GATES + ("rehearsal_required", "fulfillment_layer_required")
+
+_KIND_TO_DOMAIN: Mapping[str, str] = {
+    "inspect_cpu_pressure_candidate": "resource_pressure_review",
+    "inspect_memory_pressure_candidate": "resource_pressure_review",
+    "inspect_gpu_pressure_candidate": "resource_pressure_review",
+    "inspect_disk_pressure_candidate": "disk_safety_review",
+    "inspect_thermal_state_candidate": "thermal_safety_review",
+    "inspect_service_health_candidate": "service_health_review",
+    "request_operator_review_candidate": "operator_review",
+    "reduce_model_load_candidate": "resource_pressure_review",
+    "defer_heavy_task_candidate": "resource_pressure_review",
+    "future_cooling_policy_candidate": "future_cooling_policy_review",
+    "future_power_policy_candidate": "future_power_policy_review",
+    "future_cleanup_policy_candidate": "future_cleanup_policy_review",
+}
+_KIND_TO_GATES: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_policy_candidate": COOLING_POLICY_GATES,
+    "future_power_policy_candidate": POWER_POLICY_GATES,
+    "future_cleanup_policy_candidate": CLEANUP_POLICY_GATES,
+    "inspect_service_health_candidate": SERVICE_HEALTH_GATES,
+}
+_KIND_TO_BLOCKED_ACTIONS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_policy_candidate": ("fan_pwm_write", "thermal_actuation", "power_profile_mutation"),
+    "future_power_policy_candidate": ("power_profile_mutation",),
+    "future_cleanup_policy_candidate": ("file_delete", "disk_cleanup_mutation"),
+    "inspect_service_health_candidate": ("service_restart",),
+}
+_CONTRADICTORY_RECEIPT_STATUSES = frozenset({"host_resource_proposal_contradicted"})
+_INCOMPLETE_RECEIPT_STATUSES = frozenset({"host_resource_proposal_incomplete"})
+_BLOCKED_RECEIPT_STATUSES = frozenset({"host_resource_proposal_blocked"})
+_RECORDED_RECEIPT_STATUSES = frozenset({"host_resource_proposal_recorded", "host_resource_proposal_recorded_with_warnings"})
+
+
+@dataclass(frozen=True)
+class PrivilegeBrokerPolicy:
+    policy_id: str
+    inspect_kinds_eligible: tuple[str, ...]
+    conditional_future_kinds: tuple[str, ...]
+    required_receipt_gates: tuple[str, ...] = FUTURE_ACTION_GATES
+    required_blocked_actions: tuple[str, ...] = BLOCKED_HOST_ACTIONS
+    metadata_only: bool = True
+    eligibility_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PrivilegeBrokerEligibilityDecision:
+    decision_id: str
+    source_receipt_id: str
+    source_receipt_digest: str
+    source_proposal_kind: str
+    proposal_status: str
+    proposal_scope: str
+    pressure_labels: tuple[str, ...]
+    privilege_domain: str
+    eligibility_status: str
+    reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    missing_prerequisites: tuple[str, ...]
+    metadata_only: bool = True
+    eligibility_only: bool = True
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PrivilegeBrokerReviewReceipt:
+    receipt_id: str
+    decision_id: str
+    source_receipt_id: str
+    source_receipt_digest: str
+    privilege_domain: str
+    eligibility_status: str
+    review_status: str
+    evidence_summary: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    review_only: bool = True
+    eligibility_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    requires_control_plane_admission_for_future_action: bool = True
+    requires_operator_or_policy_approval_for_future_action: bool = True
+    requires_audit_receipt_for_future_action: bool = True
+    requires_rollback_receipt_for_future_action: bool = True
+    requires_actuation_fulfillment_layer_for_future_action: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PrivilegeBrokerValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _tuple_str(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _merge_unique(*groups: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(item) for group in groups for item in group}))
+
+
+def build_default_privilege_broker_policy() -> PrivilegeBrokerPolicy:
+    inspect = tuple(sorted(kind for kind in _KIND_TO_DOMAIN if kind.startswith("inspect_") or kind in {"request_operator_review_candidate", "reduce_model_load_candidate", "defer_heavy_task_candidate"}))
+    conditional = ("future_cleanup_policy_candidate", "future_cooling_policy_candidate", "future_power_policy_candidate")
+    material = {"inspect": inspect, "conditional": conditional, "required_receipt_gates": FUTURE_ACTION_GATES}
+    return PrivilegeBrokerPolicy(policy_id=_digest_payload("pbp_", material), inspect_kinds_eligible=inspect, conditional_future_kinds=conditional)
+
+
+def _source_digest(receipt: Any) -> str:
+    digest = str(getattr(receipt, "digest", "") or "")
+    if digest:
+        return digest
+    try:
+        return host_resource_proposal_receipt_digest(receipt)
+    except Exception:  # defensive for mapping-like test doubles; no host effect.
+        return hashlib.sha256(_canonical_json(getattr(receipt, "to_dict", lambda: dict(receipt))()).encode("utf-8")).hexdigest()
+
+
+def _source_claim_findings(receipt: Any) -> tuple[str, ...]:
+    findings: list[str] = []
+    required_true = {
+        "proposal_only": getattr(receipt, "proposal_only", True),
+        "does_not_execute": getattr(receipt, "does_not_execute", True),
+        "does_not_mutate_host": getattr(receipt, "does_not_mutate_host", True),
+        "not_authorized_for_fulfillment": getattr(receipt, "not_authorized_for_fulfillment", True),
+        "requires_privilege_broker_for_future_action": getattr(receipt, "requires_privilege_broker_for_future_action", True),
+        "requires_control_plane_admission_for_future_action": getattr(receipt, "requires_control_plane_admission_for_future_action", True),
+        "requires_operator_or_policy_approval_for_future_action": getattr(receipt, "requires_operator_or_policy_approval_for_future_action", True),
+        "requires_audit_receipt_for_future_action": getattr(receipt, "requires_audit_receipt_for_future_action", True),
+        "requires_rollback_receipt_for_future_action": getattr(receipt, "requires_rollback_receipt_for_future_action", True),
+    }
+    for flag, value in required_true.items():
+        if not value:
+            findings.append(f"source_receipt_claims_execution_or_authority:{flag}")
+    if getattr(receipt, "host_mutation_performed", False):
+        findings.append("source_receipt_claims_host_mutation")
+    missing_gates = [gate for gate in FUTURE_ACTION_GATES if gate not in tuple(getattr(receipt, "required_future_gates", ()) or ())]
+    if missing_gates:
+        findings.append("source_receipt_missing_future_gates")
+    missing_blocks = [action for action in BLOCKED_HOST_ACTIONS if action not in tuple(getattr(receipt, "blocked_actions", ()) or ())]
+    if missing_blocks:
+        findings.append("source_receipt_missing_blocked_actions")
+    return tuple(findings)
+
+
+def evaluate_privilege_broker_eligibility(receipt: Any, *, policy: PrivilegeBrokerPolicy | None = None) -> PrivilegeBrokerEligibilityDecision:
+    broker_policy = policy or build_default_privilege_broker_policy()
+    source_receipt_id = str(getattr(receipt, "receipt_id", ""))
+    source_digest = _source_digest(receipt)
+    proposal_kind = str(getattr(receipt, "proposal_kind", ""))
+    proposal_status = str(getattr(receipt, "proposal_status", ""))
+    proposal_scope = str(getattr(receipt, "proposal_scope", ""))
+    pressure_labels = tuple(sorted(str(label) for label in getattr(receipt, "pressure_labels", ()) or ()))
+    domain = _KIND_TO_DOMAIN.get(proposal_kind, "diagnostics_only")
+    warnings = set(_tuple_str(getattr(receipt, "warning_codes", ()) or ()))
+    risks = set(_tuple_str(getattr(receipt, "risk_codes", ()) or ()))
+    reasons: set[str] = {"broker_classification_only", "eligibility_is_not_authorization", "broker_decision_is_not_fulfillment"}
+    missing: set[str] = set()
+    blocked_actions = set(BLOCKED_HOST_ACTIONS)
+    blocked_actions.update(_KIND_TO_BLOCKED_ACTIONS.get(proposal_kind, ()))
+    validation = validate_host_resource_proposal_receipt(receipt)
+    source_claim_findings = _source_claim_findings(receipt)
+    required_gates = _KIND_TO_GATES.get(proposal_kind, BASE_FUTURE_GATES)
+
+    if proposal_kind in broker_policy.conditional_future_kinds:
+        required_gates = _KIND_TO_GATES[proposal_kind]
+        missing.update(required_gates)
+        reasons.add("future_privileged_action_requires_unimplemented_future_gates")
+    elif proposal_kind == "inspect_service_health_candidate":
+        reasons.add("service_restart_remains_blocked_deferred")
+    elif proposal_kind.startswith("inspect_") or proposal_kind in broker_policy.inspect_kinds_eligible:
+        reasons.add("inspect_or_review_candidate_is_metadata_only")
+    else:
+        warnings.add("unknown_or_noncanonical_proposal_kind")
+        reasons.add("noncanonical_kind_requires_operator_review")
+
+    if proposal_kind == "future_cooling_policy_candidate":
+        risks.add("cooling_control_requires_hardware_and_os_bounds")
+        blocked_actions.update(("fan_pwm_write", "thermal_actuation"))
+    if proposal_kind == "future_power_policy_candidate":
+        risks.add("power_policy_mutation_requires_backend_and_bounds")
+    if proposal_kind == "future_cleanup_policy_candidate":
+        risks.add("cleanup_requires_dry_run_path_scope_and_rollback")
+    if proposal_kind == "inspect_service_health_candidate":
+        blocked_actions.add("service_restart")
+
+    if proposal_status in _CONTRADICTORY_RECEIPT_STATUSES:
+        eligibility_status = "privilege_broker_contradicted"
+        reasons.add("source_proposal_receipt_contradicted")
+    elif proposal_status in _INCOMPLETE_RECEIPT_STATUSES:
+        eligibility_status = "privilege_broker_incomplete"
+        reasons.add("source_proposal_receipt_incomplete")
+    elif source_claim_findings:
+        if any("claims" in finding for finding in source_claim_findings):
+            eligibility_status = "privilege_broker_contradicted"
+            reasons.add("source_receipt_claims_forbidden_effect")
+        else:
+            eligibility_status = "privilege_broker_blocked"
+            reasons.add("source_receipt_missing_required_non_effect_evidence")
+        missing.update(source_claim_findings)
+    elif proposal_status in _BLOCKED_RECEIPT_STATUSES:
+        eligibility_status = "privilege_broker_blocked"
+        reasons.add("source_proposal_receipt_blocked")
+    elif not validation.ok:
+        eligibility_status = "privilege_broker_contradicted" if any("claim" in finding or "digest" in finding for finding in validation.findings) else "privilege_broker_blocked"
+        missing.update(validation.findings)
+        reasons.add("source_proposal_receipt_failed_validation")
+    elif proposal_status in _RECORDED_RECEIPT_STATUSES and proposal_kind in broker_policy.conditional_future_kinds:
+        eligibility_status = "privilege_broker_eligible_with_conditions"
+        warnings.add("future_action_still_requires_authorization_and_fulfillment")
+    elif proposal_status in _RECORDED_RECEIPT_STATUSES:
+        eligibility_status = "privilege_broker_eligible_for_future_review"
+    elif proposal_status not in HOST_RESOURCE_PROPOSAL_STATUSES:
+        eligibility_status = "privilege_broker_incomplete"
+        missing.add("unknown_source_proposal_status")
+    else:
+        eligibility_status = "privilege_broker_blocked"
+
+    material = {
+        "source_receipt_id": source_receipt_id,
+        "source_receipt_digest": source_digest,
+        "source_proposal_kind": proposal_kind,
+        "proposal_status": proposal_status,
+        "proposal_scope": proposal_scope,
+        "pressure_labels": pressure_labels,
+        "privilege_domain": domain,
+        "eligibility_status": eligibility_status,
+        "required_future_gates": required_gates,
+        "blocked_actions": tuple(sorted(blocked_actions)),
+        "missing_prerequisites": tuple(sorted(missing)),
+        "policy_id": broker_policy.policy_id,
+    }
+    return PrivilegeBrokerEligibilityDecision(
+        decision_id=_digest_payload("pbd_", material),
+        source_receipt_id=source_receipt_id,
+        source_receipt_digest=source_digest,
+        source_proposal_kind=proposal_kind,
+        proposal_status=proposal_status,
+        proposal_scope=proposal_scope,
+        pressure_labels=pressure_labels,
+        privilege_domain=domain,
+        eligibility_status=eligibility_status,
+        reason_codes=tuple(sorted(reasons)),
+        warning_codes=tuple(sorted(warnings)),
+        risk_codes=tuple(sorted(risks)),
+        required_future_gates=tuple(required_gates),
+        blocked_actions=tuple(sorted(blocked_actions)),
+        missing_prerequisites=tuple(sorted(missing)),
+    )
+
+
+def _review_status_for(decision: PrivilegeBrokerEligibilityDecision) -> str:
+    if decision.eligibility_status == "privilege_broker_contradicted":
+        return "privilege_broker_receipt_contradicted"
+    if decision.eligibility_status == "privilege_broker_incomplete":
+        return "privilege_broker_receipt_incomplete"
+    if decision.eligibility_status == "privilege_broker_blocked":
+        return "privilege_broker_receipt_blocked"
+    if decision.warning_codes or decision.eligibility_status == "privilege_broker_eligible_with_conditions":
+        return "privilege_broker_receipt_recorded_with_warnings"
+    return "privilege_broker_receipt_recorded"
+
+
+def build_privilege_broker_review_receipt(
+    decision: PrivilegeBrokerEligibilityDecision,
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> PrivilegeBrokerReviewReceipt:
+    evidence = (
+        f"source_proposal_kind:{decision.source_proposal_kind}",
+        f"eligibility_status:{decision.eligibility_status}",
+        "eligibility_is_not_authorization",
+        "broker_receipt_is_not_fulfillment",
+        "future_action_requires_control_plane_operator_audit_rollback_and_fulfillment",
+    )
+    review_status = _review_status_for(decision)
+    material = {
+        "decision_id": decision.decision_id,
+        "source_receipt_id": decision.source_receipt_id,
+        "source_receipt_digest": decision.source_receipt_digest,
+        "privilege_domain": decision.privilege_domain,
+        "eligibility_status": decision.eligibility_status,
+        "review_status": review_status,
+        "required_future_gates": decision.required_future_gates,
+        "blocked_actions": decision.blocked_actions,
+        "created_at": created_at,
+    }
+    provisional = PrivilegeBrokerReviewReceipt(
+        receipt_id=_digest_payload("pbr_", material),
+        decision_id=decision.decision_id,
+        source_receipt_id=decision.source_receipt_id,
+        source_receipt_digest=decision.source_receipt_digest,
+        privilege_domain=decision.privilege_domain,
+        eligibility_status=decision.eligibility_status,
+        review_status=review_status,
+        evidence_summary=evidence,
+        required_future_gates=decision.required_future_gates,
+        blocked_actions=decision.blocked_actions,
+        warning_codes=decision.warning_codes,
+        risk_codes=decision.risk_codes,
+        created_at=created_at,
+    )
+    return replace(provisional, digest=privilege_broker_receipt_digest(provisional))
+
+
+def privilege_broker_decision_digest(decision: PrivilegeBrokerEligibilityDecision) -> str:
+    return hashlib.sha256(_canonical_json(decision.to_dict()).encode("utf-8")).hexdigest()
+
+
+def privilege_broker_receipt_digest(receipt: PrivilegeBrokerReviewReceipt) -> str:
+    payload = receipt.to_dict()
+    payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def validate_privilege_broker_eligibility_decision(decision: PrivilegeBrokerEligibilityDecision) -> PrivilegeBrokerValidationResult:
+    findings: list[str] = []
+    if not decision.decision_id:
+        findings.append("missing_decision_id")
+    if not decision.source_receipt_id:
+        findings.append("missing_source_receipt_id")
+    if decision.privilege_domain not in PRIVILEGE_DOMAINS:
+        findings.append("unknown_privilege_domain")
+    if decision.eligibility_status not in PRIVILEGE_BROKER_ELIGIBILITY_STATUSES:
+        findings.append("unknown_eligibility_status")
+    if not decision.metadata_only or not decision.eligibility_only:
+        findings.append("decision_not_metadata_eligibility_only")
+    forbidden_false = {
+        "authorization_granted": decision.authorization_granted,
+        "fulfillment_granted": decision.fulfillment_granted,
+        "host_mutation_performed": decision.host_mutation_performed,
+        "fan_pwm_write_performed": decision.fan_pwm_write_performed,
+        "thermal_actuation_performed": decision.thermal_actuation_performed,
+        "process_kill_performed": decision.process_kill_performed,
+        "service_restart_performed": decision.service_restart_performed,
+        "package_install_performed": decision.package_install_performed,
+        "driver_install_performed": decision.driver_install_performed,
+        "provider_invocation_performed": decision.provider_invocation_performed,
+        "network_performed": decision.network_performed,
+        "prompt_assembly_performed": decision.prompt_assembly_performed,
+    }
+    for flag, value in forbidden_false.items():
+        if value:
+            findings.append(f"forbidden_decision_flag:{flag}")
+    if decision.source_proposal_kind == "future_cooling_policy_candidate" and decision.eligibility_status == "privilege_broker_eligible_for_future_review":
+        findings.append("future_cooling_cannot_be_directly_eligible")
+    if decision.source_proposal_kind == "inspect_service_health_candidate" and "service_restart" not in decision.blocked_actions:
+        findings.append("service_health_missing_restart_block")
+    if decision.source_proposal_kind == "future_cooling_policy_candidate":
+        for gate in COOLING_POLICY_GATES:
+            if gate not in decision.required_future_gates:
+                findings.append(f"future_cooling_missing_gate:{gate}")
+    return PrivilegeBrokerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_privilege_broker_review_receipt(receipt: PrivilegeBrokerReviewReceipt) -> PrivilegeBrokerValidationResult:
+    findings: list[str] = []
+    if not receipt.receipt_id:
+        findings.append("missing_receipt_id")
+    if not receipt.decision_id:
+        findings.append("missing_decision_id")
+    if receipt.privilege_domain not in PRIVILEGE_DOMAINS:
+        findings.append("unknown_privilege_domain")
+    if receipt.eligibility_status not in PRIVILEGE_BROKER_ELIGIBILITY_STATUSES:
+        findings.append("unknown_eligibility_status")
+    if receipt.review_status not in PRIVILEGE_BROKER_REVIEW_STATUSES:
+        findings.append("unknown_review_status")
+    if receipt.digest and receipt.digest != privilege_broker_receipt_digest(receipt):
+        findings.append("receipt_digest_mismatch")
+    required_true = {
+        "review_only": receipt.review_only,
+        "eligibility_only": receipt.eligibility_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment,
+        "requires_control_plane_admission_for_future_action": receipt.requires_control_plane_admission_for_future_action,
+        "requires_operator_or_policy_approval_for_future_action": receipt.requires_operator_or_policy_approval_for_future_action,
+        "requires_audit_receipt_for_future_action": receipt.requires_audit_receipt_for_future_action,
+        "requires_rollback_receipt_for_future_action": receipt.requires_rollback_receipt_for_future_action,
+        "requires_actuation_fulfillment_layer_for_future_action": receipt.requires_actuation_fulfillment_layer_for_future_action,
+    }
+    for flag, value in required_true.items():
+        if not value:
+            findings.append(f"receipt_claims_execution_or_authority:{flag}")
+    return PrivilegeBrokerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def summarize_privilege_broker_eligibility_decision(decision: PrivilegeBrokerEligibilityDecision) -> dict[str, Any]:
+    return {
+        "decision_id": decision.decision_id,
+        "source_receipt_id": decision.source_receipt_id,
+        "source_proposal_kind": decision.source_proposal_kind,
+        "privilege_domain": decision.privilege_domain,
+        "eligibility_status": decision.eligibility_status,
+        "future_gate_count": len(decision.required_future_gates),
+        "blocked_action_count": len(decision.blocked_actions),
+        "missing_prerequisite_count": len(decision.missing_prerequisites),
+        "metadata_only": decision.metadata_only,
+        "eligibility_only": decision.eligibility_only,
+        "authorization_granted": decision.authorization_granted,
+        "fulfillment_granted": decision.fulfillment_granted,
+        "host_mutation_performed": decision.host_mutation_performed,
+        "fan_pwm_write_performed": decision.fan_pwm_write_performed,
+        "thermal_actuation_performed": decision.thermal_actuation_performed,
+        "network_performed": decision.network_performed,
+        "digest": privilege_broker_decision_digest(decision),
+    }
+
+
+def summarize_privilege_broker_review_receipt(receipt: PrivilegeBrokerReviewReceipt) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt.receipt_id,
+        "decision_id": receipt.decision_id,
+        "source_receipt_id": receipt.source_receipt_id,
+        "privilege_domain": receipt.privilege_domain,
+        "eligibility_status": receipt.eligibility_status,
+        "review_status": receipt.review_status,
+        "future_gate_count": len(receipt.required_future_gates),
+        "blocked_action_count": len(receipt.blocked_actions),
+        "warning_count": len(receipt.warning_codes),
+        "risk_count": len(receipt.risk_codes),
+        "review_only": receipt.review_only,
+        "eligibility_only": receipt.eligibility_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment,
+        "digest": receipt.digest,
+    }

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -183,6 +183,16 @@ def test_phase3_policy_registry_records_are_proposal_only_and_defer_privileged_o
     assert records["host_resource_proposal_receipts"].status == "implemented"
     assert records["host_resource_proposal_receipts"].authority_level == "proposal_only"
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
-    assert records["privilege_broker"].status == "deferred"
+    assert records["privilege_broker"].status == "implemented"
+    assert records["privilege_broker"].authority_level == "eligibility_only"
     assert records["actuation_fulfillment"].status == "deferred"
     assert validate_capability_registry(registry).ok
+
+
+def test_default_registry_represents_phase4_privilege_broker_as_eligibility_only() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["privilege_broker"].status == "implemented"
+    assert records["privilege_broker"].authority_level == "eligibility_only"
+    assert records["privilege_broker"].host_actuation_performed is False
+    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"

--- a/tests/test_host_resource_policy.py
+++ b/tests/test_host_resource_policy.py
@@ -194,7 +194,8 @@ def test_capability_registry_reflects_policy_proposal_only_and_deferred_fulfillm
     assert records["host_resource_policy"].authority_level == "proposal_only"
     assert records["host_resource_proposal_receipts"].authority_level == "proposal_only"
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
-    assert records["privilege_broker"].status == "deferred"
+    assert records["privilege_broker"].status == "implemented"
+    assert records["privilege_broker"].authority_level == "eligibility_only"
     assert records["actuation_fulfillment"].status == "deferred"
     assert all(record.host_actuation_performed is False for record in records.values() if "host_resource" in record.capability_id or record.capability_id in {"direct_fan_pwm_thermal_control", "privilege_broker", "actuation_fulfillment"})
     assert validate_capability_registry(registry).ok

--- a/tests/test_privilege_broker.py
+++ b/tests/test_privilege_broker.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.host_resource_governor import build_host_resource_telemetry_snapshot, evaluate_host_resource_pressure
+from sentientos.host_resource_policy import (
+    build_host_resource_proposal_receipts,
+    evaluate_host_resource_policy,
+    evaluate_privilege_broker_for_host_resource_receipts,
+)
+from sentientos.privilege_broker import (
+    CLEANUP_POLICY_GATES,
+    COOLING_POLICY_GATES,
+    POWER_POLICY_GATES,
+    build_privilege_broker_review_receipt,
+    evaluate_privilege_broker_eligibility,
+    privilege_broker_decision_digest,
+    privilege_broker_receipt_digest,
+    summarize_privilege_broker_eligibility_decision,
+    summarize_privilege_broker_review_receipt,
+    validate_privilege_broker_eligibility_decision,
+    validate_privilege_broker_review_receipt,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _receipt_for(**snapshot_kwargs):
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id="broker-snap", **snapshot_kwargs)
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    decision = evaluate_host_resource_policy(report)
+    return {receipt.proposal_kind: receipt for receipt in build_host_resource_proposal_receipts(decision)}
+
+
+def _recorded(receipt):
+    return replace(receipt, proposal_status="host_resource_proposal_recorded", digest="")
+
+
+def test_inspect_pressure_receipts_become_eligible_for_future_review() -> None:
+    cases = [
+        (_receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"], "resource_pressure_review"),
+        (_receipt_for(cpu_utilization_percent=10, ram_utilization_percent=95, disk_utilization_percent=30)["inspect_memory_pressure_candidate"], "resource_pressure_review"),
+        (_receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=95)["inspect_disk_pressure_candidate"], "disk_safety_review"),
+        (_receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, thermal_zone_temperatures_c={"cpu": 90})["inspect_thermal_state_candidate"], "thermal_safety_review"),
+    ]
+    for receipt, domain in cases:
+        decision = evaluate_privilege_broker_eligibility(receipt)
+        assert decision.eligibility_status == "privilege_broker_eligible_for_future_review"
+        assert decision.privilege_domain == domain
+        assert decision.authorization_granted is False
+        assert decision.fulfillment_granted is False
+        assert decision.host_mutation_performed is False
+        assert validate_privilege_broker_eligibility_decision(decision).ok
+
+
+def test_future_cleanup_candidate_requires_dry_run_path_operator_audit_rollback_and_fulfillment_gates() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=95)["future_cleanup_policy_candidate"]
+    decision = evaluate_privilege_broker_eligibility(_recorded(receipt))
+    assert decision.eligibility_status == "privilege_broker_eligible_with_conditions"
+    for gate in CLEANUP_POLICY_GATES:
+        assert gate in decision.required_future_gates
+    assert "file_path_scope_declaration_required" in decision.required_future_gates
+    assert "file_delete" in decision.blocked_actions
+    assert decision.fulfillment_granted is False
+
+
+def test_future_cooling_candidate_never_direct_fulfillment_and_requires_all_cooling_gates() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, thermal_zone_temperatures_c={"cpu": 90})["future_cooling_policy_candidate"]
+    decision = evaluate_privilege_broker_eligibility(_recorded(receipt))
+    assert decision.eligibility_status == "privilege_broker_eligible_with_conditions"
+    assert decision.eligibility_status != "privilege_broker_eligible_for_future_review"
+    for gate in COOLING_POLICY_GATES:
+        assert gate in decision.required_future_gates
+    assert "fan_pwm_write" in decision.blocked_actions
+    assert "thermal_actuation" in decision.blocked_actions
+    assert decision.fan_pwm_write_performed is False
+    assert decision.thermal_actuation_performed is False
+    assert decision.fulfillment_granted is False
+
+
+def test_future_power_candidate_requires_backend_policy_operator_audit_rollback_and_fulfillment_gates() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, battery_percent=5, battery_charging=False)["future_power_policy_candidate"]
+    decision = evaluate_privilege_broker_eligibility(_recorded(receipt))
+    assert decision.eligibility_status == "privilege_broker_eligible_with_conditions"
+    for gate in POWER_POLICY_GATES:
+        assert gate in decision.required_future_gates
+    assert "power_profile_mutation" in decision.blocked_actions
+
+
+def test_inspect_service_health_is_review_only_and_does_not_grant_restart() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, service_health_labels=("daemon_degraded",))["inspect_service_health_candidate"]
+    decision = evaluate_privilege_broker_eligibility(receipt)
+    review = build_privilege_broker_review_receipt(decision)
+    assert decision.eligibility_status == "privilege_broker_eligible_for_future_review"
+    assert decision.privilege_domain == "service_health_review"
+    assert "service_restart" in decision.blocked_actions
+    assert decision.service_restart_performed is False
+    assert review.does_not_authorize_fulfillment is True
+
+
+def test_blocked_incomplete_and_contradicted_source_statuses_do_not_become_eligible() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"]
+    assert evaluate_privilege_broker_eligibility(replace(receipt, proposal_status="host_resource_proposal_blocked", digest="")).eligibility_status == "privilege_broker_blocked"
+    assert evaluate_privilege_broker_eligibility(replace(receipt, proposal_status="host_resource_proposal_incomplete", digest="")).eligibility_status == "privilege_broker_incomplete"
+    assert evaluate_privilege_broker_eligibility(replace(receipt, proposal_status="host_resource_proposal_contradicted", digest="")).eligibility_status == "privilege_broker_contradicted"
+
+
+def test_source_receipt_claiming_effects_or_missing_gates_is_rejected() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"]
+    assert evaluate_privilege_broker_eligibility(replace(receipt, does_not_execute=False, digest="")).eligibility_status == "privilege_broker_contradicted"
+    assert evaluate_privilege_broker_eligibility(replace(receipt, does_not_mutate_host=False, digest="")).eligibility_status == "privilege_broker_contradicted"
+    missing_gates = replace(receipt, required_future_gates=(), digest="")
+    blocked = evaluate_privilege_broker_eligibility(missing_gates)
+    assert blocked.eligibility_status == "privilege_broker_blocked"
+    assert "source_receipt_missing_future_gates" in blocked.missing_prerequisites
+
+
+def test_digests_are_deterministic_and_summaries_are_metadata_only() -> None:
+    receipt = _receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"]
+    first = evaluate_privilege_broker_eligibility(receipt)
+    second = evaluate_privilege_broker_eligibility(receipt)
+    assert privilege_broker_decision_digest(first) == privilege_broker_decision_digest(second)
+    review_first = build_privilege_broker_review_receipt(first)
+    review_second = build_privilege_broker_review_receipt(second)
+    assert privilege_broker_receipt_digest(review_first) == privilege_broker_receipt_digest(review_second)
+    decision_summary = summarize_privilege_broker_eligibility_decision(first)
+    receipt_summary = summarize_privilege_broker_review_receipt(review_first)
+    assert decision_summary["metadata_only"] is True
+    assert decision_summary["eligibility_only"] is True
+    assert decision_summary["authorization_granted"] is False
+    assert decision_summary["fulfillment_granted"] is False
+    assert receipt_summary["review_only"] is True
+    assert receipt_summary["does_not_authorize_fulfillment"] is True
+    assert validate_privilege_broker_review_receipt(review_first).ok
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "authorization_granted",
+        "fulfillment_granted",
+        "host_mutation_performed",
+        "fan_pwm_write_performed",
+        "thermal_actuation_performed",
+        "process_kill_performed",
+        "service_restart_performed",
+        "package_install_performed",
+        "driver_install_performed",
+        "provider_invocation_performed",
+        "network_performed",
+        "prompt_assembly_performed",
+    ],
+)
+def test_validation_rejects_forbidden_decision_flags(field: str) -> None:
+    receipt = _receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"]
+    decision = evaluate_privilege_broker_eligibility(receipt)
+    result = validate_privilege_broker_eligibility_decision(replace(decision, **{field: True}))
+    assert not result.ok
+    assert f"forbidden_decision_flag:{field}" in result.findings
+
+
+def test_pipeline_integration_from_telemetry_through_broker_review_receipts() -> None:
+    snapshot = build_host_resource_telemetry_snapshot(
+        snapshot_id="pipeline",
+        cpu_utilization_percent=95,
+        ram_utilization_percent=20,
+        disk_utilization_percent=95,
+        thermal_zone_temperatures_c={"cpu": 90},
+        fan_rpm_observations={"fan0": 1200},
+        service_health_labels=("daemon_degraded",),
+    )
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    policy_decision = evaluate_host_resource_policy(report)
+    proposal_receipts = build_host_resource_proposal_receipts(policy_decision)
+    broker_decisions, review_receipts = evaluate_privilege_broker_for_host_resource_receipts(proposal_receipts)
+    assert len(broker_decisions) == len(proposal_receipts)
+    assert len(review_receipts) == len(proposal_receipts)
+    cooling = [decision for decision in broker_decisions if decision.source_proposal_kind == "future_cooling_policy_candidate"][0]
+    service = [decision for decision in broker_decisions if decision.source_proposal_kind == "inspect_service_health_candidate"][0]
+    assert "fan_pwm_write" in cooling.blocked_actions
+    assert "thermal_actuation" in cooling.blocked_actions
+    assert cooling.fan_pwm_write_performed is False
+    assert "service_restart" in service.blocked_actions
+    assert service.service_restart_performed is False
+    assert all(validate_privilege_broker_review_receipt(receipt).ok for receipt in review_receipts)
+
+
+def test_capability_registry_reflects_privilege_broker_without_actuation_fulfillment() -> None:
+    from sentientos.capability_registry import build_default_capability_registry, update_registry_from_privilege_broker_decision, validate_capability_registry
+
+    receipt = _receipt_for(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)["inspect_cpu_pressure_candidate"]
+    decision = evaluate_privilege_broker_eligibility(receipt)
+    review = build_privilege_broker_review_receipt(decision)
+    registry = update_registry_from_privilege_broker_decision(build_default_capability_registry(), decision, (review,))
+    records = registry.by_id()
+    assert records["privilege_broker"].status == "implemented"
+    assert records["privilege_broker"].authority_level == "eligibility_only"
+    assert records["privilege_broker"].host_actuation_performed is False
+    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -142,3 +142,28 @@ def test_phase3_doc_preserves_proposal_receipt_boundaries() -> None:
     assert "PWM presence is not control authority" in phase3
     assert "Privilege Broker" in phase3
     assert "Actuation Fulfillment Layer" in phase3
+
+HOST_EMBODIMENT_PHASE4 = "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md"
+
+
+def test_navigation_links_to_host_embodiment_phase4_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase1 = _read(HOST_EMBODIMENT_PHASE1)
+    phase2 = _read(HOST_EMBODIMENT_PHASE2)
+    phase3 = _read(HOST_EMBODIMENT_PHASE3)
+    trajectory = _read(TRAJECTORY_DOC)
+    assert HOST_EMBODIMENT_PHASE4 in overview
+    assert HOST_EMBODIMENT_PHASE4 in index
+    assert HOST_EMBODIMENT_PHASE4 in phase1
+    assert HOST_EMBODIMENT_PHASE4 in phase2
+    assert HOST_EMBODIMENT_PHASE4 in phase3
+    assert HOST_EMBODIMENT_PHASE4 in trajectory
+
+
+def test_phase4_doc_preserves_privilege_broker_boundaries() -> None:
+    phase4 = _read(HOST_EMBODIMENT_PHASE4)
+    assert "Eligibility is not authorization" in phase4
+    assert "broker review receipt is not fulfillment" in phase4 or "broker receipt is not fulfillment" in phase4
+    assert "direct fan/PWM/thermal control remains blocked/deferred" in phase4
+    assert "future Actuation Fulfillment Layer" in phase4


### PR DESCRIPTION
### Motivation
- Introduce Phase 4: a metadata-only Privilege Broker that classifies Phase 3 proposal receipts for future privileged-action consideration without authorizing or performing any host effects. 
- Make missing prerequisites and future gates explicit for cooling/power/cleanup/service actions so the later Actuation Fulfillment Layer can safely rely on deterministic eligibility signals.
- Keep the authority ladder and existing Phase 1–3 non-effect boundaries intact while surfacing an eligibility-only organ for reviewer/operator workflows.

### Description
- Add `sentientos/privilege_broker.py` implementing frozen dataclasses `PrivilegeBrokerPolicy`, `PrivilegeBrokerEligibilityDecision`, `PrivilegeBrokerReviewReceipt`, and `PrivilegeBrokerValidationResult`, deterministic digests, validators, summaries, and the `evaluate_privilege_broker_eligibility(...)` / `build_privilege_broker_review_receipt(...)` helpers; all records are metadata-only and explicitly forbid effects. 
- Integrate Phase 4 with Phase 3 by adding `evaluate_privilege_broker_for_host_resource_receipts(...)` to `sentientos/host_resource_policy.py` which maps proposal receipts → broker decisions + review receipts, returning only non-effect artifacts. 
- Update `sentientos/capability_registry.py` to represent `privilege_broker` as an `eligibility_only` capability and to add `update_registry_from_privilege_broker_decision(...)`; keep `actuation_fulfillment` deferred and `direct_fan_pwm_thermal_control` blocked. 
- Add `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` and update related docs (Phase 1–3, public overview, trajectory, reviewer readiness index) to link Phase 4 and to emphasize that eligibility is not authorization and that broker receipts are not fulfillment. 
- Add focused tests `tests/test_privilege_broker.py` and update registry/policy/docs tests to reflect Phase 4 outcomes; tests assert eligibility classifications, conditional gates for cooling/power/cleanup, blocked service restart, deterministic digests/summaries, validation of forbidden flags, end-to-end pipeline integration, and capability-registry reflections.

### Testing
- Ran static compilation: `python -m py_compile sentientos/privilege_broker.py sentientos/host_resource_policy.py sentientos/capability_registry.py tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` (OK).
- Ran unit suites: `python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py` (all tests passed after fixing doc wording and minor whitespace issues). 
- Ran integration/neighbor suites: `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` (passed). 
- Built docs: bootstrapped docs deps with `python scripts/build_docs.py --bootstrap-docs` then ran `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` (docs built successfully after bootstrapping). 
- Context-hygiene check: `python scripts/verify_context_hygiene_prompt_boundaries.py` (boundary_clean). 
- Forbidden-scan: `rg -n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05382250f48320b5753fe272d475e8)