### PR TITLE
[codex:host-embodiment] add live-grant readiness wing

### DIFF
--- a/docs/architecture/host_actuation_safety_gate_wing.md
+++ b/docs/architecture/host_actuation_safety_gate_wing.md
@@ -37,3 +37,7 @@ This wing covers **safety gates** only. It answers: “What gates must be declar
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_host_actuation_safety.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_capability_registry.py`
+
+## Next wing
+
+The next organ is the [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`), which evaluates post-safety-gate readiness/preflight metadata only. Live-grant readiness is not a live grant; authorization and real actuation remain deferred.

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -54,3 +54,7 @@ Real fulfillment remains deferred. Real actuation remains deferred.
 See [Host Embodiment Reviewer Demo Trace](host_embodiment_reviewer_demo_trace.md) for the deterministic JSON/Markdown export command. The export is reviewer proof only, uses fake/sample thermal+PWM telemetry by default, and preserves the proof that PWM presence is not control authority, the controlled authorization contract is not a live grant, grant/revocation records are schema-only/future-use-only, and real actuation remains deferred.
 
 Proof path: docs/architecture/host_embodiment_reviewer_demo_trace.md
+
+## Downstream readiness link
+
+After controlled authorization contracts and safety gates, the [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`) checks readiness/preflight metadata only. Controlled authorization contract is not a live grant, and live-grant readiness is not authorization.

--- a/docs/architecture/host_live_grant_readiness_wing.md
+++ b/docs/architecture/host_live_grant_readiness_wing.md
@@ -1,0 +1,51 @@
+# Host Live-Grant Readiness Wing
+
+This wing follows the [Host Actuation Safety Gate Wing](host_actuation_safety_gate_wing.md). It adds a metadata-only, readiness/preflight layer that evaluates whether the controlled authorization contract, future grant schema, safety gate posture, and reviewer proof bundle posture are structurally present enough for a future live authorization grant to be considered by humans and policy.
+
+## Boundary
+
+Live-grant readiness is not a live grant. It is not authorization. It does not authorize fulfillment, issue a runtime authority token, execute actions, or mutate host state.
+
+Safety gates are not authorization. Controlled authorization contracts are not live grants. Grant records remain schema-only/future-use-only. An operator/policy approval packet is not approval. A grant issue preflight receipt does not issue a grant. A grant denial/deferral receipt does not mutate host state.
+
+The wing does not write fan/PWM controls, perform thermal actuation, mutate power profiles, kill processes, restart services, install packages or drivers, clean up or delete files, perform network egress, invoke providers, assemble/export prompts, transport federation state, or perform remote execution.
+
+## Records
+
+- **LiveGrantReadinessPolicy:** declares the metadata-only prerequisite policy and blocked actions.
+- **LiveGrantPrerequisite:** records one prerequisite as satisfied, missing, blocked, contradicted, or satisfied with conditions.
+- **LiveGrantPrerequisiteMatrix:** records prerequisite posture for diagnostics, operator review, resource pressure, thermal safety, future cooling, future power, future cleanup, and future service domains.
+- **OperatorPolicyApprovalPacket:** scaffolds operator, policy, scope, time, expiry, revocation, audit, and control-plane labels; it is not approval.
+- **GrantIssuePreflightReceipt:** records readiness/preflight posture; it does not issue a grant.
+- **GrantDenialDeferralReceipt:** records denial/deferral reasons; it does not mutate host state.
+
+## Future prerequisite posture
+
+Future cooling/power/service/cleanup actions remain behind explicit future live authorization, control-plane admission, audit, rollback, effect receipt, postcondition checks, supervisor observation, immutable trace, and safety gates.
+
+Future cooling readiness requires hardware allowlist, OS backend declaration, bounds policy, cooldown policy, panic stop contract, scope manifest, operator/policy labels, time bounds, expiry, revocation path, control-plane admission, audit receipt, rollback plan, rollback receipt, effect receipt, postcondition check, runtime supervisor observation, immutable trace, and reviewer proof bundle prerequisites.
+
+Future power readiness requires OS backend declaration, bounds policy, cooldown/rate-limit policy, panic stop contract, scope manifest, operator/policy labels, time bounds, expiry, revocation path, control-plane admission, audit receipt, rollback plan, rollback receipt, postcondition check, runtime supervisor observation, immutable trace, and reviewer proof bundle prerequisites.
+
+Future cleanup readiness requires file/path scope, dry-run/rehearsal evidence, operator/policy labels, time bounds, expiry, revocation path, control-plane admission, audit receipt, rollback plan, rollback receipt, effect receipt, postcondition check, immutable trace, and reviewer proof bundle prerequisites.
+
+Future service readiness requires service scope, runtime supervisor observation, panic stop, operator/policy labels, time bounds, expiry, revocation path, control-plane admission, audit receipt, rollback plan, rollback receipt, postcondition check, immutable trace, and reviewer proof bundle prerequisites.
+
+## Authority ladder
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → authorize → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **live-grant readiness/preflight only**. Real fulfillment remains deferred. Real actuation remains deferred.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle now includes `live_grant_readiness.json`. That artifact is reviewer proof only and metadata only. It summarizes the prerequisite matrix, operator/policy approval packet, grant issue preflight receipt, and denial/deferral receipt while preserving `grant_not_issued`, `approval_not_granted`, `live_authorization_granted=false`, `does_not_execute=true`, and `does_not_mutate_host=true`.
+
+## Implementation links
+
+- Module: `sentientos/live_grant_readiness.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_live_grant_readiness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -249,3 +249,5 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md` for the one-comma
 
 
 Reviewer first-run proof bundle: `docs/architecture/reviewer_first_run_proof_bundle.md`.
+
+Host live-grant readiness is documented in [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`): live-grant readiness is not a live grant, the operator/policy approval packet is not approval, grant issue preflight does not issue a grant, and real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -74,3 +74,7 @@ The reviewer should see that:
 - Trace export: `sentientos/host_embodiment_trace_export.py`
 - Capability registry: `sentientos/capability_registry.py`
 - Tests: `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`
+
+## Live-grant readiness artifact
+
+The bundle includes `live_grant_readiness.json`, documented in [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`). The artifact is metadata-only reviewer proof: live-grant readiness is not a live grant, the operator/policy approval packet is not approval, and the grant issue preflight receipt does not issue a grant.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -248,3 +248,9 @@ Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace
 ## Host Embodiment Reviewer Demo Trace
 
 See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: `python scripts/build_host_embodiment_trace.py --format json`, `python scripts/build_host_embodiment_trace.py --format markdown`, and `python scripts/build_host_embodiment_trace.py --validate-only`. The demo trace is reviewer proof only; no host mutation occurs; PWM presence is not control authority; no live authorization, real effect, network, provider invocation, prompt assembly, federation transport, or remote execution occurs.
+
+## Host Live-Grant Readiness Wing
+
+- Architecture: [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`).
+- Proof: `tests/test_live_grant_readiness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, and `tests/test_capability_registry.py`.
+- Boundary: live-grant readiness is not a live grant; operator/policy approval packet is not approval; grant issue preflight does not issue a grant; real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -394,3 +394,7 @@ Proof path: docs/architecture/host_embodiment_controlled_authorization_and_trace
 ## Host Embodiment Reviewer Demo Trace
 
 See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. The external reviewer demo script now has a deterministic metadata-only thermal+PWM trace export. It is reviewer proof only: no live host collection by default, no live authorization, no effect, no host mutation, and PWM presence is not control authority.
+
+### Host Live-Grant Readiness Wing
+
+See [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`). It sits after Host Actuation Safety Gates and before any future authorize/fulfill/effect path. It is readiness/preflight only; real actuation remains deferred.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -40,6 +40,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "host_embodiment_trace",
         "reviewer_proof_bundle",
         "host_actuation_safety",
+        "live_grant_readiness",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -68,6 +69,9 @@ AUTHORITY_LEVELS = frozenset(
         "policy_only",
         "scope_only",
         "safety_gate_only",
+        "packet_only",
+        "preflight_only",
+        "denial_deferral_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -265,6 +269,11 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("panic_stop_contract", "host_actuation_safety", "implemented", "contract_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only panic stop contracts",), deferred_surfaces=("panic stop execution", "host mutation"), forbidden_implications=("panic stop contract executes stop",)),
         _record("host_action_scope_manifest", "host_actuation_safety", "implemented", "scope_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only host action scope manifests",), deferred_surfaces=("action authorization", "host mutation"), forbidden_implications=("scope manifest authorizes action",)),
         _record("safety_gate_satisfaction_manifest", "host_actuation_safety", "implemented", "safety_gate_only", source_paths=("sentientos/host_actuation_safety.py",), proof_tests=("tests/test_host_actuation_safety.py",), implemented_surfaces=("metadata-only safety gate satisfaction manifests",), deferred_surfaces=("live authorization", "fulfillment", "real effects"), forbidden_implications=("safety satisfaction manifest is authorization or fulfillment",)),
+        _record("live_grant_readiness", "live_grant_readiness", "implemented", "readiness_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("metadata-only live-grant readiness assessment",), deferred_surfaces=("live authorization grant", "real fulfillment", "host mutation"), forbidden_implications=("live-grant readiness is a live grant", "readiness authorizes fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("live_grant_prerequisite_matrix", "live_grant_readiness", "implemented", "metadata_proof_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("metadata-only prerequisite matrix",), deferred_surfaces=("authorization approval", "live grant issuance"), forbidden_implications=("prerequisite matrix grants authority",)),
+        _record("operator_policy_approval_packet", "live_grant_readiness", "implemented", "packet_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("operator/policy approval packet scaffold",), deferred_surfaces=("operator approval", "policy approval", "live authorization grant"), forbidden_implications=("approval packet is approval",)),
+        _record("grant_issue_preflight_receipt", "live_grant_readiness", "implemented", "preflight_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("grant issue preflight receipt",), deferred_surfaces=("grant issuance", "fulfillment", "effect receipt"), forbidden_implications=("preflight receipt issues a grant",)),
+        _record("grant_denial_deferral_receipt", "live_grant_readiness", "implemented", "denial_deferral_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("grant denial/deferral receipt",), deferred_surfaces=("grant issuance", "host mutation"), forbidden_implications=("denial/deferral receipt mutates host state",)),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -834,3 +843,28 @@ def update_registry_from_safety_gate_manifest(registry: CapabilityRegistry, mani
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-actuation-safety-gate-wing.v1")
+
+
+def update_registry_from_live_grant_readiness(registry: CapabilityRegistry, readiness_wing: Any) -> CapabilityRegistry:
+    """Reflect live-grant readiness/preflight records without granting authority."""
+
+    has_matrix = bool(getattr(getattr(readiness_wing, "prerequisite_matrix", None), "matrix_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "live_grant_readiness":
+            records.append(replace(record, status="implemented" if has_matrix else record.status, authority_level="readiness_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "live_grant_prerequisite_matrix":
+            records.append(replace(record, status="implemented" if has_matrix else record.status, authority_level="metadata_proof_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "operator_policy_approval_packet":
+            records.append(replace(record, status="implemented", authority_level="packet_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "grant_issue_preflight_receipt":
+            records.append(replace(record, status="implemented", authority_level="preflight_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "grant_denial_deferral_receipt":
+            records.append(replace(record, status="implemented", authority_level="denial_deferral_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"live_authorization_grant", "real_authorization_grant", "real_effect_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-live-grant-readiness-wing.v1")

--- a/sentientos/live_grant_readiness.py
+++ b/sentientos/live_grant_readiness.py
@@ -1,0 +1,603 @@
+"""Metadata-only live-grant readiness/preflight records.
+
+This wing evaluates whether future live authorization prerequisites are
+structurally present after controlled authorization contracts and host actuation
+safety gates. It never issues a grant, authorizes fulfillment, executes host
+actions, opens network egress, invokes providers, assembles prompts, or mutates
+host state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+READINESS_STATUSES = frozenset({
+    "live_grant_readiness_ready_for_operator_policy_review",
+    "live_grant_readiness_ready_with_conditions",
+    "live_grant_readiness_blocked",
+    "live_grant_readiness_incomplete",
+    "live_grant_readiness_contradicted",
+})
+PREREQUISITE_STATUSES = frozenset({
+    "prerequisite_satisfied",
+    "prerequisite_satisfied_with_conditions",
+    "prerequisite_missing",
+    "prerequisite_blocked",
+    "prerequisite_contradicted",
+})
+APPROVAL_PACKET_STATUSES = frozenset({
+    "operator_policy_approval_packet_ready",
+    "operator_policy_approval_packet_ready_with_conditions",
+    "operator_policy_approval_packet_blocked",
+    "operator_policy_approval_packet_incomplete",
+    "operator_policy_approval_packet_contradicted",
+})
+PREFLIGHT_STATUSES = frozenset({
+    "grant_issue_preflight_recorded",
+    "grant_issue_preflight_recorded_with_warnings",
+    "grant_issue_preflight_blocked",
+    "grant_issue_preflight_incomplete",
+    "grant_issue_preflight_contradicted",
+})
+DENIAL_DEFERRAL_STATUSES = frozenset({
+    "grant_denial_deferral_recorded",
+    "grant_denial_deferral_blocked",
+    "grant_denial_deferral_incomplete",
+    "grant_denial_deferral_contradicted",
+})
+READINESS_DOMAINS = frozenset({
+    "diagnostics_live_grant_review",
+    "operator_review_live_grant_review",
+    "resource_pressure_live_grant_review",
+    "thermal_safety_live_grant_review",
+    "future_cooling_live_grant_review",
+    "future_power_live_grant_review",
+    "future_cleanup_live_grant_review",
+    "future_service_live_grant_review",
+})
+REQUIRED_PREREQUISITE_LABELS = frozenset({
+    "controlled_authorization_contract_present",
+    "future_grant_schema_present",
+    "controlled_grant_record_schema_present",
+    "revocation_record_schema_present",
+    "authorization_ledger_present",
+    "safety_gate_satisfaction_manifest_present",
+    "hardware_allowlist_present",
+    "os_backend_declaration_present",
+    "bounds_policy_present",
+    "cooldown_policy_present",
+    "panic_stop_contract_present",
+    "scope_manifest_present",
+    "operator_identity_labels_present",
+    "policy_labels_present",
+    "time_bounds_present",
+    "expiry_present",
+    "revocation_path_present",
+    "control_plane_admission_required",
+    "audit_receipt_required",
+    "rollback_plan_required",
+    "rollback_receipt_required",
+    "effect_receipt_required",
+    "postcondition_check_required",
+    "runtime_supervisor_observation_required",
+    "immutable_trace_required",
+    "reviewer_proof_bundle_present",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "live_authorization_grant",
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+
+_GATE_TO_PREREQUISITE: Mapping[str, str] = {
+    "hardware_allowlist_required": "hardware_allowlist_present",
+    "hardware_allowlist_declared": "hardware_allowlist_present",
+    "os_backend_declaration_required": "os_backend_declaration_present",
+    "os_backend_declared": "os_backend_declaration_present",
+    "bounds_policy_required": "bounds_policy_present",
+    "bounds_policy_declared": "bounds_policy_present",
+    "cooldown_policy_required": "cooldown_policy_present",
+    "cooldown_policy_declared": "cooldown_policy_present",
+    "panic_stop_required": "panic_stop_contract_present",
+    "panic_stop_declared": "panic_stop_contract_present",
+    "operator_identity_required": "operator_identity_labels_present",
+    "policy_identity_required": "policy_labels_present",
+    "explicit_scope_required": "scope_manifest_present",
+    "target_scope_declared": "scope_manifest_present",
+    "time_bounds_required": "time_bounds_present",
+    "expiry_required": "expiry_present",
+    "revocation_path_required": "revocation_path_present",
+    "control_plane_admission_required": "control_plane_admission_required",
+    "audit_receipt_required": "audit_receipt_required",
+    "rollback_plan_required": "rollback_plan_required",
+    "rollback_receipt_required": "rollback_receipt_required",
+    "effect_receipt_required": "effect_receipt_required",
+    "postcondition_check_required": "postcondition_check_required",
+    "runtime_supervisor_observation_required": "runtime_supervisor_observation_required",
+    "immutable_trace_required": "immutable_trace_required",
+}
+_COMMON_FUTURE = tuple(sorted(REQUIRED_PREREQUISITE_LABELS))
+_DOMAIN_REQUIRED: Mapping[str, tuple[str, ...]] = {
+    "diagnostics_live_grant_review": ("authorization_ledger_present", "safety_gate_satisfaction_manifest_present", "operator_identity_labels_present", "policy_labels_present", "audit_receipt_required", "immutable_trace_required"),
+    "operator_review_live_grant_review": ("authorization_ledger_present", "safety_gate_satisfaction_manifest_present", "scope_manifest_present", "operator_identity_labels_present", "policy_labels_present", "audit_receipt_required", "immutable_trace_required", "reviewer_proof_bundle_present"),
+    "resource_pressure_live_grant_review": ("authorization_ledger_present", "safety_gate_satisfaction_manifest_present", "bounds_policy_present", "operator_identity_labels_present", "policy_labels_present", "audit_receipt_required", "runtime_supervisor_observation_required", "immutable_trace_required", "reviewer_proof_bundle_present"),
+    "thermal_safety_live_grant_review": ("authorization_ledger_present", "safety_gate_satisfaction_manifest_present", "os_backend_declaration_present", "bounds_policy_present", "panic_stop_contract_present", "operator_identity_labels_present", "policy_labels_present", "postcondition_check_required", "runtime_supervisor_observation_required", "immutable_trace_required", "reviewer_proof_bundle_present"),
+    "future_cooling_live_grant_review": _COMMON_FUTURE,
+    "future_power_live_grant_review": tuple(label for label in _COMMON_FUTURE if label != "hardware_allowlist_present"),
+    "future_cleanup_live_grant_review": tuple(label for label in _COMMON_FUTURE if label not in {"hardware_allowlist_present", "os_backend_declaration_present", "cooldown_policy_present", "runtime_supervisor_observation_required"}),
+    "future_service_live_grant_review": tuple(label for label in _COMMON_FUTURE if label not in {"hardware_allowlist_present", "bounds_policy_present", "cooldown_policy_present"}),
+}
+_DOMAIN_BLOCKS: Mapping[str, tuple[str, ...]] = {
+    "future_cooling_live_grant_review": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_live_grant_review": ("power_profile_mutation",),
+    "future_cleanup_live_grant_review": ("file_cleanup", "file_delete"),
+    "future_service_live_grant_review": ("service_restart", "process_kill"),
+}
+_FORBIDDEN_SOURCE_FLAGS = (
+    "live_authorization_granted", "grants_live_authorization", "grants_control_authority",
+    "fulfillment_granted", "effect_performed", "host_mutation_performed",
+    "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed",
+    "process_kill_performed", "service_restart_performed", "file_cleanup_performed",
+    "file_delete_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed",
+    "control_authority_granted", "does_execute", "does_mutate_host",
+)
+
+@dataclass(frozen=True)
+class LiveGrantReadinessPolicy:
+    policy_id: str
+    domain_required_prerequisites: Mapping[str, tuple[str, ...]]
+    blocked_actions: tuple[str, ...]
+    proof_bundle_required: bool = True
+    metadata_only: bool = True
+    readiness_only: bool = True
+    grants_live_authorization: bool = False
+
+@dataclass(frozen=True)
+class LiveGrantPrerequisite:
+    prerequisite_id: str
+    label: str
+    status: str
+    evidence_labels: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    prerequisite_only: bool = True
+    grants_live_authorization: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LiveGrantPrerequisiteMatrix:
+    matrix_id: str
+    source_controlled_authorization_ledger_id: str | None
+    source_safety_gate_manifest_id: str | None
+    source_reviewer_proof_bundle_manifest_id: str | None
+    readiness_domain: str
+    prerequisites: tuple[LiveGrantPrerequisite, ...]
+    satisfied_labels: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    matrix_only: bool = True
+    grants_live_authorization: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class OperatorPolicyApprovalPacket:
+    packet_id: str
+    source_prerequisite_matrix_id: str
+    readiness_domain: str
+    approval_packet_status: str
+    required_operator_labels: tuple[str, ...]
+    required_policy_labels: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    required_time_bounds: tuple[str, ...]
+    required_expiry_labels: tuple[str, ...]
+    required_revocation_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_control_plane_labels: tuple[str, ...]
+    missing_approval_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    approval_packet_only: bool = True
+    approval_not_granted: bool = True
+    grants_live_authorization: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class GrantIssuePreflightReceipt:
+    receipt_id: str
+    source_prerequisite_matrix_id: str
+    source_approval_packet_id: str
+    readiness_domain: str
+    readiness_status: str
+    preflight_status: str
+    evidence_summary: Mapping[str, Any]
+    satisfied_prerequisites: tuple[str, ...]
+    missing_prerequisites: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    preflight_only: bool = True
+    grant_not_issued: bool = True
+    live_authorization_granted: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class GrantDenialDeferralReceipt:
+    receipt_id: str
+    source_preflight_receipt_id: str
+    readiness_domain: str
+    denial_deferral_status: str
+    denial_reason_codes: tuple[str, ...]
+    deferral_reason_codes: tuple[str, ...]
+    missing_prerequisites: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    denial_deferral_only: bool = True
+    grant_not_issued: bool = True
+    live_authorization_granted: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LiveGrantReadinessValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+class LiveGrantReadinessWingRecords(NamedTuple):
+    prerequisite_matrix: LiveGrantPrerequisiteMatrix
+    approval_packet: OperatorPolicyApprovalPacket
+    preflight_receipt: GrantIssuePreflightReceipt
+    denial_deferral_receipt: GrantDenialDeferralReceipt
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = record_or_payload.to_dict() if hasattr(record_or_payload, "to_dict") else dict(record_or_payload)
+    payload["digest"] = ""
+    return payload
+
+def live_grant_readiness_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+def live_grant_prerequisite_digest(record_or_payload: Any) -> str:
+    return live_grant_readiness_digest(record_or_payload)
+
+def live_grant_prerequisite_matrix_digest(record_or_payload: Any) -> str:
+    return live_grant_readiness_digest(record_or_payload)
+
+def operator_policy_approval_packet_digest(record_or_payload: Any) -> str:
+    return live_grant_readiness_digest(record_or_payload)
+
+def grant_issue_preflight_receipt_digest(record_or_payload: Any) -> str:
+    return live_grant_readiness_digest(record_or_payload)
+
+def grant_denial_deferral_receipt_digest(record_or_payload: Any) -> str:
+    return live_grant_readiness_digest(record_or_payload)
+
+def build_default_live_grant_readiness_policy() -> LiveGrantReadinessPolicy:
+    return LiveGrantReadinessPolicy(
+        policy_id="live-grant-readiness-policy-v1",
+        domain_required_prerequisites=_DOMAIN_REQUIRED,
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+    )
+
+def _source_payload(source: Any | None) -> Mapping[str, Any]:
+    if source is None:
+        return {}
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+def _source_contradictions(*sources: Any | None) -> tuple[str, ...]:
+    findings: list[str] = []
+    for name, source in zip(("controlled_authorization_ledger", "safety_gate_manifest", "reviewer_proof_bundle_manifest"), sources):
+        payload = _source_payload(source)
+        for flag in _FORBIDDEN_SOURCE_FLAGS:
+            if payload.get(flag, False):
+                findings.append(f"{name}_forbidden_flag:{flag}")
+    return tuple(findings)
+
+def _evidence_from_sources(controlled_authorization_ledger: Any | None, safety_gate_manifest: Any | None, reviewer_proof_bundle_manifest: Any | None) -> set[str]:
+    evidence: set[str] = set()
+    ledger = _source_payload(controlled_authorization_ledger)
+    if ledger:
+        evidence.add("authorization_ledger_present")
+        if ledger.get("grant_records"):
+            evidence.update({"controlled_authorization_contract_present", "future_grant_schema_present", "controlled_grant_record_schema_present"})
+        if ledger.get("revocation_records"):
+            evidence.add("revocation_record_schema_present")
+    manifest = _source_payload(safety_gate_manifest)
+    if manifest:
+        evidence.add("safety_gate_satisfaction_manifest_present")
+        if manifest.get("hardware_allowlist_manifest_id"): evidence.add("hardware_allowlist_present")
+        if manifest.get("os_backend_declaration_id"): evidence.add("os_backend_declaration_present")
+        if manifest.get("bounds_policy_id"): evidence.add("bounds_policy_present")
+        if manifest.get("cooldown_policy_id"): evidence.add("cooldown_policy_present")
+        if manifest.get("panic_stop_contract_id"): evidence.add("panic_stop_contract_present")
+        if manifest.get("host_action_scope_manifest_id"): evidence.add("scope_manifest_present")
+        for gate in tuple(manifest.get("satisfied_gate_labels", ()) or ()): evidence.add(_GATE_TO_PREREQUISITE.get(str(gate), str(gate)))
+    if reviewer_proof_bundle_manifest is not None:
+        evidence.add("reviewer_proof_bundle_present")
+    return evidence
+
+def _blocked_actions_for_domain(domain: str, safety_gate_manifest: Any | None = None) -> tuple[str, ...]:
+    blocked = set(BLOCKED_ACTION_LABELS)
+    blocked.update(_DOMAIN_BLOCKS.get(domain, ()))
+    blocked.update(tuple(_source_payload(safety_gate_manifest).get("blocked_actions", ()) or ()))
+    return tuple(sorted(blocked))
+
+def _build_prerequisite(label: str, evidence: set[str], contradicted: bool, *, created_at: str) -> LiveGrantPrerequisite:
+    status = "prerequisite_contradicted" if contradicted else "prerequisite_satisfied" if label in evidence else "prerequisite_missing"
+    provisional = LiveGrantPrerequisite(
+        prerequisite_id=f"live-grant-prerequisite-{label}",
+        label=label,
+        status=status,
+        evidence_labels=(label,) if label in evidence else (),
+        missing_labels=() if label in evidence else (label,),
+        warning_codes=(),
+        risk_codes=("live_grant_readiness_is_not_authorization",),
+    )
+    return replace(provisional, prerequisite_id="lgp_" + hashlib.sha256((label + status + created_at).encode("utf-8")).hexdigest()[:16])
+
+def build_live_grant_prerequisite_matrix(
+    readiness_domain: str,
+    *,
+    controlled_authorization_ledger: Any | None = None,
+    safety_gate_manifest: Any | None = None,
+    reviewer_proof_bundle_manifest: Any | None = None,
+    policy: LiveGrantReadinessPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> LiveGrantPrerequisiteMatrix:
+    if readiness_domain not in READINESS_DOMAINS:
+        raise ValueError(f"unknown readiness domain: {readiness_domain}")
+    policy = policy or build_default_live_grant_readiness_policy()
+    required = tuple(policy.domain_required_prerequisites.get(readiness_domain, ()))
+    evidence = _evidence_from_sources(controlled_authorization_ledger, safety_gate_manifest, reviewer_proof_bundle_manifest)
+    contradictions = _source_contradictions(controlled_authorization_ledger, safety_gate_manifest, reviewer_proof_bundle_manifest)
+    prereqs = tuple(_build_prerequisite(label, evidence, bool(contradictions), created_at=created_at) for label in required)
+    missing = tuple(sorted({label for prereq in prereqs for label in prereq.missing_labels}))
+    satisfied = tuple(sorted({prereq.label for prereq in prereqs if prereq.status.startswith("prerequisite_satisfied")}))
+    warnings = tuple(sorted(set(_tuple(_source_payload(controlled_authorization_ledger).get("warning_codes")) + _tuple(_source_payload(safety_gate_manifest).get("warning_codes")) + _tuple(_source_payload(reviewer_proof_bundle_manifest).get("warning_codes")))))
+    risks = tuple(sorted(set(_tuple(_source_payload(controlled_authorization_ledger).get("risk_codes")) + _tuple(_source_payload(safety_gate_manifest).get("risk_codes")) + _tuple(_source_payload(reviewer_proof_bundle_manifest).get("risk_codes")) + contradictions + ("live_grant_readiness_preflight_only",))))
+    if reviewer_proof_bundle_manifest is None and policy.proof_bundle_required and "reviewer_proof_bundle_present" in required:
+        warnings = tuple(sorted(set(warnings) | {"reviewer_proof_bundle_manifest_missing"}))
+    provisional = LiveGrantPrerequisiteMatrix(
+        matrix_id="",
+        source_controlled_authorization_ledger_id=_source_payload(controlled_authorization_ledger).get("ledger_id"),
+        source_safety_gate_manifest_id=_source_payload(safety_gate_manifest).get("manifest_id"),
+        source_reviewer_proof_bundle_manifest_id=_source_payload(reviewer_proof_bundle_manifest).get("manifest_id"),
+        readiness_domain=readiness_domain,
+        prerequisites=prereqs,
+        satisfied_labels=satisfied,
+        missing_labels=missing,
+        blocked_actions=_blocked_actions_for_domain(readiness_domain, safety_gate_manifest),
+        warning_codes=warnings,
+        risk_codes=risks,
+        created_at=created_at,
+        digest="",
+    )
+    with_id = replace(provisional, matrix_id="lgrm_" + hashlib.sha256(_canonical_json(_payload(provisional)).encode("utf-8")).hexdigest()[:16])
+    return replace(with_id, digest=live_grant_prerequisite_matrix_digest(with_id))
+
+def build_operator_policy_approval_packet(matrix: LiveGrantPrerequisiteMatrix, *, created_at: str | None = None) -> OperatorPolicyApprovalPacket:
+    missing = set(matrix.missing_labels)
+    if any("forbidden_flag" in risk for risk in matrix.risk_codes): status = "operator_policy_approval_packet_contradicted"
+    elif missing: status = "operator_policy_approval_packet_incomplete"
+    elif matrix.warning_codes: status = "operator_policy_approval_packet_ready_with_conditions"
+    else: status = "operator_policy_approval_packet_ready"
+    provisional = OperatorPolicyApprovalPacket(
+        packet_id="",
+        source_prerequisite_matrix_id=matrix.matrix_id,
+        readiness_domain=matrix.readiness_domain,
+        approval_packet_status=status,
+        required_operator_labels=("operator_identity_labels_present",),
+        required_policy_labels=("policy_labels_present",),
+        required_scope_labels=("scope_manifest_present",),
+        required_time_bounds=("time_bounds_present",),
+        required_expiry_labels=("expiry_present",),
+        required_revocation_labels=("revocation_path_present",),
+        required_audit_labels=("audit_receipt_required", "immutable_trace_required"),
+        required_control_plane_labels=("control_plane_admission_required",),
+        missing_approval_labels=tuple(sorted(label for label in missing if label in {"operator_identity_labels_present", "policy_labels_present", "scope_manifest_present", "time_bounds_present", "expiry_present", "revocation_path_present", "audit_receipt_required", "immutable_trace_required", "control_plane_admission_required"})),
+        blocked_actions=matrix.blocked_actions,
+        warning_codes=matrix.warning_codes,
+        risk_codes=tuple(sorted(set(matrix.risk_codes) | {"approval_packet_is_not_approval"})),
+        created_at=created_at or matrix.created_at,
+        digest="",
+    )
+    with_id = replace(provisional, packet_id="lgap_" + hashlib.sha256(_canonical_json(_payload(provisional)).encode("utf-8")).hexdigest()[:16])
+    return replace(with_id, digest=operator_policy_approval_packet_digest(with_id))
+
+def _readiness_status(matrix: LiveGrantPrerequisiteMatrix) -> str:
+    if any("forbidden_flag" in risk for risk in matrix.risk_codes): return "live_grant_readiness_contradicted"
+    if any(prereq.status == "prerequisite_blocked" for prereq in matrix.prerequisites): return "live_grant_readiness_blocked"
+    if matrix.missing_labels: return "live_grant_readiness_incomplete"
+    if matrix.warning_codes: return "live_grant_readiness_ready_with_conditions"
+    return "live_grant_readiness_ready_for_operator_policy_review"
+
+def build_grant_issue_preflight_receipt(matrix: LiveGrantPrerequisiteMatrix, approval_packet: OperatorPolicyApprovalPacket, *, created_at: str | None = None) -> GrantIssuePreflightReceipt:
+    readiness = _readiness_status(matrix)
+    preflight = {
+        "live_grant_readiness_ready_for_operator_policy_review": "grant_issue_preflight_recorded",
+        "live_grant_readiness_ready_with_conditions": "grant_issue_preflight_recorded_with_warnings",
+        "live_grant_readiness_blocked": "grant_issue_preflight_blocked",
+        "live_grant_readiness_incomplete": "grant_issue_preflight_incomplete",
+        "live_grant_readiness_contradicted": "grant_issue_preflight_contradicted",
+    }[readiness]
+    provisional = GrantIssuePreflightReceipt(
+        receipt_id="",
+        source_prerequisite_matrix_id=matrix.matrix_id,
+        source_approval_packet_id=approval_packet.packet_id,
+        readiness_domain=matrix.readiness_domain,
+        readiness_status=readiness,
+        preflight_status=preflight,
+        evidence_summary={"satisfied_count": len(matrix.satisfied_labels), "missing_count": len(matrix.missing_labels), "metadata_only": True, "grant_not_issued": True},
+        satisfied_prerequisites=matrix.satisfied_labels,
+        missing_prerequisites=matrix.missing_labels,
+        blocked_actions=matrix.blocked_actions,
+        warning_codes=matrix.warning_codes,
+        risk_codes=tuple(sorted(set(matrix.risk_codes) | {"preflight_receipt_does_not_issue_grant"})),
+        created_at=created_at or matrix.created_at,
+        digest="",
+    )
+    with_id = replace(provisional, receipt_id="lgpr_" + hashlib.sha256(_canonical_json(_payload(provisional)).encode("utf-8")).hexdigest()[:16])
+    return replace(with_id, digest=grant_issue_preflight_receipt_digest(with_id))
+
+def build_grant_denial_deferral_receipt(preflight_receipt: GrantIssuePreflightReceipt, *, created_at: str | None = None) -> GrantDenialDeferralReceipt:
+    if preflight_receipt.preflight_status.endswith("contradicted"):
+        status = "grant_denial_deferral_contradicted"
+    elif preflight_receipt.preflight_status.endswith("blocked"):
+        status = "grant_denial_deferral_blocked"
+    elif preflight_receipt.missing_prerequisites:
+        status = "grant_denial_deferral_incomplete"
+    else:
+        status = "grant_denial_deferral_recorded"
+    denial = ("live_grant_not_issued_by_readiness_wing",)
+    deferral = tuple(sorted(set(preflight_receipt.missing_prerequisites) | {"future_authorization_review_required"}))
+    provisional = GrantDenialDeferralReceipt(
+        receipt_id="",
+        source_preflight_receipt_id=preflight_receipt.receipt_id,
+        readiness_domain=preflight_receipt.readiness_domain,
+        denial_deferral_status=status,
+        denial_reason_codes=denial,
+        deferral_reason_codes=deferral,
+        missing_prerequisites=preflight_receipt.missing_prerequisites,
+        blocked_actions=preflight_receipt.blocked_actions,
+        warning_codes=preflight_receipt.warning_codes,
+        risk_codes=tuple(sorted(set(preflight_receipt.risk_codes) | {"denial_deferral_receipt_does_not_mutate_host"})),
+        created_at=created_at or preflight_receipt.created_at,
+        digest="",
+    )
+    with_id = replace(provisional, receipt_id="lgdd_" + hashlib.sha256(_canonical_json(_payload(provisional)).encode("utf-8")).hexdigest()[:16])
+    return replace(with_id, digest=grant_denial_deferral_receipt_digest(with_id))
+
+def _validate_record_flags(payload: Mapping[str, Any], prefix: str) -> list[str]:
+    findings: list[str] = []
+    for flag in ("grants_live_authorization", "live_authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed"):
+        if payload.get(flag, False): findings.append(f"{prefix}forbidden_flag:{flag}")
+    for flag in ("metadata_only", "does_not_execute", "does_not_mutate_host", "grant_not_issued", "approval_not_granted"):
+        if flag in payload and not payload.get(flag): findings.append(f"{prefix}missing_non_authority_flag:{flag}")
+    blocked = set(payload.get("blocked_actions", ()) or ())
+    if "blocked_actions" in payload and not {"live_authorization_grant", "host_mutation", "provider_invocation", "network_egress", "prompt_assembly"}.issubset(blocked):
+        findings.append(f"{prefix}missing_core_blocked_actions")
+    return findings
+
+def validate_live_grant_prerequisite(prerequisite: LiveGrantPrerequisite | Mapping[str, Any]) -> LiveGrantReadinessValidationResult:
+    payload = prerequisite.to_dict() if isinstance(prerequisite, LiveGrantPrerequisite) else dict(prerequisite)
+    findings = _validate_record_flags(payload, "prerequisite:")
+    if payload.get("status") not in PREREQUISITE_STATUSES: findings.append("prerequisite:unknown_status")
+    if not payload.get("prerequisite_only", False): findings.append("prerequisite:not_prerequisite_only")
+    return LiveGrantReadinessValidationResult(not findings, tuple(findings))
+
+def validate_live_grant_prerequisite_matrix(matrix: LiveGrantPrerequisiteMatrix | Mapping[str, Any]) -> LiveGrantReadinessValidationResult:
+    payload = matrix.to_dict() if isinstance(matrix, LiveGrantPrerequisiteMatrix) else dict(matrix)
+    findings = _validate_record_flags(payload, "matrix:")
+    if payload.get("readiness_domain") not in READINESS_DOMAINS: findings.append("matrix:unknown_readiness_domain")
+    if not payload.get("matrix_only", False): findings.append("matrix:not_matrix_only")
+    for prereq in payload.get("prerequisites", ()) or ():
+        findings.extend(f"matrix:{finding}" for finding in validate_live_grant_prerequisite(prereq).findings)
+    if payload.get("digest") and payload.get("digest") != live_grant_prerequisite_matrix_digest(payload): findings.append("matrix:digest_mismatch")
+    return LiveGrantReadinessValidationResult(not findings, tuple(findings))
+
+def validate_operator_policy_approval_packet(packet: OperatorPolicyApprovalPacket | Mapping[str, Any]) -> LiveGrantReadinessValidationResult:
+    payload = packet.to_dict() if isinstance(packet, OperatorPolicyApprovalPacket) else dict(packet)
+    findings = _validate_record_flags(payload, "approval_packet:")
+    if payload.get("approval_packet_status") not in APPROVAL_PACKET_STATUSES: findings.append("approval_packet:unknown_status")
+    if not payload.get("approval_packet_only", False): findings.append("approval_packet:not_packet_only")
+    if not payload.get("approval_not_granted", False): findings.append("approval_packet:approval_was_granted")
+    if payload.get("digest") and payload.get("digest") != operator_policy_approval_packet_digest(payload): findings.append("approval_packet:digest_mismatch")
+    return LiveGrantReadinessValidationResult(not findings, tuple(findings))
+
+def validate_grant_issue_preflight_receipt(receipt: GrantIssuePreflightReceipt | Mapping[str, Any]) -> LiveGrantReadinessValidationResult:
+    payload = receipt.to_dict() if isinstance(receipt, GrantIssuePreflightReceipt) else dict(receipt)
+    findings = _validate_record_flags(payload, "preflight_receipt:")
+    if payload.get("readiness_status") not in READINESS_STATUSES: findings.append("preflight_receipt:unknown_readiness_status")
+    if payload.get("preflight_status") not in PREFLIGHT_STATUSES: findings.append("preflight_receipt:unknown_preflight_status")
+    if not payload.get("preflight_only", False): findings.append("preflight_receipt:not_preflight_only")
+    if not payload.get("grant_not_issued", False): findings.append("preflight_receipt:grant_was_issued")
+    if payload.get("digest") and payload.get("digest") != grant_issue_preflight_receipt_digest(payload): findings.append("preflight_receipt:digest_mismatch")
+    return LiveGrantReadinessValidationResult(not findings, tuple(findings))
+
+def validate_grant_denial_deferral_receipt(receipt: GrantDenialDeferralReceipt | Mapping[str, Any]) -> LiveGrantReadinessValidationResult:
+    payload = receipt.to_dict() if isinstance(receipt, GrantDenialDeferralReceipt) else dict(receipt)
+    findings = _validate_record_flags(payload, "denial_deferral_receipt:")
+    if payload.get("denial_deferral_status") not in DENIAL_DEFERRAL_STATUSES: findings.append("denial_deferral_receipt:unknown_status")
+    if not payload.get("denial_deferral_only", False): findings.append("denial_deferral_receipt:not_denial_deferral_only")
+    if not payload.get("grant_not_issued", False): findings.append("denial_deferral_receipt:grant_was_issued")
+    if payload.get("digest") and payload.get("digest") != grant_denial_deferral_receipt_digest(payload): findings.append("denial_deferral_receipt:digest_mismatch")
+    return LiveGrantReadinessValidationResult(not findings, tuple(findings))
+
+def summarize_live_grant_prerequisite_matrix(matrix: LiveGrantPrerequisiteMatrix | Mapping[str, Any]) -> dict[str, Any]:
+    p = matrix.to_dict() if isinstance(matrix, LiveGrantPrerequisiteMatrix) else dict(matrix)
+    return {"matrix_id": p.get("matrix_id"), "readiness_domain": p.get("readiness_domain"), "satisfied_count": len(p.get("satisfied_labels", ()) or ()), "missing_count": len(p.get("missing_labels", ()) or ()), "blocked_actions": tuple(p.get("blocked_actions", ()) or ()), "metadata_only": p.get("metadata_only"), "matrix_only": p.get("matrix_only"), "grants_live_authorization": p.get("grants_live_authorization"), "fulfillment_granted": p.get("fulfillment_granted"), "effect_performed": p.get("effect_performed"), "host_mutation_performed": p.get("host_mutation_performed"), "digest": p.get("digest")}
+
+def summarize_operator_policy_approval_packet(packet: OperatorPolicyApprovalPacket | Mapping[str, Any]) -> dict[str, Any]:
+    p = packet.to_dict() if isinstance(packet, OperatorPolicyApprovalPacket) else dict(packet)
+    return {"packet_id": p.get("packet_id"), "readiness_domain": p.get("readiness_domain"), "approval_packet_status": p.get("approval_packet_status"), "missing_approval_labels": tuple(p.get("missing_approval_labels", ()) or ()), "metadata_only": p.get("metadata_only"), "approval_packet_only": p.get("approval_packet_only"), "approval_not_granted": p.get("approval_not_granted"), "grants_live_authorization": p.get("grants_live_authorization"), "does_not_execute": p.get("does_not_execute"), "does_not_mutate_host": p.get("does_not_mutate_host"), "digest": p.get("digest")}
+
+def summarize_grant_issue_preflight_receipt(receipt: GrantIssuePreflightReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = receipt.to_dict() if isinstance(receipt, GrantIssuePreflightReceipt) else dict(receipt)
+    return {"receipt_id": p.get("receipt_id"), "readiness_domain": p.get("readiness_domain"), "readiness_status": p.get("readiness_status"), "preflight_status": p.get("preflight_status"), "missing_count": len(p.get("missing_prerequisites", ()) or ()), "metadata_only": p.get("metadata_only"), "preflight_only": p.get("preflight_only"), "grant_not_issued": p.get("grant_not_issued"), "live_authorization_granted": p.get("live_authorization_granted"), "does_not_execute": p.get("does_not_execute"), "does_not_mutate_host": p.get("does_not_mutate_host"), "digest": p.get("digest")}
+
+def summarize_grant_denial_deferral_receipt(receipt: GrantDenialDeferralReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = receipt.to_dict() if isinstance(receipt, GrantDenialDeferralReceipt) else dict(receipt)
+    return {"receipt_id": p.get("receipt_id"), "readiness_domain": p.get("readiness_domain"), "denial_deferral_status": p.get("denial_deferral_status"), "missing_count": len(p.get("missing_prerequisites", ()) or ()), "metadata_only": p.get("metadata_only"), "denial_deferral_only": p.get("denial_deferral_only"), "grant_not_issued": p.get("grant_not_issued"), "live_authorization_granted": p.get("live_authorization_granted"), "does_not_execute": p.get("does_not_execute"), "does_not_mutate_host": p.get("does_not_mutate_host"), "digest": p.get("digest")}
+
+def build_live_grant_readiness_wing(
+    controlled_authorization_ledger: Any | None,
+    safety_gate_satisfaction_manifest: Any | None,
+    reviewer_proof_bundle_manifest: Any | None = None,
+    *,
+    readiness_domain: str = "future_cooling_live_grant_review",
+    policy: LiveGrantReadinessPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> LiveGrantReadinessWingRecords:
+    matrix = build_live_grant_prerequisite_matrix(readiness_domain, controlled_authorization_ledger=controlled_authorization_ledger, safety_gate_manifest=safety_gate_satisfaction_manifest, reviewer_proof_bundle_manifest=reviewer_proof_bundle_manifest, policy=policy, created_at=created_at)
+    packet = build_operator_policy_approval_packet(matrix, created_at=created_at)
+    preflight = build_grant_issue_preflight_receipt(matrix, packet, created_at=created_at)
+    denial = build_grant_denial_deferral_receipt(preflight, created_at=created_at)
+    return LiveGrantReadinessWingRecords(matrix, packet, preflight, denial)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -18,6 +18,14 @@ from typing import Any, Mapping, Sequence
 from sentientos.capability_registry import build_default_capability_registry, summarize_capability_registry
 from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace, summarize_host_embodiment_trace
 from sentientos.host_actuation_safety import build_safety_gates_for_domain, summarize_safety_gate_satisfaction_manifest
+from sentientos.controlled_authorization import build_controlled_authorization_ledger
+from sentientos.live_grant_readiness import (
+    build_live_grant_readiness_wing,
+    summarize_grant_denial_deferral_receipt,
+    summarize_grant_issue_preflight_receipt,
+    summarize_live_grant_prerequisite_matrix,
+    summarize_operator_policy_approval_packet,
+)
 from sentientos.host_embodiment_trace_export import (
     serialize_host_embodiment_trace_json,
     serialize_host_embodiment_trace_markdown,
@@ -44,6 +52,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "reviewer_readme",
         "bundle_manifest",
         "safety_gate_posture",
+        "live_grant_readiness_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -65,6 +74,7 @@ BUNDLE_FILE_NAMES = {
     "reviewer_readme": "README.md",
     "bundle_manifest": "bundle_manifest.json",
     "safety_gate_posture": "safety_gates.json",
+    "live_grant_readiness_posture": "live_grant_readiness.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -279,8 +289,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "2. `bundle_manifest.json` — artifact digests and safety flags.",
             "3. `deferred_actions.json` — deferred/blocked action inventory.",
             "4. `safety_gates.json` — metadata-only host actuation safety gate posture.",
-            "5. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "6. `capability_registry_summary.json` — metadata-only capability posture.",
+            "5. `live_grant_readiness.json` — readiness/preflight-only future live-grant posture; it is not a grant.",
+            "6. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "7. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -292,6 +303,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Host mutation performed: false",
             "- Network/provider/prompt assembly performed: false",
             "- Safety gates are not authorization and do not grant fulfillment or control authority.",
+            "- Live-grant readiness is not a live grant; the approval packet is not approval; preflight does not issue a grant.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -328,6 +340,14 @@ def build_reviewer_proof_bundle_payload(
 
     registry = build_default_capability_registry()
     safety_gates = build_safety_gates_for_domain("cooling_control_future", created_at=created_at)
+    controlled_ledger = build_controlled_authorization_ledger((), created_at=created_at)
+    live_grant_readiness = build_live_grant_readiness_wing(
+        controlled_ledger,
+        safety_gates.safety_gate_satisfaction_manifest,
+        None,
+        readiness_domain="future_cooling_live_grant_review",
+        created_at=created_at,
+    )
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
     contents: dict[str, str] = {
@@ -337,6 +357,22 @@ def build_reviewer_proof_bundle_payload(
         "capability_registry_summary": _pretty_json({"summary": summarize_capability_registry(registry), "records": [record.to_dict() for record in registry.records], "metadata_only": True, "reviewer_proof_only": True}),
         "deferred_action_inventory": _pretty_json(_deferred_action_inventory()),
         "safety_gate_posture": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "safety_gate_only": True, "proof_statement": "Safety gates declare prerequisites only; they are not authorization or fulfillment.", "summary": summarize_safety_gate_satisfaction_manifest(safety_gates.safety_gate_satisfaction_manifest), "records": safety_gates.to_dict()}),
+        "live_grant_readiness_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "readiness_preflight_only": True,
+            "proof_statement": "Live-grant readiness is not a live grant; approval packets are not approval; preflight receipts do not issue grants.",
+            "matrix_summary": summarize_live_grant_prerequisite_matrix(live_grant_readiness.prerequisite_matrix),
+            "approval_packet_summary": summarize_operator_policy_approval_packet(live_grant_readiness.approval_packet),
+            "preflight_summary": summarize_grant_issue_preflight_receipt(live_grant_readiness.preflight_receipt),
+            "denial_deferral_summary": summarize_grant_denial_deferral_receipt(live_grant_readiness.denial_deferral_receipt),
+            "records": {
+                "prerequisite_matrix": live_grant_readiness.prerequisite_matrix.to_dict(),
+                "approval_packet": live_grant_readiness.approval_packet.to_dict(),
+                "preflight_receipt": live_grant_readiness.preflight_receipt.to_dict(),
+                "denial_deferral_receipt": live_grant_readiness.denial_deferral_receipt.to_dict(),
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -378,7 +414,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -116,3 +116,14 @@ def test_reviewer_proof_bundle_cli_writes_safety_gates_json(tmp_path) -> None:
     text = safety_gates.read_text(encoding="utf-8")
     assert "safety_gate_only" in text
     assert "not authorization" in text
+
+
+def test_reviewer_proof_bundle_cli_writes_live_grant_readiness_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    live_grant = output_dir / "live_grant_readiness.json"
+    assert live_grant.exists()
+    text = live_grant.read_text(encoding="utf-8")
+    assert "Live-grant readiness is not a live grant" in text
+    assert "grant_not_issued" in text

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -396,3 +396,20 @@ def test_host_actuation_safety_capabilities_are_metadata_only_and_real_actions_b
         assert by_id[capability_id].status in {"deferred", "blocked"}
         assert by_id[capability_id].authority_level == "none"
         assert by_id[capability_id].host_actuation_performed is False
+
+
+def test_live_grant_readiness_capabilities_are_metadata_only_and_real_actions_remain_deferred() -> None:
+    registry = build_default_capability_registry()
+    records = registry.by_id()
+    assert records["live_grant_readiness"].status == "implemented"
+    assert records["live_grant_readiness"].authority_level == "readiness_only"
+    assert records["live_grant_prerequisite_matrix"].authority_level == "metadata_proof_only"
+    assert records["operator_policy_approval_packet"].authority_level == "packet_only"
+    assert records["grant_issue_preflight_receipt"].authority_level == "preflight_only"
+    assert records["grant_denial_deferral_receipt"].authority_level == "denial_deferral_only"
+    for capability_id in ["live_authorization_grant", "real_effect_execution"]:
+        assert records[capability_id].status == "deferred"
+        assert records[capability_id].host_actuation_performed is False
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+        assert records[capability_id].host_actuation_performed is False

--- a/tests/test_live_grant_readiness.py
+++ b/tests/test_live_grant_readiness.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.controlled_authorization import build_controlled_authorization_wing_for_review_receipt
+from sentientos.host_actuation_safety import build_safety_gates_for_domain
+from sentientos.live_grant_readiness import (
+    REQUIRED_PREREQUISITE_LABELS,
+    build_grant_denial_deferral_receipt,
+    build_grant_issue_preflight_receipt,
+    build_live_grant_prerequisite_matrix,
+    build_live_grant_readiness_wing,
+    build_operator_policy_approval_packet,
+    grant_issue_preflight_receipt_digest,
+    summarize_grant_denial_deferral_receipt,
+    summarize_grant_issue_preflight_receipt,
+    summarize_live_grant_prerequisite_matrix,
+    summarize_operator_policy_approval_packet,
+    validate_grant_denial_deferral_receipt,
+    validate_grant_issue_preflight_receipt,
+    validate_live_grant_prerequisite_matrix,
+    validate_operator_policy_approval_packet,
+)
+from tests.test_controlled_authorization import _review
+
+pytestmark = pytest.mark.no_legacy_skip
+FIXED = "2025-08-01T00:00:00+00:00"
+
+
+def _ledger(kind: str = "future_cooling_policy_candidate"):
+    review = _review(kind, thermal_zone_temperatures_c={"cpu": 91}) if kind == "future_cooling_policy_candidate" else _review(kind)
+    return build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema, created_at=FIXED).ledger
+
+
+def _proof_manifest():
+    return {"manifest_id": "reviewer-proof-bundle-test", "warning_codes": (), "risk_codes": (), "metadata_only": True, "reviewer_proof_only": True}
+
+
+def test_future_cooling_requires_full_prerequisites_and_blocks_fan_pwm_and_thermal() -> None:
+    manifest = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    matrix = build_live_grant_prerequisite_matrix(
+        "future_cooling_live_grant_review",
+        controlled_authorization_ledger=_ledger(),
+        safety_gate_manifest=manifest,
+        reviewer_proof_bundle_manifest=_proof_manifest(),
+        created_at=FIXED,
+    )
+    labels = {p.label for p in matrix.prerequisites}
+    assert REQUIRED_PREREQUISITE_LABELS.issubset(labels)
+    assert matrix.missing_labels == ()
+    assert {"fan_pwm_write", "thermal_actuation", "live_authorization_grant", "host_mutation"}.issubset(matrix.blocked_actions)
+    assert matrix.grants_live_authorization is False
+    assert matrix.effect_performed is False
+    assert validate_live_grant_prerequisite_matrix(matrix).ok
+
+
+@pytest.mark.parametrize(
+    ("domain", "safety_domain", "blocked"),
+    [
+        ("future_power_live_grant_review", "power_control_future", "power_profile_mutation"),
+        ("future_cleanup_live_grant_review", "cleanup_control_future", "file_cleanup"),
+        ("future_cleanup_live_grant_review", "cleanup_control_future", "file_delete"),
+        ("future_service_live_grant_review", "service_control_future", "service_restart"),
+        ("future_service_live_grant_review", "service_control_future", "process_kill"),
+    ],
+)
+def test_future_domains_keep_real_actions_blocked(domain: str, safety_domain: str, blocked: str) -> None:
+    manifest = build_safety_gates_for_domain(safety_domain, created_at=FIXED).safety_gate_satisfaction_manifest
+    matrix = build_live_grant_prerequisite_matrix(domain, controlled_authorization_ledger=_ledger(), safety_gate_manifest=manifest, reviewer_proof_bundle_manifest=_proof_manifest(), created_at=FIXED)
+    assert blocked in matrix.blocked_actions
+    assert matrix.grants_live_authorization is False
+    assert matrix.host_mutation_performed is False
+
+
+@pytest.mark.parametrize("domain,safety_domain", [("diagnostics_live_grant_review", "diagnostics_only"), ("operator_review_live_grant_review", "operator_review")])
+def test_diagnostics_and_operator_review_can_be_ready_but_grant_no_authority(domain: str, safety_domain: str) -> None:
+    manifest = build_safety_gates_for_domain(safety_domain, created_at=FIXED).safety_gate_satisfaction_manifest
+    wing = build_live_grant_readiness_wing(_ledger(), manifest, _proof_manifest(), readiness_domain=domain, created_at=FIXED)
+    assert wing.preflight_receipt.readiness_status in {"live_grant_readiness_ready_for_operator_policy_review", "live_grant_readiness_ready_with_conditions"}
+    assert wing.preflight_receipt.live_authorization_granted is False
+    assert wing.approval_packet.approval_not_granted is True
+
+
+def test_missing_sources_produce_incomplete_and_missing_proof_bundle_warns() -> None:
+    matrix = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    assert "authorization_ledger_present" in matrix.missing_labels
+    assert "safety_gate_satisfaction_manifest_present" in matrix.missing_labels
+    assert "reviewer_proof_bundle_present" in matrix.missing_labels
+    assert "reviewer_proof_bundle_manifest_missing" in matrix.warning_codes
+    packet = build_operator_policy_approval_packet(matrix)
+    receipt = build_grant_issue_preflight_receipt(matrix, packet)
+    assert packet.approval_packet_status == "operator_policy_approval_packet_incomplete"
+    assert receipt.preflight_status == "grant_issue_preflight_incomplete"
+
+
+def test_packet_preflight_and_denial_deferral_are_non_authorizing_non_mutating() -> None:
+    manifest = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    wing = build_live_grant_readiness_wing(_ledger(), manifest, _proof_manifest(), created_at=FIXED)
+    assert wing.approval_packet.approval_packet_only is True
+    assert wing.approval_packet.approval_not_granted is True
+    assert wing.approval_packet.grants_live_authorization is False
+    assert wing.preflight_receipt.preflight_only is True
+    assert wing.preflight_receipt.grant_not_issued is True
+    assert wing.preflight_receipt.live_authorization_granted is False
+    assert wing.denial_deferral_receipt.denial_deferral_only is True
+    assert wing.denial_deferral_receipt.grant_not_issued is True
+    assert wing.denial_deferral_receipt.does_not_mutate_host is True
+    assert validate_operator_policy_approval_packet(wing.approval_packet).ok
+    assert validate_grant_issue_preflight_receipt(wing.preflight_receipt).ok
+    assert validate_grant_denial_deferral_receipt(wing.denial_deferral_receipt).ok
+
+
+@pytest.mark.parametrize("flag", ["grants_live_authorization", "fulfillment_granted", "effect_performed", "host_mutation_performed"])
+def test_matrix_validation_rejects_forbidden_flags(flag: str) -> None:
+    matrix = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    bad = replace(matrix, **{flag: True})
+    result = validate_live_grant_prerequisite_matrix(bad)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+@pytest.mark.parametrize("flag", ["live_authorization_granted", "does_not_execute", "does_not_mutate_host", "grant_not_issued"])
+def test_preflight_validation_rejects_live_authorization_and_missing_non_authority_flags(flag: str) -> None:
+    matrix = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    packet = build_operator_policy_approval_packet(matrix)
+    receipt = build_grant_issue_preflight_receipt(matrix, packet)
+    bad = replace(receipt, **({flag: True} if flag == "live_authorization_granted" else {flag: False}))
+    result = validate_grant_issue_preflight_receipt(bad)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_source_claiming_network_provider_prompt_or_host_action_contradicts_readiness() -> None:
+    manifest = replace(build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest, network_performed=True)
+    wing = build_live_grant_readiness_wing(_ledger(), manifest, _proof_manifest(), created_at=FIXED)
+    assert wing.preflight_receipt.readiness_status == "live_grant_readiness_contradicted"
+    assert wing.preflight_receipt.preflight_status == "grant_issue_preflight_contradicted"
+    assert any("network_performed" in risk for risk in wing.preflight_receipt.risk_codes)
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    matrix1 = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    matrix2 = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    assert matrix1.digest == matrix2.digest
+    packet = build_operator_policy_approval_packet(matrix1)
+    receipt = build_grant_issue_preflight_receipt(matrix1, packet)
+    changed = replace(receipt, warning_codes=("new_warning",), digest="")
+    assert grant_issue_preflight_receipt_digest(changed) != receipt.digest
+
+
+def test_summaries_are_metadata_only() -> None:
+    matrix = build_live_grant_prerequisite_matrix("future_cooling_live_grant_review", created_at=FIXED)
+    packet = build_operator_policy_approval_packet(matrix)
+    preflight = build_grant_issue_preflight_receipt(matrix, packet)
+    denial = build_grant_denial_deferral_receipt(preflight)
+    assert summarize_live_grant_prerequisite_matrix(matrix)["metadata_only"] is True
+    assert summarize_operator_policy_approval_packet(packet)["approval_not_granted"] is True
+    assert summarize_grant_issue_preflight_receipt(preflight)["grant_not_issued"] is True
+    assert summarize_grant_denial_deferral_receipt(denial)["does_not_mutate_host"] is True

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -164,3 +164,13 @@ def test_bundle_includes_host_actuation_safety_gate_posture() -> None:
     assert "safety_gates" in payload
     validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
     assert validation.ok, validation.findings
+
+
+def test_reviewer_bundle_includes_live_grant_readiness_posture() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "live_grant_readiness_posture" in payload["artifacts"]
+    assert "live_grant_readiness.json" in payload["artifacts"]["bundle_manifest"]
+    text = payload["artifacts"]["live_grant_readiness_posture"]
+    assert "Live-grant readiness is not a live grant" in text
+    assert "grant_not_issued" in text
+    assert payload["live_grant_readiness"].preflight_receipt.live_authorization_granted is False

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -355,3 +355,25 @@ def test_host_actuation_safety_gate_doc_preserves_safety_only_boundaries() -> No
     assert "Panic stop contract does not execute panic stop" in doc
     assert "Real actuation remains deferred" in doc
     assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → authorize" in doc
+
+HOST_LIVE_GRANT_READINESS_WING = "docs/architecture/host_live_grant_readiness_wing.md"
+
+
+def test_navigation_links_to_host_live_grant_readiness_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    safety = _read(HOST_ACTUATION_SAFETY_GATE_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, safety, bundle, controlled, trajectory]:
+        assert HOST_LIVE_GRANT_READINESS_WING in text
+
+
+def test_host_live_grant_readiness_doc_preserves_preflight_only_boundaries() -> None:
+    doc = _read(HOST_LIVE_GRANT_READINESS_WING)
+    assert "Live-grant readiness is not a live grant" in doc
+    assert "operator/policy approval packet is not approval" in doc
+    assert "grant issue preflight receipt does not issue a grant" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → authorize" in doc


### PR DESCRIPTION
### Motivation
- Add a metadata-only readiness/preflight layer after Host Actuation Safety Gates that assesses whether controlled authorization, future grant schema, safety gate posture, and reviewer proof-bundle evidence are structurally present for a future live authorization review without issuing or enabling any live authorization or host effects.
- Preserve the repository’s deny-by-default boundary semantics so readiness artifacts remain non-authorizing, non-mutating, and proof-only.

### Description
- Add `sentientos/live_grant_readiness.py` implementing frozen record types, deterministic digests, builders, validators, summaries, and `build_live_grant_readiness_wing(...)` that composes a `LiveGrantPrerequisiteMatrix`, `OperatorPolicyApprovalPacket`, `GrantIssuePreflightReceipt`, and `GrantDenialDeferralReceipt` as metadata-only artifacts.
- Integrate readiness posture into the reviewer proof bundle by adding `live_grant_readiness_posture` → `live_grant_readiness.json` and packaging summaries and records without granting authority. The bundle remains reviewer-proof-only and metadata-only.
- Extend `sentientos/capability_registry.py` with readiness/preflight capability records (`live_grant_readiness`, `live_grant_prerequisite_matrix`, `operator_policy_approval_packet`, `grant_issue_preflight_receipt`, `grant_denial_deferral_receipt`) and add `update_registry_from_live_grant_readiness(...)` to reflect readiness posture without enabling live authority; leave live/fan/thermal/power/service/cleanup capabilities deferred or blocked.
- Add architecture doc `docs/architecture/host_live_grant_readiness_wing.md` and update reviewer/docs links and reviewer-bundle README text to document non-authorizing boundaries; add focused tests in `tests/test_live_grant_readiness.py` and update bundle, CLI, capability-registry, and docs regression tests to cover the new artifact and links.

### Testing
- Ran static compile checks: `python -m py_compile sentientos/live_grant_readiness.py sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py sentientos/capability_registry.py tests/test_live_grant_readiness.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` (success).
- Ran focused pytest suites: `python -m scripts.run_tests -q tests/test_live_grant_readiness.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py` (all tests passed).
- Ran broader integration proof suites: `python -m scripts.run_tests -q tests/test_host_actuation_safety.py tests/test_controlled_authorization.py tests/test_host_embodiment_trace.py` and `python -m scripts.run_tests -q tests/test_authorization_review.py tests/test_effect_proof.py tests/test_runtime_supervisor.py tests/test_actuation_fulfillment.py tests/test_privilege_broker.py` (passed); `tests/test_reviewer_release_readiness_index.py` initially failed due to a missing doc link which was corrected and the suite then passed.
- Reviewer bundle CLI checks: `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and `--summary` created `/tmp/sentientos-reviewer-proof/live_grant_readiness.json` (present, validated metadata-only posture).
- Docs build: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` completed after bootstrapping; initial dependencies missing were bootstrapped per repo tooling.
- Context-hygiene and forbidden-scan checks: `python scripts/verify_context_hygiene_prompt_boundaries.py` and regex scans for forbidden runtime/actuation calls matched only declarative/block labels and validation guards (no operational calls found).

All automated checks and updated regression tests for the new wing passed in this environment; the readiness artifacts are explicitly metadata-only and do not grant or execute host authority.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06201db91c832084cf652077679858)