### PR TITLE
[codex:host-embodiment] add controlled authorization trace wing

### DIFF
--- a/docs/architecture/host_embodiment_authorization_review_wing.md
+++ b/docs/architecture/host_embodiment_authorization_review_wing.md
@@ -95,3 +95,9 @@ rollback, effect receipt, and postcondition checks.
 - Authorization review tests: `tests/test_authorization_review.py`
 - Registry tests: `tests/test_capability_registry.py`
 - Docs regression: `tests/test_reviewer_release_readiness_index.py`
+
+## Next wing
+
+The next non-mutating organ is the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). It defines a controlled grant contract, schema-only/future-use-only grant and revocation records, a metadata-only ledger, and a reviewer demo trace. It does not grant live authorization or perform effects.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -1,0 +1,49 @@
+# Host Embodiment Controlled Authorization + Trace Wing
+
+This wing follows the [Authorization Review Wing](host_embodiment_authorization_review_wing.md). It defines the controlled authorization grant contract and a reviewer-facing end-to-end trace across the non-mutating host-embodiment ladder.
+
+## Boundary
+
+Authorization review is not authorization. A controlled authorization contract is not a live grant. A grant record is schema-only/future-use-only. A revocation record is schema-only/future-use-only. The authorization ledger is metadata-only and does not grant authority.
+
+This wing is contract/ledger/trace proof only. It does not execute, fulfill, mutate host state, write fan/PWM controls, change thermal settings, mutate power profiles, kill processes, restart services, clean up or delete files, install packages or drivers, perform network egress, invoke providers, assemble or export prompts, transport federation state, or perform remote execution.
+
+## Authority ladder
+
+The ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → authorize → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers only **controlled grant contract** and **trace**. The authorize, fulfill, effect receipt, postcondition check, audit, and rollback stages remain future controlled work unless represented as non-mutating schema/proof artifacts.
+
+## Controlled authorization contract
+
+`sentientos/controlled_authorization.py` defines:
+
+- `ControlledAuthorizationGrantContract`: required future grant fields, scope, expiry, revocation, audit, control-plane, rollback, effect receipt, postcondition, supervisor, immutable trace, and panic-stop gates.
+- `ControlledAuthorizationGrantRecord`: schema-only/future-use-only record. It is not a live authorization grant and does not authorize fulfillment.
+- `ControlledAuthorizationRevocationRecord`: schema-only/future-use-only revocation path record. It does not perform live revocation.
+- `ControlledAuthorizationLedger`: metadata-only ledger scaffold. It records schema grant/revocation records but does not grant authority.
+
+Future cooling, power, service, and cleanup scopes stay blocked/deferred. Future cooling keeps fan/PWM writes and thermal actuation blocked. Future power keeps power profile mutation blocked. Future service keeps service restart and process kill blocked. Future cleanup keeps cleanup and delete actions blocked.
+
+## End-to-end demo trace
+
+`sentientos/host_embodiment_trace.py` builds a deterministic reviewer proof trace using supplied fake/sample telemetry by default. The demo includes a thermal + PWM scenario to prove that PWM presence is telemetry, not authority.
+
+The trace spans collector results, inventory, telemetry, pressure, policy, proposal receipts, broker eligibility/review, fulfillment rehearsal, execution proof, authorization review, future authorization schema, controlled authorization contract, schema-only grant record, schema-only revocation record, and metadata-only ledger.
+
+Demo trace is reviewer proof only. The trace is demo/proof-only. It explicitly records no live authorization, no real fulfillment, no effect, no host mutation, no fan/PWM write, no thermal write, no power mutation, no service restart, no cleanup/delete, no provider invocation, no network egress, no prompt assembly/export, no federation transport, and no remote execution.
+
+## Future live authority requirements
+
+Future cooling/power/service/cleanup actions remain behind explicit future live authorization, control-plane admission, operator/policy identity, bounded scope, expiry, revocation path, audit receipt, rollback plan/receipt, effect receipt, postcondition checks, runtime supervisor observation, immutable trace, and panic-stop requirements.
+
+Real fulfillment remains deferred. Real actuation remains deferred.
+
+## Reviewer proof links
+
+- Module: `sentientos/controlled_authorization.py`
+- Trace builder: `sentientos/host_embodiment_trace.py`
+- Tests: `tests/test_controlled_authorization.py`, `tests/test_host_embodiment_trace.py`
+- Public proof map: [Reviewer Release Readiness Index](reviewer_release_readiness_index.md)

--- a/docs/architecture/host_embodiment_execution_proof_wing.md
+++ b/docs/architecture/host_embodiment_execution_proof_wing.md
@@ -108,3 +108,9 @@ deferred. Real actuation remains deferred.
 Reviewers should explicitly see these proof organs before any future effect:
 Effect Receipt contract, Postcondition Check plan/receipt, Rollback Plan/Receipt,
 Runtime Supervisor, and Execution Readiness Manifest.
+
+## Controlled authorization and trace link
+
+Execution readiness remains non-authorizing. The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) follows authorization review with contract-only/schema-only/ledger-only records and a demo trace; real effect execution and rollback remain deferred.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
+++ b/docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md
@@ -162,3 +162,9 @@ Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wi
 ## Next wing: Authorization Review
 
 After the Execution Proof Wing, see `docs/architecture/host_embodiment_authorization_review_wing.md`. Authorization review is not authorization; a future authorization grant schema is not a real grant; real fulfillment and real actuation remain deferred.
+
+## Controlled authorization and trace link
+
+Fulfillment rehearsal remains non-mutating. The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) links this scaffold into a reviewer trace while keeping real fulfillment, host mutation, fan/PWM writes, thermal actuation, service restart, power mutation, and cleanup/delete deferred or blocked.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -235,3 +235,9 @@ Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wi
 ## Host Embodiment Authorization Review Wing
 
 Next review-only wing: `docs/architecture/host_embodiment_authorization_review_wing.md`. Authorization review is not authorization grant; the future authorization grant schema is not a real grant; real fulfillment remains deferred; real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind explicit future authorization, control-plane admission, audit, rollback, effect receipt, and postcondition checks.
+
+### Controlled authorization + trace proof
+
+The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) adds a contract-only controlled authorization schema and a demo/proof-only host embodiment trace. The controlled authorization contract is not a live grant; the grant record is schema-only/future-use-only; the demo trace is reviewer proof only; real fulfillment and real actuation remain deferred.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -221,3 +221,21 @@ Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wi
 ## Host Embodiment Authorization Review Wing
 
 See `docs/architecture/host_embodiment_authorization_review_wing.md`. This proof surface is metadata-only review of ExecutionReadinessManifest records: authorization review is not authorization grant, a future authorization grant schema is not a real grant, real fulfillment remains deferred, and real actuation remains deferred.
+
+## Host Embodiment Controlled Authorization + Trace Wing
+
+- Architecture: [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md)
+- Code: `sentientos/controlled_authorization.py`, `sentientos/host_embodiment_trace.py`
+- Tests: `tests/test_controlled_authorization.py`, `tests/test_host_embodiment_trace.py`
+
+Reviewer assertions:
+
+- Controlled authorization contract is not a live grant.
+- Grant record is schema-only/future-use-only.
+- Revocation record is schema-only/future-use-only.
+- Authorization ledger is metadata-only and does not grant authority.
+- Demo trace is reviewer proof only.
+- Real fulfillment remains deferred.
+- Real actuation remains deferred.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -379,3 +379,9 @@ Next proof/readiness wing: `docs/architecture/host_embodiment_execution_proof_wi
 ## Host Embodiment Authorization Review Wing
 
 See `docs/architecture/host_embodiment_authorization_review_wing.md`. This next organ after the Execution Proof Wing records metadata-only authorization review packets, decisions, receipts, and a future grant schema placeholder. Authorization review is not authorization, the future authorization grant schema is not a real grant, real fulfillment remains deferred, and real actuation remains deferred.
+
+## Controlled Authorization + Trace Wing
+
+The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) is now represented as the next non-mutating organ after Authorization Review: contract-only controlled authorization, schema-only/future-use-only grant and revocation records, metadata-only ledger, and a reviewer demo trace. Live authorization, real fulfillment, real actuation, rollback execution, fan/PWM control, thermal actuation, power mutation, service restart, and cleanup/delete remain missing/deferred organs.
+
+Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -36,6 +36,8 @@ CAPABILITY_CATEGORIES = frozenset(
         "actuation_fulfillment",
         "execution_proof",
         "authorization_review",
+        "controlled_authorization",
+        "host_embodiment_trace",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -55,6 +57,9 @@ AUTHORITY_LEVELS = frozenset(
         "readiness_only",
         "review_only",
         "schema_only",
+        "contract_only",
+        "ledger_only",
+        "demo_proof_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -235,6 +240,11 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("execution_readiness_manifest", "execution_proof", "implemented", "readiness_only", source_paths=("sentientos/effect_proof.py", "sentientos/runtime_supervisor.py"), proof_tests=("tests/test_effect_proof.py", "tests/test_runtime_supervisor.py"), implemented_surfaces=("metadata-only execution readiness manifest",), deferred_surfaces=("authorization", "fulfillment", "real actuation"), forbidden_implications=("execution readiness is authorization", "readiness manifest performs effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("authorization_review", "authorization_review", "implemented", "review_only", source_paths=("sentientos/authorization_review.py",), proof_tests=("tests/test_authorization_review.py",), proof_commands=("python -m scripts.run_tests -q tests/test_authorization_review.py",), implemented_surfaces=("metadata-only authorization review packets", "authorization review decisions", "authorization review receipts"), deferred_surfaces=("real authorization grants", "real effect execution", "real rollback execution"), forbidden_implications=("authorization review is authorization", "authorization review receipt is fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("future_authorization_grant_schema", "authorization_review", "implemented", "schema_only", source_paths=("sentientos/authorization_review.py",), proof_tests=("tests/test_authorization_review.py",), implemented_surfaces=("future authorization grant schema placeholder",), deferred_surfaces=("real authorization grant issuance", "host mutation fulfillment"), forbidden_implications=("future authorization grant schema is a real grant", "schema grants fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("controlled_authorization_contract", "controlled_authorization", "implemented", "contract_only", source_paths=("sentientos/controlled_authorization.py",), proof_tests=("tests/test_controlled_authorization.py",), implemented_surfaces=("controlled authorization grant contract metadata",), deferred_surfaces=("live authorization grant", "real fulfillment", "real actuation"), forbidden_implications=("controlled authorization contract is a live grant", "contract authorizes fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("controlled_authorization_grant_record", "controlled_authorization", "implemented", "schema_only", source_paths=("sentientos/controlled_authorization.py",), proof_tests=("tests/test_controlled_authorization.py",), implemented_surfaces=("schema-only future-use grant record",), deferred_surfaces=("live authorization grant",), forbidden_implications=("grant record grants live authority",)),
+        _record("controlled_authorization_ledger", "controlled_authorization", "implemented", "ledger_only", source_paths=("sentientos/controlled_authorization.py",), proof_tests=("tests/test_controlled_authorization.py",), implemented_surfaces=("metadata-only authorization ledger scaffold",), deferred_surfaces=("runtime authority token",), forbidden_implications=("ledger grants authorization",)),
+        _record("host_embodiment_trace", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("sentientos/host_embodiment_trace.py",), proof_tests=("tests/test_host_embodiment_trace.py",), implemented_surfaces=("reviewer-facing non-mutating demo trace",), deferred_surfaces=("live authorization", "real effects", "real rollback"), forbidden_implications=("demo trace executes host actions", "trace grants authority")),
+        _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_execution", "execution_proof", "deferred", "none", deferred_surfaces=("authorized effect fulfillment", "host mutation", "effect receipt from real action"), forbidden_implications=("execution proof wing implements real effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_rollback_execution", "execution_proof", "deferred", "none", deferred_surfaces=("rollback execution", "host mutation rollback",), forbidden_implications=("rollback receipt schema executes rollback",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -247,9 +257,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-authorization-review-wing", schema_version="host-embodiment-authorization-review-wing.v1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-controlled-authorization-and-trace-wing", schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1", records=records)
 
 
 
@@ -661,3 +671,66 @@ def update_registry_from_runtime_supervisor_report(registry: CapabilityRegistry,
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-execution-proof-wing.v1")
+
+
+def update_registry_from_controlled_authorization_ledger(registry: CapabilityRegistry, ledger: Any) -> CapabilityRegistry:
+    """Reflect controlled authorization records without creating live authority."""
+
+    records: list[CapabilityRecord] = []
+    has_ledger = bool(getattr(ledger, "ledger_id", "") or getattr(ledger, "source_id", ""))
+    for record in registry.records:
+        if record.capability_id == "controlled_authorization_contract":
+            records.append(replace(record, status="implemented", authority_level="contract_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "controlled_authorization_grant_record":
+            records.append(replace(record, status="implemented", authority_level="schema_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "controlled_authorization_ledger":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_ledger else "scaffolded",
+                    authority_level="ledger_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/controlled_authorization.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_controlled_authorization.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("metadata-only controlled authorization ledger",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("controlled authorization ledger grants live authority",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"live_authorization_grant", "real_authorization_grant", "real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1")
+
+
+def update_registry_from_host_embodiment_trace(registry: CapabilityRegistry, trace: Any) -> CapabilityRegistry:
+    """Reflect reviewer demo trace proof without granting authorization or effects."""
+
+    records: list[CapabilityRecord] = []
+    has_trace = bool(getattr(trace, "trace_id", ""))
+    for record in registry.records:
+        if record.capability_id == "host_embodiment_trace":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_trace else "scaffolded",
+                    authority_level="demo_proof_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/host_embodiment_trace.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_embodiment_trace.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("full non-mutating reviewer trace artifact",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("live authorization grant", "real effect execution", "real rollback execution")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("host embodiment trace grants live authorization", "trace performs effects")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"live_authorization_grant", "real_authorization_grant", "real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1")

--- a/sentientos/controlled_authorization.py
+++ b/sentientos/controlled_authorization.py
@@ -1,0 +1,540 @@
+"""Controlled authorization grant contracts for host embodiment.
+
+This wing is contract-only, ledger-only, and trace-safe. It defines the shape of
+future controlled authorization grants without creating live authority. It never
+executes host actions, mutates host state, writes fan/PWM controls, changes
+thermal or power settings, kills processes, restarts services, installs packages
+or drivers, deletes files, performs cleanup, opens network egress, invokes
+providers, assembles prompts, transports federation state, or performs remote
+execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.authorization_review import AuthorizationReviewReceipt, FutureAuthorizationGrantSchema
+
+CONTROLLED_AUTHORIZATION_CONTRACT_STATUSES = frozenset({
+    "controlled_authorization_contract_ready",
+    "controlled_authorization_contract_ready_with_conditions",
+    "controlled_authorization_contract_blocked",
+    "controlled_authorization_contract_incomplete",
+    "controlled_authorization_contract_contradicted",
+})
+CONTROLLED_AUTHORIZATION_GRANT_STATUSES = frozenset({
+    "controlled_authorization_grant_schema_recorded",
+    "controlled_authorization_grant_schema_recorded_with_warnings",
+    "controlled_authorization_grant_blocked",
+    "controlled_authorization_grant_incomplete",
+    "controlled_authorization_grant_contradicted",
+    "controlled_authorization_grant_revoked",
+    "controlled_authorization_grant_expired",
+})
+CONTROLLED_AUTHORIZATION_REVOCATION_STATUSES = frozenset({
+    "controlled_authorization_revocation_recorded",
+    "controlled_authorization_revocation_blocked",
+    "controlled_authorization_revocation_incomplete",
+    "controlled_authorization_revocation_contradicted",
+})
+CONTROLLED_AUTHORIZATION_LEDGER_STATUSES = frozenset({
+    "controlled_authorization_ledger_current",
+    "controlled_authorization_ledger_current_with_warnings",
+    "controlled_authorization_ledger_blocked",
+    "controlled_authorization_ledger_incomplete",
+    "controlled_authorization_ledger_contradicted",
+})
+AUTHORIZATION_SCOPES = frozenset({
+    "diagnostics_only_scope",
+    "operator_review_scope",
+    "resource_pressure_review_scope",
+    "thermal_safety_review_scope",
+    "disk_safety_review_scope",
+    "service_health_review_scope",
+    "future_cooling_scope",
+    "future_power_scope",
+    "future_cleanup_scope",
+    "future_service_scope",
+})
+REQUIRED_GRANT_GATES = frozenset({
+    "source_authorization_review_receipt_required",
+    "future_authorization_grant_schema_required",
+    "operator_identity_required",
+    "policy_identity_required",
+    "explicit_scope_required",
+    "time_bounds_required",
+    "expiry_required",
+    "revocation_path_required",
+    "control_plane_admission_required",
+    "audit_receipt_required",
+    "rollback_plan_required",
+    "rollback_receipt_required",
+    "effect_receipt_required",
+    "postcondition_check_required",
+    "runtime_supervisor_observation_required",
+    "immutable_trace_required",
+    "panic_stop_required",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "live_authorization_grant",
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+
+_DOMAIN_SCOPE: Mapping[str, str] = {
+    "diagnostics_authorization_review": "diagnostics_only_scope",
+    "operator_review_authorization_review": "operator_review_scope",
+    "resource_pressure_authorization_review": "resource_pressure_review_scope",
+    "thermal_safety_authorization_review": "thermal_safety_review_scope",
+    "disk_safety_authorization_review": "disk_safety_review_scope",
+    "service_health_authorization_review": "service_health_review_scope",
+    "future_cooling_authorization_review": "future_cooling_scope",
+    "future_power_authorization_review": "future_power_scope",
+    "future_cleanup_authorization_review": "future_cleanup_scope",
+    "future_service_authorization_review": "future_service_scope",
+}
+_SCOPE_BLOCKS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_scope": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_scope": ("power_profile_mutation",),
+    "future_cleanup_scope": ("file_cleanup", "file_delete"),
+    "future_service_scope": ("service_restart", "process_kill"),
+    "service_health_review_scope": ("service_restart", "process_kill"),
+}
+_REQUIRED_SCOPE_GATES: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_scope": tuple(sorted(REQUIRED_GRANT_GATES)),
+    "future_power_scope": tuple(sorted(REQUIRED_GRANT_GATES)),
+    "future_cleanup_scope": tuple(sorted(REQUIRED_GRANT_GATES)),
+    "future_service_scope": tuple(sorted(REQUIRED_GRANT_GATES)),
+}
+
+@dataclass(frozen=True)
+class ControlledAuthorizationPolicy:
+    policy_id: str
+    required_grant_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    domain_scopes: Mapping[str, str]
+    metadata_only: bool = True
+    contract_only: bool = True
+    live_authorization_granted: bool = False
+
+@dataclass(frozen=True)
+class ControlledAuthorizationGrantContract:
+    contract_id: str
+    source_authorization_review_receipt_id: str
+    source_authorization_review_receipt_digest: str
+    future_authorization_grant_schema_id: str
+    authorization_domain: str
+    approval_class: str
+    authorization_scope: str
+    required_grant_gates: tuple[str, ...]
+    required_operator_identity_labels: tuple[str, ...]
+    required_policy_labels: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    required_time_bound_labels: tuple[str, ...]
+    required_expiry_labels: tuple[str, ...]
+    required_revocation_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_control_plane_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    missing_prerequisites: tuple[str, ...]
+    status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    contract_only: bool = True
+    live_authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class ControlledAuthorizationGrantRecord:
+    grant_record_id: str
+    contract_id: str
+    source_authorization_review_receipt_id: str
+    source_authorization_review_receipt_digest: str
+    authorization_domain: str
+    approval_class: str
+    authorization_scope: str
+    grant_status: str
+    grant_subject_labels: tuple[str, ...]
+    grant_scope_labels: tuple[str, ...]
+    grant_time_bounds: tuple[str, ...]
+    grant_expiry_label: str
+    revocation_path_labels: tuple[str, ...]
+    required_future_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    schema_only: bool = True
+    future_use_only: bool = True
+    live_authorization_granted: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    does_not_authorize_fulfillment: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class ControlledAuthorizationRevocationRecord:
+    revocation_id: str
+    grant_record_id: str
+    contract_id: str
+    source_authorization_review_receipt_id: str
+    revocation_status: str
+    revocation_reason_codes: tuple[str, ...]
+    revocation_effective_label: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    schema_only: bool = True
+    future_use_only: bool = True
+    live_revocation_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class ControlledAuthorizationLedger:
+    ledger_id: str
+    grant_records: tuple[ControlledAuthorizationGrantRecord, ...]
+    revocation_records: tuple[ControlledAuthorizationRevocationRecord, ...]
+    ledger_status: str
+    active_schema_grant_count: int
+    revoked_schema_grant_count: int
+    expired_schema_grant_count: int
+    blocked_schema_grant_count: int
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    ledger_only: bool = True
+    live_authorization_granted: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class ControlledAuthorizationValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+class ControlledAuthorizationWingRecords(NamedTuple):
+    contract: ControlledAuthorizationGrantContract
+    grant_record: ControlledAuthorizationGrantRecord
+    revocation_record: ControlledAuthorizationRevocationRecord
+    ledger: ControlledAuthorizationLedger
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _record_digest(record: Any) -> str:
+    payload = record.to_dict()
+    if "digest" in payload:
+        payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def controlled_authorization_grant_contract_digest(contract: ControlledAuthorizationGrantContract) -> str: return _record_digest(contract)
+def controlled_authorization_grant_record_digest(record: ControlledAuthorizationGrantRecord) -> str: return _record_digest(record)
+def controlled_authorization_revocation_record_digest(record: ControlledAuthorizationRevocationRecord) -> str: return _record_digest(record)
+def controlled_authorization_ledger_digest(ledger: ControlledAuthorizationLedger) -> str: return _record_digest(ledger)
+
+
+def build_default_controlled_authorization_policy() -> ControlledAuthorizationPolicy:
+    return ControlledAuthorizationPolicy(
+        policy_id="sentientos-host-embodiment-controlled-authorization.v1",
+        required_grant_gates=tuple(sorted(REQUIRED_GRANT_GATES)),
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        domain_scopes=dict(_DOMAIN_SCOPE),
+    )
+
+
+def _scope_for(receipt: AuthorizationReviewReceipt) -> str:
+    return _DOMAIN_SCOPE.get(receipt.authorization_domain, "diagnostics_only_scope")
+
+
+def _status_from_review(receipt_status: str, schema_status: str) -> tuple[str, str]:
+    joined = f"{receipt_status} {schema_status}"
+    if "contradicted" in joined:
+        return "controlled_authorization_contract_contradicted", "controlled_authorization_grant_contradicted"
+    if "incomplete" in joined:
+        return "controlled_authorization_contract_incomplete", "controlled_authorization_grant_incomplete"
+    if "blocked" in joined:
+        return "controlled_authorization_contract_blocked", "controlled_authorization_grant_blocked"
+    if "warning" in joined or "conditions" in joined:
+        return "controlled_authorization_contract_ready_with_conditions", "controlled_authorization_grant_schema_recorded_with_warnings"
+    return "controlled_authorization_contract_ready", "controlled_authorization_grant_schema_recorded"
+
+
+def _blocked_for(scope: str, source_blocked: Sequence[str]) -> tuple[str, ...]:
+    labels = set(BLOCKED_ACTION_LABELS)
+    labels.update(_SCOPE_BLOCKS.get(scope, ()))
+    labels.update(str(item) for item in source_blocked if str(item) in BLOCKED_ACTION_LABELS)
+    return tuple(sorted(labels))
+
+
+def build_controlled_authorization_grant_contract(
+    receipt: AuthorizationReviewReceipt,
+    future_schema: FutureAuthorizationGrantSchema,
+    *,
+    policy: ControlledAuthorizationPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> ControlledAuthorizationGrantContract:
+    policy = policy or build_default_controlled_authorization_policy()
+    scope = _scope_for(receipt)
+    contract_status, _ = _status_from_review(receipt.receipt_status, future_schema.schema_status)
+    missing: list[str] = []
+    if future_schema.source_authorization_review_receipt_id != receipt.receipt_id:
+        missing.append("future_schema_receipt_id_mismatch")
+    if future_schema.source_authorization_review_receipt_digest != receipt.digest:
+        missing.append("future_schema_receipt_digest_mismatch")
+    if not receipt.authorization_not_granted:
+        missing.append("source_review_must_not_grant_authorization")
+    required_gates = tuple(sorted(set(policy.required_grant_gates) | set(_REQUIRED_SCOPE_GATES.get(scope, ())) | {"source_authorization_review_receipt_required", "future_authorization_grant_schema_required"}))
+    provisional = ControlledAuthorizationGrantContract(
+        contract_id=_digest_payload("cagc_", {"receipt": receipt.receipt_id, "schema": future_schema.schema_id, "scope": scope, "created_at": created_at}),
+        source_authorization_review_receipt_id=receipt.receipt_id,
+        source_authorization_review_receipt_digest=receipt.digest,
+        future_authorization_grant_schema_id=future_schema.schema_id,
+        authorization_domain=receipt.authorization_domain,
+        approval_class=receipt.approval_class,
+        authorization_scope=scope,
+        required_grant_gates=required_gates,
+        required_operator_identity_labels=tuple(sorted(set(future_schema.required_operator_identity_labels) | {"operator_identity_required"})),
+        required_policy_labels=tuple(sorted(set(future_schema.required_policy_labels) | {"policy_identity_required"})),
+        required_scope_labels=tuple(sorted(set(future_schema.required_scope_labels) | {"explicit_scope_required", scope})),
+        required_time_bound_labels=tuple(sorted(set(future_schema.required_time_bounds) | {"time_bounds_required"})),
+        required_expiry_labels=("expiry_required", "expires_at_required", "short_lived_authorization_required"),
+        required_revocation_labels=tuple(sorted(set(future_schema.required_revocation_labels) | {"revocation_path_required"})),
+        required_audit_labels=tuple(sorted(set(future_schema.required_audit_labels) | {"audit_receipt_required", "immutable_trace_required"})),
+        required_control_plane_labels=tuple(sorted(set(future_schema.required_control_plane_labels) | {"control_plane_admission_required"})),
+        blocked_actions=_blocked_for(scope, tuple(receipt.blocked_actions) + tuple(future_schema.blocked_actions)),
+        missing_prerequisites=tuple(sorted(set(missing))),
+        status="controlled_authorization_contract_incomplete" if missing and contract_status == "controlled_authorization_contract_ready" else contract_status,
+        warning_codes=tuple(sorted(set(receipt.warning_codes) | set(future_schema.warning_codes))),
+        risk_codes=tuple(sorted(set(receipt.risk_codes) | set(future_schema.risk_codes) | {"controlled_authorization_contract_is_not_live_grant"})),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=controlled_authorization_grant_contract_digest(provisional))
+
+
+def build_controlled_authorization_grant_record(
+    contract: ControlledAuthorizationGrantContract,
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> ControlledAuthorizationGrantRecord:
+    status_map = {
+        "controlled_authorization_contract_ready": "controlled_authorization_grant_schema_recorded",
+        "controlled_authorization_contract_ready_with_conditions": "controlled_authorization_grant_schema_recorded_with_warnings",
+        "controlled_authorization_contract_blocked": "controlled_authorization_grant_blocked",
+        "controlled_authorization_contract_incomplete": "controlled_authorization_grant_incomplete",
+        "controlled_authorization_contract_contradicted": "controlled_authorization_grant_contradicted",
+    }
+    provisional = ControlledAuthorizationGrantRecord(
+        grant_record_id=_digest_payload("cagr_", {"contract": contract.contract_id, "digest": contract.digest, "created_at": created_at}),
+        contract_id=contract.contract_id,
+        source_authorization_review_receipt_id=contract.source_authorization_review_receipt_id,
+        source_authorization_review_receipt_digest=contract.source_authorization_review_receipt_digest,
+        authorization_domain=contract.authorization_domain,
+        approval_class=contract.approval_class,
+        authorization_scope=contract.authorization_scope,
+        grant_status=status_map.get(contract.status, "controlled_authorization_grant_incomplete"),
+        grant_subject_labels=contract.required_operator_identity_labels,
+        grant_scope_labels=contract.required_scope_labels,
+        grant_time_bounds=contract.required_time_bound_labels,
+        grant_expiry_label="expiry_required",
+        revocation_path_labels=contract.required_revocation_labels,
+        required_future_gates=contract.required_grant_gates,
+        blocked_actions=contract.blocked_actions,
+        warning_codes=contract.warning_codes,
+        risk_codes=tuple(sorted(set(contract.risk_codes) | {"grant_record_schema_only_future_use_only"})),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=controlled_authorization_grant_record_digest(provisional))
+
+
+def build_controlled_authorization_revocation_record(
+    grant_record: ControlledAuthorizationGrantRecord,
+    *,
+    reason_codes: Sequence[str] = ("schema_revocation_path_documented",),
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> ControlledAuthorizationRevocationRecord:
+    if grant_record.grant_status.endswith("contradicted"):
+        status = "controlled_authorization_revocation_contradicted"
+    elif grant_record.grant_status.endswith("incomplete"):
+        status = "controlled_authorization_revocation_incomplete"
+    elif grant_record.grant_status.endswith("blocked"):
+        status = "controlled_authorization_revocation_blocked"
+    else:
+        status = "controlled_authorization_revocation_recorded"
+    provisional = ControlledAuthorizationRevocationRecord(
+        revocation_id=_digest_payload("carr_", {"grant": grant_record.grant_record_id, "created_at": created_at, "reasons": tuple(reason_codes)}),
+        grant_record_id=grant_record.grant_record_id,
+        contract_id=grant_record.contract_id,
+        source_authorization_review_receipt_id=grant_record.source_authorization_review_receipt_id,
+        revocation_status=status,
+        revocation_reason_codes=tuple(str(code) for code in reason_codes),
+        revocation_effective_label="future_schema_revocation_path_only_no_live_revocation",
+        warning_codes=grant_record.warning_codes,
+        risk_codes=tuple(sorted(set(grant_record.risk_codes) | {"revocation_record_schema_only_future_use_only"})),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=controlled_authorization_revocation_record_digest(provisional))
+
+
+def build_controlled_authorization_ledger(
+    grant_records: Sequence[ControlledAuthorizationGrantRecord],
+    revocation_records: Sequence[ControlledAuthorizationRevocationRecord] = (),
+    *,
+    ledger_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> ControlledAuthorizationLedger:
+    grants = tuple(grant_records)
+    revocations = tuple(revocation_records)
+    grant_statuses = {record.grant_status for record in grants}
+    revocation_statuses = {record.revocation_status for record in revocations}
+    if any("contradicted" in status for status in grant_statuses | revocation_statuses):
+        ledger_status = "controlled_authorization_ledger_contradicted"
+    elif any("incomplete" in status for status in grant_statuses | revocation_statuses):
+        ledger_status = "controlled_authorization_ledger_incomplete"
+    elif any("blocked" in status for status in grant_statuses | revocation_statuses):
+        ledger_status = "controlled_authorization_ledger_blocked"
+    elif any(record.warning_codes for record in grants) or any(record.warning_codes for record in revocations):
+        ledger_status = "controlled_authorization_ledger_current_with_warnings"
+    else:
+        ledger_status = "controlled_authorization_ledger_current"
+    revoked_ids = {record.grant_record_id for record in revocations if record.revocation_status == "controlled_authorization_revocation_recorded"}
+    active = sum(1 for record in grants if record.grant_status.startswith("controlled_authorization_grant_schema_recorded") and record.grant_record_id not in revoked_ids)
+    provisional = ControlledAuthorizationLedger(
+        ledger_id=ledger_id or _digest_payload("cal_", {"grants": [g.grant_record_id for g in grants], "revocations": [r.revocation_id for r in revocations], "created_at": created_at}),
+        grant_records=grants,
+        revocation_records=revocations,
+        ledger_status=ledger_status,
+        active_schema_grant_count=active,
+        revoked_schema_grant_count=len(revoked_ids),
+        expired_schema_grant_count=sum(1 for record in grants if record.grant_status == "controlled_authorization_grant_expired"),
+        blocked_schema_grant_count=sum(1 for record in grants if record.grant_status == "controlled_authorization_grant_blocked"),
+        warning_codes=tuple(sorted({warning for record in grants for warning in record.warning_codes} | {warning for record in revocations for warning in record.warning_codes})),
+        risk_codes=tuple(sorted({risk for record in grants for risk in record.risk_codes} | {risk for record in revocations for risk in record.risk_codes} | {"ledger_does_not_grant_live_authority"})),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=controlled_authorization_ledger_digest(provisional))
+
+
+def _validate_non_authority(value: Any, prefix: str) -> list[str]:
+    findings: list[str] = []
+    for flag in ("live_authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "live_revocation_performed"):
+        if getattr(value, flag, False):
+            findings.append(f"{prefix}_forbidden_flag:{flag}")
+    for flag in ("metadata_only", "contract_only", "schema_only", "future_use_only", "ledger_only", "does_not_execute", "does_not_mutate_host", "does_not_authorize_fulfillment"):
+        if hasattr(value, flag) and not getattr(value, flag):
+            findings.append(f"{prefix}_missing_non_authority_flag:{flag}")
+    blocked = set(getattr(value, "blocked_actions", ()) or ())
+    forbidden_core = {"live_authorization_grant", "host_mutation", "provider_invocation", "network_egress", "prompt_assembly"}
+    if hasattr(value, "blocked_actions") and not forbidden_core.issubset(blocked):
+        findings.append(f"{prefix}_missing_core_blocked_actions")
+    return findings
+
+
+def validate_controlled_authorization_grant_contract(contract: ControlledAuthorizationGrantContract) -> ControlledAuthorizationValidationResult:
+    findings = _validate_non_authority(contract, "contract")
+    if contract.status not in CONTROLLED_AUTHORIZATION_CONTRACT_STATUSES: findings.append("unknown_contract_status")
+    if contract.authorization_scope not in AUTHORIZATION_SCOPES: findings.append("unknown_authorization_scope")
+    if contract.digest and contract.digest != controlled_authorization_grant_contract_digest(contract): findings.append("contract_digest_mismatch")
+    required = set(_SCOPE_BLOCKS.get(contract.authorization_scope, ()))
+    if not required.issubset(set(contract.blocked_actions)): findings.append("contract_missing_scope_blocked_actions")
+    return ControlledAuthorizationValidationResult(not findings, tuple(findings))
+
+
+def validate_controlled_authorization_grant_record(record: ControlledAuthorizationGrantRecord) -> ControlledAuthorizationValidationResult:
+    findings = _validate_non_authority(record, "grant_record")
+    if record.grant_status not in CONTROLLED_AUTHORIZATION_GRANT_STATUSES: findings.append("unknown_grant_status")
+    if not record.schema_only or not record.future_use_only: findings.append("grant_record_not_schema_only_future_use")
+    if record.digest and record.digest != controlled_authorization_grant_record_digest(record): findings.append("grant_record_digest_mismatch")
+    if set(_SCOPE_BLOCKS.get(record.authorization_scope, ())) - set(record.blocked_actions): findings.append("grant_record_missing_scope_blocked_actions")
+    return ControlledAuthorizationValidationResult(not findings, tuple(findings))
+
+
+def validate_controlled_authorization_revocation_record(record: ControlledAuthorizationRevocationRecord) -> ControlledAuthorizationValidationResult:
+    findings = _validate_non_authority(record, "revocation_record")
+    if record.revocation_status not in CONTROLLED_AUTHORIZATION_REVOCATION_STATUSES: findings.append("unknown_revocation_status")
+    if not record.schema_only or not record.future_use_only: findings.append("revocation_record_not_schema_only_future_use")
+    if record.live_revocation_performed: findings.append("revocation_record_claims_live_revocation")
+    if record.digest and record.digest != controlled_authorization_revocation_record_digest(record): findings.append("revocation_record_digest_mismatch")
+    return ControlledAuthorizationValidationResult(not findings, tuple(findings))
+
+
+def validate_controlled_authorization_ledger(ledger: ControlledAuthorizationLedger) -> ControlledAuthorizationValidationResult:
+    findings = _validate_non_authority(ledger, "ledger")
+    if ledger.ledger_status not in CONTROLLED_AUTHORIZATION_LEDGER_STATUSES: findings.append("unknown_ledger_status")
+    if not ledger.metadata_only or not ledger.ledger_only: findings.append("ledger_not_metadata_only")
+    if ledger.live_authorization_granted: findings.append("ledger_claims_live_authorization")
+    if ledger.host_mutation_performed: findings.append("ledger_claims_host_mutation")
+    if ledger.digest and ledger.digest != controlled_authorization_ledger_digest(ledger): findings.append("ledger_digest_mismatch")
+    for record in ledger.grant_records:
+        if not validate_controlled_authorization_grant_record(record).ok: findings.append(f"ledger_invalid_grant_record:{record.grant_record_id}")
+    for record in ledger.revocation_records:
+        if not validate_controlled_authorization_revocation_record(record).ok: findings.append(f"ledger_invalid_revocation_record:{record.revocation_id}")
+    return ControlledAuthorizationValidationResult(not findings, tuple(findings))
+
+
+def summarize_controlled_authorization_grant_contract(contract: ControlledAuthorizationGrantContract) -> dict[str, Any]:
+    return {"contract_id": contract.contract_id, "source_authorization_review_receipt_id": contract.source_authorization_review_receipt_id, "future_authorization_grant_schema_id": contract.future_authorization_grant_schema_id, "authorization_domain": contract.authorization_domain, "authorization_scope": contract.authorization_scope, "status": contract.status, "metadata_only": contract.metadata_only, "contract_only": contract.contract_only, "live_authorization_granted": contract.live_authorization_granted, "fulfillment_granted": contract.fulfillment_granted, "effect_performed": contract.effect_performed, "host_mutation_performed": contract.host_mutation_performed, "blocked_action_count": len(contract.blocked_actions), "digest": contract.digest}
+
+
+def summarize_controlled_authorization_grant_record(record: ControlledAuthorizationGrantRecord) -> dict[str, Any]:
+    return {"grant_record_id": record.grant_record_id, "contract_id": record.contract_id, "authorization_scope": record.authorization_scope, "grant_status": record.grant_status, "schema_only": record.schema_only, "future_use_only": record.future_use_only, "live_authorization_granted": record.live_authorization_granted, "does_not_execute": record.does_not_execute, "does_not_mutate_host": record.does_not_mutate_host, "does_not_authorize_fulfillment": record.does_not_authorize_fulfillment, "digest": record.digest}
+
+
+def summarize_controlled_authorization_revocation_record(record: ControlledAuthorizationRevocationRecord) -> dict[str, Any]:
+    return {"revocation_id": record.revocation_id, "grant_record_id": record.grant_record_id, "revocation_status": record.revocation_status, "schema_only": record.schema_only, "future_use_only": record.future_use_only, "live_revocation_performed": record.live_revocation_performed, "does_not_execute": record.does_not_execute, "does_not_mutate_host": record.does_not_mutate_host, "digest": record.digest}
+
+
+def summarize_controlled_authorization_ledger(ledger: ControlledAuthorizationLedger) -> dict[str, Any]:
+    return {"ledger_id": ledger.ledger_id, "ledger_status": ledger.ledger_status, "active_schema_grant_count": ledger.active_schema_grant_count, "revoked_schema_grant_count": ledger.revoked_schema_grant_count, "expired_schema_grant_count": ledger.expired_schema_grant_count, "blocked_schema_grant_count": ledger.blocked_schema_grant_count, "metadata_only": ledger.metadata_only, "ledger_only": ledger.ledger_only, "live_authorization_granted": ledger.live_authorization_granted, "host_mutation_performed": ledger.host_mutation_performed, "digest": ledger.digest}
+
+
+def build_controlled_authorization_wing_for_review_receipt(
+    receipt: AuthorizationReviewReceipt,
+    future_schema: FutureAuthorizationGrantSchema,
+    *,
+    policy: ControlledAuthorizationPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> ControlledAuthorizationWingRecords:
+    contract = build_controlled_authorization_grant_contract(receipt, future_schema, policy=policy, created_at=created_at)
+    grant_record = build_controlled_authorization_grant_record(contract, created_at=created_at)
+    revocation_record = build_controlled_authorization_revocation_record(grant_record, created_at=created_at)
+    ledger = build_controlled_authorization_ledger((grant_record,), (revocation_record,), created_at=created_at)
+    return ControlledAuthorizationWingRecords(contract, grant_record, revocation_record, ledger)

--- a/sentientos/host_embodiment_trace.py
+++ b/sentientos/host_embodiment_trace.py
@@ -1,0 +1,361 @@
+"""Reviewer-facing non-mutating host embodiment trace artifacts.
+
+The trace builder uses supplied fake/sample telemetry by default. It does not
+collect live host data unless callers explicitly pass already-built records, and
+it never mutates host state, opens network egress, invokes providers, assembles
+prompts, executes host actions, or grants authorization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+from sentientos.actuation_fulfillment import (
+    build_actuation_fulfillment_plan,
+    build_actuation_fulfillment_rehearsal_receipt,
+    summarize_actuation_fulfillment_plan,
+    summarize_actuation_fulfillment_rehearsal_receipt,
+)
+from sentientos.authorization_review import (
+    build_authorization_review_wing_for_execution_readiness,
+    summarize_authorization_review_decision,
+    summarize_authorization_review_packet,
+    summarize_authorization_review_receipt,
+    summarize_future_authorization_grant_schema,
+)
+from sentientos.controlled_authorization import (
+    BLOCKED_ACTION_LABELS,
+    build_controlled_authorization_wing_for_review_receipt,
+    summarize_controlled_authorization_grant_contract,
+    summarize_controlled_authorization_grant_record,
+    summarize_controlled_authorization_ledger,
+    summarize_controlled_authorization_revocation_record,
+)
+from sentientos.effect_proof import (
+    build_execution_proof_wing_for_rehearsal_receipt,
+    summarize_effect_receipt_contract,
+    summarize_execution_readiness_manifest,
+    summarize_future_effect_receipt_schema,
+    summarize_postcondition_check_plan,
+    summarize_rollback_plan,
+)
+from sentientos.host_collectors import collect_fan_pwm_observation, collect_thermal_sensor_observation
+from sentientos.host_inventory import build_host_inventory_from_collector_results, summarize_host_inventory_manifest
+from sentientos.host_resource_governor import build_host_resource_telemetry_from_collector_results, evaluate_host_resource_pressure, summarize_host_resource_pressure
+from sentientos.host_resource_policy import build_host_resource_proposal_receipts, evaluate_host_resource_policy, summarize_host_resource_policy_decision, summarize_host_resource_proposal_receipt
+from sentientos.privilege_broker import build_privilege_broker_review_receipt, evaluate_privilege_broker_eligibility, summarize_privilege_broker_eligibility_decision, summarize_privilege_broker_review_receipt
+
+HOST_EMBODIMENT_TRACE_STATUSES = frozenset({
+    "host_embodiment_trace_recorded",
+    "host_embodiment_trace_recorded_with_warnings",
+    "host_embodiment_trace_blocked",
+    "host_embodiment_trace_incomplete",
+    "host_embodiment_trace_contradicted",
+})
+HOST_EMBODIMENT_TRACE_STEP_KINDS = frozenset({
+    "collector_result",
+    "host_inventory_manifest",
+    "telemetry_snapshot",
+    "pressure_report",
+    "policy_decision",
+    "proposal_receipt",
+    "broker_decision",
+    "broker_review_receipt",
+    "fulfillment_plan",
+    "fulfillment_rehearsal_receipt",
+    "effect_contract",
+    "future_effect_schema",
+    "postcondition_plan",
+    "rollback_plan",
+    "execution_readiness_manifest",
+    "authorization_review_packet",
+    "authorization_review_decision",
+    "authorization_review_receipt",
+    "future_authorization_schema",
+    "controlled_authorization_contract",
+    "controlled_authorization_grant_record",
+    "controlled_authorization_revocation_record",
+    "controlled_authorization_ledger",
+})
+TRACE_BLOCKED_ACTION_LABELS = tuple(sorted(set(BLOCKED_ACTION_LABELS) | {"fan_pwm_write", "thermal_actuation", "power_profile_mutation", "service_restart", "process_kill", "file_cleanup", "file_delete", "provider_invocation", "network_egress", "prompt_assembly", "federation_transport", "remote_execution"}))
+TRACE_DEFERRED_CAPABILITY_LABELS = (
+    "live_authorization_grant",
+    "real_effect_execution",
+    "real_rollback_execution",
+    "real_fan_pwm_control",
+    "real_thermal_actuation",
+    "real_power_profile_mutation",
+    "real_service_restart",
+    "real_process_kill",
+    "real_file_cleanup",
+    "real_file_delete",
+    "network_egress",
+    "provider_invocation",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+)
+
+@dataclass(frozen=True)
+class HostEmbodimentTraceStep:
+    step_id: str
+    step_kind: str
+    source_id: str
+    source_digest: str
+    status: str
+    summary: Mapping[str, Any]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HostEmbodimentTrace:
+    trace_id: str
+    scenario_id: str
+    scenario_label: str
+    steps: tuple[HostEmbodimentTraceStep, ...]
+    trace_status: str
+    step_count: int
+    blocked_action_labels: tuple[str, ...]
+    deferred_capability_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    demo_only: bool = True
+    live_authorization_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HostEmbodimentTraceValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest_payload(prefix: str, payload: Mapping[str, Any], length: int = 24) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def _record_digest(value: Any) -> str:
+    if hasattr(value, "to_dict"):
+        payload = value.to_dict()
+    elif isinstance(value, Mapping):
+        payload = dict(value)
+    else:
+        payload = {"repr": repr(value)}
+    if "digest" in payload:
+        payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def host_embodiment_trace_digest(trace: HostEmbodimentTrace) -> str:
+    return _record_digest(trace)
+
+
+def _source_id(value: Any, *names: str) -> str:
+    for name in names:
+        attr = getattr(value, name, None)
+        if attr:
+            return str(attr)
+    return _digest_payload("src_", {"digest": _source_digest(value)}, 12)
+
+
+def _source_digest(value: Any) -> str:
+    digest = getattr(value, "digest", None)
+    if digest:
+        return str(digest)
+    return _record_digest(value)
+
+
+def _warnings(value: Any) -> tuple[str, ...]:
+    codes = list(getattr(value, "warning_codes", ()) or getattr(value, "warnings", ()) or ())
+    return tuple(str(code) for code in codes)
+
+
+def _risks(value: Any) -> tuple[str, ...]:
+    codes = list(getattr(value, "risk_codes", ()) or getattr(value, "risks", ()) or ())
+    return tuple(str(code) for code in codes)
+
+
+def _step(kind: str, value: Any, *, summary: Mapping[str, Any], status: str, id_names: Sequence[str]) -> HostEmbodimentTraceStep:
+    source_id = _source_id(value, *id_names)
+    provisional = HostEmbodimentTraceStep(
+        step_id=_digest_payload("hets_", {"kind": kind, "source": source_id, "digest": _source_digest(value)}),
+        step_kind=kind,
+        source_id=source_id,
+        source_digest=_source_digest(value),
+        status=str(status),
+        summary=dict(summary),
+        warning_codes=_warnings(value),
+        risk_codes=_risks(value),
+    )
+    return provisional
+
+
+def _collector_demo_results(created_at: str) -> tuple[Any, ...]:
+    def list_dir(path: str) -> tuple[str, ...]:
+        mapping = {
+            "/thermal": ("thermal_zone0",),
+            "/hwmon": ("hwmon0",),
+            "/hwmon/hwmon0": ("temp1_input", "fan1_input", "pwm1"),
+        }
+        return mapping.get(path, ())
+
+    def read_text(path: str) -> str:
+        if path.endswith("/thermal_zone0/temp") or path.endswith("temp1_input"):
+            return "91000\n"
+        if path.endswith("/thermal_zone0/type"):
+            return "x86_pkg_temp\n"
+        if path.endswith("fan1_input"):
+            return "1800\n"
+        if path.endswith("pwm1"):
+            return "128\n"
+        return ""
+
+    thermal = collect_thermal_sensor_observation(thermal_path="/thermal", hwmon_path="/hwmon", directory_lister=list_dir, text_reader=read_text, observed_at=created_at)
+    fan_pwm = collect_fan_pwm_observation(hwmon_path="/hwmon", directory_lister=list_dir, text_reader=read_text, observed_at=created_at)
+    return (thermal, fan_pwm)
+
+
+def build_host_embodiment_demo_trace(
+    *,
+    collector_results: Sequence[Any] | None = None,
+    scenario_id: str = "demo-thermal-pwm-non-mutating-ladder",
+    scenario_label: str = "Thermal + PWM presence proves telemetry is not control authority",
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> HostEmbodimentTrace:
+    results = tuple(collector_results) if collector_results is not None else _collector_demo_results(created_at)
+    inventory = build_host_inventory_from_collector_results(results, manifest_id=f"{scenario_id}-inventory", node_id="review-demo-node", host_id="review-demo-host")
+    snapshot = build_host_resource_telemetry_from_collector_results(results, snapshot_id=f"{scenario_id}-telemetry")
+    pressure = evaluate_host_resource_pressure(snapshot, thermal_pressure_c=80)
+    policy_decision = evaluate_host_resource_policy(pressure)
+    proposal_receipts = build_host_resource_proposal_receipts(policy_decision)
+    proposal = next((receipt for receipt in proposal_receipts if receipt.proposal_kind == "future_cooling_policy_candidate"), proposal_receipts[0])
+    broker_decision = evaluate_privilege_broker_eligibility(proposal)
+    broker_receipt = build_privilege_broker_review_receipt(broker_decision, created_at=created_at)
+    fulfillment_plan = build_actuation_fulfillment_plan(broker_receipt)
+    rehearsal_receipt = build_actuation_fulfillment_rehearsal_receipt(fulfillment_plan, created_at=created_at)
+    proof = build_execution_proof_wing_for_rehearsal_receipt(rehearsal_receipt, created_at=created_at)
+    review = build_authorization_review_wing_for_execution_readiness(proof.execution_readiness_manifest, created_at=created_at)
+    controlled = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema, created_at=created_at)
+
+    steps: list[HostEmbodimentTraceStep] = []
+    for result in results:
+        steps.append(_step("collector_result", result, summary={"collector_id": result.collector_id, "status": result.status, "telemetry_only": result.telemetry_only, "values": result.values}, status=result.status, id_names=("collector_id",)))
+    steps.extend([
+        _step("host_inventory_manifest", inventory, summary=summarize_host_inventory_manifest(inventory), status="recorded", id_names=("manifest_id",)),
+        _step("telemetry_snapshot", snapshot, summary={"snapshot_id": snapshot.snapshot_id, "thermal_zone_temperatures_c": dict(snapshot.thermal_zone_temperatures_c), "fan_rpm_observations": dict(snapshot.fan_rpm_observations), "model_runtime_pressure_labels": snapshot.model_runtime_pressure_labels, "metadata_only": snapshot.metadata_only, "no_host_actuation": snapshot.no_host_actuation}, status="recorded", id_names=("snapshot_id",)),
+        _step("pressure_report", pressure, summary=summarize_host_resource_pressure(pressure), status="recorded", id_names=("report_id",)),
+        _step("policy_decision", policy_decision, summary=summarize_host_resource_policy_decision(policy_decision), status=policy_decision.status, id_names=("decision_id",)),
+        _step("proposal_receipt", proposal, summary=summarize_host_resource_proposal_receipt(proposal), status=proposal.proposal_status, id_names=("receipt_id",)),
+        _step("broker_decision", broker_decision, summary=summarize_privilege_broker_eligibility_decision(broker_decision), status=broker_decision.eligibility_status, id_names=("decision_id",)),
+        _step("broker_review_receipt", broker_receipt, summary=summarize_privilege_broker_review_receipt(broker_receipt), status=broker_receipt.review_status, id_names=("receipt_id",)),
+        _step("fulfillment_plan", fulfillment_plan, summary=summarize_actuation_fulfillment_plan(fulfillment_plan), status=fulfillment_plan.plan_status, id_names=("plan_id",)),
+        _step("fulfillment_rehearsal_receipt", rehearsal_receipt, summary=summarize_actuation_fulfillment_rehearsal_receipt(rehearsal_receipt), status=rehearsal_receipt.rehearsal_status, id_names=("receipt_id",)),
+        _step("effect_contract", proof.effect_contract, summary=summarize_effect_receipt_contract(proof.effect_contract), status=proof.effect_contract.status, id_names=("contract_id",)),
+        _step("future_effect_schema", proof.future_effect_receipt, summary=summarize_future_effect_receipt_schema(proof.future_effect_receipt), status=proof.future_effect_receipt.status, id_names=("receipt_id",)),
+        _step("postcondition_plan", proof.postcondition_plan, summary=summarize_postcondition_check_plan(proof.postcondition_plan), status=proof.postcondition_plan.status, id_names=("plan_id",)),
+        _step("rollback_plan", proof.rollback_plan, summary=summarize_rollback_plan(proof.rollback_plan), status=proof.rollback_plan.status, id_names=("plan_id",)),
+        _step("execution_readiness_manifest", proof.execution_readiness_manifest, summary=summarize_execution_readiness_manifest(proof.execution_readiness_manifest), status=proof.execution_readiness_manifest.readiness_status, id_names=("manifest_id",)),
+        _step("authorization_review_packet", review.packet, summary=summarize_authorization_review_packet(review.packet), status=review.packet.packet_status, id_names=("packet_id",)),
+        _step("authorization_review_decision", review.decision, summary=summarize_authorization_review_decision(review.decision), status=review.decision.decision_status, id_names=("decision_id",)),
+        _step("authorization_review_receipt", review.receipt, summary=summarize_authorization_review_receipt(review.receipt), status=review.receipt.receipt_status, id_names=("receipt_id",)),
+        _step("future_authorization_schema", review.future_authorization_grant_schema, summary=summarize_future_authorization_grant_schema(review.future_authorization_grant_schema), status=review.future_authorization_grant_schema.schema_status, id_names=("schema_id",)),
+        _step("controlled_authorization_contract", controlled.contract, summary=summarize_controlled_authorization_grant_contract(controlled.contract), status=controlled.contract.status, id_names=("contract_id",)),
+        _step("controlled_authorization_grant_record", controlled.grant_record, summary=summarize_controlled_authorization_grant_record(controlled.grant_record), status=controlled.grant_record.grant_status, id_names=("grant_record_id",)),
+        _step("controlled_authorization_revocation_record", controlled.revocation_record, summary=summarize_controlled_authorization_revocation_record(controlled.revocation_record), status=controlled.revocation_record.revocation_status, id_names=("revocation_id",)),
+        _step("controlled_authorization_ledger", controlled.ledger, summary=summarize_controlled_authorization_ledger(controlled.ledger), status=controlled.ledger.ledger_status, id_names=("ledger_id",)),
+    ])
+    warnings = tuple(sorted({warning for step in steps for warning in step.warning_codes}))
+    risks = tuple(sorted({risk for step in steps for risk in step.risk_codes} | {"pwm_presence_is_not_control_authority", "demo_trace_is_reviewer_proof_only"}))
+    if any("contradicted" in step.status for step in steps):
+        trace_status = "host_embodiment_trace_contradicted"
+    elif any("incomplete" in step.status for step in steps):
+        trace_status = "host_embodiment_trace_incomplete"
+    elif any("blocked" in step.status for step in steps):
+        trace_status = "host_embodiment_trace_blocked"
+    elif warnings:
+        trace_status = "host_embodiment_trace_recorded_with_warnings"
+    else:
+        trace_status = "host_embodiment_trace_recorded"
+    provisional = HostEmbodimentTrace(
+        trace_id=_digest_payload("het_", {"scenario_id": scenario_id, "steps": [step.step_id for step in steps], "created_at": created_at}),
+        scenario_id=scenario_id,
+        scenario_label=scenario_label,
+        steps=tuple(steps),
+        trace_status=trace_status,
+        step_count=len(steps),
+        blocked_action_labels=TRACE_BLOCKED_ACTION_LABELS,
+        deferred_capability_labels=TRACE_DEFERRED_CAPABILITY_LABELS,
+        warning_codes=warnings,
+        risk_codes=risks,
+        created_at=created_at,
+        digest="",
+    )
+    return replace(provisional, digest=host_embodiment_trace_digest(provisional))
+
+
+def validate_host_embodiment_trace_step(step: HostEmbodimentTraceStep) -> HostEmbodimentTraceValidationResult:
+    findings: list[str] = []
+    if step.step_kind not in HOST_EMBODIMENT_TRACE_STEP_KINDS: findings.append("unknown_step_kind")
+    if not step.metadata_only: findings.append("step_not_metadata_only")
+    if step.effect_performed: findings.append("step_claims_effect")
+    if step.host_mutation_performed: findings.append("step_claims_host_mutation")
+    if not step.source_id: findings.append("missing_source_id")
+    if not step.source_digest: findings.append("missing_source_digest")
+    return HostEmbodimentTraceValidationResult(not findings, tuple(findings))
+
+
+def validate_host_embodiment_trace(trace: HostEmbodimentTrace) -> HostEmbodimentTraceValidationResult:
+    findings: list[str] = []
+    if trace.trace_status not in HOST_EMBODIMENT_TRACE_STATUSES: findings.append("unknown_trace_status")
+    if not trace.metadata_only or not trace.demo_only: findings.append("trace_not_metadata_demo_only")
+    for flag in ("live_authorization_granted", "effect_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if getattr(trace, flag, False): findings.append(f"trace_forbidden_flag:{flag}")
+    if trace.step_count != len(trace.steps): findings.append("trace_step_count_mismatch")
+    required_blocks = {"fan_pwm_write", "thermal_actuation", "power_profile_mutation", "service_restart", "process_kill", "file_cleanup", "file_delete", "provider_invocation", "network_egress", "prompt_assembly", "federation_transport", "remote_execution"}
+    if not required_blocks.issubset(set(trace.blocked_action_labels)): findings.append("trace_missing_required_blocked_actions")
+    required_deferred = {"live_authorization_grant", "real_effect_execution", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup"}
+    if not required_deferred.issubset(set(trace.deferred_capability_labels)): findings.append("trace_missing_required_deferred_capabilities")
+    for step in trace.steps:
+        if not validate_host_embodiment_trace_step(step).ok: findings.append(f"invalid_trace_step:{step.step_id}")
+    if trace.digest and trace.digest != host_embodiment_trace_digest(trace): findings.append("trace_digest_mismatch")
+    return HostEmbodimentTraceValidationResult(not findings, tuple(findings))
+
+
+def summarize_host_embodiment_trace(trace: HostEmbodimentTrace) -> dict[str, Any]:
+    return {
+        "trace_id": trace.trace_id,
+        "scenario_id": trace.scenario_id,
+        "scenario_label": trace.scenario_label,
+        "trace_status": trace.trace_status,
+        "step_count": trace.step_count,
+        "step_kinds": tuple(step.step_kind for step in trace.steps),
+        "metadata_only": trace.metadata_only,
+        "demo_only": trace.demo_only,
+        "live_authorization_granted": trace.live_authorization_granted,
+        "effect_performed": trace.effect_performed,
+        "host_mutation_performed": trace.host_mutation_performed,
+        "network_performed": trace.network_performed,
+        "provider_invocation_performed": trace.provider_invocation_performed,
+        "prompt_assembly_performed": trace.prompt_assembly_performed,
+        "blocked_action_labels": trace.blocked_action_labels,
+        "deferred_capability_labels": trace.deferred_capability_labels,
+        "digest": trace.digest,
+    }

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -288,3 +288,23 @@ def test_registry_updates_from_authorization_review_keep_real_actions_deferred_o
     assert records["real_power_profile_mutation"].status == "blocked"
     assert records["real_file_cleanup"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_controlled_authorization_and_trace_capabilities_are_non_live() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["controlled_authorization_contract"].status == "implemented"
+    assert records["controlled_authorization_contract"].authority_level == "contract_only"
+    assert records["controlled_authorization_grant_record"].status == "implemented"
+    assert records["controlled_authorization_grant_record"].authority_level == "schema_only"
+    assert records["controlled_authorization_ledger"].status == "implemented"
+    assert records["controlled_authorization_ledger"].authority_level == "ledger_only"
+    assert records["host_embodiment_trace"].status == "implemented"
+    assert records["host_embodiment_trace"].authority_level == "demo_proof_only"
+    assert records["live_authorization_grant"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_rollback_execution"].status == "deferred"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
+    assert all(record.host_actuation_performed is False for record in records.values())

--- a/tests/test_controlled_authorization.py
+++ b/tests/test_controlled_authorization.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.actuation_fulfillment import build_actuation_fulfillment_plan, build_actuation_fulfillment_rehearsal_receipt
+from sentientos.authorization_review import build_authorization_review_wing_for_execution_readiness
+from sentientos.controlled_authorization import (
+    build_controlled_authorization_grant_contract,
+    build_controlled_authorization_grant_record,
+    build_controlled_authorization_ledger,
+    build_controlled_authorization_revocation_record,
+    build_controlled_authorization_wing_for_review_receipt,
+    controlled_authorization_grant_contract_digest,
+    summarize_controlled_authorization_grant_contract,
+    summarize_controlled_authorization_grant_record,
+    summarize_controlled_authorization_ledger,
+    summarize_controlled_authorization_revocation_record,
+    validate_controlled_authorization_grant_contract,
+    validate_controlled_authorization_grant_record,
+    validate_controlled_authorization_ledger,
+    validate_controlled_authorization_revocation_record,
+)
+from sentientos.effect_proof import build_execution_proof_wing_for_rehearsal_receipt
+from tests.test_actuation_fulfillment import _broker_receipt_for
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _review(kind: str = "inspect_cpu_pressure_candidate", **kwargs):
+    rehearsal = build_actuation_fulfillment_rehearsal_receipt(build_actuation_fulfillment_plan(_broker_receipt_for(kind, recorded=True, **kwargs)))
+    proof = build_execution_proof_wing_for_rehearsal_receipt(rehearsal)
+    return build_authorization_review_wing_for_execution_readiness(proof.execution_readiness_manifest)
+
+
+def test_valid_authorization_review_receipt_builds_contract_and_schema_only_grant_record() -> None:
+    review = _review(cpu_utilization_percent=95, ram_utilization_percent=20, disk_utilization_percent=30)
+    wing = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema)
+    assert wing.contract.status == "controlled_authorization_contract_ready"
+    assert wing.grant_record.grant_status == "controlled_authorization_grant_schema_recorded"
+    assert wing.contract.live_authorization_granted is False
+    assert wing.grant_record.schema_only is True
+    assert wing.grant_record.future_use_only is True
+    assert wing.ledger.metadata_only is True
+    assert wing.ledger.live_authorization_granted is False
+    assert validate_controlled_authorization_grant_contract(wing.contract).ok
+    assert validate_controlled_authorization_grant_record(wing.grant_record).ok
+    assert validate_controlled_authorization_revocation_record(wing.revocation_record).ok
+    assert validate_controlled_authorization_ledger(wing.ledger).ok
+
+
+@pytest.mark.parametrize(
+    ("receipt_status", "schema_status", "contract_status", "grant_status"),
+    [
+        ("authorization_review_receipt_blocked", "future_authorization_grant_schema_blocked", "controlled_authorization_contract_blocked", "controlled_authorization_grant_blocked"),
+        ("authorization_review_receipt_incomplete", "future_authorization_grant_schema_incomplete", "controlled_authorization_contract_incomplete", "controlled_authorization_grant_incomplete"),
+        ("authorization_review_receipt_contradicted", "future_authorization_grant_schema_contradicted", "controlled_authorization_contract_contradicted", "controlled_authorization_grant_contradicted"),
+    ],
+)
+def test_review_terminal_statuses_map_to_controlled_authorization_statuses(receipt_status: str, schema_status: str, contract_status: str, grant_status: str) -> None:
+    review = _review(cpu_utilization_percent=95)
+    receipt = replace(review.receipt, receipt_status=receipt_status, digest="")
+    schema = replace(review.future_authorization_grant_schema, schema_status=schema_status, source_authorization_review_receipt_digest=receipt.digest, digest="")
+    contract = build_controlled_authorization_grant_contract(receipt, schema)
+    record = build_controlled_authorization_grant_record(contract)
+    assert contract.status == contract_status
+    assert record.grant_status == grant_status
+
+
+def test_future_scope_blocks_and_gates_are_preserved() -> None:
+    cooling = build_controlled_authorization_wing_for_review_receipt(_review("future_cooling_policy_candidate", thermal_zone_temperatures_c={"cpu": 91}).receipt, _review("future_cooling_policy_candidate", thermal_zone_temperatures_c={"cpu": 91}).future_authorization_grant_schema)
+    gates = set(cooling.contract.required_grant_gates)
+    for gate in ["operator_identity_required", "policy_identity_required", "explicit_scope_required", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required", "panic_stop_required"]:
+        assert gate in gates
+    assert {"fan_pwm_write", "thermal_actuation"}.issubset(set(cooling.contract.blocked_actions))
+
+    power = build_controlled_authorization_wing_for_review_receipt(_review("future_power_policy_candidate", battery_percent=5, battery_charging=False).receipt, _review("future_power_policy_candidate", battery_percent=5, battery_charging=False).future_authorization_grant_schema)
+    cleanup = build_controlled_authorization_wing_for_review_receipt(_review("future_cleanup_policy_candidate", disk_utilization_percent=95).receipt, _review("future_cleanup_policy_candidate", disk_utilization_percent=95).future_authorization_grant_schema)
+    service_review = _review("inspect_service_health_candidate", service_health_labels=("daemon_degraded",))
+    service = build_controlled_authorization_wing_for_review_receipt(service_review.receipt, service_review.future_authorization_grant_schema)
+    assert "power_profile_mutation" in power.contract.blocked_actions
+    assert {"file_cleanup", "file_delete"}.issubset(set(cleanup.contract.blocked_actions))
+    assert {"service_restart", "process_kill"}.issubset(set(service.contract.blocked_actions))
+
+
+def test_records_summaries_and_digests_are_metadata_only_and_deterministic() -> None:
+    review = _review(cpu_utilization_percent=95)
+    wing = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema)
+    changed = replace(wing.contract, warning_codes=("meaningful_metadata_change",), digest="")
+    assert controlled_authorization_grant_contract_digest(wing.contract) == wing.contract.digest
+    assert controlled_authorization_grant_contract_digest(changed) != wing.contract.digest
+    assert summarize_controlled_authorization_grant_contract(wing.contract)["contract_only"] is True
+    assert summarize_controlled_authorization_grant_record(wing.grant_record)["schema_only"] is True
+    assert summarize_controlled_authorization_revocation_record(wing.revocation_record)["future_use_only"] is True
+    assert summarize_controlled_authorization_ledger(wing.ledger)["metadata_only"] is True
+
+
+def test_validation_rejects_live_authority_effect_mutation_and_missing_forbidden_blocks() -> None:
+    review = _review(cpu_utilization_percent=95)
+    wing = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema)
+    assert not validate_controlled_authorization_grant_contract(replace(wing.contract, live_authorization_granted=True)).ok
+    assert not validate_controlled_authorization_grant_contract(replace(wing.contract, fulfillment_granted=True)).ok
+    assert not validate_controlled_authorization_grant_contract(replace(wing.contract, effect_performed=True)).ok
+    assert not validate_controlled_authorization_grant_contract(replace(wing.contract, host_mutation_performed=True)).ok
+    assert not validate_controlled_authorization_grant_record(replace(wing.grant_record, live_authorization_granted=True)).ok
+    assert not validate_controlled_authorization_revocation_record(replace(wing.revocation_record, live_revocation_performed=True)).ok
+    assert not validate_controlled_authorization_ledger(replace(wing.ledger, live_authorization_granted=True)).ok
+    assert not validate_controlled_authorization_grant_contract(replace(wing.contract, blocked_actions=())).ok

--- a/tests/test_host_embodiment_trace.py
+++ b/tests/test_host_embodiment_trace.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.capability_registry import build_default_capability_registry, update_registry_from_controlled_authorization_ledger, update_registry_from_host_embodiment_trace
+from sentientos.host_embodiment_trace import (
+    build_host_embodiment_demo_trace,
+    host_embodiment_trace_digest,
+    summarize_host_embodiment_trace,
+    validate_host_embodiment_trace,
+    validate_host_embodiment_trace_step,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def test_default_demo_trace_builds_full_non_mutating_ladder_with_pwm_presence() -> None:
+    trace = build_host_embodiment_demo_trace()
+    kinds = [step.step_kind for step in trace.steps]
+    for kind in [
+        "collector_result", "host_inventory_manifest", "telemetry_snapshot", "pressure_report", "policy_decision",
+        "proposal_receipt", "broker_decision", "broker_review_receipt", "fulfillment_plan", "fulfillment_rehearsal_receipt",
+        "effect_contract", "future_effect_schema", "postcondition_plan", "rollback_plan", "execution_readiness_manifest",
+        "authorization_review_packet", "authorization_review_decision", "authorization_review_receipt", "future_authorization_schema",
+        "controlled_authorization_contract", "controlled_authorization_grant_record", "controlled_authorization_revocation_record", "controlled_authorization_ledger",
+    ]:
+        assert kind in kinds
+    collector_summaries = [step.summary for step in trace.steps if step.step_kind == "collector_result"]
+    assert any(summary.get("values", {}).get("pwm_signal_observed") is True for summary in collector_summaries)
+    assert "fan_pwm_write" in trace.blocked_action_labels
+    assert "real_fan_pwm_control" in trace.deferred_capability_labels
+    assert trace.live_authorization_granted is False
+    assert trace.effect_performed is False
+    assert trace.host_mutation_performed is False
+    assert validate_host_embodiment_trace(trace).ok
+
+
+def test_trace_includes_required_blocked_and_deferred_labels() -> None:
+    trace = build_host_embodiment_demo_trace()
+    for label in ["fan_pwm_write", "thermal_actuation", "service_restart", "power_profile_mutation", "file_cleanup", "file_delete", "network_egress", "provider_invocation", "prompt_assembly", "federation_transport", "remote_execution"]:
+        assert label in trace.blocked_action_labels
+    for label in ["live_authorization_grant", "real_effect_execution", "real_rollback_execution", "real_service_restart", "real_power_profile_mutation", "real_file_cleanup"]:
+        assert label in trace.deferred_capability_labels
+
+
+def test_trace_summary_and_digest_are_reviewer_friendly_and_deterministic() -> None:
+    trace = build_host_embodiment_demo_trace()
+    summary = summarize_host_embodiment_trace(trace)
+    assert summary["metadata_only"] is True
+    assert summary["demo_only"] is True
+    assert summary["live_authorization_granted"] is False
+    assert host_embodiment_trace_digest(trace) == trace.digest
+    changed = replace(trace, scenario_label="changed reviewer label", digest="")
+    assert host_embodiment_trace_digest(changed) != trace.digest
+
+
+def test_trace_validation_rejects_forbidden_runtime_claims() -> None:
+    trace = build_host_embodiment_demo_trace()
+    for flag in ["live_authorization_granted", "effect_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"]:
+        assert not validate_host_embodiment_trace(replace(trace, **{flag: True})).ok
+    step = trace.steps[0]
+    assert not validate_host_embodiment_trace_step(replace(step, effect_performed=True)).ok
+    assert not validate_host_embodiment_trace_step(replace(step, host_mutation_performed=True)).ok
+
+
+def test_capability_registry_reflects_trace_as_demo_proof_and_live_execution_deferred() -> None:
+    trace = build_host_embodiment_demo_trace()
+    registry = update_registry_from_host_embodiment_trace(update_registry_from_controlled_authorization_ledger(build_default_capability_registry(), trace.steps[-1]), trace)
+    by_id = registry.by_id()
+    assert by_id["host_embodiment_trace"].status == "implemented"
+    assert by_id["host_embodiment_trace"].authority_level == "demo_proof_only"
+    assert by_id["controlled_authorization_contract"].authority_level == "contract_only"
+    assert by_id["controlled_authorization_grant_record"].authority_level == "schema_only"
+    assert by_id["controlled_authorization_ledger"].authority_level == "ledger_only"
+    assert by_id["live_authorization_grant"].status == "deferred"
+    assert by_id["real_effect_execution"].status == "deferred"
+    assert by_id["real_rollback_execution"].status == "deferred"
+    assert by_id["real_service_restart"].status == "blocked"
+    assert by_id["real_fan_pwm_control"].status == "blocked"
+    assert by_id["real_power_profile_mutation"].status == "blocked"
+    assert by_id["real_file_cleanup"].status == "blocked"

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -252,3 +252,25 @@ def test_authorization_review_wing_doc_preserves_review_only_boundaries() -> Non
     assert "No host mutation" in doc or "not host mutation" in doc
     for term in ["AuthorizationReviewPacket", "AuthorizationReviewDecision", "AuthorizationReviewReceipt", "FutureAuthorizationGrantSchema"]:
         assert term in doc
+
+HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING = "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md"
+
+
+def test_navigation_links_to_controlled_authorization_trace_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    auth = _read(HOST_EMBODIMENT_AUTHORIZATION_REVIEW_WING)
+    proof = _read(HOST_EMBODIMENT_EXECUTION_PROOF_WING)
+    phase5 = _read(HOST_EMBODIMENT_PHASE5)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, auth, proof, phase5, trajectory]:
+        assert HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING in text
+
+
+def test_controlled_authorization_trace_doc_preserves_non_live_boundaries() -> None:
+    doc = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    assert "controlled authorization contract is not a live grant" in doc
+    assert "grant record is schema-only/future-use-only" in doc
+    assert "Demo trace is reviewer proof only" in doc or "demo trace is reviewer proof only" in doc
+    assert "Real fulfillment remains deferred" in doc
+    assert "Real actuation remains deferred" in doc


### PR DESCRIPTION
### Motivation
- Add the next non-mutating wing after Authorization Review to define a contract-only controlled authorization grant shape and produce a deterministic, reviewer-facing, non-mutating host-embodiment trace.
- Provide a safe schema/ledger/trace scaffold so reviewers can prove the full observe→...→controlled-contract ladder without granting live authority or performing host effects.

### Description
- Add `sentientos/controlled_authorization.py` implementing contract-only dataclasses (`ControlledAuthorizationGrantContract`, `ControlledAuthorizationGrantRecord`, `ControlledAuthorizationRevocationRecord`, `ControlledAuthorizationLedger`), deterministic digest helpers, builders, validators, summaries, scope/block/gate rules, and `build_controlled_authorization_wing_for_review_receipt(...)` for composing the wing from an authorization-review receipt and future schema.
- Add `sentientos/host_embodiment_trace.py` implementing immutable trace/step records, a demo `build_host_embodiment_demo_trace(...)` that uses fake thermal+PWM telemetry by default, validators, summaries, and blocked/deferred label coverage across the non-mutating ladder.
- Update `sentientos/capability_registry.py` additively to register `controlled_authorization_contract`, `controlled_authorization_grant_record`, `controlled_authorization_ledger`, and `host_embodiment_trace` plus helpers `update_registry_from_controlled_authorization_ledger(...)` and `update_registry_from_host_embodiment_trace(...)`, while keeping all live host-effect capabilities deferred/blocked.
- Add docs `docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md` and update reviewer/public architecture docs to link the new wing and clarify non-live boundaries, and add focused tests `tests/test_controlled_authorization.py` and `tests/test_host_embodiment_trace.py` (plus small registry/test updates).

### Testing
- Ran unit test suites: `python -m scripts.run_tests -q tests/test_controlled_authorization.py tests/test_host_embodiment_trace.py tests/test_authorization_review.py tests/test_capability_registry.py` and additional integration proofs; the tests completed successfully (all added and updated tests passed).
- Ran broader suites: `python -m scripts.run_tests -q tests/test_effect_proof.py tests/test_runtime_supervisor.py tests/test_actuation_fulfillment.py tests/test_privilege_broker.py` and `python -m scripts.run_tests -q tests/test_host_collectors.py tests/test_host_inventory.py tests/test_host_resource_governor.py tests/test_host_resource_policy.py` and `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py`, all of which passed in the test runs performed.
- Docs build required bootstrapping; initial `--check-deps` reported `mkdocs` missing but `python scripts/build_docs.py --bootstrap-docs` was executed and `python scripts/build_docs.py` then completed successfully.
- Forbidden-scan and context-hygiene checks were run and showed only allowed negative-marker strings, validation guards, documentation text, or deferred/blocked capability labels; no forbidden runtime imports/calls or actuation were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0570fdedcc8320991593cfcf25d579)