### PR TITLE
[codex:dry-run] add host dry-run execution harness (simulation-only)

### DIFF
--- a/docs/architecture/host_dry_run_execution_harness_wing.md
+++ b/docs/architecture/host_dry_run_execution_harness_wing.md
@@ -1,0 +1,45 @@
+# Host Dry-Run Execution Harness Wing
+
+This wing follows the [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md). The executor contract is not an executor; it is readiness metadata. The dry-run execution harness is the next organ-sized wing and is still simulation-only: it can run only inert, deterministic, in-process simulated backend mappings against executor contract readiness records.
+
+## Boundary
+
+Dry-run execution is not real fulfillment. A dry-run result is not an effect receipt. A dry-run receipt is not proof of host mutation. `dry_run_executed=true` means only the in-process simulation mapping ran.
+
+The harness does not create real host executors, does not create OS backend implementations, does not call control-plane admission/execution, and does not mutate host state. It performs no subprocess execution, shell execution, network egress, provider invocation, prompt assembly/export, filesystem cleanup/deletion, service-manager operation, process kill, hardware control, thermal write, power-profile mutation, or fan/PWM write.
+
+## Records
+
+- **DryRunExecutionHarnessPolicy:** metadata-only policy declaring supported dry-run domains, simulated backend classes, blocked action labels, and simulation-only status.
+- **SimulatedBackendRegistry:** metadata-only registry of inert simulated backends. It is `simulated_only=true`, `no_real_backends=true`, and `host_mutation_performed=false`.
+- **DryRunExecutionRequest:** request-only record tying an executor contract readiness receipt to a requested dry-run domain and simulated backend class. It has `does_not_execute_real_backend=true`.
+- **DryRunExecutionResult:** simulation-only result. It may set `dry_run_executed=true`, but keeps `real_backend_invoked=false`, `real_fulfillment_performed=false`, `real_effect_performed=false`, `effect_performed=false`, and `host_mutation_performed=false`.
+- **DryRunExecutionReceipt:** dry-run-receipt-only evidence that simulation ran. It is not real fulfillment, not an effect receipt, and not proof of host mutation.
+- **DryRunExecutionBlockReceipt:** block/failure receipt for blocked, incomplete, contradicted, or unknown simulated-backend requests. It has `dry_run_executed=false`, `does_not_execute=true`, and `does_not_mutate_host=true`.
+
+## Simulated backends
+
+Simulated backends are pure deterministic mappings/functions inside `sentientos/dry_run_execution_harness.py`. They are labels and metadata, not real backend modules. Future cooling dry-runs preserve `fan_pwm_write` and `thermal_actuation` blocked actions. Future power dry-runs preserve `power_profile_mutation`. Future cleanup dry-runs preserve `file_cleanup` and `file_delete`. Future service dry-runs preserve `service_restart` and `process_kill`.
+
+Any record that claims real backend invocation, real fulfillment, effect execution, host mutation, fan/PWM write, thermal actuation, power mutation, service restart, cleanup/delete, network, provider, prompt assembly, subprocess execution, shell execution, OS backend invocation, or control-plane admission execution is contradicted by validation.
+
+## Future fulfillment remains deferred
+
+Real fulfillment remains deferred. Real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind a future real executor implementation, control-plane admission, audit, effect receipt, postcondition checks, rollback, supervisor observation, immutable trace, panic stop, and safety gates.
+
+The authority ladder remains:
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → dry-run execution harness → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **dry-run simulated execution only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `dry_run_execution.json`. The artifact is reviewer proof only and metadata only. It demonstrates a safe sample where executor contract readiness exists, the dry-run harness runs an inert simulated backend, `dry_run_executed=true` is allowed, and `real_backend_invoked=false`, `real_fulfillment_performed=false`, `real_effect_performed=false`, and `host_mutation_performed=false` remain invariant.
+
+## Implementation links
+
+- Module: `sentientos/dry_run_execution_harness.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_dry_run_execution_harness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -70,3 +70,6 @@ Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
 Downstream proof links include [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) and [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md); both preserve the boundary that records and contracts are not fulfillment or execution.
 
 Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/host_fulfillment_authorization_consumption_wing.md
+++ b/docs/architecture/host_fulfillment_authorization_consumption_wing.md
@@ -44,3 +44,6 @@ The reviewer proof bundle includes `fulfillment_authorization.json`. The artifac
 Next wing: [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md). Executor contract is not an executor; backend declaration does not load/invoke backend; dry-run plan is not dry-run execution; admission packet is not control-plane admission; real actuation remains deferred.
 
 Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/host_fulfillment_executor_contract_wing.md
+++ b/docs/architecture/host_fulfillment_executor_contract_wing.md
@@ -39,3 +39,6 @@ The reviewer proof bundle includes `executor_contract.json`. The artifact is rev
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_fulfillment_executor_contract.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -260,3 +260,6 @@ Reviewer proof link: [Host Fulfillment Authorization Consumption Wing](host_fulf
 Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
 
 Reviewer map: [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) (`docs/architecture/host_fulfillment_executor_contract_wing.md`) follows fulfillment authorization consumption. Executor contract is not an executor; backend declaration does not load/invoke backend; dry-run plan is not dry-run execution; admission packet is not control-plane admission; real actuation remains deferred.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -35,6 +35,11 @@ The bundle writes:
 - `capability_registry_summary.json` — metadata-only capability registry summary and records.
 - `deferred_actions.json` — deferred/blocked action inventory.
 - `safety_gates.json` — metadata-only host actuation safety gate posture; safety gates are not authorization.
+- `live_grant_readiness.json` — readiness/preflight-only live-grant posture; it is not a live grant.
+- `local_authorization.json` — local authorization-record posture; it is not fulfillment.
+- `fulfillment_authorization.json` — authorization consumption posture; consuming authorization is not fulfillment.
+- `executor_contract.json` — executor contract/readiness posture; executor contract is not an executor.
+- `dry_run_execution.json` — simulation-only dry-run harness posture; dry-run execution is not real fulfillment or an effect receipt.
 - `proof_commands.json` — proof command manifest; commands are listed but not run by default.
 - `README.md` — local reviewer guide for the bundle directory.
 - `bundle_manifest.json` — manifest, artifact digests, command records, and safety flags.
@@ -48,7 +53,12 @@ Reviewers should inspect these files in order:
 3. `bundle_manifest.json`
 4. `deferred_actions.json`
 5. `safety_gates.json`
-6. `proof_commands.json`
+6. `live_grant_readiness.json`
+7. `local_authorization.json`
+8. `fulfillment_authorization.json`
+9. `executor_contract.json`
+10. `dry_run_execution.json`
+11. `proof_commands.json`
 
 ## What the bundle proves
 
@@ -90,3 +100,10 @@ Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
 The bundle also includes `executor_contract.json` for the [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md): executor contract is not an executor, backend declaration does not load/invoke backend, dry-run plan is not dry-run execution, admission packet is not control-plane admission, and real actuation remains deferred.
 
 Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
+
+The bundle also includes `dry_run_execution.json` for the [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md): the harness uses only inert simulated backends; dry-run execution is not real fulfillment; a dry-run result is not an effect receipt; a dry-run receipt is not proof of host mutation; real actuation remains deferred.
+
+Proof path: `docs/architecture/host_dry_run_execution_harness_wing.md`.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -261,3 +261,6 @@ See `docs/architecture/host_embodiment_reviewer_demo_trace.md`. Proof commands: 
 The [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authorization_consumption_wing.md) (`docs/architecture/host_fulfillment_authorization_consumption_wing.md`) adds metadata-only fulfillment authorization request, grant consumption verification, scope match assessment, consumption receipt, and denial receipt records. Consuming authorization is not fulfillment; scope match is not execution; consumption receipts do not execute; real actuation remains deferred.
 
 - [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) (`docs/architecture/host_fulfillment_executor_contract_wing.md`): metadata-only executor contract/readiness; not an executor, not backend invocation, not dry-run execution, not control-plane admission, and not actuation.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -410,3 +410,6 @@ Path: `docs/architecture/host_fulfillment_authorization_consumption_wing.md`.
 - [Host Fulfillment Executor Contract Wing](host_fulfillment_executor_contract_wing.md) records metadata-only executor prerequisites after fulfillment authorization consumption; it is not an executor and real actuation remains deferred.
 
 Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
+
+
+See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -44,6 +44,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "local_authorization_grant",
         "fulfillment_authorization",
         "fulfillment_executor_contract",
+        "dry_run_execution_harness",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -87,6 +88,8 @@ AUTHORITY_LEVELS = frozenset(
         "precondition_only",
         "plan_only",
         "readiness_receipt_only",
+        "simulated_only",
+        "dry_run_receipt_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -309,6 +312,12 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("executor_implementation", "fulfillment_executor_contract", "deferred", "none", source_paths=("sentientos/fulfillment_executor_contract.py",), deferred_surfaces=("future executor implementation", "host mutation", "real fulfillment"), forbidden_implications=("executor contract wing implements executor"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("backend_invocation", "fulfillment_executor_contract", "deferred", "none", deferred_surfaces=("backend loading", "backend invocation"), forbidden_implications=("backend declaration invokes backend"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("control_plane_admission_for_fulfillment", "fulfillment_executor_contract", "deferred", "none", deferred_surfaces=("future control-plane admission for fulfillment",), forbidden_implications=("executor admission packet grants admission"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("dry_run_execution_harness", "dry_run_execution_harness", "implemented", "simulated_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), proof_commands=("python -m scripts.run_tests -q tests/test_dry_run_execution_harness.py",), implemented_surfaces=("deterministic in-process simulated dry-run harness",), deferred_surfaces=("real backend invocation", "real fulfillment execution", "real effect execution", "host mutation"), forbidden_implications=("dry-run harness is real fulfillment", "dry-run harness performs host mutation"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("simulated_backend_registry", "dry_run_execution_harness", "implemented", "simulated_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("inert simulated backend registry metadata",), deferred_surfaces=("real backend loading", "real backend invocation"), forbidden_implications=("simulated backend registry loads real backends",)),
+        _record("dry_run_execution_request", "dry_run_execution_harness", "implemented", "request_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("dry-run request records",), deferred_surfaces=("real backend execution",), forbidden_implications=("dry-run request executes a backend",)),
+        _record("dry_run_execution_result", "dry_run_execution_harness", "implemented", "simulated_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("simulation-only dry-run results",), deferred_surfaces=("effect receipt", "host mutation", "real fulfillment"), forbidden_implications=("dry-run result is effect receipt",)),
+        _record("dry_run_execution_receipt", "dry_run_execution_harness", "implemented", "dry_run_receipt_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("dry-run-only execution receipts",), deferred_surfaces=("proof of host mutation", "real effect receipt"), forbidden_implications=("dry-run receipt proves host mutation",)),
+        _record("real_backend_invocation", "dry_run_execution_harness", "deferred", "none", deferred_surfaces=("real backend invocation", "OS backend invocation", "control-plane execution"), forbidden_implications=("dry-run harness invokes real backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("fulfillment_execution", "fulfillment_authorization", "deferred", "none", deferred_surfaces=("future fulfillment executor", "host mutation", "effect receipt from real action"), forbidden_implications=("fulfillment authorization wing implements execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -559,6 +568,36 @@ def replace_capability_record(registry: CapabilityRegistry, capability_id: str, 
     records = tuple(replace(record, **changes) if record.capability_id == capability_id else record for record in registry.records)
     return replace(registry, records=records)
 
+
+
+def update_registry_from_dry_run_execution_receipt(registry: CapabilityRegistry, receipt: Any) -> CapabilityRegistry:
+    """Reflect a simulation-only dry-run receipt without claiming real effects."""
+
+    records: list[CapabilityRecord] = []
+    has_receipt = bool(getattr(receipt, "receipt_id", "")) or bool(isinstance(receipt, Mapping) and receipt.get("receipt_id"))
+    for record in registry.records:
+        if record.capability_id in {"dry_run_execution_harness", "dry_run_execution_result", "dry_run_execution_receipt"}:
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_receipt else record.status,
+                    authority_level="dry_run_receipt_only" if record.capability_id == "dry_run_execution_receipt" else "simulated_only",
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/dry_run_execution_harness.py",)))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_dry_run_execution_harness.py",)))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("simulation-only dry-run receipt posture",)))),
+                    deferred_surfaces=tuple(sorted(set(record.deferred_surfaces + ("real backend invocation", "real fulfillment execution", "real effect execution", "host mutation")))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("dry-run receipt is real fulfillment", "dry-run receipt is proof of host mutation")))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id in {"real_backend_invocation", "fulfillment_execution", "real_effect_execution", "real_rollback_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False))
+        elif record.capability_id in {"real_service_restart", "real_fan_pwm_control", "real_power_profile_mutation", "real_thermal_actuation", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-dry-run-execution-harness-wing.v1")
 
 
 def update_registry_from_actuation_fulfillment_plan(registry: CapabilityRegistry, plan: Any) -> CapabilityRegistry:

--- a/sentientos/dry_run_execution_harness.py
+++ b/sentientos/dry_run_execution_harness.py
@@ -1,0 +1,782 @@
+"""Deterministic dry-run execution harness for executor contract readiness.
+
+This wing is simulation-only. It may record that an inert in-process simulated
+backend mapping ran, but it does not fulfill host actions, mutate host state,
+load or invoke real backends, write fan/PWM controls, change thermal or power
+settings, restart services, kill processes, install packages or drivers, clean
+or delete files, make network calls, invoke providers, assemble prompts, spawn
+subprocess execution, run shell execution, invoke OS backends, or call
+control-plane admission/execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.fulfillment_executor_contract import ExecutorContractReadinessReceipt
+
+HARNESS_STATUSES = frozenset({
+    "dry_run_harness_ready",
+    "dry_run_harness_ready_with_warnings",
+    "dry_run_harness_blocked",
+    "dry_run_harness_incomplete",
+    "dry_run_harness_contradicted",
+})
+SIMULATED_BACKEND_STATUSES = frozenset({
+    "simulated_backend_available",
+    "simulated_backend_available_with_warnings",
+    "simulated_backend_blocked",
+    "simulated_backend_incomplete",
+    "simulated_backend_contradicted",
+})
+DRY_RUN_REQUEST_STATUSES = frozenset({
+    "dry_run_execution_request_recorded",
+    "dry_run_execution_request_recorded_with_warnings",
+    "dry_run_execution_request_blocked",
+    "dry_run_execution_request_incomplete",
+    "dry_run_execution_request_contradicted",
+})
+DRY_RUN_RESULT_STATUSES = frozenset({
+    "dry_run_execution_simulated",
+    "dry_run_execution_simulated_with_warnings",
+    "dry_run_execution_blocked",
+    "dry_run_execution_incomplete",
+    "dry_run_execution_contradicted",
+})
+DRY_RUN_RECEIPT_STATUSES = frozenset({
+    "dry_run_execution_receipt_recorded",
+    "dry_run_execution_receipt_recorded_with_warnings",
+    "dry_run_execution_receipt_blocked",
+    "dry_run_execution_receipt_incomplete",
+    "dry_run_execution_receipt_contradicted",
+})
+DRY_RUN_DOMAINS = frozenset({
+    "diagnostics_dry_run",
+    "operator_review_dry_run",
+    "resource_pressure_dry_run",
+    "thermal_safety_dry_run",
+    "future_cooling_dry_run",
+    "future_power_dry_run",
+    "future_cleanup_dry_run",
+    "future_service_dry_run",
+})
+SIMULATED_BACKEND_CLASSES = frozenset({
+    "diagnostic_backend_simulated",
+    "operator_manual_backend_simulated",
+    "cooling_backend_simulated",
+    "power_backend_simulated",
+    "cleanup_backend_simulated",
+    "service_backend_simulated",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+})
+_DOMAIN_BACKEND_CLASS = {
+    "diagnostics_dry_run": "diagnostic_backend_simulated",
+    "operator_review_dry_run": "operator_manual_backend_simulated",
+    "resource_pressure_dry_run": "diagnostic_backend_simulated",
+    "thermal_safety_dry_run": "diagnostic_backend_simulated",
+    "future_cooling_dry_run": "cooling_backend_simulated",
+    "future_power_dry_run": "power_backend_simulated",
+    "future_cleanup_dry_run": "cleanup_backend_simulated",
+    "future_service_dry_run": "service_backend_simulated",
+}
+_BACKEND_DOMAINS = {
+    "diagnostic_backend_simulated": ("diagnostics_dry_run", "resource_pressure_dry_run", "thermal_safety_dry_run"),
+    "operator_manual_backend_simulated": ("operator_review_dry_run",),
+    "cooling_backend_simulated": ("future_cooling_dry_run",),
+    "power_backend_simulated": ("future_power_dry_run",),
+    "cleanup_backend_simulated": ("future_cleanup_dry_run",),
+    "service_backend_simulated": ("future_service_dry_run",),
+}
+_DOMAIN_BLOCKS = {
+    "future_cooling_dry_run": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_dry_run": ("power_profile_mutation",),
+    "future_cleanup_dry_run": ("file_cleanup", "file_delete"),
+    "future_service_dry_run": ("service_restart", "process_kill"),
+}
+_READY_READINESS_STATUSES = {"executor_contract_readiness_recorded", "executor_contract_readiness_recorded_with_warnings"}
+_BLOCKED_READINESS_STATUSES = {"executor_contract_readiness_blocked"}
+_INCOMPLETE_READINESS_STATUSES = {"executor_contract_readiness_incomplete"}
+_CONTRADICTED_READINESS_STATUSES = {"executor_contract_readiness_contradicted"}
+_FORBIDDEN_TRUE_FLAGS = (
+    "executor_implemented",
+    "backend_loaded",
+    "backend_invoked",
+    "real_backend_invoked",
+    "control_plane_admission_granted",
+    "fulfillment_granted",
+    "real_fulfillment_performed",
+    "effect_performed",
+    "real_effect_performed",
+    "host_mutation_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "file_delete_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+    "subprocess_execution_performed",
+    "shell_execution_performed",
+    "os_backend_invoked",
+    "control_plane_admission_execution_performed",
+)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionHarnessPolicy:
+    policy_id: str
+    harness_status: str
+    supported_dry_run_domains: tuple[str, ...]
+    supported_backend_classes: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    simulated_only: bool = True
+    no_real_backends: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SimulatedBackendRecord:
+    backend_id: str
+    backend_class: str
+    supported_dry_run_domains: tuple[str, ...]
+    backend_status: str
+    simulation_labels: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    simulated_only: bool = True
+    backend_loaded: bool = False
+    backend_invoked: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SimulatedBackendRegistry:
+    registry_id: str
+    backend_records: tuple[SimulatedBackendRecord, ...]
+    supported_backend_classes: tuple[str, ...]
+    supported_dry_run_domains: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    registry_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    simulated_only: bool = True
+    no_real_backends: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionRequest:
+    request_id: str
+    source_executor_readiness_receipt_id: str
+    source_executor_readiness_receipt_digest: str
+    source_executor_contract_id: str
+    requested_dry_run_domain: str
+    requested_simulated_backend_class: str
+    requested_scope_labels: tuple[str, ...]
+    requested_step_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    request_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_request_only: bool = True
+    does_not_execute_real_backend: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionResult:
+    result_id: str
+    request_id: str
+    simulated_backend_id: str
+    dry_run_domain: str
+    simulated_backend_class: str
+    result_status: str
+    simulated_step_labels: tuple[str, ...]
+    simulated_postcondition_labels: tuple[str, ...]
+    simulated_rollback_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    simulated_only: bool = True
+    dry_run_executed: bool = True
+    real_backend_invoked: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    file_delete_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+    subprocess_execution_performed: bool = False
+    shell_execution_performed: bool = False
+    os_backend_invoked: bool = False
+    control_plane_admission_execution_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionReceipt:
+    receipt_id: str
+    request_id: str
+    result_id: str
+    source_executor_readiness_receipt_id: str
+    dry_run_domain: str
+    simulated_backend_class: str
+    receipt_status: str
+    evidence_summary: tuple[str, ...]
+    simulated_step_labels: tuple[str, ...]
+    simulated_postcondition_labels: tuple[str, ...]
+    simulated_rollback_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_receipt_only: bool = True
+    dry_run_executed: bool = True
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    real_backend_invoked: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    file_delete_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+    subprocess_execution_performed: bool = False
+    shell_execution_performed: bool = False
+    os_backend_invoked: bool = False
+    control_plane_admission_execution_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionBlockReceipt:
+    receipt_id: str
+    request_id: str | None
+    source_executor_readiness_receipt_id: str | None
+    block_status: str
+    block_reason_codes: tuple[str, ...]
+    missing_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    block_receipt_only: bool = True
+    dry_run_executed: bool = False
+    real_fulfillment_performed: bool = False
+    host_mutation_performed: bool = False
+    does_not_execute: bool = True
+    does_not_mutate_host: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunExecutionValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+class DryRunExecutionHarnessWingRecords(NamedTuple):
+    registry: SimulatedBackendRegistry
+    request: DryRunExecutionRequest
+    result_or_block_receipt: DryRunExecutionResult | DryRunExecutionBlockReceipt
+    receipt: DryRunExecutionReceipt | None
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = dict(_source_payload(record_or_payload))
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def dry_run_execution_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+simulated_backend_registry_digest = dry_run_execution_digest
+simulated_backend_record_digest = dry_run_execution_digest
+dry_run_execution_request_digest = dry_run_execution_digest
+dry_run_execution_result_digest = dry_run_execution_digest
+dry_run_execution_receipt_digest = dry_run_execution_digest
+dry_run_execution_block_receipt_digest = dry_run_execution_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def _blocked_actions(domain: str, extra: Sequence[str] | None = None) -> tuple[str, ...]:
+    return tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_DOMAIN_BLOCKS.get(domain, ())) | set(_tuple(extra))))
+
+
+def _domain_from_readiness(readiness: Mapping[str, Any], requested: str | None) -> str:
+    if requested:
+        return requested
+    blocked = set(_tuple(readiness.get("blocked_actions")))
+    if {"fan_pwm_write", "thermal_actuation"} <= blocked:
+        return "future_cooling_dry_run"
+    if "power_profile_mutation" in blocked:
+        return "future_power_dry_run"
+    if {"file_cleanup", "file_delete"} & blocked:
+        return "future_cleanup_dry_run"
+    if {"service_restart", "process_kill"} & blocked:
+        return "future_service_dry_run"
+    return "operator_review_dry_run"
+
+
+def _backend_for_domain(domain: str, requested: str | None) -> str:
+    return requested or _DOMAIN_BACKEND_CLASS.get(domain, "operator_manual_backend_simulated")
+
+
+def _status_from_readiness(readiness: Mapping[str, Any]) -> str:
+    status = str(readiness.get("readiness_status", ""))
+    if any(readiness.get(flag, False) for flag in _FORBIDDEN_TRUE_FLAGS if flag in readiness):
+        return "dry_run_execution_request_contradicted"
+    if status in _READY_READINESS_STATUSES:
+        return "dry_run_execution_request_recorded_with_warnings" if status.endswith("with_warnings") else "dry_run_execution_request_recorded"
+    if status in _BLOCKED_READINESS_STATUSES:
+        return "dry_run_execution_request_blocked"
+    if status in _CONTRADICTED_READINESS_STATUSES:
+        return "dry_run_execution_request_contradicted"
+    return "dry_run_execution_request_incomplete"
+
+
+def build_default_dry_run_harness_policy() -> DryRunExecutionHarnessPolicy:
+    return DryRunExecutionHarnessPolicy(
+        "dry-run-execution-harness-policy-v1",
+        "dry_run_harness_ready",
+        tuple(sorted(DRY_RUN_DOMAINS)),
+        tuple(sorted(SIMULATED_BACKEND_CLASSES)),
+        tuple(sorted(BLOCKED_ACTION_LABELS)),
+        (),
+        ("simulation_only_no_host_effects", "real_fulfillment_deferred"),
+    )
+
+
+def build_default_simulated_backend_registry(*, created_at: str = "1970-01-01T00:00:00+00:00") -> SimulatedBackendRegistry:
+    records = tuple(
+        SimulatedBackendRecord(
+            backend_id=f"simulated-backend-{backend_class.replace('_', '-')}",
+            backend_class=backend_class,
+            supported_dry_run_domains=tuple(sorted(domains)),
+            backend_status="simulated_backend_available",
+            simulation_labels=("in_process_deterministic_mapping", "no_real_backend_loaded", "no_host_effects"),
+            warning_codes=(),
+            risk_codes=("simulation_not_fulfillment",),
+        )
+        for backend_class, domains in sorted(_BACKEND_DOMAINS.items())
+    )
+    provisional = SimulatedBackendRegistry(
+        "simulated-backend-registry-v1",
+        records,
+        tuple(sorted(SIMULATED_BACKEND_CLASSES)),
+        tuple(sorted(DRY_RUN_DOMAINS)),
+        tuple(sorted(BLOCKED_ACTION_LABELS)),
+        "dry_run_harness_ready",
+        (),
+        ("no_real_backends_registered", "simulation_only"),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=simulated_backend_registry_digest(provisional))
+
+
+def build_dry_run_execution_request(
+    executor_readiness_receipt: ExecutorContractReadinessReceipt | Mapping[str, Any],
+    *,
+    requested_dry_run_domain: str | None = None,
+    requested_simulated_backend_class: str | None = None,
+    requested_scope_labels: Sequence[str] = (),
+    requested_step_labels: Sequence[str] = (),
+    request_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunExecutionRequest:
+    readiness = _source_payload(executor_readiness_receipt)
+    domain = _domain_from_readiness(readiness, requested_dry_run_domain)
+    backend_class = _backend_for_domain(domain, requested_simulated_backend_class)
+    status = _status_from_readiness(readiness)
+    if domain not in DRY_RUN_DOMAINS or backend_class not in SIMULATED_BACKEND_CLASSES:
+        status = "dry_run_execution_request_blocked"
+    if backend_class != _DOMAIN_BACKEND_CLASS.get(domain):
+        status = "dry_run_execution_request_blocked"
+    blocked = _blocked_actions(domain, readiness.get("blocked_actions"))
+    warnings = _tuple(readiness.get("warning_codes"))
+    risks = tuple(sorted(set(_tuple(readiness.get("risk_codes"))) | {"dry_run_execution_is_not_real_fulfillment"}))
+    provisional = DryRunExecutionRequest(
+        request_id or _digest_id("dry-run-execution-request-", {"readiness": readiness.get("receipt_id"), "domain": domain, "backend": backend_class, "status": status}),
+        str(readiness.get("receipt_id", "")),
+        str(readiness.get("digest", "")),
+        str(readiness.get("contract_id", "")),
+        domain,
+        backend_class,
+        _tuple(requested_scope_labels),
+        _tuple(requested_step_labels) or ("simulate_contract_steps", "record_no_effect_posture"),
+        blocked,
+        status,
+        warnings,
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_execution_request_digest(provisional))
+
+
+def _registry_record(registry: SimulatedBackendRegistry | Mapping[str, Any], backend_class: str) -> Mapping[str, Any] | None:
+    payload = _source_payload(registry)
+    for record in payload.get("backend_records", ()):
+        item = _source_payload(record)
+        if item.get("backend_class") == backend_class:
+            return item
+    return None
+
+
+def _simulated_labels(domain: str) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    base_steps = ("load_simulated_mapping_metadata", "match_executor_contract_record", "simulate_no_effect_backend_response")
+    domain_steps = {
+        "future_cooling_dry_run": ("simulate_cooling_plan_without_fan_pwm_or_thermal_write",),
+        "future_power_dry_run": ("simulate_power_plan_without_power_profile_mutation",),
+        "future_cleanup_dry_run": ("simulate_cleanup_plan_without_file_cleanup_or_delete",),
+        "future_service_dry_run": ("simulate_service_plan_without_restart_or_process_kill",),
+    }.get(domain, (f"simulate_{domain}",))
+    postconditions = ("dry_run_executed_in_process", "real_backend_invoked_false", "effect_performed_false", "host_mutation_performed_false")
+    rollbacks = ("rollback_not_required_no_effect_performed", "future_real_rollback_still_deferred")
+    return base_steps + domain_steps, postconditions, rollbacks
+
+
+def build_dry_run_execution_block_receipt(
+    *,
+    request: DryRunExecutionRequest | Mapping[str, Any] | None = None,
+    source_executor_readiness_receipt_id: str | None = None,
+    block_status: str = "dry_run_execution_receipt_blocked",
+    block_reason_codes: Sequence[str] = (),
+    missing_labels: Sequence[str] = (),
+    blocked_actions: Sequence[str] = (),
+    warning_codes: Sequence[str] = (),
+    risk_codes: Sequence[str] = (),
+    receipt_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunExecutionBlockReceipt:
+    req = _source_payload(request) if request is not None else {}
+    blocked = _blocked_actions(str(req.get("requested_dry_run_domain", "operator_review_dry_run")), blocked_actions or req.get("blocked_actions", ()))
+    provisional = DryRunExecutionBlockReceipt(
+        receipt_id or _digest_id("dry-run-execution-block-", {"request": req.get("request_id"), "reasons": tuple(block_reason_codes), "status": block_status}),
+        str(req.get("request_id")) if req else None,
+        source_executor_readiness_receipt_id or (str(req.get("source_executor_readiness_receipt_id")) if req else None),
+        block_status,
+        _tuple(block_reason_codes) or ("dry_run_execution_not_allowed",),
+        _tuple(missing_labels),
+        blocked,
+        _tuple(warning_codes) or _tuple(req.get("warning_codes")),
+        tuple(sorted(set(_tuple(risk_codes)) | set(_tuple(req.get("risk_codes"))) | {"dry_run_block_receipt_no_execution"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_execution_block_receipt_digest(provisional))
+
+
+def run_dry_run_execution(
+    request: DryRunExecutionRequest | Mapping[str, Any],
+    registry: SimulatedBackendRegistry | Mapping[str, Any] | None = None,
+    *,
+    result_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunExecutionResult | DryRunExecutionBlockReceipt:
+    req = _source_payload(request)
+    reg = registry or build_default_simulated_backend_registry(created_at=created_at)
+    validation = validate_dry_run_execution_request(req)
+    if not validation.ok:
+        return build_dry_run_execution_block_receipt(request=req, block_status="dry_run_execution_receipt_contradicted", block_reason_codes=validation.findings, created_at=created_at)
+    if req.get("request_status") in {"dry_run_execution_request_blocked", "dry_run_execution_request_incomplete", "dry_run_execution_request_contradicted"}:
+        status = str(req.get("request_status")).replace("request", "receipt")
+        return build_dry_run_execution_block_receipt(request=req, block_status=status, block_reason_codes=(str(req.get("request_status")),), missing_labels=("ready_executor_contract_readiness_receipt_required",), created_at=created_at)
+    record = _registry_record(reg, str(req.get("requested_simulated_backend_class")))
+    if record is None:
+        return build_dry_run_execution_block_receipt(request=req, block_reason_codes=("unknown_simulated_backend_class",), missing_labels=("registered_simulated_backend_required",), created_at=created_at)
+    if str(req.get("requested_dry_run_domain")) not in tuple(record.get("supported_dry_run_domains", ())):
+        return build_dry_run_execution_block_receipt(request=req, block_reason_codes=("simulated_backend_does_not_support_domain",), missing_labels=("matching_simulated_backend_domain_required",), created_at=created_at)
+    if record.get("backend_status") != "simulated_backend_available":
+        return build_dry_run_execution_block_receipt(request=req, block_reason_codes=("simulated_backend_not_available",), missing_labels=("available_simulated_backend_required",), created_at=created_at)
+    steps, postconditions, rollbacks = _simulated_labels(str(req.get("requested_dry_run_domain")))
+    status = "dry_run_execution_simulated_with_warnings" if req.get("warning_codes") else "dry_run_execution_simulated"
+    provisional = DryRunExecutionResult(
+        result_id or _digest_id("dry-run-execution-result-", {"request": req.get("request_id"), "backend": record.get("backend_id"), "status": status}),
+        str(req.get("request_id", "")),
+        str(record.get("backend_id", "")),
+        str(req.get("requested_dry_run_domain", "")),
+        str(req.get("requested_simulated_backend_class", "")),
+        status,
+        steps,
+        postconditions,
+        rollbacks,
+        _tuple(req.get("blocked_actions")),
+        _tuple(req.get("warning_codes")),
+        tuple(sorted(set(_tuple(req.get("risk_codes"))) | {"dry_run_result_is_not_effect_receipt"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_execution_result_digest(provisional))
+
+
+def build_dry_run_execution_receipt(
+    request: DryRunExecutionRequest | Mapping[str, Any],
+    result: DryRunExecutionResult | Mapping[str, Any],
+    *,
+    receipt_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunExecutionReceipt:
+    req = _source_payload(request)
+    res = _source_payload(result)
+    result_validation = validate_dry_run_execution_result(res)
+    status = "dry_run_execution_receipt_recorded"
+    if not result_validation.ok:
+        status = "dry_run_execution_receipt_contradicted"
+    elif res.get("warning_codes"):
+        status = "dry_run_execution_receipt_recorded_with_warnings"
+    evidence = (
+        "dry_run_execution_simulated_in_process_only",
+        "dry_run_execution_is_not_real_fulfillment",
+        "dry_run_result_is_not_effect_receipt",
+        "dry_run_receipt_is_not_proof_of_host_mutation",
+        "real_backend_invoked_false",
+        "real_effect_performed_false",
+        "host_mutation_performed_false",
+    )
+    provisional = DryRunExecutionReceipt(
+        receipt_id or _digest_id("dry-run-execution-receipt-", {"request": req.get("request_id"), "result": res.get("result_id"), "status": status}),
+        str(req.get("request_id", "")),
+        str(res.get("result_id", "")),
+        str(req.get("source_executor_readiness_receipt_id", "")),
+        str(res.get("dry_run_domain", "")),
+        str(res.get("simulated_backend_class", "")),
+        status,
+        evidence,
+        _tuple(res.get("simulated_step_labels")),
+        _tuple(res.get("simulated_postcondition_labels")),
+        _tuple(res.get("simulated_rollback_labels")),
+        _tuple(res.get("blocked_actions")),
+        _tuple(res.get("warning_codes")),
+        tuple(sorted(set(_tuple(res.get("risk_codes"))) | {"dry_run_receipt_is_not_host_mutation_proof"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_execution_receipt_digest(provisional))
+
+
+def _validate_common(payload: Mapping[str, Any], *, prefix: str, status_field: str, statuses: frozenset[str], only_field: str, digest_fn: Any) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False):
+        findings.append(prefix + "not_metadata_only")
+    if not payload.get(only_field, False):
+        findings.append(prefix + f"missing_{only_field}")
+    if payload.get("host_mutation_performed", False):
+        findings.append(prefix + "forbidden_flag:host_mutation_performed")
+    if payload.get(status_field) not in statuses:
+        findings.append(prefix + f"unknown_{status_field}")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if flag in payload and payload.get(flag, False):
+            findings.append(prefix + f"forbidden_flag:{flag}")
+    if payload.get("digest") and payload.get("digest") != digest_fn(payload):
+        findings.append(prefix + "digest_mismatch")
+    return findings
+
+
+def validate_simulated_backend_record(record: SimulatedBackendRecord | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="simulated_backend:", status_field="backend_status", statuses=SIMULATED_BACKEND_STATUSES, only_field="simulated_only", digest_fn=simulated_backend_record_digest)
+    if p.get("backend_class") not in SIMULATED_BACKEND_CLASSES:
+        f.append("simulated_backend:unknown_backend_class")
+    for domain in _tuple(p.get("supported_dry_run_domains")):
+        if domain not in DRY_RUN_DOMAINS:
+            f.append("simulated_backend:unknown_dry_run_domain")
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def validate_simulated_backend_registry(registry: SimulatedBackendRegistry | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(registry)
+    f = _validate_common(p, prefix="registry:", status_field="registry_status", statuses=HARNESS_STATUSES, only_field="simulated_only", digest_fn=simulated_backend_registry_digest)
+    if not p.get("no_real_backends", False):
+        f.append("registry:real_backends_allowed")
+    for record in p.get("backend_records", ()):
+        result = validate_simulated_backend_record(record)
+        f.extend("registry:" + item for item in result.findings)
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_execution_request(request: DryRunExecutionRequest | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(request)
+    f = _validate_common(p, prefix="request:", status_field="request_status", statuses=DRY_RUN_REQUEST_STATUSES, only_field="dry_run_request_only", digest_fn=dry_run_execution_request_digest)
+    if not p.get("does_not_execute_real_backend", False):
+        f.append("request:may_execute_real_backend")
+    if p.get("requested_dry_run_domain") not in DRY_RUN_DOMAINS:
+        f.append("request:unknown_dry_run_domain")
+    if p.get("requested_simulated_backend_class") not in SIMULATED_BACKEND_CLASSES:
+        f.append("request:unknown_simulated_backend_class")
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_execution_result(result: DryRunExecutionResult | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(result)
+    f = _validate_common(p, prefix="result:", status_field="result_status", statuses=DRY_RUN_RESULT_STATUSES, only_field="simulated_only", digest_fn=dry_run_execution_result_digest)
+    if p.get("dry_run_executed") is not True:
+        f.append("result:dry_run_not_executed")
+    if p.get("dry_run_domain") not in DRY_RUN_DOMAINS:
+        f.append("result:unknown_dry_run_domain")
+    if p.get("simulated_backend_class") not in SIMULATED_BACKEND_CLASSES:
+        f.append("result:unknown_simulated_backend_class")
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_execution_receipt(receipt: DryRunExecutionReceipt | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(receipt)
+    f = _validate_common(p, prefix="receipt:", status_field="receipt_status", statuses=DRY_RUN_RECEIPT_STATUSES, only_field="dry_run_receipt_only", digest_fn=dry_run_execution_receipt_digest)
+    if p.get("dry_run_executed") is not True:
+        f.append("receipt:dry_run_not_executed")
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_execution_block_receipt(receipt: DryRunExecutionBlockReceipt | Mapping[str, Any]) -> DryRunExecutionValidationResult:
+    p = _source_payload(receipt)
+    f = _validate_common(p, prefix="block_receipt:", status_field="block_status", statuses=DRY_RUN_RECEIPT_STATUSES, only_field="block_receipt_only", digest_fn=dry_run_execution_block_receipt_digest)
+    if p.get("dry_run_executed", True):
+        f.append("block_receipt:dry_run_executed")
+    if not p.get("does_not_execute", False):
+        f.append("block_receipt:may_execute")
+    if not p.get("does_not_mutate_host", False):
+        f.append("block_receipt:may_mutate_host")
+    return DryRunExecutionValidationResult(not f, tuple(f))
+
+
+def summarize_simulated_backend_registry(registry: SimulatedBackendRegistry | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(registry)
+    return {k: p.get(k) for k in ("registry_id", "supported_backend_classes", "supported_dry_run_domains", "blocked_actions", "registry_status", "metadata_only", "simulated_only", "no_real_backends", "host_mutation_performed", "digest")}
+
+
+def summarize_dry_run_execution_request(request: DryRunExecutionRequest | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(request)
+    return {k: p.get(k) for k in ("request_id", "source_executor_readiness_receipt_id", "source_executor_contract_id", "requested_dry_run_domain", "requested_simulated_backend_class", "request_status", "metadata_only", "dry_run_request_only", "does_not_execute_real_backend", "host_mutation_performed", "digest")}
+
+
+def summarize_dry_run_execution_result(result: DryRunExecutionResult | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(result)
+    return {k: p.get(k) for k in ("result_id", "request_id", "simulated_backend_id", "dry_run_domain", "simulated_backend_class", "result_status", "metadata_only", "simulated_only", "dry_run_executed", "real_backend_invoked", "real_fulfillment_performed", "real_effect_performed", "effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "subprocess_execution_performed", "shell_execution_performed", "os_backend_invoked", "control_plane_admission_execution_performed", "digest")}
+
+
+def summarize_dry_run_execution_receipt(receipt: DryRunExecutionReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "result_id", "source_executor_readiness_receipt_id", "dry_run_domain", "simulated_backend_class", "receipt_status", "metadata_only", "dry_run_receipt_only", "dry_run_executed", "real_fulfillment_performed", "real_effect_performed", "real_backend_invoked", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "subprocess_execution_performed", "shell_execution_performed", "os_backend_invoked", "control_plane_admission_execution_performed", "digest")}
+
+
+def summarize_dry_run_execution_block_receipt(receipt: DryRunExecutionBlockReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "source_executor_readiness_receipt_id", "block_status", "block_reason_codes", "missing_labels", "metadata_only", "block_receipt_only", "dry_run_executed", "real_fulfillment_performed", "host_mutation_performed", "does_not_execute", "does_not_mutate_host", "digest")}
+
+
+def build_dry_run_execution_harness_wing(
+    executor_readiness_receipt: ExecutorContractReadinessReceipt | Mapping[str, Any],
+    *,
+    registry: SimulatedBackendRegistry | Mapping[str, Any] | None = None,
+    requested_dry_run_domain: str | None = None,
+    requested_simulated_backend_class: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunExecutionHarnessWingRecords:
+    simulated_registry = registry if isinstance(registry, SimulatedBackendRegistry) else build_default_simulated_backend_registry(created_at=created_at)
+    request = build_dry_run_execution_request(
+        executor_readiness_receipt,
+        requested_dry_run_domain=requested_dry_run_domain,
+        requested_simulated_backend_class=requested_simulated_backend_class,
+        created_at=created_at,
+    )
+    result_or_block = run_dry_run_execution(request, simulated_registry, created_at=created_at)
+    receipt = build_dry_run_execution_receipt(request, result_or_block, created_at=created_at) if isinstance(result_or_block, DryRunExecutionResult) else None
+    return DryRunExecutionHarnessWingRecords(simulated_registry, request, result_or_block, receipt)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -42,6 +42,14 @@ from sentientos.fulfillment_executor_contract import (
     summarize_executor_precondition_manifest,
     summarize_fulfillment_executor_contract,
 )
+from sentientos.dry_run_execution_harness import (
+    build_dry_run_execution_harness_wing,
+    summarize_dry_run_execution_block_receipt,
+    summarize_dry_run_execution_receipt,
+    summarize_dry_run_execution_request,
+    summarize_dry_run_execution_result,
+    summarize_simulated_backend_registry,
+)
 from sentientos.local_authorization_grant import (
     build_local_authorization_grant_wing,
     build_operator_approval_evidence,
@@ -84,6 +92,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "local_authorization_posture",
         "fulfillment_authorization_posture",
         "executor_contract_posture",
+        "dry_run_execution_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -109,6 +118,7 @@ BUNDLE_FILE_NAMES = {
     "local_authorization_posture": "local_authorization.json",
     "fulfillment_authorization_posture": "fulfillment_authorization.json",
     "executor_contract_posture": "executor_contract.json",
+    "dry_run_execution_posture": "dry_run_execution.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -125,6 +135,12 @@ DEFERRED_ACTION_LABELS = (
     "backend_invocation",
     "control_plane_admission_for_fulfillment",
     "fulfillment_execution",
+    "dry_run_execution_harness",
+    "simulated_backend_registry",
+    "dry_run_execution_request",
+    "dry_run_execution_result",
+    "dry_run_execution_receipt",
+    "real_backend_invocation",
     "real_effect_execution",
     "real_rollback_execution",
     "real_fan_pwm_control",
@@ -331,8 +347,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "6. `local_authorization.json` — bounded local authorization-record posture; it is not fulfillment.",
             "7. `fulfillment_authorization.json` — metadata-only authorization consumption posture; consuming authorization is not fulfillment.",
             "8. `executor_contract.json` — metadata-only executor contract posture; it is not an executor.",
-            "9. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "10. `capability_registry_summary.json` — metadata-only capability posture.",
+            "9. `dry_run_execution.json` — simulation-only dry-run harness posture; it is not fulfillment or an effect receipt.",
+            "10. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "11. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -347,6 +364,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Live-grant readiness is not a live grant; the approval packet is not approval; preflight does not issue a grant.",
             "- Local authorization grant records are authority metadata only; verification does not authorize fulfillment.",
             "- Executor contract records are readiness metadata only; they do not load backends, execute dry runs, grant control-plane admission, fulfill actions, or perform effects.",
+            "- Dry-run execution runs only inert simulated in-process backends; dry_run_executed=true is simulation only, not fulfillment, not an effect receipt, and not host mutation proof.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -429,6 +447,12 @@ def build_reviewer_proof_bundle_payload(
     if fulfillment_authorization.consumption_receipt is None:
         raise ValueError("reviewer proof scenario expected consumed authorization receipt")
     executor_contract = build_fulfillment_executor_contract_wing(fulfillment_authorization.consumption_receipt, created_at=created_at)
+    dry_run_execution = build_dry_run_execution_harness_wing(
+        executor_contract.readiness_receipt,
+        requested_dry_run_domain="future_cooling_dry_run",
+        requested_simulated_backend_class="cooling_backend_simulated",
+        created_at=created_at,
+    )
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
@@ -532,6 +556,39 @@ def build_reviewer_proof_bundle_payload(
                 "readiness_receipt": executor_contract.readiness_receipt.to_dict(),
             },
         }),
+        "dry_run_execution_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "dry_run_execution_harness_only": True,
+            "simulation_only": True,
+            "proof_statement": "Dry-run execution runs only inert simulated in-process backend mappings against executor contract records; it is not real fulfillment, not an effect receipt, and not proof of host mutation.",
+            "registry_summary": summarize_simulated_backend_registry(dry_run_execution.registry),
+            "request_summary": summarize_dry_run_execution_request(dry_run_execution.request),
+            "result_summary": summarize_dry_run_execution_result(dry_run_execution.result_or_block_receipt) if dry_run_execution.receipt else None,
+            "block_receipt_summary": summarize_dry_run_execution_block_receipt(dry_run_execution.result_or_block_receipt) if dry_run_execution.receipt is None else None,
+            "receipt_summary": summarize_dry_run_execution_receipt(dry_run_execution.receipt) if dry_run_execution.receipt else None,
+            "dry_run_executed": bool(dry_run_execution.receipt and dry_run_execution.receipt.dry_run_executed),
+            "real_backend_invoked": False,
+            "real_fulfillment_performed": False,
+            "real_effect_performed": False,
+            "effect_performed": False,
+            "host_mutation_performed": False,
+            "fan_pwm_write_performed": False,
+            "thermal_actuation_performed": False,
+            "power_profile_mutation_performed": False,
+            "service_restart_performed": False,
+            "file_cleanup_performed": False,
+            "network_performed": False,
+            "provider_invocation_performed": False,
+            "prompt_assembly_performed": False,
+            "real_actuation_deferred": True,
+            "records": {
+                "registry": dry_run_execution.registry.to_dict(),
+                "request": dry_run_execution.request.to_dict(),
+                "result_or_block_receipt": dry_run_execution.result_or_block_receipt.to_dict(),
+                "receipt": dry_run_execution.receipt.to_dict() if dry_run_execution.receipt else None,
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -573,7 +630,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -176,3 +176,21 @@ def test_reviewer_proof_bundle_cli_writes_executor_contract_json(tmp_path) -> No
     assert payload["readiness_receipt_summary"]["fulfillment_granted"] is False
     assert payload["readiness_receipt_summary"]["effect_performed"] is False
     assert payload["readiness_receipt_summary"]["host_mutation_performed"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_dry_run_execution_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "dry_run_execution.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["dry_run_execution_harness_only"] is True
+    assert payload["simulation_only"] is True
+    assert payload["dry_run_executed"] is True
+    assert payload["real_backend_invoked"] is False
+    assert payload["real_fulfillment_performed"] is False
+    assert payload["real_effect_performed"] is False
+    assert payload["host_mutation_performed"] is False
+    assert payload["fan_pwm_write_performed"] is False
+    assert payload["thermal_actuation_performed"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -520,3 +520,39 @@ def test_registry_update_from_executor_contract_readiness_preserves_deferred_exe
     assert records["fulfillment_execution"].status == "deferred"
     assert records["real_fan_pwm_control"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_dry_run_execution_harness_capabilities_are_simulation_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["dry_run_execution_harness"].status == "implemented"
+    assert records["dry_run_execution_harness"].authority_level == "simulated_only"
+    assert records["simulated_backend_registry"].authority_level == "simulated_only"
+    assert records["dry_run_execution_request"].authority_level == "request_only"
+    assert records["dry_run_execution_result"].authority_level == "simulated_only"
+    assert records["dry_run_execution_receipt"].authority_level == "dry_run_receipt_only"
+    assert records["real_backend_invocation"].status == "deferred"
+    assert records["fulfillment_execution"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+        assert records[capability_id].host_actuation_performed is False
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_update_from_dry_run_execution_receipt_preserves_real_action_deferral() -> None:
+    from sentientos.capability_registry import update_registry_from_dry_run_execution_receipt
+    from sentientos.dry_run_execution_harness import build_dry_run_execution_harness_wing
+    from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+    from tests.test_fulfillment_authorization import _wing, FIXED
+
+    executor = build_fulfillment_executor_contract_wing(_wing().consumption_receipt, created_at=FIXED)
+    dry_run = build_dry_run_execution_harness_wing(executor.readiness_receipt, created_at=FIXED)
+    registry = update_registry_from_dry_run_execution_receipt(build_default_capability_registry(), dry_run.receipt)
+    records = registry.by_id()
+    assert records["dry_run_execution_receipt"].status == "implemented"
+    assert records["dry_run_execution_receipt"].authority_level == "dry_run_receipt_only"
+    assert records["real_backend_invocation"].status == "deferred"
+    assert records["fulfillment_execution"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_dry_run_execution_harness.py
+++ b/tests/test_dry_run_execution_harness.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.dry_run_execution_harness import (
+    DryRunExecutionBlockReceipt,
+    build_default_simulated_backend_registry,
+    build_dry_run_execution_harness_wing,
+    dry_run_execution_receipt_digest,
+    run_dry_run_execution,
+    summarize_dry_run_execution_block_receipt,
+    summarize_dry_run_execution_receipt,
+    summarize_dry_run_execution_request,
+    summarize_dry_run_execution_result,
+    summarize_simulated_backend_registry,
+    validate_dry_run_execution_block_receipt,
+    validate_dry_run_execution_receipt,
+    validate_dry_run_execution_request,
+    validate_dry_run_execution_result,
+    validate_simulated_backend_registry,
+)
+from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+from tests.test_fulfillment_executor_contract import _consumed_receipt
+from tests.test_fulfillment_authorization import FIXED
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _readiness(domain: str = "future_cooling_fulfillment_authorization"):
+    return build_fulfillment_executor_contract_wing(_consumed_receipt(domain), created_at=FIXED).readiness_receipt
+
+
+def test_ready_executor_contract_runs_simulated_dry_run_without_real_effects() -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    assert wing.request.request_status in {"dry_run_execution_request_recorded", "dry_run_execution_request_recorded_with_warnings"}
+    assert wing.receipt is not None
+    result = wing.result_or_block_receipt
+    assert result.result_status in {"dry_run_execution_simulated", "dry_run_execution_simulated_with_warnings"}
+    assert result.dry_run_executed is True
+    assert result.real_backend_invoked is False
+    assert result.real_fulfillment_performed is False
+    assert result.effect_performed is False
+    assert result.host_mutation_performed is False
+    assert wing.receipt.real_fulfillment_performed is False
+    assert wing.receipt.real_effect_performed is False
+    assert wing.receipt.host_mutation_performed is False
+    assert validate_simulated_backend_registry(wing.registry).ok
+    assert validate_dry_run_execution_request(wing.request).ok
+    assert validate_dry_run_execution_result(result).ok
+    assert validate_dry_run_execution_receipt(wing.receipt).ok
+
+
+@pytest.mark.parametrize(
+    ("readiness_status", "expected"),
+    [
+        ("executor_contract_readiness_blocked", "dry_run_execution_receipt_blocked"),
+        ("executor_contract_readiness_incomplete", "dry_run_execution_receipt_incomplete"),
+        ("executor_contract_readiness_contradicted", "dry_run_execution_receipt_contradicted"),
+    ],
+)
+def test_non_ready_executor_readiness_produces_block_receipt(readiness_status: str, expected: str) -> None:
+    receipt = replace(_readiness(), readiness_status=readiness_status, digest="")
+    wing = build_dry_run_execution_harness_wing(receipt, created_at=FIXED)
+    assert wing.receipt is None
+    assert isinstance(wing.result_or_block_receipt, DryRunExecutionBlockReceipt)
+    assert wing.result_or_block_receipt.block_status == expected
+    assert wing.result_or_block_receipt.dry_run_executed is False
+    assert wing.result_or_block_receipt.host_mutation_performed is False
+    assert validate_dry_run_execution_block_receipt(wing.result_or_block_receipt).ok
+
+
+def test_unknown_backend_class_produces_block_receipt() -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), requested_simulated_backend_class="unknown_backend", created_at=FIXED)
+    assert wing.receipt is None
+    assert isinstance(wing.result_or_block_receipt, DryRunExecutionBlockReceipt)
+    assert "request:unknown_simulated_backend_class" in wing.result_or_block_receipt.block_reason_codes
+
+
+@pytest.mark.parametrize(
+    ("domain", "dry_run_domain", "backend", "blocked"),
+    [
+        ("future_cooling_fulfillment_authorization", "future_cooling_dry_run", "cooling_backend_simulated", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_fulfillment_authorization", "future_power_dry_run", "power_backend_simulated", {"power_profile_mutation"}),
+        ("future_cleanup_fulfillment_authorization", "future_cleanup_dry_run", "cleanup_backend_simulated", {"file_cleanup", "file_delete"}),
+        ("future_service_fulfillment_authorization", "future_service_dry_run", "service_backend_simulated", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_domain_specific_blocks_are_preserved(domain: str, dry_run_domain: str, backend: str, blocked: set[str]) -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(domain), requested_dry_run_domain=dry_run_domain, requested_simulated_backend_class=backend, created_at=FIXED)
+    assert wing.receipt is not None
+    assert blocked <= set(wing.request.blocked_actions)
+    assert blocked <= set(wing.result_or_block_receipt.blocked_actions)
+    assert blocked <= set(wing.receipt.blocked_actions)
+
+
+@pytest.mark.parametrize(
+    ("flag", "validator"),
+    [
+        ("real_backend_invoked", validate_dry_run_execution_result),
+        ("real_fulfillment_performed", validate_dry_run_execution_result),
+        ("real_effect_performed", validate_dry_run_execution_result),
+        ("host_mutation_performed", validate_dry_run_execution_result),
+        ("fan_pwm_write_performed", validate_dry_run_execution_result),
+        ("thermal_actuation_performed", validate_dry_run_execution_result),
+        ("power_profile_mutation_performed", validate_dry_run_execution_result),
+        ("service_restart_performed", validate_dry_run_execution_result),
+        ("file_cleanup_performed", validate_dry_run_execution_result),
+        ("network_performed", validate_dry_run_execution_result),
+        ("provider_invocation_performed", validate_dry_run_execution_result),
+        ("prompt_assembly_performed", validate_dry_run_execution_result),
+        ("subprocess_execution_performed", validate_dry_run_execution_result),
+        ("shell_execution_performed", validate_dry_run_execution_result),
+        ("control_plane_admission_execution_performed", validate_dry_run_execution_result),
+    ],
+)
+def test_validation_rejects_forbidden_execution_flags(flag, validator) -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    bad = replace(wing.result_or_block_receipt, **{flag: True}) if hasattr(wing.result_or_block_receipt, flag) else {**wing.result_or_block_receipt.to_dict(), flag: True}
+    result = validator(bad)
+    assert not result.ok
+    assert any(flag in finding for finding in result.findings)
+
+
+def test_receipt_validation_rejects_real_fulfillment_and_host_mutation() -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    assert wing.receipt is not None
+    for flag in ["real_backend_invoked", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"]:
+        bad = replace(wing.receipt, **{flag: True})
+        result = validate_dry_run_execution_receipt(bad)
+        assert not result.ok
+        assert any(flag in finding for finding in result.findings)
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    first = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    second = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    assert first.receipt is not None and second.receipt is not None
+    assert first.receipt.digest == second.receipt.digest
+    changed = replace(first.receipt, evidence_summary=first.receipt.evidence_summary + ("extra_review_note",), digest="")
+    changed = replace(changed, digest=dry_run_execution_receipt_digest(changed))
+    assert changed.digest != first.receipt.digest
+
+
+def test_summaries_are_metadata_only_and_registry_is_simulated_only() -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    assert summarize_simulated_backend_registry(wing.registry)["metadata_only"] is True
+    assert summarize_simulated_backend_registry(wing.registry)["simulated_only"] is True
+    assert summarize_simulated_backend_registry(wing.registry)["no_real_backends"] is True
+    assert summarize_dry_run_execution_request(wing.request)["metadata_only"] is True
+    assert summarize_dry_run_execution_result(wing.result_or_block_receipt)["simulated_only"] is True
+    assert wing.receipt is not None
+    assert summarize_dry_run_execution_receipt(wing.receipt)["dry_run_receipt_only"] is True
+
+
+def test_registry_missing_backend_blocks_execution() -> None:
+    registry = replace(build_default_simulated_backend_registry(created_at=FIXED), backend_records=(), digest="")
+    wing = build_dry_run_execution_harness_wing(_readiness(), registry=registry, created_at=FIXED)
+    assert wing.receipt is None
+    assert summarize_dry_run_execution_block_receipt(wing.result_or_block_receipt)["dry_run_executed"] is False
+
+
+def test_executor_contract_readiness_to_dry_run_wing_records_non_mutating_posture() -> None:
+    wing = build_dry_run_execution_harness_wing(_readiness(), created_at=FIXED)
+    assert wing.registry.no_real_backends is True
+    assert wing.request.does_not_execute_real_backend is True
+    assert wing.receipt is not None
+    assert wing.receipt.dry_run_executed is True
+    assert wing.receipt.real_backend_invoked is False
+    assert wing.receipt.real_fulfillment_performed is False
+    assert wing.receipt.real_effect_performed is False

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 
 import pytest
 
@@ -233,3 +234,17 @@ def test_deferred_actions_include_executor_contract_non_execution_ladder() -> No
     for label in ["executor_implementation", "backend_invocation", "control_plane_admission_for_fulfillment", "fulfillment_execution"]:
         assert label in manifest.deferred_capability_labels
         assert label in DEFERRED_ACTION_LABELS
+
+
+def test_default_reviewer_proof_bundle_includes_dry_run_execution_artifact() -> None:
+    payload = build_reviewer_proof_bundle_payload()
+    assert "dry_run_execution_posture" in payload["artifacts"]
+    dry_run = json.loads(payload["artifacts"]["dry_run_execution_posture"])
+    assert dry_run["dry_run_execution_harness_only"] is True
+    assert dry_run["simulation_only"] is True
+    assert dry_run["dry_run_executed"] is True
+    assert dry_run["real_backend_invoked"] is False
+    assert dry_run["real_fulfillment_performed"] is False
+    assert dry_run["real_effect_performed"] is False
+    assert dry_run["host_mutation_performed"] is False
+    assert "dry_run_execution_posture" in {artifact.artifact_kind for artifact in payload["manifest"].artifact_records}

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -469,3 +469,27 @@ def test_reviewer_first_run_proof_bundle_doc_lists_executor_contract_artifact() 
     doc = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
     assert "executor_contract.json" in doc
     assert "executor contract is not an executor" in doc.lower()
+
+HOST_DRY_RUN_EXECUTION_HARNESS_WING = "docs/architecture/host_dry_run_execution_harness_wing.md"
+
+
+def test_navigation_links_to_host_dry_run_execution_harness_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    executor = _read(HOST_FULFILLMENT_EXECUTOR_CONTRACT_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, executor, bundle, controlled, trajectory]:
+        assert HOST_DRY_RUN_EXECUTION_HARNESS_WING in text
+
+
+def test_host_dry_run_execution_harness_doc_preserves_simulation_only_boundaries() -> None:
+    doc = _read(HOST_DRY_RUN_EXECUTION_HARNESS_WING)
+    assert "runs only inert simulated backends" in doc or "only inert, deterministic, in-process simulated backend" in doc
+    assert "Dry-run execution is not real fulfillment" in doc
+    assert "A dry-run result is not an effect receipt" in doc
+    assert "A dry-run receipt is not proof of host mutation" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "subprocess execution" in doc
+    assert "network egress" in doc


### PR DESCRIPTION
### Motivation
- Provide the next host-embodiment wing after the Fulfillment Executor Contract: a deterministic, metadata-only dry-run execution harness that can exercise only inert in-process simulated backends against executor contract readiness records while remaining strictly simulation-only and host-effect-free.
- Integrate the harness into the reviewer-proof packaging and the capability registry so reviewers can inspect deterministic dry-run receipts and preserved blocked-action posture without any real host actuation.

### Description
- Add `sentientos/dry_run_execution_harness.py` implementing frozen dataclasses and helpers for `DryRunExecutionHarnessPolicy`, `SimulatedBackendRecord`, `SimulatedBackendRegistry`, `DryRunExecutionRequest`, `DryRunExecutionResult`, `DryRunExecutionReceipt`, `DryRunExecutionBlockReceipt`, validation/summarize/digest helpers, deterministic simulated backends, and `build_dry_run_execution_harness_wing()` that accepts an `ExecutorContractReadinessReceipt` and returns registry/request/result/receipt records.
- Integrate harness into reviewer bundle by extending `sentientos/reviewer_proof_bundle.py` to build a `dry_run_execution.json` artifact and include the dry-run posture (registry/request/result/receipt summaries) in the bundle manifest and README.
- Update `sentientos/capability_registry.py` to declare new capability records (`dry_run_execution_harness`, `simulated_backend_registry`, `dry_run_execution_request`, `dry_run_execution_result`, `dry_run_execution_receipt`, `real_backend_invocation`), and add `update_registry_from_dry_run_execution_receipt(...)` that reflects simulation-only receipts while preserving deferred/blocked real actions.
- Add documentation `docs/architecture/host_dry_run_execution_harness_wing.md` and wire short links into existing architecture docs to state the simulation-only boundary and authority ladder.
- Add tests `tests/test_dry_run_execution_harness.py` and update reviewer-bundle / capability-registry tests to assert presence of the dry-run artifact and that all dry-run records remain metadata-only and claim no real host effects.

Files changed (key additions/edits)
- Added: `sentientos/dry_run_execution_harness.py`
- Added: `docs/architecture/host_dry_run_execution_harness_wing.md`
- Added: `tests/test_dry_run_execution_harness.py`
- Modified: `sentientos/reviewer_proof_bundle.py` (include `dry_run_execution.json` artifact and posture block)
- Modified: `sentientos/capability_registry.py` (add capability records + `update_registry_from_dry_run_execution_receipt`)
- Modified: `scripts/build_reviewer_proof_bundle.py` (no direct API changes; existing CLI uses reviewer bundle payload)
- Modified tests: `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py` to cover new artifact and docs links.

API summary (top-level helpers)
- `build_default_simulated_backend_registry()` returns a deterministic in-process-only simulated registry.
- `build_dry_run_execution_request(executor_readiness_receipt, ...)` builds a metadata-only request tying an executor readiness receipt to a dry-run domain/backend.
- `run_dry_run_execution(request, registry, ...)` executes the deterministic in-process simulation against the registry and returns a `DryRunExecutionResult` or `DryRunExecutionBlockReceipt`.
- `build_dry_run_execution_receipt(request, result, ...)` creates a dry-run receipt that is explicitly `dry_run_receipt_only` and records that no real backend, effect, or host mutation occurred.
- `build_dry_run_execution_harness_wing(executor_readiness_receipt, ...)` convenience that returns `(registry, request, result_or_block_receipt, receipt)` as `DryRunExecutionHarnessWingRecords`.

### Testing
- Compiled new modules with `python -m py_compile` (no syntax errors).
- Ran focused unit test suites via `python -m scripts.run_tests` including:
  - `tests/test_dry_run_execution_harness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py` which passed after a small test allowance for recorded-with-warnings statuses (all assertions passed).
  - Full related integrations: `tests/test_fulfillment_executor_contract.py`, `tests/test_fulfillment_authorization.py`, `tests/test_local_authorization_grant.py`, `tests/test_live_grant_readiness.py`, `tests/test_host_actuation_safety.py`, `tests/test_controlled_authorization.py`, `tests/test_authorization_review.py`, `tests/test_effect_proof.py`, and `tests/test_reviewer_release_readiness_index.py` executed and passed in this run.
- Reviewer bundle CLI checked: `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` produced `/tmp/sentientos-reviewer-proof/dry_run_execution.json` and the printed artifact fields show `dry_run_executed: True`, `real_fulfillment_performed: False`, `real_effect_performed: False`, `host_mutation_performed: False` as expected.
- Docs build: ran `python scripts/build_docs.py --bootstrap-docs` and `--check-deps` then `python scripts/build_docs.py` to ensure the new doc page is included; docs generation succeeded (local build environment installed docs deps during the run).
- Forbidden-scan: ran a negative scan for forbidden operations (e.g., `socket|requests|urllib|subprocess|os.system|Popen|shell=True|fan.*write|pwm.*write|thermal.*write|kill(|restart|pip install|driver install|delete|unlink|rmtree|prompt_assembler|admit_and_execute`) over changed modules and found only documentation/label text and no actual runtime imports/calls that perform forbidden operations.

Notes
- All dry-run records are metadata-only and validated to reject any record claiming real backend invocation, real fulfillment, effect, host mutation, fan/PWM writes, thermal actuation, power mutation, service restart, cleanup, provider invocation, network, prompt assembly, subprocess/shell execution, OS backend invocation, or control-plane execution.
- The implementation keeps the strict dry-run / simulation-only boundary; no subprocess/network/filesystem/host-effecting code was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06b0d81c6c832098c267f82e85a33c)