### PR TITLE
[codex:host-embodiment] add actuation fulfillment rehearsal scaffold

### DIFF
--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -99,7 +99,7 @@ The longer doctrine remains:
 
 Phase 1 covers observe/model and proposal candidate summaries only. It never
 fulfills an action. The next read-only discovery pass is documented in
-`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`; Phase 3 policy receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`.
+`docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`; Phase 3 policy receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`; Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`.
 
 ## Relationship to existing organs
 

--- a/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
+++ b/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
@@ -68,4 +68,4 @@ Phase 2 must not perform:
 
 ## Next phase
 
-Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`.
+Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`; Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`.

--- a/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
+++ b/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
@@ -93,4 +93,4 @@ python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 ```
 
-Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Eligibility is not authorization, and broker receipts are not fulfillment.
+Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Eligibility is not authorization, broker receipts are not fulfillment, and fulfillment rehearsal is not real fulfillment.

--- a/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
+++ b/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
@@ -156,3 +156,8 @@ python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 python scripts/verify_context_hygiene_prompt_boundaries.py
 ```
+
+
+## Next phase
+
+Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Fulfillment rehearsal is not real fulfillment, and a rehearsal receipt is not an effect receipt. Direct fan/PWM/thermal control remains blocked/deferred, and power, service, and cleanup actions remain behind future authorization, admission, audit, rollback, effect receipt, and postcondition gates.

--- a/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
+++ b/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
@@ -1,0 +1,155 @@
+# Host Embodiment Substrate Phase 5: Actuation Fulfillment Scaffold
+
+Phase 5 adds the Actuation Fulfillment Layer scaffold for host embodiment. It is
+a dry-run / rehearsal-only organ that consumes Phase 4 Privilege Broker review
+receipts and produces deterministic fulfillment rehearsal plans and fulfillment
+rehearsal receipts.
+
+Phase 5 is not real actuation. Fulfillment rehearsal is not real fulfillment. A
+rehearsal receipt is not an effect receipt. No host mutation occurs.
+
+## Authority ladder
+
+The authority ladder remains:
+
+`observe → model → propose → broker eligibility → rehearse → authorize → fulfill → audit → rollback`
+
+Phase 5 covers only `rehearse`. It does not authorize, fulfill, audit effects,
+or execute rollback.
+
+## What Phase 5 creates
+
+`sentientos/actuation_fulfillment.py` defines metadata-only records:
+
+1. `ActuationFulfillmentPolicy` — the default rehearsal policy, required future
+   gates, and blocked action vocabulary.
+2. `ActuationFulfillmentPlan` — a dry-run plan derived from a broker review
+   receipt.
+3. `ActuationFulfillmentRehearsalReceipt` — a deterministic receipt that records
+   the rehearsal classification.
+4. `ActuationFulfillmentValidationResult` — validation findings for plans and
+   rehearsal receipts.
+
+The non-mutating pipeline is now:
+
+`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → privilege broker eligibility decision → privilege broker review receipt → fulfillment rehearsal plan → fulfillment rehearsal receipt`
+
+Every stage remains metadata-only and non-mutating.
+
+## Fulfillment rehearsal is not real fulfillment
+
+Phase 5 may classify how a future action would need to be fulfilled, but it does
+not perform that future action. It does not call control-plane execution, does
+not admit a privileged host effect, and does not create an effect receipt.
+
+The plan preserves explicit non-effect flags including:
+
+- `metadata_only=True`
+- `rehearsal_only=True`
+- `authorization_granted=False`
+- `fulfillment_granted=False`
+- `host_mutation_performed=False`
+- `fan_pwm_write_performed=False`
+- `thermal_actuation_performed=False`
+- `power_profile_mutation_performed=False`
+- `process_kill_performed=False`
+- `service_restart_performed=False`
+- `package_install_performed=False`
+- `driver_install_performed=False`
+- `file_cleanup_performed=False`
+- `provider_invocation_performed=False`
+- `network_performed=False`
+- `prompt_assembly_performed=False`
+
+## Rehearsal receipt is not an effect receipt
+
+A `ActuationFulfillmentRehearsalReceipt` records only dry-run rehearsal evidence.
+It is not an effect receipt and cannot be used as proof of host mutation.
+
+The rehearsal receipt preserves explicit non-effect flags:
+
+- `rehearsal_only=True`
+- `dry_run_only=True`
+- `does_not_execute=True`
+- `does_not_mutate_host=True`
+- `does_not_authorize_fulfillment=True`
+- `effect_not_performed=True`
+- `requires_control_plane_admission_for_future_action=True`
+- `requires_operator_or_policy_approval_for_future_action=True`
+- `requires_audit_receipt_for_future_action=True`
+- `requires_rollback_receipt_for_future_action=True`
+- `requires_effect_receipt_for_future_action=True`
+- `requires_postcondition_check_for_future_action=True`
+
+## Domains, backend classes, and gates
+
+Phase 5 prepares a future real Actuation Fulfillment Layer by defining domains,
+backend classes, required gates, rehearsal steps, expected postconditions, and
+rollback requirements. Those definitions are still rehearsal metadata only.
+
+| Broker privilege domain | Fulfillment rehearsal domain | Backend class | Non-effect posture |
+| --- | --- | --- | --- |
+| `diagnostics_only` | `diagnostics_only` | `no_backend_required` | Diagnostics metadata only. |
+| `operator_review` | `operator_review` | `operator_manual_backend_future` | Operator review metadata only. |
+| `resource_pressure_review` | `resource_pressure_review` | `diagnostic_backend_future` | Rehearses diagnostics/review only. |
+| `thermal_safety_review` | `thermal_safety_review` | `diagnostic_backend_future` | Thermal safety review only; no thermal actuation. |
+| `disk_safety_review` | `disk_safety_review` | `diagnostic_backend_future` | Disk safety review only; no cleanup/deletion. |
+| `service_health_review` | `service_health_review` | `service_backend_future` | Service health review only; no restart. |
+| `future_cooling_policy_review` | `future_cooling_rehearsal` | `cooling_backend_future` | Future cooling rehearsal only; fan/PWM and thermal actions remain blocked. |
+| `future_power_policy_review` | `future_power_rehearsal` | `power_backend_future` | Future power rehearsal only; power profile mutation remains blocked. |
+| `future_cleanup_policy_review` | `future_cleanup_rehearsal` | `cleanup_backend_future` | Future cleanup rehearsal only; cleanup/deletion remains blocked. |
+
+Future real fulfillment still requires control-plane admission,
+operator/policy approval, audit receipt, rollback receipt, panic stop where
+applicable, hardware allowlist where applicable, OS backend declaration,
+bounds/cooldown policy where applicable, rehearsal, dry-run evidence, effect
+receipt, and postcondition check.
+
+## Blocked/deferred action classes
+
+The following remain blocked/deferred in Phase 5:
+
+- No direct fan/PWM control occurs.
+- No thermal actuation occurs.
+- No power profile mutation occurs.
+- No process killing occurs.
+- No service restart occurs.
+- No package installation occurs.
+- No driver installation occurs.
+- No cleanup/deletion occurs.
+- No network egress occurs.
+- No provider invocation occurs.
+- No prompt assembly or prompt export occurs.
+- No federation transport/sync/adoption occurs.
+- No remote execution occurs.
+
+## Broker eligibility is still not authorization
+
+Privilege Broker eligibility is not authorization. A broker review receipt is not
+fulfillment. Phase 5 can only rehearse fulfillment planning after broker review;
+it cannot convert eligibility into authority.
+
+Eligible broker receipts may produce rehearsal-ready diagnostics/operator-review
+plans. Eligible-with-conditions broker receipts may produce
+rehearsal-ready-with-conditions plans only when condition gates are preserved.
+Blocked, incomplete, or contradicted broker receipts produce blocked,
+incomplete, or contradicted fulfillment plans.
+
+Any source broker receipt that claims authorization, fulfillment, execution, or
+host mutation is treated as contradicted by the Phase 5 scaffold.
+
+## Proof command
+
+```bash
+python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py
+```
+
+## Related docs
+
+- `docs/architecture/host_embodiment_substrate_phase1.md`
+- `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md`
+- `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`
+- `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`
+- `docs/architecture/sentientos_trajectory_and_missing_organs.md`
+- `docs/architecture/public_technical_overview.md`
+- `docs/architecture/reviewer_release_readiness_index.md`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -215,9 +215,14 @@ Internal and legacy cultural documentation remains available and is not removed 
 
 ## Host embodiment substrate
 
-See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` and `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` for Host Embodiment Substrate phases 1 through 4.
+See `docs/architecture/host_embodiment_substrate_phase1.md` and `docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md` and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md` and `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` and `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md` for Host Embodiment Substrate phases 1 through 5.
 
 
 ### Host Embodiment Phase 4 Privilege Broker
 
 See `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Phase 4 evaluates proposal receipts for future privileged-action eligibility only. Eligibility is not authorization, a broker receipt is not fulfillment, fan/PWM/thermal control remains blocked/deferred, and the future Actuation Fulfillment Layer is still required before any effect can occur.
+
+
+### Host Embodiment Phase 5 Actuation Fulfillment Scaffold
+
+See `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Phase 5 creates fulfillment rehearsal plans and rehearsal receipts only. Fulfillment rehearsal is not real fulfillment, a rehearsal receipt is not an effect receipt, no host mutation occurs, and fan/PWM/thermal/power/service/cleanup actions remain blocked/deferred behind future control-plane admission, operator/policy approval, audit, rollback, effect receipt, and postcondition gates.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -199,5 +199,16 @@ See `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. El
 Proof command:
 
 ```bash
-python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py
+python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py
+```
+
+
+## Host Embodiment Phase 5 actuation fulfillment scaffold
+
+See `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Phase 5 creates fulfillment rehearsal plans and receipts only. Fulfillment rehearsal is not real fulfillment. A rehearsal receipt is not an effect receipt. No host mutation occurs. Fan/PWM/thermal/power/service/cleanup actions remain blocked/deferred, and future real fulfillment still requires control-plane admission, operator/policy approval, audit receipt, rollback receipt, effect receipt, and postcondition check.
+
+Proof command:
+
+```bash
+python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py
 ```

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -365,3 +365,8 @@ Phase 3 is documented in `docs/architecture/host_embodiment_substrate_phase3_pol
 ### Host Embodiment Phase 4 privilege broker eligibility
 
 Phase 4 is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. It classifies proposal receipts for future privileged-action eligibility only. Eligibility is not authorization, a broker receipt is not fulfillment, and direct fan/PWM/thermal control, service restart, power mutation, cleanup mutation, package/driver install, provider invocation, network egress, prompt assembly, federation transport/sync/adoption, and remote execution remain blocked behind future gates and the future Actuation Fulfillment Layer.
+
+
+### Host Embodiment Phase 5 actuation fulfillment scaffold
+
+Phase 5 is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. It adds the Actuation Fulfillment Layer scaffold as rehearsal-only metadata: fulfillment rehearsal is not real fulfillment, a rehearsal receipt is not an effect receipt, and no host mutation occurs. Direct fan/PWM/thermal control, service restart, power profile mutation, cleanup/deletion, process killing, package/driver installation, provider invocation, network egress, prompt assembly, federation transport/sync/adoption, and remote execution remain blocked/deferred behind future control-plane admission, operator/policy approval, audit, rollback, effect receipt, and postcondition gates.

--- a/sentientos/actuation_fulfillment.py
+++ b/sentientos/actuation_fulfillment.py
@@ -1,0 +1,649 @@
+"""Dry-run Actuation Fulfillment Layer scaffold for SentientOS Phase 5.
+
+This module is metadata-only and rehearsal-only. It evaluates Phase 4 Privilege
+Broker review receipts and produces deterministic fulfillment rehearsal plans
+and rehearsal receipts. It never performs host actions, calls control-plane
+admission/execution, mutates host state, writes fan/PWM controls, changes
+thermal or power settings, kills processes, restarts services, installs packages
+or drivers, removes files, performs network activity, invokes providers, or
+assembles prompts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+from sentientos.privilege_broker import (
+    CLEANUP_POLICY_GATES,
+    COOLING_POLICY_GATES,
+    POWER_POLICY_GATES,
+    SERVICE_HEALTH_GATES,
+    PRIVILEGE_BROKER_ELIGIBILITY_STATUSES,
+    privilege_broker_receipt_digest,
+    validate_privilege_broker_review_receipt,
+)
+
+ACTUATION_FULFILLMENT_PLAN_STATUSES = frozenset(
+    {
+        "actuation_fulfillment_plan_rehearsal_ready",
+        "actuation_fulfillment_plan_rehearsal_ready_with_conditions",
+        "actuation_fulfillment_plan_blocked",
+        "actuation_fulfillment_plan_incomplete",
+        "actuation_fulfillment_plan_contradicted",
+    }
+)
+ACTUATION_FULFILLMENT_REHEARSAL_STATUSES = frozenset(
+    {
+        "actuation_fulfillment_rehearsal_recorded",
+        "actuation_fulfillment_rehearsal_recorded_with_warnings",
+        "actuation_fulfillment_rehearsal_blocked",
+        "actuation_fulfillment_rehearsal_incomplete",
+        "actuation_fulfillment_rehearsal_contradicted",
+    }
+)
+FULFILLMENT_DOMAINS = frozenset(
+    {
+        "diagnostics_only",
+        "operator_review",
+        "resource_pressure_review",
+        "thermal_safety_review",
+        "disk_safety_review",
+        "service_health_review",
+        "future_cooling_rehearsal",
+        "future_power_rehearsal",
+        "future_cleanup_rehearsal",
+        "future_service_rehearsal",
+    }
+)
+FULFILLMENT_BACKEND_CLASSES = frozenset(
+    {
+        "no_backend_required",
+        "diagnostic_backend_future",
+        "cooling_backend_future",
+        "power_backend_future",
+        "cleanup_backend_future",
+        "service_backend_future",
+        "operator_manual_backend_future",
+    }
+)
+REQUIRED_FUTURE_GATES = (
+    "control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "panic_stop_required",
+    "hardware_allowlist_required",
+    "os_backend_declaration_required",
+    "bounds_policy_required",
+    "cooldown_policy_required",
+    "rehearsal_required",
+    "dry_run_required",
+    "effect_receipt_required",
+    "postcondition_check_required",
+)
+BASE_REQUIRED_GATES = (
+    "control_plane_admission_required",
+    "operator_or_policy_approval_required",
+    "audit_receipt_required",
+    "rollback_receipt_required",
+    "rehearsal_required",
+    "dry_run_required",
+    "effect_receipt_required",
+    "postcondition_check_required",
+)
+_DOMAIN_GATES: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_policy_review": REQUIRED_FUTURE_GATES,
+    "future_power_policy_review": (
+        "control_plane_admission_required",
+        "operator_or_policy_approval_required",
+        "audit_receipt_required",
+        "rollback_receipt_required",
+        "panic_stop_required",
+        "os_backend_declaration_required",
+        "bounds_policy_required",
+        "rehearsal_required",
+        "dry_run_required",
+        "effect_receipt_required",
+        "postcondition_check_required",
+    ),
+    "future_cleanup_policy_review": BASE_REQUIRED_GATES + ("panic_stop_required",),
+    "service_health_review": BASE_REQUIRED_GATES + ("panic_stop_required",),
+}
+_DOMAIN_BLOCKED_ACTIONS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_policy_review": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_policy_review": ("power_profile_mutation",),
+    "future_cleanup_policy_review": ("file_delete", "file_cleanup", "disk_cleanup_mutation"),
+    "service_health_review": ("service_restart",),
+}
+_BROKER_CONDITION_GATES: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_policy_review": COOLING_POLICY_GATES,
+    "future_power_policy_review": POWER_POLICY_GATES,
+    "future_cleanup_policy_review": CLEANUP_POLICY_GATES,
+    "service_health_review": SERVICE_HEALTH_GATES,
+}
+
+_DOMAIN_REHEARSAL: Mapping[str, tuple[str, str]] = {
+    "diagnostics_only": ("diagnostics_only", "no_backend_required"),
+    "operator_review": ("operator_review", "operator_manual_backend_future"),
+    "resource_pressure_review": ("resource_pressure_review", "diagnostic_backend_future"),
+    "thermal_safety_review": ("thermal_safety_review", "diagnostic_backend_future"),
+    "disk_safety_review": ("disk_safety_review", "diagnostic_backend_future"),
+    "service_health_review": ("service_health_review", "service_backend_future"),
+    "future_cooling_policy_review": ("future_cooling_rehearsal", "cooling_backend_future"),
+    "future_power_policy_review": ("future_power_rehearsal", "power_backend_future"),
+    "future_cleanup_policy_review": ("future_cleanup_rehearsal", "cleanup_backend_future"),
+    "future_actuation_fulfillment_review": ("operator_review", "operator_manual_backend_future"),
+}
+_BASE_BLOCKED_ACTIONS = (
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+)
+
+
+@dataclass(frozen=True)
+class ActuationFulfillmentPolicy:
+    policy_id: str
+    allowed_rehearsal_domains: tuple[str, ...]
+    required_future_gates: tuple[str, ...] = REQUIRED_FUTURE_GATES
+    blocked_actions: tuple[str, ...] = _BASE_BLOCKED_ACTIONS
+    metadata_only: bool = True
+    rehearsal_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ActuationFulfillmentPlan:
+    plan_id: str
+    source_broker_receipt_id: str
+    source_broker_receipt_digest: str
+    source_eligibility_status: str
+    privilege_domain: str
+    fulfillment_domain: str
+    backend_class: str
+    plan_status: str
+    reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    missing_prerequisites: tuple[str, ...]
+    rehearsal_steps: tuple[str, ...]
+    expected_postconditions: tuple[str, ...]
+    rollback_requirements: tuple[str, ...]
+    metadata_only: bool = True
+    rehearsal_only: bool = True
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ActuationFulfillmentRehearsalReceipt:
+    receipt_id: str
+    plan_id: str
+    source_broker_receipt_id: str
+    source_broker_receipt_digest: str
+    fulfillment_domain: str
+    backend_class: str
+    plan_status: str
+    rehearsal_status: str
+    evidence_summary: tuple[str, ...]
+    rehearsal_steps: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    expected_postconditions: tuple[str, ...]
+    rollback_requirements: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    rehearsal_only: bool = True
+    dry_run_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    effect_not_performed: bool = True
+    requires_control_plane_admission_for_future_action: bool = True
+    requires_operator_or_policy_approval_for_future_action: bool = True
+    requires_audit_receipt_for_future_action: bool = True
+    requires_rollback_receipt_for_future_action: bool = True
+    requires_effect_receipt_for_future_action: bool = True
+    requires_postcondition_check_for_future_action: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ActuationFulfillmentValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _merge_unique(*groups: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(item) for group in groups for item in group}))
+
+
+def _source_digest(receipt: Any) -> str:
+    digest = str(getattr(receipt, "digest", "") or "")
+    if digest:
+        return digest
+    try:
+        return privilege_broker_receipt_digest(receipt)
+    except Exception:  # defensive only for mapping-like test doubles; no host effect.
+        value = getattr(receipt, "to_dict", lambda: dict(receipt))()
+        return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def build_default_actuation_fulfillment_policy() -> ActuationFulfillmentPolicy:
+    material = {"domains": tuple(sorted(FULFILLMENT_DOMAINS)), "gates": REQUIRED_FUTURE_GATES, "blocked_actions": _BASE_BLOCKED_ACTIONS}
+    return ActuationFulfillmentPolicy(policy_id=_digest_payload("afp_", material), allowed_rehearsal_domains=tuple(sorted(FULFILLMENT_DOMAINS)))
+
+
+def _source_claim_findings(receipt: Any) -> tuple[str, ...]:
+    findings: list[str] = []
+    required_true = {
+        "review_only": getattr(receipt, "review_only", True),
+        "eligibility_only": getattr(receipt, "eligibility_only", True),
+        "does_not_execute": getattr(receipt, "does_not_execute", True),
+        "does_not_mutate_host": getattr(receipt, "does_not_mutate_host", True),
+        "does_not_authorize_fulfillment": getattr(receipt, "does_not_authorize_fulfillment", True),
+    }
+    for flag, value in required_true.items():
+        if not value:
+            findings.append(f"source_broker_receipt_claims_authority_or_effect:{flag}")
+    forbidden_false = {
+        "authorization_granted": getattr(receipt, "authorization_granted", False),
+        "fulfillment_granted": getattr(receipt, "fulfillment_granted", False),
+        "host_mutation_performed": getattr(receipt, "host_mutation_performed", False),
+        "fan_pwm_write_performed": getattr(receipt, "fan_pwm_write_performed", False),
+        "thermal_actuation_performed": getattr(receipt, "thermal_actuation_performed", False),
+        "power_profile_mutation_performed": getattr(receipt, "power_profile_mutation_performed", False),
+        "process_kill_performed": getattr(receipt, "process_kill_performed", False),
+        "service_restart_performed": getattr(receipt, "service_restart_performed", False),
+        "package_install_performed": getattr(receipt, "package_install_performed", False),
+        "driver_install_performed": getattr(receipt, "driver_install_performed", False),
+        "file_cleanup_performed": getattr(receipt, "file_cleanup_performed", False),
+        "provider_invocation_performed": getattr(receipt, "provider_invocation_performed", False),
+        "network_performed": getattr(receipt, "network_performed", False),
+        "prompt_assembly_performed": getattr(receipt, "prompt_assembly_performed", False),
+    }
+    for flag, value in forbidden_false.items():
+        if value:
+            findings.append(f"source_broker_receipt_claims_forbidden_effect:{flag}")
+    return tuple(findings)
+
+
+def _receipt_validation_findings(receipt: Any) -> tuple[str, ...]:
+    try:
+        validation = validate_privilege_broker_review_receipt(receipt)
+        return () if validation.ok else validation.findings
+    except Exception:
+        return ("source_broker_receipt_failed_validation",)
+
+
+def _plan_status_for(eligibility_status: str, *, contradicted: bool, missing: Sequence[str], warnings: Sequence[str]) -> str:
+    if contradicted or eligibility_status == "privilege_broker_contradicted":
+        return "actuation_fulfillment_plan_contradicted"
+    if eligibility_status == "privilege_broker_incomplete":
+        return "actuation_fulfillment_plan_incomplete"
+    if eligibility_status == "privilege_broker_blocked":
+        return "actuation_fulfillment_plan_blocked"
+    if missing:
+        return "actuation_fulfillment_plan_incomplete"
+    if eligibility_status == "privilege_broker_eligible_with_conditions":
+        return "actuation_fulfillment_plan_rehearsal_ready_with_conditions"
+    if warnings:
+        return "actuation_fulfillment_plan_rehearsal_ready_with_conditions"
+    return "actuation_fulfillment_plan_rehearsal_ready"
+
+
+def _rehearsal_status_for(plan_status: str, warning_codes: Sequence[str]) -> str:
+    if plan_status == "actuation_fulfillment_plan_contradicted":
+        return "actuation_fulfillment_rehearsal_contradicted"
+    if plan_status == "actuation_fulfillment_plan_incomplete":
+        return "actuation_fulfillment_rehearsal_incomplete"
+    if plan_status == "actuation_fulfillment_plan_blocked":
+        return "actuation_fulfillment_rehearsal_blocked"
+    if warning_codes or plan_status == "actuation_fulfillment_plan_rehearsal_ready_with_conditions":
+        return "actuation_fulfillment_rehearsal_recorded_with_warnings"
+    return "actuation_fulfillment_rehearsal_recorded"
+
+
+def build_actuation_fulfillment_plan(receipt: Any, *, policy: ActuationFulfillmentPolicy | None = None) -> ActuationFulfillmentPlan:
+    fulfillment_policy = policy or build_default_actuation_fulfillment_policy()
+    source_id = str(getattr(receipt, "receipt_id", ""))
+    source_digest = _source_digest(receipt)
+    eligibility_status = str(getattr(receipt, "eligibility_status", ""))
+    privilege_domain = str(getattr(receipt, "privilege_domain", "diagnostics_only") or "diagnostics_only")
+    fulfillment_domain, backend_class = _DOMAIN_REHEARSAL.get(privilege_domain, ("diagnostics_only", "diagnostic_backend_future"))
+    source_gates = tuple(str(gate) for gate in getattr(receipt, "required_future_gates", ()) or ())
+    source_blocked = tuple(str(action) for action in getattr(receipt, "blocked_actions", ()) or ())
+    warning_codes = set(str(code) for code in getattr(receipt, "warning_codes", ()) or ())
+    risk_codes = set(str(code) for code in getattr(receipt, "risk_codes", ()) or ())
+    reason_codes = {"fulfillment_rehearsal_only", "broker_eligibility_is_not_authorization", "broker_review_receipt_is_not_fulfillment"}
+    missing = set(str(item) for item in getattr(receipt, "missing_prerequisites", ()) or ())
+    claim_findings = _source_claim_findings(receipt)
+    validation_findings = _receipt_validation_findings(receipt)
+    expected_gates = _DOMAIN_GATES.get(privilege_domain, BASE_REQUIRED_GATES)
+    if eligibility_status == "privilege_broker_eligible_with_conditions":
+        missing.update(gate for gate in _BROKER_CONDITION_GATES.get(privilege_domain, expected_gates) if gate not in source_gates)
+        if missing:
+            reason_codes.add("broker_condition_gates_missing")
+        else:
+            reason_codes.add("broker_condition_gates_preserved")
+    required_future_gates = _merge_unique(source_gates, expected_gates, BASE_REQUIRED_GATES)
+    blocked_actions = _merge_unique(fulfillment_policy.blocked_actions, source_blocked, _DOMAIN_BLOCKED_ACTIONS.get(privilege_domain, ()))
+    if eligibility_status not in PRIVILEGE_BROKER_ELIGIBILITY_STATUSES:
+        missing.add("unknown_source_broker_eligibility_status")
+    if claim_findings:
+        reason_codes.add("source_broker_receipt_claims_forbidden_authority_or_effect")
+        missing.update(claim_findings)
+    if validation_findings:
+        warning_codes.add("source_broker_receipt_validation_findings_preserved")
+        missing.update(validation_findings)
+    if privilege_domain == "future_cooling_policy_review":
+        reason_codes.add("cooling_rehearsal_keeps_fan_pwm_and_thermal_actuation_blocked")
+        risk_codes.add("cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop")
+    if privilege_domain == "future_power_policy_review":
+        reason_codes.add("power_rehearsal_keeps_power_profile_mutation_blocked")
+        risk_codes.add("power_backend_requires_future_os_backend_and_bounds")
+    if privilege_domain == "future_cleanup_policy_review":
+        reason_codes.add("cleanup_rehearsal_keeps_file_cleanup_blocked")
+        risk_codes.add("cleanup_backend_requires_future_path_scope_dry_run_and_rollback")
+    if privilege_domain == "service_health_review":
+        reason_codes.add("service_health_rehearsal_keeps_restart_blocked")
+    plan_status = _plan_status_for(eligibility_status, contradicted=bool(claim_findings), missing=tuple(sorted(missing)), warnings=tuple(sorted(warning_codes)))
+    rehearsal_steps = (
+        "read_broker_review_receipt_metadata",
+        "classify_fulfillment_rehearsal_domain",
+        "preserve_required_future_gates",
+        "preserve_blocked_actions",
+        "record_expected_postconditions_without_effect",
+    )
+    expected_postconditions = (
+        "no_host_mutation_performed",
+        "no_effect_receipt_created_by_rehearsal",
+        "future_action_requires_authorize_fulfill_audit_rollback_sequence",
+    )
+    rollback_requirements = (
+        "future_real_fulfillment_must_define_rollback_receipt_before_effect",
+        "rehearsal_has_no_runtime_state_to_rollback",
+    )
+    material = {
+        "source_broker_receipt_id": source_id,
+        "source_broker_receipt_digest": source_digest,
+        "source_eligibility_status": eligibility_status,
+        "privilege_domain": privilege_domain,
+        "fulfillment_domain": fulfillment_domain,
+        "backend_class": backend_class,
+        "plan_status": plan_status,
+        "required_future_gates": required_future_gates,
+        "blocked_actions": blocked_actions,
+        "missing_prerequisites": tuple(sorted(missing)),
+    }
+    return ActuationFulfillmentPlan(
+        plan_id=_digest_payload("afpl_", material),
+        source_broker_receipt_id=source_id,
+        source_broker_receipt_digest=source_digest,
+        source_eligibility_status=eligibility_status,
+        privilege_domain=privilege_domain,
+        fulfillment_domain=fulfillment_domain,
+        backend_class=backend_class,
+        plan_status=plan_status,
+        reason_codes=tuple(sorted(reason_codes)),
+        warning_codes=tuple(sorted(warning_codes)),
+        risk_codes=tuple(sorted(risk_codes)),
+        required_future_gates=required_future_gates,
+        blocked_actions=blocked_actions,
+        missing_prerequisites=tuple(sorted(missing)),
+        rehearsal_steps=rehearsal_steps,
+        expected_postconditions=expected_postconditions,
+        rollback_requirements=rollback_requirements,
+    )
+
+
+def build_actuation_fulfillment_rehearsal_receipt(plan: ActuationFulfillmentPlan, *, created_at: str = "1970-01-01T00:00:00+00:00") -> ActuationFulfillmentRehearsalReceipt:
+    rehearsal_status = _rehearsal_status_for(plan.plan_status, plan.warning_codes)
+    evidence = (
+        f"source_broker_receipt_id:{plan.source_broker_receipt_id}",
+        f"source_eligibility_status:{plan.source_eligibility_status}",
+        f"fulfillment_domain:{plan.fulfillment_domain}",
+        "fulfillment_rehearsal_is_not_real_fulfillment",
+        "rehearsal_receipt_is_not_effect_receipt",
+        "no_host_mutation_occurs",
+    )
+    material = {
+        "plan_id": plan.plan_id,
+        "source_broker_receipt_id": plan.source_broker_receipt_id,
+        "source_broker_receipt_digest": plan.source_broker_receipt_digest,
+        "fulfillment_domain": plan.fulfillment_domain,
+        "backend_class": plan.backend_class,
+        "plan_status": plan.plan_status,
+        "rehearsal_status": rehearsal_status,
+        "created_at": created_at,
+    }
+    provisional = ActuationFulfillmentRehearsalReceipt(
+        receipt_id=_digest_payload("afrr_", material),
+        plan_id=plan.plan_id,
+        source_broker_receipt_id=plan.source_broker_receipt_id,
+        source_broker_receipt_digest=plan.source_broker_receipt_digest,
+        fulfillment_domain=plan.fulfillment_domain,
+        backend_class=plan.backend_class,
+        plan_status=plan.plan_status,
+        rehearsal_status=rehearsal_status,
+        evidence_summary=evidence,
+        rehearsal_steps=plan.rehearsal_steps,
+        required_future_gates=plan.required_future_gates,
+        blocked_actions=plan.blocked_actions,
+        expected_postconditions=plan.expected_postconditions,
+        rollback_requirements=plan.rollback_requirements,
+        warning_codes=plan.warning_codes,
+        risk_codes=plan.risk_codes,
+        created_at=created_at,
+    )
+    return replace(provisional, digest=actuation_fulfillment_rehearsal_receipt_digest(provisional))
+
+
+def actuation_fulfillment_plan_digest(plan: ActuationFulfillmentPlan) -> str:
+    return hashlib.sha256(_canonical_json(plan.to_dict()).encode("utf-8")).hexdigest()
+
+
+def actuation_fulfillment_rehearsal_receipt_digest(receipt: ActuationFulfillmentRehearsalReceipt) -> str:
+    payload = receipt.to_dict()
+    payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _validate_common_flags(value: Any, prefix: str) -> list[str]:
+    findings: list[str] = []
+    required_false = {
+        "authorization_granted": getattr(value, "authorization_granted", False),
+        "fulfillment_granted": getattr(value, "fulfillment_granted", False),
+        "host_mutation_performed": getattr(value, "host_mutation_performed", False),
+        "fan_pwm_write_performed": getattr(value, "fan_pwm_write_performed", False),
+        "thermal_actuation_performed": getattr(value, "thermal_actuation_performed", False),
+        "power_profile_mutation_performed": getattr(value, "power_profile_mutation_performed", False),
+        "process_kill_performed": getattr(value, "process_kill_performed", False),
+        "service_restart_performed": getattr(value, "service_restart_performed", False),
+        "package_install_performed": getattr(value, "package_install_performed", False),
+        "driver_install_performed": getattr(value, "driver_install_performed", False),
+        "file_cleanup_performed": getattr(value, "file_cleanup_performed", False),
+        "provider_invocation_performed": getattr(value, "provider_invocation_performed", False),
+        "network_performed": getattr(value, "network_performed", False),
+        "prompt_assembly_performed": getattr(value, "prompt_assembly_performed", False),
+    }
+    for flag, flag_value in required_false.items():
+        if flag_value:
+            findings.append(f"{prefix}_forbidden_flag:{flag}")
+    return findings
+
+
+def validate_actuation_fulfillment_plan(plan: ActuationFulfillmentPlan) -> ActuationFulfillmentValidationResult:
+    findings: list[str] = []
+    if not plan.plan_id:
+        findings.append("missing_plan_id")
+    if not plan.source_broker_receipt_id:
+        findings.append("missing_source_broker_receipt_id")
+    if plan.source_eligibility_status not in PRIVILEGE_BROKER_ELIGIBILITY_STATUSES:
+        findings.append("unknown_source_eligibility_status")
+    if plan.fulfillment_domain not in FULFILLMENT_DOMAINS:
+        findings.append("unknown_fulfillment_domain")
+    if plan.backend_class not in FULFILLMENT_BACKEND_CLASSES:
+        findings.append("unknown_backend_class")
+    if plan.plan_status not in ACTUATION_FULFILLMENT_PLAN_STATUSES:
+        findings.append("unknown_plan_status")
+    if not plan.metadata_only or not plan.rehearsal_only:
+        findings.append("plan_not_metadata_rehearsal_only")
+    findings.extend(_validate_common_flags(plan, "plan"))
+    for gate in BASE_REQUIRED_GATES:
+        if gate not in plan.required_future_gates:
+            findings.append(f"plan_missing_base_future_gate:{gate}")
+    if plan.fulfillment_domain == "future_cooling_rehearsal":
+        for action in ("fan_pwm_write", "thermal_actuation"):
+            if action not in plan.blocked_actions:
+                findings.append(f"future_cooling_missing_blocked_action:{action}")
+    if plan.fulfillment_domain == "future_power_rehearsal" and "power_profile_mutation" not in plan.blocked_actions:
+        findings.append("future_power_missing_power_profile_mutation_block")
+    if plan.fulfillment_domain == "future_cleanup_rehearsal" and not {"file_cleanup", "file_delete"}.intersection(plan.blocked_actions):
+        findings.append("future_cleanup_missing_file_cleanup_block")
+    if plan.fulfillment_domain in {"service_health_review", "future_service_rehearsal"} and "service_restart" not in plan.blocked_actions:
+        findings.append("service_health_missing_restart_block")
+    return ActuationFulfillmentValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_actuation_fulfillment_rehearsal_receipt(receipt: ActuationFulfillmentRehearsalReceipt) -> ActuationFulfillmentValidationResult:
+    findings: list[str] = []
+    if not receipt.receipt_id:
+        findings.append("missing_receipt_id")
+    if not receipt.plan_id:
+        findings.append("missing_plan_id")
+    if receipt.fulfillment_domain not in FULFILLMENT_DOMAINS:
+        findings.append("unknown_fulfillment_domain")
+    if receipt.backend_class not in FULFILLMENT_BACKEND_CLASSES:
+        findings.append("unknown_backend_class")
+    if receipt.plan_status not in ACTUATION_FULFILLMENT_PLAN_STATUSES:
+        findings.append("unknown_plan_status")
+    if receipt.rehearsal_status not in ACTUATION_FULFILLMENT_REHEARSAL_STATUSES:
+        findings.append("unknown_rehearsal_status")
+    if receipt.digest and receipt.digest != actuation_fulfillment_rehearsal_receipt_digest(receipt):
+        findings.append("receipt_digest_mismatch")
+    required_true = {
+        "rehearsal_only": receipt.rehearsal_only,
+        "dry_run_only": receipt.dry_run_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment,
+        "effect_not_performed": receipt.effect_not_performed,
+        "requires_control_plane_admission_for_future_action": receipt.requires_control_plane_admission_for_future_action,
+        "requires_operator_or_policy_approval_for_future_action": receipt.requires_operator_or_policy_approval_for_future_action,
+        "requires_audit_receipt_for_future_action": receipt.requires_audit_receipt_for_future_action,
+        "requires_rollback_receipt_for_future_action": receipt.requires_rollback_receipt_for_future_action,
+        "requires_effect_receipt_for_future_action": receipt.requires_effect_receipt_for_future_action,
+        "requires_postcondition_check_for_future_action": receipt.requires_postcondition_check_for_future_action,
+    }
+    for flag, value in required_true.items():
+        if not value:
+            findings.append(f"receipt_claims_effect_or_missing_gate:{flag}")
+    return ActuationFulfillmentValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def summarize_actuation_fulfillment_plan(plan: ActuationFulfillmentPlan) -> dict[str, Any]:
+    return {
+        "plan_id": plan.plan_id,
+        "source_broker_receipt_id": plan.source_broker_receipt_id,
+        "source_eligibility_status": plan.source_eligibility_status,
+        "privilege_domain": plan.privilege_domain,
+        "fulfillment_domain": plan.fulfillment_domain,
+        "backend_class": plan.backend_class,
+        "plan_status": plan.plan_status,
+        "future_gate_count": len(plan.required_future_gates),
+        "blocked_action_count": len(plan.blocked_actions),
+        "metadata_only": plan.metadata_only,
+        "rehearsal_only": plan.rehearsal_only,
+        "authorization_granted": plan.authorization_granted,
+        "fulfillment_granted": plan.fulfillment_granted,
+        "host_mutation_performed": plan.host_mutation_performed,
+        "fan_pwm_write_performed": plan.fan_pwm_write_performed,
+        "thermal_actuation_performed": plan.thermal_actuation_performed,
+        "power_profile_mutation_performed": plan.power_profile_mutation_performed,
+        "service_restart_performed": plan.service_restart_performed,
+        "file_cleanup_performed": plan.file_cleanup_performed,
+        "network_performed": plan.network_performed,
+        "digest": actuation_fulfillment_plan_digest(plan),
+    }
+
+
+def summarize_actuation_fulfillment_rehearsal_receipt(receipt: ActuationFulfillmentRehearsalReceipt) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt.receipt_id,
+        "plan_id": receipt.plan_id,
+        "fulfillment_domain": receipt.fulfillment_domain,
+        "backend_class": receipt.backend_class,
+        "plan_status": receipt.plan_status,
+        "rehearsal_status": receipt.rehearsal_status,
+        "future_gate_count": len(receipt.required_future_gates),
+        "blocked_action_count": len(receipt.blocked_actions),
+        "rehearsal_only": receipt.rehearsal_only,
+        "dry_run_only": receipt.dry_run_only,
+        "does_not_execute": receipt.does_not_execute,
+        "does_not_mutate_host": receipt.does_not_mutate_host,
+        "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment,
+        "effect_not_performed": receipt.effect_not_performed,
+        "digest": receipt.digest or actuation_fulfillment_rehearsal_receipt_digest(receipt),
+    }
+
+
+def build_actuation_rehearsals_for_broker_receipts(
+    receipts: Sequence[Any],
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+    policy: ActuationFulfillmentPolicy | None = None,
+) -> tuple[tuple[ActuationFulfillmentPlan, ...], tuple[ActuationFulfillmentRehearsalReceipt, ...]]:
+    """Build Phase 5 rehearsal plans/receipts from Phase 4 broker receipts.
+
+    This helper is an additive pipeline convenience. It returns metadata-only
+    dry-run plans and rehearsal receipts; it does not authorize or fulfill.
+    """
+
+    plans = tuple(build_actuation_fulfillment_plan(receipt, policy=policy) for receipt in receipts)
+    rehearsal_receipts = tuple(build_actuation_fulfillment_rehearsal_receipt(plan, created_at=created_at) for plan in plans)
+    return plans, rehearsal_receipts

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -33,6 +33,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "host_resource_proposal_receipts",
         "privilege_broker",
         "control_plane_admission",
+        "actuation_fulfillment",
         "audit_immutability",
         "self_amendment",
         "federation_evidence",
@@ -46,6 +47,7 @@ AUTHORITY_LEVELS = frozenset(
         "observation",
         "proposal_only",
         "eligibility_only",
+        "rehearsal_only",
         "gated_host_interaction",
         "privileged_host_action",
         "federation_evidence",
@@ -123,7 +125,7 @@ class CapabilityRecord:
 @dataclass(frozen=True)
 class CapabilityRegistry:
     registry_id: str
-    schema_version: str = "host-embodiment-substrate-phase4.v1"
+    schema_version: str = "host-embodiment-substrate-phase5.v1"
     records: tuple[CapabilityRecord, ...] = ()
     metadata_only: bool = True
     no_runtime_authority_expansion: bool = True
@@ -192,7 +194,7 @@ def _record(
 
 
 def build_default_capability_registry() -> CapabilityRegistry:
-    """Return the deterministic Phase 1 capability map."""
+    """Return the deterministic host embodiment capability map."""
 
     records = (
         _record("install_bootstrap", "install_bootstrap", "implemented", "observation", source_paths=("installer/setup_installer.py", "installer/dry_run.py", "scripts/package_launcher.py"), implemented_surfaces=("offline/dry-run setup metadata",), forbidden_implications=("package installation without operator action",)),
@@ -216,15 +218,16 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("blanket_hardware_control", "hardware_driver_awareness", "blocked", "none", deferred_surfaces=("stem-to-stern host actuation",), forbidden_implications=("blanket hardware control exists"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("control_plane_admission", "control_plane_admission", "implemented", "proposal_only", source_paths=("sentientos/control_plane_kernel.py", "control_plane/", "sentientos/runtime_governor.py"), proof_tests=("tests/test_control_plane_kernel.py", "tests/test_sentientosd_runtime_closure.py"), implemented_surfaces=("admission receipts and runtime gating",), forbidden_implications=("admission alone performs effects",)),
         _record("privilege_broker", "privilege_broker", "implemented", "eligibility_only", source_paths=("sentientos/privilege_broker.py", "sentientos/host_resource_policy.py"), proof_tests=("tests/test_privilege_broker.py",), proof_commands=("python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py",), implemented_surfaces=("eligibility-only classification of proposal receipts", "deterministic broker review receipts"), deferred_surfaces=("authorization", "Actuation Fulfillment Layer", "cooling fulfillment", "service restart fulfillment", "cleanup fulfillment", "power policy mutation"), forbidden_implications=("privilege broker eligibility is authorization", "broker review receipt is fulfillment", "privilege broker performs host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("actuation_fulfillment", "control_plane_admission", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "rollback execution", "host mutation effects", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("proposal receipt is actuation fulfillment", "privilege broker receipt is actuation fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("actuation_fulfillment", "actuation_fulfillment", "implemented", "rehearsal_only", source_paths=("sentientos/actuation_fulfillment.py", "sentientos/privilege_broker.py"), proof_tests=("tests/test_actuation_fulfillment.py",), proof_commands=("python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py",), implemented_surfaces=("dry-run fulfillment rehearsal plans", "non-effect fulfillment rehearsal receipts"), deferred_surfaces=("real actuation fulfillment", "rollback execution", "host mutation effects", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("rehearsal plan is authorization", "rehearsal receipt is effect receipt", "privilege broker receipt is fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_actuation_fulfillment", "actuation_fulfillment", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "privileged host mutation", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("Phase 5 implements real actuation", "rehearsal receipt is effect receipt"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
         _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase4", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase5", records=records)
 
 
 
@@ -335,10 +338,10 @@ def update_registry_from_host_resource_policy(registry: CapabilityRegistry, deci
         elif record.capability_id == "privilege_broker":
             records.append(record)
         elif record.capability_id == "actuation_fulfillment":
-            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+            records.append(replace(record, status="implemented", authority_level="rehearsal_only", host_actuation_performed=False))
         else:
             records.append(record)
-    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase3.v1")
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase5.v1")
 
 
 def _canonical_json(value: Any) -> str:
@@ -430,6 +433,60 @@ def replace_capability_record(registry: CapabilityRegistry, capability_id: str, 
     return replace(registry, records=records)
 
 
+
+def update_registry_from_actuation_fulfillment_plan(registry: CapabilityRegistry, plan: Any) -> CapabilityRegistry:
+    """Reflect a Phase 5 rehearsal plan without claiming real fulfillment."""
+
+    records: list[CapabilityRecord] = []
+    has_plan = bool(getattr(plan, "plan_id", ""))
+    for record in registry.records:
+        if record.capability_id == "actuation_fulfillment":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_plan else "scaffolded",
+                    authority_level="rehearsal_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/actuation_fulfillment.py", "sentientos/privilege_broker.py")))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_actuation_fulfillment.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("dry-run fulfillment rehearsal planning",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("real actuation fulfillment", "host mutation", "effect receipt issuance", "fan/PWM writes", "thermal actuation", "service restart", "cleanup mutation", "power profile mutation")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("fulfillment rehearsal is real fulfillment", "plan is authorization")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "real_actuation_fulfillment":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id == "direct_fan_pwm_thermal_control":
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase5.v1")
+
+
+def update_registry_from_actuation_rehearsal_receipt(registry: CapabilityRegistry, receipt: Any) -> CapabilityRegistry:
+    """Reflect a Phase 5 rehearsal receipt while keeping real host actuation deferred."""
+
+    updated = update_registry_from_actuation_fulfillment_plan(registry, receipt)
+    records: list[CapabilityRecord] = []
+    has_receipt = bool(getattr(receipt, "receipt_id", ""))
+    for record in updated.records:
+        if record.capability_id == "actuation_fulfillment":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_receipt else record.status,
+                    authority_level="rehearsal_only",
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("non-effect fulfillment rehearsal receipts",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("rehearsal receipt is effect receipt",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        else:
+            records.append(record)
+    return replace(updated, records=tuple(records), schema_version="host-embodiment-substrate-phase5.v1")
+
 def update_registry_from_privilege_broker_decision(registry: CapabilityRegistry, decision: Any, review_receipts: Sequence[Any] = ()) -> CapabilityRegistry:
     """Reflect Phase 4 broker eligibility without claiming fulfillment."""
 
@@ -453,9 +510,9 @@ def update_registry_from_privilege_broker_decision(registry: CapabilityRegistry,
                 )
             )
         elif record.capability_id == "actuation_fulfillment":
-            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+            records.append(replace(record, status="implemented", authority_level="rehearsal_only", host_actuation_performed=False))
         elif record.capability_id == "direct_fan_pwm_thermal_control":
             records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
         else:
             records.append(record)
-    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase4.v1")
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase5.v1")

--- a/tests/test_actuation_fulfillment.py
+++ b/tests/test_actuation_fulfillment.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from sentientos.actuation_fulfillment import (
+    BASE_REQUIRED_GATES,
+    REQUIRED_FUTURE_GATES,
+    actuation_fulfillment_plan_digest,
+    actuation_fulfillment_rehearsal_receipt_digest,
+    build_actuation_fulfillment_plan,
+    build_actuation_fulfillment_rehearsal_receipt,
+    build_actuation_rehearsals_for_broker_receipts,
+    summarize_actuation_fulfillment_plan,
+    summarize_actuation_fulfillment_rehearsal_receipt,
+    validate_actuation_fulfillment_plan,
+    validate_actuation_fulfillment_rehearsal_receipt,
+)
+from sentientos.capability_registry import (
+    build_default_capability_registry,
+    update_registry_from_actuation_rehearsal_receipt,
+    validate_capability_registry,
+)
+from sentientos.host_collectors import collect_fan_pwm_observation, collect_thermal_sensor_observation
+from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, build_host_resource_telemetry_snapshot, evaluate_host_resource_pressure
+from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy
+from sentientos.privilege_broker import (
+    COOLING_POLICY_GATES,
+    POWER_POLICY_GATES,
+    build_privilege_broker_review_receipt,
+    evaluate_privilege_broker_eligibility,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _broker_receipt_for(kind: str, *, recorded: bool = False, **snapshot_kwargs):
+    snapshot = build_host_resource_telemetry_snapshot(snapshot_id=f"snap-{kind}", observed_at="2026-01-01T00:00:00+00:00", **snapshot_kwargs)
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    decision = evaluate_host_resource_policy(report)
+    receipt = {receipt.proposal_kind: receipt for receipt in build_host_resource_proposal_receipts(decision)}[kind]
+    if recorded:
+        receipt = replace(receipt, proposal_status="host_resource_proposal_recorded", digest="")
+    broker_decision = evaluate_privilege_broker_eligibility(receipt)
+    return build_privilege_broker_review_receipt(broker_decision)
+
+
+def test_eligible_inspect_cpu_creates_resource_rehearsal_plan() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(plan)
+    assert plan.plan_status == "actuation_fulfillment_plan_rehearsal_ready"
+    assert plan.fulfillment_domain == "resource_pressure_review"
+    assert plan.backend_class == "diagnostic_backend_future"
+    assert plan.authorization_granted is False
+    assert plan.fulfillment_granted is False
+    assert validate_actuation_fulfillment_plan(plan).ok
+    assert rehearsal.rehearsal_status == "actuation_fulfillment_rehearsal_recorded"
+    assert rehearsal.effect_not_performed is True
+    assert validate_actuation_fulfillment_rehearsal_receipt(rehearsal).ok
+
+
+def test_eligible_with_conditions_future_cooling_preserves_gates_and_blocks_control() -> None:
+    receipt = _broker_receipt_for("future_cooling_policy_candidate", recorded=True, cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, thermal_zone_temperatures_c={"cpu": 90})
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.plan_status == "actuation_fulfillment_plan_rehearsal_ready_with_conditions"
+    assert plan.fulfillment_domain == "future_cooling_rehearsal"
+    assert plan.backend_class == "cooling_backend_future"
+    for gate in COOLING_POLICY_GATES:
+        assert gate in plan.required_future_gates
+    for gate in REQUIRED_FUTURE_GATES:
+        assert gate in plan.required_future_gates
+    assert "fan_pwm_write" in plan.blocked_actions
+    assert "thermal_actuation" in plan.blocked_actions
+    assert plan.fan_pwm_write_performed is False
+    assert plan.thermal_actuation_performed is False
+
+
+def test_future_power_rehearsal_keeps_power_profile_mutation_blocked() -> None:
+    receipt = _broker_receipt_for("future_power_policy_candidate", recorded=True, cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, battery_percent=5, battery_charging=False)
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.fulfillment_domain == "future_power_rehearsal"
+    assert plan.backend_class == "power_backend_future"
+    for gate in POWER_POLICY_GATES:
+        assert gate in plan.required_future_gates
+    assert "power_profile_mutation" in plan.blocked_actions
+    assert plan.power_profile_mutation_performed is False
+
+
+def test_future_cleanup_rehearsal_keeps_file_cleanup_blocked() -> None:
+    receipt = _broker_receipt_for("future_cleanup_policy_candidate", recorded=True, cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=95)
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.fulfillment_domain == "future_cleanup_rehearsal"
+    assert plan.backend_class == "cleanup_backend_future"
+    assert {"file_cleanup", "file_delete", "disk_cleanup_mutation"}.issubset(plan.blocked_actions)
+    assert plan.file_cleanup_performed is False
+
+
+def test_service_health_rehearsal_keeps_service_restart_blocked() -> None:
+    receipt = _broker_receipt_for("inspect_service_health_candidate", cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, service_health_labels=("daemon_degraded",))
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.fulfillment_domain == "service_health_review"
+    assert plan.backend_class == "service_backend_future"
+    assert "service_restart" in plan.blocked_actions
+    assert plan.service_restart_performed is False
+
+
+@pytest.mark.parametrize(
+    ("broker_status", "plan_status"),
+    [
+        ("privilege_broker_blocked", "actuation_fulfillment_plan_blocked"),
+        ("privilege_broker_incomplete", "actuation_fulfillment_plan_incomplete"),
+        ("privilege_broker_contradicted", "actuation_fulfillment_plan_contradicted"),
+    ],
+)
+def test_noneligible_broker_receipts_map_to_nonready_plans(broker_status: str, plan_status: str) -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    receipt = replace(receipt, eligibility_status=broker_status, review_status="privilege_broker_receipt_blocked", digest="")
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.plan_status == plan_status
+
+
+@pytest.mark.parametrize("flag", ["authorization_granted", "fulfillment_granted", "host_mutation_performed"])
+def test_source_broker_receipt_claiming_effect_or_authority_is_contradicted(flag: str) -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    data = receipt.to_dict()
+    data[flag] = True
+    source = SimpleNamespace(**data)
+    plan = build_actuation_fulfillment_plan(source)
+    assert plan.plan_status == "actuation_fulfillment_plan_contradicted"
+    assert any("source_broker_receipt_claims_forbidden" in item for item in plan.missing_prerequisites)
+
+
+def test_missing_required_future_gates_produces_incomplete_plan() -> None:
+    receipt = _broker_receipt_for("future_cooling_policy_candidate", recorded=True, cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, thermal_zone_temperatures_c={"cpu": 90})
+    receipt = replace(receipt, required_future_gates=tuple(gate for gate in receipt.required_future_gates if gate != "hardware_allowlist_required"), digest="")
+    plan = build_actuation_fulfillment_plan(receipt)
+    assert plan.plan_status == "actuation_fulfillment_plan_incomplete"
+    assert "receipt_digest_mismatch" in plan.missing_prerequisites or "broker_condition_gates_missing" in plan.reason_codes
+
+
+def test_plan_digest_deterministic_and_changes_on_metadata() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    first = build_actuation_fulfillment_plan(receipt)
+    second = build_actuation_fulfillment_plan(receipt)
+    assert actuation_fulfillment_plan_digest(first) == actuation_fulfillment_plan_digest(second)
+    changed = replace(first, warning_codes=first.warning_codes + ("extra_warning",))
+    assert actuation_fulfillment_plan_digest(changed) != actuation_fulfillment_plan_digest(first)
+
+
+def test_rehearsal_receipt_digest_deterministic_and_changes_on_metadata() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    first = build_actuation_fulfillment_rehearsal_receipt(plan)
+    second = build_actuation_fulfillment_rehearsal_receipt(plan)
+    assert first.digest == second.digest
+    changed = replace(first, warning_codes=first.warning_codes + ("extra_warning",), digest="")
+    assert actuation_fulfillment_rehearsal_receipt_digest(changed) != first.digest
+
+
+def test_plan_and_rehearsal_summaries_are_metadata_only() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(plan)
+    plan_summary = summarize_actuation_fulfillment_plan(plan)
+    rehearsal_summary = summarize_actuation_fulfillment_rehearsal_receipt(rehearsal)
+    assert plan_summary["metadata_only"] is True
+    assert plan_summary["rehearsal_only"] is True
+    assert plan_summary["authorization_granted"] is False
+    assert plan_summary["fulfillment_granted"] is False
+    assert plan_summary["host_mutation_performed"] is False
+    assert rehearsal_summary["rehearsal_only"] is True
+    assert rehearsal_summary["dry_run_only"] is True
+    assert rehearsal_summary["effect_not_performed"] is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "authorization_granted",
+        "fulfillment_granted",
+        "host_mutation_performed",
+        "fan_pwm_write_performed",
+        "thermal_actuation_performed",
+        "power_profile_mutation_performed",
+        "process_kill_performed",
+        "service_restart_performed",
+        "package_install_performed",
+        "driver_install_performed",
+        "file_cleanup_performed",
+        "provider_invocation_performed",
+        "network_performed",
+        "prompt_assembly_performed",
+    ],
+)
+def test_validation_rejects_plan_forbidden_flags(field: str) -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    bad = replace(plan, **{field: True})
+    result = validate_actuation_fulfillment_plan(bad)
+    assert not result.ok
+    assert f"plan_forbidden_flag:{field}" in result.findings
+
+
+def test_validation_rejects_rehearsal_receipt_claiming_effect_performed() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(plan)
+    bad = replace(rehearsal, effect_not_performed=False)
+    result = validate_actuation_fulfillment_rehearsal_receipt(bad)
+    assert not result.ok
+    assert "receipt_claims_effect_or_missing_gate:effect_not_performed" in result.findings
+
+
+def test_fake_collectors_to_fulfillment_rehearsal_pipeline_is_non_mutating() -> None:
+    tree = {"/thermal": ("thermal_zone0",), "/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("fan1_input", "pwm1")}
+    files = {"/thermal/thermal_zone0/temp": "90000\n", "/thermal/thermal_zone0/type": "cpu\n", "/hwmon/hwmon0/fan1_input": "1400\n", "/hwmon/hwmon0/pwm1": "128\n"}
+    results = (
+        collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/empty", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+        collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+    )
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id="collector-snap")
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    decision = evaluate_host_resource_policy(report)
+    proposal_receipts = build_host_resource_proposal_receipts(decision)
+    broker_decisions = tuple(evaluate_privilege_broker_eligibility(replace(receipt, proposal_status="host_resource_proposal_recorded", digest="") if receipt.proposal_kind == "future_cooling_policy_candidate" else receipt) for receipt in proposal_receipts)
+    broker_receipts = tuple(build_privilege_broker_review_receipt(decision) for decision in broker_decisions)
+    plans, rehearsals = build_actuation_rehearsals_for_broker_receipts(broker_receipts)
+    cooling_plans = [plan for plan in plans if plan.fulfillment_domain == "future_cooling_rehearsal"]
+    assert cooling_plans
+    assert all(plan.host_mutation_performed is False for plan in plans)
+    assert all(plan.fan_pwm_write_performed is False for plan in plans)
+    assert all(plan.thermal_actuation_performed is False for plan in plans)
+    assert all(receipt.does_not_mutate_host is True and receipt.effect_not_performed is True for receipt in rehearsals)
+
+
+def test_service_degraded_pipeline_rehearses_service_health_not_restart() -> None:
+    receipt = _broker_receipt_for("inspect_service_health_candidate", cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30, service_health_labels=("daemon_degraded",))
+    plans, rehearsals = build_actuation_rehearsals_for_broker_receipts((receipt,))
+    assert plans[0].fulfillment_domain == "service_health_review"
+    assert "service_restart" in plans[0].blocked_actions
+    assert rehearsals[0].does_not_execute is True
+
+
+def test_capability_registry_reflects_rehearsal_only_and_real_actuation_deferred() -> None:
+    receipt = _broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    plan = build_actuation_fulfillment_plan(receipt)
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(plan)
+    registry = update_registry_from_actuation_rehearsal_receipt(build_default_capability_registry(), rehearsal)
+    records = registry.by_id()
+    assert records["actuation_fulfillment"].status == "implemented"
+    assert records["actuation_fulfillment"].authority_level == "rehearsal_only"
+    assert records["actuation_fulfillment"].host_actuation_performed is False
+    assert records["real_actuation_fulfillment"].status == "deferred"
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -185,7 +185,7 @@ def test_phase3_policy_registry_records_are_proposal_only_and_defer_privileged_o
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
     assert records["privilege_broker"].status == "implemented"
     assert records["privilege_broker"].authority_level == "eligibility_only"
-    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "implemented"
     assert validate_capability_registry(registry).ok
 
 
@@ -194,5 +194,17 @@ def test_default_registry_represents_phase4_privilege_broker_as_eligibility_only
     assert records["privilege_broker"].status == "implemented"
     assert records["privilege_broker"].authority_level == "eligibility_only"
     assert records["privilege_broker"].host_actuation_performed is False
-    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "implemented"
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+
+
+def test_phase5_registry_represents_actuation_fulfillment_as_rehearsal_only() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["actuation_fulfillment"].status == "implemented"
+    assert records["actuation_fulfillment"].authority_level == "rehearsal_only"
+    assert records["actuation_fulfillment"].host_actuation_performed is False
+    assert "real actuation fulfillment" in records["actuation_fulfillment"].deferred_surfaces
+    assert records["real_actuation_fulfillment"].status == "deferred"
+    assert records["real_actuation_fulfillment"].host_actuation_performed is False
+    assert records["direct_fan_pwm_thermal_control"].status == "blocked"
+    assert validate_capability_registry(build_default_capability_registry()).ok

--- a/tests/test_host_resource_policy.py
+++ b/tests/test_host_resource_policy.py
@@ -196,6 +196,6 @@ def test_capability_registry_reflects_policy_proposal_only_and_deferred_fulfillm
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
     assert records["privilege_broker"].status == "implemented"
     assert records["privilege_broker"].authority_level == "eligibility_only"
-    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "implemented"
     assert all(record.host_actuation_performed is False for record in records.values() if "host_resource" in record.capability_id or record.capability_id in {"direct_fan_pwm_thermal_control", "privilege_broker", "actuation_fulfillment"})
     assert validate_capability_registry(registry).ok

--- a/tests/test_privilege_broker.py
+++ b/tests/test_privilege_broker.py
@@ -198,6 +198,6 @@ def test_capability_registry_reflects_privilege_broker_without_actuation_fulfill
     assert records["privilege_broker"].status == "implemented"
     assert records["privilege_broker"].authority_level == "eligibility_only"
     assert records["privilege_broker"].host_actuation_performed is False
-    assert records["actuation_fulfillment"].status == "deferred"
+    assert records["actuation_fulfillment"].status == "implemented"
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
     assert validate_capability_registry(registry).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -167,3 +167,38 @@ def test_phase4_doc_preserves_privilege_broker_boundaries() -> None:
     assert "broker review receipt is not fulfillment" in phase4 or "broker receipt is not fulfillment" in phase4
     assert "direct fan/PWM/thermal control remains blocked/deferred" in phase4
     assert "future Actuation Fulfillment Layer" in phase4
+
+HOST_EMBODIMENT_PHASE5 = "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md"
+
+
+def test_navigation_links_to_host_embodiment_phase5_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase1 = _read(HOST_EMBODIMENT_PHASE1)
+    phase2 = _read(HOST_EMBODIMENT_PHASE2)
+    phase3 = _read(HOST_EMBODIMENT_PHASE3)
+    phase4 = _read(HOST_EMBODIMENT_PHASE4)
+    trajectory = _read(TRAJECTORY_DOC)
+    assert HOST_EMBODIMENT_PHASE5 in overview
+    assert HOST_EMBODIMENT_PHASE5 in index
+    assert HOST_EMBODIMENT_PHASE5 in phase1
+    assert HOST_EMBODIMENT_PHASE5 in phase2
+    assert HOST_EMBODIMENT_PHASE5 in phase3
+    assert HOST_EMBODIMENT_PHASE5 in phase4
+    assert HOST_EMBODIMENT_PHASE5 in trajectory
+
+
+def test_phase5_doc_preserves_actuation_fulfillment_scaffold_boundaries() -> None:
+    phase5 = _read(HOST_EMBODIMENT_PHASE5)
+    assert "Fulfillment rehearsal is not real fulfillment" in phase5
+    assert "rehearsal receipt is not an effect receipt" in phase5
+    assert "No host mutation occurs" in phase5
+    assert "No direct fan/PWM control occurs" in phase5
+    assert "No thermal actuation occurs" in phase5
+    assert "No power profile mutation occurs" in phase5
+    assert "No service restart occurs" in phase5
+    assert "No cleanup/deletion occurs" in phase5
+    assert "control-plane admission" in phase5
+    assert "operator/policy approval" in phase5
+    assert "effect receipt" in phase5
+    assert "postcondition check" in phase5


### PR DESCRIPTION
### Motivation
- Introduce Phase 5: a rehearsal-only Actuation Fulfillment Layer that consumes Privilege Broker review receipts to produce deterministic dry-run fulfillment plans and rehearsal receipts without any host effects. 
- Preserve the core safety posture that broker eligibility is not authorization and that review/rehearsal artifacts must never mutate host state or perform privileged host actions. 
- Integrate the rehearsal scaffold into the existing pipeline and capability map so future real fulfillment remains gated behind admission, operator/policy approval, audit, rollback, effect receipts, and postcondition checks. 

### Description
- Add `sentientos/actuation_fulfillment.py` implementing frozen dataclasses `ActuationFulfillmentPolicy`, `ActuationFulfillmentPlan`, `ActuationFulfillmentRehearsalReceipt`, and `ActuationFulfillmentValidationResult` plus helpers like `build_actuation_fulfillment_plan(...)`, `build_actuation_fulfillment_rehearsal_receipt(...)`, `build_actuation_rehearsals_for_broker_receipts(...)`, deterministic digest, summary, and validation functions. 
- Implement mapping rules from broker privilege domains to fulfillment rehearsal domains and backend classes, preserve required future gates and blocked-actions vocabularies, and explicitly keep all non-effect flags false (e.g. `authorization_granted=False`, `effect_not_performed=True`). 
- Update `sentientos/capability_registry.py` to represent `actuation_fulfillment` as `implemented` with `authority_level='rehearsal_only'`, add `real_actuation_fulfillment` as deferred, and provide `update_registry_from_actuation_fulfillment_plan(...)` and `update_registry_from_actuation_rehearsal_receipt(...)` helpers that reflect rehearsal metadata without granting real effects. 
- Add documentation `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`, wire short links into public overview and reviewer index, and add focused tests `tests/test_actuation_fulfillment.py` plus small updates to existing tests to reflect Phase 5 registry/posture changes. 

### Testing
- Compiled modified modules with `python -m py_compile` and ran focused unit tests; `python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py` completed successfully after small iterative fixes. 
- Ran integration proof suites `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_host_resource_policy.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` and all passed. 
- Built docs with `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` and verified generated docs include the new Phase 5 page; `python scripts/verify_context_hygiene_prompt_boundaries.py` returned `boundary_clean`. 
- Performed forbidden-operation scan on changed modules and confirmed matches are documentation/negative markers and validation guards only, with no network/subprocess/provider/host-actuation calls added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a055dc206c483208d05eb5d584024cf)