### PR TITLE
[codex:executor-contract] add fulfillment executor contract wing

### DIFF
--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -66,3 +66,7 @@ Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
 See also the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md), which sits after local authorization grants and before any future fulfillment executor. Consumption receipts do not execute.
 
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
+
+Downstream proof links include [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) and [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md); both preserve the boundary that records and contracts are not fulfillment or execution.
+
+Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.

--- a/docs/architecture/host_fulfillment_authorization_consumption_wing.md
+++ b/docs/architecture/host_fulfillment_authorization_consumption_wing.md
@@ -40,3 +40,7 @@ The reviewer proof bundle includes `fulfillment_authorization.json`. The artifac
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_fulfillment_authorization.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+Next wing: [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md). Executor contract is not an executor; backend declaration does not load/invoke backend; dry-run plan is not dry-run execution; admission packet is not control-plane admission; real actuation remains deferred.
+
+Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.

--- a/docs/architecture/host_fulfillment_executor_contract_wing.md
+++ b/docs/architecture/host_fulfillment_executor_contract_wing.md
@@ -1,0 +1,41 @@
+# Host Fulfillment Executor Contract Wing
+
+This wing follows the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md). Consuming authorization is not fulfillment, and this executor contract layer is not an executor. It records the metadata a future host fulfillment executor would need to prove before any real execution backend could exist.
+
+## Boundary
+
+The executor contract is not an executor. An executor backend declaration does not load or invoke backend code. An executor dry-run plan is not dry-run execution. An executor admission packet is not control-plane admission. An executor contract readiness receipt does not implement an executor, grant fulfillment, perform effects, or mutate host state.
+
+This wing does not execute host actions, fulfill host actions, mutate host state, write fan/PWM controls, perform thermal actuation, mutate power profiles, kill processes, restart services, install packages or drivers, clean up or delete files, perform network egress, invoke providers, assemble/export prompts, transport federation state, perform remote execution, or expand runtime authority.
+
+## Records
+
+- **FulfillmentExecutorContract:** metadata-only contract for the requested fulfillment domain, future backend class, executor domain, required executor labels, blocked actions, warnings, risks, and digest. It is `contract_only=true`, `executor_implemented=false`, `backend_loaded=false`, `fulfillment_granted=false`, `effect_performed=false`, and `host_mutation_performed=false`.
+- **ExecutorBackendDeclaration:** declaration-only metadata for a future backend class and supported executor domains. Backend declaration does not load or invoke backend code; `backend_loaded=false` and `backend_invoked=false` remain invariant.
+- **ExecutorPreconditionManifest:** metadata-only list of prerequisite labels and missing labels for a future executor. It is not enforcement and performs no effect.
+- **ExecutorDryRunPlan:** plan-only metadata describing what a future dry-run would need to demonstrate. A dry-run plan is not a dry run execution; `dry_run_executed=false` remains invariant.
+- **ExecutorAdmissionPacket:** packet-only metadata that names future control-plane, audit, effect receipt, postcondition, and rollback requirements. An admission packet is not control-plane admission; `control_plane_admission_granted=false` remains invariant.
+- **ExecutorContractReadinessReceipt:** readiness-only metadata summarizing contract evidence. It does not implement an executor, load a backend, execute a dry run, grant control-plane admission, grant fulfillment, perform effects, mutate host state, write fan/PWM controls, perform thermal/power/service/cleanup actions, invoke providers, open network egress, or assemble prompts.
+
+## Future fulfillment remains deferred
+
+Real fulfillment remains deferred. Real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind future executor implementation, control-plane admission, audit, effect receipt, postcondition checks, rollback, supervisor observation, immutable trace, panic stop, and safety gates.
+
+Future cooling executor contracts preserve fan/PWM and thermal blocked action labels. Future power executor contracts preserve power mutation blocked action labels. Future cleanup executor contracts preserve cleanup/delete blocked action labels. Future service executor contracts preserve service restart/process kill blocked action labels.
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **executor contract/readiness only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `executor_contract.json`. The artifact is reviewer proof only and metadata only. It demonstrates a safe sample where authorization has been consumed for future fulfillment and executor contract records are built, while `executor_implemented=false`, `backend_loaded=false`, `backend_invoked=false`, `dry_run_executed=false`, `control_plane_admission_granted=false`, `fulfillment_granted=false`, `effect_performed=false`, and `host_mutation_performed=false`.
+
+## Implementation links
+
+- Module: `sentientos/fulfillment_executor_contract.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_fulfillment_executor_contract.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_local_authorization_grant_wing.md
+++ b/docs/architecture/host_local_authorization_grant_wing.md
@@ -48,3 +48,7 @@ The reviewer proof bundle includes `local_authorization.json`. That artifact is 
 Next organ: the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) records metadata-only future fulfillment authorization consumption. Consuming authorization is not fulfillment, and scope match is not execution.
 
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
+
+Next proof links: [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) and [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md). Local authorization remains metadata; executor contract is not execution.
+
+Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -258,3 +258,5 @@ Local authorization grant records are documented in [Host Local Authorization Gr
 Reviewer proof link: [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) documents the metadata-only authorization-consumption layer. Consuming authorization is not fulfillment; scope match is not execution; real actuation remains deferred.
 
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
+
+Reviewer map: [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) (`docs/architecture/host_fulfillment_executor_contract_wing.md`) follows fulfillment authorization consumption. Executor contract is not an executor; backend declaration does not load/invoke backend; dry-run plan is not dry-run execution; admission packet is not control-plane admission; real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -86,3 +86,7 @@ Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
 The bundle also writes `fulfillment_authorization.json` for the [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md). The artifact states that consuming authorization is not fulfillment, scope match is not execution, and no effect or host mutation is performed.
 
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
+
+The bundle also includes `executor_contract.json` for the [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md): executor contract is not an executor, backend declaration does not load/invoke backend, dry-run plan is not dry-run execution, admission packet is not control-plane admission, and real actuation remains deferred.
+
+Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -259,3 +259,5 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: 
 - Host Local Authorization Grant Wing: `docs/architecture/host_local_authorization_grant_wing.md`; proof artifact `local_authorization.json`; tests `tests/test_local_authorization_grant.py`. Local authorization grant is authority metadata, not fulfillment, and does not execute.
 
 The [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) (`docs/architecture/host_fulfillment_authorization_consumption_wing.md`) adds metadata-only fulfillment authorization request, grant consumption verification, scope match assessment, consumption receipt, and denial receipt records. Consuming authorization is not fulfillment; scope match is not execution; consumption receipts do not execute; real actuation remains deferred.
+
+- [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) (`docs/architecture/host_fulfillment_executor_contract_wing.md`): metadata-only executor contract/readiness; not an executor, not backend invocation, not dry-run execution, not control-plane admission, and not actuation.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -406,3 +406,7 @@ Path link: `docs/architecture/host_local_authorization_grant_wing.md`.
 Implemented organ link: [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) adds metadata-only pre-fulfillment grant consumption checks while real fulfillment and real actuation remain deferred.
 
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
+
+- [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) records metadata-only executor prerequisites after fulfillment authorization consumption; it is not an executor and real actuation remains deferred.
+
+Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -43,6 +43,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "live_grant_readiness",
         "local_authorization_grant",
         "fulfillment_authorization",
+        "fulfillment_executor_contract",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -83,6 +84,9 @@ AUTHORITY_LEVELS = frozenset(
         "assessment_only",
         "consumption_receipt_only",
         "denial_receipt_only",
+        "precondition_only",
+        "plan_only",
+        "readiness_receipt_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -296,6 +300,15 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("fulfillment_scope_match_assessment", "fulfillment_authorization", "implemented", "assessment_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only requested scope versus granted scope assessment",), deferred_surfaces=("execution", "host mutation"), forbidden_implications=("scope match is execution",)),
         _record("fulfillment_authorization_consumption_receipt", "fulfillment_authorization", "implemented", "consumption_receipt_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only consumption receipt for future fulfillment",), deferred_surfaces=("fulfillment execution", "real effects", "postcondition checks against real effects"), forbidden_implications=("consumption receipt performs effect",)),
         _record("fulfillment_authorization_denial_receipt", "fulfillment_authorization", "implemented", "denial_receipt_only", source_paths=("sentientos/fulfillment_authorization.py",), proof_tests=("tests/test_fulfillment_authorization.py",), implemented_surfaces=("metadata-only denial receipt for out-of-scope or non-active grants",), deferred_surfaces=("fulfillment execution",), forbidden_implications=("denial receipt executes host action",)),
+        _record("fulfillment_executor_contract", "fulfillment_executor_contract", "implemented", "contract_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), proof_commands=("python -m scripts.run_tests -q tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("metadata-only future executor contract records",), deferred_surfaces=("executor implementation", "backend invocation", "control-plane admission for fulfillment", "fulfillment execution"), forbidden_implications=("executor contract is an executor", "contract grants fulfillment"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("executor_backend_declaration", "fulfillment_executor_contract", "implemented", "declaration_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("backend declaration metadata",), deferred_surfaces=("backend loading", "backend invocation"), forbidden_implications=("backend declaration loads a backend", "backend declaration invokes a backend")),
+        _record("executor_precondition_manifest", "fulfillment_executor_contract", "implemented", "precondition_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("executor precondition manifest metadata",), deferred_surfaces=("precondition enforcement by a real executor",), forbidden_implications=("precondition manifest performs an effect",)),
+        _record("executor_dry_run_plan", "fulfillment_executor_contract", "implemented", "plan_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("dry-run plan metadata",), deferred_surfaces=("dry-run execution",), forbidden_implications=("dry-run plan executes a dry run",)),
+        _record("executor_admission_packet", "fulfillment_executor_contract", "implemented", "packet_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("control-plane admission packet metadata",), deferred_surfaces=("control-plane admission", "fulfillment execution"), forbidden_implications=("admission packet is control-plane admission",)),
+        _record("executor_contract_readiness_receipt", "fulfillment_executor_contract", "implemented", "readiness_receipt_only", source_paths=("sentientos/fulfillment_executor_contract.py",), proof_tests=("tests/test_fulfillment_executor_contract.py",), implemented_surfaces=("executor contract readiness receipt metadata",), deferred_surfaces=("executor implementation", "backend invocation", "real effects"), forbidden_implications=("readiness receipt implements executor", "readiness receipt performs effects")),
+        _record("executor_implementation", "fulfillment_executor_contract", "deferred", "none", source_paths=("sentientos/fulfillment_executor_contract.py",), deferred_surfaces=("future executor implementation", "host mutation", "real fulfillment"), forbidden_implications=("executor contract wing implements executor"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("backend_invocation", "fulfillment_executor_contract", "deferred", "none", deferred_surfaces=("backend loading", "backend invocation"), forbidden_implications=("backend declaration invokes backend"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("control_plane_admission_for_fulfillment", "fulfillment_executor_contract", "deferred", "none", deferred_surfaces=("future control-plane admission for fulfillment",), forbidden_implications=("executor admission packet grants admission"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("fulfillment_execution", "fulfillment_authorization", "deferred", "none", deferred_surfaces=("future fulfillment executor", "host mutation", "effect receipt from real action"), forbidden_implications=("fulfillment authorization wing implements execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -312,9 +325,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/host_fulfillment_executor_contract_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-fulfillment-authorization-consumption-wing", schema_version="host-fulfillment-authorization-consumption-wing.v1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-fulfillment-executor-contract-wing", schema_version="host-fulfillment-executor-contract-wing.v1", records=records)
 
 
 
@@ -947,3 +960,35 @@ def update_registry_from_local_authorization_ledger(registry: CapabilityRegistry
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-local-authorization-grant-wing.v1")
+
+
+def update_registry_from_executor_contract_readiness(registry: CapabilityRegistry, readiness_wing: Any) -> CapabilityRegistry:
+    """Reflect executor contract readiness without implementing execution."""
+
+    has_contract = bool(getattr(getattr(readiness_wing, "contract", None), "contract_id", "")) or bool(getattr(readiness_wing, "contract_id", ""))
+    has_backend = bool(getattr(getattr(readiness_wing, "backend_declaration", None), "declaration_id", "")) or bool(getattr(readiness_wing, "backend_declaration_id", ""))
+    has_manifest = bool(getattr(getattr(readiness_wing, "precondition_manifest", None), "manifest_id", "")) or bool(getattr(readiness_wing, "precondition_manifest_id", ""))
+    has_plan = bool(getattr(getattr(readiness_wing, "dry_run_plan", None), "plan_id", "")) or bool(getattr(readiness_wing, "dry_run_plan_id", ""))
+    has_packet = bool(getattr(getattr(readiness_wing, "admission_packet", None), "packet_id", "")) or bool(getattr(readiness_wing, "admission_packet_id", ""))
+    has_receipt = bool(getattr(getattr(readiness_wing, "readiness_receipt", None), "receipt_id", "")) or bool(getattr(readiness_wing, "receipt_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "fulfillment_executor_contract":
+            records.append(replace(record, status="implemented" if has_contract else record.status, authority_level="contract_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "executor_backend_declaration":
+            records.append(replace(record, status="implemented" if has_backend else record.status, authority_level="declaration_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "executor_precondition_manifest":
+            records.append(replace(record, status="implemented" if has_manifest else record.status, authority_level="precondition_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "executor_dry_run_plan":
+            records.append(replace(record, status="implemented" if has_plan else record.status, authority_level="plan_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "executor_admission_packet":
+            records.append(replace(record, status="implemented" if has_packet else record.status, authority_level="packet_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "executor_contract_readiness_receipt":
+            records.append(replace(record, status="implemented" if has_receipt else record.status, authority_level="readiness_receipt_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"executor_implementation", "backend_invocation", "control_plane_admission_for_fulfillment", "fulfillment_execution", "real_effect_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-fulfillment-executor-contract-wing.v1")

--- a/sentientos/fulfillment_executor_contract.py
+++ b/sentientos/fulfillment_executor_contract.py
@@ -1,0 +1,742 @@
+"""Metadata-only fulfillment executor contract readiness records.
+
+This wing follows fulfillment authorization consumption and defines the proof a
+future host fulfillment executor would have to provide before a real backend can
+exist. It is strictly contract/readiness-only: it does not execute or fulfill
+host actions, mutate host state, load or invoke backends, write fan/PWM controls,
+change thermal or power settings, restart services, clean files, make network
+calls, invoke providers, assemble prompts, or call control-plane admission.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.fulfillment_authorization import FulfillmentAuthorizationConsumptionReceipt
+
+CONTRACT_STATUSES = frozenset({
+    "fulfillment_executor_contract_ready",
+    "fulfillment_executor_contract_ready_with_conditions",
+    "fulfillment_executor_contract_blocked",
+    "fulfillment_executor_contract_incomplete",
+    "fulfillment_executor_contract_contradicted",
+})
+BACKEND_DECLARATION_STATUSES = frozenset({
+    "executor_backend_declared",
+    "executor_backend_declared_with_warnings",
+    "executor_backend_blocked",
+    "executor_backend_incomplete",
+    "executor_backend_contradicted",
+})
+PRECONDITION_STATUSES = frozenset({
+    "executor_preconditions_ready",
+    "executor_preconditions_ready_with_conditions",
+    "executor_preconditions_blocked",
+    "executor_preconditions_incomplete",
+    "executor_preconditions_contradicted",
+})
+DRY_RUN_PLAN_STATUSES = frozenset({
+    "executor_dry_run_plan_ready",
+    "executor_dry_run_plan_ready_with_conditions",
+    "executor_dry_run_plan_blocked",
+    "executor_dry_run_plan_incomplete",
+    "executor_dry_run_plan_contradicted",
+})
+ADMISSION_PACKET_STATUSES = frozenset({
+    "executor_admission_packet_ready",
+    "executor_admission_packet_ready_with_conditions",
+    "executor_admission_packet_blocked",
+    "executor_admission_packet_incomplete",
+    "executor_admission_packet_contradicted",
+})
+READINESS_RECEIPT_STATUSES = frozenset({
+    "executor_contract_readiness_recorded",
+    "executor_contract_readiness_recorded_with_warnings",
+    "executor_contract_readiness_blocked",
+    "executor_contract_readiness_incomplete",
+    "executor_contract_readiness_contradicted",
+})
+EXECUTOR_DOMAINS = frozenset({
+    "diagnostics_executor_contract",
+    "operator_review_executor_contract",
+    "resource_pressure_executor_contract",
+    "thermal_safety_executor_contract",
+    "future_cooling_executor_contract",
+    "future_power_executor_contract",
+    "future_cleanup_executor_contract",
+    "future_service_executor_contract",
+})
+BACKEND_CLASSES = frozenset({
+    "diagnostic_backend_future",
+    "operator_manual_backend_future",
+    "cooling_backend_future",
+    "power_backend_future",
+    "cleanup_backend_future",
+    "service_backend_future",
+})
+REQUIRED_EXECUTOR_LABELS = frozenset({
+    "fulfillment_authorization_consumption_required",
+    "local_authorization_grant_required",
+    "scope_match_required",
+    "grant_not_expired_required",
+    "grant_not_revoked_required",
+    "backend_declaration_required",
+    "executor_identity_required",
+    "dry_run_plan_required",
+    "precondition_manifest_required",
+    "control_plane_admission_required_for_future_execution",
+    "effect_receipt_required_for_future_execution",
+    "postcondition_check_required_for_future_execution",
+    "rollback_receipt_required_for_future_execution",
+    "audit_receipt_required_for_future_execution",
+    "runtime_supervisor_observation_required",
+    "immutable_trace_required",
+    "panic_stop_required",
+    "safety_gates_required",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+})
+_DOMAIN_TO_EXECUTOR = {
+    "diagnostics_fulfillment_authorization": "diagnostics_executor_contract",
+    "operator_review_fulfillment_authorization": "operator_review_executor_contract",
+    "resource_pressure_fulfillment_authorization": "resource_pressure_executor_contract",
+    "thermal_safety_fulfillment_authorization": "thermal_safety_executor_contract",
+    "future_cooling_fulfillment_authorization": "future_cooling_executor_contract",
+    "future_power_fulfillment_authorization": "future_power_executor_contract",
+    "future_cleanup_fulfillment_authorization": "future_cleanup_executor_contract",
+    "future_service_fulfillment_authorization": "future_service_executor_contract",
+}
+_EXECUTOR_TO_BACKEND = {
+    "diagnostics_executor_contract": "diagnostic_backend_future",
+    "operator_review_executor_contract": "operator_manual_backend_future",
+    "resource_pressure_executor_contract": "diagnostic_backend_future",
+    "thermal_safety_executor_contract": "diagnostic_backend_future",
+    "future_cooling_executor_contract": "cooling_backend_future",
+    "future_power_executor_contract": "power_backend_future",
+    "future_cleanup_executor_contract": "cleanup_backend_future",
+    "future_service_executor_contract": "service_backend_future",
+}
+_DOMAIN_BLOCKS = {
+    "future_cooling_executor_contract": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_executor_contract": ("power_profile_mutation",),
+    "future_cleanup_executor_contract": ("file_cleanup", "file_delete"),
+    "future_service_executor_contract": ("service_restart", "process_kill"),
+}
+_CONSUMPTION_STATUS_MAP = {
+    "fulfillment_authorization_consumption_recorded": ("fulfillment_executor_contract_ready", "executor_backend_declared", "executor_preconditions_ready", "executor_dry_run_plan_ready", "executor_admission_packet_ready", "executor_contract_readiness_recorded"),
+    "fulfillment_authorization_consumption_recorded_with_warnings": ("fulfillment_executor_contract_ready_with_conditions", "executor_backend_declared_with_warnings", "executor_preconditions_ready_with_conditions", "executor_dry_run_plan_ready_with_conditions", "executor_admission_packet_ready_with_conditions", "executor_contract_readiness_recorded_with_warnings"),
+    "fulfillment_authorization_consumption_blocked": ("fulfillment_executor_contract_blocked", "executor_backend_blocked", "executor_preconditions_blocked", "executor_dry_run_plan_blocked", "executor_admission_packet_blocked", "executor_contract_readiness_blocked"),
+    "fulfillment_authorization_consumption_expired": ("fulfillment_executor_contract_blocked", "executor_backend_blocked", "executor_preconditions_blocked", "executor_dry_run_plan_blocked", "executor_admission_packet_blocked", "executor_contract_readiness_blocked"),
+    "fulfillment_authorization_consumption_revoked": ("fulfillment_executor_contract_blocked", "executor_backend_blocked", "executor_preconditions_blocked", "executor_dry_run_plan_blocked", "executor_admission_packet_blocked", "executor_contract_readiness_blocked"),
+    "fulfillment_authorization_consumption_out_of_scope": ("fulfillment_executor_contract_blocked", "executor_backend_blocked", "executor_preconditions_blocked", "executor_dry_run_plan_blocked", "executor_admission_packet_blocked", "executor_contract_readiness_blocked"),
+    "fulfillment_authorization_consumption_incomplete": ("fulfillment_executor_contract_incomplete", "executor_backend_incomplete", "executor_preconditions_incomplete", "executor_dry_run_plan_incomplete", "executor_admission_packet_incomplete", "executor_contract_readiness_incomplete"),
+    "fulfillment_authorization_consumption_contradicted": ("fulfillment_executor_contract_contradicted", "executor_backend_contradicted", "executor_preconditions_contradicted", "executor_dry_run_plan_contradicted", "executor_admission_packet_contradicted", "executor_contract_readiness_contradicted"),
+}
+_FORBIDDEN_TRUE_FLAGS = (
+    "executor_implemented",
+    "backend_loaded",
+    "backend_invoked",
+    "dry_run_executed",
+    "control_plane_admission_granted",
+    "fulfillment_granted",
+    "effect_performed",
+    "host_mutation_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+)
+
+
+@dataclass(frozen=True)
+class FulfillmentExecutorPolicy:
+    policy_id: str
+    required_executor_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    metadata_only: bool = True
+    executor_contract_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentExecutorContract:
+    contract_id: str
+    source_consumption_receipt_id: str
+    source_consumption_receipt_digest: str
+    requested_fulfillment_domain: str
+    backend_class: str
+    executor_domain: str
+    contract_status: str
+    required_executor_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    contract_only: bool = True
+    executor_implemented: bool = False
+    backend_loaded: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutorBackendDeclaration:
+    declaration_id: str
+    contract_id: str
+    backend_class: str
+    backend_label: str
+    supported_executor_domains: tuple[str, ...]
+    unsupported_executor_domains: tuple[str, ...]
+    required_privilege_labels: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    declaration_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    declaration_only: bool = True
+    backend_loaded: bool = False
+    backend_invoked: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutorPreconditionManifest:
+    manifest_id: str
+    contract_id: str
+    source_consumption_receipt_id: str
+    precondition_labels: tuple[str, ...]
+    missing_precondition_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    precondition_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    precondition_only: bool = True
+    host_mutation_performed: bool = False
+    effect_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutorDryRunPlan:
+    plan_id: str
+    contract_id: str
+    backend_class: str
+    dry_run_steps: tuple[str, ...]
+    expected_no_effect_labels: tuple[str, ...]
+    required_observation_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    dry_run_plan_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_plan_only: bool = True
+    dry_run_executed: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutorAdmissionPacket:
+    packet_id: str
+    contract_id: str
+    source_consumption_receipt_id: str
+    backend_declaration_id: str
+    precondition_manifest_id: str
+    dry_run_plan_id: str
+    executor_domain: str
+    admission_packet_status: str
+    required_control_plane_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_effect_receipt_labels: tuple[str, ...]
+    required_postcondition_labels: tuple[str, ...]
+    required_rollback_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    admission_packet_only: bool = True
+    control_plane_admission_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutorContractReadinessReceipt:
+    receipt_id: str
+    contract_id: str
+    backend_declaration_id: str
+    precondition_manifest_id: str
+    dry_run_plan_id: str
+    admission_packet_id: str
+    readiness_status: str
+    evidence_summary: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    readiness_receipt_only: bool = True
+    executor_implemented: bool = False
+    backend_loaded: bool = False
+    dry_run_executed: bool = False
+    control_plane_admission_granted: bool = False
+    fulfillment_granted: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FulfillmentExecutorValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+class FulfillmentExecutorContractWingRecords(NamedTuple):
+    contract: FulfillmentExecutorContract
+    backend_declaration: ExecutorBackendDeclaration
+    precondition_manifest: ExecutorPreconditionManifest
+    dry_run_plan: ExecutorDryRunPlan
+    admission_packet: ExecutorAdmissionPacket
+    readiness_receipt: ExecutorContractReadinessReceipt
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = dict(_source_payload(record_or_payload))
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def fulfillment_executor_contract_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+executor_backend_declaration_digest = fulfillment_executor_contract_digest
+executor_precondition_manifest_digest = fulfillment_executor_contract_digest
+executor_dry_run_plan_digest = fulfillment_executor_contract_digest
+executor_admission_packet_digest = fulfillment_executor_contract_digest
+executor_contract_readiness_receipt_digest = fulfillment_executor_contract_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def build_default_fulfillment_executor_policy() -> FulfillmentExecutorPolicy:
+    return FulfillmentExecutorPolicy(
+        "fulfillment-executor-contract-policy-v1",
+        tuple(sorted(REQUIRED_EXECUTOR_LABELS)),
+        tuple(sorted(BLOCKED_ACTION_LABELS)),
+    )
+
+
+def _statuses_for_consumption(receipt: Mapping[str, Any]) -> tuple[str, str, str, str, str, str]:
+    status = str(receipt.get("consumption_status", ""))
+    if any(receipt.get(flag, False) for flag in _FORBIDDEN_TRUE_FLAGS if flag in receipt):
+        return _CONSUMPTION_STATUS_MAP["fulfillment_authorization_consumption_contradicted"]
+    if status in _CONSUMPTION_STATUS_MAP and receipt.get("authorization_consumed_for_future_fulfillment", False):
+        return _CONSUMPTION_STATUS_MAP[status]
+    if status in _CONSUMPTION_STATUS_MAP and status != "fulfillment_authorization_consumption_recorded":
+        return _CONSUMPTION_STATUS_MAP[status]
+    return _CONSUMPTION_STATUS_MAP["fulfillment_authorization_consumption_incomplete"]
+
+
+def _executor_domain(receipt: Mapping[str, Any], requested: str | None = None) -> str:
+    return requested or _DOMAIN_TO_EXECUTOR.get(str(receipt.get("requested_fulfillment_domain", "")), "operator_review_executor_contract")
+
+
+def _backend_class(executor_domain: str, requested: str | None = None) -> str:
+    if requested in BACKEND_CLASSES:
+        return requested
+    return _EXECUTOR_TO_BACKEND.get(executor_domain, "operator_manual_backend_future")
+
+
+def _blocked_actions(receipt: Mapping[str, Any], executor_domain: str, extra: Sequence[str] | None = None) -> tuple[str, ...]:
+    return tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_tuple(receipt.get("blocked_actions"))) | set(_DOMAIN_BLOCKS.get(executor_domain, ())) | set(_tuple(extra))))
+
+
+def _missing_labels(receipt: Mapping[str, Any]) -> tuple[str, ...]:
+    if receipt.get("authorization_consumed_for_future_fulfillment") and str(receipt.get("consumption_status")) in {"fulfillment_authorization_consumption_recorded", "fulfillment_authorization_consumption_recorded_with_warnings"}:
+        return ()
+    return ("valid_fulfillment_authorization_consumption_required",)
+
+
+def build_fulfillment_executor_contract(
+    consumption_receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any],
+    *,
+    executor_domain: str | None = None,
+    backend_class: str | None = None,
+    required_executor_labels: Sequence[str] | None = None,
+    blocked_actions: Sequence[str] | None = None,
+    contract_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> FulfillmentExecutorContract:
+    receipt = _source_payload(consumption_receipt)
+    domain = _executor_domain(receipt, executor_domain)
+    backend = _backend_class(domain, backend_class)
+    statuses = _statuses_for_consumption(receipt)
+    required = tuple(sorted(set(REQUIRED_EXECUTOR_LABELS) | set(_tuple(required_executor_labels))))
+    blocked = _blocked_actions(receipt, domain, blocked_actions)
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"executor_contract_is_not_executor", "backend_declaration_is_not_loaded_backend"}))
+    provisional = FulfillmentExecutorContract(
+        contract_id or _digest_id("fulfillment-executor-contract-", {"receipt": receipt.get("receipt_id"), "domain": domain, "backend": backend, "status": statuses[0]}),
+        str(receipt.get("receipt_id", "")),
+        str(receipt.get("digest", "")),
+        str(receipt.get("requested_fulfillment_domain", "")),
+        backend,
+        domain,
+        statuses[0],
+        required,
+        blocked,
+        tuple(sorted(set(_tuple(receipt.get("warning_codes"))))),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=fulfillment_executor_contract_digest(provisional))
+
+
+def build_executor_backend_declaration(contract: FulfillmentExecutorContract | Mapping[str, Any], *, backend_label: str | None = None, declaration_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutorBackendDeclaration:
+    c = _source_payload(contract)
+    status = {
+        "fulfillment_executor_contract_ready": "executor_backend_declared",
+        "fulfillment_executor_contract_ready_with_conditions": "executor_backend_declared_with_warnings",
+        "fulfillment_executor_contract_blocked": "executor_backend_blocked",
+        "fulfillment_executor_contract_incomplete": "executor_backend_incomplete",
+        "fulfillment_executor_contract_contradicted": "executor_backend_contradicted",
+    }.get(str(c.get("contract_status")), "executor_backend_incomplete")
+    supported = (str(c.get("executor_domain", "")),) if status not in {"executor_backend_incomplete", "executor_backend_contradicted"} else ()
+    unsupported = tuple(sorted(EXECUTOR_DOMAINS - set(supported)))
+    provisional = ExecutorBackendDeclaration(
+        declaration_id or _digest_id("executor-backend-declaration-", {"contract": c.get("contract_id"), "backend": c.get("backend_class"), "status": status}),
+        str(c.get("contract_id", "")),
+        str(c.get("backend_class", "")),
+        backend_label or f"{c.get('backend_class', '')}:declaration-only:not-loaded:not-invoked",
+        supported,
+        unsupported,
+        ("local_authorization_grant_required", "control_plane_admission_required_for_future_execution", "panic_stop_required"),
+        ("scope_match_required",),
+        status,
+        _tuple(c.get("warning_codes")),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"backend_declaration_does_not_load_or_invoke_backend"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=executor_backend_declaration_digest(provisional))
+
+
+def build_executor_precondition_manifest(contract: FulfillmentExecutorContract | Mapping[str, Any], consumption_receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any], *, manifest_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutorPreconditionManifest:
+    c = _source_payload(contract)
+    r = _source_payload(consumption_receipt)
+    missing = _missing_labels(r)
+    status = {
+        "fulfillment_executor_contract_ready": "executor_preconditions_ready",
+        "fulfillment_executor_contract_ready_with_conditions": "executor_preconditions_ready_with_conditions",
+        "fulfillment_executor_contract_blocked": "executor_preconditions_blocked",
+        "fulfillment_executor_contract_incomplete": "executor_preconditions_incomplete",
+        "fulfillment_executor_contract_contradicted": "executor_preconditions_contradicted",
+    }.get(str(c.get("contract_status")), "executor_preconditions_incomplete")
+    if missing and status == "executor_preconditions_ready":
+        status = "executor_preconditions_incomplete"
+    provisional = ExecutorPreconditionManifest(
+        manifest_id or _digest_id("executor-precondition-manifest-", {"contract": c.get("contract_id"), "missing": missing, "status": status}),
+        str(c.get("contract_id", "")),
+        str(r.get("receipt_id", "")),
+        tuple(sorted(REQUIRED_EXECUTOR_LABELS)),
+        missing,
+        _tuple(c.get("blocked_actions")),
+        status,
+        _tuple(c.get("warning_codes")),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"precondition_manifest_is_metadata_only"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=executor_precondition_manifest_digest(provisional))
+
+
+def build_executor_dry_run_plan(contract: FulfillmentExecutorContract | Mapping[str, Any], *, plan_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutorDryRunPlan:
+    c = _source_payload(contract)
+    status = {
+        "fulfillment_executor_contract_ready": "executor_dry_run_plan_ready",
+        "fulfillment_executor_contract_ready_with_conditions": "executor_dry_run_plan_ready_with_conditions",
+        "fulfillment_executor_contract_blocked": "executor_dry_run_plan_blocked",
+        "fulfillment_executor_contract_incomplete": "executor_dry_run_plan_incomplete",
+        "fulfillment_executor_contract_contradicted": "executor_dry_run_plan_contradicted",
+    }.get(str(c.get("contract_status")), "executor_dry_run_plan_incomplete")
+    provisional = ExecutorDryRunPlan(
+        plan_id or _digest_id("executor-dry-run-plan-", {"contract": c.get("contract_id"), "backend": c.get("backend_class"), "status": status}),
+        str(c.get("contract_id", "")),
+        str(c.get("backend_class", "")),
+        ("review_contract_metadata", "verify_precondition_manifest", "prepare_future_control_plane_packet_without_admission", "record_no_effect_expectations"),
+        ("dry_run_plan_is_not_execution", "no_fulfillment_granted", "no_effect_performed", "no_host_mutation_performed"),
+        ("runtime_supervisor_observation_required", "immutable_trace_required", "audit_receipt_required_for_future_execution"),
+        _tuple(c.get("blocked_actions")),
+        status,
+        _tuple(c.get("warning_codes")),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"dry_run_plan_is_not_dry_run_execution"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=executor_dry_run_plan_digest(provisional))
+
+
+def build_executor_admission_packet(contract: FulfillmentExecutorContract | Mapping[str, Any], backend_declaration: ExecutorBackendDeclaration | Mapping[str, Any], precondition_manifest: ExecutorPreconditionManifest | Mapping[str, Any], dry_run_plan: ExecutorDryRunPlan | Mapping[str, Any], consumption_receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any], *, packet_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutorAdmissionPacket:
+    c = _source_payload(contract)
+    b = _source_payload(backend_declaration)
+    m = _source_payload(precondition_manifest)
+    p = _source_payload(dry_run_plan)
+    r = _source_payload(consumption_receipt)
+    status = {
+        "fulfillment_executor_contract_ready": "executor_admission_packet_ready",
+        "fulfillment_executor_contract_ready_with_conditions": "executor_admission_packet_ready_with_conditions",
+        "fulfillment_executor_contract_blocked": "executor_admission_packet_blocked",
+        "fulfillment_executor_contract_incomplete": "executor_admission_packet_incomplete",
+        "fulfillment_executor_contract_contradicted": "executor_admission_packet_contradicted",
+    }.get(str(c.get("contract_status")), "executor_admission_packet_incomplete")
+    provisional = ExecutorAdmissionPacket(
+        packet_id or _digest_id("executor-admission-packet-", {"contract": c.get("contract_id"), "backend": b.get("declaration_id"), "manifest": m.get("manifest_id"), "plan": p.get("plan_id"), "status": status}),
+        str(c.get("contract_id", "")),
+        str(r.get("receipt_id", "")),
+        str(b.get("declaration_id", "")),
+        str(m.get("manifest_id", "")),
+        str(p.get("plan_id", "")),
+        str(c.get("executor_domain", "")),
+        status,
+        ("control_plane_admission_required_for_future_execution", "operator_authority_required", "panic_stop_required", "safety_gates_required"),
+        ("audit_receipt_required_for_future_execution", "immutable_trace_required"),
+        ("effect_receipt_required_for_future_execution",),
+        ("postcondition_check_required_for_future_execution",),
+        ("rollback_receipt_required_for_future_execution",),
+        _tuple(c.get("blocked_actions")),
+        tuple(sorted(set(_tuple(c.get("warning_codes"))) | set(_tuple(b.get("warning_codes"))) | set(_tuple(m.get("warning_codes"))) | set(_tuple(p.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"admission_packet_is_not_control_plane_admission"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=executor_admission_packet_digest(provisional))
+
+
+def build_executor_contract_readiness_receipt(contract: FulfillmentExecutorContract | Mapping[str, Any], backend_declaration: ExecutorBackendDeclaration | Mapping[str, Any], precondition_manifest: ExecutorPreconditionManifest | Mapping[str, Any], dry_run_plan: ExecutorDryRunPlan | Mapping[str, Any], admission_packet: ExecutorAdmissionPacket | Mapping[str, Any], *, receipt_id: str | None = None, created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutorContractReadinessReceipt:
+    c = _source_payload(contract)
+    b = _source_payload(backend_declaration)
+    m = _source_payload(precondition_manifest)
+    p = _source_payload(dry_run_plan)
+    a = _source_payload(admission_packet)
+    status = {
+        "fulfillment_executor_contract_ready": "executor_contract_readiness_recorded",
+        "fulfillment_executor_contract_ready_with_conditions": "executor_contract_readiness_recorded_with_warnings",
+        "fulfillment_executor_contract_blocked": "executor_contract_readiness_blocked",
+        "fulfillment_executor_contract_incomplete": "executor_contract_readiness_incomplete",
+        "fulfillment_executor_contract_contradicted": "executor_contract_readiness_contradicted",
+    }.get(str(c.get("contract_status")), "executor_contract_readiness_incomplete")
+    missing = tuple(sorted(set(_tuple(m.get("missing_precondition_labels")))))
+    evidence = (
+        "executor_contract_recorded_metadata_only",
+        "backend_declaration_not_loaded_or_invoked",
+        "precondition_manifest_recorded_metadata_only",
+        "dry_run_plan_not_executed",
+        "admission_packet_not_control_plane_admission",
+        "readiness_receipt_does_not_implement_executor_or_perform_effects",
+    )
+    provisional = ExecutorContractReadinessReceipt(
+        receipt_id or _digest_id("executor-contract-readiness-", {"contract": c.get("contract_id"), "packet": a.get("packet_id"), "status": status, "missing": missing}),
+        str(c.get("contract_id", "")),
+        str(b.get("declaration_id", "")),
+        str(m.get("manifest_id", "")),
+        str(p.get("plan_id", "")),
+        str(a.get("packet_id", "")),
+        status,
+        evidence,
+        missing,
+        _tuple(c.get("blocked_actions")),
+        tuple(sorted(set(_tuple(c.get("warning_codes"))) | set(_tuple(a.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"readiness_receipt_is_not_executor_implementation", "real_fulfillment_remains_deferred"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=executor_contract_readiness_receipt_digest(provisional))
+
+
+def _validate_common(payload: Mapping[str, Any], *, prefix: str, status_field: str, statuses: frozenset[str], only_field: str, digest_fn: Any) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False):
+        findings.append(prefix + "not_metadata_only")
+    if not payload.get(only_field, False):
+        findings.append(prefix + f"not_{only_field}")
+    if payload.get(status_field) not in statuses:
+        findings.append(prefix + "unknown_status")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if payload.get(flag, False):
+            findings.append(prefix + f"forbidden_flag:{flag}")
+    if payload.get("digest") and payload.get("digest") != digest_fn(payload):
+        findings.append(prefix + "digest_mismatch")
+    return findings
+
+
+def validate_fulfillment_executor_contract(contract: FulfillmentExecutorContract | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(contract)
+    f = _validate_common(p, prefix="contract:", status_field="contract_status", statuses=CONTRACT_STATUSES, only_field="contract_only", digest_fn=fulfillment_executor_contract_digest)
+    if p.get("executor_domain") not in EXECUTOR_DOMAINS:
+        f.append("contract:unknown_executor_domain")
+    if p.get("backend_class") not in BACKEND_CLASSES:
+        f.append("contract:unknown_backend_class")
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def validate_executor_backend_declaration(declaration: ExecutorBackendDeclaration | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(declaration)
+    f = _validate_common(p, prefix="backend:", status_field="declaration_status", statuses=BACKEND_DECLARATION_STATUSES, only_field="declaration_only", digest_fn=executor_backend_declaration_digest)
+    if p.get("backend_class") not in BACKEND_CLASSES:
+        f.append("backend:unknown_backend_class")
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def validate_executor_precondition_manifest(manifest: ExecutorPreconditionManifest | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(manifest)
+    f = _validate_common(p, prefix="preconditions:", status_field="precondition_status", statuses=PRECONDITION_STATUSES, only_field="precondition_only", digest_fn=executor_precondition_manifest_digest)
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def validate_executor_dry_run_plan(plan: ExecutorDryRunPlan | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(plan)
+    f = _validate_common(p, prefix="dry_run_plan:", status_field="dry_run_plan_status", statuses=DRY_RUN_PLAN_STATUSES, only_field="dry_run_plan_only", digest_fn=executor_dry_run_plan_digest)
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def validate_executor_admission_packet(packet: ExecutorAdmissionPacket | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(packet)
+    f = _validate_common(p, prefix="admission_packet:", status_field="admission_packet_status", statuses=ADMISSION_PACKET_STATUSES, only_field="admission_packet_only", digest_fn=executor_admission_packet_digest)
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def validate_executor_contract_readiness_receipt(receipt: ExecutorContractReadinessReceipt | Mapping[str, Any]) -> FulfillmentExecutorValidationResult:
+    p = _source_payload(receipt)
+    f = _validate_common(p, prefix="readiness:", status_field="readiness_status", statuses=READINESS_RECEIPT_STATUSES, only_field="readiness_receipt_only", digest_fn=executor_contract_readiness_receipt_digest)
+    return FulfillmentExecutorValidationResult(not f, tuple(f))
+
+
+def summarize_fulfillment_executor_contract(contract: FulfillmentExecutorContract | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(contract)
+    return {k: p.get(k) for k in ("contract_id", "source_consumption_receipt_id", "requested_fulfillment_domain", "backend_class", "executor_domain", "contract_status", "metadata_only", "contract_only", "executor_implemented", "backend_loaded", "fulfillment_granted", "effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_executor_backend_declaration(declaration: ExecutorBackendDeclaration | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(declaration)
+    return {k: p.get(k) for k in ("declaration_id", "contract_id", "backend_class", "backend_label", "declaration_status", "metadata_only", "declaration_only", "backend_loaded", "backend_invoked", "host_mutation_performed", "digest")}
+
+
+def summarize_executor_precondition_manifest(manifest: ExecutorPreconditionManifest | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(manifest)
+    return {k: p.get(k) for k in ("manifest_id", "contract_id", "source_consumption_receipt_id", "missing_precondition_labels", "precondition_status", "metadata_only", "precondition_only", "effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_executor_dry_run_plan(plan: ExecutorDryRunPlan | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(plan)
+    return {k: p.get(k) for k in ("plan_id", "contract_id", "backend_class", "dry_run_plan_status", "metadata_only", "dry_run_plan_only", "dry_run_executed", "effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_executor_admission_packet(packet: ExecutorAdmissionPacket | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(packet)
+    return {k: p.get(k) for k in ("packet_id", "contract_id", "source_consumption_receipt_id", "executor_domain", "admission_packet_status", "metadata_only", "admission_packet_only", "control_plane_admission_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_executor_contract_readiness_receipt(receipt: ExecutorContractReadinessReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "contract_id", "readiness_status", "metadata_only", "readiness_receipt_only", "executor_implemented", "backend_loaded", "dry_run_executed", "control_plane_admission_granted", "fulfillment_granted", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "digest")}
+
+
+def build_fulfillment_executor_contract_wing(
+    consumption_receipt: FulfillmentAuthorizationConsumptionReceipt | Mapping[str, Any],
+    *,
+    executor_domain: str | None = None,
+    backend_class: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> FulfillmentExecutorContractWingRecords:
+    contract = build_fulfillment_executor_contract(consumption_receipt, executor_domain=executor_domain, backend_class=backend_class, created_at=created_at)
+    backend_declaration = build_executor_backend_declaration(contract, created_at=created_at)
+    precondition_manifest = build_executor_precondition_manifest(contract, consumption_receipt, created_at=created_at)
+    dry_run_plan = build_executor_dry_run_plan(contract, created_at=created_at)
+    admission_packet = build_executor_admission_packet(contract, backend_declaration, precondition_manifest, dry_run_plan, consumption_receipt, created_at=created_at)
+    readiness_receipt = build_executor_contract_readiness_receipt(contract, backend_declaration, precondition_manifest, dry_run_plan, admission_packet, created_at=created_at)
+    return FulfillmentExecutorContractWingRecords(contract, backend_declaration, precondition_manifest, dry_run_plan, admission_packet, readiness_receipt)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -33,6 +33,15 @@ from sentientos.fulfillment_authorization import (
     summarize_fulfillment_scope_match_assessment,
     summarize_grant_consumption_verification,
 )
+from sentientos.fulfillment_executor_contract import (
+    build_fulfillment_executor_contract_wing,
+    summarize_executor_admission_packet,
+    summarize_executor_backend_declaration,
+    summarize_executor_contract_readiness_receipt,
+    summarize_executor_dry_run_plan,
+    summarize_executor_precondition_manifest,
+    summarize_fulfillment_executor_contract,
+)
 from sentientos.local_authorization_grant import (
     build_local_authorization_grant_wing,
     build_operator_approval_evidence,
@@ -74,6 +83,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "live_grant_readiness_posture",
         "local_authorization_posture",
         "fulfillment_authorization_posture",
+        "executor_contract_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -98,6 +108,7 @@ BUNDLE_FILE_NAMES = {
     "live_grant_readiness_posture": "live_grant_readiness.json",
     "local_authorization_posture": "local_authorization.json",
     "fulfillment_authorization_posture": "fulfillment_authorization.json",
+    "executor_contract_posture": "executor_contract.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -110,6 +121,9 @@ FORBIDDEN_MANIFEST_FLAGS = (
 )
 DEFERRED_ACTION_LABELS = (
     "live_authorization_grant",
+    "executor_implementation",
+    "backend_invocation",
+    "control_plane_admission_for_fulfillment",
     "fulfillment_execution",
     "real_effect_execution",
     "real_rollback_execution",
@@ -316,8 +330,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "5. `live_grant_readiness.json` — readiness/preflight-only future live-grant posture; it is not a grant.",
             "6. `local_authorization.json` — bounded local authorization-record posture; it is not fulfillment.",
             "7. `fulfillment_authorization.json` — metadata-only authorization consumption posture; consuming authorization is not fulfillment.",
-            "8. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "9. `capability_registry_summary.json` — metadata-only capability posture.",
+            "8. `executor_contract.json` — metadata-only executor contract posture; it is not an executor.",
+            "9. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "10. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -331,6 +346,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Safety gates are not authorization and do not grant fulfillment or control authority.",
             "- Live-grant readiness is not a live grant; the approval packet is not approval; preflight does not issue a grant.",
             "- Local authorization grant records are authority metadata only; verification does not authorize fulfillment.",
+            "- Executor contract records are readiness metadata only; they do not load backends, execute dry runs, grant control-plane admission, fulfill actions, or perform effects.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -410,6 +426,9 @@ def build_reviewer_proof_bundle_payload(
         requested_time_label=created_at,
         created_at=created_at,
     )
+    if fulfillment_authorization.consumption_receipt is None:
+        raise ValueError("reviewer proof scenario expected consumed authorization receipt")
+    executor_contract = build_fulfillment_executor_contract_wing(fulfillment_authorization.consumption_receipt, created_at=created_at)
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
@@ -484,6 +503,35 @@ def build_reviewer_proof_bundle_payload(
                 "denial_receipt": fulfillment_authorization.denial_receipt.to_dict() if fulfillment_authorization.denial_receipt else None,
             },
         }),
+        "executor_contract_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "executor_contract_readiness_only": True,
+            "proof_statement": "Executor contract records define prerequisites for a future executor only; the contract is not an executor, backend declarations are not loaded or invoked, dry-run plans are not executed, admission packets are not control-plane admission, and readiness receipts perform no effects.",
+            "contract_summary": summarize_fulfillment_executor_contract(executor_contract.contract),
+            "backend_declaration_summary": summarize_executor_backend_declaration(executor_contract.backend_declaration),
+            "precondition_manifest_summary": summarize_executor_precondition_manifest(executor_contract.precondition_manifest),
+            "dry_run_plan_summary": summarize_executor_dry_run_plan(executor_contract.dry_run_plan),
+            "admission_packet_summary": summarize_executor_admission_packet(executor_contract.admission_packet),
+            "readiness_receipt_summary": summarize_executor_contract_readiness_receipt(executor_contract.readiness_receipt),
+            "executor_implemented": False,
+            "backend_loaded": False,
+            "backend_invoked": False,
+            "dry_run_executed": False,
+            "control_plane_admission_granted": False,
+            "fulfillment_granted": False,
+            "effect_performed": False,
+            "host_mutation_performed": False,
+            "real_actuation_deferred": True,
+            "records": {
+                "contract": executor_contract.contract.to_dict(),
+                "backend_declaration": executor_contract.backend_declaration.to_dict(),
+                "precondition_manifest": executor_contract.precondition_manifest.to_dict(),
+                "dry_run_plan": executor_contract.dry_run_plan.to_dict(),
+                "admission_packet": executor_contract.admission_packet.to_dict(),
+                "readiness_receipt": executor_contract.readiness_receipt.to_dict(),
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -525,7 +573,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -158,3 +158,21 @@ def test_reviewer_proof_bundle_cli_writes_fulfillment_authorization_json(tmp_pat
     assert payload["host_mutation_performed"] is False
     assert payload["consumption_receipt_summary"]["fan_pwm_write_performed"] is False
     assert payload["consumption_receipt_summary"]["thermal_actuation_performed"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_executor_contract_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "executor_contract.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["executor_contract_readiness_only"] is True
+    assert payload["contract_summary"]["executor_implemented"] is False
+    assert payload["backend_declaration_summary"]["backend_loaded"] is False
+    assert payload["backend_declaration_summary"]["backend_invoked"] is False
+    assert payload["dry_run_plan_summary"]["dry_run_executed"] is False
+    assert payload["admission_packet_summary"]["control_plane_admission_granted"] is False
+    assert payload["readiness_receipt_summary"]["fulfillment_granted"] is False
+    assert payload["readiness_receipt_summary"]["effect_performed"] is False
+    assert payload["readiness_receipt_summary"]["host_mutation_performed"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -483,3 +483,40 @@ def test_registry_update_from_fulfillment_authorization_consumption_keeps_real_a
     assert records["real_service_restart"].status == "blocked"
     assert records["real_file_cleanup"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_fulfillment_executor_contract_capabilities_are_contract_only_and_real_execution_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["fulfillment_executor_contract"].status == "implemented"
+    assert records["fulfillment_executor_contract"].authority_level == "contract_only"
+    assert records["executor_backend_declaration"].authority_level == "declaration_only"
+    assert records["executor_precondition_manifest"].authority_level == "precondition_only"
+    assert records["executor_dry_run_plan"].authority_level == "plan_only"
+    assert records["executor_admission_packet"].authority_level == "packet_only"
+    assert records["executor_contract_readiness_receipt"].authority_level == "readiness_receipt_only"
+    for capability_id in ["executor_implementation", "backend_invocation", "control_plane_admission_for_fulfillment", "fulfillment_execution", "real_effect_execution"]:
+        assert records[capability_id].status == "deferred"
+        assert records[capability_id].host_actuation_performed is False
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status in {"blocked", "deferred"}
+        assert records[capability_id].host_actuation_performed is False
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_update_from_executor_contract_readiness_preserves_deferred_execution() -> None:
+    from sentientos.capability_registry import update_registry_from_executor_contract_readiness
+    from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+    from tests.test_fulfillment_authorization import _wing, FIXED
+
+    receipt = _wing().consumption_receipt
+    wing = build_fulfillment_executor_contract_wing(receipt, created_at=FIXED)
+    registry = update_registry_from_executor_contract_readiness(build_default_capability_registry(), wing)
+    records = registry.by_id()
+    assert records["fulfillment_executor_contract"].authority_level == "contract_only"
+    assert records["executor_contract_readiness_receipt"].authority_level == "readiness_receipt_only"
+    assert records["executor_implementation"].status == "deferred"
+    assert records["backend_invocation"].status == "deferred"
+    assert records["control_plane_admission_for_fulfillment"].status == "deferred"
+    assert records["fulfillment_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_fulfillment_executor_contract.py
+++ b/tests/test_fulfillment_executor_contract.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.fulfillment_executor_contract import (
+    build_fulfillment_executor_contract_wing,
+    executor_contract_readiness_receipt_digest,
+    summarize_executor_admission_packet,
+    summarize_executor_backend_declaration,
+    summarize_executor_contract_readiness_receipt,
+    summarize_executor_dry_run_plan,
+    summarize_executor_precondition_manifest,
+    summarize_fulfillment_executor_contract,
+    validate_executor_admission_packet,
+    validate_executor_backend_declaration,
+    validate_executor_contract_readiness_receipt,
+    validate_executor_dry_run_plan,
+    validate_executor_precondition_manifest,
+    validate_fulfillment_executor_contract,
+)
+from tests.test_fulfillment_authorization import FIXED, _wing
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _consumed_receipt(domain: str = "future_cooling_fulfillment_authorization"):
+    scope = domain.replace("_fulfillment_authorization", "_scope").replace("future_cooling_scope", "future_cooling_scope")
+    if domain == "future_power_fulfillment_authorization":
+        scope = "future_power_scope"
+    elif domain == "future_cleanup_fulfillment_authorization":
+        scope = "future_cleanup_scope"
+    elif domain == "future_service_fulfillment_authorization":
+        scope = "future_service_scope"
+    return _wing(scope=scope, fulfillment_domain=domain).consumption_receipt
+
+
+def test_consumed_authorization_builds_executor_contract_wing_without_execution() -> None:
+    wing = build_fulfillment_executor_contract_wing(_consumed_receipt(), created_at=FIXED)
+    assert wing.contract.contract_status in {"fulfillment_executor_contract_ready", "fulfillment_executor_contract_ready_with_conditions"}
+    assert wing.contract.contract_only is True
+    assert wing.contract.executor_implemented is False
+    assert wing.contract.backend_loaded is False
+    assert wing.backend_declaration.declaration_only is True
+    assert wing.backend_declaration.backend_loaded is False
+    assert wing.backend_declaration.backend_invoked is False
+    assert wing.precondition_manifest.precondition_only is True
+    assert wing.dry_run_plan.dry_run_plan_only is True
+    assert wing.dry_run_plan.dry_run_executed is False
+    assert wing.admission_packet.admission_packet_only is True
+    assert wing.admission_packet.control_plane_admission_granted is False
+    assert wing.readiness_receipt.readiness_receipt_only is True
+    assert wing.readiness_receipt.executor_implemented is False
+    assert wing.readiness_receipt.fulfillment_granted is False
+    assert wing.readiness_receipt.effect_performed is False
+    assert wing.readiness_receipt.host_mutation_performed is False
+    assert validate_fulfillment_executor_contract(wing.contract).ok
+    assert validate_executor_backend_declaration(wing.backend_declaration).ok
+    assert validate_executor_precondition_manifest(wing.precondition_manifest).ok
+    assert validate_executor_dry_run_plan(wing.dry_run_plan).ok
+    assert validate_executor_admission_packet(wing.admission_packet).ok
+    assert validate_executor_contract_readiness_receipt(wing.readiness_receipt).ok
+
+
+@pytest.mark.parametrize(
+    ("consumption_status", "consumed", "expected"),
+    [
+        ("fulfillment_authorization_consumption_blocked", False, "executor_contract_readiness_blocked"),
+        ("fulfillment_authorization_consumption_expired", False, "executor_contract_readiness_blocked"),
+        ("fulfillment_authorization_consumption_revoked", False, "executor_contract_readiness_blocked"),
+        ("fulfillment_authorization_consumption_out_of_scope", False, "executor_contract_readiness_blocked"),
+        ("fulfillment_authorization_consumption_incomplete", False, "executor_contract_readiness_incomplete"),
+        ("fulfillment_authorization_consumption_contradicted", False, "executor_contract_readiness_contradicted"),
+    ],
+)
+def test_blocked_incomplete_and_contradicted_consumption_map_to_readiness_statuses(consumption_status: str, consumed: bool, expected: str) -> None:
+    receipt = replace(_consumed_receipt(), consumption_status=consumption_status, authorization_consumed_for_future_fulfillment=consumed, digest="")
+    wing = build_fulfillment_executor_contract_wing(receipt, created_at=FIXED)
+    assert wing.readiness_receipt.readiness_status == expected
+    if expected != "executor_contract_readiness_contradicted":
+        assert wing.precondition_manifest.missing_precondition_labels == ("valid_fulfillment_authorization_consumption_required",)
+
+
+@pytest.mark.parametrize(
+    ("domain", "blocked"),
+    [
+        ("future_cooling_fulfillment_authorization", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_fulfillment_authorization", {"power_profile_mutation"}),
+        ("future_cleanup_fulfillment_authorization", {"file_cleanup", "file_delete"}),
+        ("future_service_fulfillment_authorization", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_domain_specific_blocks_are_preserved(domain: str, blocked: set[str]) -> None:
+    wing = build_fulfillment_executor_contract_wing(_consumed_receipt(domain), created_at=FIXED)
+    assert blocked <= set(wing.contract.blocked_actions)
+    assert blocked <= set(wing.readiness_receipt.blocked_actions)
+
+
+@pytest.mark.parametrize(
+    ("record_name", "flag"),
+    [
+        ("contract", "fulfillment_granted"),
+        ("contract", "effect_performed"),
+        ("contract", "host_mutation_performed"),
+        ("contract", "backend_loaded"),
+        ("backend_declaration", "backend_loaded"),
+        ("backend_declaration", "backend_invoked"),
+        ("dry_run_plan", "dry_run_executed"),
+        ("admission_packet", "control_plane_admission_granted"),
+        ("readiness_receipt", "fan_pwm_write_performed"),
+        ("readiness_receipt", "thermal_actuation_performed"),
+        ("readiness_receipt", "power_profile_mutation_performed"),
+        ("readiness_receipt", "service_restart_performed"),
+        ("readiness_receipt", "file_cleanup_performed"),
+        ("readiness_receipt", "provider_invocation_performed"),
+        ("readiness_receipt", "network_performed"),
+        ("readiness_receipt", "prompt_assembly_performed"),
+    ],
+)
+def test_validation_rejects_forbidden_true_flags(record_name: str, flag: str) -> None:
+    wing = build_fulfillment_executor_contract_wing(_consumed_receipt(), created_at=FIXED)
+    record = replace(getattr(wing, record_name), **{flag: True, "digest": ""})
+    validators = {
+        "contract": validate_fulfillment_executor_contract,
+        "backend_declaration": validate_executor_backend_declaration,
+        "dry_run_plan": validate_executor_dry_run_plan,
+        "admission_packet": validate_executor_admission_packet,
+        "readiness_receipt": validate_executor_contract_readiness_receipt,
+    }
+    result = validators[record_name](record)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    one = build_fulfillment_executor_contract_wing(_consumed_receipt(), created_at=FIXED)
+    two = build_fulfillment_executor_contract_wing(_consumed_receipt(), created_at=FIXED)
+    assert one.readiness_receipt.digest == two.readiness_receipt.digest
+    changed = replace(one.readiness_receipt, evidence_summary=one.readiness_receipt.evidence_summary + ("additional_reviewer_note",), digest="")
+    assert executor_contract_readiness_receipt_digest(changed) != one.readiness_receipt.digest
+
+
+def test_summaries_are_metadata_only_and_non_authorizing() -> None:
+    wing = build_fulfillment_executor_contract_wing(_consumed_receipt(), created_at=FIXED)
+    summaries = (
+        summarize_fulfillment_executor_contract(wing.contract),
+        summarize_executor_backend_declaration(wing.backend_declaration),
+        summarize_executor_precondition_manifest(wing.precondition_manifest),
+        summarize_executor_dry_run_plan(wing.dry_run_plan),
+        summarize_executor_admission_packet(wing.admission_packet),
+        summarize_executor_contract_readiness_receipt(wing.readiness_receipt),
+    )
+    for summary in summaries:
+        assert summary["metadata_only"] is True
+        assert summary.get("effect_performed") is not True
+        assert summary.get("host_mutation_performed") is not True
+    assert summaries[0]["executor_implemented"] is False
+    assert summaries[1]["backend_invoked"] is False
+    assert summaries[3]["dry_run_executed"] is False
+    assert summaries[4]["control_plane_admission_granted"] is False
+    assert summaries[5]["fulfillment_granted"] is False

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -206,3 +206,30 @@ def test_reviewer_bundle_includes_fulfillment_authorization_consumption_posture_
     assert wing.consumption_receipt.host_mutation_performed is False
     validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
     assert validation.ok, validation.findings
+
+
+def test_bundle_includes_executor_contract_posture_without_execution() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    artifacts = payload["artifacts"]
+    manifest = payload["manifest"]
+    assert "executor_contract_posture" in artifacts
+    assert any(record.artifact_kind == "executor_contract_posture" and record.relative_path == "executor_contract.json" for record in manifest.artifact_records)
+    assert "Executor contract records define prerequisites" in artifacts["executor_contract_posture"]
+    wing = payload["executor_contract"]
+    assert wing.contract.executor_implemented is False
+    assert wing.backend_declaration.backend_loaded is False
+    assert wing.backend_declaration.backend_invoked is False
+    assert wing.dry_run_plan.dry_run_executed is False
+    assert wing.admission_packet.control_plane_admission_granted is False
+    assert wing.readiness_receipt.fulfillment_granted is False
+    assert wing.readiness_receipt.effect_performed is False
+    assert wing.readiness_receipt.host_mutation_performed is False
+    validation = validate_reviewer_proof_bundle_manifest(manifest)
+    assert validation.ok, validation.findings
+
+
+def test_deferred_actions_include_executor_contract_non_execution_ladder() -> None:
+    manifest = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)["manifest"]
+    for label in ["executor_implementation", "backend_invocation", "control_plane_admission_for_fulfillment", "fulfillment_execution"]:
+        assert label in manifest.deferred_capability_labels
+        assert label in DEFERRED_ACTION_LABELS

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -433,3 +433,39 @@ def test_reviewer_first_run_proof_bundle_doc_lists_fulfillment_authorization_art
     doc = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
     assert "fulfillment_authorization.json" in doc
     assert "consuming authorization is not fulfillment" in doc
+
+HOST_FULFILLMENT_EXECUTOR_CONTRACT_WING = "docs/architecture/host_fulfillment_executor_contract_wing.md"
+
+
+def test_navigation_links_to_host_fulfillment_executor_contract_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    consumption = _read(HOST_FULFILLMENT_AUTHORIZATION_CONSUMPTION_WING)
+    local = _read(HOST_LOCAL_AUTHORIZATION_GRANT_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, consumption, local, bundle, controlled, trajectory]:
+        assert HOST_FULFILLMENT_EXECUTOR_CONTRACT_WING in text
+
+
+def test_host_fulfillment_executor_contract_doc_preserves_contract_only_boundaries() -> None:
+    doc = _read(HOST_FULFILLMENT_EXECUTOR_CONTRACT_WING)
+    assert "executor contract is not an executor" in doc.lower()
+    assert "backend declaration does not load or invoke backend" in doc
+    assert "dry-run plan is not dry-run execution" in doc
+    assert "admission packet is not control-plane admission" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "executor_implemented=false" in doc
+    assert "backend_loaded=false" in doc
+    assert "dry_run_executed=false" in doc
+    assert "control_plane_admission_granted=false" in doc
+    assert "fulfillment_granted=false" in doc
+    assert "effect_performed=false" in doc
+    assert "host_mutation_performed=false" in doc
+
+
+def test_reviewer_first_run_proof_bundle_doc_lists_executor_contract_artifact() -> None:
+    doc = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    assert "executor_contract.json" in doc
+    assert "executor contract is not an executor" in doc.lower()


### PR DESCRIPTION
### Motivation

- Add a conservative, metadata-only executor contract/readiness layer that records the proof a future host fulfillment executor must provide before any real backend or execution can exist. 
- Preserve the existing strict non-execution boundaries (no host mutation, no fan/PWM writes, no provider/network/prompt calls, no control-plane admission) while enabling deterministic readiness artifacts for reviewers. 
- Integrate the new readiness posture into the reviewer proof bundle and the capability registry so review tooling can show executor-contract posture without claiming execution authority.

### Description

- Introduced `sentientos/fulfillment_executor_contract.py` defining frozen dataclasses and helpers for `FulfillmentExecutorPolicy`, `FulfillmentExecutorContract`, `ExecutorBackendDeclaration`, `ExecutorPreconditionManifest`, `ExecutorDryRunPlan`, `ExecutorAdmissionPacket`, `ExecutorContractReadinessReceipt`, validators, summaries, deterministic digest helpers, and `build_fulfillment_executor_contract_wing(...)` which assembles the full metadata-only wing from a `FulfillmentAuthorizationConsumptionReceipt`.
- Extended `sentientos/reviewer_proof_bundle.py` to produce an `executor_contract.json` artifact (`executor_contract_posture`) built from a consumed authorization receipt while preserving all non-execution invariants and added the artifact kind/file name.
- Updated `sentientos/capability_registry.py` to advertise the new contract/readiness surfaces (contract, backend declaration, precondition manifest, dry-run plan, admission packet, readiness receipt) as metadata/contract-only surfaces and to keep executor implementation, backend invocation, control-plane admission, fulfillment execution, and real actuation deferred/blocked; added `update_registry_from_executor_contract_readiness(...)` helper.
- Added architecture doc `docs/architecture/host_fulfillment_executor_contract_wing.md`, wired reviewer-facing links in existing docs, and added focused tests: `tests/test_fulfillment_executor_contract.py` plus updates to reviewer-bundle, bundle-script, capability-registry, and release-readiness index tests to assert the non-executing contract posture.

### Testing

- Static/byte-compile checks: `py_compile` on the new and modified modules succeeded with no syntax errors.
- Unit tests: ran targeted suites `tests/test_fulfillment_executor_contract.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py` and their related integration proofs; the test runs passed after adding the new tests and doc links (one test failure in a doc-link assertion was fixed by adding the doc references). 
- Reviewer bundle and docs: `scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` created `/tmp/sentientos-reviewer-proof/executor_contract.json` and the bundle validated, and `scripts/build_docs.py --bootstrap-docs` then `--check-deps` / `build` completed (initially reported missing `mkdocs` which was resolved by the documented bootstrap step).
- Safety/forbidden scan and context hygiene: `scripts/verify_context_hygiene_prompt_boundaries.py` and a forbidden-pattern scan were run and only matched allowed boundary labels / documentation text; no forbidden runtime calls or host-mutating operations were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0679d0f1948320b1a9275ad998b8bf)