### PR TITLE
[codex:host-embodiment] add authorization review wing

### DIFF
--- a/docs/architecture/host_embodiment_authorization_review_wing.md
+++ b/docs/architecture/host_embodiment_authorization_review_wing.md
@@ -1,0 +1,97 @@
+# Host Embodiment Authorization Review Wing
+
+The Host Embodiment Authorization Review Wing follows the Host Embodiment
+Execution Proof Wing. The Execution Proof Wing produces an
+`ExecutionReadinessManifest`; this wing asks only whether that readiness manifest
+is complete enough, safe enough, and bounded enough to be presented for future
+operator/policy authorization consideration.
+
+This wing is metadata-only authorization review. It is not authorization, not a
+real authorization grant, not real actuation, not execution, not host mutation,
+not direct fan/PWM control, not thermal actuation, not power profile mutation,
+not process killing, not service restart, not package or driver installation,
+not file cleanup or deletion, not network egress, not provider invocation, not
+prompt assembly/export, not federation transport/sync/adoption, and not remote
+execution.
+
+## Authority ladder
+
+The authority ladder remains:
+
+`observe → model → propose → broker eligibility → rehearse → readiness → authorization review → authorize → fulfill → effect receipt → postcondition check → audit → rollback`
+
+This wing covers `authorization review` only. It does not authorize, fulfill,
+create an effect receipt from a real effect, perform a postcondition check from a
+real effect, audit a real effect, or execute rollback.
+
+## Core boundaries
+
+- Execution readiness is not authorization.
+- A future effect schema is not proof of effect.
+- A postcondition plan is not a postcondition check from a real effect.
+- A rollback plan is not rollback execution.
+- A runtime supervisor report is not permission to restart/kill.
+- An authorization review decision is not an authorization grant; authorization review is not authorization grant.
+- An authorization review receipt is not fulfillment.
+- A Future Authorization Grant schema is not a real grant.
+- Real fulfillment remains deferred.
+- Real actuation remains deferred.
+
+## Review artifacts
+
+`sentientos/authorization_review.py` defines the authorization-review artifacts:
+
+1. `AuthorizationReviewPacket` records the source execution readiness manifest,
+   source digest, proof identifiers, readiness status, authorization-review
+   gates, satisfied/missing gates, blocked actions, warnings, and risk codes.
+   It is `metadata_only`, `review_only`, and never grants authorization or
+   fulfillment.
+2. `AuthorizationReviewDecision` records the authorization domain, approval
+   class, decision status, required/missing gates, blocked actions, warnings, and
+   risks. It explicitly keeps authorization, fulfillment, effect, host mutation,
+   fan/PWM, thermal, power, service restart, cleanup, provider, network, and
+   prompt flags false.
+3. `AuthorizationReviewReceipt` records that review happened. It is a receipt of
+   review only: authorization is not granted, fulfillment is not authorized, no
+   host mutation occurs, and future action still requires control-plane
+   admission, operator/policy approval, audit receipt, rollback receipt, effect
+   receipt, and postcondition check.
+4. `FutureAuthorizationGrantSchema` is a placeholder schema for a possible
+   future grant record. It is `schema_only`, `future_use_only`, not an
+   authorization grant, does not execute, does not mutate host state, and does
+   not authorize fulfillment.
+
+## Domain mapping and gates
+
+| Execution readiness effect domain | Authorization review domain | Approval class | Extra gates/blockers |
+| --- | --- | --- | --- |
+| `diagnostics_only` | `diagnostics_authorization_review` | `no_operator_action_required_for_diagnostics` | Review-only diagnostics; no action grant. |
+| `operator_review` | `operator_review_authorization_review` | `operator_explicit_approval_required` | Operator review only; no fulfillment grant. |
+| `resource_pressure_review` | `resource_pressure_authorization_review` | `operator_explicit_approval_required` | Control-plane, approval, audit, rollback, effect receipt, postcondition, immutable trace remain required. |
+| `thermal_safety_review` | `thermal_safety_authorization_review` | `policy_explicit_approval_required` | Runtime supervisor observation remains required; cooling actuation is not authorized. |
+| `disk_safety_review` | `disk_safety_authorization_review` | `policy_explicit_approval_required` | Dry-run/rehearsal evidence remains required; cleanup/deletion is not authorized. |
+| `service_health_review` | `service_health_authorization_review` | `operator_explicit_approval_required` | Runtime supervisor observation remains required; restart/kill remains blocked. |
+| `future_cooling_effect` | `future_cooling_authorization_review` | `future_hardware_safety_approval_required` | Hardware allowlist, OS backend, bounds, cooldown, panic stop, control-plane admission, audit, rollback, effect receipt, postcondition check, immutable trace; fan/PWM and thermal actuation remain blocked. |
+| `future_power_effect` | `future_power_authorization_review` | `dual_operator_policy_approval_required` | OS backend, bounds/policy, control-plane admission, audit, rollback, effect receipt, postcondition check, immutable trace; power mutation remains blocked. |
+| `future_cleanup_effect` | `future_cleanup_authorization_review` | `future_filesystem_scope_approval_required` | Filesystem scope, path/scope labels, dry-run/rehearsal evidence, control-plane admission, audit, rollback, effect receipt, postcondition check; cleanup/delete remain blocked. |
+| `future_service_effect` | `future_service_authorization_review` | `future_service_scope_approval_required` | Service scope, runtime supervisor observation, control-plane admission, audit, rollback, effect receipt, postcondition check; service restart/process kill remain blocked. |
+
+## Pipeline position
+
+The non-mutating pipeline is now:
+
+`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → broker eligibility decision → broker review receipt → fulfillment rehearsal plan → fulfillment rehearsal receipt → effect receipt contract → future effect receipt schema → postcondition plan → rollback plan → execution readiness manifest → authorization review packet → authorization review decision → authorization review receipt → future authorization grant schema`
+
+All stages remain metadata-only and non-mutating. Readiness and review do not
+collapse into authorization. Future cooling, power, service, and cleanup actions
+remain behind explicit future authorization, control-plane admission, audit,
+rollback, effect receipt, and postcondition checks.
+
+## Reviewer proof links
+
+- Module: `sentientos/authorization_review.py`
+- Upstream proof module: `sentientos/effect_proof.py`
+- Capability registry: `sentientos/capability_registry.py`
+- Authorization review tests: `tests/test_authorization_review.py`
+- Registry tests: `tests/test_capability_registry.py`
+- Docs regression: `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_embodiment_execution_proof_wing.md
+++ b/docs/architecture/host_embodiment_execution_proof_wing.md
@@ -15,9 +15,9 @@ federation transport/sync/adoption, and not remote execution.
 
 The authority ladder remains:
 
-`observe → model → propose → broker eligibility → rehearse → readiness → authorize → fulfill → effect receipt → postcondition check → audit → rollback`
+`observe → model → propose → broker eligibility → rehearse → readiness → authorization review → authorize → fulfill → effect receipt → postcondition check → audit → rollback`
 
-This wing covers `readiness` and proof scaffolding only. It does not authorize,
+This wing covers `readiness` and proof scaffolding only; the next wing is `docs/architecture/host_embodiment_authorization_review_wing.md`. It does not authorize,
 fulfill, create a real effect receipt, perform postcondition checks against real
 effects, audit a real effect, or execute rollback.
 
@@ -87,7 +87,7 @@ only. No effect is performed.
 
 The non-mutating pipeline is now:
 
-`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → broker eligibility decision → broker review receipt → fulfillment rehearsal plan → fulfillment rehearsal receipt → effect receipt contract → future effect receipt schema → postcondition plan → rollback plan → execution readiness manifest → optional runtime supervisor readiness report`
+`collector results → telemetry snapshot → pressure report → policy decision → proposal receipt → broker eligibility decision → broker review receipt → fulfillment rehearsal plan → fulfillment rehearsal receipt → effect receipt contract → future effect receipt schema → postcondition plan → rollback plan → execution readiness manifest → optional runtime supervisor readiness report → authorization review packet → authorization review decision → authorization review receipt → future authorization grant schema`
 
 All stages remain metadata-only and non-mutating. Real fulfillment remains
 deferred. Real actuation remains deferred.
@@ -96,6 +96,7 @@ deferred. Real actuation remains deferred.
 
 - Module: `sentientos/effect_proof.py`
 - Module: `sentientos/runtime_supervisor.py`
+- Authorization Review Wing: `docs/architecture/host_embodiment_authorization_review_wing.md`
 - Capability registry: `sentientos/capability_registry.py`
 - Tests: `tests/test_effect_proof.py`
 - Tests: `tests/test_runtime_supervisor.py`

--- a/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
+++ b/docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md
@@ -166,3 +166,7 @@ Phase 5 actuation fulfillment rehearsal is documented in `docs/architecture/host
 ## Host Embodiment Execution Proof Wing
 
 Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.
+
+## Later authorization-review wing
+
+The later authorization-review layer is documented at `docs/architecture/host_embodiment_authorization_review_wing.md`. Eligibility is not authorization, authorization review is not authorization grant, and future host actions still require explicit future authorization, control-plane admission, audit, rollback, effect receipt, and postcondition checks.

--- a/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
+++ b/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
@@ -158,3 +158,7 @@ python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_pr
 ## Host Embodiment Execution Proof Wing
 
 Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.
+
+## Next wing: Authorization Review
+
+After the Execution Proof Wing, see `docs/architecture/host_embodiment_authorization_review_wing.md`. Authorization review is not authorization; a future authorization grant schema is not a real grant; real fulfillment and real actuation remain deferred.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -231,3 +231,7 @@ See `docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_sc
 ## Host Embodiment Execution Proof Wing
 
 Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.
+
+## Host Embodiment Authorization Review Wing
+
+Next review-only wing: `docs/architecture/host_embodiment_authorization_review_wing.md`. Authorization review is not authorization grant; the future authorization grant schema is not a real grant; real fulfillment remains deferred; real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind explicit future authorization, control-plane admission, audit, rollback, effect receipt, and postcondition checks.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -217,3 +217,7 @@ python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_pr
 ## Host Embodiment Execution Proof Wing
 
 Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.
+
+## Host Embodiment Authorization Review Wing
+
+See `docs/architecture/host_embodiment_authorization_review_wing.md`. This proof surface is metadata-only review of ExecutionReadinessManifest records: authorization review is not authorization grant, a future authorization grant schema is not a real grant, real fulfillment remains deferred, and real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -375,3 +375,7 @@ Phase 5 is documented in `docs/architecture/host_embodiment_substrate_phase5_act
 ## Host Embodiment Execution Proof Wing
 
 Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wing.md`. Execution readiness is not authorization; the future effect receipt schema is not proof of effect; the Runtime Supervisor does not restart/kill services; real actuation remains deferred.
+
+## Host Embodiment Authorization Review Wing
+
+See `docs/architecture/host_embodiment_authorization_review_wing.md`. This next organ after the Execution Proof Wing records metadata-only authorization review packets, decisions, receipts, and a future grant schema placeholder. Authorization review is not authorization, the future authorization grant schema is not a real grant, real fulfillment remains deferred, and real actuation remains deferred.

--- a/sentientos/authorization_review.py
+++ b/sentientos/authorization_review.py
@@ -1,0 +1,673 @@
+"""Metadata-only authorization review for execution readiness manifests.
+
+This wing evaluates whether an ExecutionReadinessManifest is complete, bounded,
+and safe enough to be presented for future operator/policy authorization
+consideration. It does not grant authorization, execute host actions, mutate host
+state, write fan/PWM controls, change thermal or power settings, kill processes,
+restart services, install packages or drivers, delete files, perform cleanup,
+perform network calls, invoke providers, assemble prompts, transport federation
+state, or perform remote execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.effect_proof import EXECUTION_READINESS_STATUSES, ExecutionReadinessManifest, execution_readiness_manifest_digest
+
+AUTHORIZATION_REVIEW_PACKET_STATUSES = frozenset({
+    "authorization_review_packet_ready",
+    "authorization_review_packet_ready_with_conditions",
+    "authorization_review_packet_blocked",
+    "authorization_review_packet_incomplete",
+    "authorization_review_packet_contradicted",
+})
+AUTHORIZATION_REVIEW_DECISION_STATUSES = frozenset({
+    "authorization_review_eligible_for_operator_review",
+    "authorization_review_eligible_with_conditions",
+    "authorization_review_blocked",
+    "authorization_review_incomplete",
+    "authorization_review_contradicted",
+})
+AUTHORIZATION_REVIEW_RECEIPT_STATUSES = frozenset({
+    "authorization_review_receipt_recorded",
+    "authorization_review_receipt_recorded_with_warnings",
+    "authorization_review_receipt_blocked",
+    "authorization_review_receipt_incomplete",
+    "authorization_review_receipt_contradicted",
+})
+FUTURE_AUTHORIZATION_GRANT_SCHEMA_STATUSES = frozenset({
+    "future_authorization_grant_schema_ready",
+    "future_authorization_grant_schema_ready_with_conditions",
+    "future_authorization_grant_schema_blocked",
+    "future_authorization_grant_schema_incomplete",
+    "future_authorization_grant_schema_contradicted",
+})
+AUTHORIZATION_DOMAINS = frozenset({
+    "diagnostics_authorization_review",
+    "operator_review_authorization_review",
+    "resource_pressure_authorization_review",
+    "thermal_safety_authorization_review",
+    "disk_safety_authorization_review",
+    "service_health_authorization_review",
+    "future_cooling_authorization_review",
+    "future_power_authorization_review",
+    "future_cleanup_authorization_review",
+    "future_service_authorization_review",
+})
+APPROVAL_CLASSES = frozenset({
+    "no_operator_action_required_for_diagnostics",
+    "operator_explicit_approval_required",
+    "policy_explicit_approval_required",
+    "dual_operator_policy_approval_required",
+    "future_hardware_safety_approval_required",
+    "future_filesystem_scope_approval_required",
+    "future_service_scope_approval_required",
+})
+BASE_AUTHORIZATION_GATES = (
+    "execution_readiness_manifest_required",
+    "effect_receipt_contract_required",
+    "future_effect_receipt_schema_required",
+    "postcondition_plan_required",
+    "rollback_plan_required",
+    "control_plane_admission_required_for_future_action",
+    "operator_or_policy_approval_required_for_future_action",
+    "audit_receipt_required_for_future_action",
+    "rollback_receipt_required_for_future_action",
+    "effect_receipt_required_for_future_action",
+    "postcondition_check_required_for_future_action",
+    "immutable_trace_required_for_future_action",
+)
+REQUIRED_AUTHORIZATION_GATES = frozenset(BASE_AUTHORIZATION_GATES + (
+    "runtime_supervisor_observation_required",
+    "panic_stop_required_for_future_action",
+    "hardware_allowlist_required_for_future_action",
+    "os_backend_declaration_required_for_future_action",
+    "bounds_policy_required_for_future_action",
+    "cooldown_policy_required_for_future_action",
+    "dry_run_rehearsal_evidence_required_for_future_action",
+    "filesystem_scope_required_for_future_action",
+    "path_scope_labels_required_for_future_action",
+    "service_scope_required_for_future_action",
+))
+BLOCKED_ACTION_LABELS = frozenset({
+    "authorization_grant",
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+
+_EFFECT_TO_AUTH_DOMAIN: Mapping[str, str] = {
+    "diagnostics_only": "diagnostics_authorization_review",
+    "operator_review": "operator_review_authorization_review",
+    "resource_pressure_review": "resource_pressure_authorization_review",
+    "thermal_safety_review": "thermal_safety_authorization_review",
+    "disk_safety_review": "disk_safety_authorization_review",
+    "service_health_review": "service_health_authorization_review",
+    "future_cooling_effect": "future_cooling_authorization_review",
+    "future_power_effect": "future_power_authorization_review",
+    "future_cleanup_effect": "future_cleanup_authorization_review",
+    "future_service_effect": "future_service_authorization_review",
+}
+_DOMAIN_APPROVAL: Mapping[str, str] = {
+    "diagnostics_authorization_review": "no_operator_action_required_for_diagnostics",
+    "operator_review_authorization_review": "operator_explicit_approval_required",
+    "resource_pressure_authorization_review": "operator_explicit_approval_required",
+    "thermal_safety_authorization_review": "policy_explicit_approval_required",
+    "disk_safety_authorization_review": "policy_explicit_approval_required",
+    "service_health_authorization_review": "operator_explicit_approval_required",
+    "future_cooling_authorization_review": "future_hardware_safety_approval_required",
+    "future_power_authorization_review": "dual_operator_policy_approval_required",
+    "future_cleanup_authorization_review": "future_filesystem_scope_approval_required",
+    "future_service_authorization_review": "future_service_scope_approval_required",
+}
+_PROOF_TO_AUTH_GATE: Mapping[str, str] = {
+    "control_plane_admission_required": "control_plane_admission_required_for_future_action",
+    "operator_or_policy_approval_required": "operator_or_policy_approval_required_for_future_action",
+    "audit_receipt_required": "audit_receipt_required_for_future_action",
+    "rollback_receipt_required": "rollback_receipt_required_for_future_action",
+    "effect_receipt_required": "effect_receipt_required_for_future_action",
+    "postcondition_check_required": "postcondition_check_required_for_future_action",
+    "panic_stop_required": "panic_stop_required_for_future_action",
+    "immutable_trace_required": "immutable_trace_required_for_future_action",
+    "runtime_supervisor_observation_required": "runtime_supervisor_observation_required",
+    "rollback_plan_required": "rollback_plan_required",
+    "hardware_allowlist_required": "hardware_allowlist_required_for_future_action",
+    "os_backend_declaration_required": "os_backend_declaration_required_for_future_action",
+    "bounds_policy_required": "bounds_policy_required_for_future_action",
+    "cooldown_policy_required": "cooldown_policy_required_for_future_action",
+    "dry_run_required": "dry_run_rehearsal_evidence_required_for_future_action",
+    "rehearsal_required": "dry_run_rehearsal_evidence_required_for_future_action",
+}
+_DOMAIN_REQUIRED_GATES: Mapping[str, tuple[str, ...]] = {
+    "diagnostics_authorization_review": (
+        "execution_readiness_manifest_required", "effect_receipt_contract_required", "future_effect_receipt_schema_required", "postcondition_plan_required", "rollback_plan_required", "immutable_trace_required_for_future_action",
+    ),
+    "operator_review_authorization_review": BASE_AUTHORIZATION_GATES,
+    "resource_pressure_authorization_review": BASE_AUTHORIZATION_GATES,
+    "thermal_safety_authorization_review": BASE_AUTHORIZATION_GATES + ("runtime_supervisor_observation_required",),
+    "disk_safety_authorization_review": BASE_AUTHORIZATION_GATES + ("dry_run_rehearsal_evidence_required_for_future_action",),
+    "service_health_authorization_review": BASE_AUTHORIZATION_GATES + ("runtime_supervisor_observation_required",),
+    "future_cooling_authorization_review": BASE_AUTHORIZATION_GATES + ("runtime_supervisor_observation_required", "panic_stop_required_for_future_action", "hardware_allowlist_required_for_future_action", "os_backend_declaration_required_for_future_action", "bounds_policy_required_for_future_action", "cooldown_policy_required_for_future_action"),
+    "future_power_authorization_review": BASE_AUTHORIZATION_GATES + ("runtime_supervisor_observation_required", "panic_stop_required_for_future_action", "os_backend_declaration_required_for_future_action", "bounds_policy_required_for_future_action"),
+    "future_cleanup_authorization_review": BASE_AUTHORIZATION_GATES + ("dry_run_rehearsal_evidence_required_for_future_action", "filesystem_scope_required_for_future_action", "path_scope_labels_required_for_future_action"),
+    "future_service_authorization_review": BASE_AUTHORIZATION_GATES + ("runtime_supervisor_observation_required", "service_scope_required_for_future_action"),
+}
+_BLOCKED_ACTION_MAP: Mapping[str, str] = {
+    "host_mutation_without_authorization": "host_mutation",
+    "fan_pwm_write_without_allowlist": "fan_pwm_write",
+    "thermal_actuation_without_policy": "thermal_actuation",
+    "power_profile_mutation_without_policy": "power_profile_mutation",
+    "process_kill_without_authorization": "process_kill",
+    "service_restart_without_authorization": "service_restart",
+    "package_install_without_authorization": "package_install",
+    "driver_install_without_authorization": "driver_install",
+    "file_cleanup_without_scope": "file_cleanup",
+    "file_delete_without_scope": "file_delete",
+    "provider_invocation": "provider_invocation",
+    "network_egress": "network_egress",
+    "prompt_assembly": "prompt_assembly",
+    "federation_transport": "federation_transport",
+    "remote_execution": "remote_execution",
+}
+_DOMAIN_BLOCKS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_authorization_review": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_authorization_review": ("power_profile_mutation",),
+    "future_cleanup_authorization_review": ("file_cleanup", "file_delete"),
+    "future_service_authorization_review": ("service_restart", "process_kill"),
+    "service_health_authorization_review": ("service_restart", "process_kill"),
+}
+
+@dataclass(frozen=True)
+class AuthorizationReviewPolicy:
+    policy_id: str
+    domain_required_gates: Mapping[str, tuple[str, ...]]
+    domain_approval_classes: Mapping[str, str]
+    blocked_actions: tuple[str, ...]
+    metadata_only: bool = True
+    review_only: bool = True
+    authorization_granted: bool = False
+
+@dataclass(frozen=True)
+class AuthorizationReviewPacket:
+    packet_id: str
+    source_execution_readiness_manifest_id: str
+    source_execution_readiness_manifest_digest: str
+    effect_contract_id: str
+    future_effect_receipt_id: str
+    postcondition_plan_id: str
+    rollback_plan_id: str
+    runtime_supervisor_report_id: str | None
+    effect_domain: str
+    backend_class: str
+    readiness_status: str
+    packet_status: str
+    approval_class: str
+    required_authorization_gates: tuple[str, ...]
+    satisfied_authorization_gates: tuple[str, ...]
+    missing_authorization_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    review_only: bool = True
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class AuthorizationReviewDecision:
+    decision_id: str
+    packet_id: str
+    source_execution_readiness_manifest_id: str
+    source_execution_readiness_manifest_digest: str
+    authorization_domain: str
+    approval_class: str
+    decision_status: str
+    reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    required_authorization_gates: tuple[str, ...]
+    missing_authorization_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    metadata_only: bool = True
+    review_only: bool = True
+    authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class AuthorizationReviewReceipt:
+    receipt_id: str
+    decision_id: str
+    packet_id: str
+    source_execution_readiness_manifest_id: str
+    source_execution_readiness_manifest_digest: str
+    authorization_domain: str
+    approval_class: str
+    decision_status: str
+    receipt_status: str
+    evidence_summary: tuple[str, ...]
+    required_authorization_gates: tuple[str, ...]
+    missing_authorization_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    review_only: bool = True
+    authorization_not_granted: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    requires_future_authorization_grant: bool = True
+    requires_control_plane_admission_for_future_action: bool = True
+    requires_operator_or_policy_approval_for_future_action: bool = True
+    requires_audit_receipt_for_future_action: bool = True
+    requires_rollback_receipt_for_future_action: bool = True
+    requires_effect_receipt_for_future_action: bool = True
+    requires_postcondition_check_for_future_action: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class FutureAuthorizationGrantSchema:
+    schema_id: str
+    source_authorization_review_receipt_id: str
+    source_authorization_review_receipt_digest: str
+    authorization_domain: str
+    approval_class: str
+    schema_status: str
+    required_authority_refs: tuple[str, ...]
+    required_operator_identity_labels: tuple[str, ...]
+    required_policy_labels: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    required_time_bounds: tuple[str, ...]
+    required_revocation_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_control_plane_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    schema_only: bool = True
+    future_use_only: bool = True
+    authorization_granted: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class AuthorizationReviewValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+class AuthorizationReviewWingRecords(NamedTuple):
+    packet: AuthorizationReviewPacket
+    decision: AuthorizationReviewDecision
+    receipt: AuthorizationReviewReceipt
+    future_authorization_grant_schema: FutureAuthorizationGrantSchema
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _record_digest(record: Any) -> str:
+    payload = record.to_dict()
+    if "digest" in payload:
+        payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def authorization_review_packet_digest(packet: AuthorizationReviewPacket) -> str: return _record_digest(packet)
+def authorization_review_decision_digest(decision: AuthorizationReviewDecision) -> str: return _record_digest(decision)
+def authorization_review_receipt_digest(receipt: AuthorizationReviewReceipt) -> str: return _record_digest(receipt)
+def future_authorization_grant_schema_digest(schema: FutureAuthorizationGrantSchema) -> str: return _record_digest(schema)
+
+
+def build_default_authorization_review_policy() -> AuthorizationReviewPolicy:
+    return AuthorizationReviewPolicy(
+        policy_id="sentientos-host-embodiment-authorization-review.v1",
+        domain_required_gates={domain: tuple(sorted(gates)) for domain, gates in _DOMAIN_REQUIRED_GATES.items()},
+        domain_approval_classes=dict(_DOMAIN_APPROVAL),
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+    )
+
+
+def _auth_domain_for_manifest(manifest: Any) -> str:
+    return _EFFECT_TO_AUTH_DOMAIN.get(str(getattr(manifest, "effect_domain", "diagnostics_only")), "diagnostics_authorization_review")
+
+
+def _blocked_actions_for_manifest(manifest: Any, authorization_domain: str) -> tuple[str, ...]:
+    labels = {"authorization_grant", "host_mutation", "provider_invocation", "network_egress", "prompt_assembly", "federation_transport", "remote_execution"}
+    labels.update(_DOMAIN_BLOCKS.get(authorization_domain, ()))
+    for action in getattr(manifest, "blocked_actions", ()) or ():
+        mapped = _BLOCKED_ACTION_MAP.get(str(action), str(action))
+        if mapped in BLOCKED_ACTION_LABELS:
+            labels.add(mapped)
+    return tuple(sorted(labels & set(BLOCKED_ACTION_LABELS)))
+
+
+def _source_contradictions(manifest: Any) -> tuple[str, ...]:
+    findings: list[str] = []
+    required_true = ("metadata_only", "readiness_only")
+    for flag in required_true:
+        if not getattr(manifest, flag, True):
+            findings.append(f"source_manifest_missing_non_authority_flag:{flag}")
+    forbidden_false = (
+        "authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed",
+        "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed",
+        "process_kill_performed", "service_restart_performed", "package_install_performed", "driver_install_performed",
+        "file_cleanup_performed", "file_delete_performed", "provider_invocation_performed", "network_performed",
+        "prompt_assembly_performed",
+    )
+    for flag in forbidden_false:
+        if getattr(manifest, flag, False):
+            findings.append(f"source_manifest_claims_forbidden_authority_or_effect:{flag}")
+    if getattr(manifest, "readiness_status", "") not in EXECUTION_READINESS_STATUSES:
+        findings.append("source_manifest_unknown_readiness_status")
+    digest = str(getattr(manifest, "digest", "") or "")
+    return tuple(findings)
+
+
+def _satisfied_auth_gates(manifest: Any) -> tuple[str, ...]:
+    gates = {
+        "execution_readiness_manifest_required",
+        "effect_receipt_contract_required" if getattr(manifest, "effect_contract_id", "") else "",
+        "future_effect_receipt_schema_required" if getattr(manifest, "future_effect_receipt_id", "") else "",
+        "postcondition_plan_required" if getattr(manifest, "postcondition_plan_id", "") else "",
+        "rollback_plan_required" if getattr(manifest, "rollback_plan_id", "") else "",
+    }
+    for gate in getattr(manifest, "satisfied_proof_gates", ()) or ():
+        mapped = _PROOF_TO_AUTH_GATE.get(str(gate))
+        if mapped:
+            gates.add(mapped)
+    if getattr(manifest, "runtime_supervisor_report_id", None):
+        gates.add("runtime_supervisor_observation_required")
+    effect_domain = str(getattr(manifest, "effect_domain", ""))
+    if effect_domain == "future_cleanup_effect":
+        gates.update({"filesystem_scope_required_for_future_action", "path_scope_labels_required_for_future_action"})
+    if effect_domain == "future_service_effect":
+        gates.add("service_scope_required_for_future_action")
+    return tuple(sorted(g for g in gates if g))
+
+
+def _packet_status(readiness_status: str, contradictions: Sequence[str], missing: Sequence[str]) -> str:
+    if contradictions or readiness_status.endswith("contradicted"):
+        return "authorization_review_packet_contradicted"
+    if readiness_status.endswith("incomplete"):
+        return "authorization_review_packet_incomplete"
+    if readiness_status.endswith("blocked"):
+        return "authorization_review_packet_blocked"
+    if missing:
+        return "authorization_review_packet_incomplete"
+    if readiness_status.endswith("with_conditions"):
+        return "authorization_review_packet_ready_with_conditions"
+    return "authorization_review_packet_ready"
+
+
+def build_authorization_review_packet(manifest: ExecutionReadinessManifest, *, policy: AuthorizationReviewPolicy | None = None) -> AuthorizationReviewPacket:
+    policy = policy or build_default_authorization_review_policy()
+    authorization_domain = _auth_domain_for_manifest(manifest)
+    required = tuple(sorted(policy.domain_required_gates.get(authorization_domain, BASE_AUTHORIZATION_GATES)))
+    satisfied = _satisfied_auth_gates(manifest)
+    missing = tuple(sorted(set(required) - set(satisfied)))
+    contradictions = _source_contradictions(manifest)
+    warnings = tuple(sorted(set(getattr(manifest, "warning_codes", ()) or ()) | set(contradictions)))
+    blocked = _blocked_actions_for_manifest(manifest, authorization_domain)
+    material = {"manifest": manifest.manifest_id, "digest": manifest.digest, "domain": authorization_domain, "required": required}
+    return AuthorizationReviewPacket(
+        packet_id=_digest_payload("arp_", material),
+        source_execution_readiness_manifest_id=manifest.manifest_id,
+        source_execution_readiness_manifest_digest=manifest.digest,
+        effect_contract_id=manifest.effect_contract_id,
+        future_effect_receipt_id=manifest.future_effect_receipt_id,
+        postcondition_plan_id=manifest.postcondition_plan_id,
+        rollback_plan_id=manifest.rollback_plan_id,
+        runtime_supervisor_report_id=manifest.runtime_supervisor_report_id,
+        effect_domain=manifest.effect_domain,
+        backend_class=manifest.backend_class,
+        readiness_status=manifest.readiness_status,
+        packet_status=_packet_status(manifest.readiness_status, contradictions, missing),
+        approval_class=policy.domain_approval_classes.get(authorization_domain, "operator_explicit_approval_required"),
+        required_authorization_gates=required,
+        satisfied_authorization_gates=satisfied,
+        missing_authorization_gates=missing,
+        blocked_actions=blocked,
+        warning_codes=warnings,
+        risk_codes=tuple(sorted(set(getattr(manifest, "risk_codes", ()) or ()))),
+    )
+
+
+def evaluate_authorization_review(packet: AuthorizationReviewPacket) -> AuthorizationReviewDecision:
+    domain = _EFFECT_TO_AUTH_DOMAIN.get(packet.effect_domain, "diagnostics_authorization_review")
+    reasons: list[str] = []
+    if packet.packet_status.endswith("contradicted"):
+        status = "authorization_review_contradicted"; reasons.append("source_readiness_or_packet_contradicted")
+    elif packet.packet_status.endswith("incomplete"):
+        status = "authorization_review_incomplete"; reasons.append("required_authorization_review_gates_missing")
+    elif packet.packet_status.endswith("blocked"):
+        status = "authorization_review_blocked"; reasons.append("source_readiness_blocked")
+    elif packet.readiness_status.endswith("with_conditions") or packet.packet_status.endswith("with_conditions"):
+        status = "authorization_review_eligible_with_conditions"; reasons.append("readiness_conditions_must_be_resolved_before_authorization")
+    else:
+        status = "authorization_review_eligible_for_operator_review"; reasons.append("ready_for_future_operator_policy_authorization_review")
+    if packet.missing_authorization_gates and status.startswith("authorization_review_eligible"):
+        status = "authorization_review_incomplete"
+        reasons.append("missing_authorization_review_gates")
+    material = {"packet": packet.packet_id, "status": status, "domain": domain, "missing": packet.missing_authorization_gates}
+    return AuthorizationReviewDecision(
+        decision_id=_digest_payload("ard_", material),
+        packet_id=packet.packet_id,
+        source_execution_readiness_manifest_id=packet.source_execution_readiness_manifest_id,
+        source_execution_readiness_manifest_digest=packet.source_execution_readiness_manifest_digest,
+        authorization_domain=domain,
+        approval_class=packet.approval_class,
+        decision_status=status,
+        reason_codes=tuple(sorted(set(reasons))),
+        warning_codes=packet.warning_codes,
+        risk_codes=packet.risk_codes,
+        required_authorization_gates=packet.required_authorization_gates,
+        missing_authorization_gates=packet.missing_authorization_gates,
+        blocked_actions=packet.blocked_actions,
+    )
+
+
+def _receipt_status(decision_status: str, warnings: Sequence[str]) -> str:
+    if decision_status.endswith("contradicted"):
+        return "authorization_review_receipt_contradicted"
+    if decision_status.endswith("incomplete"):
+        return "authorization_review_receipt_incomplete"
+    if decision_status.endswith("blocked"):
+        return "authorization_review_receipt_blocked"
+    if warnings or decision_status.endswith("conditions"):
+        return "authorization_review_receipt_recorded_with_warnings"
+    return "authorization_review_receipt_recorded"
+
+
+def build_authorization_review_receipt(decision: AuthorizationReviewDecision, *, created_at: str = "1970-01-01T00:00:00+00:00") -> AuthorizationReviewReceipt:
+    evidence = (
+        "authorization_review_only",
+        "authorization_not_granted",
+        "future_authorization_grant_required",
+        "control_plane_admission_required_before_any_future_action",
+    )
+    provisional = AuthorizationReviewReceipt(
+        receipt_id=_digest_payload("arr_", {"decision": decision.decision_id, "created_at": created_at}),
+        decision_id=decision.decision_id,
+        packet_id=decision.packet_id,
+        source_execution_readiness_manifest_id=decision.source_execution_readiness_manifest_id,
+        source_execution_readiness_manifest_digest=decision.source_execution_readiness_manifest_digest,
+        authorization_domain=decision.authorization_domain,
+        approval_class=decision.approval_class,
+        decision_status=decision.decision_status,
+        receipt_status=_receipt_status(decision.decision_status, decision.warning_codes),
+        evidence_summary=evidence,
+        required_authorization_gates=decision.required_authorization_gates,
+        missing_authorization_gates=decision.missing_authorization_gates,
+        blocked_actions=decision.blocked_actions,
+        warning_codes=decision.warning_codes,
+        risk_codes=decision.risk_codes,
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=authorization_review_receipt_digest(provisional))
+
+
+def _schema_status(receipt_status: str) -> str:
+    if receipt_status.endswith("contradicted"):
+        return "future_authorization_grant_schema_contradicted"
+    if receipt_status.endswith("incomplete"):
+        return "future_authorization_grant_schema_incomplete"
+    if receipt_status.endswith("blocked"):
+        return "future_authorization_grant_schema_blocked"
+    if receipt_status.endswith("warnings"):
+        return "future_authorization_grant_schema_ready_with_conditions"
+    return "future_authorization_grant_schema_ready"
+
+
+def build_future_authorization_grant_schema(receipt: AuthorizationReviewReceipt, *, created_at: str = "1970-01-01T00:00:00+00:00") -> FutureAuthorizationGrantSchema:
+    domain = receipt.authorization_domain
+    scope_labels = ["bounded_scope_required", domain]
+    if domain == "future_cooling_authorization_review":
+        scope_labels += ["hardware_allowlist_required", "cooling_bounds_required", "cooldown_policy_required"]
+    if domain == "future_power_authorization_review":
+        scope_labels += ["os_backend_required", "power_bounds_policy_required"]
+    if domain == "future_cleanup_authorization_review":
+        scope_labels += ["filesystem_scope_required", "path_scope_required", "dry_run_evidence_required"]
+    if domain == "future_service_authorization_review":
+        scope_labels += ["service_scope_required", "runtime_supervisor_observation_required"]
+    provisional = FutureAuthorizationGrantSchema(
+        schema_id=_digest_payload("fags_", {"receipt": receipt.receipt_id, "digest": receipt.digest, "created_at": created_at}),
+        source_authorization_review_receipt_id=receipt.receipt_id,
+        source_authorization_review_receipt_digest=receipt.digest,
+        authorization_domain=domain,
+        approval_class=receipt.approval_class,
+        schema_status=_schema_status(receipt.receipt_status),
+        required_authority_refs=("future_authorization_grant", "operator_or_policy_approval", "control_plane_admission"),
+        required_operator_identity_labels=("operator_identity_required", "operator_presence_required"),
+        required_policy_labels=("policy_label_required", receipt.approval_class),
+        required_scope_labels=tuple(sorted(set(scope_labels))),
+        required_time_bounds=("issued_at_required", "expires_at_required", "short_lived_authorization_required"),
+        required_revocation_labels=("revocation_path_required", "panic_stop_required"),
+        required_audit_labels=("audit_receipt_required", "immutable_trace_required"),
+        required_control_plane_labels=("control_plane_admission_required", "admission_receipt_required"),
+        blocked_actions=receipt.blocked_actions,
+        warning_codes=receipt.warning_codes,
+        risk_codes=receipt.risk_codes,
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=future_authorization_grant_schema_digest(provisional))
+
+
+def _validate_common(value: Any, prefix: str) -> list[str]:
+    findings: list[str] = []
+    forbidden_false = (
+        "authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed",
+        "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed",
+        "process_kill_performed", "service_restart_performed", "package_install_performed", "driver_install_performed",
+        "file_cleanup_performed", "file_delete_performed", "provider_invocation_performed", "network_performed",
+        "prompt_assembly_performed",
+    )
+    for flag in forbidden_false:
+        if getattr(value, flag, False):
+            findings.append(f"{prefix}_forbidden_flag:{flag}")
+    for flag in ("metadata_only", "review_only", "schema_only", "future_use_only", "does_not_execute", "does_not_mutate_host", "does_not_authorize_fulfillment", "authorization_not_granted"):
+        if hasattr(value, flag) and not getattr(value, flag):
+            findings.append(f"{prefix}_missing_non_authority_flag:{flag}")
+    return findings
+
+
+def validate_authorization_review_packet(packet: AuthorizationReviewPacket) -> AuthorizationReviewValidationResult:
+    findings = _validate_common(packet, "packet")
+    if not packet.packet_id: findings.append("missing_packet_id")
+    if packet.packet_status not in AUTHORIZATION_REVIEW_PACKET_STATUSES: findings.append("unknown_packet_status")
+    if packet.approval_class not in APPROVAL_CLASSES: findings.append("unknown_approval_class")
+    missing = tuple(sorted(set(packet.required_authorization_gates) - set(packet.satisfied_authorization_gates)))
+    if missing != tuple(packet.missing_authorization_gates): findings.append("packet_missing_gate_mismatch")
+    return AuthorizationReviewValidationResult(not findings, tuple(findings))
+
+
+def validate_authorization_review_decision(decision: AuthorizationReviewDecision) -> AuthorizationReviewValidationResult:
+    findings = _validate_common(decision, "decision")
+    if decision.authorization_domain not in AUTHORIZATION_DOMAINS: findings.append("unknown_authorization_domain")
+    if decision.approval_class not in APPROVAL_CLASSES: findings.append("unknown_approval_class")
+    if decision.decision_status not in AUTHORIZATION_REVIEW_DECISION_STATUSES: findings.append("unknown_decision_status")
+    return AuthorizationReviewValidationResult(not findings, tuple(findings))
+
+
+def validate_authorization_review_receipt(receipt: AuthorizationReviewReceipt) -> AuthorizationReviewValidationResult:
+    findings = _validate_common(receipt, "receipt")
+    if receipt.receipt_status not in AUTHORIZATION_REVIEW_RECEIPT_STATUSES: findings.append("unknown_receipt_status")
+    if not receipt.authorization_not_granted: findings.append("receipt_authorization_was_granted")
+    if receipt.digest and receipt.digest != authorization_review_receipt_digest(receipt): findings.append("receipt_digest_mismatch")
+    return AuthorizationReviewValidationResult(not findings, tuple(findings))
+
+
+def validate_future_authorization_grant_schema(schema: FutureAuthorizationGrantSchema) -> AuthorizationReviewValidationResult:
+    findings = _validate_common(schema, "future_schema")
+    if schema.schema_status not in FUTURE_AUTHORIZATION_GRANT_SCHEMA_STATUSES: findings.append("unknown_schema_status")
+    if not schema.schema_only or not schema.future_use_only: findings.append("future_schema_not_schema_only_future_use")
+    if schema.digest and schema.digest != future_authorization_grant_schema_digest(schema): findings.append("future_schema_digest_mismatch")
+    return AuthorizationReviewValidationResult(not findings, tuple(findings))
+
+
+def summarize_authorization_review_packet(packet: AuthorizationReviewPacket) -> dict[str, Any]:
+    return {"packet_id": packet.packet_id, "source_execution_readiness_manifest_id": packet.source_execution_readiness_manifest_id, "readiness_status": packet.readiness_status, "packet_status": packet.packet_status, "approval_class": packet.approval_class, "metadata_only": packet.metadata_only, "review_only": packet.review_only, "authorization_granted": packet.authorization_granted, "fulfillment_granted": packet.fulfillment_granted, "effect_performed": packet.effect_performed, "host_mutation_performed": packet.host_mutation_performed, "missing_authorization_gate_count": len(packet.missing_authorization_gates)}
+
+
+def summarize_authorization_review_decision(decision: AuthorizationReviewDecision) -> dict[str, Any]:
+    return {"decision_id": decision.decision_id, "packet_id": decision.packet_id, "authorization_domain": decision.authorization_domain, "approval_class": decision.approval_class, "decision_status": decision.decision_status, "metadata_only": decision.metadata_only, "review_only": decision.review_only, "authorization_granted": decision.authorization_granted, "fulfillment_granted": decision.fulfillment_granted, "effect_performed": decision.effect_performed, "host_mutation_performed": decision.host_mutation_performed, "missing_authorization_gate_count": len(decision.missing_authorization_gates)}
+
+
+def summarize_authorization_review_receipt(receipt: AuthorizationReviewReceipt) -> dict[str, Any]:
+    return {"receipt_id": receipt.receipt_id, "decision_id": receipt.decision_id, "authorization_domain": receipt.authorization_domain, "receipt_status": receipt.receipt_status, "review_only": receipt.review_only, "authorization_not_granted": receipt.authorization_not_granted, "does_not_execute": receipt.does_not_execute, "does_not_mutate_host": receipt.does_not_mutate_host, "does_not_authorize_fulfillment": receipt.does_not_authorize_fulfillment, "digest": receipt.digest}
+
+
+def summarize_future_authorization_grant_schema(schema: FutureAuthorizationGrantSchema) -> dict[str, Any]:
+    return {"schema_id": schema.schema_id, "source_authorization_review_receipt_id": schema.source_authorization_review_receipt_id, "authorization_domain": schema.authorization_domain, "schema_status": schema.schema_status, "schema_only": schema.schema_only, "future_use_only": schema.future_use_only, "authorization_granted": schema.authorization_granted, "does_not_execute": schema.does_not_execute, "does_not_mutate_host": schema.does_not_mutate_host, "does_not_authorize_fulfillment": schema.does_not_authorize_fulfillment, "digest": schema.digest}
+
+
+def build_authorization_review_wing_for_execution_readiness(manifest: ExecutionReadinessManifest, *, policy: AuthorizationReviewPolicy | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> AuthorizationReviewWingRecords:
+    packet = build_authorization_review_packet(manifest, policy=policy)
+    decision = evaluate_authorization_review(packet)
+    receipt = build_authorization_review_receipt(decision, created_at=created_at)
+    schema = build_future_authorization_grant_schema(receipt, created_at=created_at)
+    return AuthorizationReviewWingRecords(packet, decision, receipt, schema)

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -35,6 +35,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "control_plane_admission",
         "actuation_fulfillment",
         "execution_proof",
+        "authorization_review",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -52,6 +53,8 @@ AUTHORITY_LEVELS = frozenset(
         "rehearsal_only",
         "proof_only",
         "readiness_only",
+        "review_only",
+        "schema_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -230,6 +233,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("rollback_planning", "execution_proof", "implemented", "proof_only", source_paths=("sentientos/effect_proof.py",), proof_tests=("tests/test_effect_proof.py",), implemented_surfaces=("metadata-only rollback plans and rollback receipt schemas",), deferred_surfaces=("real rollback execution",), forbidden_implications=("rollback plan executes rollback",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("runtime_supervisor", "runtime_supervision", "implemented", "telemetry_readiness_only", source_paths=("sentientos/runtime_supervisor.py",), proof_tests=("tests/test_runtime_supervisor.py",), proof_commands=("python -m scripts.run_tests -q tests/test_runtime_supervisor.py",), implemented_surfaces=("supplied service telemetry snapshots", "runtime supervisor readiness reports"), deferred_surfaces=("service restart", "process kill", "service manager mutation"), forbidden_implications=("runtime supervisor restarts or kills services",), requires_audit_receipt=True),
         _record("execution_readiness_manifest", "execution_proof", "implemented", "readiness_only", source_paths=("sentientos/effect_proof.py", "sentientos/runtime_supervisor.py"), proof_tests=("tests/test_effect_proof.py", "tests/test_runtime_supervisor.py"), implemented_surfaces=("metadata-only execution readiness manifest",), deferred_surfaces=("authorization", "fulfillment", "real actuation"), forbidden_implications=("execution readiness is authorization", "readiness manifest performs effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("authorization_review", "authorization_review", "implemented", "review_only", source_paths=("sentientos/authorization_review.py",), proof_tests=("tests/test_authorization_review.py",), proof_commands=("python -m scripts.run_tests -q tests/test_authorization_review.py",), implemented_surfaces=("metadata-only authorization review packets", "authorization review decisions", "authorization review receipts"), deferred_surfaces=("real authorization grants", "real effect execution", "real rollback execution"), forbidden_implications=("authorization review is authorization", "authorization review receipt is fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("future_authorization_grant_schema", "authorization_review", "implemented", "schema_only", source_paths=("sentientos/authorization_review.py",), proof_tests=("tests/test_authorization_review.py",), implemented_surfaces=("future authorization grant schema placeholder",), deferred_surfaces=("real authorization grant issuance", "host mutation fulfillment"), forbidden_implications=("future authorization grant schema is a real grant", "schema grants fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_execution", "execution_proof", "deferred", "none", deferred_surfaces=("authorized effect fulfillment", "host mutation", "effect receipt from real action"), forbidden_implications=("execution proof wing implements real effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_rollback_execution", "execution_proof", "deferred", "none", deferred_surfaces=("rollback execution", "host mutation rollback",), forbidden_implications=("rollback receipt schema executes rollback",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_service_restart", "runtime_supervision", "blocked", "none", deferred_surfaces=("service restart", "service stop", "process kill"), forbidden_implications=("runtime supervisor grants restart authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -241,9 +247,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-execution-proof-wing", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-authorization-review-wing", schema_version="host-embodiment-authorization-review-wing.v1", records=records)
 
 
 
@@ -572,6 +578,62 @@ def update_registry_from_execution_readiness_manifest(registry: CapabilityRegist
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-execution-proof-wing.v1")
+
+
+def update_registry_from_authorization_review_decision(registry: CapabilityRegistry, decision: Any) -> CapabilityRegistry:
+    """Reflect authorization review eligibility without granting authorization."""
+
+    records: list[CapabilityRecord] = []
+    has_decision = bool(getattr(decision, "decision_id", ""))
+    for record in registry.records:
+        if record.capability_id == "authorization_review":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_decision else "scaffolded",
+                    authority_level="review_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/authorization_review.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_authorization_review.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("authorization review decision is not authorization",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("real authorization grant", "real effect execution", "real rollback execution")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("authorization review decision grants authorization",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"real_authorization_grant", "real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-authorization-review-wing.v1")
+
+
+def update_registry_from_future_authorization_schema(registry: CapabilityRegistry, schema: Any) -> CapabilityRegistry:
+    """Reflect the future grant schema placeholder without creating a grant."""
+
+    updated = registry
+    records: list[CapabilityRecord] = []
+    has_schema = bool(getattr(schema, "schema_id", ""))
+    for record in updated.records:
+        if record.capability_id == "future_authorization_grant_schema":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_schema else "scaffolded",
+                    authority_level="schema_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/authorization_review.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_authorization_review.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("schema-only future authorization grant placeholder",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("future authorization grant schema is a real grant",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        else:
+            records.append(record)
+    return replace(updated, records=tuple(records), schema_version="host-embodiment-authorization-review-wing.v1")
 
 
 def update_registry_from_runtime_supervisor_report(registry: CapabilityRegistry, report: Any) -> CapabilityRegistry:

--- a/tests/test_authorization_review.py
+++ b/tests/test_authorization_review.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+from sentientos.authorization_review import (
+    authorization_review_decision_digest,
+    authorization_review_receipt_digest,
+    build_authorization_review_packet,
+    build_authorization_review_wing_for_execution_readiness,
+    build_default_authorization_review_policy,
+    build_future_authorization_grant_schema,
+    evaluate_authorization_review,
+    future_authorization_grant_schema_digest,
+    summarize_authorization_review_decision,
+    summarize_authorization_review_packet,
+    summarize_authorization_review_receipt,
+    summarize_future_authorization_grant_schema,
+    validate_authorization_review_decision,
+    validate_authorization_review_packet,
+    validate_authorization_review_receipt,
+    validate_future_authorization_grant_schema,
+)
+from sentientos.effect_proof import build_execution_proof_wing_for_rehearsal_receipt, build_execution_readiness_manifest
+from sentientos.host_collectors import collect_fan_pwm_observation, collect_thermal_sensor_observation
+from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, evaluate_host_resource_pressure
+from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy
+from sentientos.privilege_broker import build_privilege_broker_review_receipt, evaluate_privilege_broker_eligibility
+from tests.test_actuation_fulfillment import _broker_receipt_for
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _manifest(kind: str, *, recorded: bool = False, **kwargs):
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for(kind, recorded=recorded, **kwargs)))
+    return build_execution_proof_wing_for_rehearsal_receipt(rehearsal).execution_readiness_manifest
+
+
+def _wing(kind: str, *, recorded: bool = False, **kwargs):
+    return build_authorization_review_wing_for_execution_readiness(_manifest(kind, recorded=recorded, **kwargs))
+
+
+def test_valid_execution_readiness_manifest_builds_authorization_review_wing() -> None:
+    wing = _wing("inspect_cpu_pressure_candidate", cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    assert wing.packet.packet_status == "authorization_review_packet_ready"
+    assert wing.decision.decision_status == "authorization_review_eligible_for_operator_review"
+    assert wing.receipt.receipt_status == "authorization_review_receipt_recorded"
+    assert wing.future_authorization_grant_schema.schema_status == "future_authorization_grant_schema_ready"
+    assert wing.decision.authorization_granted is False
+    assert wing.decision.fulfillment_granted is False
+    assert wing.receipt.authorization_not_granted is True
+    assert wing.receipt.does_not_authorize_fulfillment is True
+    assert wing.future_authorization_grant_schema.schema_only is True
+    assert wing.future_authorization_grant_schema.future_use_only is True
+    assert validate_authorization_review_packet(wing.packet).ok
+    assert validate_authorization_review_decision(wing.decision).ok
+    assert validate_authorization_review_receipt(wing.receipt).ok
+    assert validate_future_authorization_grant_schema(wing.future_authorization_grant_schema).ok
+
+
+@pytest.mark.parametrize(
+    ("readiness_status", "expected"),
+    [
+        ("execution_readiness_blocked", "authorization_review_blocked"),
+        ("execution_readiness_incomplete", "authorization_review_incomplete"),
+        ("execution_readiness_contradicted", "authorization_review_contradicted"),
+        ("execution_readiness_for_authorization_review_with_conditions", "authorization_review_eligible_with_conditions"),
+    ],
+)
+def test_readiness_statuses_map_to_authorization_decisions(readiness_status: str, expected: str) -> None:
+    manifest = replace(_manifest("inspect_cpu_pressure_candidate", cpu_utilization_percent=95), readiness_status=readiness_status)
+    packet = build_authorization_review_packet(manifest)
+    decision = evaluate_authorization_review(packet)
+    assert decision.decision_status == expected
+
+
+def test_future_cooling_requires_hardware_operator_policy_panic_control_audit_rollback_effect_postcondition_immutable_backend_bounds_cooldown() -> None:
+    wing = _wing("future_cooling_policy_candidate", recorded=True, thermal_zone_temperatures_c={"cpu": 90}, cpu_utilization_percent=10, ram_utilization_percent=20, disk_utilization_percent=30)
+    gates = set(wing.packet.required_authorization_gates)
+    for gate in [
+        "hardware_allowlist_required_for_future_action",
+        "operator_or_policy_approval_required_for_future_action",
+        "panic_stop_required_for_future_action",
+        "control_plane_admission_required_for_future_action",
+        "audit_receipt_required_for_future_action",
+        "rollback_receipt_required_for_future_action",
+        "effect_receipt_required_for_future_action",
+        "postcondition_check_required_for_future_action",
+        "immutable_trace_required_for_future_action",
+        "os_backend_declaration_required_for_future_action",
+        "bounds_policy_required_for_future_action",
+        "cooldown_policy_required_for_future_action",
+    ]:
+        assert gate in gates
+    assert wing.packet.approval_class == "future_hardware_safety_approval_required"
+    assert {"fan_pwm_write", "thermal_actuation"}.issubset(set(wing.packet.blocked_actions))
+    assert wing.decision.authorization_granted is False
+
+
+def test_future_power_cleanup_and_service_require_domain_specific_authorization_gates() -> None:
+    power = _wing("future_power_policy_candidate", recorded=True, battery_percent=5, battery_charging=False)
+    cleanup = _wing("future_cleanup_policy_candidate", recorded=True, disk_utilization_percent=95)
+    service_health = _wing("inspect_service_health_candidate", service_health_labels=("daemon_degraded",))
+    service_manifest = replace(_manifest("inspect_service_health_candidate", service_health_labels=("daemon_degraded",)), effect_domain="future_service_effect")
+    service = build_authorization_review_wing_for_execution_readiness(service_manifest)
+    for gate in ["operator_or_policy_approval_required_for_future_action", "os_backend_declaration_required_for_future_action", "bounds_policy_required_for_future_action", "control_plane_admission_required_for_future_action", "audit_receipt_required_for_future_action", "rollback_receipt_required_for_future_action", "effect_receipt_required_for_future_action", "postcondition_check_required_for_future_action", "immutable_trace_required_for_future_action"]:
+        assert gate in power.packet.required_authorization_gates
+    for gate in ["filesystem_scope_required_for_future_action", "dry_run_rehearsal_evidence_required_for_future_action", "path_scope_labels_required_for_future_action", "control_plane_admission_required_for_future_action", "audit_receipt_required_for_future_action", "rollback_receipt_required_for_future_action", "effect_receipt_required_for_future_action", "postcondition_check_required_for_future_action"]:
+        assert gate in cleanup.packet.required_authorization_gates
+    for gate in ["service_scope_required_for_future_action", "runtime_supervisor_observation_required", "control_plane_admission_required_for_future_action", "audit_receipt_required_for_future_action", "rollback_receipt_required_for_future_action", "effect_receipt_required_for_future_action", "postcondition_check_required_for_future_action"]:
+        assert gate in service.packet.required_authorization_gates
+    assert "power_profile_mutation" in power.packet.blocked_actions
+    assert {"file_cleanup", "file_delete"}.issubset(cleanup.packet.blocked_actions)
+    assert {"service_restart", "process_kill"}.issubset(service.packet.blocked_actions)
+    assert "runtime_supervisor_observation_required" in service_health.packet.required_authorization_gates
+
+
+def test_diagnostics_and_operator_review_can_be_eligible_but_never_authorize() -> None:
+    diagnostics = _wing("inspect_cpu_pressure_candidate", cpu_utilization_percent=95)
+    operator_manifest = replace(_manifest("inspect_cpu_pressure_candidate", cpu_utilization_percent=95), effect_domain="operator_review")
+    operator = build_authorization_review_wing_for_execution_readiness(operator_manifest)
+    assert diagnostics.decision.decision_status == "authorization_review_eligible_for_operator_review"
+    assert operator.decision.decision_status == "authorization_review_eligible_for_operator_review"
+    for wing in [diagnostics, operator]:
+        assert wing.packet.authorization_granted is False
+        assert wing.decision.authorization_granted is False
+        assert wing.receipt.authorization_not_granted is True
+        assert wing.future_authorization_grant_schema.authorization_granted is False
+
+
+@pytest.mark.parametrize("flag", ["authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed"])
+def test_source_manifest_claiming_authority_or_effect_is_contradicted(flag: str) -> None:
+    manifest = replace(_manifest("inspect_cpu_pressure_candidate", cpu_utilization_percent=95), **{flag: True})
+    wing = build_authorization_review_wing_for_execution_readiness(manifest)
+    assert wing.packet.packet_status == "authorization_review_packet_contradicted"
+    assert wing.decision.decision_status == "authorization_review_contradicted"
+
+
+def test_missing_required_gates_produce_incomplete_decision() -> None:
+    manifest = _manifest("future_cooling_policy_candidate", recorded=True, thermal_zone_temperatures_c={"cpu": 90})
+    manifest = replace(manifest, satisfied_proof_gates=tuple(g for g in manifest.satisfied_proof_gates if g != "panic_stop_required"))
+    wing = build_authorization_review_wing_for_execution_readiness(manifest)
+    assert "panic_stop_required_for_future_action" in wing.packet.missing_authorization_gates
+    assert wing.decision.decision_status == "authorization_review_incomplete"
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    wing = _wing("inspect_cpu_pressure_candidate", cpu_utilization_percent=95)
+    assert authorization_review_decision_digest(wing.decision) == authorization_review_decision_digest(wing.decision)
+    assert authorization_review_decision_digest(replace(wing.decision, reason_codes=wing.decision.reason_codes + ("extra_reason",))) != authorization_review_decision_digest(wing.decision)
+    assert authorization_review_receipt_digest(wing.receipt) == authorization_review_receipt_digest(wing.receipt)
+    assert authorization_review_receipt_digest(replace(wing.receipt, evidence_summary=wing.receipt.evidence_summary + ("extra_evidence",), digest="")) != authorization_review_receipt_digest(wing.receipt)
+    schema = wing.future_authorization_grant_schema
+    assert future_authorization_grant_schema_digest(schema) == future_authorization_grant_schema_digest(schema)
+    assert future_authorization_grant_schema_digest(replace(schema, required_scope_labels=schema.required_scope_labels + ("extra_scope",), digest="")) != future_authorization_grant_schema_digest(schema)
+
+
+def test_summaries_are_metadata_only_and_schema_is_not_real_grant() -> None:
+    wing = _wing("inspect_cpu_pressure_candidate", cpu_utilization_percent=95)
+    assert summarize_authorization_review_packet(wing.packet)["metadata_only"] is True
+    assert summarize_authorization_review_decision(wing.decision)["review_only"] is True
+    assert summarize_authorization_review_receipt(wing.receipt)["authorization_not_granted"] is True
+    schema_summary = summarize_future_authorization_grant_schema(wing.future_authorization_grant_schema)
+    assert schema_summary["schema_only"] is True
+    assert schema_summary["future_use_only"] is True
+    assert schema_summary["authorization_granted"] is False
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed",
+        "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed",
+        "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed",
+        "prompt_assembly_performed",
+    ],
+)
+def test_validation_rejects_forbidden_authority_and_effect_flags(flag: str) -> None:
+    decision = replace(_wing("inspect_cpu_pressure_candidate", cpu_utilization_percent=95).decision, **{flag: True})
+    result = validate_authorization_review_decision(decision)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_integration_pipeline_to_authorization_review_remains_non_mutating() -> None:
+    tree = {"/thermal": ("thermal_zone0",), "/thermal/thermal_zone0": ("type", "temp"), "/hwmon": ("hwmon0",), "/hwmon/hwmon0": ("name", "pwm1", "fan1_input")}
+    files = {"/thermal/thermal_zone0/type": "cpu\n", "/thermal/thermal_zone0/temp": "90000\n", "/hwmon/hwmon0/name": "test\n", "/hwmon/hwmon0/pwm1": "120\n", "/hwmon/hwmon0/fan1_input": "1400\n"}
+    results = (
+        collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/empty", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+        collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=lambda path: tree.get(path, ()), text_reader=lambda path: files[path], observed_at="2026-01-01T00:00:00+00:00"),
+    )
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id="collector-snap")
+    report = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=85)
+    policy_decision = evaluate_host_resource_policy(report)
+    proposal_receipts = build_host_resource_proposal_receipts(policy_decision)
+    broker_decisions = tuple(evaluate_privilege_broker_eligibility(replace(receipt, proposal_status="host_resource_proposal_recorded", digest="") if receipt.proposal_kind == "future_cooling_policy_candidate" else receipt) for receipt in proposal_receipts)
+    broker_receipts = tuple(build_privilege_broker_review_receipt(decision) for decision in broker_decisions)
+    rehearsals = tuple(build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(receipt)) for receipt in broker_receipts)
+    execution_wings = tuple(build_execution_proof_wing_for_rehearsal_receipt(receipt) for receipt in rehearsals)
+    authorization_wings = tuple(build_authorization_review_wing_for_execution_readiness(wing.execution_readiness_manifest) for wing in execution_wings)
+    assert authorization_wings
+    for wing in authorization_wings:
+        decision = wing.decision
+        assert decision.authorization_granted is False
+        assert decision.fulfillment_granted is False
+        assert decision.effect_performed is False
+        assert decision.host_mutation_performed is False
+        assert decision.fan_pwm_write_performed is False
+        assert decision.thermal_actuation_performed is False
+        assert decision.power_profile_mutation_performed is False
+        assert decision.service_restart_performed is False
+        assert decision.file_cleanup_performed is False
+        assert getattr(decision, "file_delete_performed", False) is False
+        assert decision.provider_invocation_performed is False
+        assert decision.network_performed is False
+        assert decision.prompt_assembly_performed is False
+
+
+def test_policy_mapping_is_deterministic() -> None:
+    policy = build_default_authorization_review_policy()
+    assert policy.domain_approval_classes["future_cooling_authorization_review"] == "future_hardware_safety_approval_required"
+    assert "cooldown_policy_required_for_future_action" in policy.domain_required_gates["future_cooling_authorization_review"]

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -246,3 +246,45 @@ def test_registry_updates_from_execution_readiness_and_supervisor_keep_real_acti
     assert records["real_file_cleanup"].status == "blocked"
     assert records["real_effect_execution"].status == "deferred"
     assert validate_capability_registry(registry).ok
+
+
+def test_authorization_review_capabilities_are_review_and_schema_only() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["authorization_review"].status == "implemented"
+    assert records["authorization_review"].authority_level == "review_only"
+    assert records["authorization_review"].host_actuation_performed is False
+    assert "real authorization grants" in records["authorization_review"].deferred_surfaces
+    assert records["future_authorization_grant_schema"].status == "implemented"
+    assert records["future_authorization_grant_schema"].authority_level == "schema_only"
+    assert records["future_authorization_grant_schema"].host_actuation_performed is False
+    assert records["real_authorization_grant"].status == "deferred"
+    for capability_id in ["real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"]:
+        assert records[capability_id].status == "deferred"
+    for capability_id in ["real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_updates_from_authorization_review_keep_real_actions_deferred_or_blocked() -> None:
+    from sentientos.authorization_review import build_authorization_review_wing_for_execution_readiness
+    from sentientos.capability_registry import update_registry_from_authorization_review_decision, update_registry_from_future_authorization_schema
+    from sentientos.effect_proof import build_execution_proof_wing_for_rehearsal_receipt
+    from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+    from tests.test_actuation_fulfillment import _broker_receipt_for
+
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for("inspect_cpu_pressure_candidate", cpu_utilization_percent=95)))
+    manifest = build_execution_proof_wing_for_rehearsal_receipt(rehearsal).execution_readiness_manifest
+    wing = build_authorization_review_wing_for_execution_readiness(manifest)
+    registry = update_registry_from_future_authorization_schema(update_registry_from_authorization_review_decision(build_default_capability_registry(), wing.decision), wing.future_authorization_grant_schema)
+    records = registry.by_id()
+    assert records["authorization_review"].status == "implemented"
+    assert records["authorization_review"].authority_level == "review_only"
+    assert records["future_authorization_grant_schema"].authority_level == "schema_only"
+    assert records["real_authorization_grant"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_rollback_execution"].status == "deferred"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -228,3 +228,27 @@ def test_execution_proof_wing_doc_preserves_readiness_boundaries() -> None:
     assert "Real actuation remains deferred" in doc
     for term in ["Effect Receipt", "Postcondition Check", "Rollback Plan", "RollbackReceipt", "Runtime Supervisor", "Execution Readiness Manifest"]:
         assert term in doc
+
+HOST_EMBODIMENT_AUTHORIZATION_REVIEW_WING = "docs/architecture/host_embodiment_authorization_review_wing.md"
+
+
+def test_navigation_links_to_host_embodiment_authorization_review_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    phase4 = _read(HOST_EMBODIMENT_PHASE4)
+    phase5 = _read(HOST_EMBODIMENT_PHASE5)
+    execution = _read(HOST_EMBODIMENT_EXECUTION_PROOF_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, phase4, phase5, execution, trajectory]:
+        assert HOST_EMBODIMENT_AUTHORIZATION_REVIEW_WING in text
+
+
+def test_authorization_review_wing_doc_preserves_review_only_boundaries() -> None:
+    doc = _read(HOST_EMBODIMENT_AUTHORIZATION_REVIEW_WING)
+    assert "authorization review is not authorization grant" in doc
+    assert "Future Authorization Grant schema is not a real grant" in doc or "future authorization grant schema is not a real grant" in doc
+    assert "Real fulfillment remains deferred" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "No host mutation" in doc or "not host mutation" in doc
+    for term in ["AuthorizationReviewPacket", "AuthorizationReviewDecision", "AuthorizationReviewReceipt", "FutureAuthorizationGrantSchema"]:
+        assert term in doc


### PR DESCRIPTION
### Motivation

- Add a metadata-only authorization-review layer after the Execution Proof Wing to decide whether an `ExecutionReadinessManifest` is suitable to present for future operator/policy authorization consideration without granting any authorization or performing any host action.
- Preserve the repository posture that readiness/rehearsal/eligibility are evidence-only and do not cause host mutation, fan/PWM writes, thermal/power changes, service restarts, package/driver installs, file deletions, provider/network calls, or prompt/provider invocation.

### Description

- New review module: add `sentientos/authorization_review.py` which defines frozen dataclasses and helpers for `AuthorizationReviewPolicy`, `AuthorizationReviewPacket`, `AuthorizationReviewDecision`, `AuthorizationReviewReceipt`, `FutureAuthorizationGrantSchema`, deterministic digest helpers, validators, summaries, and the end-to-end builder `build_authorization_review_wing_for_execution_readiness(...)` that produces packet→decision→receipt→future schema from an `ExecutionReadinessManifest`.
- Domain/gates mapping and semantics: implement authorization domains, approval classes, blocked-action vocabulary, and domain-specific required authorization gates (including future cooling/power/cleanup/service gate sets and mappings from proof gates to authorization gates).
- Capability registry integration: update `sentientos/capability_registry.py` to represent `authorization_review` (implemented `review_only`) and `future_authorization_grant_schema` (implemented `schema_only`) while keeping real grants and real-effect capabilities deferred/blocked; add `update_registry_from_authorization_review_decision(...)` and `update_registry_from_future_authorization_schema(...)` helpers that update the registry additively without claiming real host authority.
- Docs and links: add `docs/architecture/host_embodiment_authorization_review_wing.md` and update related architecture docs and reviewer index to link the new wing and to explicitly state that review is not authorization and future grant schema is not a real grant.
- Tests: add `tests/test_authorization_review.py` and extend `tests/test_capability_registry.py` and `tests/test_reviewer_release_readiness_index.py` to cover mapping, validation, deterministic digests, pipeline integration, and capability-registry reflections.

### Testing

- Ran compilation checks: `python -m py_compile sentientos/authorization_review.py sentientos/effect_proof.py sentientos/capability_registry.py tests/test_authorization_review.py tests/test_effect_proof.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` (succeeded).
- Ran focused unit suites: `python -m scripts.run_tests -q tests/test_authorization_review.py tests/test_effect_proof.py tests/test_capability_registry.py` (all tests passed after adjustments).
- Ran broader integration suites: `python -m scripts.run_tests -q tests/test_actuation_fulfillment.py tests/test_runtime_supervisor.py tests/test_privilege_broker.py` and `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_host_resource_policy.py` (passed).
- Docs build: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` (succeeded after bootstrapping dependencies).
- Context-hygiene and forbidden-scan: `python scripts/verify_context_hygiene_prompt_boundaries.py` and repository grep for forbidden runtime/network/host-actuation calls returned only documentation strings, blocked-action labels, validation guard flags, or deferred capability labels (no runtime imports/calls that perform host mutation or network/provider operations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a056bcdf8308320b1c0c1af278ed273)