### PR TITLE
[codex:reviewer-proof] add first-run proof bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 For technical reviewers, start here: [`docs/architecture/public_technical_overview.md`](docs/architecture/public_technical_overview.md).
 
+To generate a local reviewer proof bundle, run `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof` (metadata-only; fake/sample host telemetry by default).
+
 > ⚠️ **Codex-first builds.** Do not run local host builds—use the Codex CI workflow or open the repository inside the provided VS Code Dev Container.
 
 [![Docker Pull](https://img.shields.io/static/v1?label=Docker%20Pull&message=ghcr.io/zombinator85/sentientos&color=blue)](https://github.com/zombinator85/sentientos/pkgs/container/sentientos)

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -1,6 +1,6 @@
 # Host Embodiment Controlled Authorization + Trace Wing
 
-This wing follows the [Authorization Review Wing](host_embodiment_authorization_review_wing.md). It defines the controlled authorization grant contract and a reviewer-facing end-to-end trace across the non-mutating host-embodiment ladder.
+This wing follows the [Authorization Review Wing](host_embodiment_authorization_review_wing.md). The practical first-run reviewer command path is the [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It defines the controlled authorization grant contract and a reviewer-facing end-to-end trace across the non-mutating host-embodiment ladder.
 
 ## Boundary
 

--- a/docs/architecture/host_embodiment_reviewer_demo_trace.md
+++ b/docs/architecture/host_embodiment_reviewer_demo_trace.md
@@ -1,6 +1,6 @@
 # Host Embodiment Reviewer Demo Trace
 
-This doc follows the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). The reviewer demo trace is a deterministic, non-mutating proof artifact for seeing the full host embodiment ladder breathe without moving the body.
+This doc follows the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). For the one-command local archive path, see the [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). The reviewer demo trace is a deterministic, non-mutating proof artifact for seeing the full host embodiment ladder breathe without moving the body.
 
 ## Boundary
 

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -245,3 +245,6 @@ Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace
 ## Host Embodiment Reviewer Demo Trace
 
 See `docs/architecture/host_embodiment_reviewer_demo_trace.md` for the one-command deterministic reviewer trace. Run `python scripts/build_host_embodiment_trace.py --format json`, `python scripts/build_host_embodiment_trace.py --format markdown`, or `python scripts/build_host_embodiment_trace.py --validate-only`. The demo trace is reviewer proof only, no host mutation occurs, PWM presence is not control authority, the controlled authorization contract is not a live grant, and grant/revocation records are schema-only/future-use-only.
+
+
+Reviewer first-run proof bundle: `docs/architecture/reviewer_first_run_proof_bundle.md`.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -1,0 +1,72 @@
+# Reviewer First-Run Proof Bundle
+
+This doc is the first practical reviewer command path after reading the [public technical overview](public_technical_overview.md). It packages the current deterministic, non-mutating host-embodiment proof chain into one local output directory so a serious reviewer can run one safe command, inspect the story, and archive the artifacts.
+
+## Boundary
+
+The reviewer proof bundle is metadata/export-only. It packages the deterministic non-mutating host-embodiment trace and the capability/deferred-action posture.
+
+By default, the bundle uses fake/sample thermal+PWM telemetry. It does not collect live host data by default, does not grant authorization, does not perform effects, does not mutate host state, does not perform fan/PWM writes, does not perform thermal writes, does not mutate power profiles, does not restart services, does not clean up or delete files, does not perform network egress, does not invoke providers, does not assemble/export prompts, does not transport/sync/adopt federation state, and does not perform remote execution.
+
+The command writes only explicit local bundle files under the caller-supplied output directory.
+
+## Run the first proof bundle
+
+From the repository root:
+
+```bash
+python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof
+python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force
+python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --summary
+```
+
+`--force` overwrites only the known bundle files inside the explicit output directory. It does not delete unrelated files.
+
+`--verify` is intentionally unsupported in this packaging pass. The default command lists bounded local proof commands in `proof_commands.json` with `proof_command_not_run`; reviewers can run those commands separately when they want to verify the chain.
+
+## Generated files
+
+The bundle writes:
+
+- `trace.json` — deterministic sorted-key trace JSON.
+- `trace.md` — reviewer-readable Markdown trace.
+- `trace.summary.txt` — compact summary of the non-mutating proof posture.
+- `capability_registry_summary.json` — metadata-only capability registry summary and records.
+- `deferred_actions.json` — deferred/blocked action inventory.
+- `proof_commands.json` — proof command manifest; commands are listed but not run by default.
+- `README.md` — local reviewer guide for the bundle directory.
+- `bundle_manifest.json` — manifest, artifact digests, command records, and safety flags.
+
+## Inspect first
+
+Reviewers should inspect these files in order:
+
+1. `README.md`
+2. `trace.md`
+3. `bundle_manifest.json`
+4. `deferred_actions.json`
+5. `proof_commands.json`
+
+## What the bundle proves
+
+The bundle exposes the same non-mutating ladder as the host embodiment trace:
+
+collector results → inventory → telemetry → pressure → policy → proposal → broker eligibility → broker review → fulfillment rehearsal → execution proof → authorization review → controlled authorization contract → schema-only grant/revocation records → metadata-only ledger → reviewer trace.
+
+The reviewer should see that:
+
+- PWM presence is telemetry, not control authority.
+- The controlled authorization contract is not a live grant.
+- Grant/revocation records are schema-only/future-use-only.
+- Real effect execution and rollback execution remain deferred.
+- Real fan/PWM control, thermal actuation, power mutation, service restart, cleanup, provider invocation, prompt export, federation transport/sync/adoption, and remote execution remain deferred or blocked.
+- The proof command manifest is inventory by default, not execution.
+
+## Implementation links
+
+- Bundle module: `sentientos/reviewer_proof_bundle.py`
+- Bundle CLI: `scripts/build_reviewer_proof_bundle.py`
+- Trace builder: `sentientos/host_embodiment_trace.py`
+- Trace export: `sentientos/host_embodiment_trace_export.py`
+- Capability registry: `sentientos/capability_registry.py`
+- Tests: `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -1,5 +1,9 @@
 # Reviewer Release-Readiness Proof Index
 
+## Reviewer first-run proof bundle
+
+Reviewers can generate the local non-mutating host-embodiment proof archive with `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof`; see [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It uses fake/sample telemetry by default, performs no live host collection by default, and performs no host mutation.
+
 ## What this index is
 
 This is a reviewer-facing map of the currently implemented proof surfaces for the

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -1,5 +1,9 @@
 # SentientOS Trajectory and Missing Organs
 
+## Reviewer first-run proof bundle
+
+Reviewers can generate the local non-mutating host-embodiment proof archive with `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof`; see [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It uses fake/sample telemetry by default, performs no live host collection by default, and performs no host mutation.
+
 ## What SentientOS is becoming
 
 SentientOS is becoming a user-space operating substrate for governed AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ sosctl = "sosctl:main"
 verify_audits = "sentientos.verify_audits:main"
 audit_immutability_verifier = "sentientos.vow_artifacts:run_immutability_verifier_main"
 reconcile_audits = "scripts.reconcile_audits:main"
+sentientos-reviewer-proof-bundle = "scripts.build_reviewer_proof_bundle:main"
 
 [project.entry-points."sentientos.plugins"]
 telegram-bot = "telegram_bot"

--- a/scripts/build_reviewer_proof_bundle.py
+++ b/scripts/build_reviewer_proof_bundle.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Build the SentientOS reviewer first-run proof bundle."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.reviewer_proof_bundle import (
+    build_reviewer_proof_bundle_payload,
+    summarize_reviewer_proof_bundle_manifest,
+    validate_reviewer_proof_bundle_manifest,
+    write_reviewer_proof_bundle,
+)
+
+
+def _summary_text(summary: dict[str, object], output_dir: str) -> str:
+    return "\n".join(
+        [
+            "SentientOS Reviewer First-Run Proof Bundle",
+            f"output_dir: {output_dir}",
+            f"manifest_id: {summary['manifest_id']}",
+            f"scenario: {summary['scenario_id']}",
+            f"status: {summary['bundle_status']}",
+            f"artifacts: {summary['artifact_count']}",
+            f"proof commands listed: {summary['proof_command_count']}",
+            f"proof commands executed: {summary['proof_commands_executed']}",
+            "metadata only: true",
+            "reviewer proof only: true",
+            "fake/sample telemetry by default: true",
+            "live host collection performed: false",
+            "live authorization / effects / host mutation / network / provider / prompt assembly: false",
+            f"digest: {summary['digest']}",
+            "",
+        ]
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only SentientOS reviewer proof bundle")
+    parser.add_argument("--output-dir", required=True, help="explicit local output directory for bundle files")
+    parser.add_argument("--scenario", choices=("thermal_pwm_demo",), default="thermal_pwm_demo", help="deterministic reviewer scenario")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00", help="deterministic creation timestamp")
+    parser.add_argument("--verify", action="store_true", help="unsupported in this pass; proof commands are listed but not run")
+    parser.add_argument("--no-verify", action="store_true", help="list proof commands without running them (default)")
+    parser.add_argument("--summary", action="store_true", help="print compact summary after writing")
+    parser.add_argument("--manifest-only", action="store_true", help="write only bundle_manifest.json")
+    parser.add_argument("--force", action="store_true", help="overwrite existing bundle files within output directory")
+    args = parser.parse_args(argv)
+
+    if args.verify:
+        print("--verify is not implemented in this packaging pass; inspect proof_commands.json and run commands separately", file=sys.stderr)
+        return 2
+    if not str(args.output_dir):
+        print("output directory is required", file=sys.stderr)
+        return 2
+    output_dir = Path(args.output_dir)
+    if str(args.output_dir).strip() == "":
+        print("output directory is required", file=sys.stderr)
+        return 2
+    try:
+        payload = build_reviewer_proof_bundle_payload(scenario=args.scenario, created_at=args.created_at)
+        manifest = payload["manifest"]
+        validation = validate_reviewer_proof_bundle_manifest(manifest)
+        if not validation.ok:
+            print("reviewer proof bundle validation failed: " + ", ".join(validation.findings), file=sys.stderr)
+            return 2
+        write_reviewer_proof_bundle(output_dir, payload, force=args.force, manifest_only=args.manifest_only)
+        summary = summarize_reviewer_proof_bundle_manifest(manifest)
+        print(_summary_text(summary, str(output_dir)), end="")
+        return 0
+    except (OSError, TypeError, ValueError, FileExistsError) as exc:
+        print(f"reviewer proof bundle failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -38,6 +38,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "authorization_review",
         "controlled_authorization",
         "host_embodiment_trace",
+        "reviewer_proof_bundle",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -246,6 +247,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("host_embodiment_trace", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("sentientos/host_embodiment_trace.py",), proof_tests=("tests/test_host_embodiment_trace.py",), implemented_surfaces=("reviewer-facing non-mutating demo trace",), deferred_surfaces=("live authorization", "real effects", "real rollback"), forbidden_implications=("demo trace executes host actions", "trace grants authority")),
         _record("host_embodiment_trace_export", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("sentientos/host_embodiment_trace_export.py",), proof_tests=("tests/test_host_embodiment_trace_export.py",), proof_commands=("python scripts/build_host_embodiment_trace.py --format json", "python scripts/build_host_embodiment_trace.py --format markdown", "python scripts/build_host_embodiment_trace.py --validate-only"), implemented_surfaces=("deterministic sorted-key JSON trace export", "reviewer Markdown trace summary", "explicit-path artifact writing"), deferred_surfaces=("live host collection", "live authorization", "real effects"), forbidden_implications=("trace export collects live host data", "trace export grants authority", "trace export performs effects")),
         _record("reviewer_demo_trace", "host_embodiment_trace", "implemented", "demo_proof_only", source_paths=("scripts/build_host_embodiment_trace.py", "tests/fixtures/host_embodiment_trace_thermal_pwm_demo.json"), proof_tests=("tests/test_build_host_embodiment_trace_script.py",), proof_commands=("python scripts/build_host_embodiment_trace.py --format json", "python scripts/build_host_embodiment_trace.py --summary"), implemented_surfaces=("deterministic fake/sample thermal+PWM reviewer demo",), deferred_surfaces=("live host collection", "host mutation", "runtime authority token"), forbidden_implications=("reviewer demo performs live collection by default", "reviewer demo authorizes host actions")),
+        _record("reviewer_proof_bundle", "reviewer_proof_bundle", "implemented", "demo_proof_only", source_paths=("sentientos/reviewer_proof_bundle.py",), proof_tests=("tests/test_reviewer_proof_bundle.py",), proof_commands=("python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force",), implemented_surfaces=("metadata-only first-run reviewer proof bundle", "deterministic local packaging of demo trace, capability posture, deferred actions, and proof commands"), deferred_surfaces=("live host trace collection", "live authorization", "real effects", "host mutation"), forbidden_implications=("reviewer proof bundle collects live host data", "reviewer proof bundle grants authority", "reviewer proof bundle performs effects")),
+        _record("reviewer_proof_bundle_cli", "reviewer_proof_bundle", "implemented", "demo_proof_only", source_paths=("scripts/build_reviewer_proof_bundle.py",), proof_tests=("tests/test_build_reviewer_proof_bundle_script.py",), proof_commands=("python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force",), implemented_surfaces=("one-command local proof bundle writer",), deferred_surfaces=("verification command execution by default", "live host collection", "host mutation"), forbidden_implications=("CLI performs live verification by default", "CLI mutates host state beyond explicit bundle files")),
+        _record("proof_command_manifest", "reviewer_proof_bundle", "implemented", "proof_only", source_paths=("sentientos/reviewer_proof_bundle.py",), proof_tests=("tests/test_reviewer_proof_bundle.py",), implemented_surfaces=("bounded local proof command inventory",), deferred_surfaces=("default proof command execution", "network commands", "provider invocation"), forbidden_implications=("listed proof commands have run", "proof command manifest grants runtime authority")),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -264,6 +268,33 @@ def build_default_capability_registry() -> CapabilityRegistry:
     )
     return CapabilityRegistry(registry_id="sentientos-host-embodiment-controlled-authorization-and-trace-wing", schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1", records=records)
 
+
+
+def update_registry_from_reviewer_proof_bundle(registry: CapabilityRegistry, manifest: Any) -> CapabilityRegistry:
+    """Reflect reviewer proof bundle packaging without claiming live authority."""
+
+    has_manifest = bool(getattr(manifest, "manifest_id", "")) or (isinstance(manifest, Mapping) and bool(manifest.get("manifest_id")))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id in {"reviewer_proof_bundle", "reviewer_proof_bundle_cli", "proof_command_manifest"}:
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_manifest else record.status,
+                    authority_level="demo_proof_only" if record.capability_id != "proof_command_manifest" else "proof_only",
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "live_host_trace_collection":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"live_authorization_grant", "real_effect_execution", "real_rollback_execution"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"real_fan_pwm_control", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="reviewer-first-run-proof-bundle.v1")
 
 
 def update_registry_from_host_inventory(registry: CapabilityRegistry, manifest: Any) -> CapabilityRegistry:

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -1,0 +1,483 @@
+"""Reviewer first-run proof bundle for non-mutating host embodiment.
+
+This module builds deterministic, metadata-only bundle payloads from existing
+reviewer proof surfaces. It does not collect live host data by default, open
+network egress, invoke providers, assemble prompts, grant authorization, execute
+host actions, or mutate host state except for writing explicit caller-requested
+bundle files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sentientos.capability_registry import build_default_capability_registry, summarize_capability_registry
+from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace, summarize_host_embodiment_trace
+from sentientos.host_embodiment_trace_export import (
+    serialize_host_embodiment_trace_json,
+    serialize_host_embodiment_trace_markdown,
+    validate_trace_export_payload,
+)
+
+REVIEWER_PROOF_BUNDLE_STATUSES = frozenset(
+    {
+        "reviewer_proof_bundle_ready",
+        "reviewer_proof_bundle_ready_with_warnings",
+        "reviewer_proof_bundle_blocked",
+        "reviewer_proof_bundle_incomplete",
+        "reviewer_proof_bundle_contradicted",
+    }
+)
+REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
+    {
+        "trace_json",
+        "trace_markdown",
+        "trace_summary",
+        "capability_registry_summary",
+        "deferred_action_inventory",
+        "proof_command_manifest",
+        "reviewer_readme",
+        "bundle_manifest",
+    }
+)
+REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
+    {
+        "proof_command_listed",
+        "proof_command_verified",
+        "proof_command_skipped",
+        "proof_command_failed",
+        "proof_command_not_run",
+    }
+)
+BUNDLE_FILE_NAMES = {
+    "trace_json": "trace.json",
+    "trace_markdown": "trace.md",
+    "trace_summary": "trace.summary.txt",
+    "capability_registry_summary": "capability_registry_summary.json",
+    "deferred_action_inventory": "deferred_actions.json",
+    "proof_command_manifest": "proof_commands.json",
+    "reviewer_readme": "README.md",
+    "bundle_manifest": "bundle_manifest.json",
+}
+FORBIDDEN_MANIFEST_FLAGS = (
+    "live_host_collection_performed",
+    "live_authorization_granted",
+    "effect_performed",
+    "host_mutation_performed",
+    "network_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+)
+DEFERRED_ACTION_LABELS = (
+    "live_authorization_grant",
+    "real_effect_execution",
+    "real_rollback_execution",
+    "real_fan_pwm_control",
+    "real_thermal_actuation",
+    "real_power_profile_mutation",
+    "real_service_restart",
+    "real_file_cleanup",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly_export",
+    "federation_transport_sync_adoption",
+    "remote_execution",
+)
+BLOCKED_ACTION_LABELS = (
+    "fan_pwm_write",
+    "thermal_write",
+    "power_profile_mutation",
+    "service_restart",
+    "file_cleanup_or_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly_export",
+    "federation_transport_sync_adoption",
+    "remote_execution",
+)
+
+
+@dataclass(frozen=True)
+class ReviewerProofBundleArtifact:
+    artifact_id: str
+    artifact_kind: str
+    relative_path: str
+    media_type: str
+    digest: str
+    byte_count: int
+    metadata_only: bool = True
+    contains_live_host_data: bool = False
+    contains_prompt_text: bool = False
+    contains_secret_material: bool = False
+    contains_provider_material: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReviewerProofCommandRecord:
+    command_id: str
+    command: tuple[str, ...]
+    purpose: str
+    expected_posture: str
+    status: str
+    exit_code: int | None = None
+    output_digest: str | None = None
+    warning_codes: tuple[str, ...] = ()
+    risk_codes: tuple[str, ...] = ()
+    executed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReviewerProofBundleManifest:
+    manifest_id: str
+    scenario_id: str
+    scenario_label: str
+    bundle_status: str
+    created_at: str
+    trace_id: str
+    trace_digest: str
+    artifact_records: tuple[ReviewerProofBundleArtifact, ...]
+    proof_command_records: tuple[ReviewerProofCommandRecord, ...]
+    blocked_action_labels: tuple[str, ...]
+    deferred_capability_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    digest: str
+    metadata_only: bool = True
+    reviewer_proof_only: bool = True
+    live_host_collection_performed: bool = False
+    live_authorization_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReviewerProofBundleValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _pretty_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, indent=2, ensure_ascii=True, default=str) + "\n"
+
+
+def _digest_text(prefix: str, content: str, length: int = 24) -> str:
+    return prefix + hashlib.sha256(content.encode("utf-8")).hexdigest()[:length]
+
+
+def reviewer_proof_artifact_digest(content: str | bytes) -> str:
+    data = content if isinstance(content, bytes) else content.encode("utf-8")
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def reviewer_proof_bundle_manifest_digest(manifest_or_payload: ReviewerProofBundleManifest | Mapping[str, Any]) -> str:
+    payload = manifest_or_payload.to_dict() if isinstance(manifest_or_payload, ReviewerProofBundleManifest) else dict(manifest_or_payload)
+    payload["digest"] = ""
+    return _digest_text("reviewer-proof-bundle-manifest-", _canonical_json(payload))
+
+
+def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord, ...]:
+    commands = (
+        (("python", "scripts/build_host_embodiment_trace.py", "--validate-only"), "Validate the deterministic host embodiment demo trace."),
+        (("python", "scripts/build_host_embodiment_trace.py", "--format", "json"), "Print deterministic trace JSON."),
+        (("python", "scripts/build_host_embodiment_trace.py", "--format", "markdown"), "Print deterministic trace Markdown."),
+        (("python", "-m", "scripts.run_tests", "-q", "tests/test_host_embodiment_trace.py", "tests/test_host_embodiment_trace_export.py", "tests/test_build_host_embodiment_trace_script.py"), "Run trace and trace export tests."),
+        (("python", "-m", "scripts.run_tests", "-q", "tests/test_controlled_authorization.py", "tests/test_authorization_review.py", "tests/test_effect_proof.py", "tests/test_runtime_supervisor.py"), "Run authorization review, proof, and runtime readiness tests."),
+        (("python", "-m", "scripts.run_tests", "-q", "tests/test_actuation_fulfillment.py", "tests/test_privilege_broker.py", "tests/test_host_resource_policy.py", "tests/test_host_resource_governor.py", "tests/test_host_inventory.py", "tests/test_host_collectors.py"), "Run non-mutating host resource ladder tests."),
+        (("python", "-m", "scripts.run_tests", "-q", "tests/test_capability_registry.py", "tests/test_reviewer_release_readiness_index.py"), "Run capability registry and reviewer documentation proof tests."),
+        (("python", "scripts/build_docs.py", "--check-deps"), "Check documentation build dependencies."),
+        (("python", "scripts/build_docs.py"), "Build documentation locally."),
+        (("python", "scripts/verify_context_hygiene_prompt_boundaries.py"), "Verify prompt/provider boundary hygiene."),
+    )
+    return tuple(
+        ReviewerProofCommandRecord(
+            command_id=f"proof-command-{index:02d}",
+            command=command,
+            purpose=purpose,
+            expected_posture="bounded local reviewer check; no live authorization, no effects, no host mutation",
+            status="proof_command_not_run",
+        )
+        for index, (command, purpose) in enumerate(commands, start=1)
+    )
+
+
+def _trace_summary_text(trace: Any) -> str:
+    summary = summarize_host_embodiment_trace(trace)
+    return "\n".join(
+        [
+            "SentientOS Reviewer First-Run Proof Bundle Trace Summary",
+            f"scenario: {summary['scenario_id']}",
+            f"status: {summary['trace_status']}",
+            f"steps: {summary['step_count']}",
+            "reviewer proof only: true",
+            "metadata only: true",
+            "fake/sample telemetry by default: true",
+            "live host collection performed: false",
+            "live authorization granted: false",
+            "effect performed: false",
+            "host mutation performed: false",
+            "network performed: false",
+            "provider invocation performed: false",
+            "prompt assembly performed: false",
+            "PWM presence is not control authority: true",
+            f"digest: {summary['digest']}",
+            "",
+        ]
+    )
+
+
+def _deferred_action_inventory() -> dict[str, Any]:
+    return {
+        "inventory_id": "reviewer-proof-bundle-deferred-actions-v1",
+        "metadata_only": True,
+        "reviewer_proof_only": True,
+        "deferred_action_labels": DEFERRED_ACTION_LABELS,
+        "blocked_action_labels": BLOCKED_ACTION_LABELS,
+        "proof_statement": "All listed actions remain deferred or blocked; the bundle is an export-only inspection artifact.",
+        "no_live_authorization": True,
+        "no_effects": True,
+        "no_host_mutation": True,
+        "no_network": True,
+        "no_provider": True,
+        "no_prompt_assembly": True,
+    }
+
+
+def _readme_text(manifest_id: str, trace_digest: str) -> str:
+    return "\n".join(
+        [
+            "# SentientOS Reviewer First-Run Proof Bundle",
+            "",
+            "This local bundle packages the deterministic non-mutating host-embodiment reviewer demo trace.",
+            "It uses fake/sample thermal+PWM telemetry by default and does not collect live host data.",
+            "",
+            "## Inspect first",
+            "",
+            "1. `trace.md` — reviewer-readable trace ladder.",
+            "2. `bundle_manifest.json` — artifact digests and safety flags.",
+            "3. `deferred_actions.json` — deferred/blocked action inventory.",
+            "4. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "5. `capability_registry_summary.json` — metadata-only capability posture.",
+            "",
+            "## Safety posture",
+            "",
+            "- Reviewer proof only: true",
+            "- Metadata only: true",
+            "- Live host collection performed: false",
+            "- Live authorization granted: false",
+            "- Effect performed: false",
+            "- Host mutation performed: false",
+            "- Network/provider/prompt assembly performed: false",
+            "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
+            "",
+            f"Manifest ID: `{manifest_id}`",
+            f"Trace digest: `{trace_digest}`",
+            "",
+        ]
+    )
+
+
+def _artifact(kind: str, content: str) -> ReviewerProofBundleArtifact:
+    media_type = "application/json" if BUNDLE_FILE_NAMES[kind].endswith(".json") else ("text/markdown" if BUNDLE_FILE_NAMES[kind].endswith(".md") else "text/plain")
+    return ReviewerProofBundleArtifact(
+        artifact_id=f"reviewer-proof-{kind.replace('_', '-')}",
+        artifact_kind=kind,
+        relative_path=BUNDLE_FILE_NAMES[kind],
+        media_type=media_type,
+        digest=reviewer_proof_artifact_digest(content),
+        byte_count=len(content.encode("utf-8")),
+    )
+
+
+def build_reviewer_proof_bundle_payload(
+    *,
+    scenario: str = "thermal_pwm_demo",
+    created_at: str = "1970-01-01T00:00:00+00:00",
+    proof_command_records: Sequence[ReviewerProofCommandRecord] | None = None,
+) -> dict[str, Any]:
+    if scenario != "thermal_pwm_demo":
+        raise ValueError(f"unsupported scenario: {scenario}")
+    trace = build_host_embodiment_demo_trace(created_at=created_at)
+    trace_validation = validate_trace_export_payload(trace)
+    if not trace_validation.ok:
+        raise ValueError("invalid trace export payload: " + ", ".join(trace_validation.findings))
+
+    registry = build_default_capability_registry()
+    commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
+    manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
+    contents: dict[str, str] = {
+        "trace_json": serialize_host_embodiment_trace_json(trace),
+        "trace_markdown": serialize_host_embodiment_trace_markdown(trace),
+        "trace_summary": _trace_summary_text(trace),
+        "capability_registry_summary": _pretty_json({"summary": summarize_capability_registry(registry), "records": [record.to_dict() for record in registry.records], "metadata_only": True, "reviewer_proof_only": True}),
+        "deferred_action_inventory": _pretty_json(_deferred_action_inventory()),
+        "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
+        "reviewer_readme": _readme_text(manifest_id, trace.digest),
+    }
+    artifact_records = tuple(_artifact(kind, content) for kind, content in contents.items())
+    # The manifest artifact record describes the canonical manifest payload before
+    # the final pretty JSON wrapper is materialized; this avoids recursive digest
+    # ambiguity while still giving reviewers a stable manifest payload digest.
+    manifest_artifact = ReviewerProofBundleArtifact(
+        artifact_id="reviewer-proof-bundle-manifest",
+        artifact_kind="bundle_manifest",
+        relative_path=BUNDLE_FILE_NAMES["bundle_manifest"],
+        media_type="application/json",
+        digest="pending",
+        byte_count=0,
+    )
+    manifest = ReviewerProofBundleManifest(
+        manifest_id=manifest_id,
+        scenario_id=trace.scenario_id,
+        scenario_label=trace.scenario_label,
+        bundle_status="reviewer_proof_bundle_ready",
+        created_at=created_at,
+        trace_id=trace.trace_id,
+        trace_digest=trace.digest,
+        artifact_records=artifact_records + (manifest_artifact,),
+        proof_command_records=commands,
+        blocked_action_labels=BLOCKED_ACTION_LABELS,
+        deferred_capability_labels=DEFERRED_ACTION_LABELS,
+        warning_codes=(),
+        risk_codes=(),
+        digest="",
+    )
+    manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
+    manifest_json = _pretty_json(manifest.to_dict())
+    manifest_artifact = replace(
+        manifest_artifact,
+        digest=reviewer_proof_artifact_digest(manifest_json),
+        byte_count=len(manifest_json.encode("utf-8")),
+    )
+    manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
+    manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
+    contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry}
+
+
+def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:
+    payload = manifest.to_dict() if isinstance(manifest, ReviewerProofBundleManifest) else dict(manifest)
+    findings: list[str] = []
+    if not payload.get("manifest_id"):
+        findings.append("missing_manifest_id")
+    if payload.get("bundle_status") not in REVIEWER_PROOF_BUNDLE_STATUSES:
+        findings.append("unknown_bundle_status")
+    if not payload.get("metadata_only", False):
+        findings.append("manifest_not_metadata_only")
+    if not payload.get("reviewer_proof_only", False):
+        findings.append("manifest_not_reviewer_proof_only")
+    for flag in FORBIDDEN_MANIFEST_FLAGS:
+        if payload.get(flag, False):
+            findings.append(f"manifest_forbidden_flag:{flag}")
+    artifacts = payload.get("artifact_records", ())
+    if not isinstance(artifacts, (list, tuple)) or not artifacts:
+        findings.append("missing_artifact_records")
+        artifacts = ()
+    seen_kinds: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            findings.append(f"artifact_not_mapping:{index}")
+            continue
+        kind = str(artifact.get("artifact_kind", ""))
+        seen_kinds.add(kind)
+        if kind not in REVIEWER_PROOF_ARTIFACT_KINDS:
+            findings.append(f"unknown_artifact_kind:{kind}")
+        if not artifact.get("metadata_only", False):
+            findings.append(f"artifact_not_metadata_only:{kind}")
+        for flag in ("contains_live_host_data", "contains_prompt_text", "contains_secret_material", "contains_provider_material"):
+            if artifact.get(flag, False):
+                findings.append(f"artifact_forbidden_flag:{kind}:{flag}")
+        if ".." in Path(str(artifact.get("relative_path", ""))).parts:
+            findings.append(f"artifact_relative_path_escapes:{kind}")
+    missing = REVIEWER_PROOF_ARTIFACT_KINDS - seen_kinds
+    if missing:
+        findings.append("missing_artifact_kinds:" + ",".join(sorted(missing)))
+    commands = payload.get("proof_command_records", ())
+    if not isinstance(commands, (list, tuple)) or not commands:
+        findings.append("missing_proof_command_records")
+        commands = ()
+    for index, command in enumerate(commands):
+        if not isinstance(command, Mapping):
+            findings.append(f"proof_command_not_mapping:{index}")
+            continue
+        if command.get("status") not in REVIEWER_PROOF_COMMAND_STATUSES:
+            findings.append(f"unknown_proof_command_status:{command.get('command_id', index)}")
+        if command.get("executed", False) and command.get("status") == "proof_command_not_run":
+            findings.append(f"proof_command_executed_but_not_run:{command.get('command_id', index)}")
+    for label in DEFERRED_ACTION_LABELS:
+        if label not in tuple(payload.get("deferred_capability_labels", ())):
+            findings.append(f"missing_deferred_label:{label}")
+    return ReviewerProofBundleValidationResult(not findings, tuple(findings))
+
+
+def summarize_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> dict[str, Any]:
+    payload = manifest.to_dict() if isinstance(manifest, ReviewerProofBundleManifest) else dict(manifest)
+    return {
+        "manifest_id": payload.get("manifest_id"),
+        "scenario_id": payload.get("scenario_id"),
+        "bundle_status": payload.get("bundle_status"),
+        "artifact_count": len(payload.get("artifact_records", ()) or ()),
+        "proof_command_count": len(payload.get("proof_command_records", ()) or ()),
+        "proof_commands_executed": sum(1 for record in payload.get("proof_command_records", ()) if isinstance(record, Mapping) and record.get("executed")),
+        "metadata_only": payload.get("metadata_only"),
+        "reviewer_proof_only": payload.get("reviewer_proof_only"),
+        "live_host_collection_performed": payload.get("live_host_collection_performed"),
+        "live_authorization_granted": payload.get("live_authorization_granted"),
+        "effect_performed": payload.get("effect_performed"),
+        "host_mutation_performed": payload.get("host_mutation_performed"),
+        "network_performed": payload.get("network_performed"),
+        "provider_invocation_performed": payload.get("provider_invocation_performed"),
+        "prompt_assembly_performed": payload.get("prompt_assembly_performed"),
+        "digest": payload.get("digest"),
+    }
+
+
+def write_reviewer_proof_bundle(
+    output_dir: str | Path,
+    payload: Mapping[str, Any] | None = None,
+    *,
+    force: bool = False,
+    manifest_only: bool = False,
+) -> tuple[Path, ...]:
+    path = Path(output_dir)
+    if not str(output_dir):
+        raise ValueError("output directory is required")
+    if path == path.anchor or path.resolve() == Path(path.anchor).resolve():
+        raise ValueError("refusing to write bundle to filesystem root")
+    if path.exists() and not path.is_dir():
+        raise ValueError("output path must be a directory, not a file")
+    path.mkdir(parents=True, exist_ok=True)
+    bundle_payload = dict(payload or build_reviewer_proof_bundle_payload())
+    artifacts = dict(bundle_payload["artifacts"])
+    selected = {"bundle_manifest": artifacts["bundle_manifest"]} if manifest_only else artifacts
+    targets = tuple(path / BUNDLE_FILE_NAMES[kind] for kind in selected)
+    existing = tuple(target for target in targets if target.exists())
+    if existing and not force:
+        raise FileExistsError("bundle files already exist; pass --force to overwrite: " + ", ".join(str(target) for target in existing))
+    written: list[Path] = []
+    for kind in sorted(selected, key=lambda item: BUNDLE_FILE_NAMES[item]):
+        target = path / BUNDLE_FILE_NAMES[kind]
+        if target.parent != path:
+            raise ValueError("bundle target escaped output directory")
+        target.write_text(selected[kind], encoding="utf-8")
+        written.append(target)
+    return tuple(written)

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import build_reviewer_proof_bundle as script
+from sentientos.reviewer_proof_bundle import BUNDLE_FILE_NAMES, validate_reviewer_proof_bundle_manifest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run_main(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            code = script.main(args)
+        except SystemExit as exc:
+            code = int(exc.code or 0)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_requires_output_dir() -> None:
+    code, _stdout, stderr = _run_main([])
+    assert code != 0
+    assert "output-dir" in stderr
+
+
+def test_refuses_empty_root_and_file_output_dir(tmp_path: Path) -> None:
+    code, _stdout, stderr = _run_main(["--output-dir", "/"])
+    assert code != 0
+    assert "filesystem root" in stderr
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("not a directory", encoding="utf-8")
+    code, _stdout, stderr = _run_main(["--output-dir", str(file_path)])
+    assert code != 0
+    assert "directory" in stderr
+
+
+def test_writes_expected_files_and_manifest_validates(tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(out)])
+    assert code == 0, stderr
+    assert "proof commands executed: 0" in stdout
+    for relative in BUNDLE_FILE_NAMES.values():
+        assert (out / relative).exists(), relative
+    manifest = json.loads((out / "bundle_manifest.json").read_text(encoding="utf-8"))
+    validation = validate_reviewer_proof_bundle_manifest(manifest)
+    assert validation.ok, validation.findings
+    assert all(record["executed"] is False for record in manifest["proof_command_records"])
+    assert all(record["status"] == "proof_command_not_run" for record in manifest["proof_command_records"])
+
+
+def test_summary_prints_compact_summary(tmp_path: Path) -> None:
+    code, stdout, stderr = _run_main(["--output-dir", str(tmp_path / "bundle"), "--summary"])
+    assert code == 0, stderr
+    assert "SentientOS Reviewer First-Run Proof Bundle" in stdout
+    assert "metadata only: true" in stdout
+    assert "fake/sample telemetry by default: true" in stdout
+
+
+def test_existing_files_require_force_and_force_overwrites_only_bundle_files(tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    code, _stdout, stderr = _run_main(["--output-dir", str(out)])
+    assert code == 0, stderr
+    sentinel = out / "sentinel.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    code, _stdout, stderr = _run_main(["--output-dir", str(out)])
+    assert code != 0
+    assert "--force" in stderr
+    (out / "trace.summary.txt").write_text("changed", encoding="utf-8")
+    code, _stdout, stderr = _run_main(["--output-dir", str(out), "--force"])
+    assert code == 0, stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert "changed" not in (out / "trace.summary.txt").read_text(encoding="utf-8")
+
+
+def test_default_does_not_run_live_collection_network_provider_or_prompt(tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    code, _stdout, stderr = _run_main(["--output-dir", str(out)])
+    assert code == 0, stderr
+    manifest = json.loads((out / "bundle_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["live_host_collection_performed"] is False
+    assert manifest["live_authorization_granted"] is False
+    assert manifest["effect_performed"] is False
+    assert manifest["host_mutation_performed"] is False
+    assert manifest["network_performed"] is False
+    assert manifest["provider_invocation_performed"] is False
+    assert manifest["prompt_assembly_performed"] is False
+
+
+def test_manifest_only_writes_only_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    code, _stdout, stderr = _run_main(["--output-dir", str(out), "--manifest-only"])
+    assert code == 0, stderr
+    assert (out / "bundle_manifest.json").exists()
+    assert not (out / "trace.json").exists()
+
+
+def test_verify_is_explicitly_unsupported(tmp_path: Path) -> None:
+    code, _stdout, stderr = _run_main(["--output-dir", str(tmp_path / "bundle"), "--verify"])
+    assert code == 2
+    assert "not implemented" in stderr

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -330,3 +330,41 @@ def test_trace_export_and_reviewer_demo_capabilities_are_proof_only() -> None:
     assert records["real_service_restart"].status == "blocked"
     assert records["real_file_cleanup"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_reviewer_proof_bundle_capabilities_are_export_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["reviewer_proof_bundle"].status == "implemented"
+    assert records["reviewer_proof_bundle"].authority_level == "demo_proof_only"
+    assert records["reviewer_proof_bundle"].host_actuation_performed is False
+    assert records["reviewer_proof_bundle_cli"].status == "implemented"
+    assert records["reviewer_proof_bundle_cli"].authority_level == "demo_proof_only"
+    assert records["reviewer_proof_bundle_cli"].host_actuation_performed is False
+    assert records["proof_command_manifest"].status == "implemented"
+    assert records["proof_command_manifest"].authority_level == "proof_only"
+    assert records["live_host_trace_collection"].status == "deferred"
+    assert records["live_authorization_grant"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    for capability_id in ["real_fan_pwm_control", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status in {"blocked", "deferred"}
+        assert records[capability_id].host_actuation_performed is False
+
+
+def test_registry_updates_from_reviewer_proof_bundle_keep_authority_deferred() -> None:
+    from sentientos.capability_registry import update_registry_from_reviewer_proof_bundle
+    from sentientos.reviewer_proof_bundle import build_reviewer_proof_bundle_payload
+
+    manifest = build_reviewer_proof_bundle_payload()["manifest"]
+    registry = update_registry_from_reviewer_proof_bundle(build_default_capability_registry(), manifest)
+    records = registry.by_id()
+    assert records["reviewer_proof_bundle"].status == "implemented"
+    assert records["reviewer_proof_bundle_cli"].status == "implemented"
+    assert records["proof_command_manifest"].status == "implemented"
+    assert records["live_host_trace_collection"].status == "deferred"
+    assert records["live_authorization_grant"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.reviewer_proof_bundle import (
+    DEFERRED_ACTION_LABELS,
+    ReviewerProofBundleArtifact,
+    build_default_reviewer_proof_commands,
+    build_reviewer_proof_bundle_payload,
+    reviewer_proof_artifact_digest,
+    reviewer_proof_bundle_manifest_digest,
+    summarize_reviewer_proof_bundle_manifest,
+    validate_reviewer_proof_bundle_manifest,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+FIXED_CREATED_AT = "2025-07-30T00:00:00+00:00"
+
+
+def test_default_bundle_payload_is_deterministic_with_fixed_created_at() -> None:
+    first = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    second = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert first["manifest"].to_dict() == second["manifest"].to_dict()
+    assert first["artifacts"] == second["artifacts"]
+    assert first["manifest"].created_at == FIXED_CREATED_AT
+    assert first["manifest"].bundle_status == "reviewer_proof_bundle_ready"
+
+
+def test_manifest_validates_and_digests_are_deterministic() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    manifest = payload["manifest"]
+    validation = validate_reviewer_proof_bundle_manifest(manifest)
+    assert validation.ok, validation.findings
+    assert reviewer_proof_bundle_manifest_digest(manifest) == manifest.digest
+    assert reviewer_proof_artifact_digest(payload["artifacts"]["trace_json"]) == next(
+        artifact.digest for artifact in manifest.artifact_records if artifact.artifact_kind == "trace_json"
+    )
+
+
+def test_manifest_summary_is_metadata_only_and_reviewer_proof_only() -> None:
+    manifest = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)["manifest"]
+    summary = summarize_reviewer_proof_bundle_manifest(manifest)
+    assert summary["metadata_only"] is True
+    assert summary["reviewer_proof_only"] is True
+    assert summary["live_host_collection_performed"] is False
+    assert summary["live_authorization_granted"] is False
+    assert summary["effect_performed"] is False
+    assert summary["host_mutation_performed"] is False
+    assert summary["network_performed"] is False
+    assert summary["provider_invocation_performed"] is False
+    assert summary["prompt_assembly_performed"] is False
+
+
+def test_default_proof_commands_are_listed_and_not_run() -> None:
+    commands = build_default_reviewer_proof_commands()
+    assert commands
+    assert all(command.status == "proof_command_not_run" for command in commands)
+    assert all(command.executed is False for command in commands)
+    rendered = [" ".join(command.command) for command in commands]
+    assert "python scripts/build_host_embodiment_trace.py --validate-only" in rendered
+    assert "python scripts/verify_context_hygiene_prompt_boundaries.py" in rendered
+
+
+def test_bundle_includes_expected_artifacts_and_content() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    artifacts = payload["artifacts"]
+    for key in [
+        "trace_json",
+        "trace_markdown",
+        "trace_summary",
+        "capability_registry_summary",
+        "deferred_action_inventory",
+        "proof_command_manifest",
+        "reviewer_readme",
+        "bundle_manifest",
+    ]:
+        assert key in artifacts
+    assert "fake/sample" in artifacts["trace_summary"]
+    assert "PWM presence is not control authority" in artifacts["trace_markdown"]
+    assert "reviewer_proof_bundle" in artifacts["capability_registry_summary"]
+    assert "real_fan_pwm_control" in artifacts["deferred_action_inventory"]
+    assert "proof_command_not_run" in artifacts["proof_command_manifest"]
+
+
+def test_deferred_actions_cover_non_mutating_boundary() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    manifest = payload["manifest"]
+    for label in [
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+        "real_power_profile_mutation",
+        "real_service_restart",
+        "real_file_cleanup",
+        "provider_invocation",
+        "network_egress",
+        "prompt_assembly_export",
+        "federation_transport_sync_adoption",
+        "remote_execution",
+    ]:
+        assert label in manifest.deferred_capability_labels
+        assert label in DEFERRED_ACTION_LABELS
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "live_host_collection_performed",
+        "live_authorization_granted",
+        "effect_performed",
+        "host_mutation_performed",
+        "network_performed",
+        "provider_invocation_performed",
+        "prompt_assembly_performed",
+    ],
+)
+def test_validation_rejects_forbidden_manifest_flags(flag: str) -> None:
+    manifest = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)["manifest"]
+    bad = replace(manifest, **{flag: True})
+    result = validate_reviewer_proof_bundle_manifest(bad)
+    assert not result.ok
+    assert f"manifest_forbidden_flag:{flag}" in result.findings
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["contains_live_host_data", "contains_prompt_text", "contains_secret_material", "contains_provider_material"],
+)
+def test_artifact_validation_rejects_forbidden_material_flags(flag: str) -> None:
+    manifest = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)["manifest"]
+    artifacts = list(manifest.artifact_records)
+    artifacts[0] = replace(artifacts[0], **{flag: True})
+    bad = replace(manifest, artifact_records=tuple(artifacts))
+    result = validate_reviewer_proof_bundle_manifest(bad)
+    assert not result.ok
+    assert any(f"artifact_forbidden_flag:{artifacts[0].artifact_kind}:{flag}" == finding for finding in result.findings)
+
+
+def test_validation_rejects_unknown_artifact_kind() -> None:
+    manifest = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)["manifest"]
+    artifacts = list(manifest.artifact_records)
+    artifacts.append(
+        ReviewerProofBundleArtifact(
+            artifact_id="bad",
+            artifact_kind="unknown",
+            relative_path="bad.txt",
+            media_type="text/plain",
+            digest="sha256:bad",
+            byte_count=3,
+        )
+    )
+    result = validate_reviewer_proof_bundle_manifest(replace(manifest, artifact_records=tuple(artifacts)))
+    assert not result.ok
+    assert "unknown_artifact_kind:unknown" in result.findings

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -302,3 +302,34 @@ def test_reviewer_demo_trace_doc_preserves_demo_boundaries_and_commands() -> Non
     assert "PWM presence is not control authority" in doc
     assert "controlled authorization contract is not a live grant" in doc
     assert "schema-only/future-use-only" in doc
+
+REVIEWER_FIRST_RUN_PROOF_BUNDLE = "docs/architecture/reviewer_first_run_proof_bundle.md"
+
+
+def test_navigation_links_to_reviewer_first_run_proof_bundle_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    trajectory = _read(TRAJECTORY_DOC)
+    reviewer_demo = _read(HOST_EMBODIMENT_REVIEWER_DEMO_TRACE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    for text in [overview, index, trajectory, reviewer_demo, controlled]:
+        assert REVIEWER_FIRST_RUN_PROOF_BUNDLE in text
+
+
+def test_reviewer_first_run_proof_bundle_doc_preserves_boundary_and_file_list() -> None:
+    doc = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    assert "python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof" in doc
+    assert "fake/sample thermal+PWM telemetry" in doc
+    assert "does not collect live host data by default" in doc
+    assert "does not mutate host state" in doc
+    for filename in [
+        "trace.json",
+        "trace.md",
+        "trace.summary.txt",
+        "capability_registry_summary.json",
+        "deferred_actions.json",
+        "proof_commands.json",
+        "README.md",
+        "bundle_manifest.json",
+    ]:
+        assert filename in doc


### PR DESCRIPTION
### Motivation

- Provide a single, safe, deterministic reviewer path that packages the non-mutating host-embodiment demo trace and the system posture so an auditor can discover, inspect, and archive the proof artifacts with one command. 
- Keep the bundle metadata-only and explicitly prevent any live host collection, authorization grant, effect, or host mutation in the default flow.

### Description

- Add a new metadata-only bundle module `sentientos/reviewer_proof_bundle.py` that defines frozen dataclasses for artifacts/commands/manifests, builds a deterministic payload from the existing demo trace and capability registry, validates safety flags, computes stable digests, and writes artifacts only into an explicit output directory. 
- Add a CLI `scripts/build_reviewer_proof_bundle.py` that requires `--output-dir`, defaults to the `thermal_pwm_demo` scenario, writes the canonical files (`trace.json`, `trace.md`, `trace.summary.txt`, `capability_registry_summary.json`, `deferred_actions.json`, `proof_commands.json`, `README.md`, `bundle_manifest.json`), refuses root/invalid outputs, requires `--force` to overwrite, and intentionally marks `--verify` unsupported in this pass. 
- Integrate new proof surfaces into the capability registry (`sentientos/capability_registry.py`) by adding `reviewer_proof_bundle`, `reviewer_proof_bundle_cli`, and `proof_command_manifest` as export/proof-only records and by adding `update_registry_from_reviewer_proof_bundle(...)` to reflect packaging without granting authority; keep all privileged/real-actuation capabilities deferred or blocked. 
- Add docs `docs/architecture/reviewer_first_run_proof_bundle.md`, update reviewer navigation and short README pointer, and add focused tests for the module, CLI, capability-registry integration, and docs links. 

### Testing

- Ran static compile check: `python -m py_compile` on the new/modified modules (passes). 
- Unit test suites executed: `python -m scripts.run_tests -q tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py` (all passed). 
- Broader proof suites executed: `python -m scripts.run_tests -q tests/test_host_embodiment_trace.py tests/test_host_embodiment_trace_export.py tests/test_build_host_embodiment_trace_script.py` and `python -m scripts.run_tests -q tests/test_controlled_authorization.py tests/test_authorization_review.py tests/test_effect_proof.py tests/test_runtime_supervisor.py` (all passed). 
- Docs tooling exercised: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` (initial dependency bootstrap performed per repo guidance; docs build succeeded). 
- CLI runtime checked: `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and `... --summary --force` produced the expected bundle files and printed a compact summary. 
- Safety/forbidden-scan: ran repo forbidden-operation checks against the new modules; matches are only marker/blocked label strings and explicit safe output-file writes, with no runtime network/subprocess/actuation or provider SDK invocations added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06031a04e48320893887439c0b1854)