### PR TITLE
[codex:host-embodiment] add fulfillment authorization consumption wing

### DIFF
--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -62,3 +62,7 @@ After controlled authorization contracts and safety gates, the [Host Live-Grant 
 Later ladder link: [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) records scoped local authorization metadata after live-grant readiness without executing host actions.
 
 Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
+
+See also the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md), which sits after local authorization grants and before any future fulfillment executor. Consumption receipts do not execute.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/docs/architecture/host_fulfillment_authorization_consumption_wing.md
+++ b/docs/architecture/host_fulfillment_authorization_consumption_wing.md
@@ -1,0 +1,42 @@
+# Host Fulfillment Authorization Consumption Wing
+
+This wing follows the [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md). A local authorization grant is authority metadata, not fulfillment. Fulfillment authorization consumption checks whether a future fulfillment request fits a local authorization grant before any future executor is allowed to proceed.
+
+## Boundary
+
+Fulfillment authorization consumption is not fulfillment. Scope match is not execution. Grant verification is not host mutation. A consumption receipt does not execute. A denial receipt does not execute.
+
+This wing does not execute host actions, fulfill host actions, mutate host state, write fan/PWM controls, perform thermal actuation, mutate power profiles, kill processes, restart services, install packages or drivers, clean up or delete files, perform network egress, invoke providers, assemble/export prompts, transport federation state, or perform remote execution.
+
+`authorization_consumed_for_future_fulfillment=true` may appear only on a verified, scope-matched, active-grant consumption receipt. Even then, `fulfillment_granted=false`, `effect_performed=false`, `host_mutation_performed=false`, and all concrete action flags remain false.
+
+## Records
+
+- **FulfillmentAuthorizationRequest:** metadata-only request record for a future fulfillment executor's requested domain, backend class, scope labels, time label, required labels, blocked actions, warnings, risks, and digest.
+- **GrantConsumptionVerification:** metadata-only verification that copies local grant and local verification status into a consumption posture. It has `authorizes_fulfillment=false`.
+- **FulfillmentScopeMatchAssessment:** metadata-only requested-scope versus granted-scope assessment. Scope match is not execution.
+- **FulfillmentAuthorizationConsumptionReceipt:** metadata-only receipt that records authorization consumption posture for future fulfillment. The receipt does not execute and does not grant fulfillment.
+- **FulfillmentAuthorizationDenialReceipt:** metadata-only denial receipt for blocked, incomplete, contradicted, expired, revoked, or out-of-scope consumption attempts. The denial receipt does not execute.
+
+## Future fulfillment remains deferred
+
+Real fulfillment remains deferred. Real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind a future fulfillment executor plus control-plane admission, audit receipt, rollback receipt, effect receipt, postcondition checks, runtime supervisor observation, immutable trace, and safety gates.
+
+Future cooling consumption preserves fan/PWM and thermal blocked action labels. Future power consumption preserves power mutation blocked action labels. Future cleanup consumption preserves cleanup/delete blocked action labels. Future service consumption preserves service restart/process kill blocked action labels.
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **fulfillment authorization consumption/pre-fulfillment only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `fulfillment_authorization.json`. The artifact is reviewer proof only and metadata only. It demonstrates a safe sample where a local authorization grant is active, local grant verification is valid, fulfillment authorization consumption may be recorded, but `fulfillment_granted=false`, `effect_performed=false`, `host_mutation_performed=false`, and real actuation remains deferred.
+
+## Implementation links
+
+- Module: `sentientos/fulfillment_authorization.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_fulfillment_authorization.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_live_grant_readiness_wing.md
+++ b/docs/architecture/host_live_grant_readiness_wing.md
@@ -53,3 +53,7 @@ The reviewer proof bundle now includes `live_grant_readiness.json`. That artifac
 Next: [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) records bounded local authorization metadata after readiness; it is still not fulfillment.
 
 Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
+
+Downstream link: after local authorization grants, the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) can record metadata-only future fulfillment authorization consumption without execution.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/docs/architecture/host_local_authorization_grant_wing.md
+++ b/docs/architecture/host_local_authorization_grant_wing.md
@@ -44,3 +44,7 @@ The reviewer proof bundle includes `local_authorization.json`. That artifact is 
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_local_authorization_grant.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+Next organ: the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) records metadata-only future fulfillment authorization consumption. Consuming authorization is not fulfillment, and scope match is not execution.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -254,3 +254,7 @@ Host live-grant readiness is documented in [Host Live-Grant Readiness Wing](host
 
 
 Local authorization grant records are documented in [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md) (`docs/architecture/host_local_authorization_grant_wing.md`): a local authorization grant is authority metadata, not fulfillment; grant verification is not fulfillment authorization; real actuation remains deferred.
+
+Reviewer proof link: [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) documents the metadata-only authorization-consumption layer. Consuming authorization is not fulfillment; scope match is not execution; real actuation remains deferred.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -82,3 +82,7 @@ The bundle includes `live_grant_readiness.json`, documented in [Host Live-Grant 
 The bundle also includes `local_authorization.json` for the [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md); this is authority metadata only and does not authorize fulfillment.
 
 Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
+
+The bundle also writes `fulfillment_authorization.json` for the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md). The artifact states that consuming authorization is not fulfillment, scope match is not execution, and no effect or host mutation is performed.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -257,3 +257,5 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: 
 
 
 - Host Local Authorization Grant Wing: `docs/architecture/host_local_authorization_grant_wing.md`; proof artifact `local_authorization.json`; tests `tests/test_local_authorization_grant.py`. Local authorization grant is authority metadata, not fulfillment, and does not execute.
+
+The [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) (`docs/architecture/host_fulfillment_authorization_consumption_wing.md`) adds metadata-only fulfillment authorization request, grant consumption verification, scope match assessment, consumption receipt, and denial receipt records. Consuming authorization is not fulfillment; scope match is not execution; consumption receipts do not execute; real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -402,3 +402,7 @@ See [Host Live-Grant Readiness Wing](host_live_grant_readiness_wing.md) (`docs/a
 - [Host Local Authorization Grant Wing](host_local_authorization_grant_wing.md): implemented bounded authorization-record lifecycle; fulfillment and actuation remain deferred.
 
 Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
+
+Implemented organ link: [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) adds metadata-only pre-fulfillment grant consumption checks while real fulfillment and real actuation remain deferred.
+
+Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -42,6 +42,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "host_actuation_safety",
         "live_grant_readiness",
         "local_authorization_grant",
+        "fulfillment_authorization",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -78,6 +79,10 @@ AUTHORITY_LEVELS = frozenset(
         "revocation_record_only",
         "expiry_evaluation_only",
         "verification_only",
+        "request_only",
+        "assessment_only",
+        "consumption_receipt_only",
+        "denial_receipt_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -285,7 +290,13 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("local_authorization_revocation_receipt", "local_authorization_grant", "implemented", "revocation_record_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("local authorization revocation metadata receipt",), deferred_surfaces=("revocation effect execution",), forbidden_implications=("revocation receipt executes host action",)),
         _record("local_authorization_expiry_evaluation", "local_authorization_grant", "implemented", "expiry_evaluation_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("metadata-only grant expiry evaluation",), deferred_surfaces=("scheduler or host action execution",), forbidden_implications=("expiry evaluation executes host action",)),
         _record("local_authorization_verification", "local_authorization_grant", "implemented", "verification_only", source_paths=("sentientos/local_authorization_grant.py",), proof_tests=("tests/test_local_authorization_grant.py",), implemented_surfaces=("grant lookup and verification metadata",), deferred_surfaces=("fulfillment authorization consumption",), forbidden_implications=("verification authorizes fulfillment",)),
-        _record("fulfillment_authorization_consumption", "local_authorization_grant", "deferred", "none", source_paths=("sentientos/local_authorization_grant.py",), deferred_surfaces=("future executor consumption of grant verification", "control-plane admitted fulfillment"), forbidden_implications=("local authorization wing consumes grants for effects",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("fulfillment_authorization_consumption", "fulfillment_authorization", "implemented", "consumption_receipt_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), proof_commands=("python -m scripts.run_tests -q tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only fulfillment authorization consumption receipts",), deferred_surfaces=("fulfillment execution", "real effect execution", "host mutation"), forbidden_implications=("authorization consumption is fulfillment", "consumption receipt executes host action"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("fulfillment_authorization_request", "fulfillment_authorization", "implemented", "request_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only future fulfillment authorization requests",), deferred_surfaces=("fulfillment execution", "host mutation"), forbidden_implications=("fulfillment authorization request grants fulfillment",)),
+        _record("grant_consumption_verification", "fulfillment_authorization", "implemented", "verification_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("non-authorizing grant consumption verification metadata",), deferred_surfaces=("fulfillment authorization grant", "effect execution"), forbidden_implications=("grant consumption verification authorizes fulfillment",)),
+        _record("fulfillment_scope_match_assessment", "fulfillment_authorization", "implemented", "assessment_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only requested scope versus granted scope assessment",), deferred_surfaces=("execution", "host mutation"), forbidden_implications=("scope match is execution",)),
+        _record("fulfillment_authorization_consumption_receipt", "fulfillment_authorization", "implemented", "consumption_receipt_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only consumption receipt for future fulfillment",), deferred_surfaces=("fulfillment execution", "real effects", "postcondition checks against real effects"), forbidden_implications=("consumption receipt performs effect",)),
+        _record("fulfillment_authorization_denial_receipt", "fulfillment_authorization", "implemented", "denial_receipt_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only denial receipt for out-of-scope or non-active grants",), deferred_surfaces=("fulfillment execution",), forbidden_implications=("denial receipt executes host action",)),
+        _record("fulfillment_execution", "fulfillment_authorization", "deferred", "none", deferred_surfaces=("future fulfillment executor", "host mutation", "effect receipt from real action"), forbidden_implications=("fulfillment authorization wing implements execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_authorization_grant", "authorization_review", "deferred", "none", deferred_surfaces=("operator/policy authorization grant issuance",), forbidden_implications=("authorization review wing grants authorization",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -301,9 +312,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-controlled-authorization-and-trace-wing", schema_version="host-embodiment-controlled-authorization-and-trace-wing.v1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-fulfillment-authorization-consumption-wing", schema_version="host-fulfillment-authorization-consumption-wing.v1", records=records)
 
 
 
@@ -882,6 +893,35 @@ def update_registry_from_live_grant_readiness(registry: CapabilityRegistry, read
     return replace(registry, records=tuple(records), schema_version="host-live-grant-readiness-wing.v1")
 
 
+
+def update_registry_from_fulfillment_authorization_consumption(registry: CapabilityRegistry, wing: Any) -> CapabilityRegistry:
+    """Reflect metadata-only fulfillment authorization consumption without execution."""
+
+    has_request = bool(getattr(getattr(wing, "request", None), "request_id", "")) or bool(getattr(wing, "request_id", ""))
+    has_verification = bool(getattr(getattr(wing, "grant_consumption_verification", None), "verification_id", "")) or bool(getattr(wing, "verification_id", ""))
+    has_assessment = bool(getattr(getattr(wing, "scope_match_assessment", None), "assessment_id", "")) or bool(getattr(wing, "assessment_id", ""))
+    has_consumption = bool(getattr(getattr(wing, "consumption_receipt", None), "receipt_id", "")) or bool(getattr(wing, "receipt_id", ""))
+    has_denial = bool(getattr(getattr(wing, "denial_receipt", None), "receipt_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "fulfillment_authorization_request":
+            records.append(replace(record, status="implemented" if has_request else record.status, authority_level="request_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "grant_consumption_verification":
+            records.append(replace(record, status="implemented" if has_verification else record.status, authority_level="verification_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "fulfillment_scope_match_assessment":
+            records.append(replace(record, status="implemented" if has_assessment else record.status, authority_level="assessment_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"fulfillment_authorization_consumption", "fulfillment_authorization_consumption_receipt"}:
+            records.append(replace(record, status="implemented" if has_consumption else record.status, authority_level="consumption_receipt_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "fulfillment_authorization_denial_receipt":
+            records.append(replace(record, status="implemented" if (has_denial or not has_consumption) else record.status, authority_level="denial_receipt_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"fulfillment_execution", "real_effect_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-fulfillment-authorization-consumption-wing.v1")
+
 def update_registry_from_local_authorization_ledger(registry: CapabilityRegistry, ledger: Any) -> CapabilityRegistry:
     """Reflect local authorization grant records without claiming fulfillment."""
 
@@ -898,7 +938,9 @@ def update_registry_from_local_authorization_ledger(registry: CapabilityRegistry
             records.append(replace(record, status="implemented", authority_level="expiry_evaluation_only", host_actuation_performed=False, metadata_only=True))
         elif record.capability_id == "local_authorization_verification":
             records.append(replace(record, status="implemented", authority_level="verification_only", host_actuation_performed=False, metadata_only=True))
-        elif record.capability_id in {"fulfillment_authorization_consumption", "real_authorization_grant", "real_effect_execution", "real_actuation_fulfillment"}:
+        elif record.capability_id in {"fulfillment_authorization_consumption", "fulfillment_authorization_request", "grant_consumption_verification", "fulfillment_scope_match_assessment", "fulfillment_authorization_consumption_receipt", "fulfillment_authorization_denial_receipt"}:
+            records.append(replace(record, status="implemented", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"fulfillment_execution", "real_authorization_grant", "real_effect_execution", "real_actuation_fulfillment"}:
             records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
         elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
             records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))

--- a/sentientos/fulfillment_authorization.py
+++ b/sentientos/fulfillment_authorization.py
@@ -1,0 +1,726 @@
+"""Metadata-only fulfillment authorization consumption records.
+
+This wing follows local authorization grants and records whether a future
+fulfillment request fits an active local authorization grant. It is strictly
+pre-fulfillment: it does not execute, fulfill, mutate host state, write fan/PWM
+controls, change thermal or power settings, restart services, clean files, make
+network calls, invoke providers, or assemble prompts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+REQUEST_STATUSES = frozenset({
+    "fulfillment_authorization_request_recorded",
+    "fulfillment_authorization_request_recorded_with_warnings",
+    "fulfillment_authorization_request_blocked",
+    "fulfillment_authorization_request_incomplete",
+    "fulfillment_authorization_request_contradicted",
+})
+CONSUMPTION_VERIFICATION_STATUSES = frozenset({
+    "grant_consumption_verified",
+    "grant_consumption_verified_with_conditions",
+    "grant_consumption_blocked",
+    "grant_consumption_expired",
+    "grant_consumption_revoked",
+    "grant_consumption_out_of_scope",
+    "grant_consumption_incomplete",
+    "grant_consumption_contradicted",
+})
+SCOPE_MATCH_STATUSES = frozenset({
+    "fulfillment_scope_match",
+    "fulfillment_scope_match_with_conditions",
+    "fulfillment_scope_mismatch",
+    "fulfillment_scope_missing",
+    "fulfillment_scope_contradicted",
+})
+CONSUMPTION_RECEIPT_STATUSES = frozenset({
+    "fulfillment_authorization_consumption_recorded",
+    "fulfillment_authorization_consumption_recorded_with_warnings",
+    "fulfillment_authorization_consumption_blocked",
+    "fulfillment_authorization_consumption_expired",
+    "fulfillment_authorization_consumption_revoked",
+    "fulfillment_authorization_consumption_out_of_scope",
+    "fulfillment_authorization_consumption_incomplete",
+    "fulfillment_authorization_consumption_contradicted",
+})
+DENIAL_RECEIPT_STATUSES = frozenset({
+    "fulfillment_authorization_denial_recorded",
+    "fulfillment_authorization_denial_blocked",
+    "fulfillment_authorization_denial_incomplete",
+    "fulfillment_authorization_denial_contradicted",
+})
+FULFILLMENT_DOMAINS = frozenset({
+    "diagnostics_fulfillment_authorization",
+    "operator_review_fulfillment_authorization",
+    "resource_pressure_fulfillment_authorization",
+    "thermal_safety_fulfillment_authorization",
+    "future_cooling_fulfillment_authorization",
+    "future_power_fulfillment_authorization",
+    "future_cleanup_fulfillment_authorization",
+    "future_service_fulfillment_authorization",
+})
+REQUIRED_REQUEST_LABELS = frozenset({
+    "local_authorization_grant_required",
+    "local_authorization_verification_required",
+    "grant_not_expired_required",
+    "grant_not_revoked_required",
+    "grant_scope_match_required",
+    "fulfillment_domain_declared",
+    "fulfillment_backend_declared",
+    "effect_receipt_contract_required",
+    "postcondition_plan_required",
+    "rollback_plan_required",
+    "runtime_supervisor_observation_required",
+    "control_plane_admission_required_for_fulfillment",
+    "audit_receipt_required_for_fulfillment",
+    "effect_receipt_required_for_fulfillment",
+    "postcondition_check_required_for_fulfillment",
+    "rollback_receipt_required_for_fulfillment",
+    "immutable_trace_required_for_fulfillment",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+_DOMAIN_SCOPE = {
+    "diagnostics_fulfillment_authorization": "diagnostics_only_scope",
+    "operator_review_fulfillment_authorization": "operator_review_scope",
+    "resource_pressure_fulfillment_authorization": "resource_pressure_review_scope",
+    "thermal_safety_fulfillment_authorization": "thermal_safety_review_scope",
+    "future_cooling_fulfillment_authorization": "future_cooling_scope",
+    "future_power_fulfillment_authorization": "future_power_scope",
+    "future_cleanup_fulfillment_authorization": "future_cleanup_scope",
+    "future_service_fulfillment_authorization": "future_service_scope",
+}
+_DOMAIN_BLOCKS = {
+    "future_cooling_fulfillment_authorization": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_fulfillment_authorization": ("power_profile_mutation",),
+    "future_cleanup_fulfillment_authorization": ("file_cleanup", "file_delete"),
+    "future_service_fulfillment_authorization": ("service_restart", "process_kill"),
+}
+_FUTURE_GATES = tuple(sorted({
+    "control_plane_admission_required_for_fulfillment",
+    "audit_receipt_required_for_fulfillment",
+    "effect_receipt_required_for_fulfillment",
+    "postcondition_check_required_for_fulfillment",
+    "rollback_receipt_required_for_fulfillment",
+    "runtime_supervisor_observation_required",
+    "immutable_trace_required_for_fulfillment",
+    "safety_gates_required_for_fulfillment",
+}))
+_FORBIDDEN_TRUE_FLAGS = (
+    "fulfillment_granted",
+    "effect_performed",
+    "host_mutation_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+)
+
+
+@dataclass(frozen=True)
+class FulfillmentAuthorizationPolicy:
+    policy_id: str
+    required_request_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    metadata_only: bool = True
+    pre_fulfillment_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentAuthorizationRequest:
+    request_id: str
+    source_local_authorization_grant_id: str
+    source_local_authorization_grant_digest: str
+    source_grant_verification_id: str | None
+    requested_fulfillment_domain: str
+    requested_backend_class: str
+    requested_scope_labels: tuple[str, ...]
+    requested_time_label: str
+    required_request_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    request_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    request_only: bool = True
+    fulfillment_requested: bool = True
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GrantConsumptionVerification:
+    verification_id: str
+    request_id: str
+    grant_id: str
+    grant_status: str
+    grant_verification_status: str
+    consumption_status: str
+    checked_scope_labels: tuple[str, ...]
+    checked_time_label: str
+    checked_revocation_labels: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    digest: str
+    metadata_only: bool = True
+    verification_only: bool = True
+    authorizes_fulfillment: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentScopeMatchAssessment:
+    assessment_id: str
+    request_id: str
+    grant_id: str
+    requested_scope_labels: tuple[str, ...]
+    granted_scope_labels: tuple[str, ...]
+    matched_scope_labels: tuple[str, ...]
+    missing_scope_labels: tuple[str, ...]
+    extra_scope_labels: tuple[str, ...]
+    scope_match_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    digest: str
+    metadata_only: bool = True
+    assessment_only: bool = True
+    authorizes_fulfillment: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentAuthorizationConsumptionReceipt:
+    receipt_id: str
+    request_id: str
+    grant_id: str
+    grant_consumption_verification_id: str
+    scope_match_assessment_id: str
+    requested_fulfillment_domain: str
+    requested_backend_class: str
+    consumption_status: str
+    evidence_summary: tuple[str, ...]
+    required_future_fulfillment_gates: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    consumption_receipt_only: bool = True
+    authorization_consumed_for_future_fulfillment: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentAuthorizationDenialReceipt:
+    receipt_id: str
+    request_id: str
+    grant_id: str | None
+    denial_status: str
+    denial_reason_codes: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    denial_receipt_only: bool = True
+    authorization_consumed_for_future_fulfillment: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentAuthorizationValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+class FulfillmentAuthorizationWingRecords(NamedTuple):
+    request: FulfillmentAuthorizationRequest
+    grant_consumption_verification: GrantConsumptionVerification
+    scope_match_assessment: FulfillmentScopeMatchAssessment
+    consumption_receipt: FulfillmentAuthorizationConsumptionReceipt | None
+    denial_receipt: FulfillmentAuthorizationDenialReceipt | None
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = record_or_payload.to_dict() if hasattr(record_or_payload, "to_dict") else dict(record_or_payload)
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def fulfillment_authorization_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+fulfillment_authorization_request_digest = fulfillment_authorization_digest
+grant_consumption_verification_digest = fulfillment_authorization_digest
+fulfillment_scope_match_assessment_digest = fulfillment_authorization_digest
+fulfillment_authorization_consumption_receipt_digest = fulfillment_authorization_digest
+fulfillment_authorization_denial_receipt_digest = fulfillment_authorization_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def build_default_fulfillment_authorization_policy() -> FulfillmentAuthorizationPolicy:
+    return FulfillmentAuthorizationPolicy(
+        "fulfillment-authorization-consumption-policy-v1",
+        tuple(sorted(REQUIRED_REQUEST_LABELS)),
+        tuple(sorted(BLOCKED_ACTION_LABELS)),
+    )
+
+
+def _domain_blocks(domain: str) -> tuple[str, ...]:
+    return tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_DOMAIN_BLOCKS.get(domain, ()))))
+
+
+def build_fulfillment_authorization_request(
+    grant: Any,
+    grant_verification: Any | None,
+    *,
+    requested_fulfillment_domain: str,
+    requested_backend_class: str,
+    requested_scope_labels: Sequence[str] | None = None,
+    requested_time_label: str = "1970-01-01T00:00:00+00:00",
+    required_request_labels: Sequence[str] | None = None,
+    blocked_actions: Sequence[str] | None = None,
+    request_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> FulfillmentAuthorizationRequest:
+    g = _source_payload(grant)
+    v = _source_payload(grant_verification) if grant_verification is not None else {}
+    labels = _tuple(requested_scope_labels) or tuple(sorted({_DOMAIN_SCOPE.get(requested_fulfillment_domain, "")} - {""}))
+    required = _tuple(required_request_labels) or tuple(sorted(REQUIRED_REQUEST_LABELS))
+    blocked = tuple(sorted(set(_tuple(blocked_actions)) | set(_tuple(g.get("blocked_actions"))) | set(_domain_blocks(requested_fulfillment_domain))))
+    missing = sorted(REQUIRED_REQUEST_LABELS - set(required))
+    warnings: set[str] = set()
+    risks = {"fulfillment_authorization_consumption_is_not_fulfillment"}
+    status = "fulfillment_authorization_request_recorded"
+    if requested_fulfillment_domain not in FULFILLMENT_DOMAINS:
+        status = "fulfillment_authorization_request_contradicted"
+        risks.add("unknown_fulfillment_domain")
+    elif not requested_backend_class:
+        status = "fulfillment_authorization_request_incomplete"
+        warnings.add("fulfillment_backend_missing")
+    elif missing or not g.get("grant_id") or not v.get("verification_id"):
+        status = "fulfillment_authorization_request_incomplete"
+        warnings.update(missing)
+    elif blocked:
+        status = "fulfillment_authorization_request_recorded_with_warnings"
+        warnings.add("blocked_actions_preserved_for_future_fulfillment")
+    rid = request_id or _digest_id("fulfillment-auth-request-", {"grant": g.get("grant_id"), "verification": v.get("verification_id"), "domain": requested_fulfillment_domain, "backend": requested_backend_class, "scope": labels, "time": requested_time_label})
+    provisional = FulfillmentAuthorizationRequest(
+        rid,
+        str(g.get("grant_id", "")),
+        str(g.get("digest", "")),
+        str(v.get("verification_id")) if v.get("verification_id") else None,
+        requested_fulfillment_domain,
+        requested_backend_class,
+        labels,
+        requested_time_label,
+        required,
+        blocked,
+        status,
+        tuple(sorted(warnings)),
+        tuple(sorted(risks)),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=fulfillment_authorization_request_digest(provisional))
+
+
+def _consumption_status(grant: Mapping[str, Any], grant_verification: Mapping[str, Any], request: Mapping[str, Any]) -> str:
+    gstatus = str(grant.get("grant_status", ""))
+    vstatus = str(grant_verification.get("verification_status", ""))
+    if "contradicted" in gstatus or "contradicted" in vstatus or "contradicted" in str(request.get("request_status", "")):
+        return "grant_consumption_contradicted"
+    if "blocked" in gstatus or "blocked" in vstatus or "blocked" in str(request.get("request_status", "")):
+        return "grant_consumption_blocked"
+    if "revoked" in gstatus or "revoked" in vstatus:
+        return "grant_consumption_revoked"
+    if "expired" in gstatus or "expired" in vstatus:
+        return "grant_consumption_expired"
+    if "incomplete" in gstatus or "incomplete" in vstatus or "incomplete" in str(request.get("request_status", "")):
+        return "grant_consumption_incomplete"
+    if set(_tuple(request.get("requested_scope_labels"))) - set(_tuple(grant.get("granted_scope_labels"))):
+        return "grant_consumption_out_of_scope"
+    if gstatus == "local_authorization_grant_active_with_conditions" or vstatus == "local_authorization_verification_valid_with_conditions":
+        return "grant_consumption_verified_with_conditions"
+    if gstatus == "local_authorization_grant_active" and vstatus == "local_authorization_verification_valid":
+        return "grant_consumption_verified"
+    return "grant_consumption_incomplete"
+
+
+def verify_grant_consumption_for_fulfillment(grant: Any, grant_verification: Any, request: Any) -> GrantConsumptionVerification:
+    g = _source_payload(grant)
+    v = _source_payload(grant_verification)
+    r = _source_payload(request)
+    requested = _tuple(r.get("requested_scope_labels"))
+    missing = tuple(sorted((set(requested) - set(_tuple(g.get("granted_scope_labels")))) | set(_tuple(v.get("missing_labels")))))
+    status = _consumption_status(g, v, r)
+    provisional = GrantConsumptionVerification(
+        _digest_id("grant-consumption-verification-", {"request": r.get("request_id"), "grant": g.get("grant_id"), "status": status, "scope": requested}),
+        str(r.get("request_id", "")),
+        str(g.get("grant_id", "")),
+        str(g.get("grant_status", "")),
+        str(v.get("verification_status", "")),
+        status,
+        requested,
+        str(r.get("requested_time_label", v.get("checked_time_label", ""))),
+        _tuple(v.get("checked_revocation_labels")),
+        missing,
+        tuple(sorted(set(_tuple(r.get("blocked_actions"))) | set(_tuple(g.get("blocked_actions"))))),
+        tuple(sorted(set(_tuple(r.get("warning_codes"))) | set(_tuple(v.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(r.get("risk_codes"))) | set(_tuple(v.get("risk_codes"))) | {"grant_consumption_verification_is_not_fulfillment_authorization"})),
+        "",
+    )
+    return replace(provisional, digest=grant_consumption_verification_digest(provisional))
+
+
+def assess_fulfillment_scope_match(grant: Any, request: Any) -> FulfillmentScopeMatchAssessment:
+    g = _source_payload(grant)
+    r = _source_payload(request)
+    requested = set(_tuple(r.get("requested_scope_labels")))
+    granted = set(_tuple(g.get("granted_scope_labels")))
+    matched = requested & granted
+    missing = requested - granted
+    extra = granted - requested
+    if "contradicted" in str(r.get("request_status", "")) or "contradicted" in str(g.get("grant_status", "")):
+        status = "fulfillment_scope_contradicted"
+    elif not requested or not granted:
+        status = "fulfillment_scope_missing"
+    elif missing:
+        status = "fulfillment_scope_mismatch"
+    elif extra or str(g.get("grant_status")) == "local_authorization_grant_active_with_conditions":
+        status = "fulfillment_scope_match_with_conditions"
+    else:
+        status = "fulfillment_scope_match"
+    provisional = FulfillmentScopeMatchAssessment(
+        _digest_id("fulfillment-scope-match-", {"request": r.get("request_id"), "grant": g.get("grant_id"), "requested": sorted(requested), "granted": sorted(granted)}),
+        str(r.get("request_id", "")),
+        str(g.get("grant_id", "")),
+        tuple(sorted(requested)),
+        tuple(sorted(granted)),
+        tuple(sorted(matched)),
+        tuple(sorted(missing)),
+        tuple(sorted(extra)),
+        status,
+        tuple(sorted(set(_tuple(r.get("warning_codes"))))),
+        ("scope_match_is_not_execution",),
+        "",
+    )
+    return replace(provisional, digest=fulfillment_scope_match_assessment_digest(provisional))
+
+
+def _receipt_status(consumption_status: str, scope_status: str) -> str:
+    if consumption_status == "grant_consumption_verified" and scope_status == "fulfillment_scope_match":
+        return "fulfillment_authorization_consumption_recorded"
+    if consumption_status == "grant_consumption_verified_with_conditions" and scope_status in {"fulfillment_scope_match", "fulfillment_scope_match_with_conditions"}:
+        return "fulfillment_authorization_consumption_recorded_with_warnings"
+    if consumption_status.endswith("expired"):
+        return "fulfillment_authorization_consumption_expired"
+    if consumption_status.endswith("revoked"):
+        return "fulfillment_authorization_consumption_revoked"
+    if consumption_status.endswith("out_of_scope") or scope_status == "fulfillment_scope_mismatch":
+        return "fulfillment_authorization_consumption_out_of_scope"
+    if consumption_status.endswith("contradicted") or scope_status == "fulfillment_scope_contradicted":
+        return "fulfillment_authorization_consumption_contradicted"
+    if consumption_status.endswith("incomplete") or scope_status == "fulfillment_scope_missing":
+        return "fulfillment_authorization_consumption_incomplete"
+    return "fulfillment_authorization_consumption_blocked"
+
+
+def build_fulfillment_authorization_consumption_receipt(request: Any, verification: Any, assessment: Any, *, receipt_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> FulfillmentAuthorizationConsumptionReceipt:
+    r = _source_payload(request)
+    v = _source_payload(verification)
+    a = _source_payload(assessment)
+    status = _receipt_status(str(v.get("consumption_status", "")), str(a.get("scope_match_status", "")))
+    consumed = status in {"fulfillment_authorization_consumption_recorded", "fulfillment_authorization_consumption_recorded_with_warnings"}
+    provisional = FulfillmentAuthorizationConsumptionReceipt(
+        receipt_id or _digest_id("fulfillment-auth-consumption-", {"request": r.get("request_id"), "verification": v.get("verification_id"), "assessment": a.get("assessment_id"), "status": status}),
+        str(r.get("request_id", "")),
+        str(v.get("grant_id", "")),
+        str(v.get("verification_id", "")),
+        str(a.get("assessment_id", "")),
+        str(r.get("requested_fulfillment_domain", "")),
+        str(r.get("requested_backend_class", "")),
+        status,
+        (
+            f"grant_status:{v.get('grant_status', '')}",
+            f"grant_verification_status:{v.get('grant_verification_status', '')}",
+            f"scope_match_status:{a.get('scope_match_status', '')}",
+            "consumption_receipt_does_not_execute",
+            "real_fulfillment_remains_deferred",
+        ),
+        _FUTURE_GATES,
+        tuple(sorted(set(_tuple(r.get("blocked_actions"))) | set(_tuple(v.get("blocked_actions"))))),
+        tuple(sorted(set(_tuple(r.get("warning_codes"))) | set(_tuple(v.get("warning_codes"))) | set(_tuple(a.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(r.get("risk_codes"))) | set(_tuple(v.get("risk_codes"))) | set(_tuple(a.get("risk_codes"))) | {"consumption_receipt_is_not_fulfillment"})),
+        created_at,
+        "",
+        authorization_consumed_for_future_fulfillment=consumed,
+    )
+    return replace(provisional, digest=fulfillment_authorization_consumption_receipt_digest(provisional))
+
+
+def build_fulfillment_authorization_denial_receipt(request: Any, verification: Any | None = None, assessment: Any | None = None, *, receipt_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> FulfillmentAuthorizationDenialReceipt:
+    r = _source_payload(request)
+    v = _source_payload(verification) if verification is not None else {}
+    a = _source_payload(assessment) if assessment is not None else {}
+    reasons = set()
+    for status in (r.get("request_status"), v.get("consumption_status"), a.get("scope_match_status")):
+        if status:
+            reasons.add(str(status))
+    if not reasons:
+        reasons.add("fulfillment_authorization_denied")
+    if any("contradicted" in reason for reason in reasons):
+        status = "fulfillment_authorization_denial_contradicted"
+    elif any("incomplete" in reason or "missing" in reason for reason in reasons):
+        status = "fulfillment_authorization_denial_incomplete"
+    elif any("blocked" in reason for reason in reasons):
+        status = "fulfillment_authorization_denial_blocked"
+    else:
+        status = "fulfillment_authorization_denial_recorded"
+    missing = tuple(sorted(set(_tuple(v.get("missing_labels"))) | set(_tuple(a.get("missing_scope_labels"))) | (REQUIRED_REQUEST_LABELS - set(_tuple(r.get("required_request_labels"))))))
+    provisional = FulfillmentAuthorizationDenialReceipt(
+        receipt_id or _digest_id("fulfillment-auth-denial-", {"request": r.get("request_id"), "grant": v.get("grant_id"), "reasons": sorted(reasons)}),
+        str(r.get("request_id", "")),
+        str(v.get("grant_id")) if v.get("grant_id") else None,
+        status,
+        tuple(sorted(reasons | {"denial_receipt_does_not_execute"})),
+        missing,
+        tuple(sorted(set(_tuple(r.get("blocked_actions"))) | set(_tuple(v.get("blocked_actions"))))),
+        tuple(sorted(set(_tuple(r.get("warning_codes"))) | set(_tuple(v.get("warning_codes"))) | set(_tuple(a.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(r.get("risk_codes"))) | set(_tuple(v.get("risk_codes"))) | set(_tuple(a.get("risk_codes"))) | {"denial_is_not_fulfillment"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=fulfillment_authorization_denial_receipt_digest(provisional))
+
+
+def _validate_common(payload: Mapping[str, Any], prefix: str) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False):
+        findings.append(prefix + "not_metadata_only")
+    for flag in ("does_not_execute", "does_not_mutate_host"):
+        if flag in payload and not payload.get(flag, False):
+            findings.append(prefix + flag + "_false")
+    return findings
+
+
+def validate_fulfillment_authorization_request(request: FulfillmentAuthorizationRequest | Mapping[str, Any]) -> FulfillmentAuthorizationValidationResult:
+    p = _source_payload(request)
+    f = _validate_common(p, "request:")
+    if p.get("request_status") not in REQUEST_STATUSES:
+        f.append("request:unknown_status")
+    if p.get("requested_fulfillment_domain") not in FULFILLMENT_DOMAINS:
+        f.append("request:unknown_domain")
+    if not p.get("request_only", False):
+        f.append("request:not_request_only")
+    for flag in ("fulfillment_granted", "effect_performed", "host_mutation_performed"):
+        if p.get(flag, False):
+            f.append(f"request:forbidden_flag:{flag}")
+    if p.get("digest") and p.get("digest") != fulfillment_authorization_request_digest(p):
+        f.append("request:digest_mismatch")
+    return FulfillmentAuthorizationValidationResult(not f, tuple(f))
+
+
+def validate_grant_consumption_verification(verification: GrantConsumptionVerification | Mapping[str, Any]) -> FulfillmentAuthorizationValidationResult:
+    p = _source_payload(verification)
+    f = _validate_common(p, "verification:")
+    if p.get("consumption_status") not in CONSUMPTION_VERIFICATION_STATUSES:
+        f.append("verification:unknown_status")
+    if not p.get("verification_only", False):
+        f.append("verification:not_verification_only")
+    if p.get("authorizes_fulfillment", False):
+        f.append("verification:authorizes_fulfillment")
+    if p.get("digest") and p.get("digest") != grant_consumption_verification_digest(p):
+        f.append("verification:digest_mismatch")
+    return FulfillmentAuthorizationValidationResult(not f, tuple(f))
+
+
+def validate_fulfillment_scope_match_assessment(assessment: FulfillmentScopeMatchAssessment | Mapping[str, Any]) -> FulfillmentAuthorizationValidationResult:
+    p = _source_payload(assessment)
+    f = _validate_common(p, "scope:")
+    if p.get("scope_match_status") not in SCOPE_MATCH_STATUSES:
+        f.append("scope:unknown_status")
+    if not p.get("assessment_only", False):
+        f.append("scope:not_assessment_only")
+    if p.get("authorizes_fulfillment", False):
+        f.append("scope:authorizes_fulfillment")
+    if p.get("digest") and p.get("digest") != fulfillment_scope_match_assessment_digest(p):
+        f.append("scope:digest_mismatch")
+    return FulfillmentAuthorizationValidationResult(not f, tuple(f))
+
+
+def validate_fulfillment_authorization_consumption_receipt(receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any]) -> FulfillmentAuthorizationValidationResult:
+    p = _source_payload(receipt)
+    f: list[str] = []
+    if not p.get("metadata_only", False):
+        f.append("receipt:not_metadata_only")
+    if not p.get("consumption_receipt_only", False):
+        f.append("receipt:not_consumption_receipt_only")
+    if p.get("consumption_status") not in CONSUMPTION_RECEIPT_STATUSES:
+        f.append("receipt:unknown_status")
+    if p.get("authorization_consumed_for_future_fulfillment", False) and p.get("consumption_status") not in {"fulfillment_authorization_consumption_recorded", "fulfillment_authorization_consumption_recorded_with_warnings"}:
+        f.append("receipt:consumed_without_verified_scope_match")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if p.get(flag, False):
+            f.append(f"receipt:forbidden_flag:{flag}")
+    if p.get("digest") and p.get("digest") != fulfillment_authorization_consumption_receipt_digest(p):
+        f.append("receipt:digest_mismatch")
+    return FulfillmentAuthorizationValidationResult(not f, tuple(f))
+
+
+def validate_fulfillment_authorization_denial_receipt(receipt: FulfillmentAuthorizationDenialReceipt | Mapping[str, Any]) -> FulfillmentAuthorizationValidationResult:
+    p = _source_payload(receipt)
+    f = _validate_common(p, "denial:")
+    if p.get("denial_status") not in DENIAL_RECEIPT_STATUSES:
+        f.append("denial:unknown_status")
+    if not p.get("denial_receipt_only", False):
+        f.append("denial:not_denial_receipt_only")
+    for flag in ("authorization_consumed_for_future_fulfillment", "fulfillment_granted", "effect_performed", "host_mutation_performed"):
+        if p.get(flag, False):
+            f.append(f"denial:forbidden_flag:{flag}")
+    if p.get("digest") and p.get("digest") != fulfillment_authorization_denial_receipt_digest(p):
+        f.append("denial:digest_mismatch")
+    return FulfillmentAuthorizationValidationResult(not f, tuple(f))
+
+
+def summarize_fulfillment_authorization_request(request: FulfillmentAuthorizationRequest | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(request)
+    return {k: p.get(k) for k in ("request_id", "source_local_authorization_grant_id", "requested_fulfillment_domain", "requested_backend_class", "request_status", "metadata_only", "request_only", "fulfillment_requested", "fulfillment_granted", "effect_performed", "host_mutation_performed", "does_not_execute", "does_not_mutate_host", "digest")}
+
+
+def summarize_grant_consumption_verification(verification: GrantConsumptionVerification | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(verification)
+    return {k: p.get(k) for k in ("verification_id", "request_id", "grant_id", "grant_status", "grant_verification_status", "consumption_status", "metadata_only", "verification_only", "authorizes_fulfillment", "does_not_execute", "does_not_mutate_host", "digest")}
+
+
+def summarize_fulfillment_scope_match_assessment(assessment: FulfillmentScopeMatchAssessment | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(assessment)
+    return {k: p.get(k) for k in ("assessment_id", "request_id", "grant_id", "scope_match_status", "matched_scope_labels", "missing_scope_labels", "metadata_only", "assessment_only", "authorizes_fulfillment", "does_not_execute", "does_not_mutate_host", "digest")}
+
+
+def summarize_fulfillment_authorization_consumption_receipt(receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "grant_id", "consumption_status", "metadata_only", "consumption_receipt_only", "authorization_consumed_for_future_fulfillment", "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_fulfillment_authorization_denial_receipt(receipt: FulfillmentAuthorizationDenialReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "grant_id", "denial_status", "metadata_only", "denial_receipt_only", "authorization_consumed_for_future_fulfillment", "fulfillment_granted", "effect_performed", "host_mutation_performed", "does_not_execute", "does_not_mutate_host", "digest")}
+
+
+def build_fulfillment_authorization_wing(
+    grant: Any,
+    grant_verification: Any,
+    *,
+    requested_fulfillment_domain: str,
+    requested_backend_class: str,
+    requested_scope_labels: Sequence[str] | None = None,
+    requested_time_label: str = "1970-01-01T00:00:00+00:00",
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> FulfillmentAuthorizationWingRecords:
+    request = build_fulfillment_authorization_request(
+        grant,
+        grant_verification,
+        requested_fulfillment_domain=requested_fulfillment_domain,
+        requested_backend_class=requested_backend_class,
+        requested_scope_labels=requested_scope_labels,
+        requested_time_label=requested_time_label,
+        created_at=created_at,
+    )
+    verification = verify_grant_consumption_for_fulfillment(grant, grant_verification, request)
+    assessment = assess_fulfillment_scope_match(grant, request)
+    receipt = build_fulfillment_authorization_consumption_receipt(request, verification, assessment, created_at=created_at)
+    if receipt.authorization_consumed_for_future_fulfillment:
+        return FulfillmentAuthorizationWingRecords(request, verification, assessment, receipt, None)
+    denial = build_fulfillment_authorization_denial_receipt(request, verification, assessment, created_at=created_at)
+    return FulfillmentAuthorizationWingRecords(request, verification, assessment, None, denial)

--- a/sentientos/local_authorization_grant.py
+++ b/sentientos/local_authorization_grant.py
@@ -427,7 +427,7 @@ def verify_local_authorization_grant(grant: LocalAuthorizationGrant | Mapping[st
         status = "local_authorization_verification_blocked"
     elif str(g.get("grant_status", "")).endswith("incomplete") or missing:
         status = "local_authorization_verification_incomplete"
-    elif str(g.get("grant_status", "")).endswith("expired") or (expiry_evaluation is not None and "expired" in str(_source_payload(expiry_evaluation).get("expiry_status"))):
+    elif str(g.get("grant_status", "")).endswith("expired") or (expiry_evaluation is not None and str(_source_payload(expiry_evaluation).get("expiry_status")) == "local_authorization_expiry_expired"):
         status = "local_authorization_verification_expired"
     elif str(g.get("grant_status", "")).endswith("revoked") or any(_source_payload(r).get("revocation_status") == "local_authorization_revocation_recorded" for r in revocation_receipts):
         status = "local_authorization_verification_revoked"

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -25,6 +25,14 @@ from sentientos.live_grant_readiness import (
     summarize_live_grant_prerequisite_matrix,
     summarize_operator_policy_approval_packet,
 )
+from sentientos.fulfillment_authorization import (
+    build_fulfillment_authorization_wing,
+    summarize_fulfillment_authorization_consumption_receipt,
+    summarize_fulfillment_authorization_denial_receipt,
+    summarize_fulfillment_authorization_request,
+    summarize_fulfillment_scope_match_assessment,
+    summarize_grant_consumption_verification,
+)
 from sentientos.local_authorization_grant import (
     build_local_authorization_grant_wing,
     build_operator_approval_evidence,
@@ -65,6 +73,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "safety_gate_posture",
         "live_grant_readiness_posture",
         "local_authorization_posture",
+        "fulfillment_authorization_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -88,6 +97,7 @@ BUNDLE_FILE_NAMES = {
     "safety_gate_posture": "safety_gates.json",
     "live_grant_readiness_posture": "live_grant_readiness.json",
     "local_authorization_posture": "local_authorization.json",
+    "fulfillment_authorization_posture": "fulfillment_authorization.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -100,6 +110,7 @@ FORBIDDEN_MANIFEST_FLAGS = (
 )
 DEFERRED_ACTION_LABELS = (
     "live_authorization_grant",
+    "fulfillment_execution",
     "real_effect_execution",
     "real_rollback_execution",
     "real_fan_pwm_control",
@@ -304,8 +315,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "4. `safety_gates.json` — metadata-only host actuation safety gate posture.",
             "5. `live_grant_readiness.json` — readiness/preflight-only future live-grant posture; it is not a grant.",
             "6. `local_authorization.json` — bounded local authorization-record posture; it is not fulfillment.",
-            "7. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "8. `capability_registry_summary.json` — metadata-only capability posture.",
+            "7. `fulfillment_authorization.json` — metadata-only authorization consumption posture; consuming authorization is not fulfillment.",
+            "8. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "9. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -372,13 +384,30 @@ def build_reviewer_proof_bundle_payload(
         readiness_domain="future_cooling_live_grant_review",
         created_at=created_at,
     )
-    operator_evidence = build_operator_approval_evidence(created_at=created_at)
-    policy_evidence = build_policy_approval_evidence(created_at=created_at)
+    operator_evidence = build_operator_approval_evidence(
+        approval_time_bounds=("not_before:1970-01-01T00:00:00+00:00", "not_after:2999-01-01T00:00:00+00:00"),
+        approval_expiry_label="expires:2999-01-01T00:00:00+00:00",
+        created_at=created_at,
+    )
+    policy_evidence = build_policy_approval_evidence(
+        policy_time_bounds=("not_before:1970-01-01T00:00:00+00:00", "not_after:2999-01-01T00:00:00+00:00"),
+        policy_expiry_label="expires:2999-01-01T00:00:00+00:00",
+        created_at=created_at,
+    )
     local_authorization = build_local_authorization_grant_wing(
         live_grant_readiness.preflight_receipt,
         live_grant_readiness.prerequisite_matrix,
         operator_evidence,
         policy_evidence,
+        created_at=created_at,
+    )
+    fulfillment_authorization = build_fulfillment_authorization_wing(
+        local_authorization.grant,
+        local_authorization.verification,
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_cooling_fulfillment_executor",
+        requested_scope_labels=("future_cooling_scope",),
+        requested_time_label=created_at,
         created_at=created_at,
     )
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
@@ -432,6 +461,29 @@ def build_reviewer_proof_bundle_payload(
                 "ledger": local_authorization.ledger.to_dict(),
             },
         }),
+        "fulfillment_authorization_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "consumption_pre_fulfillment_only": True,
+            "proof_statement": "Fulfillment authorization consumption checks grant scope for a future executor; consuming authorization is not fulfillment, scope match is not execution, and no effect or host mutation is performed.",
+            "request_summary": summarize_fulfillment_authorization_request(fulfillment_authorization.request),
+            "grant_consumption_verification_summary": summarize_grant_consumption_verification(fulfillment_authorization.grant_consumption_verification),
+            "scope_match_assessment_summary": summarize_fulfillment_scope_match_assessment(fulfillment_authorization.scope_match_assessment),
+            "consumption_receipt_summary": summarize_fulfillment_authorization_consumption_receipt(fulfillment_authorization.consumption_receipt) if fulfillment_authorization.consumption_receipt else None,
+            "denial_receipt_summary": summarize_fulfillment_authorization_denial_receipt(fulfillment_authorization.denial_receipt) if fulfillment_authorization.denial_receipt else None,
+            "authorization_consumed_for_future_fulfillment": bool(fulfillment_authorization.consumption_receipt and fulfillment_authorization.consumption_receipt.authorization_consumed_for_future_fulfillment),
+            "fulfillment_granted": False,
+            "effect_performed": False,
+            "host_mutation_performed": False,
+            "real_actuation_deferred": True,
+            "records": {
+                "request": fulfillment_authorization.request.to_dict(),
+                "grant_consumption_verification": fulfillment_authorization.grant_consumption_verification.to_dict(),
+                "scope_match_assessment": fulfillment_authorization.scope_match_assessment.to_dict(),
+                "consumption_receipt": fulfillment_authorization.consumption_receipt.to_dict() if fulfillment_authorization.consumption_receipt else None,
+                "denial_receipt": fulfillment_authorization.denial_receipt.to_dict() if fulfillment_authorization.denial_receipt else None,
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -473,7 +525,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -142,3 +142,19 @@ def test_reviewer_proof_bundle_cli_writes_local_authorization_json(tmp_path) -> 
     assert payload["grant_summary"]["effect_performed"] is False
     assert payload["grant_summary"]["host_mutation_performed"] is False
     assert payload["verification_summary"]["authorizes_fulfillment"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_fulfillment_authorization_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "fulfillment_authorization.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["consumption_pre_fulfillment_only"] is True
+    assert payload["authorization_consumed_for_future_fulfillment"] is True
+    assert payload["fulfillment_granted"] is False
+    assert payload["effect_performed"] is False
+    assert payload["host_mutation_performed"] is False
+    assert payload["consumption_receipt_summary"]["fan_pwm_write_performed"] is False
+    assert payload["consumption_receipt_summary"]["thermal_actuation_performed"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -425,7 +425,7 @@ def test_local_authorization_capabilities_are_record_only_and_real_actions_defer
     assert records["local_authorization_revocation_receipt"].authority_level == "revocation_record_only"
     assert records["local_authorization_expiry_evaluation"].authority_level == "expiry_evaluation_only"
     assert records["local_authorization_verification"].authority_level == "verification_only"
-    assert records["fulfillment_authorization_consumption"].status == "deferred"
+    assert records["fulfillment_authorization_consumption"].status == "implemented"
     assert records["real_effect_execution"].status == "deferred"
     assert records["real_fan_pwm_control"].status in {"blocked", "deferred"}
     assert records["real_thermal_actuation"].status in {"blocked", "deferred"}
@@ -443,7 +443,43 @@ def test_registry_updates_from_local_authorization_ledger_without_fulfillment() 
     records = registry.by_id()
     assert records["local_authorization_grant"].authority_level == "local_authorization_record_only"
     assert records["local_authorization_grant_ledger"].authority_level == "authorization_ledger_only"
-    assert records["fulfillment_authorization_consumption"].status == "deferred"
+    assert records["fulfillment_authorization_consumption"].status == "implemented"
     assert records["real_effect_execution"].status == "deferred"
     assert records["real_fan_pwm_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok
+
+
+def test_fulfillment_authorization_capabilities_are_metadata_only_and_execution_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["fulfillment_authorization_request"].status == "implemented"
+    assert records["fulfillment_authorization_request"].authority_level == "request_only"
+    assert records["grant_consumption_verification"].status == "implemented"
+    assert records["grant_consumption_verification"].authority_level == "verification_only"
+    assert records["fulfillment_scope_match_assessment"].status == "implemented"
+    assert records["fulfillment_scope_match_assessment"].authority_level == "assessment_only"
+    assert records["fulfillment_authorization_consumption_receipt"].status == "implemented"
+    assert records["fulfillment_authorization_consumption_receipt"].authority_level == "consumption_receipt_only"
+    assert records["fulfillment_authorization_denial_receipt"].status == "implemented"
+    assert records["fulfillment_authorization_denial_receipt"].authority_level == "denial_receipt_only"
+    assert records["fulfillment_execution"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_update_from_fulfillment_authorization_consumption_keeps_real_actions_blocked() -> None:
+    from sentientos.capability_registry import update_registry_from_fulfillment_authorization_consumption
+    from tests.test_fulfillment_authorization import _wing
+
+    registry = update_registry_from_fulfillment_authorization_consumption(build_default_capability_registry(), _wing())
+    records = registry.by_id()
+    assert records["fulfillment_authorization_consumption_receipt"].status == "implemented"
+    assert records["fulfillment_execution"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert records["real_thermal_actuation"].status == "blocked"
+    assert records["real_power_profile_mutation"].status == "blocked"
+    assert records["real_service_restart"].status == "blocked"
+    assert records["real_file_cleanup"].status == "blocked"
     assert validate_capability_registry(registry).ok

--- a/tests/test_fulfillment_authorization.py
+++ b/tests/test_fulfillment_authorization.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.controlled_authorization import build_controlled_authorization_wing_for_review_receipt
+from sentientos.fulfillment_authorization import (
+    build_fulfillment_authorization_request,
+    build_fulfillment_authorization_wing,
+    fulfillment_authorization_request_digest,
+    summarize_fulfillment_authorization_consumption_receipt,
+    summarize_fulfillment_authorization_denial_receipt,
+    summarize_fulfillment_authorization_request,
+    summarize_fulfillment_scope_match_assessment,
+    summarize_grant_consumption_verification,
+    validate_fulfillment_authorization_consumption_receipt,
+    validate_fulfillment_authorization_denial_receipt,
+    validate_fulfillment_authorization_request,
+    validate_fulfillment_scope_match_assessment,
+    validate_grant_consumption_verification,
+)
+from sentientos.host_actuation_safety import build_safety_gates_for_domain
+from sentientos.live_grant_readiness import build_live_grant_readiness_wing
+from sentientos.local_authorization_grant import (
+    build_local_authorization_grant,
+    build_local_authorization_grant_expiry_evaluation,
+    build_local_authorization_grant_revocation_receipt,
+    build_operator_approval_evidence,
+    build_policy_approval_evidence,
+    verify_local_authorization_grant,
+)
+from tests.test_controlled_authorization import _review
+
+pytestmark = pytest.mark.no_legacy_skip
+FIXED = "2025-08-01T00:00:00+00:00"
+
+
+def _grant(scope: str = "future_cooling_scope", domain: str = "future_cooling_local_authorization", readiness_domain: str = "future_cooling_live_grant_review"):
+    review = _review("future_cooling_policy_candidate", thermal_zone_temperatures_c={"cpu": 91})
+    ledger = build_controlled_authorization_wing_for_review_receipt(review.receipt, review.future_authorization_grant_schema, created_at=FIXED).ledger
+    safety = build_safety_gates_for_domain("cooling_control_future", created_at=FIXED).safety_gate_satisfaction_manifest
+    readiness = build_live_grant_readiness_wing(ledger, safety, {"manifest_id": "proof", "metadata_only": True}, readiness_domain=readiness_domain, created_at=FIXED)
+    op = build_operator_approval_evidence(
+        approval_scope_labels=(scope,),
+        approval_time_bounds=("not_before:1970-01-01T00:00:00+00:00", "not_after:2999-01-01T00:00:00+00:00"),
+        approval_expiry_label="expires:2999-01-01T00:00:00+00:00",
+        created_at=FIXED,
+    )
+    pol = build_policy_approval_evidence(
+        policy_scope_labels=(scope,),
+        policy_time_bounds=("not_before:1970-01-01T00:00:00+00:00", "not_after:2999-01-01T00:00:00+00:00"),
+        policy_expiry_label="expires:2999-01-01T00:00:00+00:00",
+        created_at=FIXED,
+    )
+    grant = build_local_authorization_grant(readiness.preflight_receipt, readiness.prerequisite_matrix, op, pol, authorization_domain=domain, grant_scope=scope, created_at=FIXED)
+    expiry = build_local_authorization_grant_expiry_evaluation(grant, evaluated_at=FIXED)
+    verification = verify_local_authorization_grant(grant, checked_scope_labels=(scope,), checked_time_label=FIXED, expiry_evaluation=expiry)
+    return grant, verification
+
+
+def _wing(scope: str = "future_cooling_scope", fulfillment_domain: str = "future_cooling_fulfillment_authorization"):
+    grant, verification = _grant(scope=scope, domain=fulfillment_domain.replace("_fulfillment_authorization", "_local_authorization"))
+    return build_fulfillment_authorization_wing(
+        grant,
+        verification,
+        requested_fulfillment_domain=fulfillment_domain,
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=(scope,),
+        requested_time_label=FIXED,
+        created_at=FIXED,
+    )
+
+
+def test_active_valid_matching_scope_records_consumed_authorization_without_fulfillment() -> None:
+    wing = _wing()
+    assert wing.denial_receipt is None
+    assert wing.consumption_receipt is not None
+    assert wing.grant_consumption_verification.consumption_status in {"grant_consumption_verified", "grant_consumption_verified_with_conditions"}
+    assert wing.scope_match_assessment.scope_match_status in {"fulfillment_scope_match", "fulfillment_scope_match_with_conditions"}
+    assert wing.consumption_receipt.authorization_consumed_for_future_fulfillment is True
+    assert wing.consumption_receipt.fulfillment_granted is False
+    assert wing.consumption_receipt.effect_performed is False
+    assert wing.consumption_receipt.host_mutation_performed is False
+    assert validate_fulfillment_authorization_request(wing.request).ok
+    assert validate_grant_consumption_verification(wing.grant_consumption_verification).ok
+    assert validate_fulfillment_scope_match_assessment(wing.scope_match_assessment).ok
+    assert validate_fulfillment_authorization_consumption_receipt(wing.consumption_receipt).ok
+
+
+def test_grant_consumption_verification_does_not_authorize_fulfillment() -> None:
+    wing = _wing()
+    assert wing.grant_consumption_verification.authorizes_fulfillment is False
+    assert wing.grant_consumption_verification.does_not_execute is True
+    assert wing.grant_consumption_verification.does_not_mutate_host is True
+
+
+@pytest.mark.parametrize(
+    ("grant_status", "verification_status", "expected"),
+    [
+        ("local_authorization_grant_blocked", "local_authorization_verification_blocked", "grant_consumption_blocked"),
+        ("local_authorization_grant_incomplete", "local_authorization_verification_incomplete", "grant_consumption_incomplete"),
+        ("local_authorization_grant_contradicted", "local_authorization_verification_contradicted", "grant_consumption_contradicted"),
+        ("local_authorization_grant_expired", "local_authorization_verification_expired", "grant_consumption_expired"),
+        ("local_authorization_grant_revoked", "local_authorization_verification_revoked", "grant_consumption_revoked"),
+    ],
+)
+def test_non_active_grants_produce_denial(grant_status: str, verification_status: str, expected: str) -> None:
+    grant, verification = _grant()
+    grant = replace(grant, grant_status=grant_status, live_authorization_granted=False, digest="")
+    verification = replace(verification, verification_status=verification_status, digest="")
+    wing = build_fulfillment_authorization_wing(
+        grant,
+        verification,
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=("future_cooling_scope",),
+        requested_time_label=FIXED,
+        created_at=FIXED,
+    )
+    assert wing.consumption_receipt is None
+    assert wing.denial_receipt is not None
+    assert wing.grant_consumption_verification.consumption_status == expected
+    assert expected in wing.denial_receipt.denial_reason_codes
+    assert wing.denial_receipt.effect_performed is False
+    assert wing.denial_receipt.host_mutation_performed is False
+    assert validate_fulfillment_authorization_denial_receipt(wing.denial_receipt).ok
+
+
+def test_requested_scope_exceeding_grant_scope_produces_out_of_scope_denial() -> None:
+    grant, verification = _grant()
+    wing = build_fulfillment_authorization_wing(
+        grant,
+        verification,
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=("future_cooling_scope", "future_power_scope"),
+        requested_time_label=FIXED,
+        created_at=FIXED,
+    )
+    assert wing.denial_receipt is not None
+    assert wing.grant_consumption_verification.consumption_status == "grant_consumption_out_of_scope"
+    assert wing.scope_match_assessment.scope_match_status == "fulfillment_scope_mismatch"
+    assert "future_power_scope" in wing.denial_receipt.missing_labels
+
+
+def test_missing_required_request_labels_produce_incomplete_denial() -> None:
+    grant, verification = _grant()
+    request = build_fulfillment_authorization_request(
+        grant,
+        verification,
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=("future_cooling_scope",),
+        requested_time_label=FIXED,
+        required_request_labels=("local_authorization_grant_required",),
+        created_at=FIXED,
+    )
+    assert request.request_status == "fulfillment_authorization_request_incomplete"
+    assert validate_fulfillment_authorization_request(request).ok
+
+
+@pytest.mark.parametrize(
+    ("domain", "scope", "expected_blocks"),
+    [
+        ("future_cooling_fulfillment_authorization", "future_cooling_scope", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_fulfillment_authorization", "future_power_scope", {"power_profile_mutation"}),
+        ("future_cleanup_fulfillment_authorization", "future_cleanup_scope", {"file_cleanup", "file_delete"}),
+        ("future_service_fulfillment_authorization", "future_service_scope", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_domain_consumption_preserves_blocked_actions(domain: str, scope: str, expected_blocks: set[str]) -> None:
+    wing = _wing(scope=scope, fulfillment_domain=domain)
+    record = wing.consumption_receipt or wing.denial_receipt
+    assert record is not None
+    assert expected_blocks <= set(record.blocked_actions)
+
+
+@pytest.mark.parametrize("flag", ["fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed"])
+def test_consumption_validation_rejects_forbidden_action_flags(flag: str) -> None:
+    receipt = _wing().consumption_receipt
+    assert receipt is not None
+    bad = dict(receipt.to_dict())
+    bad[flag] = True
+    assert not validate_fulfillment_authorization_consumption_receipt(bad).ok
+
+
+def test_request_validation_rejects_fulfillment_effect_or_host_mutation_claims() -> None:
+    request = _wing().request
+    for flag in ("fulfillment_granted", "effect_performed", "host_mutation_performed"):
+        bad = dict(request.to_dict())
+        bad[flag] = True
+        assert not validate_fulfillment_authorization_request(bad).ok
+
+
+def test_denial_receipt_does_not_execute_or_mutate() -> None:
+    grant, verification = _grant()
+    wing = build_fulfillment_authorization_wing(
+        grant,
+        verification,
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=("future_power_scope",),
+        requested_time_label=FIXED,
+        created_at=FIXED,
+    )
+    assert wing.denial_receipt is not None
+    assert wing.denial_receipt.authorization_consumed_for_future_fulfillment is False
+    assert wing.denial_receipt.does_not_execute is True
+    assert wing.denial_receipt.does_not_mutate_host is True
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    request = _wing().request
+    same = replace(request, digest="")
+    same = replace(same, digest=fulfillment_authorization_request_digest(same))
+    assert same.digest == request.digest
+    changed = replace(request, requested_backend_class="other_future_backend", digest="")
+    changed = replace(changed, digest=fulfillment_authorization_request_digest(changed))
+    assert changed.digest != request.digest
+
+
+def test_summaries_are_metadata_only_and_non_executing() -> None:
+    wing = _wing()
+    assert summarize_fulfillment_authorization_request(wing.request)["metadata_only"] is True
+    assert summarize_grant_consumption_verification(wing.grant_consumption_verification)["authorizes_fulfillment"] is False
+    assert summarize_fulfillment_scope_match_assessment(wing.scope_match_assessment)["authorizes_fulfillment"] is False
+    assert summarize_fulfillment_authorization_consumption_receipt(wing.consumption_receipt)["effect_performed"] is False
+    denial_wing = build_fulfillment_authorization_wing(
+        _grant()[0],
+        _grant()[1],
+        requested_fulfillment_domain="future_cooling_fulfillment_authorization",
+        requested_backend_class="future_metadata_only_executor",
+        requested_scope_labels=("future_power_scope",),
+        requested_time_label=FIXED,
+        created_at=FIXED,
+    )
+    assert denial_wing.denial_receipt is not None
+    assert summarize_fulfillment_authorization_denial_receipt(denial_wing.denial_receipt)["effect_performed"] is False

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -189,3 +189,20 @@ def test_reviewer_bundle_includes_local_authorization_posture_without_fulfillmen
     assert grant.effect_performed is False
     assert grant.host_mutation_performed is False
     assert payload["local_authorization"].verification.authorizes_fulfillment is False
+
+
+def test_reviewer_bundle_includes_fulfillment_authorization_consumption_posture_without_execution() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "fulfillment_authorization_posture" in payload["artifacts"]
+    assert "fulfillment_authorization.json" in payload["artifacts"]["bundle_manifest"]
+    text = payload["artifacts"]["fulfillment_authorization_posture"]
+    assert "consuming authorization is not fulfillment" in text
+    assert "scope match is not execution" in text
+    wing = payload["fulfillment_authorization"]
+    assert wing.consumption_receipt is not None
+    assert wing.consumption_receipt.authorization_consumed_for_future_fulfillment is True
+    assert wing.consumption_receipt.fulfillment_granted is False
+    assert wing.consumption_receipt.effect_performed is False
+    assert wing.consumption_receipt.host_mutation_performed is False
+    validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
+    assert validation.ok, validation.findings

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -403,3 +403,33 @@ def test_host_local_authorization_grant_doc_preserves_record_only_boundaries() -
     assert "Expiry evaluation is metadata-only" in doc
     assert "Real actuation remains deferred" in doc
     assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfill" in doc
+
+HOST_FULFILLMENT_AUTHORIZATION_CONSUMPTION_WING = "docs/architecture/host_fulfillment_authorization_consumption_wing.md"
+
+
+def test_navigation_links_to_host_fulfillment_authorization_consumption_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    local = _read(HOST_LOCAL_AUTHORIZATION_GRANT_WING)
+    live = _read(HOST_LIVE_GRANT_READINESS_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, local, live, bundle, controlled, trajectory]:
+        assert HOST_FULFILLMENT_AUTHORIZATION_CONSUMPTION_WING in text
+
+
+def test_host_fulfillment_authorization_consumption_doc_preserves_pre_fulfillment_boundaries() -> None:
+    doc = _read(HOST_FULFILLMENT_AUTHORIZATION_CONSUMPTION_WING)
+    assert "Fulfillment authorization consumption is not fulfillment" in doc
+    assert "Scope match is not execution" in doc
+    assert "A consumption receipt does not execute" in doc
+    assert "A denial receipt does not execute" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → fulfill" in doc
+
+
+def test_reviewer_first_run_proof_bundle_doc_lists_fulfillment_authorization_artifact() -> None:
+    doc = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    assert "fulfillment_authorization.json" in doc
+    assert "consuming authorization is not fulfillment" in doc


### PR DESCRIPTION
### Motivation

- Add a metadata-only pre-fulfillment wing that models an executor's attempt to consume a local authorization grant without performing any effects or host mutations.
- Ensure the system can verify grant/verification/scope compatibility and emit non-executing consumption or denial receipts while preserving blocked/deferred action posture.

### Description

- New module `sentientos/fulfillment_authorization.py` implementing frozen dataclasses and helpers for `FulfillmentAuthorizationPolicy`, `FulfillmentAuthorizationRequest`, `GrantConsumptionVerification`, `FulfillmentScopeMatchAssessment`, `FulfillmentAuthorizationConsumptionReceipt`, `FulfillmentAuthorizationDenialReceipt`, validation, summaries, deterministic digests, and `build_fulfillment_authorization_wing(...)` which returns the full wing records.
- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py` now includes `fulfillment_authorization.json` and a `fulfillment_authorization_posture` artifact (metadata-only, reviewer-proof-only) and returns the wing in the payload; proofs remain non-mutating.
- Capability registry updates in `sentientos/capability_registry.py` to represent fulfillment authorization capability records (request/verification/assessment/consumption/denial) and to keep execution/effect capabilities deferred or blocked.
- Docs added/updated: `docs/architecture/host_fulfillment_authorization_consumption_wing.md` plus cross-links from existing architecture docs and reviewer bundle docs clarifying that consumption is not fulfillment and receipts do not execute.
- Tests added and adapted: `tests/test_fulfillment_authorization.py` plus updates to bundle/registry/bundle-script tests to include and assert fulfillment authorization posture and non-execution invariants.
- Minor fix in `sentientos/local_authorization_grant.py` to tighten expiry detection logic (avoid substring expiry misclassification).

### Testing

- Unit suites: ran focused tests including `tests/test_fulfillment_authorization.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py`; all executed green in final run after iterative fixes.
- Integration/coverage checks: ran related host-readiness and control-plane suites `tests/test_local_authorization_grant.py`, `tests/test_live_grant_readiness.py`, `tests/test_host_actuation_safety.py`, `tests/test_controlled_authorization.py`, `tests/test_authorization_review.py`, `tests/test_effect_proof.py`, and `tests/test_actuation_fulfillment.py`; these passed in the final verification runs.
- Reviewer bundle CLI: `scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and summary mode succeeded and produced `/tmp/sentientos-reviewer-proof/fulfillment_authorization.json` with expected metadata-only posture.
- Docs build: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` were run (bootstrap required installing docs deps), and the docs build completed.
- Context-hygiene and forbidden-scan: `scripts/verify_context_hygiene_prompt_boundaries.py` passed and repository forbidden-scan showed only allowed marker strings and blocked/deferred labels; no runtime actuation or network/provider calls were added.

Files changed (high level): `sentientos/fulfillment_authorization.py`, `sentientos/reviewer_proof_bundle.py`, `sentientos/capability_registry.py`, `sentientos/local_authorization_grant.py`, docs under `docs/architecture/`, and tests under `tests/` (added/updated to assert metadata-only, non-executing posture).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a064f3defc88320be19633a4b6ad8cd)