### PR TITLE
[codex:host-embodiment] add local authorization grant wing

### DIFF
--- a/docs/architecture/host_actuation_safety_gate_wing.md
+++ b/docs/architecture/host_actuation_safety_gate_wing.md
@@ -41,3 +41,7 @@ This wing covers **safety gates** only. It answers: “What gates must be declar
 ## Next wing
 
 The next organ is the [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`), which evaluates post-safety-gate readiness/preflight metadata only. Live-grant readiness is not a live grant; authorization and real actuation remain deferred.
+
+See also: [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md), which follows live-grant readiness and remains authorization-record-only.
+
+Path link: `docs/architecture/host_local_authorization_grant_wing.md`.

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -58,3 +58,7 @@ Proof path: docs/architecture/host_embodiment_reviewer_demo_trace.md
 ## Downstream readiness link
 
 After controlled authorization contracts and safety gates, the [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`) checks readiness/preflight metadata only. Controlled authorization contract is not a live grant, and live-grant readiness is not authorization.
+
+Later ladder link: [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) records scoped local authorization metadata after live-grant readiness without executing host actions.
+
+Path link: `docs/architecture/host_local_authorization_grant_wing.md`.

--- a/docs/architecture/host_live_grant_readiness_wing.md
+++ b/docs/architecture/host_live_grant_readiness_wing.md
@@ -49,3 +49,7 @@ The reviewer proof bundle now includes `live_grant_readiness.json`. That artifac
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_live_grant_readiness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+Next: [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) records bounded local authorization metadata after readiness; it is still not fulfillment.
+
+Path link: `docs/architecture/host_local_authorization_grant_wing.md`.

--- a/docs/architecture/host_local_authorization_grant_wing.md
+++ b/docs/architecture/host_local_authorization_grant_wing.md
@@ -1,0 +1,46 @@
+# Host Local Authorization Grant Wing
+
+This wing follows the [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md). Live-grant readiness is not a live grant; it is a preflight posture. The local authorization grant wing creates bounded local authorization grant records only after readiness prerequisites and operator/policy approval evidence are present.
+
+## Boundary
+
+A local authorization grant is authority metadata, not fulfillment. A local authorization grant does not execute. A local authorization grant does not mutate host state. It does not write fan/PWM controls, perform thermal actuation, mutate power profiles, kill processes, restart services, install packages or drivers, clean up or delete files, perform network egress, invoke providers, assemble/export prompts, transport federation state, or perform remote execution.
+
+An active local authorization grant may record `live_authorization_granted=true`, but that flag remains record-local authority metadata. It does not set `fulfillment_granted`, does not perform an effect, and does not bypass future fulfillment checks.
+
+## Records
+
+- **OperatorApprovalEvidence:** metadata-only operator approval evidence with scope, time bounds, expiry, revocation, risk, warning, and digest labels.
+- **PolicyApprovalEvidence:** metadata-only policy approval evidence with scope, time bounds, expiry, revocation, risk, warning, and digest labels.
+- **LocalAuthorizationGrant:** a scoped, expiring, revocable local authority record. It is not fulfillment and has all effect and host-mutation flags false.
+- **LocalAuthorizationGrantLedger:** metadata-only aggregation of grant, revocation, and expiry posture.
+- **LocalAuthorizationGrantRevocationReceipt:** revocation metadata. The revocation receipt records revocation metadata and does not execute host action.
+- **LocalAuthorizationGrantExpiryEvaluation:** expiry metadata. Expiry evaluation is metadata-only and evaluates labels/timestamps only.
+- **LocalAuthorizationGrantVerification:** lookup/check metadata. Grant verification is not fulfillment authorization and has `authorizes_fulfillment=false`.
+
+## Grant conditions
+
+A grant can be active only when live-grant readiness/preflight is ready or ready-with-conditions and operator approval evidence plus policy approval evidence are present. Blocked, incomplete, or contradicted preflight/evidence produces blocked, incomplete, or contradicted grant records.
+
+Future cooling, power, service, and cleanup grants preserve blocked action labels. Future cooling keeps fan/PWM and thermal action labels blocked. Future power keeps power mutation blocked. Future service keeps service restart and process kill blocked. Future cleanup keeps cleanup and delete labels blocked.
+
+## Future fulfillment remains deferred
+
+Real fulfillment remains deferred. Real actuation remains deferred. Future cooling/power/service/cleanup actions remain behind future fulfillment verification, control-plane admission, audit, rollback, effect receipt, postcondition checks, runtime supervisor observation, immutable trace, and safety gates.
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **local authorization grant lifecycle only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `local_authorization.json`. That artifact is reviewer proof only and metadata only. It includes deterministic sample operator and policy evidence, a bounded local authorization grant record, expiry evaluation, verification, revocation schema example, and ledger summary. The sample may show an active local authorization record, but `fulfillment_granted=false`, `effect_performed=false`, `host_mutation_performed=false`, and grant verification does not authorize fulfillment.
+
+## Implementation links
+
+- Module: `sentientos/local_authorization_grant.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_local_authorization_grant.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -251,3 +251,6 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md` for the one-comma
 Reviewer first-run proof bundle: `docs/architecture/reviewer_first_run_proof_bundle.md`.
 
 Host live-grant readiness is documented in [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`): live-grant readiness is not a live grant, the operator/policy approval packet is not approval, grant issue preflight does not issue a grant, and real actuation remains deferred.
+
+
+Local authorization grant records are documented in [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) (`docs/architecture/host_local_authorization_grant_wing.md`): a local authorization grant is authority metadata, not fulfillment; grant verification is not fulfillment authorization; real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -78,3 +78,7 @@ The reviewer should see that:
 ## Live-grant readiness artifact
 
 The bundle includes `live_grant_readiness.json`, documented in [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`). The artifact is metadata-only reviewer proof: live-grant readiness is not a live grant, the operator/policy approval packet is not approval, and the grant issue preflight receipt does not issue a grant.
+
+The bundle also includes `local_authorization.json` for the [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md); this is authority metadata only and does not authorize fulfillment.
+
+Path link: `docs/architecture/host_local_authorization_grant_wing.md`.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -254,3 +254,6 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: 
 - Architecture: [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`).
 - Proof: `tests/test_live_grant_readiness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, and `tests/test_capability_registry.py`.
 - Boundary: live-grant readiness is not a live grant; operator/policy approval packet is not approval; grant issue preflight does not issue a grant; real actuation remains deferred.
+
+
+- Host Local Authorization Grant Wing: `docs/architecture/host_local_authorization_grant_wing.md`; proof artifact `local_authorization.json`; tests `tests/test_local_authorization_grant.py`. Local authorization grant is authority metadata, not fulfillment, and does not execute.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -398,3 +398,7 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. The external rev
 ### Host Live-Grant Readiness Wing
 
 See [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/architecture/host_live_grant_readiness_wing.md`). It sits after Host Actuation Safety Gates and before any future authorize/fulfill/effect path. It is readiness/preflight only; real actuation remains deferred.
+
+- [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md): implemented bounded authorization-record lifecycle; fulfillment and actuation remain deferred.
+
+Path link: `docs/architecture/host_local_authorization_grant_wing.md`.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -41,6 +41,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "reviewer_proof_bundle",
         "host_actuation_safety",
         "live_grant_readiness",
+        "local_authorization_grant",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -72,6 +73,11 @@ AUTHORITY_LEVELS = frozenset(
         "packet_only",
         "preflight_only",
         "denial_deferral_only",
+        "local_authorization_record_only",
+        "authorization_ledger_only",
+        "revocation_record_only",
+        "expiry_evaluation_only",
+        "verification_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -274,6 +280,12 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("operator_policy_approval_packet", "live_grant_readiness", "implemented", "packet_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("operator/policy approval packet scaffold",), deferred_surfaces=("operator approval", "policy approval", "live authorization grant"), forbidden_implications=("approval packet is approval",)),
         _record("grant_issue_preflight_receipt", "live_grant_readiness", "implemented", "preflight_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("grant issue preflight receipt",), deferred_surfaces=("grant issuance", "fulfillment", "effect receipt"), forbidden_implications=("preflight receipt issues a grant",)),
         _record("grant_denial_deferral_receipt", "live_grant_readiness", "implemented", "denial_deferral_only", source_paths=("sentientos/live_grant_readiness.py",), proof_tests=("tests/test_live_grant_readiness.py",), implemented_surfaces=("grant denial/deferral receipt",), deferred_surfaces=("grant issuance", "host mutation"), forbidden_implications=("denial/deferral receipt mutates host state",)),
+        _record("local_authorization_grant", "local_authorization_grant", "implemented", "local_authorization_record_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), proof_commands=("python -m scripts.run_tests -q tests/test_local_authorization_grant.py",), implemented_surfaces=("bounded local authorization record lifecycle",), deferred_surfaces=("fulfillment authorization consumption", "real effect execution", "host mutation"), forbidden_implications=("local authorization grant is fulfillment", "local authorization grant executes host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("local_authorization_grant_ledger", "local_authorization_grant", "implemented", "authorization_ledger_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("metadata-only local authorization grant ledger",), deferred_surfaces=("host action fulfillment",), forbidden_implications=("ledger mutates host state",)),
+        _record("local_authorization_revocation_receipt", "local_authorization_grant", "implemented", "revocation_record_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("local authorization revocation metadata receipt",), deferred_surfaces=("revocation effect execution",), forbidden_implications=("revocation receipt executes host action",)),
+        _record("local_authorization_expiry_evaluation", "local_authorization_grant", "implemented", "expiry_evaluation_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("metadata-only grant expiry evaluation",), deferred_surfaces=("scheduler or host action execution",), forbidden_implications=("expiry evaluation executes host action",)),
+        _record("local_authorization_verification", "local_authorization_grant", "implemented", "verification_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("grant lookup and verification metadata",), deferred_surfaces=("fulfillment authorization consumption",), forbidden_implications=("verification authorizes fulfillment",)),
+        _record("fulfillment_authorization_consumption", "local_authorization_grant", "deferred", "none", source_paths=("sentientos/local_authorization_grant.py",), deferred_surfaces=("future executor consumption of grant verification", "control-plane admitted fulfillment"), forbidden_implications=("local authorization wing consumes grants for effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -289,7 +301,7 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
     return CapabilityRegistry(registry_id="sentientos-host-embodiment-controlled-authorization-and-trace-wing", schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1", records=records)
 
@@ -868,3 +880,28 @@ def update_registry_from_live_grant_readiness(registry: CapabilityRegistry, read
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-live-grant-readiness-wing.v1")
+
+
+def update_registry_from_local_authorization_ledger(registry: CapabilityRegistry, ledger: Any) -> CapabilityRegistry:
+    """Reflect local authorization grant records without claiming fulfillment."""
+
+    has_ledger = bool(getattr(ledger, "ledger_id", "")) or (isinstance(ledger, Mapping) and bool(ledger.get("ledger_id")))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "local_authorization_grant":
+            records.append(replace(record, status="implemented" if has_ledger else record.status, authority_level="local_authorization_record_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_authorization_grant_ledger":
+            records.append(replace(record, status="implemented" if has_ledger else record.status, authority_level="authorization_ledger_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_authorization_revocation_receipt":
+            records.append(replace(record, status="implemented", authority_level="revocation_record_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_authorization_expiry_evaluation":
+            records.append(replace(record, status="implemented", authority_level="expiry_evaluation_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_authorization_verification":
+            records.append(replace(record, status="implemented", authority_level="verification_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"fulfillment_authorization_consumption", "real_authorization_grant", "real_effect_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-local-authorization-grant-wing.v1")

--- a/sentientos/local_authorization_grant.py
+++ b/sentientos/local_authorization_grant.py
@@ -1,0 +1,542 @@
+"""Metadata-only local authorization grant records.
+
+This wing follows live-grant readiness and records bounded local authorization
+metadata. It does not fulfill actions, execute host changes, perform provider
+work, assemble prompts, or mutate host state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+GRANT_STATUSES = frozenset({
+    "local_authorization_grant_active",
+    "local_authorization_grant_active_with_conditions",
+    "local_authorization_grant_blocked",
+    "local_authorization_grant_incomplete",
+    "local_authorization_grant_contradicted",
+    "local_authorization_grant_revoked",
+    "local_authorization_grant_expired",
+})
+APPROVAL_EVIDENCE_STATUSES = frozenset({
+    "approval_evidence_present",
+    "approval_evidence_present_with_conditions",
+    "approval_evidence_missing",
+    "approval_evidence_blocked",
+    "approval_evidence_contradicted",
+})
+LEDGER_STATUSES = frozenset({
+    "local_authorization_grant_ledger_current",
+    "local_authorization_grant_ledger_current_with_warnings",
+    "local_authorization_grant_ledger_blocked",
+    "local_authorization_grant_ledger_incomplete",
+    "local_authorization_grant_ledger_contradicted",
+})
+REVOCATION_STATUSES = frozenset({
+    "local_authorization_revocation_recorded",
+    "local_authorization_revocation_blocked",
+    "local_authorization_revocation_incomplete",
+    "local_authorization_revocation_contradicted",
+})
+EXPIRY_STATUSES = frozenset({
+    "local_authorization_expiry_not_expired",
+    "local_authorization_expiry_expired",
+    "local_authorization_expiry_missing_bounds",
+    "local_authorization_expiry_contradicted",
+})
+VERIFICATION_STATUSES = frozenset({
+    "local_authorization_verification_valid",
+    "local_authorization_verification_valid_with_conditions",
+    "local_authorization_verification_blocked",
+    "local_authorization_verification_expired",
+    "local_authorization_verification_revoked",
+    "local_authorization_verification_incomplete",
+    "local_authorization_verification_contradicted",
+})
+AUTHORIZATION_DOMAINS = frozenset({
+    "diagnostics_local_authorization",
+    "operator_review_local_authorization",
+    "resource_pressure_local_authorization",
+    "thermal_safety_local_authorization",
+    "future_cooling_local_authorization",
+    "future_power_local_authorization",
+    "future_cleanup_local_authorization",
+    "future_service_local_authorization",
+})
+GRANT_SCOPES = frozenset({
+    "diagnostics_only_scope",
+    "operator_review_scope",
+    "resource_pressure_review_scope",
+    "thermal_safety_review_scope",
+    "future_cooling_scope",
+    "future_power_scope",
+    "future_cleanup_scope",
+    "future_service_scope",
+})
+REQUIRED_GRANT_PREREQUISITES = frozenset({
+    "live_grant_readiness_preflight_required",
+    "operator_approval_evidence_required",
+    "policy_approval_evidence_required",
+    "explicit_scope_required",
+    "time_bounds_required",
+    "expiry_required",
+    "revocation_path_required",
+    "control_plane_admission_required_for_future_fulfillment",
+    "audit_receipt_required_for_future_fulfillment",
+    "rollback_receipt_required_for_future_fulfillment",
+    "effect_receipt_required_for_future_fulfillment",
+    "postcondition_check_required_for_future_fulfillment",
+    "runtime_supervisor_observation_required_for_future_fulfillment",
+    "immutable_trace_required_for_future_fulfillment",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+_DOMAIN_SCOPE = {
+    "diagnostics_local_authorization": "diagnostics_only_scope",
+    "operator_review_local_authorization": "operator_review_scope",
+    "resource_pressure_local_authorization": "resource_pressure_review_scope",
+    "thermal_safety_local_authorization": "thermal_safety_review_scope",
+    "future_cooling_local_authorization": "future_cooling_scope",
+    "future_power_local_authorization": "future_power_scope",
+    "future_cleanup_local_authorization": "future_cleanup_scope",
+    "future_service_local_authorization": "future_service_scope",
+}
+_READINESS_DOMAIN = {
+    "diagnostics_live_grant_review": "diagnostics_local_authorization",
+    "operator_review_live_grant_review": "operator_review_local_authorization",
+    "resource_pressure_live_grant_review": "resource_pressure_local_authorization",
+    "thermal_safety_live_grant_review": "thermal_safety_local_authorization",
+    "future_cooling_live_grant_review": "future_cooling_local_authorization",
+    "future_power_live_grant_review": "future_power_local_authorization",
+    "future_cleanup_live_grant_review": "future_cleanup_local_authorization",
+    "future_service_live_grant_review": "future_service_local_authorization",
+}
+_DOMAIN_BLOCKS = {
+    "future_cooling_local_authorization": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_local_authorization": ("power_profile_mutation",),
+    "future_cleanup_local_authorization": ("file_cleanup", "file_delete"),
+    "future_service_local_authorization": ("service_restart", "process_kill"),
+}
+_FORBIDDEN_TRUE_FLAGS = (
+    "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed",
+    "thermal_actuation_performed", "power_profile_mutation_performed", "process_kill_performed",
+    "service_restart_performed", "package_install_performed", "driver_install_performed",
+    "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed",
+)
+
+@dataclass(frozen=True)
+class LocalAuthorizationPolicy:
+    policy_id: str
+    required_prerequisites: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    metadata_only: bool = True
+    authorization_record_only: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class OperatorApprovalEvidence:
+    evidence_id: str
+    operator_identity_label: str
+    approval_scope_labels: tuple[str, ...]
+    approval_time_bounds: tuple[str, ...]
+    approval_expiry_label: str
+    approval_revocation_label: str
+    approval_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    approval_evidence_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class PolicyApprovalEvidence:
+    evidence_id: str
+    policy_identity_label: str
+    policy_scope_labels: tuple[str, ...]
+    policy_time_bounds: tuple[str, ...]
+    policy_expiry_label: str
+    policy_revocation_label: str
+    approval_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    approval_evidence_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrant:
+    grant_id: str
+    source_live_grant_preflight_receipt_id: str
+    source_live_grant_preflight_receipt_digest: str
+    source_prerequisite_matrix_id: str
+    operator_approval_evidence_id: str
+    operator_approval_evidence_digest: str
+    policy_approval_evidence_id: str
+    policy_approval_evidence_digest: str
+    authorization_domain: str
+    grant_scope: str
+    grant_status: str
+    granted_scope_labels: tuple[str, ...]
+    granted_time_bounds: tuple[str, ...]
+    expiry_label: str
+    revocation_path_labels: tuple[str, ...]
+    required_future_fulfillment_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    authorization_record_only: bool = True
+    live_authorization_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrantRevocationReceipt:
+    receipt_id: str
+    grant_id: str
+    revocation_status: str
+    revocation_reason_codes: tuple[str, ...]
+    revocation_effective_label: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    revocation_record_only: bool = True
+    live_authorization_revoked: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrantExpiryEvaluation:
+    evaluation_id: str
+    grant_id: str
+    expiry_status: str
+    evaluated_at: str
+    expiry_label: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    digest: str
+    metadata_only: bool = True
+    expiry_evaluation_only: bool = True
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrantVerification:
+    verification_id: str
+    grant_id: str
+    verification_status: str
+    checked_scope_labels: tuple[str, ...]
+    checked_time_label: str
+    checked_revocation_labels: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    digest: str
+    metadata_only: bool = True
+    verification_only: bool = True
+    authorizes_fulfillment: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrantLedger:
+    ledger_id: str
+    grant_records: tuple[LocalAuthorizationGrant, ...]
+    revocation_receipts: tuple[LocalAuthorizationGrantRevocationReceipt, ...]
+    expiry_evaluations: tuple[LocalAuthorizationGrantExpiryEvaluation, ...]
+    ledger_status: str
+    active_grant_count: int
+    revoked_grant_count: int
+    expired_grant_count: int
+    blocked_grant_count: int
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    authorization_ledger_only: bool = True
+    host_mutation_performed: bool = False
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class LocalAuthorizationGrantValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+class LocalAuthorizationGrantWingRecords(NamedTuple):
+    grant: LocalAuthorizationGrant
+    expiry_evaluation: LocalAuthorizationGrantExpiryEvaluation
+    verification: LocalAuthorizationGrantVerification
+    revocation_receipt: LocalAuthorizationGrantRevocationReceipt
+    ledger: LocalAuthorizationGrantLedger
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = record_or_payload.to_dict() if hasattr(record_or_payload, "to_dict") else dict(record_or_payload)
+    payload["digest"] = ""
+    return payload
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+def local_authorization_grant_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+operator_approval_evidence_digest = local_authorization_grant_digest
+policy_approval_evidence_digest = local_authorization_grant_digest
+local_authorization_grant_revocation_receipt_digest = local_authorization_grant_digest
+local_authorization_grant_expiry_evaluation_digest = local_authorization_grant_digest
+local_authorization_grant_verification_digest = local_authorization_grant_digest
+local_authorization_grant_ledger_digest = local_authorization_grant_digest
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+def build_default_local_authorization_policy() -> LocalAuthorizationPolicy:
+    return LocalAuthorizationPolicy("local-authorization-grant-policy-v1", tuple(sorted(REQUIRED_GRANT_PREREQUISITES)), tuple(sorted(BLOCKED_ACTION_LABELS)))
+
+def build_operator_approval_evidence(*, evidence_id: str | None = None, operator_identity_label: str = "sample_operator", approval_scope_labels: Sequence[str] = ("future_cooling_scope",), approval_time_bounds: Sequence[str] = ("not_before:1970-01-01T00:00:00+00:00", "not_after:1970-01-02T00:00:00+00:00"), approval_expiry_label: str = "expires:1970-01-02T00:00:00+00:00", approval_revocation_label: str = "revocable:local_authorization_revocation_receipt", approval_status: str = "approval_evidence_present", warning_codes: Sequence[str] = (), risk_codes: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> OperatorApprovalEvidence:
+    eid = evidence_id or _digest_id("operator-approval-", {"operator": operator_identity_label, "scope": _tuple(approval_scope_labels), "created_at": created_at})
+    provisional = OperatorApprovalEvidence(eid, operator_identity_label, _tuple(approval_scope_labels), _tuple(approval_time_bounds), approval_expiry_label, approval_revocation_label, approval_status, _tuple(warning_codes), _tuple(risk_codes), created_at, "")
+    return replace(provisional, digest=operator_approval_evidence_digest(provisional))
+
+def build_policy_approval_evidence(*, evidence_id: str | None = None, policy_identity_label: str = "sample_policy", policy_scope_labels: Sequence[str] = ("future_cooling_scope",), policy_time_bounds: Sequence[str] = ("not_before:1970-01-01T00:00:00+00:00", "not_after:1970-01-02T00:00:00+00:00"), policy_expiry_label: str = "expires:1970-01-02T00:00:00+00:00", policy_revocation_label: str = "revocable:local_authorization_revocation_receipt", approval_status: str = "approval_evidence_present", warning_codes: Sequence[str] = (), risk_codes: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> PolicyApprovalEvidence:
+    eid = evidence_id or _digest_id("policy-approval-", {"policy": policy_identity_label, "scope": _tuple(policy_scope_labels), "created_at": created_at})
+    provisional = PolicyApprovalEvidence(eid, policy_identity_label, _tuple(policy_scope_labels), _tuple(policy_time_bounds), policy_expiry_label, policy_revocation_label, approval_status, _tuple(warning_codes), _tuple(risk_codes), created_at, "")
+    return replace(provisional, digest=policy_approval_evidence_digest(provisional))
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+def _grant_status(preflight: Mapping[str, Any], operator: OperatorApprovalEvidence | Mapping[str, Any] | None, policy: PolicyApprovalEvidence | Mapping[str, Any] | None) -> str:
+    pstatus = str(preflight.get("preflight_status", ""))
+    rstatus = str(preflight.get("readiness_status", ""))
+    op = _source_payload(operator) if operator is not None else {"approval_status": "approval_evidence_missing"}
+    pol = _source_payload(policy) if policy is not None else {"approval_status": "approval_evidence_missing"}
+    statuses = (str(op.get("approval_status", "")), str(pol.get("approval_status", "")))
+    if "contradicted" in pstatus or "contradicted" in rstatus or any("contradicted" in s for s in statuses):
+        return "local_authorization_grant_contradicted"
+    if "blocked" in pstatus or "blocked" in rstatus or any("blocked" in s for s in statuses):
+        return "local_authorization_grant_blocked"
+    if "incomplete" in pstatus or "incomplete" in rstatus or any("missing" in s for s in statuses):
+        return "local_authorization_grant_incomplete"
+    if pstatus == "grant_issue_preflight_recorded_with_warnings" or rstatus == "live_grant_readiness_ready_with_conditions" or any(s == "approval_evidence_present_with_conditions" for s in statuses):
+        return "local_authorization_grant_active_with_conditions"
+    if pstatus == "grant_issue_preflight_recorded" and rstatus == "live_grant_readiness_ready_for_operator_policy_review" and all(s == "approval_evidence_present" for s in statuses):
+        return "local_authorization_grant_active"
+    return "local_authorization_grant_incomplete"
+
+def build_local_authorization_grant(preflight_receipt: Any, prerequisite_matrix: Any, operator_approval_evidence: OperatorApprovalEvidence | Mapping[str, Any] | None, policy_approval_evidence: PolicyApprovalEvidence | Mapping[str, Any] | None, *, authorization_domain: str | None = None, grant_scope: str | None = None, grant_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> LocalAuthorizationGrant:
+    preflight = _source_payload(preflight_receipt)
+    matrix = _source_payload(prerequisite_matrix)
+    op = _source_payload(operator_approval_evidence) if operator_approval_evidence is not None else {}
+    pol = _source_payload(policy_approval_evidence) if policy_approval_evidence is not None else {}
+    domain = authorization_domain or _READINESS_DOMAIN.get(str(preflight.get("readiness_domain") or matrix.get("readiness_domain")), "future_cooling_local_authorization")
+    scope = grant_scope or _DOMAIN_SCOPE.get(domain, "future_cooling_scope")
+    status = _grant_status(preflight, operator_approval_evidence, policy_approval_evidence)
+    blocked = tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_tuple(preflight.get("blocked_actions"))) | set(_tuple(matrix.get("blocked_actions"))) | set(_DOMAIN_BLOCKS.get(domain, ()))) )
+    warnings = set(_tuple(preflight.get("warning_codes"))) | set(_tuple(matrix.get("warning_codes"))) | set(_tuple(op.get("warning_codes"))) | set(_tuple(pol.get("warning_codes")))
+    risks = set(_tuple(preflight.get("risk_codes"))) | set(_tuple(matrix.get("risk_codes"))) | set(_tuple(op.get("risk_codes"))) | set(_tuple(pol.get("risk_codes"))) | {"local_authorization_is_not_fulfillment"}
+    if not op:
+        warnings.add("operator_approval_evidence_missing")
+    if not pol:
+        warnings.add("policy_approval_evidence_missing")
+    gid = grant_id or _digest_id("local-auth-grant-", {"preflight": preflight.get("receipt_id"), "operator": op.get("evidence_id"), "policy": pol.get("evidence_id"), "domain": domain, "scope": scope})
+    provisional = LocalAuthorizationGrant(
+        gid, str(preflight.get("receipt_id", "")), str(preflight.get("digest", "")), str(matrix.get("matrix_id", preflight.get("source_prerequisite_matrix_id", ""))),
+        str(op.get("evidence_id", "")), str(op.get("digest", "")), str(pol.get("evidence_id", "")), str(pol.get("digest", "")), domain, scope, status,
+        tuple(sorted(set(_tuple(op.get("approval_scope_labels"))) | set(_tuple(pol.get("policy_scope_labels"))) | {scope})),
+        tuple(sorted(set(_tuple(op.get("approval_time_bounds"))) | set(_tuple(pol.get("policy_time_bounds"))))),
+        str(op.get("approval_expiry_label") or pol.get("policy_expiry_label") or ""),
+        tuple(sorted({str(op.get("approval_revocation_label", "")), str(pol.get("policy_revocation_label", ""))} - {""})),
+        tuple(sorted(REQUIRED_GRANT_PREREQUISITES)), blocked, tuple(sorted(warnings)), tuple(sorted(risks)), created_at, "",
+        live_authorization_granted=status in {"local_authorization_grant_active", "local_authorization_grant_active_with_conditions"},
+    )
+    return replace(provisional, digest=local_authorization_grant_digest(provisional))
+
+def build_local_authorization_grant_revocation_receipt(grant: LocalAuthorizationGrant | Mapping[str, Any], *, receipt_id: str | None = None, revocation_status: str = "local_authorization_revocation_recorded", revocation_reason_codes: Sequence[str] = ("operator_or_policy_revocation_recorded",), revocation_effective_label: str = "effective:immediate", warning_codes: Sequence[str] = (), risk_codes: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> LocalAuthorizationGrantRevocationReceipt:
+    g = _source_payload(grant)
+    rid = receipt_id or _digest_id("local-auth-revocation-", {"grant": g.get("grant_id"), "status": revocation_status, "created_at": created_at})
+    provisional = LocalAuthorizationGrantRevocationReceipt(rid, str(g.get("grant_id", "")), revocation_status, _tuple(revocation_reason_codes), revocation_effective_label, _tuple(warning_codes), _tuple(risk_codes), created_at, "", live_authorization_revoked=revocation_status == "local_authorization_revocation_recorded")
+    return replace(provisional, digest=local_authorization_grant_revocation_receipt_digest(provisional))
+
+def build_local_authorization_grant_expiry_evaluation(grant: LocalAuthorizationGrant | Mapping[str, Any], *, evaluated_at: str = "1970-01-01T00:00:00+00:00", expiry_status: str | None = None, warning_codes: Sequence[str] = (), risk_codes: Sequence[str] = ()) -> LocalAuthorizationGrantExpiryEvaluation:
+    g = _source_payload(grant)
+    expiry = str(g.get("expiry_label", ""))
+    status = expiry_status or ("local_authorization_expiry_missing_bounds" if not expiry else ("local_authorization_expiry_expired" if expiry.startswith("expired") or (expiry.startswith("expires:") and evaluated_at > expiry.removeprefix("expires:")) else "local_authorization_expiry_not_expired"))
+    provisional = LocalAuthorizationGrantExpiryEvaluation(_digest_id("local-auth-expiry-", {"grant": g.get("grant_id"), "evaluated_at": evaluated_at, "expiry": expiry}), str(g.get("grant_id", "")), status, evaluated_at, expiry, _tuple(warning_codes), _tuple(risk_codes), "")
+    return replace(provisional, digest=local_authorization_grant_expiry_evaluation_digest(provisional))
+
+def verify_local_authorization_grant(grant: LocalAuthorizationGrant | Mapping[str, Any], *, checked_scope_labels: Sequence[str] | None = None, checked_time_label: str = "1970-01-01T00:00:00+00:00", checked_revocation_labels: Sequence[str] = (), expiry_evaluation: LocalAuthorizationGrantExpiryEvaluation | Mapping[str, Any] | None = None, revocation_receipts: Sequence[LocalAuthorizationGrantRevocationReceipt | Mapping[str, Any]] = ()) -> LocalAuthorizationGrantVerification:
+    g = _source_payload(grant)
+    checked = _tuple(checked_scope_labels) or _tuple(g.get("granted_scope_labels"))
+    missing = tuple(sorted(set(checked) - set(_tuple(g.get("granted_scope_labels")))))
+    status = "local_authorization_verification_valid"
+    if str(g.get("grant_status", "")).endswith("contradicted"):
+        status = "local_authorization_verification_contradicted"
+    elif str(g.get("grant_status", "")).endswith("blocked"):
+        status = "local_authorization_verification_blocked"
+    elif str(g.get("grant_status", "")).endswith("incomplete") or missing:
+        status = "local_authorization_verification_incomplete"
+    elif str(g.get("grant_status", "")).endswith("expired") or (expiry_evaluation is not None and "expired" in str(_source_payload(expiry_evaluation).get("expiry_status"))):
+        status = "local_authorization_verification_expired"
+    elif str(g.get("grant_status", "")).endswith("revoked") or any(_source_payload(r).get("revocation_status") == "local_authorization_revocation_recorded" for r in revocation_receipts):
+        status = "local_authorization_verification_revoked"
+    elif str(g.get("grant_status")) == "local_authorization_grant_active_with_conditions":
+        status = "local_authorization_verification_valid_with_conditions"
+    provisional = LocalAuthorizationGrantVerification(_digest_id("local-auth-verification-", {"grant": g.get("grant_id"), "scope": checked, "time": checked_time_label, "rev": _tuple(checked_revocation_labels)}), str(g.get("grant_id", "")), status, checked, checked_time_label, _tuple(checked_revocation_labels), missing, (), ("verification_is_not_fulfillment_authorization",), "")
+    return replace(provisional, digest=local_authorization_grant_verification_digest(provisional))
+
+def build_local_authorization_grant_ledger(grant_records: Sequence[LocalAuthorizationGrant], revocation_receipts: Sequence[LocalAuthorizationGrantRevocationReceipt] = (), expiry_evaluations: Sequence[LocalAuthorizationGrantExpiryEvaluation] = (), *, ledger_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> LocalAuthorizationGrantLedger:
+    grants = tuple(grant_records); revocations = tuple(revocation_receipts); expiries = tuple(expiry_evaluations)
+    statuses = {g.grant_status for g in grants} | {r.revocation_status for r in revocations} | {e.expiry_status for e in expiries}
+    if any("contradicted" in s for s in statuses): ledger_status = "local_authorization_grant_ledger_contradicted"
+    elif any("incomplete" in s or "missing" in s for s in statuses): ledger_status = "local_authorization_grant_ledger_incomplete"
+    elif any("blocked" in s for s in statuses): ledger_status = "local_authorization_grant_ledger_blocked"
+    elif any(g.warning_codes for g in grants) or any(r.warning_codes for r in revocations) or any(e.warning_codes for e in expiries): ledger_status = "local_authorization_grant_ledger_current_with_warnings"
+    else: ledger_status = "local_authorization_grant_ledger_current"
+    revoked_ids = {r.grant_id for r in revocations if r.revocation_status == "local_authorization_revocation_recorded"}
+    expired_ids = {e.grant_id for e in expiries if e.expiry_status == "local_authorization_expiry_expired"}
+    provisional = LocalAuthorizationGrantLedger(ledger_id or _digest_id("local-auth-ledger-", {"grants": [g.grant_id for g in grants], "revocations": [r.receipt_id for r in revocations], "expiries": [e.evaluation_id for e in expiries]}), grants, revocations, expiries, ledger_status, sum(1 for g in grants if g.grant_status.startswith("local_authorization_grant_active") and g.grant_id not in revoked_ids and g.grant_id not in expired_ids), len(revoked_ids), len(expired_ids), sum(1 for g in grants if g.grant_status == "local_authorization_grant_blocked"), tuple(sorted({w for g in grants for w in g.warning_codes})), tuple(sorted({r for g in grants for r in g.risk_codes} | {"ledger_does_not_mutate_host"})), created_at, "")
+    return replace(provisional, digest=local_authorization_grant_ledger_digest(provisional))
+
+def _validate_common(payload: Mapping[str, Any], prefix: str) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False): findings.append(prefix + "not_metadata_only")
+    for flag in ("does_not_execute", "does_not_mutate_host"):
+        if flag in payload and not payload.get(flag, False): findings.append(prefix + flag + "_false")
+    return findings
+
+def validate_operator_approval_evidence(evidence: OperatorApprovalEvidence | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(evidence); f = _validate_common(p, "operator_approval:")
+    if p.get("approval_status") not in APPROVAL_EVIDENCE_STATUSES: f.append("operator_approval:unknown_status")
+    if not p.get("approval_evidence_only", False): f.append("operator_approval:not_evidence_only")
+    if p.get("digest") and p.get("digest") != operator_approval_evidence_digest(p): f.append("operator_approval:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_policy_approval_evidence(evidence: PolicyApprovalEvidence | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(evidence); f = _validate_common(p, "policy_approval:")
+    if p.get("approval_status") not in APPROVAL_EVIDENCE_STATUSES: f.append("policy_approval:unknown_status")
+    if not p.get("approval_evidence_only", False): f.append("policy_approval:not_evidence_only")
+    if p.get("digest") and p.get("digest") != policy_approval_evidence_digest(p): f.append("policy_approval:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_local_authorization_grant(grant: LocalAuthorizationGrant | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(grant); f = _validate_common(p, "grant:")
+    if p.get("grant_status") not in GRANT_STATUSES: f.append("grant:unknown_status")
+    if p.get("authorization_domain") not in AUTHORIZATION_DOMAINS: f.append("grant:unknown_domain")
+    if p.get("grant_scope") not in GRANT_SCOPES: f.append("grant:unknown_scope")
+    if not p.get("authorization_record_only", False): f.append("grant:not_authorization_record_only")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if p.get(flag, False): f.append(f"grant:forbidden_flag:{flag}")
+    if p.get("live_authorization_granted", False) and p.get("grant_status") not in {"local_authorization_grant_active", "local_authorization_grant_active_with_conditions"}: f.append("grant:live_authorization_without_active_status")
+    if p.get("digest") and p.get("digest") != local_authorization_grant_digest(p): f.append("grant:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_local_authorization_grant_revocation_receipt(receipt: LocalAuthorizationGrantRevocationReceipt | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(receipt); f = _validate_common(p, "revocation:")
+    if p.get("revocation_status") not in REVOCATION_STATUSES: f.append("revocation:unknown_status")
+    if p.get("live_authorization_revoked", False) and p.get("revocation_status") != "local_authorization_revocation_recorded": f.append("revocation:revoked_flag_without_recorded_status")
+    if p.get("digest") and p.get("digest") != local_authorization_grant_revocation_receipt_digest(p): f.append("revocation:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_local_authorization_grant_expiry_evaluation(evaluation: LocalAuthorizationGrantExpiryEvaluation | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(evaluation); f = _validate_common(p, "expiry:")
+    if p.get("expiry_status") not in EXPIRY_STATUSES: f.append("expiry:unknown_status")
+    if not p.get("expiry_evaluation_only", False): f.append("expiry:not_evaluation_only")
+    if p.get("digest") and p.get("digest") != local_authorization_grant_expiry_evaluation_digest(p): f.append("expiry:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_local_authorization_grant_verification(verification: LocalAuthorizationGrantVerification | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(verification); f = _validate_common(p, "verification:")
+    if p.get("verification_status") not in VERIFICATION_STATUSES: f.append("verification:unknown_status")
+    if p.get("authorizes_fulfillment", False): f.append("verification:authorizes_fulfillment")
+    if p.get("digest") and p.get("digest") != local_authorization_grant_verification_digest(p): f.append("verification:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def validate_local_authorization_grant_ledger(ledger: LocalAuthorizationGrantLedger | Mapping[str, Any]) -> LocalAuthorizationGrantValidationResult:
+    p = _source_payload(ledger); f: list[str] = []
+    if not p.get("metadata_only", False): f.append("ledger:not_metadata_only")
+    if not p.get("authorization_ledger_only", False): f.append("ledger:not_authorization_ledger_only")
+    if p.get("host_mutation_performed", False): f.append("ledger:host_mutation_performed")
+    if p.get("ledger_status") not in LEDGER_STATUSES: f.append("ledger:unknown_status")
+    if p.get("digest") and p.get("digest") != local_authorization_grant_ledger_digest(p): f.append("ledger:digest_mismatch")
+    return LocalAuthorizationGrantValidationResult(not f, tuple(f))
+
+def summarize_operator_approval_evidence(evidence: OperatorApprovalEvidence | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(evidence); return {k: p.get(k) for k in ("evidence_id", "operator_identity_label", "approval_status", "metadata_only", "approval_evidence_only", "does_not_execute", "does_not_mutate_host", "digest")}
+
+def summarize_policy_approval_evidence(evidence: PolicyApprovalEvidence | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(evidence); return {k: p.get(k) for k in ("evidence_id", "policy_identity_label", "approval_status", "metadata_only", "approval_evidence_only", "does_not_execute", "does_not_mutate_host", "digest")}
+
+def summarize_local_authorization_grant(grant: LocalAuthorizationGrant | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(grant); return {k: p.get(k) for k in ("grant_id", "authorization_domain", "grant_scope", "grant_status", "metadata_only", "authorization_record_only", "live_authorization_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "digest")}
+
+def summarize_local_authorization_grant_revocation_receipt(receipt: LocalAuthorizationGrantRevocationReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt); return {k: p.get(k) for k in ("receipt_id", "grant_id", "revocation_status", "metadata_only", "revocation_record_only", "live_authorization_revoked", "does_not_execute", "does_not_mutate_host", "digest")}
+
+def summarize_local_authorization_grant_expiry_evaluation(evaluation: LocalAuthorizationGrantExpiryEvaluation | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(evaluation); return {k: p.get(k) for k in ("evaluation_id", "grant_id", "expiry_status", "metadata_only", "expiry_evaluation_only", "does_not_execute", "does_not_mutate_host", "digest")}
+
+def summarize_local_authorization_grant_verification(verification: LocalAuthorizationGrantVerification | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(verification); return {k: p.get(k) for k in ("verification_id", "grant_id", "verification_status", "metadata_only", "verification_only", "authorizes_fulfillment", "does_not_execute", "does_not_mutate_host", "digest")}
+
+def summarize_local_authorization_grant_ledger(ledger: LocalAuthorizationGrantLedger | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(ledger); return {k: p.get(k) for k in ("ledger_id", "ledger_status", "active_grant_count", "revoked_grant_count", "expired_grant_count", "blocked_grant_count", "metadata_only", "authorization_ledger_only", "host_mutation_performed", "digest")}
+
+def build_local_authorization_grant_wing(preflight_receipt: Any, prerequisite_matrix: Any, operator_approval_evidence: OperatorApprovalEvidence, policy_approval_evidence: PolicyApprovalEvidence, *, authorization_domain: str | None = None, grant_scope: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> LocalAuthorizationGrantWingRecords:
+    grant = build_local_authorization_grant(preflight_receipt, prerequisite_matrix, operator_approval_evidence, policy_approval_evidence, authorization_domain=authorization_domain, grant_scope=grant_scope, created_at=created_at)
+    expiry = build_local_authorization_grant_expiry_evaluation(grant, evaluated_at=created_at)
+    verification = verify_local_authorization_grant(grant, checked_scope_labels=grant.granted_scope_labels, checked_time_label=created_at, expiry_evaluation=expiry)
+    revocation = build_local_authorization_grant_revocation_receipt(grant, revocation_status="local_authorization_revocation_incomplete", revocation_reason_codes=("example_revocation_schema_not_exercised",), created_at=created_at)
+    ledger = build_local_authorization_grant_ledger((grant,), (), (expiry,), created_at=created_at)
+    return LocalAuthorizationGrantWingRecords(grant, expiry, verification, revocation, ledger)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -18,13 +18,24 @@ from typing import Any, Mapping, Sequence
 from sentientos.capability_registry import build_default_capability_registry, summarize_capability_registry
 from sentientos.host_embodiment_trace import build_host_embodiment_demo_trace, summarize_host_embodiment_trace
 from sentientos.host_actuation_safety import build_safety_gates_for_domain, summarize_safety_gate_satisfaction_manifest
-from sentientos.controlled_authorization import build_controlled_authorization_ledger
 from sentientos.live_grant_readiness import (
     build_live_grant_readiness_wing,
     summarize_grant_denial_deferral_receipt,
     summarize_grant_issue_preflight_receipt,
     summarize_live_grant_prerequisite_matrix,
     summarize_operator_policy_approval_packet,
+)
+from sentientos.local_authorization_grant import (
+    build_local_authorization_grant_wing,
+    build_operator_approval_evidence,
+    build_policy_approval_evidence,
+    summarize_local_authorization_grant,
+    summarize_local_authorization_grant_expiry_evaluation,
+    summarize_local_authorization_grant_ledger,
+    summarize_local_authorization_grant_revocation_receipt,
+    summarize_local_authorization_grant_verification,
+    summarize_operator_approval_evidence,
+    summarize_policy_approval_evidence,
 )
 from sentientos.host_embodiment_trace_export import (
     serialize_host_embodiment_trace_json,
@@ -53,6 +64,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "bundle_manifest",
         "safety_gate_posture",
         "live_grant_readiness_posture",
+        "local_authorization_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -75,6 +87,7 @@ BUNDLE_FILE_NAMES = {
     "bundle_manifest": "bundle_manifest.json",
     "safety_gate_posture": "safety_gates.json",
     "live_grant_readiness_posture": "live_grant_readiness.json",
+    "local_authorization_posture": "local_authorization.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -290,8 +303,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "3. `deferred_actions.json` — deferred/blocked action inventory.",
             "4. `safety_gates.json` — metadata-only host actuation safety gate posture.",
             "5. `live_grant_readiness.json` — readiness/preflight-only future live-grant posture; it is not a grant.",
-            "6. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "7. `capability_registry_summary.json` — metadata-only capability posture.",
+            "6. `local_authorization.json` — bounded local authorization-record posture; it is not fulfillment.",
+            "7. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "8. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -304,6 +318,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Network/provider/prompt assembly performed: false",
             "- Safety gates are not authorization and do not grant fulfillment or control authority.",
             "- Live-grant readiness is not a live grant; the approval packet is not approval; preflight does not issue a grant.",
+            "- Local authorization grant records are authority metadata only; verification does not authorize fulfillment.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -339,17 +354,34 @@ def build_reviewer_proof_bundle_payload(
         raise ValueError("invalid trace export payload: " + ", ".join(trace_validation.findings))
 
     registry = build_default_capability_registry()
+    manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
     safety_gates = build_safety_gates_for_domain("cooling_control_future", created_at=created_at)
-    controlled_ledger = build_controlled_authorization_ledger((), created_at=created_at)
+    controlled_ledger = {
+        "ledger_id": "sample-controlled-authorization-ledger-for-reviewer-proof",
+        "grant_records": ({"grant_record_id": "sample-controlled-grant-schema"},),
+        "revocation_records": ({"revocation_id": "sample-revocation-schema"},),
+        "metadata_only": True,
+        "ledger_only": True,
+        "host_mutation_performed": False,
+    }
+    proof_manifest_stub = {"manifest_id": manifest_id, "metadata_only": True, "reviewer_proof_only": True}
     live_grant_readiness = build_live_grant_readiness_wing(
         controlled_ledger,
         safety_gates.safety_gate_satisfaction_manifest,
-        None,
+        proof_manifest_stub,
         readiness_domain="future_cooling_live_grant_review",
         created_at=created_at,
     )
+    operator_evidence = build_operator_approval_evidence(created_at=created_at)
+    policy_evidence = build_policy_approval_evidence(created_at=created_at)
+    local_authorization = build_local_authorization_grant_wing(
+        live_grant_readiness.preflight_receipt,
+        live_grant_readiness.prerequisite_matrix,
+        operator_evidence,
+        policy_evidence,
+        created_at=created_at,
+    )
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
-    manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
         "trace_markdown": serialize_host_embodiment_trace_markdown(trace),
@@ -371,6 +403,33 @@ def build_reviewer_proof_bundle_payload(
                 "approval_packet": live_grant_readiness.approval_packet.to_dict(),
                 "preflight_receipt": live_grant_readiness.preflight_receipt.to_dict(),
                 "denial_deferral_receipt": live_grant_readiness.denial_deferral_receipt.to_dict(),
+            },
+        }),
+
+        "local_authorization_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "authorization_record_only": True,
+            "proof_statement": "A local authorization grant is authority metadata, not fulfillment; verification does not authorize fulfillment and no effect or host mutation is performed.",
+            "operator_approval_evidence_summary": summarize_operator_approval_evidence(operator_evidence),
+            "policy_approval_evidence_summary": summarize_policy_approval_evidence(policy_evidence),
+            "grant_summary": summarize_local_authorization_grant(local_authorization.grant),
+            "expiry_evaluation_summary": summarize_local_authorization_grant_expiry_evaluation(local_authorization.expiry_evaluation),
+            "verification_summary": summarize_local_authorization_grant_verification(local_authorization.verification),
+            "revocation_receipt_summary": summarize_local_authorization_grant_revocation_receipt(local_authorization.revocation_receipt),
+            "ledger_summary": summarize_local_authorization_grant_ledger(local_authorization.ledger),
+            "fulfillment_granted": False,
+            "effect_performed": False,
+            "host_mutation_performed": False,
+            "real_actuation_deferred": True,
+            "records": {
+                "operator_approval_evidence": operator_evidence.to_dict(),
+                "policy_approval_evidence": policy_evidence.to_dict(),
+                "grant": local_authorization.grant.to_dict(),
+                "expiry_evaluation": local_authorization.expiry_evaluation.to_dict(),
+                "verification": local_authorization.verification.to_dict(),
+                "revocation_receipt_schema_example": local_authorization.revocation_receipt.to_dict(),
+                "ledger": local_authorization.ledger.to_dict(),
             },
         }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
@@ -414,7 +473,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -127,3 +127,18 @@ def test_reviewer_proof_bundle_cli_writes_live_grant_readiness_json(tmp_path) ->
     text = live_grant.read_text(encoding="utf-8")
     assert "Live-grant readiness is not a live grant" in text
     assert "grant_not_issued" in text
+
+
+def test_reviewer_proof_bundle_cli_writes_local_authorization_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    local_authorization = output_dir / "local_authorization.json"
+    assert local_authorization.exists()
+    payload = json.loads(local_authorization.read_text(encoding="utf-8"))
+    assert payload["authorization_record_only"] is True
+    assert payload["grant_summary"]["live_authorization_granted"] is True
+    assert payload["grant_summary"]["fulfillment_granted"] is False
+    assert payload["grant_summary"]["effect_performed"] is False
+    assert payload["grant_summary"]["host_mutation_performed"] is False
+    assert payload["verification_summary"]["authorizes_fulfillment"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -413,3 +413,37 @@ def test_live_grant_readiness_capabilities_are_metadata_only_and_real_actions_re
     for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
         assert records[capability_id].status == "blocked"
         assert records[capability_id].host_actuation_performed is False
+
+
+def test_local_authorization_capabilities_are_record_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["local_authorization_grant"].status == "implemented"
+    assert records["local_authorization_grant"].authority_level == "local_authorization_record_only"
+    assert records["local_authorization_grant"].host_actuation_performed is False
+    assert "host mutation" in records["local_authorization_grant"].deferred_surfaces
+    assert records["local_authorization_grant_ledger"].authority_level == "authorization_ledger_only"
+    assert records["local_authorization_revocation_receipt"].authority_level == "revocation_record_only"
+    assert records["local_authorization_expiry_evaluation"].authority_level == "expiry_evaluation_only"
+    assert records["local_authorization_verification"].authority_level == "verification_only"
+    assert records["fulfillment_authorization_consumption"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status in {"blocked", "deferred"}
+    assert records["real_thermal_actuation"].status in {"blocked", "deferred"}
+    assert records["real_power_profile_mutation"].status in {"blocked", "deferred"}
+    assert records["real_service_restart"].status in {"blocked", "deferred"}
+    assert records["real_file_cleanup"].status in {"blocked", "deferred"}
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_updates_from_local_authorization_ledger_without_fulfillment() -> None:
+    from sentientos.capability_registry import update_registry_from_local_authorization_ledger
+    from sentientos.local_authorization_grant import build_local_authorization_grant_ledger
+
+    registry = update_registry_from_local_authorization_ledger(build_default_capability_registry(), build_local_authorization_grant_ledger(()))
+    records = registry.by_id()
+    assert records["local_authorization_grant"].authority_level == "local_authorization_record_only"
+    assert records["local_authorization_grant_ledger"].authority_level == "authorization_ledger_only"
+    assert records["fulfillment_authorization_consumption"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_local_authorization_grant.py
+++ b/tests/test_local_authorization_grant.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.controlled_authorization import build_controlled_authorization_wing_for_review_receipt
+from sentientos.host_actuation_safety import build_safety_gates_for_domain
+from sentientos.live_grant_readiness import build_live_grant_readiness_wing
+from sentientos.local_authorization_grant import (
+    build_local_authorization_grant,
+    build_local_authorization_grant_expiry_evaluation,
+    build_local_authorization_grant_ledger,
+    build_local_authorization_grant_revocation_receipt,
+    build_local_authorization_grant_wing,
+    build_operator_approval_evidence,
+    build_policy_approval_evidence,
+    local_authorization_grant_digest,
+    summarize_local_authorization_grant,
+    summarize_local_authorization_grant_expiry_evaluation,
+    summarize_local_authorization_grant_ledger,
+    summarize_local_authorization_grant_revocation_receipt,
+    summarize_local_authorization_grant_verification,
+    summarize_operator_approval_evidence,
+    summarize_policy_approval_evidence,
+    validate_local_authorization_grant,
+    validate_local_authorization_grant_expiry_evaluation,
+    validate_local_authorization_grant_ledger,
+    validate_local_authorization_grant_revocation_receipt,
+    validate_local_authorization_grant_verification,
+    validate_operator_approval_evidence,
+    validate_policy_approval_evidence,
+    verify_local_authorization_grant,
+)
+from tests.test_controlled_authorization import _review
+
+pytestmark = pytest.mark.no_legacy_skip
+FIXED = "2025-08-01T00:00:00+00:00"
+
+
+def _readiness(kind: str = "future_cooling_policy_candidate", readiness_domain: str = "future_cooling_live_grant_review", safety_domain: str = "cooling_control_future"):
+    review = _review(kind, thermal_zone_temperatures_c={"cpu": 91}) if kind == "future_cooling_policy_candidate" else _review(kind)
+    ledger = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema, created_at=FIXED).ledger
+    safety = build_safety_gates_for_domain(safety_domain, created_at=FIXED).safety_gate_satisfaction_manifest
+    return build_live_grant_readiness_wing(ledger, safety, {"manifest_id": "reviewer-proof", "metadata_only": True}, readiness_domain=readiness_domain, created_at=FIXED)
+
+
+def _approvals(scope: str = "future_cooling_scope"):
+    return (
+        build_operator_approval_evidence(approval_scope_labels=(scope,), created_at=FIXED),
+        build_policy_approval_evidence(policy_scope_labels=(scope,), created_at=FIXED),
+    )
+
+
+def test_ready_preflight_and_valid_approval_evidence_produces_active_non_fulfillment_grant() -> None:
+    readiness = _readiness()
+    operator, policy = _approvals()
+    wing = build_local_authorization_grant_wing(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    grant = wing.grant
+    assert grant.grant_status in {"local_authorization_grant_active", "local_authorization_grant_active_with_conditions"}
+    assert grant.live_authorization_granted is True
+    assert grant.fulfillment_granted is False
+    assert grant.effect_performed is False
+    assert grant.host_mutation_performed is False
+    assert validate_operator_approval_evidence(operator).ok
+    assert validate_policy_approval_evidence(policy).ok
+    assert validate_local_authorization_grant(grant).ok
+    assert wing.verification.authorizes_fulfillment is False
+    assert validate_local_authorization_grant_verification(wing.verification).ok
+
+
+@pytest.mark.parametrize(
+    ("preflight_status", "readiness_status", "expected"),
+    [
+        ("grant_issue_preflight_blocked", "live_grant_readiness_blocked", "local_authorization_grant_blocked"),
+        ("grant_issue_preflight_incomplete", "live_grant_readiness_incomplete", "local_authorization_grant_incomplete"),
+        ("grant_issue_preflight_contradicted", "live_grant_readiness_contradicted", "local_authorization_grant_contradicted"),
+    ],
+)
+def test_non_ready_preflights_produce_non_active_grant(preflight_status: str, readiness_status: str, expected: str) -> None:
+    readiness = _readiness()
+    preflight = replace(readiness.preflight_receipt, preflight_status=preflight_status, readiness_status=readiness_status, digest="")
+    preflight = replace(preflight, digest=readiness.preflight_receipt.digest)
+    operator, policy = _approvals()
+    grant = build_local_authorization_grant(preflight, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    assert grant.grant_status == expected
+    assert grant.live_authorization_granted is False
+
+
+@pytest.mark.parametrize(
+    ("operator_status", "policy_status", "expected"),
+    [
+        ("approval_evidence_missing", "approval_evidence_present", "local_authorization_grant_incomplete"),
+        ("approval_evidence_present", "approval_evidence_missing", "local_authorization_grant_incomplete"),
+        ("approval_evidence_blocked", "approval_evidence_present", "local_authorization_grant_blocked"),
+        ("approval_evidence_present", "approval_evidence_contradicted", "local_authorization_grant_contradicted"),
+    ],
+)
+def test_missing_or_bad_approval_evidence_blocks_or_incompletes(operator_status: str, policy_status: str, expected: str) -> None:
+    readiness = _readiness()
+    operator = build_operator_approval_evidence(approval_status=operator_status, created_at=FIXED)
+    policy = build_policy_approval_evidence(approval_status=policy_status, created_at=FIXED)
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    assert grant.grant_status == expected
+    assert grant.live_authorization_granted is False
+
+
+@pytest.mark.parametrize(
+    ("domain", "scope", "readiness_domain", "safety_domain", "blocked"),
+    [
+        ("future_cooling_local_authorization", "future_cooling_scope", "future_cooling_live_grant_review", "cooling_control_future", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_local_authorization", "future_power_scope", "future_power_live_grant_review", "power_control_future", {"power_profile_mutation"}),
+        ("future_cleanup_local_authorization", "future_cleanup_scope", "future_cleanup_live_grant_review", "cleanup_control_future", {"file_cleanup", "file_delete"}),
+        ("future_service_local_authorization", "future_service_scope", "future_service_live_grant_review", "service_control_future", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_domains_preserve_blocked_real_actions(domain: str, scope: str, readiness_domain: str, safety_domain: str, blocked: set[str]) -> None:
+    readiness = _readiness(readiness_domain=readiness_domain, safety_domain=safety_domain)
+    operator, policy = _approvals(scope)
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, authorization_domain=domain, grant_scope=scope, created_at=FIXED)
+    assert blocked.issubset(set(grant.blocked_actions))
+    assert set(grant.required_future_fulfillment_gates) >= {"control_plane_admission_required_for_future_fulfillment", "effect_receipt_required_for_future_fulfillment"}
+    assert grant.host_mutation_performed is False
+
+
+def test_revocation_expiry_verification_and_ledger_are_metadata_only() -> None:
+    readiness = _readiness()
+    operator, policy = _approvals()
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    revocation = build_local_authorization_grant_revocation_receipt(grant, created_at=FIXED)
+    expiry = build_local_authorization_grant_expiry_evaluation(grant, evaluated_at="1970-01-03T00:00:00+00:00")
+    verification = verify_local_authorization_grant(grant, expiry_evaluation=expiry, revocation_receipts=(revocation,))
+    ledger = build_local_authorization_grant_ledger((grant,), (revocation,), (expiry,), created_at=FIXED)
+    assert revocation.live_authorization_revoked is True
+    assert revocation.does_not_execute is True and revocation.does_not_mutate_host is True
+    assert expiry.metadata_only is True and expiry.expiry_evaluation_only is True
+    assert expiry.expiry_status == "local_authorization_expiry_expired"
+    assert verification.authorizes_fulfillment is False
+    assert ledger.active_grant_count == 0
+    assert ledger.revoked_grant_count == 1
+    assert ledger.expired_grant_count == 1
+    assert ledger.host_mutation_performed is False
+    assert validate_local_authorization_grant_revocation_receipt(revocation).ok
+    assert validate_local_authorization_grant_expiry_evaluation(expiry).ok
+    assert validate_local_authorization_grant_verification(verification).ok
+    assert validate_local_authorization_grant_ledger(ledger).ok
+
+
+@pytest.mark.parametrize("flag", [
+    "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed",
+    "thermal_actuation_performed", "power_profile_mutation_performed", "process_kill_performed",
+    "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed",
+])
+def test_validation_rejects_forbidden_action_flags(flag: str) -> None:
+    readiness = _readiness()
+    operator, policy = _approvals()
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    bad = replace(grant, **{flag: True})
+    result = validate_local_authorization_grant(bad)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    readiness = _readiness()
+    operator, policy = _approvals()
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    assert grant.digest == local_authorization_grant_digest(grant)
+    same = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    changed = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, grant_scope="operator_review_scope", authorization_domain="operator_review_local_authorization", created_at=FIXED)
+    assert same.digest == grant.digest
+    assert changed.digest != grant.digest
+
+
+def test_summaries_are_metadata_only() -> None:
+    readiness = _readiness()
+    operator, policy = _approvals()
+    wing = build_local_authorization_grant_wing(readiness.preflight_receipt, readiness.prerequisite_matrix, operator, policy, created_at=FIXED)
+    summaries = (
+        summarize_operator_approval_evidence(operator),
+        summarize_policy_approval_evidence(policy),
+        summarize_local_authorization_grant(wing.grant),
+        summarize_local_authorization_grant_revocation_receipt(wing.revocation_receipt),
+        summarize_local_authorization_grant_expiry_evaluation(wing.expiry_evaluation),
+        summarize_local_authorization_grant_verification(wing.verification),
+        summarize_local_authorization_grant_ledger(wing.ledger),
+    )
+    assert all(summary["metadata_only"] is True for summary in summaries)
+    assert wing.verification.authorizes_fulfillment is False

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -174,3 +174,18 @@ def test_reviewer_bundle_includes_live_grant_readiness_posture() -> None:
     assert "Live-grant readiness is not a live grant" in text
     assert "grant_not_issued" in text
     assert payload["live_grant_readiness"].preflight_receipt.live_authorization_granted is False
+
+
+def test_reviewer_bundle_includes_local_authorization_posture_without_fulfillment() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "local_authorization_posture" in payload["artifacts"]
+    assert "local_authorization.json" in payload["artifacts"]["bundle_manifest"]
+    text = payload["artifacts"]["local_authorization_posture"]
+    assert "authority metadata, not fulfillment" in text
+    assert "authorizes_fulfillment" in text
+    grant = payload["local_authorization"].grant
+    assert grant.live_authorization_granted is True
+    assert grant.fulfillment_granted is False
+    assert grant.effect_performed is False
+    assert grant.host_mutation_performed is False
+    assert payload["local_authorization"].verification.authorizes_fulfillment is False

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -377,3 +377,29 @@ def test_host_live_grant_readiness_doc_preserves_preflight_only_boundaries() -> 
     assert "grant issue preflight receipt does not issue a grant" in doc
     assert "Real actuation remains deferred" in doc
     assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → authorize" in doc
+
+HOST_LOCAL_AUTHORIZATION_GRANT_WING = "docs/architecture/host_local_authorization_grant_wing.md"
+
+
+def test_navigation_links_to_host_local_authorization_grant_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    safety = _read(HOST_ACTUATION_SAFETY_GATE_WING)
+    live = _read(HOST_LIVE_GRANT_READINESS_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, safety, live, bundle, controlled, trajectory]:
+        assert HOST_LOCAL_AUTHORIZATION_GRANT_WING in text
+
+
+def test_host_local_authorization_grant_doc_preserves_record_only_boundaries() -> None:
+    doc = _read(HOST_LOCAL_AUTHORIZATION_GRANT_WING)
+    assert "A local authorization grant is authority metadata, not fulfillment" in doc
+    assert "A local authorization grant does not execute" in doc
+    assert "A local authorization grant does not mutate host state" in doc
+    assert "Grant verification is not fulfillment authorization" in doc
+    assert "revocation receipt records revocation metadata and does not execute host action" in doc
+    assert "Expiry evaluation is metadata-only" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfill" in doc


### PR DESCRIPTION
### Motivation

- Add the next host-embodiment wing after Live-Grant Readiness to represent bounded, auditable local authorization grant records while preserving a strict non-execution policy. 
- Provide deterministic, metadata-only evidence shapes for operator/policy approvals, revocation, expiry, verification, and a ledger so future fulfillment remains gated and audited.

### Description

- Add a new metadata-only wing module `sentientos/local_authorization_grant.py` that defines `OperatorApprovalEvidence`, `PolicyApprovalEvidence`, `LocalAuthorizationGrant`, `LocalAuthorizationGrantLedger`, `LocalAuthorizationGrantRevocationReceipt`, `LocalAuthorizationGrantExpiryEvaluation`, `LocalAuthorizationGrantVerification`, validation, deterministic digest helpers, summaries, and `build_local_authorization_grant_wing(...)` that composes grant/expiry/verification/ledger artifacts without executing host actions.
- Integrate the wing into reviewer tooling by extending `sentientos/reviewer_proof_bundle.py` to emit `local_authorization.json` (artifact `local_authorization_posture`) containing deterministic sample approval evidence and a metadata-only grant example that explicitly keeps `fulfillment_granted=False`, `effect_performed=False`, and `host_mutation_performed=False` while showing `live_authorization_granted` as a record label only.
- Update `sentientos/capability_registry.py` to add record-only capability entries (`local_authorization_grant`, `local_authorization_grant_ledger`, `local_authorization_revocation_receipt`, `local_authorization_expiry_evaluation`, `local_authorization_verification`, and `fulfillment_authorization_consumption`) and provide `update_registry_from_local_authorization_ledger(...)` to reflect ledger posture without claiming fulfillment; maintain deferred/blocked status for all real host-effect capabilities.
- Add architecture doc `docs/architecture/host_local_authorization_grant_wing.md` and link it from existing docs and the reviewer index; update reviewer bundle README and tests to include and validate the new artifact; add focused unit tests `tests/test_local_authorization_grant.py` and update bundle/capability/docs tests.

### Testing

- Ran module compilation and unit test matrix: `python -m py_compile sentientos/local_authorization_grant.py sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py sentientos/capability_registry.py tests/test_local_authorization_grant.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` (compiled OK).
- Ran focused test suites via test runner and CI-style commands and observed green results: `python -m scripts.run_tests -q tests/test_local_authorization_grant.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py` (passed), plus wider suites `tests/test_live_grant_readiness.py tests/test_host_actuation_safety.py tests/test_controlled_authorization.py` and `tests/test_authorization_review.py tests/test_effect_proof.py tests/test_runtime_supervisor.py tests/test_actuation_fulfillment.py tests/test_privilege_broker.py` and `tests/test_reviewer_release_readiness_index.py` (all passed in this environment).
- Reviewer bundle CLI exercised: `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` produced `/tmp/sentientos-reviewer-proof/local_authorization.json` and the manifest validated via `validate_reviewer_proof_bundle_manifest()`.
- Docs build required a docs bootstrap step (`python scripts/build_docs.py --bootstrap-docs`) to install `mkdocs` in the environment, after which `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` completed (noting bootstrap is environment-specific).
- Performed forbidden-scan and context-hygiene checks (grep for network/exec/hardware writes and `scripts/verify_context_hygiene_prompt_boundaries.py`) and found only documentation/marker strings and blocked/deferred labels; no forbidden runtime calls or host-actuation performed by the new code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a064b7aef588320add7936f7dbabd21)