### PR TITLE
[codex:host-embodiment] add reviewer trace export demo

### DIFF
--- a/docs/architecture/host_embodiment_authorization_review_wing.md
+++ b/docs/architecture/host_embodiment_authorization_review_wing.md
@@ -101,3 +101,9 @@ rollback, effect receipt, and postcondition checks.
 The next non-mutating organ is the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). It defines a controlled grant contract, schema-only/future-use-only grant and revocation records, a metadata-only ledger, and a reviewer demo trace. It does not grant live authorization or perform effects.
 
 Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+
+## Next reviewer demo trace
+
+The controlled authorization and reviewer export path continues in [Host Embodiment Reviewer Demo Trace](host_embodiment_reviewer_demo_trace.md). The demo is reviewer proof only and does not create live authorization or host mutation.
+
+Proof path: docs/architecture/host_embodiment_reviewer_demo_trace.md

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -47,3 +47,9 @@ Real fulfillment remains deferred. Real actuation remains deferred.
 - Trace builder: `sentientos/host_embodiment_trace.py`
 - Tests: `tests/test_controlled_authorization.py`, `tests/test_host_embodiment_trace.py`
 - Public proof map: [Reviewer Release Readiness Index](reviewer_release_readiness_index.md)
+
+## Reviewer demo trace export
+
+See [Host Embodiment Reviewer Demo Trace](host_embodiment_reviewer_demo_trace.md) for the deterministic JSON/Markdown export command. The export is reviewer proof only, uses fake/sample thermal+PWM telemetry by default, and preserves the proof that PWM presence is not control authority, the controlled authorization contract is not a live grant, grant/revocation records are schema-only/future-use-only, and real actuation remains deferred.
+
+Proof path: docs/architecture/host_embodiment_reviewer_demo_trace.md

--- a/docs/architecture/host_embodiment_execution_proof_wing.md
+++ b/docs/architecture/host_embodiment_execution_proof_wing.md
@@ -114,3 +114,9 @@ Runtime Supervisor, and Execution Readiness Manifest.
 Execution readiness remains non-authorizing. The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) follows authorization review with contract-only/schema-only/ledger-only records and a demo trace; real effect execution and rollback remain deferred.
 
 Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+
+## Reviewer demo trace link
+
+After execution proof and authorization review, reviewers can inspect the deterministic non-mutating export in [Host Embodiment Reviewer Demo Trace](host_embodiment_reviewer_demo_trace.md).
+
+Proof path: docs/architecture/host_embodiment_reviewer_demo_trace.md

--- a/docs/architecture/host_embodiment_reviewer_demo_trace.md
+++ b/docs/architecture/host_embodiment_reviewer_demo_trace.md
@@ -1,0 +1,50 @@
+# Host Embodiment Reviewer Demo Trace
+
+This doc follows the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). The reviewer demo trace is a deterministic, non-mutating proof artifact for seeing the full host embodiment ladder breathe without moving the body.
+
+## Boundary
+
+The demo trace is reviewer proof only. It is metadata-only export/proof, not live authorization, not real fulfillment, not real effect, not host mutation, not direct fan/PWM control, not thermal actuation, not power profile mutation, not process killing, not service restart, not package or driver installation, not file cleanup or deletion, not network egress, not provider invocation, not prompt assembly/export, not federation transport/sync/adoption, and not remote execution.
+
+The default demo uses fake/sample thermal+PWM telemetry. It does not perform live host collection by default. PWM presence is shown as a signal, not control authority.
+
+## What the demo proves
+
+The trace exports the non-mutating ladder:
+
+collector results → inventory → telemetry → pressure → policy → proposal → broker eligibility → broker review → fulfillment rehearsal → execution proof → authorization review → future authorization schema → controlled authorization contract → schema-only grant record → schema-only revocation record → metadata-only ledger → reviewer trace.
+
+Reviewers should inspect that:
+
+- PWM presence is not control authority.
+- The controlled authorization contract is not a live grant.
+- Grant/revocation records are schema-only/future-use-only.
+- The ledger is metadata-only.
+- Real actuation remains deferred.
+- No fan/PWM/thermal/power/service/cleanup actions occur.
+- No live authorization, no effect, and no host mutation occur.
+- No network, provider, prompt, federation, or remote execution path is exercised.
+
+## How to run
+
+From the repository root:
+
+```bash
+python scripts/build_host_embodiment_trace.py --format json
+python scripts/build_host_embodiment_trace.py --format markdown
+python scripts/build_host_embodiment_trace.py --validate-only
+python scripts/build_host_embodiment_trace.py --format json --output /tmp/sentientos-host-embodiment-trace.json
+```
+
+## Expected outputs
+
+`--format json` emits the full deterministic trace payload with sorted keys. `--format markdown` emits a concise reviewer-readable summary. `--validate-only` exits successfully when the generated trace remains proof-only and prints no artifact. `--output PATH` writes only the explicit caller-supplied artifact path.
+
+The golden fixture for the built-in thermal+PWM demo is `tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json`. It contains no secrets, no real host identifiers, no prompt text, and no provider/network endpoint.
+
+## Implementation links
+
+- Export helpers: `sentientos/host_embodiment_trace_export.py`
+- Demo CLI: `scripts/build_host_embodiment_trace.py`
+- Trace builder: `sentientos/host_embodiment_trace.py`
+- Tests: `tests/test_host_embodiment_trace_export.py`, `tests/test_build_host_embodiment_trace_script.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -241,3 +241,7 @@ Next review-only wing: `docs/architecture/host_embodiment_authorization_review_w
 The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) adds a contract-only controlled authorization schema and a demo/proof-only host embodiment trace. The controlled authorization contract is not a live grant; the grant record is schema-only/future-use-only; the demo trace is reviewer proof only; real fulfillment and real actuation remain deferred.
 
 Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+
+## Host Embodiment Reviewer Demo Trace
+
+See `docs/architecture/host_embodiment_reviewer_demo_trace.md` for the one-command deterministic reviewer trace. Run `python scripts/build_host_embodiment_trace.py --format json`, `python scripts/build_host_embodiment_trace.py --format markdown`, or `python scripts/build_host_embodiment_trace.py --validate-only`. The demo trace is reviewer proof only, no host mutation occurs, PWM presence is not control authority, the controlled authorization contract is not a live grant, and grant/revocation records are schema-only/future-use-only.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -239,3 +239,7 @@ Reviewer assertions:
 - Real actuation remains deferred.
 
 Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+
+## Host Embodiment Reviewer Demo Trace
+
+See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: `python scripts/build_host_embodiment_trace.py --format json`, `python scripts/build_host_embodiment_trace.py --format markdown`, and `python scripts/build_host_embodiment_trace.py --validate-only`. The demo trace is reviewer proof only; no host mutation occurs; PWM presence is not control authority; no live authorization, real effect, network, provider invocation, prompt assembly, federation transport, or remote execution occurs.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -385,3 +385,7 @@ See `docs/architecture/host_embodiment_authorization_review_wing.md`. This next 
 The [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) is now represented as the next non-mutating organ after Authorization Review: contract-only controlled authorization, schema-only/future-use-only grant and revocation records, metadata-only ledger, and a reviewer demo trace. Live authorization, real fulfillment, real actuation, rollback execution, fan/PWM control, thermal actuation, power mutation, service restart, and cleanup/delete remain missing/deferred organs.
 
 Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+
+## Host Embodiment Reviewer Demo Trace
+
+See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. The external reviewer demo script now has a deterministic metadata-only thermal+PWM trace export. It is reviewer proof only: no live host collection by default, no live authorization, no effect, no host mutation, and PWM presence is not control authority.

--- a/scripts/build_host_embodiment_trace.py
+++ b/scripts/build_host_embodiment_trace.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Build the deterministic Host Embodiment reviewer demo trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace, summarize_host_embodiment_trace
+from sentientos.host_embodiment_trace_export import (
+    serialize_host_embodiment_trace_json,
+    serialize_host_embodiment_trace_markdown,
+    validate_trace_export_payload,
+    write_trace_export_artifact,
+)
+
+SCENARIO_ALIASES = {
+    "thermal_pwm_demo": "demo-thermal-pwm-non-mutating-ladder",
+}
+
+
+def build_trace_for_scenario(scenario: str):
+    if scenario not in SCENARIO_ALIASES:
+        raise ValueError(f"unsupported scenario: {scenario}")
+    return build_host_embodiment_demo_trace(scenario_id=SCENARIO_ALIASES[scenario])
+
+
+def _summary_text(trace) -> str:
+    summary = summarize_host_embodiment_trace(trace)
+    return "\n".join(
+        [
+            "Host Embodiment Reviewer Demo Trace Summary",
+            f"scenario: {summary['scenario_id']}",
+            f"status: {summary['trace_status']}",
+            f"steps: {summary['step_count']}",
+            "reviewer proof only: true",
+            "fake/sample telemetry by default: true",
+            "pwm presence is not control authority: true",
+            "controlled authorization contract is not live grant: true",
+            "grant/revocation records schema-only/future-use-only: true",
+            "no live authorization / no effect / no host mutation / no network / no provider / no prompt assembly: true",
+            f"digest: {summary['digest']}",
+            "",
+        ]
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a deterministic non-mutating host embodiment reviewer trace")
+    parser.add_argument("--format", choices=("json", "markdown"), default="json", help="output format")
+    parser.add_argument("--output", help="explicit file path for writing the artifact")
+    parser.add_argument("--scenario", choices=tuple(SCENARIO_ALIASES), default="thermal_pwm_demo", help="deterministic demo scenario")
+    parser.add_argument("--validate-only", action="store_true", help="validate the generated trace and print no artifact")
+    parser.add_argument("--summary", action="store_true", help="print a compact reviewer summary")
+    args = parser.parse_args(argv)
+
+    try:
+        trace = build_trace_for_scenario(args.scenario)
+        result = validate_trace_export_payload(trace)
+        if not result.ok:
+            print("trace validation failed: " + ", ".join(result.findings), file=sys.stderr)
+            return 2
+        if args.validate_only:
+            return 0
+        content = _summary_text(trace) if args.summary else (
+            serialize_host_embodiment_trace_markdown(trace) if args.format == "markdown" else serialize_host_embodiment_trace_json(trace)
+        )
+        if args.output:
+            write_trace_export_artifact(args.output, content)
+        else:
+            print(content, end="")
+        return 0
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"host embodiment trace export failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -244,6 +244,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("controlled_authorization_grant_record", "controlled_authorization", "implemented", "schema_only", source_paths=("sentientos/controlled_authorization.py",), proof_tests=("tests/test_controlled_authorization.py",), implemented_surfaces=("schema-only future-use grant record",), deferred_surfaces=("live authorization grant",), forbidden_implications=("grant record grants live authority",)),
         _record("controlled_authorization_ledger", "controlled_authorization", "implemented", "ledger_only", source_paths=("sentientos/controlled_authorization.py",), proof_tests=("tests/test_controlled_authorization.py",), implemented_surfaces=("metadata-only authorization ledger scaffold",), deferred_surfaces=("runtime authority token",), forbidden_implications=("ledger grants authorization",)),
         _record("host_embodiment_trace", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("sentientos/host_embodiment_trace.py",), proof_tests=("tests/test_host_embodiment_trace.py",), implemented_surfaces=("reviewer-facing non-mutating demo trace",), deferred_surfaces=("live authorization", "real effects", "real rollback"), forbidden_implications=("demo trace executes host actions", "trace grants authority")),
+        _record("host_embodiment_trace_export", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("sentientos/host_embodiment_trace_export.py",), proof_tests=("tests/test_host_embodiment_trace_export.py",), proof_commands=("python scripts/build_host_embodiment_trace.py --format json", "python scripts/build_host_embodiment_trace.py --format markdown", "python scripts/build_host_embodiment_trace.py --validate-only"), implemented_surfaces=("deterministic sorted-key JSON trace export", "reviewer Markdown trace summary", "explicit-path artifact writing"), deferred_surfaces=("live host collection", "live authorization", "real effects"), forbidden_implications=("trace export collects live host data", "trace export grants authority", "trace export performs effects")),
+        _record("reviewer_demo_trace", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("scripts/build_host_embodiment_trace.py", "tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json"), proof_tests=("tests/test_build_host_embodiment_trace_script.py",), proof_commands=("python scripts/build_host_embodiment_trace.py --format json", "python scripts/build_host_embodiment_trace.py --summary"), implemented_surfaces=("deterministic fake/sample thermal+PWM reviewer demo",), deferred_surfaces=("live host collection", "host mutation", "runtime authority token"), forbidden_implications=("reviewer demo performs live collection by default", "reviewer demo authorizes host actions")),
+        _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_execution", "execution_proof", "deferred", "none", deferred_surfaces=("authorized effect fulfillment", "host mutation", "effect receipt from real action"), forbidden_implications=("execution proof wing implements real effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -734,3 +737,36 @@ def update_registry_from_host_embodiment_trace(registry: CapabilityRegistry, tra
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1")
+
+
+def update_registry_from_trace_export(registry: CapabilityRegistry, trace: Any) -> CapabilityRegistry:
+    """Reflect trace export/demo proof without live collection or authority."""
+
+    records: list[CapabilityRecord] = []
+    has_trace = bool(getattr(trace, "trace_id", ""))
+    for record in registry.records:
+        if record.capability_id == "host_embodiment_trace_export":
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_trace else "scaffolded",
+                    authority_level="demo_proof_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/host_embodiment_trace_export.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_host_embodiment_trace_export.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("deterministic reviewer trace export",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("trace export grants live authorization", "trace export performs host mutation")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "reviewer_demo_trace":
+            records.append(replace(record, status="implemented" if has_trace else "scaffolded", authority_level="demo_proof_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "live_host_trace_collection":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"live_authorization_grant", "real_authorization_grant", "real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-embodiment-reviewer-demo-trace.v1")

--- a/sentientos/host_embodiment_trace_export.py
+++ b/sentientos/host_embodiment_trace_export.py
@@ -1,0 +1,283 @@
+"""Deterministic reviewer exports for host embodiment traces.
+
+This module is metadata/export only. It does not collect live host data, mutate
+host state, open network egress, invoke providers, assemble prompts, execute host
+actions, or grant authorization.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from sentientos.host_embodiment_trace import (
+    HOST_EMBODIMENT_TRACE_STEP_KINDS,
+    HostEmbodimentTrace,
+    HostEmbodimentTraceValidationResult,
+    summarize_host_embodiment_trace,
+    validate_host_embodiment_trace,
+)
+
+FORBIDDEN_TRACE_EXPORT_FLAGS = (
+    "live_authorization_granted",
+    "effect_performed",
+    "host_mutation_performed",
+    "network_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+)
+REQUIRED_BLOCKED_ACTION_LABELS = frozenset(
+    {
+        "fan_pwm_write",
+        "thermal_actuation",
+        "power_profile_mutation",
+        "service_restart",
+        "process_kill",
+        "file_cleanup",
+        "file_delete",
+        "provider_invocation",
+        "network_egress",
+        "prompt_assembly",
+        "federation_transport",
+        "remote_execution",
+    }
+)
+REQUIRED_DEFERRED_CAPABILITY_LABELS = frozenset(
+    {
+        "live_authorization_grant",
+        "real_effect_execution",
+        "real_rollback_execution",
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+        "real_power_profile_mutation",
+        "real_service_restart",
+        "real_process_kill",
+        "real_file_cleanup",
+        "real_file_delete",
+        "network_egress",
+        "provider_invocation",
+        "prompt_assembly",
+        "federation_transport",
+        "remote_execution",
+    }
+)
+LADDER_STAGE_LABELS = (
+    "collector results",
+    "inventory",
+    "telemetry",
+    "pressure",
+    "policy",
+    "proposal",
+    "broker eligibility",
+    "broker review",
+    "fulfillment rehearsal",
+    "execution proof",
+    "authorization review",
+    "future authorization schema",
+    "controlled authorization contract",
+    "schema-only grant record",
+    "schema-only revocation record",
+    "metadata-only ledger",
+    "reviewer trace",
+)
+
+
+def _plain(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return dict(value)
+    return value
+
+
+def _trace_payload(trace_or_payload: HostEmbodimentTrace | Mapping[str, Any]) -> dict[str, Any]:
+    payload = _plain(trace_or_payload)
+    if not isinstance(payload, dict):
+        raise TypeError("trace export payload must be a HostEmbodimentTrace or mapping")
+    return payload
+
+
+def serialize_host_embodiment_trace_json(trace: HostEmbodimentTrace | Mapping[str, Any]) -> str:
+    """Return deterministic sorted-key JSON for a trace payload."""
+
+    payload = _trace_payload(trace)
+    result = validate_trace_export_payload(payload)
+    if not result.ok:
+        raise ValueError("invalid trace export payload: " + ", ".join(result.findings))
+    return json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+
+
+def _list_items(items: tuple[str, ...] | list[str], *, limit: int | None = None) -> str:
+    selected = list(items if limit is None else items[:limit])
+    return ", ".join(str(item) for item in selected)
+
+
+def serialize_host_embodiment_trace_markdown(trace: HostEmbodimentTrace | Mapping[str, Any]) -> str:
+    """Return a concise reviewer-readable Markdown summary for a trace."""
+
+    payload = _trace_payload(trace)
+    result = validate_trace_export_payload(payload)
+    if not result.ok:
+        raise ValueError("invalid trace export payload: " + ", ".join(result.findings))
+
+    steps = payload.get("steps", ())
+    step_kinds = tuple(str(step.get("step_kind", "")) for step in steps if isinstance(step, Mapping))
+    blocked = tuple(str(item) for item in payload.get("blocked_action_labels", ()))
+    deferred = tuple(str(item) for item in payload.get("deferred_capability_labels", ()))
+    flags = {flag: bool(payload.get(flag, False)) for flag in FORBIDDEN_TRACE_EXPORT_FLAGS}
+    lines = [
+        "# Host Embodiment Reviewer Demo Trace",
+        "",
+        f"- Scenario: {payload.get('scenario_label', '<missing>')}",
+        f"- Scenario ID: `{payload.get('scenario_id', '<missing>')}`",
+        f"- Trace status: `{payload.get('trace_status', '<missing>')}`",
+        f"- Step count: {payload.get('step_count', len(steps))}",
+        f"- Digest: `{payload.get('digest', '<missing>')}`",
+        "",
+        "## Key ladder stages",
+        "",
+    ]
+    lines.extend(f"- {stage}" for stage in LADDER_STAGE_LABELS)
+    lines.extend(
+        [
+            "",
+            "## Trace step kinds",
+            "",
+            _list_items(step_kinds),
+            "",
+            "## Blocked/deferred capabilities",
+            "",
+            f"- Blocked actions: {_list_items(blocked)}",
+            f"- Deferred capabilities: {_list_items(deferred)}",
+            "",
+            "## Reviewer proof statements",
+            "",
+            "- PWM presence is not control authority; the demo records PWM telemetry as a signal only.",
+            "- The controlled authorization contract is not a live grant and cannot authorize fulfillment.",
+            "- Grant/revocation records are schema-only/future-use-only and issue no runtime authority token.",
+            "- Real actuation remains deferred; fulfillment is rehearsal/proof only.",
+            "- The default reviewer demo uses fake/sample thermal+PWM telemetry, not live host collection.",
+            "- The metadata-only ledger is an inspection artifact, not an authorization mechanism.",
+            "",
+            "## Proof flags",
+            "",
+        ]
+    )
+    flag_labels = {
+        "live_authorization_granted": "no live authorization",
+        "effect_performed": "no effect",
+        "host_mutation_performed": "no host mutation",
+        "network_performed": "no network",
+        "provider_invocation_performed": "no provider",
+        "prompt_assembly_performed": "no prompt assembly",
+    }
+    for flag, label in flag_labels.items():
+        lines.append(f"- {label}: `{not flags[flag]}`")
+    lines.extend(
+        [
+            "- no fan/PWM writes: `True`",
+            "- no thermal writes: `True`",
+            "- no power mutation: `True`",
+            "- no service restart: `True`",
+            "- no cleanup/delete: `True`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def validate_trace_export_payload(trace_or_payload: HostEmbodimentTrace | Mapping[str, Any]) -> HostEmbodimentTraceValidationResult:
+    """Validate that an export payload remains demo/proof-only."""
+
+    if isinstance(trace_or_payload, HostEmbodimentTrace):
+        base = validate_host_embodiment_trace(trace_or_payload)
+        payload = trace_or_payload.to_dict()
+        findings = list(base.findings)
+    else:
+        payload = _trace_payload(trace_or_payload)
+        findings = []
+
+    if not payload.get("metadata_only", False):
+        findings.append("export_payload_not_metadata_only")
+    if not payload.get("demo_only", False):
+        findings.append("export_payload_not_demo_only")
+    for flag in FORBIDDEN_TRACE_EXPORT_FLAGS:
+        if payload.get(flag, False):
+            findings.append(f"export_forbidden_flag:{flag}")
+    steps = payload.get("steps", ())
+    if not isinstance(steps, (list, tuple)):
+        findings.append("export_steps_not_sequence")
+        steps = ()
+    if payload.get("step_count") != len(steps):
+        findings.append("export_step_count_mismatch")
+    seen_kinds: set[str] = set()
+    for index, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            findings.append(f"export_step_not_mapping:{index}")
+            continue
+        step_kind = str(step.get("step_kind", ""))
+        seen_kinds.add(step_kind)
+        if step_kind not in HOST_EMBODIMENT_TRACE_STEP_KINDS:
+            findings.append(f"export_unknown_step_kind:{step_kind}")
+        if not step.get("metadata_only", False):
+            findings.append(f"export_step_not_metadata_only:{index}:{step_kind}")
+        if step.get("effect_performed", False):
+            findings.append(f"export_step_claims_effect:{index}:{step_kind}")
+        if step.get("host_mutation_performed", False):
+            findings.append(f"export_step_claims_host_mutation:{index}:{step_kind}")
+    missing_blocks = REQUIRED_BLOCKED_ACTION_LABELS - set(payload.get("blocked_action_labels", ()))
+    if missing_blocks:
+        findings.append("export_missing_blocked_actions:" + ",".join(sorted(missing_blocks)))
+    missing_deferred = REQUIRED_DEFERRED_CAPABILITY_LABELS - set(payload.get("deferred_capability_labels", ()))
+    if missing_deferred:
+        findings.append("export_missing_deferred_capabilities:" + ",".join(sorted(missing_deferred)))
+    required_steps = {
+        "collector_result",
+        "host_inventory_manifest",
+        "telemetry_snapshot",
+        "pressure_report",
+        "policy_decision",
+        "proposal_receipt",
+        "broker_decision",
+        "broker_review_receipt",
+        "fulfillment_rehearsal_receipt",
+        "execution_readiness_manifest",
+        "authorization_review_receipt",
+        "future_authorization_schema",
+        "controlled_authorization_contract",
+        "controlled_authorization_grant_record",
+        "controlled_authorization_revocation_record",
+        "controlled_authorization_ledger",
+    }
+    missing_steps = required_steps - seen_kinds
+    if missing_steps:
+        findings.append("export_missing_ladder_steps:" + ",".join(sorted(missing_steps)))
+    return HostEmbodimentTraceValidationResult(not findings, tuple(findings))
+
+
+def write_trace_export_artifact(output_path: str | Path, content: str, *, create_parent: bool = False) -> Path:
+    """Write export content to an explicit caller-supplied path.
+
+    The target path is the only final artifact path. Parent directories are only
+    created when the caller opts in with ``create_parent=True``.
+    """
+
+    path = Path(output_path)
+    if not str(path):
+        raise ValueError("output path is required")
+    if path.exists() and path.is_dir():
+        raise ValueError("output path must be a file path, not a directory")
+    parent = path.parent if str(path.parent) else Path(".")
+    if not parent.exists():
+        if create_parent:
+            parent.mkdir(parents=True, exist_ok=True)
+        else:
+            raise ValueError("output parent does not exist; pass create_parent=True to create it")
+    temporary = parent / f".{path.name}.tmp"
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(path)
+    return path

--- a/tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json
+++ b/tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json
@@ -1,0 +1,944 @@
+{
+  "blocked_action_labels": [
+    "driver_install",
+    "fan_pwm_write",
+    "federation_transport",
+    "file_cleanup",
+    "file_delete",
+    "host_mutation",
+    "live_authorization_grant",
+    "network_egress",
+    "package_install",
+    "power_profile_mutation",
+    "process_kill",
+    "prompt_assembly",
+    "provider_invocation",
+    "remote_execution",
+    "service_restart",
+    "thermal_actuation"
+  ],
+  "created_at": "1970-01-01T00:00:00+00:00",
+  "deferred_capability_labels": [
+    "live_authorization_grant",
+    "real_effect_execution",
+    "real_rollback_execution",
+    "real_fan_pwm_control",
+    "real_thermal_actuation",
+    "real_power_profile_mutation",
+    "real_service_restart",
+    "real_process_kill",
+    "real_file_cleanup",
+    "real_file_delete",
+    "network_egress",
+    "provider_invocation",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution"
+  ],
+  "demo_only": true,
+  "digest": "d11a53b05a1d10428b8f26f226d784b944a2fd591ae3902f4fab4e9fd4ad4ec1",
+  "effect_performed": false,
+  "host_mutation_performed": false,
+  "live_authorization_granted": false,
+  "metadata_only": true,
+  "network_performed": false,
+  "prompt_assembly_performed": false,
+  "provider_invocation_performed": false,
+  "risk_codes": [
+    "controlled_authorization_contract_is_not_live_grant",
+    "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+    "cooling_control_requires_hardware_and_os_bounds",
+    "demo_trace_is_reviewer_proof_only",
+    "future_cooling_requires_privileged_gates",
+    "grant_record_schema_only_future_use_only",
+    "ledger_does_not_grant_live_authority",
+    "pwm_presence_is_not_control_authority",
+    "revocation_record_schema_only_future_use_only"
+  ],
+  "scenario_id": "demo-thermal-pwm-non-mutating-ladder",
+  "scenario_label": "Thermal + PWM presence proves telemetry is not control authority",
+  "step_count": 24,
+  "steps": [
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [],
+      "source_digest": "870270c0425fb7aa6d155bd3f3ecc45e35197979c822926b84ff9c57fb34bcc1",
+      "source_id": "thermal_sensors",
+      "status": "available",
+      "step_id": "hets_5550f46a4ed64090dc1ec228",
+      "step_kind": "collector_result",
+      "summary": {
+        "collector_id": "thermal_sensors",
+        "status": "available",
+        "telemetry_only": true,
+        "values": {
+          "control_available": false,
+          "thermal_actuation_deferred": true,
+          "zones": [
+            {
+              "control_available": false,
+              "id": "thermal_zone0",
+              "label": "x86_pkg_temp",
+              "telemetry_only": true,
+              "temperature_c": 91.0
+            },
+            {
+              "control_available": false,
+              "id": "hwmon0/temp1_input",
+              "label": "hwmon0:temp1_input",
+              "telemetry_only": true,
+              "temperature_c": 91.0
+            }
+          ]
+        }
+      },
+      "warning_codes": []
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "pwm_presence_is_not_control_authority"
+      ],
+      "source_digest": "b2d562966fa1a4bc3eb642da5528b161ed2ade097bd08ddd8f617bd70c79a897",
+      "source_id": "fan_pwm",
+      "status": "available",
+      "step_id": "hets_459d038ffd96341eaae97f71",
+      "step_kind": "collector_result",
+      "summary": {
+        "collector_id": "fan_pwm",
+        "status": "available",
+        "telemetry_only": true,
+        "values": {
+          "control_available": false,
+          "control_deferred": true,
+          "fans": [
+            {
+              "control_available": false,
+              "id": "hwmon0/fan1_input",
+              "rpm": 1800.0,
+              "telemetry_only": true
+            }
+          ],
+          "pwm_signal_observed": true,
+          "pwm_signals": [
+            {
+              "control_available": false,
+              "control_deferred": true,
+              "id": "hwmon0/pwm1",
+              "possible_controller_observed": true,
+              "pwm_signal_observed": true,
+              "requires_future_allowlist": true,
+              "requires_privilege_broker": true,
+              "telemetry_only": true
+            }
+          ],
+          "requires_future_allowlist": true,
+          "requires_privilege_broker": true,
+          "telemetry_only": true
+        }
+      },
+      "warning_codes": []
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [],
+      "source_digest": "1a082c15dc212ecc4c0398e6d5d5410d338471df5aba80e7680f1c3f2029d1b2",
+      "source_id": "demo-thermal-pwm-non-mutating-ladder-inventory",
+      "status": "recorded",
+      "step_id": "hets_172eab4e3334f76c3e0483c5",
+      "step_kind": "host_inventory_manifest",
+      "summary": {
+        "architecture": "unknown",
+        "device_count": 0,
+        "digest": "1a082c15dc212ecc4c0398e6d5d5410d338471df5aba80e7680f1c3f2029d1b2",
+        "fan_pwm_status": "available",
+        "fan_pwm_telemetry_only": true,
+        "host_id": "review-demo-host",
+        "manifest_id": "demo-thermal-pwm-non-mutating-ladder-inventory",
+        "metadata_only": true,
+        "no_host_actuation": true,
+        "no_provider_network_prompt_authority": true,
+        "node_id": "review-demo-node",
+        "os_family": "unknown",
+        "sensor_count": 3,
+        "unsupported_deferred_labels": [
+          "fan_pwm_control_deferred",
+          "pwm_presence_not_control_authority",
+          "requires_future_allowlist",
+          "requires_privilege_broker",
+          "thermal_actuation_deferred"
+        ],
+        "warning_risk_codes": [
+          "risk:pwm_presence_is_not_control_authority"
+        ]
+      },
+      "warning_codes": []
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [],
+      "source_digest": "0add24e792da014ecf71a0c6eddbac57457029384e584eb8e6abeee1cbaef7af",
+      "source_id": "demo-thermal-pwm-non-mutating-ladder-telemetry",
+      "status": "recorded",
+      "step_id": "hets_aaa2930a605cacabdecd2965",
+      "step_kind": "telemetry_snapshot",
+      "summary": {
+        "fan_rpm_observations": {
+          "hwmon0/fan1_input": 1800.0
+        },
+        "metadata_only": true,
+        "model_runtime_pressure_labels": [
+          "pwm_signal_observed_not_control_authority"
+        ],
+        "no_host_actuation": true,
+        "snapshot_id": "demo-thermal-pwm-non-mutating-ladder-telemetry",
+        "thermal_zone_temperatures_c": {
+          "hwmon0/temp1_input": 91.0,
+          "thermal_zone0": 91.0
+        }
+      },
+      "warning_codes": []
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [],
+      "source_digest": "de65bad07f54f6266a318fbf19a283b1e0ddf28df4707bda0a85eec9aafc5b5b",
+      "source_id": "hrr_0a7c6892785a40e236f847d8",
+      "status": "recorded",
+      "step_id": "hets_4a64601e867081af198bcd79",
+      "step_kind": "pressure_report",
+      "summary": {
+        "candidate_kinds": [
+          "future_cooling_policy_candidate",
+          "inspect_thermal_state_candidate"
+        ],
+        "digest": "de65bad07f54f6266a318fbf19a283b1e0ddf28df4707bda0a85eec9aafc5b5b",
+        "finding_count": 2,
+        "metadata_only": true,
+        "no_fan_pwm_writes": true,
+        "no_host_actuation": true,
+        "no_process_kill_restart_install": true,
+        "no_provider_network_prompt_authority": true,
+        "observe_model_propose_only": true,
+        "pressure_labels": [
+          "fan_signal_present",
+          "telemetry_incomplete",
+          "thermal_pressure"
+        ],
+        "proposal_candidate_count": 2,
+        "report_id": "hrr_0a7c6892785a40e236f847d8",
+        "snapshot_id": "demo-thermal-pwm-non-mutating-ladder-telemetry"
+      },
+      "warning_codes": []
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "d32c958ce5fcdb0722e689a5ce6b6e1c00debaee757c6b9f55854962ab82bc63",
+      "source_id": "hrpd_acb08c608bccc87cb3bd4259",
+      "status": "host_resource_policy_incomplete",
+      "step_id": "hets_4ee5108d33095daf7275cf4a",
+      "step_kind": "policy_decision",
+      "summary": {
+        "blocked_proposal_kind_count": 1,
+        "decision_id": "hrpd_acb08c608bccc87cb3bd4259",
+        "digest": "d32c958ce5fcdb0722e689a5ce6b6e1c00debaee757c6b9f55854962ab82bc63",
+        "fan_pwm_write_performed": false,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "network_performed": false,
+        "pressure_labels": [
+          "fan_signal_present",
+          "telemetry_incomplete",
+          "thermal_pressure"
+        ],
+        "proposal_kind_count": 3,
+        "proposal_only": true,
+        "report_digest": "de65bad07f54f6266a318fbf19a283b1e0ddf28df4707bda0a85eec9aafc5b5b",
+        "report_id": "hrr_0a7c6892785a40e236f847d8",
+        "risk_count": 1,
+        "selected_policy_rule_count": 3,
+        "status": "host_resource_policy_incomplete",
+        "thermal_actuation_performed": false,
+        "warning_count": 4
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "5917f208c4d59b72e517cd2442fc3f9193c1942163fba0aa3d065b10e675ad6d",
+      "source_id": "hrpr_ec77822f40f59b35607e2141",
+      "status": "host_resource_proposal_blocked",
+      "step_id": "hets_aa67353b54b0e78dc96a6185",
+      "step_kind": "proposal_receipt",
+      "summary": {
+        "blocked_action_count": 12,
+        "decision_id": "hrpd_acb08c608bccc87cb3bd4259",
+        "digest": "5917f208c4d59b72e517cd2442fc3f9193c1942163fba0aa3d065b10e675ad6d",
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "future_gate_count": 5,
+        "not_authorized_for_fulfillment": true,
+        "pressure_labels": [
+          "fan_signal_present",
+          "telemetry_incomplete",
+          "thermal_pressure"
+        ],
+        "proposal_kind": "future_cooling_policy_candidate",
+        "proposal_only": true,
+        "proposal_scope": "future_privilege_broker_queue",
+        "proposal_status": "host_resource_proposal_blocked",
+        "receipt_id": "hrpr_ec77822f40f59b35607e2141",
+        "report_id": "hrr_0a7c6892785a40e236f847d8",
+        "risk_count": 1,
+        "warning_count": 4
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "8c2c909681d9498a2a47201993f423037e7813d5771f93646670a9fd833bb0f1",
+      "source_id": "pbd_5baf56a400f1fe5ed0c1e841",
+      "status": "privilege_broker_blocked",
+      "step_id": "hets_0d357c4b1dd3bec2d210929b",
+      "step_kind": "broker_decision",
+      "summary": {
+        "authorization_granted": false,
+        "blocked_action_count": 13,
+        "decision_id": "pbd_5baf56a400f1fe5ed0c1e841",
+        "digest": "8c2c909681d9498a2a47201993f423037e7813d5771f93646670a9fd833bb0f1",
+        "eligibility_only": true,
+        "eligibility_status": "privilege_broker_blocked",
+        "fan_pwm_write_performed": false,
+        "fulfillment_granted": false,
+        "future_gate_count": 11,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "missing_prerequisite_count": 11,
+        "network_performed": false,
+        "privilege_domain": "future_cooling_policy_review",
+        "source_proposal_kind": "future_cooling_policy_candidate",
+        "source_receipt_id": "hrpr_ec77822f40f59b35607e2141",
+        "thermal_actuation_performed": false
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "3511e9ea242712fd63405a63acc61f534fbb696d842818de040586646c7aa52b",
+      "source_id": "pbr_3822e7b72b1335b3b95f19e7",
+      "status": "privilege_broker_receipt_blocked",
+      "step_id": "hets_d30237e03c0260d1ee38e5fd",
+      "step_kind": "broker_review_receipt",
+      "summary": {
+        "blocked_action_count": 13,
+        "decision_id": "pbd_5baf56a400f1fe5ed0c1e841",
+        "digest": "3511e9ea242712fd63405a63acc61f534fbb696d842818de040586646c7aa52b",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "eligibility_only": true,
+        "eligibility_status": "privilege_broker_blocked",
+        "future_gate_count": 11,
+        "privilege_domain": "future_cooling_policy_review",
+        "receipt_id": "pbr_3822e7b72b1335b3b95f19e7",
+        "review_only": true,
+        "review_status": "privilege_broker_receipt_blocked",
+        "risk_count": 2,
+        "source_receipt_id": "hrpr_ec77822f40f59b35607e2141",
+        "warning_count": 4
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "131755809df17a367d964d3f568d26e96b438e2c58f89850c03316c9230acd3e",
+      "source_id": "afpl_24dcaf445997a0fde107b36d",
+      "status": "actuation_fulfillment_plan_blocked",
+      "step_id": "hets_2b6849279d08479f3258f143",
+      "step_kind": "fulfillment_plan",
+      "summary": {
+        "authorization_granted": false,
+        "backend_class": "cooling_backend_future",
+        "blocked_action_count": 15,
+        "digest": "131755809df17a367d964d3f568d26e96b438e2c58f89850c03316c9230acd3e",
+        "fan_pwm_write_performed": false,
+        "file_cleanup_performed": false,
+        "fulfillment_domain": "future_cooling_rehearsal",
+        "fulfillment_granted": false,
+        "future_gate_count": 14,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "network_performed": false,
+        "plan_id": "afpl_24dcaf445997a0fde107b36d",
+        "plan_status": "actuation_fulfillment_plan_blocked",
+        "power_profile_mutation_performed": false,
+        "privilege_domain": "future_cooling_policy_review",
+        "rehearsal_only": true,
+        "service_restart_performed": false,
+        "source_broker_receipt_id": "pbr_3822e7b72b1335b3b95f19e7",
+        "source_eligibility_status": "privilege_broker_blocked",
+        "thermal_actuation_performed": false
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "10f9dab2cb01ff180066daaba66330bafe8aa72f85486c0b9daa044b5e52ef05",
+      "source_id": "afrr_f8ade0526b0fb9d2968eeebd",
+      "status": "actuation_fulfillment_rehearsal_blocked",
+      "step_id": "hets_19515171bbae1bc9f359f5df",
+      "step_kind": "fulfillment_rehearsal_receipt",
+      "summary": {
+        "backend_class": "cooling_backend_future",
+        "blocked_action_count": 15,
+        "digest": "10f9dab2cb01ff180066daaba66330bafe8aa72f85486c0b9daa044b5e52ef05",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "dry_run_only": true,
+        "effect_not_performed": true,
+        "fulfillment_domain": "future_cooling_rehearsal",
+        "future_gate_count": 14,
+        "plan_id": "afpl_24dcaf445997a0fde107b36d",
+        "plan_status": "actuation_fulfillment_plan_blocked",
+        "receipt_id": "afrr_f8ade0526b0fb9d2968eeebd",
+        "rehearsal_only": true,
+        "rehearsal_status": "actuation_fulfillment_rehearsal_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "66dcbf95a96302274f8722a24e73bed28994bfd48a13d22ea2e14cfacb880db9",
+      "source_id": "erc_6457d8ac87019f62aa780b7d",
+      "status": "effect_receipt_contract_blocked",
+      "step_id": "hets_6df9fd9ae8eecbf524a3e744",
+      "step_kind": "effect_contract",
+      "summary": {
+        "authorization_granted": false,
+        "backend_class": "cooling_backend_future",
+        "blocked_action_count": 15,
+        "contract_id": "erc_6457d8ac87019f62aa780b7d",
+        "contract_only": true,
+        "effect_domain": "future_cooling_effect",
+        "effect_performed": false,
+        "fulfillment_granted": false,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "proof_gate_count": 17,
+        "status": "effect_receipt_contract_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "42a83a1a6af98eaf092043ae174d295488ac94b3b4625aa61504864adaf0cd2a",
+      "source_id": "fers_e0deb08766f2a70dc2ca7606",
+      "status": "future_effect_receipt_blocked",
+      "step_id": "hets_a1608fa1f3be60afb07afdc8",
+      "step_kind": "future_effect_schema",
+      "summary": {
+        "contract_id": "erc_6457d8ac87019f62aa780b7d",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "effect_performed": false,
+        "future_use_only": true,
+        "planned_effect_domain": "future_cooling_effect",
+        "receipt_id": "fers_e0deb08766f2a70dc2ca7606",
+        "schema_only": true,
+        "status": "future_effect_receipt_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "b5ece0d6e87986f1dd6b18613e47bd2c2ffbe4236f6acbf602f106ce555c5bb6",
+      "source_id": "pcp_0ccc9114fd1c3ea7f12966f4",
+      "status": "postcondition_plan_blocked",
+      "step_id": "hets_f6588f237a227ed087252aec",
+      "step_kind": "postcondition_plan",
+      "summary": {
+        "check_performed": false,
+        "contract_id": "erc_6457d8ac87019f62aa780b7d",
+        "effect_domain": "future_cooling_effect",
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "plan_id": "pcp_0ccc9114fd1c3ea7f12966f4",
+        "plan_only": true,
+        "status": "postcondition_plan_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "641adac1711d562043679558633fb79379eb8ccbbbc349e639af512b75ba1f9f",
+      "source_id": "rbp_d0d8a6793e43efe0645ba179",
+      "status": "rollback_plan_blocked",
+      "step_id": "hets_801def41236bf8fb98657101",
+      "step_kind": "rollback_plan",
+      "summary": {
+        "contract_id": "erc_6457d8ac87019f62aa780b7d",
+        "effect_domain": "future_cooling_effect",
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "plan_id": "rbp_d0d8a6793e43efe0645ba179",
+        "plan_only": true,
+        "rollback_performed": false,
+        "status": "rollback_plan_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "ab415cad9d0ae7d8c3fe7f3d03bc8a275d61687858bf60a17db24f34a2ca50d5",
+      "source_id": "erm_2e1ec4b3e0a90fb3f55b6bd8",
+      "status": "execution_readiness_blocked",
+      "step_id": "hets_7b062f054152155ea1aecf22",
+      "step_kind": "execution_readiness_manifest",
+      "summary": {
+        "authorization_granted": false,
+        "effect_contract_id": "erc_6457d8ac87019f62aa780b7d",
+        "effect_domain": "future_cooling_effect",
+        "effect_performed": false,
+        "fulfillment_granted": false,
+        "future_effect_receipt_id": "fers_e0deb08766f2a70dc2ca7606",
+        "host_mutation_performed": false,
+        "manifest_id": "erm_2e1ec4b3e0a90fb3f55b6bd8",
+        "metadata_only": true,
+        "missing_proof_gate_count": 0,
+        "readiness_only": true,
+        "readiness_status": "execution_readiness_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "262e8cae225bda4bc623523aad6f60efab908992d70abbaf7b479b9e238c24d1",
+      "source_id": "arp_f2b0d3134f95a174787b3a34",
+      "status": "authorization_review_packet_blocked",
+      "step_id": "hets_dbe05d0b229eb957ec426dbb",
+      "step_kind": "authorization_review_packet",
+      "summary": {
+        "approval_class": "future_hardware_safety_approval_required",
+        "authorization_granted": false,
+        "effect_performed": false,
+        "fulfillment_granted": false,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "missing_authorization_gate_count": 0,
+        "packet_id": "arp_f2b0d3134f95a174787b3a34",
+        "packet_status": "authorization_review_packet_blocked",
+        "readiness_status": "execution_readiness_blocked",
+        "review_only": true,
+        "source_execution_readiness_manifest_id": "erm_2e1ec4b3e0a90fb3f55b6bd8"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "ee15bfae952e0bb46a0399ada54ad8194c02c8d96909c012523ef8ba77eaebf4",
+      "source_id": "ard_1f4b3ae1659d4f5b004b58e6",
+      "status": "authorization_review_blocked",
+      "step_id": "hets_076c26815d008848203cad96",
+      "step_kind": "authorization_review_decision",
+      "summary": {
+        "approval_class": "future_hardware_safety_approval_required",
+        "authorization_domain": "future_cooling_authorization_review",
+        "authorization_granted": false,
+        "decision_id": "ard_1f4b3ae1659d4f5b004b58e6",
+        "decision_status": "authorization_review_blocked",
+        "effect_performed": false,
+        "fulfillment_granted": false,
+        "host_mutation_performed": false,
+        "metadata_only": true,
+        "missing_authorization_gate_count": 0,
+        "packet_id": "arp_f2b0d3134f95a174787b3a34",
+        "review_only": true
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "6db52a41cf9185a7ff42aded529ac6baa91e89151c77ef3ef4721dd2d3b8c191",
+      "source_id": "arr_84cecae44852778625267e23",
+      "status": "authorization_review_receipt_blocked",
+      "step_id": "hets_c96cc5317257edd453fb6506",
+      "step_kind": "authorization_review_receipt",
+      "summary": {
+        "authorization_domain": "future_cooling_authorization_review",
+        "authorization_not_granted": true,
+        "decision_id": "ard_1f4b3ae1659d4f5b004b58e6",
+        "digest": "6db52a41cf9185a7ff42aded529ac6baa91e89151c77ef3ef4721dd2d3b8c191",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "receipt_id": "arr_84cecae44852778625267e23",
+        "receipt_status": "authorization_review_receipt_blocked",
+        "review_only": true
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "71a377d0d30c64f686ebd21ffd5bb4a85aff6dd1d42bbaac8c2023e740d10f1b",
+      "source_id": "fags_096664f56425751bdbc3176a",
+      "status": "future_authorization_grant_schema_blocked",
+      "step_id": "hets_860c7a8086a2d0ecc1e53e1e",
+      "step_kind": "future_authorization_schema",
+      "summary": {
+        "authorization_domain": "future_cooling_authorization_review",
+        "authorization_granted": false,
+        "digest": "71a377d0d30c64f686ebd21ffd5bb4a85aff6dd1d42bbaac8c2023e740d10f1b",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "future_use_only": true,
+        "schema_id": "fags_096664f56425751bdbc3176a",
+        "schema_only": true,
+        "schema_status": "future_authorization_grant_schema_blocked",
+        "source_authorization_review_receipt_id": "arr_84cecae44852778625267e23"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "controlled_authorization_contract_is_not_live_grant",
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates"
+      ],
+      "source_digest": "10f4bd576425a884511b0f1660d297c92ad4abc4c72fb6d954acf9615cb0c451",
+      "source_id": "cagc_aa5985484dfe566de9289b83",
+      "status": "controlled_authorization_contract_blocked",
+      "step_id": "hets_af5bf3de9a2c7b4744964237",
+      "step_kind": "controlled_authorization_contract",
+      "summary": {
+        "authorization_domain": "future_cooling_authorization_review",
+        "authorization_scope": "future_cooling_scope",
+        "blocked_action_count": 16,
+        "contract_id": "cagc_aa5985484dfe566de9289b83",
+        "contract_only": true,
+        "digest": "10f4bd576425a884511b0f1660d297c92ad4abc4c72fb6d954acf9615cb0c451",
+        "effect_performed": false,
+        "fulfillment_granted": false,
+        "future_authorization_grant_schema_id": "fags_096664f56425751bdbc3176a",
+        "host_mutation_performed": false,
+        "live_authorization_granted": false,
+        "metadata_only": true,
+        "source_authorization_review_receipt_id": "arr_84cecae44852778625267e23",
+        "status": "controlled_authorization_contract_blocked"
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "controlled_authorization_contract_is_not_live_grant",
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates",
+        "grant_record_schema_only_future_use_only"
+      ],
+      "source_digest": "f390726c1339365a2df41d1fb6448964dec4b743fa2a20e7939e3acfa36cdb5e",
+      "source_id": "cagr_8b0eae356e6baefead1f19ed",
+      "status": "controlled_authorization_grant_blocked",
+      "step_id": "hets_46c60bd74f0116bfd0050e59",
+      "step_kind": "controlled_authorization_grant_record",
+      "summary": {
+        "authorization_scope": "future_cooling_scope",
+        "contract_id": "cagc_aa5985484dfe566de9289b83",
+        "digest": "f390726c1339365a2df41d1fb6448964dec4b743fa2a20e7939e3acfa36cdb5e",
+        "does_not_authorize_fulfillment": true,
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "future_use_only": true,
+        "grant_record_id": "cagr_8b0eae356e6baefead1f19ed",
+        "grant_status": "controlled_authorization_grant_blocked",
+        "live_authorization_granted": false,
+        "schema_only": true
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "controlled_authorization_contract_is_not_live_grant",
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates",
+        "grant_record_schema_only_future_use_only",
+        "revocation_record_schema_only_future_use_only"
+      ],
+      "source_digest": "86fe59e9b272101b10f3cfd35ffd6683e1e7146fab1344d2533a6cfac6406670",
+      "source_id": "carr_5a5c472a0d897da79ca17add",
+      "status": "controlled_authorization_revocation_blocked",
+      "step_id": "hets_ec8d98c40064150a6e137183",
+      "step_kind": "controlled_authorization_revocation_record",
+      "summary": {
+        "digest": "86fe59e9b272101b10f3cfd35ffd6683e1e7146fab1344d2533a6cfac6406670",
+        "does_not_execute": true,
+        "does_not_mutate_host": true,
+        "future_use_only": true,
+        "grant_record_id": "cagr_8b0eae356e6baefead1f19ed",
+        "live_revocation_performed": false,
+        "revocation_id": "carr_5a5c472a0d897da79ca17add",
+        "revocation_status": "controlled_authorization_revocation_blocked",
+        "schema_only": true
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    },
+    {
+      "effect_performed": false,
+      "host_mutation_performed": false,
+      "metadata_only": true,
+      "risk_codes": [
+        "controlled_authorization_contract_is_not_live_grant",
+        "cooling_backend_requires_future_allowlist_bounds_cooldown_and_panic_stop",
+        "cooling_control_requires_hardware_and_os_bounds",
+        "future_cooling_requires_privileged_gates",
+        "grant_record_schema_only_future_use_only",
+        "ledger_does_not_grant_live_authority",
+        "revocation_record_schema_only_future_use_only"
+      ],
+      "source_digest": "a52e71d078cbc8f7dcce174a70768078884011a514feb7ba15a3344b43a62ddb",
+      "source_id": "cal_2f38955078b74ad8edb79130",
+      "status": "controlled_authorization_ledger_blocked",
+      "step_id": "hets_2c5074ccfcc5c1fbae02647c",
+      "step_kind": "controlled_authorization_ledger",
+      "summary": {
+        "active_schema_grant_count": 0,
+        "blocked_schema_grant_count": 1,
+        "digest": "a52e71d078cbc8f7dcce174a70768078884011a514feb7ba15a3344b43a62ddb",
+        "expired_schema_grant_count": 0,
+        "host_mutation_performed": false,
+        "ledger_id": "cal_2f38955078b74ad8edb79130",
+        "ledger_only": true,
+        "ledger_status": "controlled_authorization_ledger_blocked",
+        "live_authorization_granted": false,
+        "metadata_only": true,
+        "revoked_schema_grant_count": 0
+      },
+      "warning_codes": [
+        "fan_pwm_signal_is_observation_only",
+        "incomplete_telemetry_blocks_automatic_readiness",
+        "pwm_presence_is_not_control_authority",
+        "thermal_pressure_is_not_cooling_authorization"
+      ]
+    }
+  ],
+  "trace_id": "het_914794048260a160dddfcbe5",
+  "trace_status": "host_embodiment_trace_incomplete",
+  "warning_codes": [
+    "fan_pwm_signal_is_observation_only",
+    "incomplete_telemetry_blocks_automatic_readiness",
+    "pwm_presence_is_not_control_authority",
+    "thermal_pressure_is_not_cooling_authorization"
+  ]
+}

--- a/tests/test_build_host_embodiment_trace_script.py
+++ b/tests/test_build_host_embodiment_trace_script.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import build_host_embodiment_trace as script
+from sentientos.host_embodiment_trace_export import validate_trace_export_payload
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run_main(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            code = script.main(args)
+        except SystemExit as exc:
+            code = int(exc.code or 0)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_default_run_prints_valid_json_trace() -> None:
+    code, stdout, stderr = _run_main([])
+    assert code == 0, stderr
+    payload = json.loads(stdout)
+    assert payload["scenario_id"] == "demo-thermal-pwm-non-mutating-ladder"
+    assert payload["demo_only"] is True
+    assert payload["metadata_only"] is True
+    assert validate_trace_export_payload(payload).ok
+
+
+def test_format_markdown_prints_summary() -> None:
+    code, stdout, stderr = _run_main(["--format", "markdown"])
+    assert code == 0, stderr
+    assert stdout.startswith("# Host Embodiment Reviewer Demo Trace")
+    assert "PWM presence is not control authority" in stdout
+    assert "no host mutation" in stdout
+
+
+def test_validate_only_exits_zero_without_artifact_output() -> None:
+    code, stdout, stderr = _run_main(["--validate-only"])
+    assert code == 0, stderr
+    assert stdout == ""
+
+
+def test_summary_prints_compact_reviewer_summary() -> None:
+    code, stdout, stderr = _run_main(["--summary"])
+    assert code == 0, stderr
+    assert "Host Embodiment Reviewer Demo Trace Summary" in stdout
+    assert "reviewer proof only: true" in stdout
+    assert "fake/sample telemetry by default: true" in stdout
+
+
+def test_output_writes_requested_file(tmp_path: Path) -> None:
+    output = tmp_path / "trace.json"
+    code, stdout, stderr = _run_main(["--format", "json", "--output", str(output)])
+    assert code == 0, stderr
+    assert stdout == ""
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert validate_trace_export_payload(payload).ok
+
+
+def test_invalid_format_exits_nonzero() -> None:
+    code, stdout, stderr = _run_main(["--format", "yaml"])
+    assert code != 0
+    assert stdout == ""
+    assert "invalid choice" in stderr
+
+
+def test_invalid_output_path_exits_nonzero_without_partial_target(tmp_path: Path) -> None:
+    output = tmp_path / "missing" / "trace.json"
+    code, stdout, stderr = _run_main(["--output", str(output)])
+    assert code != 0
+    assert stdout == ""
+    assert "output parent does not exist" in stderr
+    assert not output.exists()
+
+
+def test_script_source_does_not_call_live_collectors_or_forbidden_apis() -> None:
+    source = Path("scripts/build_host_embodiment_trace.py").read_text(encoding="utf-8")
+    forbidden = [
+        "collect_thermal_sensor_observation",
+        "collect_fan_pwm_observation",
+        "socket",
+        "requests",
+        "urllib",
+        "subprocess",
+        "os.system",
+        "Popen",
+        "prompt_assembler",
+        "admit_and_execute",
+    ]
+    for term in forbidden:
+        assert term not in source
+
+
+def test_generated_trace_includes_all_major_ladder_step_kinds_and_blocks() -> None:
+    trace = script.build_trace_for_scenario("thermal_pwm_demo")
+    kinds = {step.step_kind for step in trace.steps}
+    for kind in [
+        "collector_result",
+        "host_inventory_manifest",
+        "telemetry_snapshot",
+        "pressure_report",
+        "policy_decision",
+        "proposal_receipt",
+        "broker_decision",
+        "broker_review_receipt",
+        "fulfillment_rehearsal_receipt",
+        "execution_readiness_manifest",
+        "authorization_review_receipt",
+        "future_authorization_schema",
+        "controlled_authorization_contract",
+        "controlled_authorization_grant_record",
+        "controlled_authorization_revocation_record",
+        "controlled_authorization_ledger",
+    ]:
+        assert kind in kinds
+    for label in [
+        "fan_pwm_write",
+        "thermal_actuation",
+        "service_restart",
+        "power_profile_mutation",
+        "file_cleanup",
+        "file_delete",
+        "provider_invocation",
+        "network_egress",
+        "prompt_assembly",
+        "federation_transport",
+        "remote_execution",
+    ]:
+        assert label in trace.blocked_action_labels
+    assert validate_trace_export_payload(trace).ok

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -308,3 +308,25 @@ def test_controlled_authorization_and_trace_capabilities_are_non_live() -> None:
     assert records["real_power_profile_mutation"].status == "blocked"
     assert records["real_file_cleanup"].status == "blocked"
     assert all(record.host_actuation_performed is False for record in records.values())
+
+
+def test_trace_export_and_reviewer_demo_capabilities_are_proof_only() -> None:
+    from sentientos.capability_registry import update_registry_from_trace_export
+    from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace
+
+    trace = build_host_embodiment_demo_trace()
+    registry = update_registry_from_trace_export(build_default_capability_registry(), trace)
+    records = registry.by_id()
+    assert records["host_embodiment_trace_export"].status == "implemented"
+    assert records["host_embodiment_trace_export"].authority_level == "demo_proof_only"
+    assert records["host_embodiment_trace_export"].host_actuation_performed is False
+    assert records["reviewer_demo_trace"].status == "implemented"
+    assert records["reviewer_demo_trace"].authority_level == "demo_proof_only"
+    assert records["live_host_trace_collection"].status == "deferred"
+    assert records["live_authorization_grant"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_host_embodiment_trace_export.py
+++ b/tests/test_host_embodiment_trace_export.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace
+from sentientos.host_embodiment_trace_export import (
+    serialize_host_embodiment_trace_json,
+    serialize_host_embodiment_trace_markdown,
+    validate_trace_export_payload,
+    write_trace_export_artifact,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def test_json_serialization_is_deterministic_and_matches_golden_fixture() -> None:
+    trace = build_host_embodiment_demo_trace(scenario_id="demo-thermal-pwm-non-mutating-ladder")
+    first = serialize_host_embodiment_trace_json(trace)
+    second = serialize_host_embodiment_trace_json(trace)
+    fixture = Path("tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json").read_text(encoding="utf-8")
+    assert first == second
+    assert first == fixture
+    assert '"scenario_id": "demo-thermal-pwm-non-mutating-ladder"' in first
+    assert first.index('"blocked_action_labels"') < first.index('"created_at"')
+
+
+def test_markdown_serialization_contains_reviewer_proof_language() -> None:
+    trace = build_host_embodiment_demo_trace()
+    markdown = serialize_host_embodiment_trace_markdown(trace)
+    for expected in [
+        "Thermal + PWM presence proves telemetry is not control authority",
+        "Trace status",
+        "Step count",
+        "collector results",
+        "metadata-only ledger",
+        "PWM presence is not control authority",
+        "controlled authorization contract is not a live grant",
+        "Grant/revocation records are schema-only/future-use-only",
+        "Real actuation remains deferred",
+        "no live authorization",
+        "no host mutation",
+        "no effect",
+        "no network",
+        "no provider",
+        "no prompt assembly",
+        "fake/sample thermal+PWM telemetry",
+    ]:
+        assert expected in markdown
+
+
+def test_validation_rejects_payload_claiming_forbidden_activity() -> None:
+    trace = build_host_embodiment_demo_trace().to_dict()
+    for flag in [
+        "live_authorization_granted",
+        "effect_performed",
+        "host_mutation_performed",
+        "network_performed",
+        "provider_invocation_performed",
+        "prompt_assembly_performed",
+    ]:
+        bad = dict(trace)
+        bad[flag] = True
+        result = validate_trace_export_payload(bad)
+        assert not result.ok
+        assert f"export_forbidden_flag:{flag}" in result.findings
+
+
+def test_validation_rejects_step_claiming_host_mutation_or_effect() -> None:
+    payload = build_host_embodiment_demo_trace().to_dict()
+    steps = list(payload["steps"])
+    steps[0] = dict(steps[0], effect_performed=True, host_mutation_performed=True)
+    payload["steps"] = steps
+    result = validate_trace_export_payload(payload)
+    assert not result.ok
+    assert any("export_step_claims_effect" in finding for finding in result.findings)
+    assert any("export_step_claims_host_mutation" in finding for finding in result.findings)
+
+
+def test_validation_rejects_missing_blocked_and_deferred_labels() -> None:
+    payload = build_host_embodiment_demo_trace().to_dict()
+    payload["blocked_action_labels"] = []
+    payload["deferred_capability_labels"] = []
+    result = validate_trace_export_payload(payload)
+    assert not result.ok
+    assert any("export_missing_blocked_actions" in finding for finding in result.findings)
+    assert any("export_missing_deferred_capabilities" in finding for finding in result.findings)
+
+
+def test_validation_rejects_trace_object_claiming_live_authorization() -> None:
+    trace = replace(build_host_embodiment_demo_trace(), live_authorization_granted=True)
+    result = validate_trace_export_payload(trace)
+    assert not result.ok
+    assert "trace_forbidden_flag:live_authorization_granted" in result.findings
+
+
+def test_output_artifact_writes_only_explicit_path_and_is_deterministic(tmp_path: Path) -> None:
+    trace = build_host_embodiment_demo_trace()
+    content = serialize_host_embodiment_trace_json(trace)
+    output = tmp_path / "explicit" / "trace.json"
+    with pytest.raises(ValueError):
+        write_trace_export_artifact(output, content)
+    written = write_trace_export_artifact(output, content, create_parent=True)
+    assert written == output
+    assert output.read_text(encoding="utf-8") == content
+    write_trace_export_artifact(output, content, create_parent=True)
+    assert output.read_text(encoding="utf-8") == content
+    assert not (tmp_path / "trace.json").exists()
+
+
+def test_golden_fixture_contains_no_secrets_real_host_identifiers_or_provider_endpoints() -> None:
+    fixture = Path("tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json").read_text(encoding="utf-8").lower()
+    for forbidden in [
+        "api_key",
+        "secret",
+        "token",
+        "bearer",
+        "password",
+        "/home/",
+        "c:\\users",
+        "prompt text",
+        "openai",
+        "anthropic",
+        "http://",
+        "https://",
+    ]:
+        assert forbidden not in fixture

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -274,3 +274,31 @@ def test_controlled_authorization_trace_doc_preserves_non_live_boundaries() -> N
     assert "Demo trace is reviewer proof only" in doc or "demo trace is reviewer proof only" in doc
     assert "Real fulfillment remains deferred" in doc
     assert "Real actuation remains deferred" in doc
+
+HOST_EMBODIMENT_REVIEWER_DEMO_TRACE = "docs/architecture/host_embodiment_reviewer_demo_trace.md"
+
+
+def test_navigation_links_to_host_embodiment_reviewer_demo_trace_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    auth = _read(HOST_EMBODIMENT_AUTHORIZATION_REVIEW_WING)
+    proof = _read(HOST_EMBODIMENT_EXECUTION_PROOF_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, controlled, auth, proof, trajectory]:
+        assert HOST_EMBODIMENT_REVIEWER_DEMO_TRACE in text
+
+
+def test_reviewer_demo_trace_doc_preserves_demo_boundaries_and_commands() -> None:
+    doc = _read(HOST_EMBODIMENT_REVIEWER_DEMO_TRACE)
+    for command in [
+        "python scripts/build_host_embodiment_trace.py --format json",
+        "python scripts/build_host_embodiment_trace.py --format markdown",
+        "python scripts/build_host_embodiment_trace.py --validate-only",
+    ]:
+        assert command in doc
+    assert "demo trace is reviewer proof only" in doc.lower()
+    assert "no host mutation" in doc.lower()
+    assert "PWM presence is not control authority" in doc
+    assert "controlled authorization contract is not a live grant" in doc
+    assert "schema-only/future-use-only" in doc


### PR DESCRIPTION
### Motivation

- Provide reviewers a single, deterministic, non-mutating proof artifact that shows the full host-embodiment ladder (collector → inventory → telemetry → pressure → policy → proposal → broker → rehearsal → readiness → authorization → controlled contract → grant/revocation/ledger → reviewer trace) without performing any live host actions. 
- Make it trivial to generate, validate, inspect, and optionally write a metadata-only trace in JSON or Markdown from a safe CLI so reviewers can confirm blocked/deferred boundaries (fan/PWM, thermal, power, service, cleanup, provider/network/prompt, live authorization). 
- Ensure export helpers, CLI, fixtures, registry entries and docs explicitly assert that the demo is proof-only and that no live authorization, effect, or host mutation occurs.

### Description

- Added deterministic export helpers in `sentientos/host_embodiment_trace_export.py` including `serialize_host_embodiment_trace_json`, `serialize_host_embodiment_trace_markdown`, `validate_trace_export_payload`, and `write_trace_export_artifact` with sorted-key JSON, concise reviewer Markdown, strict validation, and safe explicit-path atomic write semantics. 
- Added a reviewer CLI `scripts/build_host_embodiment_trace.py` that builds the built-in `thermal_pwm_demo` from fake/sample telemetry, supports `--format json|markdown`, `--output PATH`, `--validate-only`, and `--summary`, and validates before emitting or writing artifacts. 
- Added a golden fixture and tests: `tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json`, `tests/test_host_embodiment_trace_export.py`, and `tests/test_build_host_embodiment_trace_script.py`, and updated registry/tests to reflect proof-only capabilities via `sentientos/capability_registry.py` and `tests/test_capability_registry.py`. 
- Documentation updates include `docs/architecture/host_embodiment_reviewer_demo_trace.md` and short-link additions in the controlled-authorization, authorization-review, execution-proof, public overview, readiness index, and trajectory docs to surface the demo and its run commands.

### Testing

- Type-check/compile: ran `python -m py_compile` on modified modules and files and compilation succeeded. 
- Unit tests: ran focused suites with `python -m scripts.run_tests -q` including `tests/test_host_embodiment_trace.py`, `tests/test_host_embodiment_trace_export.py`, `tests/test_build_host_embodiment_trace_script.py`, `tests/test_capability_registry.py`, `tests/test_controlled_authorization.py`, `tests/test_authorization_review.py`, `tests/test_effect_proof.py`, `tests/test_runtime_supervisor.py`, `tests/test_reviewer_release_readiness_index.py`, and `tests/test_control_plane_kernel.py` / `tests/test_sentientosd_runtime_closure.py`, and all executed successfully. 
- CLI and docs: ran `python scripts/build_host_embodiment_trace.py --validate-only`, `--format json`, `--format markdown`, and `--summary` (artifacts written when requested), and ran `python scripts/build_docs.py --bootstrap-docs` then `--check-deps` / `build_docs` which required a docs bootstrap step and then succeeded. 
- Forbidden-scan / hygiene: ran the prompt-boundary and forbidden-operation scans and verified there are no implementations of forbidden operations (network/provider/subprocess/host actuation); the scan returned only blocked/deferred marker strings and documentation/registry guard labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05fc1b90b483208e2c822d65d7beb9)