### PR TITLE
[codex:host-actuation] add safety gate wing

### DIFF
--- a/docs/architecture/host_actuation_safety_gate_wing.md
+++ b/docs/architecture/host_actuation_safety_gate_wing.md
@@ -1,0 +1,39 @@
+# Host Actuation Safety Gate Wing
+
+This wing follows the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md) and the [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md). It adds metadata-only safety gates that define what future host actuation must declare and satisfy before live authorization could even be reviewed.
+
+## Boundary
+
+This is a safety-gate/proof wing only. Controlled authorization contract is not a live grant. Safety gates are not authorization. SafetyGateSatisfactionManifest is not authorization or fulfillment. Real fulfillment remains deferred. Real actuation remains deferred.
+
+The wing does not execute, fulfill, mutate host state, write fan/PWM controls, change thermal settings, mutate power profiles, kill processes, restart services, clean up or delete files, install packages or drivers, perform network egress, invoke providers, assemble or export prompts, transport federation state, or perform remote execution.
+
+## Safety records
+
+- **Hardware Allowlist Manifest:** declares hardware metadata and domain eligibility. Hardware allowlist does not grant control.
+- **OS Backend Declaration:** declares the future backend class and OS family. OS backend declaration does not load/invoke backend.
+- **Bounds Policy:** declares future bounds/rates/forbidden values. Bounds policy does not enforce live bounds.
+- **Cooldown Policy:** declares future intervals/attempt limits. Cooldown policy does not sleep, wait, or enforce live cooldown.
+- **Panic Stop Contract:** declares future triggers, stops, operator overrides, and recovery labels. Panic stop contract does not execute panic stop.
+- **Host Action Scope Manifest:** declares target/path/service/hardware/time/expiry/revocation scope. Scope manifest does not authorize action.
+- **Host Actuation Gate Assessment:** evaluates whether a gate has metadata evidence or is missing.
+- **SafetyGateSatisfactionManifest:** summarizes satisfied and missing gates plus blocked actions; it is not authorization or fulfillment.
+
+## Future gate requirements
+
+Future cooling/power/service/cleanup actions remain behind explicit future live authorization, control-plane admission, audit, rollback, effect receipt, postcondition checks, supervisor observation, immutable trace, and these safety gates. Future fan/PWM writes, thermal actuation, power profile mutation, service restart, process kill, cleanup/delete, package install, driver install, network egress, provider invocation, prompt assembly, federation transport, and remote execution remain blocked/deferred by this wing.
+
+## Authority ladder
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → authorize → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **safety gates** only. It answers: “What gates must be declared, checked, and satisfied before future live authorization could even be reviewed?” It does not answer: “Perform the action.”
+
+## Implementation links
+
+- Module: `sentientos/host_actuation_safety.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_host_actuation_safety.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_capability_registry.py`

--- a/docs/architecture/host_embodiment_authorization_review_wing.md
+++ b/docs/architecture/host_embodiment_authorization_review_wing.md
@@ -1,5 +1,6 @@
 # Host Embodiment Authorization Review Wing
 
+After authorization review and controlled authorization contracts, the [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`) records metadata-only prerequisites; those safety gates are not authorization.
 The Host Embodiment Authorization Review Wing follows the Host Embodiment
 Execution Proof Wing. The Execution Proof Wing produces an
 `ExecutionReadinessManifest`; this wing asks only whether that readiness manifest

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -1,5 +1,6 @@
 # Host Embodiment Controlled Authorization + Trace Wing
 
+The next organ after this contract/trace layer is the [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`), which declares metadata-only prerequisites and still grants no live authorization.
 This wing follows the [Authorization Review Wing](host_embodiment_authorization_review_wing.md). The practical first-run reviewer command path is the [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It defines the controlled authorization grant contract and a reviewer-facing end-to-end trace across the non-mutating host-embodiment ladder.
 
 ## Boundary

--- a/docs/architecture/host_embodiment_reviewer_demo_trace.md
+++ b/docs/architecture/host_embodiment_reviewer_demo_trace.md
@@ -1,5 +1,6 @@
 # Host Embodiment Reviewer Demo Trace
 
+Related next proof surface: [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`). The safety gates are metadata-only and do not authorize actuation.
 This doc follows the [Host Embodiment Controlled Authorization + Trace Wing](host_embodiment_controlled_authorization_and_trace_wing.md). For the one-command local archive path, see the [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). The reviewer demo trace is a deterministic, non-mutating proof artifact for seeing the full host embodiment ladder breathe without moving the body.
 
 ## Boundary

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -1,5 +1,6 @@
 # Public Technical Overview for Reviewers
 
+Host actuation safety gates are documented in [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`): safety gates are not authorization, hardware allowlists do not grant control, OS backend declarations do not load/invoke backends, panic stop contracts do not execute panic stop, and real actuation remains deferred.
 ## SentientOS in one paragraph
 
 SentientOS is a deterministic governance-and-audit runtime for operator-directed AI automation. It can remember prior artifacts, retrieve bounded context, reflect on outcomes, propose improvements, rehearse changes, and participate in federation workflows, but authority is never implicit: changes move through explicit custody, policy, audit, immutability, and local-governance gates before adoption.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -1,5 +1,6 @@
 # Reviewer First-Run Proof Bundle
 
+The bundle now includes `safety_gates.json`; see the [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`) for the metadata-only safety gate posture. Safety gates are not authorization.
 This doc is the first practical reviewer command path after reading the [public technical overview](public_technical_overview.md). It packages the current deterministic, non-mutating host-embodiment proof chain into one local output directory so a serious reviewer can run one safe command, inspect the story, and archive the artifacts.
 
 ## Boundary
@@ -33,6 +34,7 @@ The bundle writes:
 - `trace.summary.txt` — compact summary of the non-mutating proof posture.
 - `capability_registry_summary.json` — metadata-only capability registry summary and records.
 - `deferred_actions.json` — deferred/blocked action inventory.
+- `safety_gates.json` — metadata-only host actuation safety gate posture; safety gates are not authorization.
 - `proof_commands.json` — proof command manifest; commands are listed but not run by default.
 - `README.md` — local reviewer guide for the bundle directory.
 - `bundle_manifest.json` — manifest, artifact digests, command records, and safety flags.
@@ -45,7 +47,8 @@ Reviewers should inspect these files in order:
 2. `trace.md`
 3. `bundle_manifest.json`
 4. `deferred_actions.json`
-5. `proof_commands.json`
+5. `safety_gates.json`
+6. `proof_commands.json`
 
 ## What the bundle proves
 
@@ -57,6 +60,7 @@ The reviewer should see that:
 
 - PWM presence is telemetry, not control authority.
 - The controlled authorization contract is not a live grant.
+- Safety gates are metadata-only prerequisites, not authorization or fulfillment.
 - Grant/revocation records are schema-only/future-use-only.
 - Real effect execution and rollback execution remain deferred.
 - Real fan/PWM control, thermal actuation, power mutation, service restart, cleanup, provider invocation, prompt export, federation transport/sync/adoption, and remote execution remain deferred or blocked.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -1,5 +1,6 @@
 # Reviewer Release-Readiness Proof Index
 
+The [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`) adds metadata-only safety gate proof records to the reviewer bundle. Safety gates are not authorization; hardware allowlists do not grant control; OS backend declarations do not load/invoke backends; panic stop contracts do not execute panic stop; real actuation remains deferred.
 ## Reviewer first-run proof bundle
 
 Reviewers can generate the local non-mutating host-embodiment proof archive with `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof`; see [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It uses fake/sample telemetry by default, performs no live host collection by default, and performs no host mutation.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -1,5 +1,6 @@
 # SentientOS Trajectory and Missing Organs
 
+The [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md) (`docs/architecture/host_actuation_safety_gate_wing.md`) is now the metadata-only organ that declares hardware allowlist, backend, bounds, cooldown, panic, scope, assessment, and satisfaction gates before any future live authorization review. Real actuation remains deferred.
 ## Reviewer first-run proof bundle
 
 Reviewers can generate the local non-mutating host-embodiment proof archive with `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof`; see [Reviewer First-Run Proof Bundle](reviewer_first_run_proof_bundle.md) (`docs/architecture/reviewer_first_run_proof_bundle.md`). It uses fake/sample telemetry by default, performs no live host collection by default, and performs no host mutation.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -39,6 +39,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "controlled_authorization",
         "host_embodiment_trace",
         "reviewer_proof_bundle",
+        "host_actuation_safety",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -61,6 +62,12 @@ AUTHORITY_LEVELS = frozenset(
         "contract_only",
         "ledger_only",
         "demo_proof_only",
+        "metadata_proof_only",
+        "allowlist_only",
+        "declaration_only",
+        "policy_only",
+        "scope_only",
+        "safety_gate_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -250,6 +257,14 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("reviewer_proof_bundle", "reviewer_proof_bundle", "implemented", "demo_proof_only", source_paths=("sentientos/reviewer_proof_bundle.py",), proof_tests=("tests/test_reviewer_proof_bundle.py",), proof_commands=("python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force",), implemented_surfaces=("metadata-only first-run reviewer proof bundle", "deterministic local packaging of demo trace, capability posture, deferred actions, and proof commands"), deferred_surfaces=("live host trace collection", "live authorization", "real effects", "host mutation"), forbidden_implications=("reviewer proof bundle collects live host data", "reviewer proof bundle grants authority", "reviewer proof bundle performs effects")),
         _record("reviewer_proof_bundle_cli", "reviewer_proof_bundle", "implemented", "demo_proof_only", source_paths=("scripts/build_reviewer_proof_bundle.py",), proof_tests=("tests/test_build_reviewer_proof_bundle_script.py",), proof_commands=("python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force",), implemented_surfaces=("one-command local proof bundle writer",), deferred_surfaces=("verification command execution by default", "live host collection", "host mutation"), forbidden_implications=("CLI performs live verification by default", "CLI mutates host state beyond explicit bundle files")),
         _record("proof_command_manifest", "reviewer_proof_bundle", "implemented", "proof_only", source_paths=("sentientos/reviewer_proof_bundle.py",), proof_tests=("tests/test_reviewer_proof_bundle.py",), implemented_surfaces=("bounded local proof command inventory",), deferred_surfaces=("default proof command execution", "network commands", "provider invocation"), forbidden_implications=("listed proof commands have run", "proof command manifest grants runtime authority")),
+        _record("host_actuation_safety_gates", "host_actuation_safety", "implemented", "metadata_proof_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only safety gate prerequisite assessment",), deferred_surfaces=("live authorization grant", "real actuation", "host mutation"), forbidden_implications=("safety gates are authorization", "safety gates perform effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("hardware_allowlist_manifest", "host_actuation_safety", "implemented", "allowlist_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only hardware allowlist manifests",), deferred_surfaces=("hardware control authority", "host mutation"), forbidden_implications=("hardware allowlist grants control",)),
+        _record("os_backend_declaration", "host_actuation_safety", "implemented", "declaration_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("declaration-only OS backend records",), deferred_surfaces=("backend loading", "backend invocation", "host mutation"), forbidden_implications=("OS backend declaration loads or invokes backend",)),
+        _record("bounds_policy", "host_actuation_safety", "implemented", "policy_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only bounds policy records",), deferred_surfaces=("live bounds enforcement", "host mutation"), forbidden_implications=("bounds policy enforces live action",)),
+        _record("cooldown_policy", "host_actuation_safety", "implemented", "policy_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only cooldown policy records",), deferred_surfaces=("live cooldown enforcement", "host mutation"), forbidden_implications=("cooldown policy waits or enforces live action",)),
+        _record("panic_stop_contract", "host_actuation_safety", "implemented", "contract_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only panic stop contracts",), deferred_surfaces=("panic stop execution", "host mutation"), forbidden_implications=("panic stop contract executes stop",)),
+        _record("host_action_scope_manifest", "host_actuation_safety", "implemented", "scope_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only host action scope manifests",), deferred_surfaces=("action authorization", "host mutation"), forbidden_implications=("scope manifest authorizes action",)),
+        _record("safety_gate_satisfaction_manifest", "host_actuation_safety", "implemented", "safety_gate_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only safety gate satisfaction manifests",), deferred_surfaces=("live authorization", "fulfillment", "real effects"), forbidden_implications=("safety satisfaction manifest is authorization or fulfillment",)),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -258,6 +273,7 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("real_service_restart", "runtime_supervision", "blocked", "none", deferred_surfaces=("service restart", "service stop", "process kill"), forbidden_implications=("runtime supervisor grants restart authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_fan_pwm_control", "execution_proof", "blocked", "none", deferred_surfaces=("fan/PWM writes", "thermal actuation"), forbidden_implications=("execution proof wing grants fan/PWM control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_power_profile_mutation", "execution_proof", "blocked", "none", deferred_surfaces=("power profile mutation",), forbidden_implications=("execution proof wing grants power mutation",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_thermal_actuation", "execution_proof", "blocked", "none", deferred_surfaces=("thermal actuation",), forbidden_implications=("safety gate wing grants thermal actuation",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_file_cleanup", "execution_proof", "blocked", "none", deferred_surfaces=("file cleanup", "file delete",), forbidden_implications=("execution proof wing grants cleanup authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("audit_immutability", "audit_immutability", "implemented", "observation", source_paths=("scripts/audit_immutability_verifier.py", "scripts/verify_audits.py", "vow/immutable_manifest.json"), proof_commands=("python scripts/verify_audits.py --strict", "python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json"), implemented_surfaces=("audit verification",)),
         _record("self_amendment", "self_amendment", "partial", "self_amendment", source_paths=("sentientos/autonomy/runtime.py", "sentientos/autonomy/rehearsal.py"), implemented_surfaces=("rehearsal/governed composition surfaces",), deferred_surfaces=("unapproved self-modification",), forbidden_implications=("runtime authority expansion",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -801,3 +817,20 @@ def update_registry_from_trace_export(registry: CapabilityRegistry, trace: Any) 
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-embodiment-reviewer-demo-trace.v1")
+
+
+def update_registry_from_safety_gate_manifest(registry: CapabilityRegistry, manifest: Any) -> CapabilityRegistry:
+    """Reflect metadata-only safety gate posture without claiming authorization."""
+
+    has_manifest = bool(getattr(manifest, "manifest_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "host_actuation_safety_gates":
+            records.append(replace(record, status="implemented" if has_manifest else record.status, authority_level="metadata_proof_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"live_authorization_grant", "real_effect_execution"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-actuation-safety-gate-wing.v1")

--- a/sentientos/host_actuation_safety.py
+++ b/sentientos/host_actuation_safety.py
@@ -1,0 +1,703 @@
+"""Metadata-only host actuation safety gate records.
+
+This wing declares the gates that future host actuation would have to satisfy
+before live authorization or fulfillment could be reviewed.  It does not grant
+live authorization, execute actions, inspect privileged devices, open network
+connections, invoke providers, assemble prompts, or mutate host state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+SAFETY_STATUSES = frozenset({
+    "host_actuation_safety_ready",
+    "host_actuation_safety_ready_with_conditions",
+    "host_actuation_safety_blocked",
+    "host_actuation_safety_incomplete",
+    "host_actuation_safety_contradicted",
+})
+GATE_ASSESSMENT_STATUSES = frozenset({
+    "host_actuation_gate_satisfied",
+    "host_actuation_gate_satisfied_with_conditions",
+    "host_actuation_gate_missing",
+    "host_actuation_gate_blocked",
+    "host_actuation_gate_contradicted",
+})
+SAFETY_DOMAINS = frozenset({
+    "diagnostics_only",
+    "operator_review",
+    "thermal_safety",
+    "cooling_control_future",
+    "power_control_future",
+    "service_control_future",
+    "cleanup_control_future",
+    "driver_control_future",
+    "package_control_future",
+    "file_control_future",
+})
+SAFETY_GATE_LABELS = frozenset({
+    "hardware_allowlist_required", "hardware_allowlist_declared",
+    "os_backend_declaration_required", "os_backend_declared",
+    "bounds_policy_required", "bounds_policy_declared",
+    "cooldown_policy_required", "cooldown_policy_declared",
+    "panic_stop_required", "panic_stop_declared",
+    "operator_identity_required", "policy_identity_required",
+    "explicit_scope_required", "target_scope_declared",
+    "time_bounds_required", "expiry_required", "revocation_path_required",
+    "control_plane_admission_required", "audit_receipt_required",
+    "rollback_plan_required", "rollback_receipt_required", "effect_receipt_required",
+    "postcondition_check_required", "runtime_supervisor_observation_required",
+    "immutable_trace_required", "dry_run_rehearsal_required",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "live_authorization_grant", "host_mutation", "fan_pwm_write",
+    "thermal_actuation", "power_profile_mutation", "process_kill",
+    "service_restart", "package_install", "driver_install", "file_cleanup",
+    "file_delete", "provider_invocation", "network_egress", "prompt_assembly",
+    "federation_transport", "remote_execution",
+})
+FUTURE_DOMAINS = frozenset({
+    "cooling_control_future", "power_control_future", "service_control_future",
+    "cleanup_control_future", "driver_control_future", "package_control_future",
+    "file_control_future",
+})
+_REQUIRED_GATES: Mapping[str, tuple[str, ...]] = {
+    "diagnostics_only": ("operator_identity_required", "policy_identity_required", "audit_receipt_required", "immutable_trace_required"),
+    "operator_review": ("operator_identity_required", "policy_identity_required", "explicit_scope_required", "audit_receipt_required", "immutable_trace_required"),
+    "thermal_safety": ("os_backend_declaration_required", "bounds_policy_required", "panic_stop_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "audit_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "cooling_control_future": ("hardware_allowlist_required", "os_backend_declaration_required", "bounds_policy_required", "cooldown_policy_required", "panic_stop_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "power_control_future": ("os_backend_declaration_required", "bounds_policy_required", "cooldown_policy_required", "panic_stop_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "cleanup_control_future": ("bounds_policy_required", "dry_run_rehearsal_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "immutable_trace_required"),
+    "service_control_future": ("panic_stop_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "driver_control_future": ("os_backend_declaration_required", "panic_stop_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required"),
+    "package_control_future": ("os_backend_declaration_required", "bounds_policy_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "immutable_trace_required"),
+    "file_control_future": ("bounds_policy_required", "dry_run_rehearsal_required", "operator_identity_required", "policy_identity_required", "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required", "revocation_path_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "postcondition_check_required", "immutable_trace_required"),
+}
+_BLOCKED_BY_DOMAIN: Mapping[str, tuple[str, ...]] = {
+    "cooling_control_future": ("live_authorization_grant", "host_mutation", "fan_pwm_write", "thermal_actuation", "network_egress", "provider_invocation", "prompt_assembly"),
+    "power_control_future": ("live_authorization_grant", "host_mutation", "power_profile_mutation", "network_egress", "provider_invocation", "prompt_assembly"),
+    "cleanup_control_future": ("live_authorization_grant", "host_mutation", "file_cleanup", "file_delete", "network_egress", "provider_invocation", "prompt_assembly"),
+    "service_control_future": ("live_authorization_grant", "host_mutation", "service_restart", "process_kill", "network_egress", "provider_invocation", "prompt_assembly"),
+    "driver_control_future": ("live_authorization_grant", "host_mutation", "driver_install", "network_egress", "provider_invocation", "prompt_assembly"),
+    "package_control_future": ("live_authorization_grant", "host_mutation", "package_install", "network_egress", "provider_invocation", "prompt_assembly"),
+    "file_control_future": ("live_authorization_grant", "host_mutation", "file_cleanup", "file_delete", "network_egress", "provider_invocation", "prompt_assembly"),
+}
+_DECLARED_FOR_REQUIRED = {
+    "hardware_allowlist_required": "hardware_allowlist_declared",
+    "os_backend_declaration_required": "os_backend_declared",
+    "bounds_policy_required": "bounds_policy_declared",
+    "cooldown_policy_required": "cooldown_policy_declared",
+    "panic_stop_required": "panic_stop_declared",
+}
+
+@dataclass(frozen=True)
+class HostActuationSafetyPolicy:
+    policy_id: str
+    required_gates_by_domain: Mapping[str, tuple[str, ...]]
+    blocked_actions_by_domain: Mapping[str, tuple[str, ...]]
+    metadata_only: bool = True
+    safety_gate_only: bool = True
+    grants_live_authorization: bool = False
+    grants_control_authority: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HardwareAllowlistEntry:
+    entry_id: str
+    hardware_kind: str
+    hardware_label: str
+    vendor_label: str | None
+    model_label: str | None
+    os_family: str
+    backend_class: str
+    allowed_for_domains: tuple[str, ...]
+    denied_for_domains: tuple[str, ...]
+    required_bounds_policy_labels: tuple[str, ...]
+    required_cooldown_policy_labels: tuple[str, ...]
+    required_panic_stop_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    allowlist_only: bool = True
+    grants_control_authority: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HardwareAllowlistManifest:
+    manifest_id: str
+    entries: tuple[HardwareAllowlistEntry, ...]
+    allowed_domain_labels: tuple[str, ...]
+    denied_domain_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    allowlist_only: bool = True
+    grants_control_authority: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class OSBackendDeclaration:
+    declaration_id: str
+    backend_class: str
+    os_family: str
+    backend_label: str
+    supported_domains: tuple[str, ...]
+    unsupported_domains: tuple[str, ...]
+    required_privilege_labels: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    declaration_only: bool = True
+    backend_loaded: bool = False
+    backend_invoked: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class BoundsPolicy:
+    policy_id: str
+    domain: str
+    target_label: str
+    lower_bound_label: str
+    upper_bound_label: str
+    step_limit_label: str
+    rate_limit_label: str
+    forbidden_value_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    policy_only: bool = True
+    bounds_enforced_live: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class CooldownPolicy:
+    policy_id: str
+    domain: str
+    target_label: str
+    minimum_interval_label: str
+    maximum_attempts_label: str
+    cooldown_reset_label: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    policy_only: bool = True
+    cooldown_enforced_live: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class PanicStopContract:
+    contract_id: str
+    domain: str
+    trigger_labels: tuple[str, ...]
+    stop_labels: tuple[str, ...]
+    operator_override_labels: tuple[str, ...]
+    recovery_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    contract_only: bool = True
+    panic_stop_executed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HostActionScopeManifest:
+    scope_id: str
+    domain: str
+    target_labels: tuple[str, ...]
+    allowed_action_labels: tuple[str, ...]
+    forbidden_action_labels: tuple[str, ...]
+    path_scope_labels: tuple[str, ...]
+    service_scope_labels: tuple[str, ...]
+    hardware_scope_labels: tuple[str, ...]
+    time_bound_labels: tuple[str, ...]
+    expiry_labels: tuple[str, ...]
+    revocation_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    scope_only: bool = True
+    grants_control_authority: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HostActuationGateAssessment:
+    assessment_id: str
+    source_controlled_authorization_contract_id: str | None
+    source_controlled_authorization_contract_digest: str | None
+    domain: str
+    gate_label: str
+    gate_status: str
+    evidence_labels: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    assessment_only: bool = True
+    grants_control_authority: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class SafetyGateSatisfactionManifest:
+    manifest_id: str
+    source_controlled_authorization_contract_id: str | None
+    source_controlled_authorization_contract_digest: str | None
+    domain: str
+    safety_status: str
+    hardware_allowlist_manifest_id: str | None
+    os_backend_declaration_id: str | None
+    bounds_policy_id: str | None
+    cooldown_policy_id: str | None
+    panic_stop_contract_id: str | None
+    host_action_scope_manifest_id: str | None
+    gate_assessment_ids: tuple[str, ...]
+    satisfied_gate_labels: tuple[str, ...]
+    missing_gate_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    safety_gate_only: bool = True
+    grants_live_authorization: bool = False
+    grants_control_authority: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class HostActuationSafetyValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class HostActuationSafetyBundle:
+    hardware_allowlist_manifest: HardwareAllowlistManifest | None
+    os_backend_declaration: OSBackendDeclaration | None
+    bounds_policy: BoundsPolicy | None
+    cooldown_policy: CooldownPolicy | None
+    panic_stop_contract: PanicStopContract | None
+    host_action_scope_manifest: HostActionScopeManifest | None
+    gate_assessments: tuple[HostActuationGateAssessment, ...]
+    safety_gate_satisfaction_manifest: SafetyGateSatisfactionManifest
+    metadata_only: bool = True
+    safety_gate_only: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+def _record_payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = record_or_payload.to_dict() if hasattr(record_or_payload, "to_dict") else dict(record_or_payload)
+    payload["digest"] = ""
+    return payload
+
+def host_actuation_safety_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_record_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+hardware_allowlist_manifest_digest = host_actuation_safety_digest
+os_backend_declaration_digest = host_actuation_safety_digest
+bounds_policy_digest = host_actuation_safety_digest
+cooldown_policy_digest = host_actuation_safety_digest
+panic_stop_contract_digest = host_actuation_safety_digest
+host_action_scope_manifest_digest = host_actuation_safety_digest
+safety_gate_satisfaction_manifest_digest = host_actuation_safety_digest
+
+def host_actuation_gate_assessment_digest(assessment: HostActuationGateAssessment | Mapping[str, Any]) -> str:
+    payload = assessment.to_dict() if isinstance(assessment, HostActuationGateAssessment) else dict(assessment)
+    return "sha256:" + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def build_default_host_actuation_safety_policy() -> HostActuationSafetyPolicy:
+    return HostActuationSafetyPolicy(
+        policy_id="host-actuation-safety-gate-policy-v1",
+        required_gates_by_domain={key: tuple(value) for key, value in _REQUIRED_GATES.items()},
+        blocked_actions_by_domain={key: tuple(value) for key, value in _BLOCKED_BY_DOMAIN.items()},
+    )
+
+def _safe_domain(domain: str) -> str:
+    if domain not in SAFETY_DOMAINS:
+        raise ValueError(f"unsupported safety domain: {domain}")
+    return domain
+
+def _default_created(created_at: str | None) -> str:
+    return created_at or "1970-01-01T00:00:00+00:00"
+
+def build_hardware_allowlist_manifest(domain: str, *, created_at: str | None = None, entries: Sequence[HardwareAllowlistEntry] | None = None) -> HardwareAllowlistManifest:
+    domain = _safe_domain(domain)
+    default_entry = HardwareAllowlistEntry(
+        entry_id=f"hardware-allowlist-entry-{domain}",
+        hardware_kind="reviewer_declared_hardware_target",
+        hardware_label=f"metadata-only-{domain}-target",
+        vendor_label=None,
+        model_label=None,
+        os_family="declared_os_family_only",
+        backend_class="declared_backend_class_only",
+        allowed_for_domains=(domain,),
+        denied_for_domains=tuple(sorted(SAFETY_DOMAINS - {domain})),
+        required_bounds_policy_labels=("bounds_policy_declared",),
+        required_cooldown_policy_labels=("cooldown_policy_declared",),
+        required_panic_stop_labels=("panic_stop_declared",),
+        warning_codes=("allowlist_does_not_grant_control",),
+        risk_codes=(),
+    )
+    provisional = HardwareAllowlistManifest(
+        manifest_id=f"hardware-allowlist-manifest-{domain}",
+        entries=tuple(entries) if entries is not None else (default_entry,),
+        allowed_domain_labels=(domain,),
+        denied_domain_labels=tuple(sorted(SAFETY_DOMAINS - {domain})),
+        warning_codes=("metadata_allowlist_only",),
+        risk_codes=(),
+        created_at=_default_created(created_at),
+        digest="",
+    )
+    return replace(provisional, digest=hardware_allowlist_manifest_digest(provisional))
+
+def build_os_backend_declaration(domain: str, *, created_at: str | None = None) -> OSBackendDeclaration:
+    domain = _safe_domain(domain)
+    provisional = OSBackendDeclaration(
+        declaration_id=f"os-backend-declaration-{domain}",
+        backend_class="declared_backend_class_only",
+        os_family="declared_os_family_only",
+        backend_label=f"metadata-only-{domain}-backend",
+        supported_domains=(domain,),
+        unsupported_domains=tuple(sorted(SAFETY_DOMAINS - {domain})),
+        required_privilege_labels=("future_operator_privilege_review_required",),
+        required_scope_labels=("explicit_scope_required", "target_scope_declared"),
+        warning_codes=("backend_not_loaded_or_invoked",),
+        risk_codes=(),
+        created_at=_default_created(created_at),
+        digest="",
+    )
+    return replace(provisional, digest=os_backend_declaration_digest(provisional))
+
+def build_bounds_policy(domain: str, *, created_at: str | None = None, target_label: str = "declared_target_only") -> BoundsPolicy:
+    domain = _safe_domain(domain)
+    provisional = BoundsPolicy(
+        policy_id=f"bounds-policy-{domain}", domain=domain, target_label=target_label,
+        lower_bound_label="declared_lower_bound_only", upper_bound_label="declared_upper_bound_only",
+        step_limit_label="declared_step_limit_only", rate_limit_label="declared_rate_limit_only",
+        forbidden_value_labels=("unbounded_value", "unsafe_value"),
+        warning_codes=("bounds_not_enforced_live",), risk_codes=(), created_at=_default_created(created_at), digest="",
+    )
+    return replace(provisional, digest=bounds_policy_digest(provisional))
+
+def build_cooldown_policy(domain: str, *, created_at: str | None = None, target_label: str = "declared_target_only") -> CooldownPolicy:
+    domain = _safe_domain(domain)
+    provisional = CooldownPolicy(
+        policy_id=f"cooldown-policy-{domain}", domain=domain, target_label=target_label,
+        minimum_interval_label="declared_minimum_interval_only", maximum_attempts_label="declared_maximum_attempts_only",
+        cooldown_reset_label="declared_cooldown_reset_only", warning_codes=("cooldown_not_enforced_live",),
+        risk_codes=(), created_at=_default_created(created_at), digest="",
+    )
+    return replace(provisional, digest=cooldown_policy_digest(provisional))
+
+def build_panic_stop_contract(domain: str, *, created_at: str | None = None) -> PanicStopContract:
+    domain = _safe_domain(domain)
+    provisional = PanicStopContract(
+        contract_id=f"panic-stop-contract-{domain}", domain=domain,
+        trigger_labels=("operator_panic_signal", "supervisor_anomaly_signal"),
+        stop_labels=("future_control_grant_suspend", "future_fulfillment_halt"),
+        operator_override_labels=("local_operator_required",),
+        recovery_labels=("manual_review_required", "postcondition_recheck_required"),
+        warning_codes=("panic_stop_not_executed",), risk_codes=(), created_at=_default_created(created_at), digest="",
+    )
+    return replace(provisional, digest=panic_stop_contract_digest(provisional))
+
+def build_host_action_scope_manifest(domain: str, *, created_at: str | None = None) -> HostActionScopeManifest:
+    domain = _safe_domain(domain)
+    forbidden = _BLOCKED_BY_DOMAIN.get(domain, tuple(sorted(BLOCKED_ACTION_LABELS)))
+    provisional = HostActionScopeManifest(
+        scope_id=f"host-action-scope-{domain}", domain=domain,
+        target_labels=(f"metadata-only-{domain}-target",),
+        allowed_action_labels=("declare_safety_gate_posture", "review_gate_evidence"),
+        forbidden_action_labels=tuple(sorted(set(forbidden))),
+        path_scope_labels=("explicit_path_scope_required",) if domain in {"cleanup_control_future", "file_control_future"} else (),
+        service_scope_labels=("explicit_service_scope_required",) if domain == "service_control_future" else (),
+        hardware_scope_labels=("explicit_hardware_scope_required",) if domain in {"cooling_control_future", "power_control_future", "thermal_safety"} else (),
+        time_bound_labels=("time_bounds_required",), expiry_labels=("expiry_required",), revocation_labels=("revocation_path_required",),
+        warning_codes=("scope_manifest_does_not_authorize_action",), risk_codes=(), created_at=_default_created(created_at), digest="",
+    )
+    return replace(provisional, digest=host_action_scope_manifest_digest(provisional))
+
+
+def _declared_labels(hardware: HardwareAllowlistManifest | None, os_backend: OSBackendDeclaration | None, bounds: BoundsPolicy | None, cooldown: CooldownPolicy | None, panic: PanicStopContract | None, scope: HostActionScopeManifest | None) -> set[str]:
+    labels = {"operator_identity_required", "policy_identity_required", "time_bounds_required", "expiry_required", "revocation_path_required", "control_plane_admission_required", "audit_receipt_required", "rollback_plan_required", "rollback_receipt_required", "effect_receipt_required", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required", "dry_run_rehearsal_required"}
+    if hardware: labels.add("hardware_allowlist_declared")
+    if os_backend: labels.add("os_backend_declared")
+    if bounds: labels.add("bounds_policy_declared")
+    if cooldown: labels.add("cooldown_policy_declared")
+    if panic: labels.add("panic_stop_declared")
+    if scope:
+        labels.update({"explicit_scope_required", "target_scope_declared"})
+    return labels
+
+def assess_host_actuation_safety_gates(
+    domain: str, *,
+    hardware_allowlist_manifest: HardwareAllowlistManifest | None = None,
+    os_backend_declaration: OSBackendDeclaration | None = None,
+    bounds_policy: BoundsPolicy | None = None,
+    cooldown_policy: CooldownPolicy | None = None,
+    panic_stop_contract: PanicStopContract | None = None,
+    host_action_scope_manifest: HostActionScopeManifest | None = None,
+    source_controlled_authorization_contract_id: str | None = None,
+    source_controlled_authorization_contract_digest: str | None = None,
+) -> tuple[HostActuationGateAssessment, ...]:
+    domain = _safe_domain(domain)
+    declared = _declared_labels(hardware_allowlist_manifest, os_backend_declaration, bounds_policy, cooldown_policy, panic_stop_contract, host_action_scope_manifest)
+    assessments: list[HostActuationGateAssessment] = []
+    for gate in _REQUIRED_GATES[domain]:
+        declared_gate = _DECLARED_FOR_REQUIRED.get(gate, gate)
+        satisfied = declared_gate in declared or gate in declared
+        status = "host_actuation_gate_satisfied" if satisfied else "host_actuation_gate_missing"
+        missing = () if satisfied else (gate, declared_gate)
+        evidence = (declared_gate,) if satisfied else ()
+        assessment = HostActuationGateAssessment(
+            assessment_id=f"host-actuation-gate-{domain}-{gate}",
+            source_controlled_authorization_contract_id=source_controlled_authorization_contract_id,
+            source_controlled_authorization_contract_digest=source_controlled_authorization_contract_digest,
+            domain=domain, gate_label=gate, gate_status=status, evidence_labels=evidence,
+            missing_labels=missing, blocked_actions=tuple(sorted(_BLOCKED_BY_DOMAIN.get(domain, ()))),
+            warning_codes=("gate_assessment_metadata_only",), risk_codes=(),
+        )
+        assessments.append(assessment)
+    return tuple(assessments)
+
+def build_safety_gate_satisfaction_manifest(
+    domain: str, *,
+    hardware_allowlist_manifest: HardwareAllowlistManifest | None = None,
+    os_backend_declaration: OSBackendDeclaration | None = None,
+    bounds_policy: BoundsPolicy | None = None,
+    cooldown_policy: CooldownPolicy | None = None,
+    panic_stop_contract: PanicStopContract | None = None,
+    host_action_scope_manifest: HostActionScopeManifest | None = None,
+    gate_assessments: Sequence[HostActuationGateAssessment] | None = None,
+    source_controlled_authorization_contract_id: str | None = None,
+    source_controlled_authorization_contract_digest: str | None = None,
+    created_at: str | None = None,
+) -> SafetyGateSatisfactionManifest:
+    domain = _safe_domain(domain)
+    assessments = tuple(gate_assessments) if gate_assessments is not None else assess_host_actuation_safety_gates(
+        domain,
+        hardware_allowlist_manifest=hardware_allowlist_manifest,
+        os_backend_declaration=os_backend_declaration,
+        bounds_policy=bounds_policy,
+        cooldown_policy=cooldown_policy,
+        panic_stop_contract=panic_stop_contract,
+        host_action_scope_manifest=host_action_scope_manifest,
+        source_controlled_authorization_contract_id=source_controlled_authorization_contract_id,
+        source_controlled_authorization_contract_digest=source_controlled_authorization_contract_digest,
+    )
+    missing = tuple(sorted({label for assessment in assessments for label in assessment.missing_labels}))
+    satisfied = tuple(sorted({assessment.gate_label for assessment in assessments if assessment.gate_status in {"host_actuation_gate_satisfied", "host_actuation_gate_satisfied_with_conditions"}}))
+    status = "host_actuation_safety_ready" if not missing and domain in {"diagnostics_only", "operator_review"} else "host_actuation_safety_ready_with_conditions" if not missing else "host_actuation_safety_incomplete"
+    blocked = tuple(sorted(set(_BLOCKED_BY_DOMAIN.get(domain, ("live_authorization_grant", "host_mutation"))) | {"live_authorization_grant", "host_mutation"}))
+    provisional = SafetyGateSatisfactionManifest(
+        manifest_id=f"safety-gate-satisfaction-{domain}",
+        source_controlled_authorization_contract_id=source_controlled_authorization_contract_id,
+        source_controlled_authorization_contract_digest=source_controlled_authorization_contract_digest,
+        domain=domain, safety_status=status,
+        hardware_allowlist_manifest_id=getattr(hardware_allowlist_manifest, "manifest_id", None),
+        os_backend_declaration_id=getattr(os_backend_declaration, "declaration_id", None),
+        bounds_policy_id=getattr(bounds_policy, "policy_id", None),
+        cooldown_policy_id=getattr(cooldown_policy, "policy_id", None),
+        panic_stop_contract_id=getattr(panic_stop_contract, "contract_id", None),
+        host_action_scope_manifest_id=getattr(host_action_scope_manifest, "scope_id", None),
+        gate_assessment_ids=tuple(assessment.assessment_id for assessment in assessments),
+        satisfied_gate_labels=satisfied, missing_gate_labels=missing, blocked_actions=blocked,
+        warning_codes=("safety_gates_are_not_authorization",), risk_codes=(), created_at=_default_created(created_at), digest="",
+    )
+    return replace(provisional, digest=safety_gate_satisfaction_manifest_digest(provisional))
+
+
+def build_safety_gates_for_domain(domain: str, *, created_at: str | None = None) -> HostActuationSafetyBundle:
+    domain = _safe_domain(domain)
+    hardware = build_hardware_allowlist_manifest(domain, created_at=created_at) if domain == "cooling_control_future" else None
+    os_backend = build_os_backend_declaration(domain, created_at=created_at) if any(g == "os_backend_declaration_required" for g in _REQUIRED_GATES[domain]) else None
+    bounds = build_bounds_policy(domain, created_at=created_at) if any(g == "bounds_policy_required" for g in _REQUIRED_GATES[domain]) else None
+    cooldown = build_cooldown_policy(domain, created_at=created_at) if any(g == "cooldown_policy_required" for g in _REQUIRED_GATES[domain]) else None
+    panic = build_panic_stop_contract(domain, created_at=created_at) if any(g == "panic_stop_required" for g in _REQUIRED_GATES[domain]) else None
+    scope = build_host_action_scope_manifest(domain, created_at=created_at)
+    assessments = assess_host_actuation_safety_gates(domain, hardware_allowlist_manifest=hardware, os_backend_declaration=os_backend, bounds_policy=bounds, cooldown_policy=cooldown, panic_stop_contract=panic, host_action_scope_manifest=scope)
+    manifest = build_safety_gate_satisfaction_manifest(domain, hardware_allowlist_manifest=hardware, os_backend_declaration=os_backend, bounds_policy=bounds, cooldown_policy=cooldown, panic_stop_contract=panic, host_action_scope_manifest=scope, gate_assessments=assessments, created_at=created_at)
+    return HostActuationSafetyBundle(hardware, os_backend, bounds, cooldown, panic, scope, assessments, manifest)
+
+_AUTH_DOMAIN_MAP = {
+    "future_cooling_authorization_review": "cooling_control_future",
+    "future_power_authorization_review": "power_control_future",
+    "future_cleanup_authorization_review": "cleanup_control_future",
+    "future_service_authorization_review": "service_control_future",
+    "thermal_safety_authorization_review": "thermal_safety",
+    "operator_review_authorization_review": "operator_review",
+    "diagnostics_authorization_review": "diagnostics_only",
+}
+
+def build_safety_gates_for_controlled_authorization_contract(contract: Any, *, created_at: str | None = None) -> HostActuationSafetyBundle:
+    domain = _AUTH_DOMAIN_MAP.get(str(getattr(contract, "authorization_domain", "")), str(getattr(contract, "authorization_domain", "diagnostics_only")))
+    if domain not in SAFETY_DOMAINS:
+        domain = "diagnostics_only"
+    base = build_safety_gates_for_domain(domain, created_at=created_at)
+    assessments = assess_host_actuation_safety_gates(
+        domain,
+        hardware_allowlist_manifest=base.hardware_allowlist_manifest,
+        os_backend_declaration=base.os_backend_declaration,
+        bounds_policy=base.bounds_policy,
+        cooldown_policy=base.cooldown_policy,
+        panic_stop_contract=base.panic_stop_contract,
+        host_action_scope_manifest=base.host_action_scope_manifest,
+        source_controlled_authorization_contract_id=getattr(contract, "contract_id", None),
+        source_controlled_authorization_contract_digest=getattr(contract, "digest", None),
+    )
+    manifest = build_safety_gate_satisfaction_manifest(
+        domain,
+        hardware_allowlist_manifest=base.hardware_allowlist_manifest,
+        os_backend_declaration=base.os_backend_declaration,
+        bounds_policy=base.bounds_policy,
+        cooldown_policy=base.cooldown_policy,
+        panic_stop_contract=base.panic_stop_contract,
+        host_action_scope_manifest=base.host_action_scope_manifest,
+        gate_assessments=assessments,
+        source_controlled_authorization_contract_id=getattr(contract, "contract_id", None),
+        source_controlled_authorization_contract_digest=getattr(contract, "digest", None),
+        created_at=created_at,
+    )
+    return replace(base, gate_assessments=assessments, safety_gate_satisfaction_manifest=manifest)
+
+
+def _validate_common(payload: Mapping[str, Any], *, prefix: str) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False): findings.append(prefix + "not_metadata_only")
+    for flag in ("grants_live_authorization", "live_authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "process_kill_performed", "service_restart_performed", "package_install_performed", "driver_install_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "grants_control_authority", "backend_loaded", "backend_invoked", "bounds_enforced_live", "cooldown_enforced_live", "panic_stop_executed"):
+        if payload.get(flag, False): findings.append(prefix + "forbidden_flag:" + flag)
+    return findings
+
+def validate_hardware_allowlist_manifest(manifest: HardwareAllowlistManifest | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = manifest.to_dict() if isinstance(manifest, HardwareAllowlistManifest) else dict(manifest)
+    findings = _validate_common(payload, prefix="hardware_allowlist_manifest:")
+    if not payload.get("allowlist_only", False): findings.append("hardware_allowlist_manifest:not_allowlist_only")
+    for entry in payload.get("entries", ()) or ():
+        findings.extend(_validate_common(entry, prefix="hardware_allowlist_entry:"))
+        if entry.get("grants_control_authority", False): findings.append("hardware_allowlist_entry:forbidden_flag:grants_control_authority")
+    if payload.get("digest") and payload.get("digest") != hardware_allowlist_manifest_digest(payload): findings.append("hardware_allowlist_manifest:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_os_backend_declaration(declaration: OSBackendDeclaration | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = declaration.to_dict() if isinstance(declaration, OSBackendDeclaration) else dict(declaration)
+    findings = _validate_common(payload, prefix="os_backend_declaration:")
+    if not payload.get("declaration_only", False): findings.append("os_backend_declaration:not_declaration_only")
+    if payload.get("digest") and payload.get("digest") != os_backend_declaration_digest(payload): findings.append("os_backend_declaration:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_bounds_policy(policy: BoundsPolicy | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = policy.to_dict() if isinstance(policy, BoundsPolicy) else dict(policy)
+    findings = _validate_common(payload, prefix="bounds_policy:")
+    if not payload.get("policy_only", False): findings.append("bounds_policy:not_policy_only")
+    if payload.get("digest") and payload.get("digest") != bounds_policy_digest(payload): findings.append("bounds_policy:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_cooldown_policy(policy: CooldownPolicy | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = policy.to_dict() if isinstance(policy, CooldownPolicy) else dict(policy)
+    findings = _validate_common(payload, prefix="cooldown_policy:")
+    if not payload.get("policy_only", False): findings.append("cooldown_policy:not_policy_only")
+    if payload.get("digest") and payload.get("digest") != cooldown_policy_digest(payload): findings.append("cooldown_policy:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_panic_stop_contract(contract: PanicStopContract | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = contract.to_dict() if isinstance(contract, PanicStopContract) else dict(contract)
+    findings = _validate_common(payload, prefix="panic_stop_contract:")
+    if not payload.get("contract_only", False): findings.append("panic_stop_contract:not_contract_only")
+    if payload.get("digest") and payload.get("digest") != panic_stop_contract_digest(payload): findings.append("panic_stop_contract:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_host_action_scope_manifest(scope: HostActionScopeManifest | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = scope.to_dict() if isinstance(scope, HostActionScopeManifest) else dict(scope)
+    findings = _validate_common(payload, prefix="host_action_scope_manifest:")
+    if not payload.get("scope_only", False): findings.append("host_action_scope_manifest:not_scope_only")
+    if payload.get("digest") and payload.get("digest") != host_action_scope_manifest_digest(payload): findings.append("host_action_scope_manifest:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_host_actuation_gate_assessment(assessment: HostActuationGateAssessment | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = assessment.to_dict() if isinstance(assessment, HostActuationGateAssessment) else dict(assessment)
+    findings = _validate_common(payload, prefix="host_actuation_gate_assessment:")
+    if payload.get("gate_status") not in GATE_ASSESSMENT_STATUSES: findings.append("host_actuation_gate_assessment:unknown_status")
+    if not payload.get("assessment_only", False): findings.append("host_actuation_gate_assessment:not_assessment_only")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+def validate_safety_gate_satisfaction_manifest(manifest: SafetyGateSatisfactionManifest | Mapping[str, Any]) -> HostActuationSafetyValidationResult:
+    payload = manifest.to_dict() if isinstance(manifest, SafetyGateSatisfactionManifest) else dict(manifest)
+    findings = _validate_common(payload, prefix="safety_gate_satisfaction_manifest:")
+    if payload.get("safety_status") not in SAFETY_STATUSES: findings.append("safety_gate_satisfaction_manifest:unknown_status")
+    if not payload.get("safety_gate_only", False): findings.append("safety_gate_satisfaction_manifest:not_safety_gate_only")
+    if payload.get("digest") and payload.get("digest") != safety_gate_satisfaction_manifest_digest(payload): findings.append("safety_gate_satisfaction_manifest:digest_mismatch")
+    return HostActuationSafetyValidationResult(not findings, tuple(findings))
+
+
+def summarize_hardware_allowlist_manifest(manifest: HardwareAllowlistManifest) -> dict[str, Any]:
+    return {"manifest_id": manifest.manifest_id, "entry_count": len(manifest.entries), "metadata_only": manifest.metadata_only, "allowlist_only": manifest.allowlist_only, "grants_control_authority": manifest.grants_control_authority, "host_mutation_performed": manifest.host_mutation_performed, "digest": manifest.digest}
+
+def summarize_os_backend_declaration(declaration: OSBackendDeclaration) -> dict[str, Any]:
+    return {"declaration_id": declaration.declaration_id, "backend_class": declaration.backend_class, "metadata_only": declaration.metadata_only, "declaration_only": declaration.declaration_only, "backend_loaded": declaration.backend_loaded, "backend_invoked": declaration.backend_invoked, "host_mutation_performed": declaration.host_mutation_performed, "digest": declaration.digest}
+
+def summarize_bounds_policy(policy: BoundsPolicy) -> dict[str, Any]:
+    return {"policy_id": policy.policy_id, "domain": policy.domain, "metadata_only": policy.metadata_only, "policy_only": policy.policy_only, "bounds_enforced_live": policy.bounds_enforced_live, "host_mutation_performed": policy.host_mutation_performed, "digest": policy.digest}
+
+def summarize_cooldown_policy(policy: CooldownPolicy) -> dict[str, Any]:
+    return {"policy_id": policy.policy_id, "domain": policy.domain, "metadata_only": policy.metadata_only, "policy_only": policy.policy_only, "cooldown_enforced_live": policy.cooldown_enforced_live, "host_mutation_performed": policy.host_mutation_performed, "digest": policy.digest}
+
+def summarize_panic_stop_contract(contract: PanicStopContract) -> dict[str, Any]:
+    return {"contract_id": contract.contract_id, "domain": contract.domain, "metadata_only": contract.metadata_only, "contract_only": contract.contract_only, "panic_stop_executed": contract.panic_stop_executed, "host_mutation_performed": contract.host_mutation_performed, "digest": contract.digest}
+
+def summarize_host_action_scope_manifest(scope: HostActionScopeManifest) -> dict[str, Any]:
+    return {"scope_id": scope.scope_id, "domain": scope.domain, "metadata_only": scope.metadata_only, "scope_only": scope.scope_only, "grants_control_authority": scope.grants_control_authority, "host_mutation_performed": scope.host_mutation_performed, "digest": scope.digest}
+
+def summarize_host_actuation_gate_assessment(assessment: HostActuationGateAssessment) -> dict[str, Any]:
+    return {"assessment_id": assessment.assessment_id, "domain": assessment.domain, "gate_label": assessment.gate_label, "gate_status": assessment.gate_status, "metadata_only": assessment.metadata_only, "assessment_only": assessment.assessment_only, "grants_control_authority": assessment.grants_control_authority, "host_mutation_performed": assessment.host_mutation_performed}
+
+def summarize_safety_gate_satisfaction_manifest(manifest: SafetyGateSatisfactionManifest) -> dict[str, Any]:
+    return {"manifest_id": manifest.manifest_id, "domain": manifest.domain, "safety_status": manifest.safety_status, "satisfied_gate_count": len(manifest.satisfied_gate_labels), "missing_gate_count": len(manifest.missing_gate_labels), "blocked_actions": manifest.blocked_actions, "metadata_only": manifest.metadata_only, "safety_gate_only": manifest.safety_gate_only, "grants_live_authorization": manifest.grants_live_authorization, "grants_control_authority": manifest.grants_control_authority, "fulfillment_granted": manifest.fulfillment_granted, "effect_performed": manifest.effect_performed, "host_mutation_performed": manifest.host_mutation_performed, "digest": manifest.digest}
+
+def summarize_host_actuation_safety_policy(policy: HostActuationSafetyPolicy) -> dict[str, Any]:
+    return {"policy_id": policy.policy_id, "domain_count": len(policy.required_gates_by_domain), "metadata_only": policy.metadata_only, "safety_gate_only": policy.safety_gate_only, "grants_live_authorization": policy.grants_live_authorization, "grants_control_authority": policy.grants_control_authority, "host_mutation_performed": policy.host_mutation_performed}

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -17,6 +17,7 @@ from typing import Any, Mapping, Sequence
 
 from sentientos.capability_registry import build_default_capability_registry, summarize_capability_registry
 from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace, summarize_host_embodiment_trace
+from sentientos.host_actuation_safety import build_safety_gates_for_domain, summarize_safety_gate_satisfaction_manifest
 from sentientos.host_embodiment_trace_export import (
     serialize_host_embodiment_trace_json,
     serialize_host_embodiment_trace_markdown,
@@ -42,6 +43,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "proof_command_manifest",
         "reviewer_readme",
         "bundle_manifest",
+        "safety_gate_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -62,6 +64,7 @@ BUNDLE_FILE_NAMES = {
     "proof_command_manifest": "proof_commands.json",
     "reviewer_readme": "README.md",
     "bundle_manifest": "bundle_manifest.json",
+    "safety_gate_posture": "safety_gates.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -275,8 +278,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "1. `trace.md` — reviewer-readable trace ladder.",
             "2. `bundle_manifest.json` — artifact digests and safety flags.",
             "3. `deferred_actions.json` — deferred/blocked action inventory.",
-            "4. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "5. `capability_registry_summary.json` — metadata-only capability posture.",
+            "4. `safety_gates.json` — metadata-only host actuation safety gate posture.",
+            "5. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "6. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -287,6 +291,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Effect performed: false",
             "- Host mutation performed: false",
             "- Network/provider/prompt assembly performed: false",
+            "- Safety gates are not authorization and do not grant fulfillment or control authority.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -322,6 +327,7 @@ def build_reviewer_proof_bundle_payload(
         raise ValueError("invalid trace export payload: " + ", ".join(trace_validation.findings))
 
     registry = build_default_capability_registry()
+    safety_gates = build_safety_gates_for_domain("cooling_control_future", created_at=created_at)
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
     contents: dict[str, str] = {
@@ -330,6 +336,7 @@ def build_reviewer_proof_bundle_payload(
         "trace_summary": _trace_summary_text(trace),
         "capability_registry_summary": _pretty_json({"summary": summarize_capability_registry(registry), "records": [record.to_dict() for record in registry.records], "metadata_only": True, "reviewer_proof_only": True}),
         "deferred_action_inventory": _pretty_json(_deferred_action_inventory()),
+        "safety_gate_posture": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "safety_gate_only": True, "proof_statement": "Safety gates declare prerequisites only; they are not authorization or fulfillment.", "summary": summarize_safety_gate_satisfaction_manifest(safety_gates.safety_gate_satisfaction_manifest), "records": safety_gates.to_dict()}),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -371,7 +378,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -105,3 +105,14 @@ def test_verify_is_explicitly_unsupported(tmp_path: Path) -> None:
     code, _stdout, stderr = _run_main(["--output-dir", str(tmp_path / "bundle"), "--verify"])
     assert code == 2
     assert "not implemented" in stderr
+
+
+def test_reviewer_proof_bundle_cli_writes_safety_gates_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, _stdout, stderr = _run_main(["--output-dir", str(output_dir), "--force"])
+    assert code == 0, stderr
+    safety_gates = output_dir / "safety_gates.json"
+    assert safety_gates.exists()
+    text = safety_gates.read_text(encoding="utf-8")
+    assert "safety_gate_only" in text
+    assert "not authorization" in text

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -368,3 +368,31 @@ def test_registry_updates_from_reviewer_proof_bundle_keep_authority_deferred() -
     assert records["real_service_restart"].status == "blocked"
     assert records["real_file_cleanup"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_host_actuation_safety_capabilities_are_metadata_only_and_real_actions_blocked() -> None:
+    registry = build_default_capability_registry()
+    by_id = registry.by_id()
+    expected = {
+        "host_actuation_safety_gates": "metadata_proof_only",
+        "hardware_allowlist_manifest": "allowlist_only",
+        "os_backend_declaration": "declaration_only",
+        "bounds_policy": "policy_only",
+        "cooldown_policy": "policy_only",
+        "panic_stop_contract": "contract_only",
+        "host_action_scope_manifest": "scope_only",
+        "safety_gate_satisfaction_manifest": "safety_gate_only",
+    }
+    for capability_id, authority in expected.items():
+        record = by_id[capability_id]
+        assert record.status == "implemented"
+        assert record.authority_level == authority
+        assert record.metadata_only is True
+        assert record.host_actuation_performed is False
+    for capability_id in [
+        "live_authorization_grant", "real_effect_execution", "real_fan_pwm_control", "real_thermal_actuation",
+        "real_power_profile_mutation", "real_service_restart", "real_file_cleanup",
+    ]:
+        assert by_id[capability_id].status in {"deferred", "blocked"}
+        assert by_id[capability_id].authority_level == "none"
+        assert by_id[capability_id].host_actuation_performed is False

--- a/tests/test_host_actuation_safety.py
+++ b/tests/test_host_actuation_safety.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.host_actuation_safety import (
+    build_bounds_policy,
+    build_cooldown_policy,
+    build_hardware_allowlist_manifest,
+    build_host_action_scope_manifest,
+    build_os_backend_declaration,
+    build_panic_stop_contract,
+    build_safety_gate_satisfaction_manifest,
+    build_safety_gates_for_controlled_authorization_contract,
+    build_safety_gates_for_domain,
+    safety_gate_satisfaction_manifest_digest,
+    summarize_safety_gate_satisfaction_manifest,
+    validate_bounds_policy,
+    validate_cooldown_policy,
+    validate_hardware_allowlist_manifest,
+    validate_host_action_scope_manifest,
+    validate_os_backend_declaration,
+    validate_panic_stop_contract,
+    validate_safety_gate_satisfaction_manifest,
+)
+from sentientos.controlled_authorization import ControlledAuthorizationGrantContract
+
+FIXED = "2025-07-30T00:00:00+00:00"
+
+
+def test_default_cooling_safety_gate_manifest_requires_declared_gates_and_blocks_actuation() -> None:
+    bundle = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED)
+    manifest = bundle.safety_gate_satisfaction_manifest
+    assert manifest.safety_status == "host_actuation_safety_ready_with_conditions"
+    for gate in [
+        "hardware_allowlist_required", "os_backend_declaration_required", "bounds_policy_required",
+        "cooldown_policy_required", "panic_stop_required", "operator_identity_required", "policy_identity_required",
+        "explicit_scope_required", "target_scope_declared", "time_bounds_required", "expiry_required",
+        "revocation_path_required", "control_plane_admission_required", "audit_receipt_required",
+        "rollback_plan_required", "rollback_receipt_required", "effect_receipt_required",
+        "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required",
+    ]:
+        assert gate in manifest.satisfied_gate_labels
+    assert manifest.missing_gate_labels == ()
+    assert {"fan_pwm_write", "thermal_actuation", "live_authorization_grant", "host_mutation"}.issubset(manifest.blocked_actions)
+    assert manifest.grants_live_authorization is False
+    assert manifest.grants_control_authority is False
+    assert manifest.fulfillment_granted is False
+    assert manifest.effect_performed is False
+    assert manifest.host_mutation_performed is False
+
+
+@pytest.mark.parametrize(
+    ("domain", "blocked"),
+    [
+        ("power_control_future", "power_profile_mutation"),
+        ("cleanup_control_future", "file_cleanup"),
+        ("cleanup_control_future", "file_delete"),
+        ("service_control_future", "service_restart"),
+        ("service_control_future", "process_kill"),
+    ],
+)
+def test_future_domains_keep_real_actions_blocked(domain: str, blocked: str) -> None:
+    manifest = build_safety_gates_for_domain(domain, created_at=FIXED).safety_gate_satisfaction_manifest
+    assert blocked in manifest.blocked_actions
+    assert manifest.grants_live_authorization is False
+    assert manifest.host_mutation_performed is False
+
+
+@pytest.mark.parametrize("domain", ["diagnostics_only", "operator_review"])
+def test_diagnostics_and_operator_review_are_ready_but_grant_no_authority(domain: str) -> None:
+    manifest = build_safety_gates_for_domain(domain, created_at=FIXED).safety_gate_satisfaction_manifest
+    assert manifest.safety_status in {"host_actuation_safety_ready", "host_actuation_safety_ready_with_conditions"}
+    assert manifest.grants_control_authority is False
+    assert manifest.grants_live_authorization is False
+
+
+def test_metadata_records_do_not_execute_or_enforce_live_actions() -> None:
+    hardware = build_hardware_allowlist_manifest("cooling_control_future", created_at=FIXED)
+    os_backend = build_os_backend_declaration("cooling_control_future", created_at=FIXED)
+    bounds = build_bounds_policy("cooling_control_future", created_at=FIXED)
+    cooldown = build_cooldown_policy("cooling_control_future", created_at=FIXED)
+    panic = build_panic_stop_contract("cooling_control_future", created_at=FIXED)
+    scope = build_host_action_scope_manifest("cooling_control_future", created_at=FIXED)
+    assert hardware.grants_control_authority is False
+    assert os_backend.backend_loaded is False and os_backend.backend_invoked is False
+    assert bounds.bounds_enforced_live is False
+    assert cooldown.cooldown_enforced_live is False
+    assert panic.panic_stop_executed is False
+    assert scope.grants_control_authority is False
+    assert validate_hardware_allowlist_manifest(hardware).ok
+    assert validate_os_backend_declaration(os_backend).ok
+    assert validate_bounds_policy(bounds).ok
+    assert validate_cooldown_policy(cooldown).ok
+    assert validate_panic_stop_contract(panic).ok
+    assert validate_host_action_scope_manifest(scope).ok
+
+
+def test_missing_required_gates_produce_incomplete_manifest() -> None:
+    manifest = build_safety_gate_satisfaction_manifest("cooling_control_future", created_at=FIXED)
+    assert manifest.safety_status == "host_actuation_safety_incomplete"
+    assert "hardware_allowlist_required" in manifest.missing_gate_labels
+    assert "os_backend_declaration_required" in manifest.missing_gate_labels
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "grants_live_authorization", "grants_control_authority", "fulfillment_granted", "effect_performed",
+        "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed",
+        "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed",
+        "network_performed", "provider_invocation_performed", "prompt_assembly_performed",
+    ],
+)
+def test_safety_manifest_validation_rejects_forbidden_flags(flag: str) -> None:
+    manifest = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    bad = replace(manifest, **{flag: True})
+    result = validate_safety_gate_satisfaction_manifest(bad)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_record_specific_validation_rejects_live_claims() -> None:
+    assert not validate_hardware_allowlist_manifest(replace(build_hardware_allowlist_manifest("cooling_control_future"), grants_control_authority=True)).ok
+    assert not validate_os_backend_declaration(replace(build_os_backend_declaration("cooling_control_future"), backend_loaded=True)).ok
+    assert not validate_bounds_policy(replace(build_bounds_policy("cooling_control_future"), bounds_enforced_live=True)).ok
+    assert not validate_cooldown_policy(replace(build_cooldown_policy("cooling_control_future"), cooldown_enforced_live=True)).ok
+    assert not validate_panic_stop_contract(replace(build_panic_stop_contract("cooling_control_future"), panic_stop_executed=True)).ok
+    assert not validate_host_action_scope_manifest(replace(build_host_action_scope_manifest("cooling_control_future"), grants_control_authority=True)).ok
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    first = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    second = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    assert first.digest == second.digest
+    changed = replace(first, warning_codes=("changed",), digest="")
+    assert safety_gate_satisfaction_manifest_digest(changed) != first.digest
+
+
+def test_summaries_are_metadata_only() -> None:
+    manifest = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    summary = summarize_safety_gate_satisfaction_manifest(manifest)
+    assert summary["metadata_only"] is True
+    assert summary["safety_gate_only"] is True
+    assert summary["grants_live_authorization"] is False
+    assert summary["effect_performed"] is False
+
+
+def test_controlled_authorization_contract_integrates_to_safety_gates() -> None:
+    contract = ControlledAuthorizationGrantContract(
+        contract_id="contract-1",
+        source_authorization_review_receipt_id="receipt-1",
+        source_authorization_review_receipt_digest="sha256:receipt",
+        future_authorization_grant_schema_id="schema-1",
+        authorization_domain="future_cooling_authorization_review",
+        approval_class="future_controlled_grant_contract",
+        authorization_scope="future_cooling_scope",
+        required_grant_gates=(),
+        required_operator_identity_labels=("operator",),
+        required_policy_labels=("policy",),
+        required_scope_labels=("scope",),
+        required_time_bound_labels=("time",),
+        required_expiry_labels=("expiry",),
+        required_revocation_labels=("revocation",),
+        required_audit_labels=("audit",),
+        required_control_plane_labels=("control-plane",),
+        blocked_actions=("fan_pwm_write",),
+        missing_prerequisites=(),
+        status="controlled_authorization_contract_ready",
+        warning_codes=(),
+        risk_codes=(),
+        created_at=FIXED,
+        digest="sha256:contract",
+    )
+    bundle = build_safety_gates_for_controlled_authorization_contract(contract, created_at=FIXED)
+    manifest = bundle.safety_gate_satisfaction_manifest
+    assert manifest.domain == "cooling_control_future"
+    assert manifest.source_controlled_authorization_contract_id == "contract-1"
+    assert manifest.source_controlled_authorization_contract_digest == "sha256:contract"
+    assert "fan_pwm_write" in manifest.blocked_actions

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -154,3 +154,13 @@ def test_validation_rejects_unknown_artifact_kind() -> None:
     result = validate_reviewer_proof_bundle_manifest(replace(manifest, artifact_records=tuple(artifacts)))
     assert not result.ok
     assert "unknown_artifact_kind:unknown" in result.findings
+
+
+def test_bundle_includes_host_actuation_safety_gate_posture() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "safety_gate_posture" in payload["artifacts"]
+    assert "safety_gates.json" in payload["artifacts"]["bundle_manifest"]
+    assert "Safety gates declare prerequisites only" in payload["artifacts"]["safety_gate_posture"]
+    assert "safety_gates" in payload
+    validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
+    assert validation.ok, validation.findings

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -328,8 +328,30 @@ def test_reviewer_first_run_proof_bundle_doc_preserves_boundary_and_file_list() 
         "trace.summary.txt",
         "capability_registry_summary.json",
         "deferred_actions.json",
+        "safety_gates.json",
         "proof_commands.json",
         "README.md",
         "bundle_manifest.json",
     ]:
         assert filename in doc
+
+HOST_ACTUATION_SAFETY_GATE_WING = "docs/architecture/host_actuation_safety_gate_wing.md"
+
+
+def test_navigation_links_to_host_actuation_safety_gate_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    for text in [overview, index, bundle, controlled]:
+        assert HOST_ACTUATION_SAFETY_GATE_WING in text
+
+
+def test_host_actuation_safety_gate_doc_preserves_safety_only_boundaries() -> None:
+    doc = _read(HOST_ACTUATION_SAFETY_GATE_WING)
+    assert "Safety gates are not authorization" in doc
+    assert "Hardware allowlist does not grant control" in doc
+    assert "OS backend declaration does not load/invoke backend" in doc
+    assert "Panic stop contract does not execute panic stop" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → authorize" in doc


### PR DESCRIPTION
### Motivation

- Introduce a metadata-only safety gate wing that declares the prerequisites future host actuation must satisfy before any live authorization or fulfillment can be considered. 
- Make safety posture explicit and reviewer-visible while preserving the repository’s existing non-mutating, proof-only boundaries for authorization and effect execution. 
- Ensure capability posture and reviewer bundles reflect safety-gate metadata without granting or performing any live host actions. 

### Description

- Add a new metadata-only module `sentientos/host_actuation_safety.py` that defines frozen dataclasses and helper builders/validators/summarizers for `HardwareAllowlistEntry`, `HardwareAllowlistManifest`, `OSBackendDeclaration`, `BoundsPolicy`, `CooldownPolicy`, `PanicStopContract`, `HostActionScopeManifest`, `HostActuationGateAssessment`, `SafetyGateSatisfactionManifest`, `HostActuationSafetyPolicy`, and a `HostActuationSafetyBundle`; all records default to metadata-only and explicitly forbid live authorization, host mutation, fan/PWM/thermal/power/service/cleanup/provider/network/prompt actions. 
- Integrate with controlled authorization via `build_safety_gates_for_controlled_authorization_contract(...)` and provide `build_safety_gates_for_domain(...)` and `assess_host_actuation_safety_gates(...)` to produce conservative gate assessments and satisfaction manifests (deterministic digests included). 
- Extend reviewer proof-bundle code (`sentientos/reviewer_proof_bundle.py`) to include a `safety_gates.json` artifact (artifact kind `safety_gate_posture`) and return a `safety_gates` bundle alongside trace and capability registry summaries; README and bundle manifest text updated to state safety gates are not authorization. 
- Update capability registry (`sentientos/capability_registry.py`) to add `host_actuation_safety` category, new authority levels (`metadata_proof_only`, `allowlist_only`, `declaration_only`, `policy_only`, `scope_only`, `safety_gate_only`), add capability records for safety-gate artifacts, and add `update_registry_from_safety_gate_manifest(...)` which reflects safety posture without claiming authorization or execution. 
- Add documentation `docs/architecture/host_actuation_safety_gate_wing.md` and update architecture docs and reviewer maps so the new wing is linked from the public overview and reviewer index. 
- Add tests: `tests/test_host_actuation_safety.py` plus updates to `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py` to assert inclusion, metadata-only posture, forbidden-flag validation, deterministic digests, and that blocked/deferred capabilities remain blocked/deferred. 

### Testing

- Ran the new unit/integration suites successfully: `python -m scripts.run_tests -q tests/test_host_actuation_safety.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` and additional core suites `tests/test_controlled_authorization.py`, `tests/test_host_embodiment_trace.py`, `tests/test_host_embodiment_trace_export.py`, `tests/test_authorization_review.py`, `tests/test_effect_proof.py`, `tests/test_runtime_supervisor.py`, `tests/test_actuation_fulfillment.py`, `tests/test_privilege_broker.py`, `tests/test_control_plane_kernel.py`, `tests/test_sentientosd_runtime_closure.py` (all passed in the environment used for this PR run). 
- Verified reviewer bundle CLI produced the additional artifact at `safety_gates.json` using `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and `--summary`; the generated `safety_gates.json` contains `safety_gate_only` and the expected warning text that safety gates are not authorization. 
- Built docs successfully after bootstrapping (`python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py`) and ran `python scripts/verify_context_hygiene_prompt_boundaries.py` (no prompt/provider-boundary issues). 

Files changed (high level): `sentientos/host_actuation_safety.py`, `sentientos/reviewer_proof_bundle.py`, `sentientos/capability_registry.py`, `docs/architecture/host_actuation_safety_gate_wing.md` and updates to several docs, plus tests `tests/test_host_actuation_safety.py` and updates to reviewer/capability tests and bundle script tests to cover safety-gate artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06065c5ee88320ba6fa7ccf16dd78f)