### PR TITLE
[codex:host-embodiment] add execution proof wing

### DIFF
--- a/docs/architecture/host_embodiment_execution_proof_wing.md
+++ b/docs/architecture/host_embodiment_execution_proof_wing.md
@@ -1,0 +1,109 @@
+# Host Embodiment Execution Proof Wing
+
+The Host Embodiment Execution Proof Wing follows Host Embodiment Substrate Phase
+5. Phase 5 rehearses fulfillment; this wing defines what any future real host
+execution would have to prove before SentientOS could ever perform an effect.
+
+This wing is proof/readiness/supervision scaffolding only. It is not real
+actuation, not execution, not host mutation, not direct fan/PWM control, not
+thermal actuation, not power profile mutation, not process killing, not service
+restart, not package or driver installation, not file cleanup or deletion, not
+network egress, not provider invocation, not prompt assembly/export, not
+federation transport/sync/adoption, and not remote execution.
+
+## Authority ladder
+
+The authority ladder remains:
+
+`observe → model → propose → broker eligibility → rehearse → readiness → authorize → fulfill → effect receipt → postcondition check → audit → rollback`
+
+This wing covers `readiness` and proof scaffolding only. It does not authorize,
+fulfill, create a real effect receipt, perform postcondition checks against real
+effects, audit a real effect, or execute rollback.
+
+## New proof contracts
+
+`sentientos/effect_proof.py` defines metadata-only records:
+
+1. `EffectReceiptContract` — a proof contract for what a future effect receipt
+   must bind: source rehearsal receipt, digest, fulfillment domain, backend
+   class, effect domain, proof gates, blocked actions, authority references,
+   preconditions, postconditions, rollback labels, audit labels, and supervisor
+   labels. The Effect Receipt contract is not an effect receipt from a real
+   action.
+2. `FutureEffectReceipt` — a schema/placeholder for a future receipt. The future
+   effect receipt schema is not proof that an effect occurred.
+3. `PostconditionCheckPlan` and `PostconditionCheckReceipt` — schema/rehearsal
+   records for future postcondition checks. They are schema/rehearsal-only until
+   real effects exist.
+4. `RollbackPlan` and `RollbackReceipt` — schema/rehearsal records for future
+   rollback proof. They are schema/rehearsal-only until real rollback exists.
+5. `ExecutionReadinessManifest` — a readiness manifest linking the contract,
+   future receipt schema, postcondition plan, rollback plan, optional runtime
+   supervisor report, required proof gates, satisfied gates, missing gates, and
+   blocked actions. The Execution Readiness Manifest is not authorization.
+
+The future effect receipt schema is not proof that an effect occurred.
+
+## Runtime Supervisor scaffold
+
+`sentientos/runtime_supervisor.py` defines a Runtime Supervisor scaffold for
+supplied service/runtime observations. It can record `RuntimeServiceRecord`
+metadata, `RuntimeSupervisorSnapshot` telemetry, and
+`RuntimeSupervisorReadinessReport` readiness evidence.
+
+The Runtime Supervisor is observation/readiness-only. It does not inspect
+privileged live services unless data is supplied, does not restart services,
+does not stop services, does not kill processes, does not mutate service
+managers, does not install packages, does not mutate host state, and does not
+perform network calls. Degraded service records become readiness warnings or
+blocked/contradicted reports; they do not become restart authority.
+
+## Proof gates before future effects
+
+Future cooling effects require hardware allowlist, OS backend declaration,
+bounds policy, cooldown policy, panic stop, postcondition checks, rollback plan
+and rollback receipt, audit receipt, runtime supervisor observation, and
+immutable trace. Fan/PWM writes and thermal actuation remain blocked/deferred.
+
+Future power effects require OS backend declaration, bounds/policy gates,
+postcondition checks, rollback plan/receipt, audit receipt, runtime supervisor
+observation, and immutable trace. Power profile mutation remains
+blocked/deferred.
+
+Future cleanup effects require path/file scope, dry-run evidence,
+postcondition checks, rollback plan/receipt, audit receipt, runtime supervisor
+observation, and immutable trace. File cleanup and file deletion remain
+blocked/deferred.
+
+Future service effects require service scope, runtime supervisor observation,
+postcondition checks, rollback plan/receipt, audit receipt, and immutable trace.
+Service restart and process killing remain blocked/deferred.
+
+Diagnostics and operator-review effects remain readiness-for-authorization-review
+only. No effect is performed.
+
+## Pipeline position
+
+The non-mutating pipeline is now:
+
+`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → broker eligibility decision → broker review receipt → fulfillment rehearsal plan → fulfillment rehearsal receipt → effect receipt contract → future effect receipt schema → postcondition plan → rollback plan → execution readiness manifest → optional runtime supervisor readiness report`
+
+All stages remain metadata-only and non-mutating. Real fulfillment remains
+deferred. Real actuation remains deferred.
+
+## Reviewer proof links
+
+- Module: `sentientos/effect_proof.py`
+- Module: `sentientos/runtime_supervisor.py`
+- Capability registry: `sentientos/capability_registry.py`
+- Tests: `tests/test_effect_proof.py`
+- Tests: `tests/test_runtime_supervisor.py`
+- Registry tests: `tests/test_capability_registry.py`
+- Docs regression: `tests/test_reviewer_release_readiness_index.py`
+
+## Named review checklist
+
+Reviewers should explicitly see these proof organs before any future effect:
+Effect Receipt contract, Postcondition Check plan/receipt, Rollback Plan/Receipt,
+Runtime Supervisor, and Execution Readiness Manifest.

--- a/docs/architecture/host_embodiment_substrate_phase1.md
+++ b/docs/architecture/host_embodiment_substrate_phase1.md
@@ -125,3 +125,8 @@ python scripts/verify_context_hygiene_prompt_boundaries.py
 python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 ```
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
+++ b/docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md
@@ -69,3 +69,8 @@ Phase 2 must not perform:
 ## Next phase
 
 Phase 3 policy and proposal receipts are documented in `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`; Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`; Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`.
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
+++ b/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
@@ -94,3 +94,8 @@ python scripts/build_docs.py
 ```
 
 Phase 4 privilege broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Eligibility is not authorization, broker receipts are not fulfillment, and fulfillment rehearsal is not real fulfillment.
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
+++ b/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
@@ -161,3 +161,8 @@ python scripts/verify_context_hygiene_prompt_boundaries.py
 ## Next phase
 
 Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Fulfillment rehearsal is not real fulfillment, and a rehearsal receipt is not an effect receipt. Direct fan/PWM/thermal control remains blocked/deferred, and power, service, and cleanup actions remain behind future authorization, admission, audit, rollback, effect receipt, and postcondition gates.
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
+++ b/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
@@ -153,3 +153,8 @@ python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_pr
 - `docs/architecture/sentientos_trajectory_and_missing_organs.md`
 - `docs/architecture/public_technical_overview.md`
 - `docs/architecture/reviewer_release_readiness_index.md`
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -226,3 +226,8 @@ See `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md`. Ph
 ### Host Embodiment Phase 5 Actuation Fulfillment Scaffold
 
 See `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. Phase 5 creates fulfillment rehearsal plans and rehearsal receipts only. Fulfillment rehearsal is not real fulfillment, a rehearsal receipt is not an effect receipt, no host mutation occurs, and fan/PWM/thermal/power/service/cleanup actions remain blocked/deferred behind future control-plane admission, operator/policy approval, audit, rollback, effect receipt, and postcondition gates.
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -212,3 +212,8 @@ Proof command:
 ```bash
 python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py
 ```
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -370,3 +370,8 @@ Phase 4 is documented in `docs/architecture/host_embodiment_substrate_phase4_pri
 ### Host Embodiment Phase 5 actuation fulfillment scaffold
 
 Phase 5 is documented in `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md`. It adds the Actuation Fulfillment Layer scaffold as rehearsal-only metadata: fulfillment rehearsal is not real fulfillment, a rehearsal receipt is not an effect receipt, and no host mutation occurs. Direct fan/PWM/thermal control, service restart, power profile mutation, cleanup/deletion, process killing, package/driver installation, provider invocation, network egress, prompt assembly, federation transport/sync/adoption, and remote execution remain blocked/deferred behind future control-plane admission, operator/policy approval, audit, rollback, effect receipt, and postcondition gates.
+
+
+## Host Embodiment Execution Proof Wing
+
+Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -34,6 +34,8 @@ CAPABILITY_CATEGORIES = frozenset(
         "privilege_broker",
         "control_plane_admission",
         "actuation_fulfillment",
+        "execution_proof",
+        "runtime_supervision",
         "audit_immutability",
         "self_amendment",
         "federation_evidence",
@@ -48,6 +50,9 @@ AUTHORITY_LEVELS = frozenset(
         "proposal_only",
         "eligibility_only",
         "rehearsal_only",
+        "proof_only",
+        "readiness_only",
+        "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
         "federation_evidence",
@@ -125,7 +130,7 @@ class CapabilityRecord:
 @dataclass(frozen=True)
 class CapabilityRegistry:
     registry_id: str
-    schema_version: str = "host-embodiment-substrate-phase5.v1"
+    schema_version: str = "host-embodiment-execution-proof-wing.v1"
     records: tuple[CapabilityRecord, ...] = ()
     metadata_only: bool = True
     no_runtime_authority_expansion: bool = True
@@ -220,14 +225,25 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("privilege_broker", "privilege_broker", "implemented", "eligibility_only", source_paths=("sentientos/privilege_broker.py", "sentientos/host_resource_policy.py"), proof_tests=("tests/test_privilege_broker.py",), proof_commands=("python -m scripts.run_tests -q tests/test_privilege_broker.py tests/test_host_resource_policy.py tests/test_capability_registry.py",), implemented_surfaces=("eligibility-only classification of proposal receipts", "deterministic broker review receipts"), deferred_surfaces=("authorization", "Actuation Fulfillment Layer", "cooling fulfillment", "service restart fulfillment", "cleanup fulfillment", "power policy mutation"), forbidden_implications=("privilege broker eligibility is authorization", "broker review receipt is fulfillment", "privilege broker performs host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("actuation_fulfillment", "actuation_fulfillment", "implemented", "rehearsal_only", source_paths=("sentientos/actuation_fulfillment.py", "sentientos/privilege_broker.py"), proof_tests=("tests/test_actuation_fulfillment.py",), proof_commands=("python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_privilege_broker.py tests/test_capability_registry.py",), implemented_surfaces=("dry-run fulfillment rehearsal plans", "non-effect fulfillment rehearsal receipts"), deferred_surfaces=("real actuation fulfillment", "rollback execution", "host mutation effects", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("rehearsal plan is authorization", "rehearsal receipt is effect receipt", "privilege broker receipt is fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_actuation_fulfillment", "actuation_fulfillment", "deferred", "none", deferred_surfaces=("candidate-to-effect fulfillment", "privileged host mutation", "fan/PWM writes", "thermal actuation", "service restart", "power profile mutation", "cleanup mutation"), forbidden_implications=("Phase 5 implements real actuation", "rehearsal receipt is effect receipt"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("effect_receipt_contract", "execution_proof", "implemented", "proof_only", source_paths=("sentientos/effect_proof.py",), proof_tests=("tests/test_effect_proof.py",), proof_commands=("python -m scripts.run_tests -q tests/test_effect_proof.py",), implemented_surfaces=("metadata-only effect receipt contract schema", "proof gates for future effects"), deferred_surfaces=("real effect receipt issuance", "real host action execution"), forbidden_implications=("effect receipt contract is a real effect receipt", "contract grants authorization"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("postcondition_checks", "execution_proof", "implemented", "proof_only", source_paths=("sentientos/effect_proof.py",), proof_tests=("tests/test_effect_proof.py",), implemented_surfaces=("metadata-only postcondition plan and rehearsal receipt schemas",), deferred_surfaces=("postcondition checks against real effects",), forbidden_implications=("postcondition schema proves an effect occurred",), requires_audit_receipt=True),
+        _record("rollback_planning", "execution_proof", "implemented", "proof_only", source_paths=("sentientos/effect_proof.py",), proof_tests=("tests/test_effect_proof.py",), implemented_surfaces=("metadata-only rollback plans and rollback receipt schemas",), deferred_surfaces=("real rollback execution",), forbidden_implications=("rollback plan executes rollback",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("runtime_supervisor", "runtime_supervision", "implemented", "telemetry_readiness_only", source_paths=("sentientos/runtime_supervisor.py",), proof_tests=("tests/test_runtime_supervisor.py",), proof_commands=("python -m scripts.run_tests -q tests/test_runtime_supervisor.py",), implemented_surfaces=("supplied service telemetry snapshots", "runtime supervisor readiness reports"), deferred_surfaces=("service restart", "process kill", "service manager mutation"), forbidden_implications=("runtime supervisor restarts or kills services",), requires_audit_receipt=True),
+        _record("execution_readiness_manifest", "execution_proof", "implemented", "readiness_only", source_paths=("sentientos/effect_proof.py", "sentientos/runtime_supervisor.py"), proof_tests=("tests/test_effect_proof.py", "tests/test_runtime_supervisor.py"), implemented_surfaces=("metadata-only execution readiness manifest",), deferred_surfaces=("authorization", "fulfillment", "real actuation"), forbidden_implications=("execution readiness is authorization", "readiness manifest performs effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_effect_execution", "execution_proof", "deferred", "none", deferred_surfaces=("authorized effect fulfillment", "host mutation", "effect receipt from real action"), forbidden_implications=("execution proof wing implements real effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_rollback_execution", "execution_proof", "deferred", "none", deferred_surfaces=("rollback execution", "host mutation rollback",), forbidden_implications=("rollback receipt schema executes rollback",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_service_restart", "runtime_supervision", "blocked", "none", deferred_surfaces=("service restart", "service stop", "process kill"), forbidden_implications=("runtime supervisor grants restart authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_fan_pwm_control", "execution_proof", "blocked", "none", deferred_surfaces=("fan/PWM writes", "thermal actuation"), forbidden_implications=("execution proof wing grants fan/PWM control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_power_profile_mutation", "execution_proof", "blocked", "none", deferred_surfaces=("power profile mutation",), forbidden_implications=("execution proof wing grants power mutation",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_file_cleanup", "execution_proof", "blocked", "none", deferred_surfaces=("file cleanup", "file delete",), forbidden_implications=("execution proof wing grants cleanup authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
         _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-phase5", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-execution-proof-wing", records=records)
 
 
 
@@ -516,3 +532,70 @@ def update_registry_from_privilege_broker_decision(registry: CapabilityRegistry,
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-substrate-phase5.v1")
+
+
+def update_registry_from_execution_readiness_manifest(registry: CapabilityRegistry, manifest: Any) -> CapabilityRegistry:
+    """Reflect execution proof readiness without claiming authorization or effects."""
+
+    records: list[CapabilityRecord] = []
+    has_manifest = bool(getattr(manifest, "manifest_id", ""))
+    for record in registry.records:
+        if record.capability_id in {"effect_receipt_contract", "postcondition_checks", "rollback_planning"}:
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_manifest else record.status,
+                    authority_level="proof_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/effect_proof.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_effect_proof.py",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "execution_readiness_manifest":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_manifest else "scaffolded",
+                    authority_level="readiness_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/effect_proof.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_effect_proof.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("execution readiness manifests are not authorization",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("real effect execution", "real rollback execution")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("readiness manifest grants fulfillment",)))) ,
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"real_effect_execution", "real_rollback_execution", "real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup", "direct_fan_pwm_thermal_control", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="blocked" if record.capability_id not in {"real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"} else "deferred", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-execution-proof-wing.v1")
+
+
+def update_registry_from_runtime_supervisor_report(registry: CapabilityRegistry, report: Any) -> CapabilityRegistry:
+    """Reflect runtime supervisor readiness without restart/kill authority."""
+
+    records: list[CapabilityRecord] = []
+    has_report = bool(getattr(report, "report_id", ""))
+    for record in registry.records:
+        if record.capability_id == "runtime_supervisor":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_report else "scaffolded",
+                    authority_level="telemetry_readiness_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/runtime_supervisor.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_runtime_supervisor.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("runtime supervisor readiness reports do not restart or kill services",)))) ,
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("real service restart", "real process kill")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "real_service_restart":
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-execution-proof-wing.v1")

--- a/sentientos/effect_proof.py
+++ b/sentientos/effect_proof.py
@@ -1,0 +1,470 @@
+"""Execution proof scaffolding for future SentientOS host effects.
+
+This module is metadata-only/proof-only. It defines contracts for future effect
+receipts, postcondition checks, rollback evidence, and execution readiness. It
+never performs host actions, mutates host state, writes fan/PWM controls, changes
+thermal or power settings, kills processes, restarts services, installs packages
+or drivers, removes files, performs network activity, invokes providers, or
+assembles prompts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.actuation_fulfillment import ACTUATION_FULFILLMENT_REHEARSAL_STATUSES, actuation_fulfillment_rehearsal_receipt_digest
+
+EFFECT_RECEIPT_CONTRACT_STATUSES = frozenset({"effect_receipt_contract_ready", "effect_receipt_contract_ready_with_conditions", "effect_receipt_contract_blocked", "effect_receipt_contract_incomplete", "effect_receipt_contract_contradicted"})
+FUTURE_EFFECT_RECEIPT_STATUSES = frozenset({"future_effect_receipt_schema_ready", "future_effect_receipt_schema_ready_with_conditions", "future_effect_receipt_blocked", "future_effect_receipt_incomplete", "future_effect_receipt_contradicted"})
+POSTCONDITION_STATUSES = frozenset({"postcondition_plan_ready", "postcondition_plan_ready_with_conditions", "postcondition_plan_blocked", "postcondition_plan_incomplete", "postcondition_plan_contradicted", "postcondition_receipt_recorded", "postcondition_receipt_recorded_with_warnings", "postcondition_receipt_blocked", "postcondition_receipt_incomplete", "postcondition_receipt_contradicted"})
+ROLLBACK_STATUSES = frozenset({"rollback_plan_ready", "rollback_plan_ready_with_conditions", "rollback_plan_blocked", "rollback_plan_incomplete", "rollback_plan_contradicted", "rollback_receipt_recorded", "rollback_receipt_recorded_with_warnings", "rollback_receipt_blocked", "rollback_receipt_incomplete", "rollback_receipt_contradicted"})
+EXECUTION_READINESS_STATUSES = frozenset({"execution_readiness_for_authorization_review", "execution_readiness_for_authorization_review_with_conditions", "execution_readiness_blocked", "execution_readiness_incomplete", "execution_readiness_contradicted"})
+EFFECT_DOMAINS = frozenset({"diagnostics_only", "operator_review", "resource_pressure_review", "thermal_safety_review", "disk_safety_review", "service_health_review", "future_cooling_effect", "future_power_effect", "future_cleanup_effect", "future_service_effect"})
+EFFECT_BACKEND_CLASSES = frozenset({"no_backend_required", "diagnostic_backend_future", "cooling_backend_future", "power_backend_future", "cleanup_backend_future", "service_backend_future", "operator_manual_backend_future"})
+REQUIRED_PROOF_GATES = frozenset({"control_plane_admission_required", "operator_or_policy_approval_required", "audit_receipt_required", "rollback_receipt_required", "rollback_plan_required", "panic_stop_required", "hardware_allowlist_required", "os_backend_declaration_required", "bounds_policy_required", "cooldown_policy_required", "rehearsal_required", "dry_run_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"})
+BASE_PROOF_GATES = ("control_plane_admission_required", "operator_or_policy_approval_required", "audit_receipt_required", "rollback_receipt_required", "rollback_plan_required", "rehearsal_required", "dry_run_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required")
+BLOCKED_ACTION_LABELS = frozenset({"host_mutation_without_authorization", "fan_pwm_write_without_allowlist", "thermal_actuation_without_policy", "power_profile_mutation_without_policy", "process_kill_without_authorization", "service_restart_without_authorization", "package_install_without_authorization", "driver_install_without_authorization", "file_cleanup_without_scope", "file_delete_without_scope", "provider_invocation", "network_egress", "prompt_assembly", "federation_transport", "remote_execution"})
+
+_DOMAIN_EFFECT: Mapping[str, str] = {
+    "future_cooling_rehearsal": "future_cooling_effect",
+    "future_power_rehearsal": "future_power_effect",
+    "future_cleanup_rehearsal": "future_cleanup_effect",
+    "future_service_rehearsal": "future_service_effect",
+}
+_ACTION_LABELS: Mapping[str, str] = {
+    "host_mutation": "host_mutation_without_authorization",
+    "fan_pwm_write": "fan_pwm_write_without_allowlist",
+    "thermal_actuation": "thermal_actuation_without_policy",
+    "power_profile_mutation": "power_profile_mutation_without_policy",
+    "process_kill": "process_kill_without_authorization",
+    "service_restart": "service_restart_without_authorization",
+    "package_install": "package_install_without_authorization",
+    "driver_install": "driver_install_without_authorization",
+    "file_cleanup": "file_cleanup_without_scope",
+    "file_delete": "file_delete_without_scope",
+    "disk_cleanup_mutation": "file_cleanup_without_scope",
+    "provider_invocation": "provider_invocation",
+    "network_egress": "network_egress",
+    "prompt_assembly": "prompt_assembly",
+}
+_DOMAIN_REQUIRED_GATES: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_effect": tuple(sorted(REQUIRED_PROOF_GATES)),
+    "future_power_effect": ("control_plane_admission_required", "operator_or_policy_approval_required", "audit_receipt_required", "rollback_receipt_required", "rollback_plan_required", "panic_stop_required", "os_backend_declaration_required", "bounds_policy_required", "rehearsal_required", "dry_run_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "future_cleanup_effect": BASE_PROOF_GATES + ("panic_stop_required",),
+    "future_service_effect": BASE_PROOF_GATES + ("panic_stop_required",),
+}
+_DOMAIN_EXTRA_AUTHORITY: Mapping[str, tuple[str, ...]] = {
+    "future_cleanup_effect": ("path_or_file_scope_required",),
+    "future_service_effect": ("service_scope_required",),
+}
+_DOMAIN_REQUIRED_BLOCKS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_effect": ("fan_pwm_write_without_allowlist", "thermal_actuation_without_policy"),
+    "future_power_effect": ("power_profile_mutation_without_policy",),
+    "future_cleanup_effect": ("file_cleanup_without_scope", "file_delete_without_scope"),
+    "future_service_effect": ("service_restart_without_authorization", "process_kill_without_authorization"),
+}
+
+@dataclass(frozen=True)
+class EffectProofValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class EffectReceiptContract:
+    contract_id: str
+    source_rehearsal_receipt_id: str
+    source_rehearsal_receipt_digest: str
+    fulfillment_domain: str
+    backend_class: str
+    effect_domain: str
+    required_proof_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    required_authority_refs: tuple[str, ...]
+    required_precondition_labels: tuple[str, ...]
+    required_postcondition_labels: tuple[str, ...]
+    required_rollback_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_supervisor_labels: tuple[str, ...]
+    status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    contract_only: bool = True
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class FutureEffectReceipt:
+    receipt_id: str
+    contract_id: str
+    source_rehearsal_receipt_id: str
+    source_rehearsal_receipt_digest: str
+    planned_effect_domain: str
+    backend_class: str
+    status: str
+    required_authority_refs: tuple[str, ...]
+    required_precondition_labels: tuple[str, ...]
+    required_postcondition_labels: tuple[str, ...]
+    required_rollback_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_supervisor_labels: tuple[str, ...]
+    expected_effect_summary: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    schema_only: bool = True
+    future_use_only: bool = True
+    effect_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class PostconditionCheckPlan:
+    plan_id: str
+    contract_id: str
+    source_rehearsal_receipt_id: str
+    effect_domain: str
+    postcondition_labels: tuple[str, ...]
+    observation_sources: tuple[str, ...]
+    expected_state_labels: tuple[str, ...]
+    forbidden_state_labels: tuple[str, ...]
+    required_evidence_labels: tuple[str, ...]
+    status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    plan_only: bool = True
+    check_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class PostconditionCheckReceipt:
+    receipt_id: str
+    plan_id: str
+    contract_id: str
+    source_effect_receipt_id_or_placeholder: str
+    observed_postcondition_labels: tuple[str, ...]
+    missing_postcondition_labels: tuple[str, ...]
+    contradicted_postcondition_labels: tuple[str, ...]
+    status: str
+    evidence_summary: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    receipt_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    check_is_schema_or_rehearsal_only: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class RollbackPlan:
+    plan_id: str
+    contract_id: str
+    effect_domain: str
+    rollback_strategy_labels: tuple[str, ...]
+    rollback_preconditions: tuple[str, ...]
+    rollback_steps: tuple[str, ...]
+    rollback_postconditions: tuple[str, ...]
+    rollback_blocked_actions: tuple[str, ...]
+    status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    plan_only: bool = True
+    rollback_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class RollbackReceipt:
+    receipt_id: str
+    plan_id: str
+    contract_id: str
+    source_effect_receipt_id_or_placeholder: str
+    rollback_status: str
+    rollback_evidence_summary: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    receipt_only: bool = True
+    rollback_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    rollback_is_schema_or_rehearsal_only: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class ExecutionReadinessManifest:
+    manifest_id: str
+    source_rehearsal_receipt_id: str
+    source_rehearsal_receipt_digest: str
+    effect_contract_id: str
+    future_effect_receipt_id: str
+    postcondition_plan_id: str
+    rollback_plan_id: str
+    runtime_supervisor_report_id: str | None
+    readiness_status: str
+    effect_domain: str
+    backend_class: str
+    required_proof_gates: tuple[str, ...]
+    satisfied_proof_gates: tuple[str, ...]
+    missing_proof_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    readiness_only: bool = True
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+class ExecutionProofWingRecords(NamedTuple):
+    effect_contract: EffectReceiptContract
+    future_effect_receipt: FutureEffectReceipt
+    postcondition_plan: PostconditionCheckPlan
+    rollback_plan: RollbackPlan
+    execution_readiness_manifest: ExecutionReadinessManifest
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+def _record_digest(record: Any) -> str:
+    payload = record.to_dict()
+    if "digest" in payload:
+        payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+def _source_digest(receipt: Any) -> str:
+    digest = str(getattr(receipt, "digest", "") or "")
+    return digest or actuation_fulfillment_rehearsal_receipt_digest(receipt)
+
+def _effect_domain(receipt: Any) -> str:
+    domain = str(getattr(receipt, "fulfillment_domain", "diagnostics_only") or "diagnostics_only")
+    return _DOMAIN_EFFECT.get(domain, domain if domain in EFFECT_DOMAINS else "diagnostics_only")
+
+def _blocked_actions(source_actions: Sequence[str], effect_domain: str) -> tuple[str, ...]:
+    labels = {_ACTION_LABELS.get(str(action), str(action)) for action in source_actions}
+    labels.update({"host_mutation_without_authorization", "provider_invocation", "network_egress", "prompt_assembly", "federation_transport", "remote_execution"})
+    labels.update(_DOMAIN_REQUIRED_BLOCKS.get(effect_domain, ()))
+    return tuple(sorted(label for label in labels if label in BLOCKED_ACTION_LABELS))
+
+def _source_findings(receipt: Any) -> tuple[str, ...]:
+    findings: list[str] = []
+    if str(getattr(receipt, "rehearsal_status", "")) not in ACTUATION_FULFILLMENT_REHEARSAL_STATUSES:
+        findings.append("source_rehearsal_unknown_status")
+    required_true = {"rehearsal_only": True, "dry_run_only": True, "does_not_execute": True, "does_not_mutate_host": True, "does_not_authorize_fulfillment": True, "effect_not_performed": True}
+    for flag in required_true:
+        if not getattr(receipt, flag, True):
+            findings.append(f"source_rehearsal_claims_authority_or_effect:{flag}")
+    forbidden_false = ("effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "file_delete_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed")
+    for flag in forbidden_false:
+        if getattr(receipt, flag, False):
+            findings.append(f"source_rehearsal_claims_forbidden_effect:{flag}")
+    return tuple(findings)
+
+def _status_kind(rehearsal_status: str, findings: Sequence[str], warnings: Sequence[str]) -> str:
+    if findings or rehearsal_status.endswith("contradicted"):
+        return "contradicted"
+    if rehearsal_status.endswith("incomplete"):
+        return "incomplete"
+    if rehearsal_status.endswith("blocked"):
+        return "blocked"
+    if warnings or rehearsal_status.endswith("with_warnings"):
+        return "conditions"
+    return "ready"
+
+def _contract_status(kind: str) -> str:
+    return {"contradicted":"effect_receipt_contract_contradicted","incomplete":"effect_receipt_contract_incomplete","blocked":"effect_receipt_contract_blocked","conditions":"effect_receipt_contract_ready_with_conditions"}.get(kind, "effect_receipt_contract_ready")
+
+def _future_status(kind: str) -> str:
+    return {"contradicted":"future_effect_receipt_contradicted","incomplete":"future_effect_receipt_incomplete","blocked":"future_effect_receipt_blocked","conditions":"future_effect_receipt_schema_ready_with_conditions"}.get(kind, "future_effect_receipt_schema_ready")
+
+def _plan_status(kind: str, prefix: str) -> str:
+    suffix = {"contradicted":"contradicted","incomplete":"incomplete","blocked":"blocked","conditions":"ready_with_conditions"}.get(kind, "ready")
+    return f"{prefix}_{suffix}"
+
+def _readiness_status(kind: str) -> str:
+    return {"contradicted":"execution_readiness_contradicted","incomplete":"execution_readiness_incomplete","blocked":"execution_readiness_blocked","conditions":"execution_readiness_for_authorization_review_with_conditions"}.get(kind, "execution_readiness_for_authorization_review")
+
+def build_effect_receipt_contract(receipt: Any) -> EffectReceiptContract:
+    source_id = str(getattr(receipt, "receipt_id", ""))
+    source_digest = _source_digest(receipt)
+    effect_domain = _effect_domain(receipt)
+    gates = tuple(sorted(set(getattr(receipt, "required_future_gates", ()) or ()) | set(_DOMAIN_REQUIRED_GATES.get(effect_domain, BASE_PROOF_GATES))))
+    blocked = _blocked_actions(tuple(getattr(receipt, "blocked_actions", ()) or ()), effect_domain)
+    warnings = tuple(sorted(set(getattr(receipt, "warning_codes", ()) or ())))
+    risks = tuple(sorted(set(getattr(receipt, "risk_codes", ()) or ())))
+    findings = _source_findings(receipt)
+    kind = _status_kind(str(getattr(receipt, "rehearsal_status", "")), findings, warnings)
+    if not gates:
+        kind = "incomplete"
+    material = {"source": source_id, "digest": source_digest, "effect_domain": effect_domain, "gates": gates, "blocked": blocked}
+    postconditions = tuple(getattr(receipt, "expected_postconditions", ()) or ("future_effect_postconditions_declared",))
+    rollback = tuple(getattr(receipt, "rollback_requirements", ()) or ("rollback_plan_required",))
+    return EffectReceiptContract(
+        contract_id=_digest_payload("erc_", material), source_rehearsal_receipt_id=source_id, source_rehearsal_receipt_digest=source_digest,
+        fulfillment_domain=str(getattr(receipt, "fulfillment_domain", "diagnostics_only")), backend_class=str(getattr(receipt, "backend_class", "no_backend_required")), effect_domain=effect_domain,
+        required_proof_gates=gates, blocked_actions=blocked, required_authority_refs=tuple(sorted(("control_plane_admission", "operator_or_policy_approval") + _DOMAIN_EXTRA_AUTHORITY.get(effect_domain, ()))),
+        required_precondition_labels=tuple(sorted(("dry_run_rehearsal_receipt", "source_rehearsal_integrity") + _DOMAIN_EXTRA_AUTHORITY.get(effect_domain, ()))),
+        required_postcondition_labels=postconditions, required_rollback_labels=rollback, required_audit_labels=("audit_receipt_required", "immutable_trace_required"), required_supervisor_labels=("runtime_supervisor_observation_required",),
+        status=_contract_status(kind), warning_codes=tuple(sorted(set(warnings + findings))), risk_codes=risks,
+    )
+
+def build_future_effect_receipt_schema(contract: EffectReceiptContract, *, created_at: str = "1970-01-01T00:00:00+00:00") -> FutureEffectReceipt:
+    kind = "ready"
+    if contract.status.endswith("contradicted"): kind = "contradicted"
+    elif contract.status.endswith("incomplete"): kind = "incomplete"
+    elif contract.status.endswith("blocked"): kind = "blocked"
+    elif contract.status.endswith("conditions"): kind = "conditions"
+    material = {"contract": contract.contract_id, "domain": contract.effect_domain, "created_at": created_at}
+    provisional = FutureEffectReceipt(_digest_payload("fers_", material), contract.contract_id, contract.source_rehearsal_receipt_id, contract.source_rehearsal_receipt_digest, contract.effect_domain, contract.backend_class, _future_status(kind), contract.required_authority_refs, contract.required_precondition_labels, contract.required_postcondition_labels, contract.required_rollback_labels, contract.required_audit_labels, contract.required_supervisor_labels, ("schema_placeholder_only", "not_proof_that_effect_occurred"), contract.blocked_actions, contract.warning_codes, contract.risk_codes, created_at, "")
+    return replace(provisional, digest=future_effect_receipt_digest(provisional))
+
+def build_postcondition_check_plan(contract: EffectReceiptContract) -> PostconditionCheckPlan:
+    kind = "contradicted" if contract.status.endswith("contradicted") else "incomplete" if contract.status.endswith("incomplete") else "blocked" if contract.status.endswith("blocked") else "conditions" if contract.status.endswith("conditions") else "ready"
+    labels = contract.required_postcondition_labels or ("future_state_observed",)
+    material = {"contract": contract.contract_id, "labels": labels}
+    return PostconditionCheckPlan(_digest_payload("pcp_", material), contract.contract_id, contract.source_rehearsal_receipt_id, contract.effect_domain, labels, ("runtime_supervisor_snapshot", "effect_receipt", "audit_trace"), tuple(f"expected:{label}" for label in labels), contract.blocked_actions, ("postcondition_evidence_summary", "immutable_trace"), _plan_status(kind, "postcondition_plan"), contract.warning_codes, contract.risk_codes)
+
+def build_postcondition_check_receipt(plan: PostconditionCheckPlan, *, observed_postcondition_labels: Sequence[str] = (), source_effect_receipt_id_or_placeholder: str = "future-effect-receipt-placeholder", created_at: str = "1970-01-01T00:00:00+00:00") -> PostconditionCheckReceipt:
+    observed = tuple(sorted(str(x) for x in observed_postcondition_labels))
+    missing = tuple(label for label in plan.postcondition_labels if label not in observed)
+    status = "postcondition_receipt_recorded" if not missing else "postcondition_receipt_recorded_with_warnings"
+    provisional = PostconditionCheckReceipt(_digest_payload("pcr_", {"plan": plan.plan_id, "observed": observed, "created_at": created_at}), plan.plan_id, plan.contract_id, source_effect_receipt_id_or_placeholder, observed, missing, (), status, ("schema_or_rehearsal_only", "no_effect_verified"), plan.warning_codes, plan.risk_codes, created_at, "")
+    return replace(provisional, digest=postcondition_check_receipt_digest(provisional))
+
+def build_rollback_plan(contract: EffectReceiptContract) -> RollbackPlan:
+    kind = "contradicted" if contract.status.endswith("contradicted") else "incomplete" if contract.status.endswith("incomplete") else "blocked" if contract.status.endswith("blocked") else "conditions" if contract.status.endswith("conditions") else "ready"
+    steps = contract.required_rollback_labels or ("future_rollback_steps_declared",)
+    material = {"contract": contract.contract_id, "steps": steps}
+    return RollbackPlan(_digest_payload("rbp_", material), contract.contract_id, contract.effect_domain, ("restore_prior_state", "operator_review_before_rollback"), ("rollback_authority_required", "effect_receipt_required"), steps, ("rollback_postconditions_checked",), contract.blocked_actions, _plan_status(kind, "rollback_plan"), contract.warning_codes, contract.risk_codes)
+
+def build_rollback_receipt(plan: RollbackPlan, *, source_effect_receipt_id_or_placeholder: str = "future-effect-receipt-placeholder", created_at: str = "1970-01-01T00:00:00+00:00") -> RollbackReceipt:
+    provisional = RollbackReceipt(_digest_payload("rbr_", {"plan": plan.plan_id, "created_at": created_at}), plan.plan_id, plan.contract_id, source_effect_receipt_id_or_placeholder, "rollback_receipt_recorded", ("schema_or_rehearsal_only", "rollback_not_performed"), plan.warning_codes, plan.risk_codes, created_at, "")
+    return replace(provisional, digest=rollback_receipt_digest(provisional))
+
+def build_execution_readiness_manifest(contract: EffectReceiptContract, future_receipt: FutureEffectReceipt, postcondition_plan: PostconditionCheckPlan, rollback_plan: RollbackPlan, *, runtime_supervisor_report: Any | None = None, satisfied_proof_gates: Sequence[str] | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutionReadinessManifest:
+    supplied = set(str(gate) for gate in (satisfied_proof_gates if satisfied_proof_gates is not None else contract.required_proof_gates))
+    if runtime_supervisor_report is not None:
+        supplied.add("runtime_supervisor_observation_required")
+    missing = tuple(sorted(set(contract.required_proof_gates) - supplied))
+    kind = "ready"
+    if contract.status.endswith("contradicted") or future_receipt.status.endswith("contradicted") or postcondition_plan.status.endswith("contradicted") or rollback_plan.status.endswith("contradicted"):
+        kind = "contradicted"
+    elif missing or contract.status.endswith("incomplete"):
+        kind = "incomplete"
+    elif contract.status.endswith("blocked"):
+        kind = "blocked"
+    elif contract.status.endswith("conditions") or future_receipt.status.endswith("conditions"):
+        kind = "conditions"
+    material = {"contract": contract.contract_id, "future": future_receipt.receipt_id, "post": postcondition_plan.plan_id, "rollback": rollback_plan.plan_id, "supervisor": getattr(runtime_supervisor_report, "report_id", None), "created_at": created_at}
+    provisional = ExecutionReadinessManifest(_digest_payload("erm_", material), contract.source_rehearsal_receipt_id, contract.source_rehearsal_receipt_digest, contract.contract_id, future_receipt.receipt_id, postcondition_plan.plan_id, rollback_plan.plan_id, getattr(runtime_supervisor_report, "report_id", None), _readiness_status(kind), contract.effect_domain, contract.backend_class, contract.required_proof_gates, tuple(sorted(supplied & set(contract.required_proof_gates))), missing, contract.blocked_actions, tuple(sorted(set(contract.warning_codes + getattr(runtime_supervisor_report, "warning_codes", ()) ))), tuple(sorted(set(contract.risk_codes + getattr(runtime_supervisor_report, "risk_codes", ())))), created_at, "")
+    return replace(provisional, digest=execution_readiness_manifest_digest(provisional))
+
+def build_execution_proof_wing_for_rehearsal_receipt(receipt: Any, *, runtime_supervisor_report: Any | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutionProofWingRecords:
+    contract = build_effect_receipt_contract(receipt)
+    future_receipt = build_future_effect_receipt_schema(contract, created_at=created_at)
+    postcondition_plan = build_postcondition_check_plan(contract)
+    rollback_plan = build_rollback_plan(contract)
+    manifest = build_execution_readiness_manifest(contract, future_receipt, postcondition_plan, rollback_plan, runtime_supervisor_report=runtime_supervisor_report, created_at=created_at)
+    return ExecutionProofWingRecords(contract, future_receipt, postcondition_plan, rollback_plan, manifest)
+
+# Digest helpers
+def effect_receipt_contract_digest(contract: EffectReceiptContract) -> str: return _record_digest(contract)
+def future_effect_receipt_digest(receipt: FutureEffectReceipt) -> str: return _record_digest(receipt)
+def postcondition_check_plan_digest(plan: PostconditionCheckPlan) -> str: return _record_digest(plan)
+def postcondition_check_receipt_digest(receipt: PostconditionCheckReceipt) -> str: return _record_digest(receipt)
+def rollback_plan_digest(plan: RollbackPlan) -> str: return _record_digest(plan)
+def rollback_receipt_digest(receipt: RollbackReceipt) -> str: return _record_digest(receipt)
+def execution_readiness_manifest_digest(manifest: ExecutionReadinessManifest) -> str: return _record_digest(manifest)
+
+def _validate_common(value: Any, prefix: str) -> list[str]:
+    findings: list[str] = []
+    required_false = ("authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "process_kill_performed", "service_restart_performed", "package_install_performed", "driver_install_performed", "file_cleanup_performed", "file_delete_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed")
+    for flag in required_false:
+        if getattr(value, flag, False):
+            findings.append(f"{prefix}_forbidden_flag:{flag}")
+    for flag in ("metadata_only", "readiness_only", "schema_only", "future_use_only", "does_not_execute", "does_not_mutate_host", "does_not_authorize_fulfillment", "contract_only", "plan_only", "receipt_only"):
+        if hasattr(value, flag) and not getattr(value, flag):
+            findings.append(f"{prefix}_missing_non_effect_flag:{flag}")
+    return findings
+
+def validate_effect_receipt_contract(contract: EffectReceiptContract) -> EffectProofValidationResult:
+    findings = _validate_common(contract, "contract")
+    if not contract.contract_id: findings.append("missing_contract_id")
+    if contract.effect_domain not in EFFECT_DOMAINS: findings.append("unknown_effect_domain")
+    if contract.backend_class not in EFFECT_BACKEND_CLASSES: findings.append("unknown_backend_class")
+    if contract.status not in EFFECT_RECEIPT_CONTRACT_STATUSES: findings.append("unknown_contract_status")
+    for gate in BASE_PROOF_GATES:
+        if gate not in contract.required_proof_gates: findings.append(f"contract_missing_base_gate:{gate}")
+    for label in _DOMAIN_REQUIRED_BLOCKS.get(contract.effect_domain, ()):
+        if label not in contract.blocked_actions: findings.append(f"contract_missing_blocked_action:{label}")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_future_effect_receipt_schema(receipt: FutureEffectReceipt) -> EffectProofValidationResult:
+    findings = _validate_common(receipt, "future_receipt")
+    if receipt.status not in FUTURE_EFFECT_RECEIPT_STATUSES: findings.append("unknown_future_receipt_status")
+    if receipt.digest and receipt.digest != future_effect_receipt_digest(receipt): findings.append("future_receipt_digest_mismatch")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_postcondition_check_plan(plan: PostconditionCheckPlan) -> EffectProofValidationResult:
+    findings = _validate_common(plan, "postcondition_plan")
+    if plan.status not in POSTCONDITION_STATUSES: findings.append("unknown_postcondition_plan_status")
+    if not plan.postcondition_labels: findings.append("missing_postcondition_labels")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_postcondition_check_receipt(receipt: PostconditionCheckReceipt) -> EffectProofValidationResult:
+    findings = _validate_common(receipt, "postcondition_receipt")
+    if receipt.status not in POSTCONDITION_STATUSES: findings.append("unknown_postcondition_receipt_status")
+    if receipt.digest and receipt.digest != postcondition_check_receipt_digest(receipt): findings.append("postcondition_receipt_digest_mismatch")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_rollback_plan(plan: RollbackPlan) -> EffectProofValidationResult:
+    findings = _validate_common(plan, "rollback_plan")
+    if plan.status not in ROLLBACK_STATUSES: findings.append("unknown_rollback_plan_status")
+    if not plan.rollback_steps: findings.append("missing_rollback_steps")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_rollback_receipt(receipt: RollbackReceipt) -> EffectProofValidationResult:
+    findings = _validate_common(receipt, "rollback_receipt")
+    if receipt.rollback_status not in ROLLBACK_STATUSES: findings.append("unknown_rollback_receipt_status")
+    if receipt.digest and receipt.digest != rollback_receipt_digest(receipt): findings.append("rollback_receipt_digest_mismatch")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def validate_execution_readiness_manifest(manifest: ExecutionReadinessManifest) -> EffectProofValidationResult:
+    findings = _validate_common(manifest, "readiness_manifest")
+    if manifest.readiness_status not in EXECUTION_READINESS_STATUSES: findings.append("unknown_readiness_status")
+    if manifest.digest and manifest.digest != execution_readiness_manifest_digest(manifest): findings.append("readiness_digest_mismatch")
+    missing = tuple(sorted(set(manifest.required_proof_gates) - set(manifest.satisfied_proof_gates)))
+    if tuple(manifest.missing_proof_gates) != missing: findings.append("readiness_missing_gate_mismatch")
+    if missing and manifest.readiness_status not in {"execution_readiness_incomplete", "execution_readiness_blocked", "execution_readiness_contradicted"}: findings.append("readiness_missing_gates_not_blocked_or_incomplete")
+    return EffectProofValidationResult(not findings, tuple(findings))
+
+def summarize_effect_receipt_contract(contract: EffectReceiptContract) -> dict[str, Any]: return {"contract_id": contract.contract_id, "effect_domain": contract.effect_domain, "backend_class": contract.backend_class, "status": contract.status, "proof_gate_count": len(contract.required_proof_gates), "blocked_action_count": len(contract.blocked_actions), "metadata_only": contract.metadata_only, "contract_only": contract.contract_only, "effect_performed": contract.effect_performed, "host_mutation_performed": contract.host_mutation_performed, "authorization_granted": contract.authorization_granted, "fulfillment_granted": contract.fulfillment_granted}
+def summarize_future_effect_receipt_schema(receipt: FutureEffectReceipt) -> dict[str, Any]: return {"receipt_id": receipt.receipt_id, "contract_id": receipt.contract_id, "planned_effect_domain": receipt.planned_effect_domain, "status": receipt.status, "schema_only": receipt.schema_only, "future_use_only": receipt.future_use_only, "effect_performed": receipt.effect_performed, "does_not_execute": receipt.does_not_execute, "does_not_mutate_host": receipt.does_not_mutate_host, "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment}
+def summarize_postcondition_check_plan(plan: PostconditionCheckPlan) -> dict[str, Any]: return {"plan_id": plan.plan_id, "contract_id": plan.contract_id, "effect_domain": plan.effect_domain, "status": plan.status, "metadata_only": plan.metadata_only, "plan_only": plan.plan_only, "check_performed": plan.check_performed, "host_mutation_performed": plan.host_mutation_performed}
+def summarize_postcondition_check_receipt(receipt: PostconditionCheckReceipt) -> dict[str, Any]: return {"receipt_id": receipt.receipt_id, "plan_id": receipt.plan_id, "status": receipt.status, "receipt_only": receipt.receipt_only, "does_not_execute": receipt.does_not_execute, "does_not_mutate_host": receipt.does_not_mutate_host, "check_is_schema_or_rehearsal_only": receipt.check_is_schema_or_rehearsal_only}
+def summarize_rollback_plan(plan: RollbackPlan) -> dict[str, Any]: return {"plan_id": plan.plan_id, "contract_id": plan.contract_id, "effect_domain": plan.effect_domain, "status": plan.status, "metadata_only": plan.metadata_only, "plan_only": plan.plan_only, "rollback_performed": plan.rollback_performed, "host_mutation_performed": plan.host_mutation_performed}
+def summarize_rollback_receipt(receipt: RollbackReceipt) -> dict[str, Any]: return {"receipt_id": receipt.receipt_id, "plan_id": receipt.plan_id, "rollback_status": receipt.rollback_status, "receipt_only": receipt.receipt_only, "rollback_performed": receipt.rollback_performed, "does_not_execute": receipt.does_not_execute, "does_not_mutate_host": receipt.does_not_mutate_host, "rollback_is_schema_or_rehearsal_only": receipt.rollback_is_schema_or_rehearsal_only}
+def summarize_execution_readiness_manifest(manifest: ExecutionReadinessManifest) -> dict[str, Any]: return {"manifest_id": manifest.manifest_id, "effect_contract_id": manifest.effect_contract_id, "future_effect_receipt_id": manifest.future_effect_receipt_id, "readiness_status": manifest.readiness_status, "effect_domain": manifest.effect_domain, "metadata_only": manifest.metadata_only, "readiness_only": manifest.readiness_only, "authorization_granted": manifest.authorization_granted, "fulfillment_granted": manifest.fulfillment_granted, "effect_performed": manifest.effect_performed, "host_mutation_performed": manifest.host_mutation_performed, "missing_proof_gate_count": len(manifest.missing_proof_gates)}

--- a/sentientos/runtime_supervisor.py
+++ b/sentientos/runtime_supervisor.py
@@ -1,0 +1,184 @@
+"""Metadata-only runtime supervisor scaffold for SentientOS.
+
+The supervisor records supplied service telemetry and readiness evidence for
+future host effects. It does not inspect privileged live services, restart or
+stop services, kill processes, install packages, alter service managers, mutate
+host state, or perform network activity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+SERVICE_STATUSES = frozenset({"service_status_nominal", "service_status_degraded", "service_status_unknown", "service_status_unavailable", "service_status_blocked", "service_status_contradicted"})
+SUPERVISOR_STATUSES = frozenset({"runtime_supervisor_snapshot_recorded", "runtime_supervisor_snapshot_recorded_with_warnings", "runtime_supervisor_snapshot_incomplete", "runtime_supervisor_snapshot_contradicted", "runtime_supervisor_readiness_ready_for_review", "runtime_supervisor_readiness_ready_with_conditions", "runtime_supervisor_readiness_blocked", "runtime_supervisor_readiness_incomplete", "runtime_supervisor_readiness_contradicted"})
+REQUIRED_SUPERVISOR_GATES = ("runtime_supervisor_observation_required", "service_scope_required", "postcondition_check_required", "audit_receipt_required")
+
+@dataclass(frozen=True)
+class RuntimeSupervisorValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class RuntimeServiceRecord:
+    service_id: str
+    service_label: str
+    service_kind: str
+    observed_status: str
+    desired_status_label: str
+    health_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    restart_supported: bool = False
+    restart_authorized: bool = False
+    stop_authorized: bool = False
+    kill_authorized: bool = False
+    host_mutation_performed: bool = False
+    telemetry_only: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class RuntimeSupervisorSnapshot:
+    snapshot_id: str
+    node_id: str
+    host_id: str
+    service_records: tuple[RuntimeServiceRecord, ...]
+    observed_at: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    telemetry_only: bool = True
+    host_mutation_performed: bool = False
+    service_restart_performed: bool = False
+    process_kill_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class RuntimeSupervisorReadinessReport:
+    report_id: str
+    snapshot_id: str
+    related_execution_readiness_manifest_id: str | None
+    service_summary_counts: Mapping[str, int]
+    degraded_service_ids: tuple[str, ...]
+    blocked_service_ids: tuple[str, ...]
+    supervisor_status: str
+    required_future_gates: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    readiness_only: bool = True
+    restart_authorized: bool = False
+    kill_authorized: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+def _record_digest(record: Any) -> str:
+    payload = record.to_dict()
+    if "digest" in payload:
+        payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+def build_runtime_supervisor_snapshot(*, service_records: Sequence[RuntimeServiceRecord], snapshot_id: str | None = None, node_id: str = "local-node", host_id: str = "local-host", observed_at: str = "1970-01-01T00:00:00+00:00", warning_codes: Sequence[str] = (), risk_codes: Sequence[str] = ()) -> RuntimeSupervisorSnapshot:
+    records = tuple(service_records)
+    warnings = set(str(code) for code in warning_codes)
+    risks = set(str(code) for code in risk_codes)
+    for record in records:
+        warnings.update(record.warning_codes)
+        risks.update(record.risk_codes)
+        if record.observed_status in {"service_status_unknown", "service_status_unavailable"}:
+            warnings.add(f"service_observation_{record.observed_status}:{record.service_id}")
+        if record.observed_status in {"service_status_blocked", "service_status_contradicted"}:
+            risks.add(f"service_observation_{record.observed_status}:{record.service_id}")
+    material = {"node_id": node_id, "host_id": host_id, "records": [record.to_dict() for record in records], "observed_at": observed_at}
+    return RuntimeSupervisorSnapshot(snapshot_id or _digest_payload("rss_", material), node_id, host_id, records, observed_at, tuple(sorted(warnings)), tuple(sorted(risks)))
+
+def build_runtime_supervisor_readiness_report(snapshot: RuntimeSupervisorSnapshot, *, related_execution_readiness_manifest_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> RuntimeSupervisorReadinessReport:
+    counts: dict[str, int] = {status: 0 for status in sorted(SERVICE_STATUSES)}
+    degraded: list[str] = []
+    blocked: list[str] = []
+    warnings = set(snapshot.warning_codes)
+    risks = set(snapshot.risk_codes)
+    contradicted = False
+    for record in snapshot.service_records:
+        counts[record.observed_status] = counts.get(record.observed_status, 0) + 1
+        if record.restart_authorized or record.stop_authorized or record.kill_authorized or record.host_mutation_performed:
+            contradicted = True
+            risks.add(f"service_record_claims_runtime_authority:{record.service_id}")
+        if record.observed_status == "service_status_degraded":
+            degraded.append(record.service_id)
+        if record.observed_status in {"service_status_blocked", "service_status_unavailable"}:
+            blocked.append(record.service_id)
+        if record.observed_status == "service_status_unknown":
+            warnings.add(f"service_status_unknown:{record.service_id}")
+    if snapshot.host_mutation_performed or snapshot.service_restart_performed or snapshot.process_kill_performed:
+        contradicted = True
+        risks.add("snapshot_claims_host_mutation_or_service_action")
+    if contradicted:
+        status = "runtime_supervisor_readiness_contradicted"
+    elif blocked:
+        status = "runtime_supervisor_readiness_blocked"
+    elif degraded or warnings:
+        status = "runtime_supervisor_readiness_ready_with_conditions"
+    else:
+        status = "runtime_supervisor_readiness_ready_for_review"
+    material = {"snapshot": snapshot.snapshot_id, "manifest": related_execution_readiness_manifest_id, "created_at": created_at, "status": status}
+    provisional = RuntimeSupervisorReadinessReport(_digest_payload("rsr_", material), snapshot.snapshot_id, related_execution_readiness_manifest_id, counts, tuple(sorted(degraded)), tuple(sorted(blocked)), status, REQUIRED_SUPERVISOR_GATES, tuple(sorted(warnings)), tuple(sorted(risks)), created_at, "")
+    return replace(provisional, digest=runtime_supervisor_readiness_digest(provisional))
+
+def validate_runtime_service_record(record: RuntimeServiceRecord) -> RuntimeSupervisorValidationResult:
+    findings: list[str] = []
+    if not record.service_id: findings.append("missing_service_id")
+    if record.observed_status not in SERVICE_STATUSES: findings.append("unknown_service_status")
+    if not record.telemetry_only: findings.append("service_record_not_telemetry_only")
+    if record.restart_authorized: findings.append("service_record_claims_restart_authorization")
+    if record.stop_authorized: findings.append("service_record_claims_stop_authorization")
+    if record.kill_authorized: findings.append("service_record_claims_kill_authorization")
+    if record.host_mutation_performed: findings.append("service_record_claims_host_mutation")
+    return RuntimeSupervisorValidationResult(not findings, tuple(findings))
+
+def validate_runtime_supervisor_snapshot(snapshot: RuntimeSupervisorSnapshot) -> RuntimeSupervisorValidationResult:
+    findings: list[str] = []
+    if not snapshot.snapshot_id: findings.append("missing_snapshot_id")
+    if not snapshot.metadata_only or not snapshot.telemetry_only: findings.append("snapshot_not_metadata_telemetry_only")
+    if snapshot.host_mutation_performed: findings.append("snapshot_claims_host_mutation")
+    if snapshot.service_restart_performed: findings.append("snapshot_claims_service_restart")
+    if snapshot.process_kill_performed: findings.append("snapshot_claims_process_kill")
+    for record in snapshot.service_records:
+        result = validate_runtime_service_record(record)
+        if not result.ok:
+            findings.extend(f"service:{record.service_id}:{finding}" for finding in result.findings)
+    return RuntimeSupervisorValidationResult(not findings, tuple(findings))
+
+def validate_runtime_supervisor_readiness_report(report: RuntimeSupervisorReadinessReport) -> RuntimeSupervisorValidationResult:
+    findings: list[str] = []
+    if not report.report_id: findings.append("missing_report_id")
+    if report.supervisor_status not in SUPERVISOR_STATUSES: findings.append("unknown_supervisor_status")
+    if report.digest and report.digest != runtime_supervisor_readiness_digest(report): findings.append("runtime_supervisor_readiness_digest_mismatch")
+    if not report.metadata_only or not report.readiness_only: findings.append("report_not_metadata_readiness_only")
+    if report.restart_authorized: findings.append("report_claims_restart_authorization")
+    if report.kill_authorized: findings.append("report_claims_kill_authorization")
+    if report.host_mutation_performed: findings.append("report_claims_host_mutation")
+    return RuntimeSupervisorValidationResult(not findings, tuple(findings))
+
+def runtime_supervisor_snapshot_digest(snapshot: RuntimeSupervisorSnapshot) -> str:
+    return _record_digest(snapshot)
+
+def runtime_supervisor_readiness_digest(report: RuntimeSupervisorReadinessReport) -> str:
+    return _record_digest(report)
+
+def summarize_runtime_supervisor_snapshot(snapshot: RuntimeSupervisorSnapshot) -> dict[str, Any]:
+    return {"snapshot_id": snapshot.snapshot_id, "node_id": snapshot.node_id, "host_id": snapshot.host_id, "service_count": len(snapshot.service_records), "metadata_only": snapshot.metadata_only, "telemetry_only": snapshot.telemetry_only, "host_mutation_performed": snapshot.host_mutation_performed, "service_restart_performed": snapshot.service_restart_performed, "process_kill_performed": snapshot.process_kill_performed}
+
+def summarize_runtime_supervisor_readiness_report(report: RuntimeSupervisorReadinessReport) -> dict[str, Any]:
+    return {"report_id": report.report_id, "snapshot_id": report.snapshot_id, "supervisor_status": report.supervisor_status, "degraded_service_ids": report.degraded_service_ids, "blocked_service_ids": report.blocked_service_ids, "metadata_only": report.metadata_only, "readiness_only": report.readiness_only, "restart_authorized": report.restart_authorized, "kill_authorized": report.kill_authorized, "host_mutation_performed": report.host_mutation_performed}

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -208,3 +208,41 @@ def test_phase5_registry_represents_actuation_fulfillment_as_rehearsal_only() ->
     assert records["real_actuation_fulfillment"].host_actuation_performed is False
     assert records["direct_fan_pwm_thermal_control"].status == "blocked"
     assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_execution_proof_wing_capabilities_are_proof_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["effect_receipt_contract"].status == "implemented"
+    assert records["effect_receipt_contract"].authority_level == "proof_only"
+    assert records["postcondition_checks"].authority_level == "proof_only"
+    assert records["rollback_planning"].authority_level == "proof_only"
+    assert records["runtime_supervisor"].authority_level == "telemetry_readiness_only"
+    assert records["execution_readiness_manifest"].authority_level == "readiness_only"
+    for capability_id in ["real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"]:
+        assert records[capability_id].status == "deferred"
+    for capability_id in ["real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_updates_from_execution_readiness_and_supervisor_keep_real_actions_blocked() -> None:
+    from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+    from sentientos.capability_registry import update_registry_from_execution_readiness_manifest, update_registry_from_runtime_supervisor_report
+    from sentientos.effect_proof import build_execution_proof_wing_for_rehearsal_receipt
+    from sentientos.runtime_supervisor import RuntimeServiceRecord, build_runtime_supervisor_readiness_report, build_runtime_supervisor_snapshot
+    from tests.test_actuation_fulfillment import _broker_receipt_for
+
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95)))
+    manifest = build_execution_proof_wing_for_rehearsal_receipt(rehearsal).execution_readiness_manifest
+    service = RuntimeServiceRecord("svc", "svc", "daemon", "service_status_nominal", "desired_nominal", (), (), ())
+    report = build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(service,)))
+    registry = update_registry_from_runtime_supervisor_report(update_registry_from_execution_readiness_manifest(build_default_capability_registry(), manifest), report)
+    records = registry.by_id()
+    assert records["execution_readiness_manifest"].status == "implemented"
+    assert records["runtime_supervisor"].status == "implemented"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
+    assert records["real_effect_execution"].status == "deferred"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_effect_proof.py
+++ b/tests/test_effect_proof.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+from sentientos.effect_proof import (
+    build_effect_receipt_contract,
+    build_execution_proof_wing_for_rehearsal_receipt,
+    build_execution_readiness_manifest,
+    build_future_effect_receipt_schema,
+    build_postcondition_check_plan,
+    build_postcondition_check_receipt,
+    build_rollback_plan,
+    build_rollback_receipt,
+    effect_receipt_contract_digest,
+    execution_readiness_manifest_digest,
+    future_effect_receipt_digest,
+    postcondition_check_plan_digest,
+    postcondition_check_receipt_digest,
+    rollback_plan_digest,
+    rollback_receipt_digest,
+    summarize_effect_receipt_contract,
+    summarize_execution_readiness_manifest,
+    summarize_future_effect_receipt_schema,
+    summarize_postcondition_check_plan,
+    summarize_postcondition_check_receipt,
+    summarize_rollback_plan,
+    summarize_rollback_receipt,
+    validate_effect_receipt_contract,
+    validate_execution_readiness_manifest,
+    validate_future_effect_receipt_schema,
+    validate_postcondition_check_plan,
+    validate_postcondition_check_receipt,
+    validate_rollback_plan,
+    validate_rollback_receipt,
+)
+from tests.test_actuation_fulfillment import _broker_receipt_for
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _rehearsal(kind: str, **kwargs):
+    return build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for(kind, **kwargs)))
+
+
+def test_valid_phase5_rehearsal_builds_execution_proof_wing() -> None:
+    wing = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30))
+    assert wing.effect_contract.status == "effect_receipt_contract_ready"
+    assert wing.future_effect_receipt.status == "future_effect_receipt_schema_ready"
+    assert wing.postcondition_plan.status == "postcondition_plan_ready"
+    assert wing.rollback_plan.status == "rollback_plan_ready"
+    assert wing.execution_readiness_manifest.readiness_status == "execution_readiness_for_authorization_review"
+    assert validate_effect_receipt_contract(wing.effect_contract).ok
+    assert validate_future_effect_receipt_schema(wing.future_effect_receipt).ok
+    assert validate_postcondition_check_plan(wing.postcondition_plan).ok
+    assert validate_rollback_plan(wing.rollback_plan).ok
+    assert validate_execution_readiness_manifest(wing.execution_readiness_manifest).ok
+
+
+@pytest.mark.parametrize(
+    ("source_status", "expected"),
+    [
+        ("actuation_fulfillment_rehearsal_blocked", "execution_readiness_blocked"),
+        ("actuation_fulfillment_rehearsal_incomplete", "execution_readiness_incomplete"),
+        ("actuation_fulfillment_rehearsal_contradicted", "execution_readiness_contradicted"),
+    ],
+)
+def test_blocked_incomplete_contradicted_rehearsal_status_flows_to_readiness(source_status: str, expected: str) -> None:
+    rehearsal = replace(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95), rehearsal_status=source_status)
+    wing = build_execution_proof_wing_for_rehearsal_receipt(rehearsal)
+    assert wing.execution_readiness_manifest.readiness_status == expected
+
+
+def test_future_cooling_rehearsal_requires_cooling_gates_and_keeps_control_blocked() -> None:
+    rehearsal = _rehearsal("future_cooling_policy_candidate", recorded=True, thermal_zone_temperatures_c={"cpu": 90})
+    wing = build_execution_proof_wing_for_rehearsal_receipt(rehearsal)
+    gates = set(wing.effect_contract.required_proof_gates)
+    for gate in ["hardware_allowlist_required", "os_backend_declaration_required", "bounds_policy_required", "cooldown_policy_required", "panic_stop_required", "postcondition_check_required", "rollback_plan_required", "rollback_receipt_required", "audit_receipt_required", "runtime_supervisor_observation_required", "immutable_trace_required"]:
+        assert gate in gates
+    assert "fan_pwm_write_without_allowlist" in wing.effect_contract.blocked_actions
+    assert "thermal_actuation_without_policy" in wing.effect_contract.blocked_actions
+
+
+def test_future_power_cleanup_and_service_rehearsals_keep_mutations_blocked() -> None:
+    power = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("future_power_policy_candidate", recorded=True, battery_percent=5, battery_charging=False))
+    cleanup = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("future_cleanup_policy_candidate", recorded=True, disk_utilization_percent=95))
+    service = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("inspect_service_health_candidate", service_health_labels=("daemon_degraded",)))
+    assert "power_profile_mutation_without_policy" in power.effect_contract.blocked_actions
+    assert {"file_cleanup_without_scope", "file_delete_without_scope"}.issubset(cleanup.effect_contract.blocked_actions)
+    assert "service_restart_without_authorization" in service.effect_contract.blocked_actions
+    assert power.execution_readiness_manifest.authorization_granted is False
+    assert cleanup.execution_readiness_manifest.effect_performed is False
+    assert service.execution_readiness_manifest.host_mutation_performed is False
+
+
+def test_readiness_future_receipts_postconditions_and_rollback_remain_non_effects() -> None:
+    wing = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95))
+    post_receipt = build_postcondition_check_receipt(wing.postcondition_plan)
+    rollback_receipt = build_rollback_receipt(wing.rollback_plan)
+    assert wing.execution_readiness_manifest.authorization_granted is False
+    assert wing.execution_readiness_manifest.fulfillment_granted is False
+    assert wing.future_effect_receipt.schema_only is True
+    assert wing.future_effect_receipt.effect_performed is False
+    assert post_receipt.check_is_schema_or_rehearsal_only is True
+    assert rollback_receipt.rollback_is_schema_or_rehearsal_only is True
+    assert validate_postcondition_check_receipt(post_receipt).ok
+    assert validate_rollback_receipt(rollback_receipt).ok
+
+
+def test_digests_are_deterministic_for_all_records_and_summaries_metadata_only() -> None:
+    wing = build_execution_proof_wing_for_rehearsal_receipt(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95))
+    post_receipt = build_postcondition_check_receipt(wing.postcondition_plan)
+    rollback_receipt = build_rollback_receipt(wing.rollback_plan)
+    assert effect_receipt_contract_digest(wing.effect_contract) == effect_receipt_contract_digest(wing.effect_contract)
+    assert future_effect_receipt_digest(wing.future_effect_receipt) == wing.future_effect_receipt.digest
+    assert postcondition_check_plan_digest(wing.postcondition_plan) == postcondition_check_plan_digest(wing.postcondition_plan)
+    assert postcondition_check_receipt_digest(post_receipt) == post_receipt.digest
+    assert rollback_plan_digest(wing.rollback_plan) == rollback_plan_digest(wing.rollback_plan)
+    assert rollback_receipt_digest(rollback_receipt) == rollback_receipt.digest
+    assert execution_readiness_manifest_digest(wing.execution_readiness_manifest) == wing.execution_readiness_manifest.digest
+    assert summarize_effect_receipt_contract(wing.effect_contract)["metadata_only"] is True
+    assert summarize_future_effect_receipt_schema(wing.future_effect_receipt)["schema_only"] is True
+    assert summarize_postcondition_check_plan(wing.postcondition_plan)["metadata_only"] is True
+    assert summarize_postcondition_check_receipt(post_receipt)["receipt_only"] is True
+    assert summarize_rollback_plan(wing.rollback_plan)["metadata_only"] is True
+    assert summarize_rollback_receipt(rollback_receipt)["receipt_only"] is True
+    assert summarize_execution_readiness_manifest(wing.execution_readiness_manifest)["readiness_only"] is True
+
+
+@pytest.mark.parametrize("flag", ["authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed"])
+def test_validation_rejects_authority_effect_and_forbidden_flags(flag: str) -> None:
+    contract = build_effect_receipt_contract(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95))
+    bad = replace(contract, **{flag: True}) if hasattr(contract, flag) else contract
+    result = validate_effect_receipt_contract(bad)
+    if hasattr(contract, flag):
+        assert not result.ok
+
+
+def test_source_rehearsal_claiming_effect_or_host_mutation_contradicts_readiness() -> None:
+    rehearsal = replace(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95), effect_not_performed=False)
+    wing = build_execution_proof_wing_for_rehearsal_receipt(rehearsal)
+    assert wing.execution_readiness_manifest.readiness_status == "execution_readiness_contradicted"
+
+
+def test_missing_proof_gates_produce_incomplete_readiness() -> None:
+    contract = build_effect_receipt_contract(_rehearsal("inspect_cpu_pressure_candidate", cpu_utilization_percent=95))
+    future = build_future_effect_receipt_schema(contract)
+    post = build_postcondition_check_plan(contract)
+    rollback = build_rollback_plan(contract)
+    manifest = build_execution_readiness_manifest(contract, future, post, rollback, satisfied_proof_gates=("audit_receipt_required",))
+    assert manifest.readiness_status == "execution_readiness_incomplete"
+    assert manifest.missing_proof_gates
+    assert validate_execution_readiness_manifest(manifest).ok
+
+
+def test_full_non_mutating_pipeline_from_collector_to_execution_readiness() -> None:
+    from sentientos.host_collectors import collect_thermal_sensor_observation
+    from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, evaluate_host_resource_pressure
+    from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy
+    from sentientos.privilege_broker import build_privilege_broker_review_receipt, evaluate_privilege_broker_eligibility
+
+    result = collect_thermal_sensor_observation(
+        thermal_path="/thermal",
+        directory_lister=lambda path: ("thermal_zone0",) if path == "/thermal" else (),
+        text_reader=lambda path: "90000\n" if path.endswith("temp") else "x86_pkg_temp\n",
+        observed_at="2026-01-01T00:00:00+00:00",
+    )
+    snapshot = build_host_resource_telemetry_from_collector_results((result,), snapshot_id="collector-snap")
+    pressure = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=80)
+    decision = evaluate_host_resource_policy(pressure)
+    proposal = {receipt.proposal_kind: receipt for receipt in build_host_resource_proposal_receipts(decision)}["future_cooling_policy_candidate"]
+    broker = build_privilege_broker_review_receipt(evaluate_privilege_broker_eligibility(proposal))
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(broker))
+    wing = build_execution_proof_wing_for_rehearsal_receipt(rehearsal)
+
+    assert wing.effect_contract.effect_performed is False
+    assert wing.execution_readiness_manifest.host_mutation_performed is False
+    assert "fan_pwm_write_without_allowlist" in wing.execution_readiness_manifest.blocked_actions
+    assert "thermal_actuation_without_policy" in wing.execution_readiness_manifest.blocked_actions
+    assert "power_profile_mutation_without_policy" in wing.execution_readiness_manifest.blocked_actions
+    assert "service_restart_without_authorization" in wing.execution_readiness_manifest.blocked_actions
+    assert "file_cleanup_without_scope" in wing.execution_readiness_manifest.blocked_actions
+    assert "provider_invocation" in wing.execution_readiness_manifest.blocked_actions
+    assert "network_egress" in wing.execution_readiness_manifest.blocked_actions
+    assert "prompt_assembly" in wing.execution_readiness_manifest.blocked_actions
+    assert wing.execution_readiness_manifest.authorization_granted is False

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -202,3 +202,29 @@ def test_phase5_doc_preserves_actuation_fulfillment_scaffold_boundaries() -> Non
     assert "operator/policy approval" in phase5
     assert "effect receipt" in phase5
     assert "postcondition check" in phase5
+
+HOST_EMBODIMENT_EXECUTION_PROOF_WING = "docs/architecture/host_embodiment_execution_proof_wing.md"
+
+
+def test_navigation_links_to_host_embodiment_execution_proof_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase1 = _read(HOST_EMBODIMENT_PHASE1)
+    phase2 = _read(HOST_EMBODIMENT_PHASE2)
+    phase3 = _read(HOST_EMBODIMENT_PHASE3)
+    phase4 = _read(HOST_EMBODIMENT_PHASE4)
+    phase5 = _read(HOST_EMBODIMENT_PHASE5)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, phase1, phase2, phase3, phase4, phase5, trajectory]:
+        assert HOST_EMBODIMENT_EXECUTION_PROOF_WING in text
+
+
+def test_execution_proof_wing_doc_preserves_readiness_boundaries() -> None:
+    doc = _read(HOST_EMBODIMENT_EXECUTION_PROOF_WING)
+    assert "Execution Readiness Manifest is not authorization" in doc
+    assert "future effect receipt schema is not proof that an effect occurred" in doc
+    assert "does not restart services" in doc
+    assert "does not kill processes" in doc
+    assert "Real actuation remains deferred" in doc
+    for term in ["Effect Receipt", "Postcondition Check", "Rollback Plan", "RollbackReceipt", "Runtime Supervisor", "Execution Readiness Manifest"]:
+        assert term in doc

--- a/tests/test_runtime_supervisor.py
+++ b/tests/test_runtime_supervisor.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.runtime_supervisor import (
+    RuntimeServiceRecord,
+    build_runtime_supervisor_readiness_report,
+    build_runtime_supervisor_snapshot,
+    runtime_supervisor_readiness_digest,
+    runtime_supervisor_snapshot_digest,
+    summarize_runtime_supervisor_readiness_report,
+    summarize_runtime_supervisor_snapshot,
+    validate_runtime_service_record,
+    validate_runtime_supervisor_readiness_report,
+    validate_runtime_supervisor_snapshot,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _record(service_id: str = "svc", status: str = "service_status_nominal") -> RuntimeServiceRecord:
+    return RuntimeServiceRecord(service_id, service_id, "daemon", status, "desired_nominal", ("healthy",), (), ())
+
+
+def test_clean_supplied_service_records_produce_snapshot_and_readiness() -> None:
+    snapshot = build_runtime_supervisor_snapshot(service_records=(_record(),), snapshot_id="snap")
+    report = build_runtime_supervisor_readiness_report(snapshot)
+    assert report.supervisor_status == "runtime_supervisor_readiness_ready_for_review"
+    assert report.restart_authorized is False
+    assert report.kill_authorized is False
+    assert validate_runtime_supervisor_snapshot(snapshot).ok
+    assert validate_runtime_supervisor_readiness_report(report).ok
+
+
+def test_degraded_service_produces_conditions_not_restart() -> None:
+    snapshot = build_runtime_supervisor_snapshot(service_records=(_record("svc-deg", "service_status_degraded"),))
+    report = build_runtime_supervisor_readiness_report(snapshot)
+    assert report.supervisor_status == "runtime_supervisor_readiness_ready_with_conditions"
+    assert report.degraded_service_ids == ("svc-deg",)
+    assert report.restart_authorized is False
+
+
+def test_unavailable_and_unknown_services_warn_or_block() -> None:
+    unknown = build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(_record("svc-u", "service_status_unknown"),)))
+    unavailable = build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(_record("svc-x", "service_status_unavailable"),)))
+    assert unknown.supervisor_status == "runtime_supervisor_readiness_ready_with_conditions"
+    assert any("unknown" in code for code in unknown.warning_codes)
+    assert unavailable.supervisor_status == "runtime_supervisor_readiness_blocked"
+
+
+def test_service_record_claiming_restart_or_kill_authorization_is_contradicted() -> None:
+    restart = replace(_record(), restart_authorized=True)
+    kill = replace(_record("kill"), kill_authorized=True)
+    assert not validate_runtime_service_record(restart).ok
+    assert not validate_runtime_service_record(kill).ok
+    report = build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(restart, kill)))
+    assert report.supervisor_status == "runtime_supervisor_readiness_contradicted"
+
+
+def test_snapshot_and_report_claiming_mutation_are_rejected() -> None:
+    snapshot = replace(build_runtime_supervisor_snapshot(service_records=(_record(),)), host_mutation_performed=True)
+    assert not validate_runtime_supervisor_snapshot(snapshot).ok
+    report = replace(build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(_record(),))), restart_authorized=True)
+    assert not validate_runtime_supervisor_readiness_report(report).ok
+
+
+def test_supervisor_report_can_be_referenced_by_execution_readiness_manifest() -> None:
+    from sentientos.effect_proof import build_execution_proof_wing_for_rehearsal_receipt
+    from tests.test_actuation_fulfillment import _broker_receipt_for
+    from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for("inspect_service_health_candidate", service_health_labels=("daemon_degraded",))))
+    report = build_runtime_supervisor_readiness_report(build_runtime_supervisor_snapshot(service_records=(_record(),)))
+    wing = build_execution_proof_wing_for_rehearsal_receipt(rehearsal, runtime_supervisor_report=report)
+    assert wing.execution_readiness_manifest.runtime_supervisor_report_id == report.report_id
+    assert wing.execution_readiness_manifest.authorization_granted is False
+
+
+def test_runtime_supervisor_digests_are_deterministic_and_summaries_metadata_only() -> None:
+    snapshot = build_runtime_supervisor_snapshot(service_records=(_record(),), snapshot_id="snap")
+    report = build_runtime_supervisor_readiness_report(snapshot)
+    assert runtime_supervisor_snapshot_digest(snapshot) == runtime_supervisor_snapshot_digest(snapshot)
+    assert runtime_supervisor_readiness_digest(report) == runtime_supervisor_readiness_digest(report)
+    assert summarize_runtime_supervisor_snapshot(snapshot)["metadata_only"] is True
+    summary = summarize_runtime_supervisor_readiness_report(report)
+    assert summary["metadata_only"] is True
+    assert summary["restart_authorized"] is False


### PR DESCRIPTION
### Motivation

- Add a non-actuating, proof/readiness wing after Phase 5 so future real host effects can only proceed when deterministic proof artifacts exist. 
- Capture the contracts and evidence a future effect must produce (effect receipt contract, future receipt schema, postcondition plans/receipts, rollback plans/receipts, execution readiness manifest) without performing any host mutation. 
- Provide a telemetry/readiness-only Runtime Supervisor scaffold for service observations that explicitly does not restart/kill/mutate services. 

### Description

- Added `sentientos/effect_proof.py` with frozen dataclasses for `EffectReceiptContract`, `FutureEffectReceipt`, `PostconditionCheckPlan`, `PostconditionCheckReceipt`, `RollbackPlan`, `RollbackReceipt`, `ExecutionReadinessManifest`, builders, validators, deterministic digest helpers, summaries, and `build_execution_proof_wing_for_rehearsal_receipt(...)` that composes the wing from a Phase 5 rehearsal receipt. 
- Added `sentientos/runtime_supervisor.py` with `RuntimeServiceRecord`, `RuntimeSupervisorSnapshot`, `RuntimeSupervisorReadinessReport`, builders, validators, digests, and summaries that treat supplied telemetry as metadata/readiness-only. 
- Updated `sentientos/capability_registry.py` additively to declare new proof/readiness capabilities (`effect_receipt_contract`, `postcondition_checks`, `rollback_planning`, `runtime_supervisor`, `execution_readiness_manifest`) and to keep all real-execution surfaces (real effect execution, service restart, fan/PWM, power mutation, cleanup, etc.) deferred or blocked, plus new helpers `update_registry_from_execution_readiness_manifest(...)` and `update_registry_from_runtime_supervisor_report(...)`. 
- Added docs `docs/architecture/host_embodiment_execution_proof_wing.md` and wired short links into Phase 1–5 and overview docs; added focused tests `tests/test_effect_proof.py` and `tests/test_runtime_supervisor.py` and updated capability/README regression tests. 

### Testing

- Ran unit suites: `python -m scripts.run_tests -q tests/test_effect_proof.py tests/test_runtime_supervisor.py tests/test_actuation_fulfillment.py tests/test_capability_registry.py` and `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_host_resource_policy.py tests/test_privilege_broker.py` which completed successfully. 
- Ran docs build and hygiene checks: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`, and `python scripts/verify_context_hygiene_prompt_boundaries.py`, which produced docs and reported no context-hygiene findings after a brief bootstrap step. 
- Performed forbidden-scan `rg -n "socket|requests|urllib|subprocess|os\.system|Popen|fan.*write|pwm.*write|thermal.*write|power profile|kill\(|restart|pip install|driver install|delete|unlink|rmtree|prompt_assembler|admit_and_execute"` on modified modules and classified matches as allowed negative marker strings, metadata labels, or validation guards; no forbidden runtime calls or regressions were introduced. 
- All added/updated tests passed in the final run and the docs regression tests were updated and validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05623f1e4083208b2c60d8f8b05833)