### PR TITLE
[codex:dry-run-audit] add dry-run audit closure wing

### DIFF
--- a/docs/architecture/host_dry_run_audit_closure_wing.md
+++ b/docs/architecture/host_dry_run_audit_closure_wing.md
@@ -1,0 +1,43 @@
+# Host Dry-Run Effect Verification / Audit Closure Wing
+
+This wing follows the [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md). It consumes `DryRunExecutionReceipt` metadata and records dry-run effect verification, simulated postcondition verification, simulated rollback rehearsal, dry-run audit closure, and a dry-run closure bundle.
+
+## Boundary
+
+Dry-run execution is not real fulfillment. Dry-run effect verification is not a real effect receipt. Dry-run postcondition verification is not a real host postcondition check. Dry-run rollback rehearsal is not real rollback. Dry-run audit closure is not a production audit receipt.
+
+The wing is metadata-only and dry-run verification/audit-only. It performs no subprocess execution, shell execution, network egress, provider invocation, prompt assembly/export, host mutation, service restart, process kill, file cleanup/deletion, package installation, driver installation, hardware write, thermal actuation, power-profile mutation, or fan/PWM write.
+
+## Records
+
+- **DryRunEffectVerification:** records simulated dry-run effect evidence while keeping `real_effect_receipt_created=false`, `real_effect_performed=false`, `real_backend_invoked=false`, and `host_mutation_performed=false`.
+- **DryRunPostconditionVerification:** compares expected and observed simulated postcondition labels only. It keeps `real_postcondition_check_performed=false` and does not inspect real host state.
+- **DryRunRollbackRehearsal:** records simulated rollback labels only. It keeps `real_rollback_performed=false` and does not execute rollback.
+- **DryRunAuditClosureReceipt:** closes the dry-run evidence chain without becoming a production audit receipt. It keeps `production_audit_receipt_created=false`, `real_effect_receipt_created=false`, `real_postcondition_check_performed=false`, `real_rollback_performed=false`, `real_fulfillment_performed=false`, `real_effect_performed=false`, and `host_mutation_performed=false`.
+- **DryRunClosureBundle:** bundles the dry-run verification, simulated postcondition, simulated rollback, and audit closure records. It is not fulfillment and keeps real action flags false.
+
+## Future action domains remain blocked/deferred
+
+Future cooling closure preserves `fan_pwm_write` and `thermal_actuation` blocked actions. Future power closure preserves `power_profile_mutation`. Future cleanup closure preserves `file_cleanup` and `file_delete`. Future service closure preserves `service_restart` and `process_kill`.
+
+Real fulfillment remains deferred. Real effect receipts remain deferred. Real postcondition checks remain deferred. Real rollback remains deferred. Real actuation remains deferred. Future cooling, power, service, and cleanup actions remain behind future real executor implementation, control-plane admission, audit, effect receipt, postcondition checks, rollback, supervisor observation, immutable trace, panic stop, operator authority, and safety gates.
+
+Any record claiming real fulfillment, real effect, host mutation, fan/PWM write, thermal actuation, power mutation, service restart, cleanup, network, provider, prompt assembly, subprocess execution, shell execution, OS backend invocation, control-plane execution, real effect receipt, real postcondition check, real rollback, or production audit receipt is rejected/contradicted by validation.
+
+## Authority ladder
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → dry-run execution harness → dry-run verification/audit closure → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **dry-run verification and audit closure only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `dry_run_audit_closure.json`. The artifact is reviewer proof only and metadata only. It demonstrates a safe sample where dry-run execution occurred through a simulated backend, dry-run closure records are built, no real effect receipt is created, no real host postcondition check occurs, no real rollback occurs, no production audit receipt is created, and real actuation remains deferred.
+
+## Implementation links
+
+- Module: `sentientos/dry_run_audit_closure.py`
+- Dry-run execution source: `sentientos/dry_run_execution_harness.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_dry_run_audit_closure.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_dry_run_execution_harness_wing.md
+++ b/docs/architecture/host_dry_run_execution_harness_wing.md
@@ -43,3 +43,7 @@ The reviewer proof bundle includes `dry_run_execution.json`. The artifact is rev
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_dry_run_execution_harness.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+Next wing: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). It verifies dry-run evidence only; dry-run effect verification is not a real effect receipt, dry-run postcondition verification is not a real host postcondition check, dry-run rollback rehearsal is not real rollback, and dry-run audit closure is not a production audit receipt.
+
+Proof path: docs/architecture/host_dry_run_audit_closure_wing.md

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -73,3 +73,7 @@ Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+Downstream dry-run proof link: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). It preserves the boundary that dry-run closure is not fulfillment, effect receipt, real host postcondition check, rollback, production audit, or actuation.
+
+Proof path: docs/architecture/host_dry_run_audit_closure_wing.md

--- a/docs/architecture/host_fulfillment_executor_contract_wing.md
+++ b/docs/architecture/host_fulfillment_executor_contract_wing.md
@@ -42,3 +42,7 @@ The reviewer proof bundle includes `executor_contract.json`. The artifact is rev
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md), which follows the dry-run execution harness and remains metadata-only; it does not create real effect receipts, real postcondition checks, real rollback, production audit receipts, or actuation.
+
+Proof path: docs/architecture/host_dry_run_audit_closure_wing.md

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -263,3 +263,5 @@ Reviewer map: [Host Fulfillment Executor Contract Wing](host_fulfillment_executo
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md) (`docs/architecture/host_dry_run_audit_closure_wing.md`), which verifies dry-run evidence only; it is not a real effect receipt, not a real host postcondition check, not real rollback, not a production audit receipt, and real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -107,3 +107,7 @@ Proof path: `docs/architecture/host_dry_run_execution_harness_wing.md`.
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+The bundle also includes `dry_run_audit_closure.json`; see [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). Dry-run audit closure verifies dry-run evidence only and is not a real effect receipt, not a real host postcondition check, not real rollback, and not a production audit receipt.
+
+Proof path: docs/architecture/host_dry_run_audit_closure_wing.md

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -264,3 +264,5 @@ The [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authoriza
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md) (`docs/architecture/host_dry_run_audit_closure_wing.md`). Dry-run effect verification is not a real effect receipt; dry-run postcondition verification is not real host postcondition check; dry-run rollback rehearsal is not real rollback; dry-run audit closure is not production audit receipt; real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -413,3 +413,5 @@ Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
 
 
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
+
+- Host Dry-Run Effect Verification / Audit Closure Wing: `docs/architecture/host_dry_run_audit_closure_wing.md`. Dry-run effect verification is not a real effect receipt; dry-run postcondition verification is not a real host postcondition check; dry-run rollback rehearsal is not real rollback; dry-run audit closure is not a production audit receipt; real actuation remains deferred.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -45,6 +45,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "fulfillment_authorization",
         "fulfillment_executor_contract",
         "dry_run_execution_harness",
+        "dry_run_audit_closure",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -90,6 +91,11 @@ AUTHORITY_LEVELS = frozenset(
         "readiness_receipt_only",
         "simulated_only",
         "dry_run_receipt_only",
+        "dry_run_verification_only",
+        "dry_run_postcondition_only",
+        "dry_run_rollback_only",
+        "dry_run_audit_only",
+        "dry_run_closure_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -317,6 +323,14 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("dry_run_execution_request", "dry_run_execution_harness", "implemented", "request_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("dry-run request records",), deferred_surfaces=("real backend execution",), forbidden_implications=("dry-run request executes a backend",)),
         _record("dry_run_execution_result", "dry_run_execution_harness", "implemented", "simulated_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("simulation-only dry-run results",), deferred_surfaces=("effect receipt", "host mutation", "real fulfillment"), forbidden_implications=("dry-run result is effect receipt",)),
         _record("dry_run_execution_receipt", "dry_run_execution_harness", "implemented", "dry_run_receipt_only", source_paths=("sentientos/dry_run_execution_harness.py",), proof_tests=("tests/test_dry_run_execution_harness.py",), implemented_surfaces=("dry-run-only execution receipts",), deferred_surfaces=("proof of host mutation", "real effect receipt"), forbidden_implications=("dry-run receipt proves host mutation",)),
+        _record("dry_run_effect_verification", "dry_run_audit_closure", "implemented", "dry_run_verification_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only dry-run effect verification records",), deferred_surfaces=("real effect receipt creation", "real effect execution"), forbidden_implications=("dry-run effect verification is a real effect receipt",)),
+        _record("dry_run_postcondition_verification", "dry_run_audit_closure", "implemented", "dry_run_postcondition_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only simulated postcondition verification records",), deferred_surfaces=("real host postcondition checks",), forbidden_implications=("dry-run postcondition verification checks real host state",)),
+        _record("dry_run_rollback_rehearsal", "dry_run_audit_closure", "implemented", "dry_run_rollback_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only rollback rehearsal records",), deferred_surfaces=("real rollback execution",), forbidden_implications=("dry-run rollback rehearsal executes rollback",)),
+        _record("dry_run_audit_closure_receipt", "dry_run_audit_closure", "implemented", "dry_run_audit_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only dry-run audit closure receipts",), deferred_surfaces=("production audit receipt for host effects",), forbidden_implications=("dry-run audit closure is a production audit receipt",)),
+        _record("dry_run_closure_bundle", "dry_run_audit_closure", "implemented", "dry_run_closure_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only dry-run closure bundles",), deferred_surfaces=("real fulfillment", "real effect receipt", "real postcondition check", "real rollback"), forbidden_implications=("dry-run closure bundle fulfills host actions",)),
+        _record("real_effect_receipt_creation", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real effect receipt creation",), forbidden_implications=("dry-run audit closure creates real effect receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_postcondition_check", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real host postcondition checking",), forbidden_implications=("dry-run audit closure checks real host postconditions",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("production_audit_receipt_for_host_effect", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("production audit receipts for real host effects",), forbidden_implications=("dry-run audit closure emits production audit receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_backend_invocation", "dry_run_execution_harness", "deferred", "none", deferred_surfaces=("real backend invocation", "OS backend invocation", "control-plane execution"), forbidden_implications=("dry-run harness invokes real backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("fulfillment_execution", "fulfillment_authorization", "deferred", "none", deferred_surfaces=("future fulfillment executor", "host mutation", "effect receipt from real action"), forbidden_implications=("fulfillment authorization wing implements execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
@@ -336,7 +350,7 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
         _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/host_fulfillment_executor_contract_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-fulfillment-executor-contract-wing", schema_version="host-fulfillment-executor-contract-wing.v1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-embodiment-dry-run-audit-closure-wing", schema_version="host-dry-run-audit-closure-wing.v1", records=records)
 
 
 
@@ -599,6 +613,35 @@ def update_registry_from_dry_run_execution_receipt(registry: CapabilityRegistry,
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-dry-run-execution-harness-wing.v1")
 
+
+
+def update_registry_from_dry_run_audit_closure(registry: CapabilityRegistry, closure_wing: Any) -> CapabilityRegistry:
+    """Reflect dry-run audit closure records without claiming real effects."""
+
+    has_effect = bool(getattr(getattr(closure_wing, "effect_verification", None), "verification_id", "")) or bool(getattr(closure_wing, "verification_id", ""))
+    has_post = bool(getattr(getattr(closure_wing, "postcondition_verification", None), "verification_id", "")) or bool(getattr(closure_wing, "postcondition_verification_id", ""))
+    has_rollback = bool(getattr(getattr(closure_wing, "rollback_rehearsal", None), "rehearsal_id", "")) or bool(getattr(closure_wing, "rollback_rehearsal_id", ""))
+    has_audit = bool(getattr(getattr(closure_wing, "audit_closure_receipt", None), "receipt_id", "")) or bool(getattr(closure_wing, "audit_closure_receipt_id", ""))
+    has_bundle = bool(getattr(getattr(closure_wing, "closure_bundle", None), "bundle_id", "")) or bool(getattr(closure_wing, "bundle_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "dry_run_effect_verification":
+            records.append(replace(record, status="implemented" if has_effect else record.status, authority_level="dry_run_verification_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "dry_run_postcondition_verification":
+            records.append(replace(record, status="implemented" if has_post else record.status, authority_level="dry_run_postcondition_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "dry_run_rollback_rehearsal":
+            records.append(replace(record, status="implemented" if has_rollback else record.status, authority_level="dry_run_rollback_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "dry_run_audit_closure_receipt":
+            records.append(replace(record, status="implemented" if has_audit else record.status, authority_level="dry_run_audit_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "dry_run_closure_bundle":
+            records.append(replace(record, status="implemented" if has_bundle else record.status, authority_level="dry_run_closure_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_effect_receipt_creation", "real_postcondition_check", "real_rollback_execution", "production_audit_receipt_for_host_effect", "fulfillment_execution", "real_effect_execution", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-dry-run-audit-closure-wing.v1")
 
 def update_registry_from_actuation_fulfillment_plan(registry: CapabilityRegistry, plan: Any) -> CapabilityRegistry:
     """Reflect a Phase 5 rehearsal plan without claiming real fulfillment."""

--- a/sentientos/dry_run_audit_closure.py
+++ b/sentientos/dry_run_audit_closure.py
@@ -1,0 +1,666 @@
+"""Metadata-only dry-run verification and audit closure records.
+
+This wing verifies dry-run execution receipts without converting them into real
+fulfillment, real effect receipts, real postcondition checks, real rollback, or
+production audit receipts. It does not mutate host state, write fan/PWM controls,
+change thermal or power settings, kill processes, restart services, install
+packages or drivers, delete or clean files, perform network calls, invoke
+providers, assemble prompts, spawn subprocess execution, run shell execution,
+invoke OS backends, or call control-plane admission/execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.dry_run_execution_harness import DryRunExecutionReceipt
+
+VERIFICATION_STATUSES = frozenset({
+    "dry_run_verification_recorded",
+    "dry_run_verification_recorded_with_warnings",
+    "dry_run_verification_blocked",
+    "dry_run_verification_incomplete",
+    "dry_run_verification_contradicted",
+})
+POSTCONDITION_STATUSES = frozenset({
+    "dry_run_postcondition_verified",
+    "dry_run_postcondition_verified_with_warnings",
+    "dry_run_postcondition_blocked",
+    "dry_run_postcondition_incomplete",
+    "dry_run_postcondition_contradicted",
+})
+ROLLBACK_STATUSES = frozenset({
+    "dry_run_rollback_rehearsed",
+    "dry_run_rollback_rehearsed_with_warnings",
+    "dry_run_rollback_blocked",
+    "dry_run_rollback_incomplete",
+    "dry_run_rollback_contradicted",
+})
+AUDIT_CLOSURE_STATUSES = frozenset({
+    "dry_run_audit_closure_recorded",
+    "dry_run_audit_closure_recorded_with_warnings",
+    "dry_run_audit_closure_blocked",
+    "dry_run_audit_closure_incomplete",
+    "dry_run_audit_closure_contradicted",
+})
+BUNDLE_STATUSES = frozenset({
+    "dry_run_closure_bundle_ready",
+    "dry_run_closure_bundle_ready_with_warnings",
+    "dry_run_closure_bundle_blocked",
+    "dry_run_closure_bundle_incomplete",
+    "dry_run_closure_bundle_contradicted",
+})
+CLOSURE_DOMAINS = frozenset({
+    "diagnostics_dry_run_closure",
+    "operator_review_dry_run_closure",
+    "resource_pressure_dry_run_closure",
+    "thermal_safety_dry_run_closure",
+    "future_cooling_dry_run_closure",
+    "future_power_dry_run_closure",
+    "future_cleanup_dry_run_closure",
+    "future_service_dry_run_closure",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+    "real_effect_receipt",
+    "real_postcondition_check",
+    "real_rollback_execution",
+    "production_audit_receipt",
+})
+_DOMAIN_BLOCKS = {
+    "future_cooling_dry_run_closure": ("fan_pwm_write", "thermal_actuation"),
+    "future_power_dry_run_closure": ("power_profile_mutation",),
+    "future_cleanup_dry_run_closure": ("file_cleanup", "file_delete"),
+    "future_service_dry_run_closure": ("service_restart", "process_kill"),
+}
+_FORBIDDEN_TRUE_FLAGS = (
+    "real_effect_receipt_created",
+    "real_postcondition_check_performed",
+    "real_rollback_performed",
+    "production_audit_receipt_created",
+    "real_fulfillment_performed",
+    "real_effect_performed",
+    "real_backend_invoked",
+    "host_mutation_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "file_delete_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+    "subprocess_execution_performed",
+    "shell_execution_performed",
+    "os_backend_invoked",
+    "control_plane_admission_execution_performed",
+)
+
+
+@dataclass(frozen=True)
+class DryRunAuditClosurePolicy:
+    policy_id: str
+    supported_closure_domains: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    metadata_only: bool = True
+    dry_run_audit_closure_only: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunEffectVerification:
+    verification_id: str
+    source_dry_run_receipt_id: str
+    source_dry_run_receipt_digest: str
+    dry_run_domain: str
+    simulated_backend_class: str
+    verification_status: str
+    simulated_effect_labels: tuple[str, ...]
+    verified_no_effect_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_verification_only: bool = True
+    real_effect_receipt_created: bool = False
+    real_effect_performed: bool = False
+    real_backend_invoked: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunPostconditionVerification:
+    verification_id: str
+    source_dry_run_receipt_id: str
+    source_effect_verification_id: str
+    dry_run_domain: str
+    postcondition_status: str
+    expected_simulated_postcondition_labels: tuple[str, ...]
+    observed_simulated_postcondition_labels: tuple[str, ...]
+    missing_simulated_postcondition_labels: tuple[str, ...]
+    contradicted_simulated_postcondition_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_postcondition_only: bool = True
+    real_postcondition_check_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunRollbackRehearsal:
+    rehearsal_id: str
+    source_dry_run_receipt_id: str
+    source_effect_verification_id: str
+    dry_run_domain: str
+    rollback_status: str
+    simulated_rollback_labels: tuple[str, ...]
+    rollback_precondition_labels: tuple[str, ...]
+    rollback_postcondition_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_rollback_only: bool = True
+    real_rollback_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunAuditClosureReceipt:
+    receipt_id: str
+    source_dry_run_receipt_id: str
+    source_effect_verification_id: str
+    source_postcondition_verification_id: str
+    source_rollback_rehearsal_id: str
+    dry_run_domain: str
+    audit_closure_status: str
+    evidence_summary: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_audit_only: bool = True
+    production_audit_receipt_created: bool = False
+    real_effect_receipt_created: bool = False
+    real_postcondition_check_performed: bool = False
+    real_rollback_performed: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunClosureBundle:
+    bundle_id: str
+    source_dry_run_receipt_id: str
+    effect_verification_id: str
+    postcondition_verification_id: str
+    rollback_rehearsal_id: str
+    audit_closure_receipt_id: str
+    closure_domain: str
+    bundle_status: str
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    dry_run_closure_only: bool = True
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunAuditClosureValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+class DryRunAuditClosureWingRecords(NamedTuple):
+    effect_verification: DryRunEffectVerification
+    postcondition_verification: DryRunPostconditionVerification
+    rollback_rehearsal: DryRunRollbackRehearsal
+    audit_closure_receipt: DryRunAuditClosureReceipt
+    closure_bundle: DryRunClosureBundle
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = dict(_source_payload(record_or_payload))
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def dry_run_audit_closure_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+dry_run_effect_verification_digest = dry_run_audit_closure_digest
+dry_run_postcondition_verification_digest = dry_run_audit_closure_digest
+dry_run_rollback_rehearsal_digest = dry_run_audit_closure_digest
+dry_run_audit_closure_receipt_digest = dry_run_audit_closure_digest
+dry_run_closure_bundle_digest = dry_run_audit_closure_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def _closure_domain(dry_run_domain: str) -> str:
+    candidate = dry_run_domain.replace("_dry_run", "_dry_run_closure")
+    return candidate if candidate in CLOSURE_DOMAINS else "operator_review_dry_run_closure"
+
+
+def _blocked_actions(closure_domain: str, extra: Sequence[str] | None = None) -> tuple[str, ...]:
+    return tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_DOMAIN_BLOCKS.get(closure_domain, ())) | set(_tuple(extra))))
+
+
+def _receipt_status(receipt: Mapping[str, Any]) -> str:
+    status = str(receipt.get("receipt_status", ""))
+    if any(receipt.get(flag, False) for flag in _FORBIDDEN_TRUE_FLAGS if flag in receipt):
+        return "contradicted"
+    if receipt.get("dry_run_executed") is not True:
+        return "incomplete"
+    if status == "dry_run_execution_receipt_recorded":
+        return "recorded"
+    if status == "dry_run_execution_receipt_recorded_with_warnings":
+        return "recorded_with_warnings"
+    if status == "dry_run_execution_receipt_blocked":
+        return "blocked"
+    if status == "dry_run_execution_receipt_contradicted":
+        return "contradicted"
+    return "incomplete"
+
+
+def _status(kind: str, base: str) -> str:
+    table = {
+        "effect": {
+            "recorded": "dry_run_verification_recorded",
+            "recorded_with_warnings": "dry_run_verification_recorded_with_warnings",
+            "blocked": "dry_run_verification_blocked",
+            "incomplete": "dry_run_verification_incomplete",
+            "contradicted": "dry_run_verification_contradicted",
+        },
+        "postcondition": {
+            "recorded": "dry_run_postcondition_verified",
+            "recorded_with_warnings": "dry_run_postcondition_verified_with_warnings",
+            "blocked": "dry_run_postcondition_blocked",
+            "incomplete": "dry_run_postcondition_incomplete",
+            "contradicted": "dry_run_postcondition_contradicted",
+        },
+        "rollback": {
+            "recorded": "dry_run_rollback_rehearsed",
+            "recorded_with_warnings": "dry_run_rollback_rehearsed_with_warnings",
+            "blocked": "dry_run_rollback_blocked",
+            "incomplete": "dry_run_rollback_incomplete",
+            "contradicted": "dry_run_rollback_contradicted",
+        },
+        "audit": {
+            "recorded": "dry_run_audit_closure_recorded",
+            "recorded_with_warnings": "dry_run_audit_closure_recorded_with_warnings",
+            "blocked": "dry_run_audit_closure_blocked",
+            "incomplete": "dry_run_audit_closure_incomplete",
+            "contradicted": "dry_run_audit_closure_contradicted",
+        },
+        "bundle": {
+            "recorded": "dry_run_closure_bundle_ready",
+            "recorded_with_warnings": "dry_run_closure_bundle_ready_with_warnings",
+            "blocked": "dry_run_closure_bundle_blocked",
+            "incomplete": "dry_run_closure_bundle_incomplete",
+            "contradicted": "dry_run_closure_bundle_contradicted",
+        },
+    }
+    return table[kind].get(base, table[kind]["incomplete"])
+
+
+def build_default_dry_run_audit_closure_policy() -> DryRunAuditClosurePolicy:
+    return DryRunAuditClosurePolicy(
+        "dry-run-audit-closure-policy-v1",
+        tuple(sorted(CLOSURE_DOMAINS)),
+        tuple(sorted(BLOCKED_ACTION_LABELS)),
+        (),
+        ("dry_run_verification_not_real_effect", "real_audit_closure_deferred"),
+    )
+
+
+def build_dry_run_effect_verification(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    *,
+    verification_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunEffectVerification:
+    receipt = _source_payload(dry_run_receipt)
+    base = _receipt_status(receipt)
+    closure_domain = _closure_domain(str(receipt.get("dry_run_domain", "")))
+    blocked = _blocked_actions(closure_domain, receipt.get("blocked_actions"))
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"dry_run_effect_verification_is_not_real_effect_receipt"}))
+    provisional = DryRunEffectVerification(
+        verification_id or _digest_id("dry-run-effect-verification-", {"receipt": receipt.get("receipt_id"), "status": base}),
+        str(receipt.get("receipt_id", "")),
+        str(receipt.get("digest", "")),
+        closure_domain,
+        str(receipt.get("simulated_backend_class", "")),
+        _status("effect", base),
+        _tuple(receipt.get("simulated_step_labels")) or ("simulated_dry_run_effect_metadata",),
+        ("real_effect_receipt_created_false", "real_effect_performed_false", "host_mutation_performed_false"),
+        blocked,
+        _tuple(receipt.get("warning_codes")),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_effect_verification_digest(provisional))
+
+
+def build_dry_run_postcondition_verification(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    effect_verification: DryRunEffectVerification | Mapping[str, Any],
+    *,
+    verification_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunPostconditionVerification:
+    receipt = _source_payload(dry_run_receipt)
+    effect = _source_payload(effect_verification)
+    base = _receipt_status(receipt)
+    expected = _tuple(receipt.get("simulated_postcondition_labels")) or ("dry_run_metadata_present",)
+    observed = expected if base in {"recorded", "recorded_with_warnings"} else ()
+    missing = tuple(label for label in expected if label not in observed)
+    contradicted = ("real_postcondition_claim_present",) if base == "contradicted" else ()
+    if missing and base in {"recorded", "recorded_with_warnings"}:
+        base = "incomplete"
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"dry_run_postcondition_is_not_real_host_postcondition_check"}))
+    provisional = DryRunPostconditionVerification(
+        verification_id or _digest_id("dry-run-postcondition-verification-", {"receipt": receipt.get("receipt_id"), "effect": effect.get("verification_id"), "status": base}),
+        str(receipt.get("receipt_id", "")),
+        str(effect.get("verification_id", "")),
+        str(effect.get("dry_run_domain", _closure_domain(str(receipt.get("dry_run_domain", ""))))),
+        _status("postcondition", base),
+        expected,
+        observed,
+        missing,
+        contradicted,
+        _blocked_actions(str(effect.get("dry_run_domain", "operator_review_dry_run_closure")), receipt.get("blocked_actions")),
+        _tuple(receipt.get("warning_codes")),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_postcondition_verification_digest(provisional))
+
+
+def build_dry_run_rollback_rehearsal(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    effect_verification: DryRunEffectVerification | Mapping[str, Any],
+    *,
+    rehearsal_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunRollbackRehearsal:
+    receipt = _source_payload(dry_run_receipt)
+    effect = _source_payload(effect_verification)
+    base = _receipt_status(receipt)
+    labels = _tuple(receipt.get("simulated_rollback_labels")) or ("rollback_not_required_no_real_effect",)
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"dry_run_rollback_rehearsal_is_not_real_rollback"}))
+    provisional = DryRunRollbackRehearsal(
+        rehearsal_id or _digest_id("dry-run-rollback-rehearsal-", {"receipt": receipt.get("receipt_id"), "effect": effect.get("verification_id"), "status": base}),
+        str(receipt.get("receipt_id", "")),
+        str(effect.get("verification_id", "")),
+        str(effect.get("dry_run_domain", _closure_domain(str(receipt.get("dry_run_domain", ""))))),
+        _status("rollback", base),
+        labels,
+        ("real_effect_performed_false", "real_rollback_not_required_for_dry_run", "future_real_rollback_deferred"),
+        ("real_rollback_performed_false", "host_mutation_performed_false"),
+        _blocked_actions(str(effect.get("dry_run_domain", "operator_review_dry_run_closure")), receipt.get("blocked_actions")),
+        _tuple(receipt.get("warning_codes")),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_rollback_rehearsal_digest(provisional))
+
+
+def build_dry_run_audit_closure_receipt(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    effect_verification: DryRunEffectVerification | Mapping[str, Any],
+    postcondition_verification: DryRunPostconditionVerification | Mapping[str, Any],
+    rollback_rehearsal: DryRunRollbackRehearsal | Mapping[str, Any],
+    *,
+    receipt_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunAuditClosureReceipt:
+    receipt = _source_payload(dry_run_receipt)
+    effect = _source_payload(effect_verification)
+    post = _source_payload(postcondition_verification)
+    rollback = _source_payload(rollback_rehearsal)
+    base = _receipt_status(receipt)
+    evidence = (
+        "dry_run_effect_verification_recorded_without_real_effect_receipt",
+        "dry_run_postcondition_verification_recorded_without_real_host_check",
+        "dry_run_rollback_rehearsal_recorded_without_real_rollback",
+        "dry_run_audit_closure_is_not_production_audit_receipt",
+        "real_fulfillment_performed_false",
+        "host_mutation_performed_false",
+    )
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"dry_run_audit_closure_is_not_production_audit_receipt"}))
+    provisional = DryRunAuditClosureReceipt(
+        receipt_id or _digest_id("dry-run-audit-closure-receipt-", {"receipt": receipt.get("receipt_id"), "effect": effect.get("verification_id"), "status": base}),
+        str(receipt.get("receipt_id", "")),
+        str(effect.get("verification_id", "")),
+        str(post.get("verification_id", "")),
+        str(rollback.get("rehearsal_id", "")),
+        str(effect.get("dry_run_domain", _closure_domain(str(receipt.get("dry_run_domain", ""))))),
+        _status("audit", base),
+        evidence,
+        _blocked_actions(str(effect.get("dry_run_domain", "operator_review_dry_run_closure")), receipt.get("blocked_actions")),
+        _tuple(receipt.get("warning_codes")),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_audit_closure_receipt_digest(provisional))
+
+
+def build_dry_run_closure_bundle(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    effect_verification: DryRunEffectVerification | Mapping[str, Any],
+    postcondition_verification: DryRunPostconditionVerification | Mapping[str, Any],
+    rollback_rehearsal: DryRunRollbackRehearsal | Mapping[str, Any],
+    audit_closure_receipt: DryRunAuditClosureReceipt | Mapping[str, Any],
+    *,
+    bundle_id: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunClosureBundle:
+    receipt = _source_payload(dry_run_receipt)
+    effect = _source_payload(effect_verification)
+    post = _source_payload(postcondition_verification)
+    rollback = _source_payload(rollback_rehearsal)
+    audit = _source_payload(audit_closure_receipt)
+    base = _receipt_status(receipt)
+    risks = tuple(sorted(set(_tuple(receipt.get("risk_codes"))) | {"dry_run_closure_bundle_is_not_real_fulfillment"}))
+    provisional = DryRunClosureBundle(
+        bundle_id or _digest_id("dry-run-closure-bundle-", {"receipt": receipt.get("receipt_id"), "audit": audit.get("receipt_id"), "status": base}),
+        str(receipt.get("receipt_id", "")),
+        str(effect.get("verification_id", "")),
+        str(post.get("verification_id", "")),
+        str(rollback.get("rehearsal_id", "")),
+        str(audit.get("receipt_id", "")),
+        str(effect.get("dry_run_domain", _closure_domain(str(receipt.get("dry_run_domain", ""))))),
+        _status("bundle", base),
+        _blocked_actions(str(effect.get("dry_run_domain", "operator_review_dry_run_closure")), receipt.get("blocked_actions")),
+        _tuple(receipt.get("warning_codes")),
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=dry_run_closure_bundle_digest(provisional))
+
+
+def _validate_common(payload: Mapping[str, Any], *, prefix: str, status_field: str, statuses: frozenset[str], only_field: str, digest_fn: Any) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False):
+        findings.append(prefix + "not_metadata_only")
+    if not payload.get(only_field, False):
+        findings.append(prefix + f"missing_{only_field}")
+    if payload.get(status_field) not in statuses:
+        findings.append(prefix + f"unknown_{status_field}")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if flag in payload and payload.get(flag, False):
+            findings.append(prefix + f"forbidden_flag:{flag}")
+    if payload.get("digest") and payload.get("digest") != digest_fn(payload):
+        findings.append(prefix + "digest_mismatch")
+    return findings
+
+
+def validate_dry_run_effect_verification(record: DryRunEffectVerification | Mapping[str, Any]) -> DryRunAuditClosureValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="effect_verification:", status_field="verification_status", statuses=VERIFICATION_STATUSES, only_field="dry_run_verification_only", digest_fn=dry_run_effect_verification_digest)
+    if p.get("dry_run_domain") not in CLOSURE_DOMAINS:
+        f.append("effect_verification:unknown_dry_run_domain")
+    return DryRunAuditClosureValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_postcondition_verification(record: DryRunPostconditionVerification | Mapping[str, Any]) -> DryRunAuditClosureValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="postcondition_verification:", status_field="postcondition_status", statuses=POSTCONDITION_STATUSES, only_field="dry_run_postcondition_only", digest_fn=dry_run_postcondition_verification_digest)
+    if p.get("dry_run_domain") not in CLOSURE_DOMAINS:
+        f.append("postcondition_verification:unknown_dry_run_domain")
+    return DryRunAuditClosureValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_rollback_rehearsal(record: DryRunRollbackRehearsal | Mapping[str, Any]) -> DryRunAuditClosureValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="rollback_rehearsal:", status_field="rollback_status", statuses=ROLLBACK_STATUSES, only_field="dry_run_rollback_only", digest_fn=dry_run_rollback_rehearsal_digest)
+    if p.get("dry_run_domain") not in CLOSURE_DOMAINS:
+        f.append("rollback_rehearsal:unknown_dry_run_domain")
+    return DryRunAuditClosureValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_audit_closure_receipt(record: DryRunAuditClosureReceipt | Mapping[str, Any]) -> DryRunAuditClosureValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="audit_closure:", status_field="audit_closure_status", statuses=AUDIT_CLOSURE_STATUSES, only_field="dry_run_audit_only", digest_fn=dry_run_audit_closure_receipt_digest)
+    if p.get("dry_run_domain") not in CLOSURE_DOMAINS:
+        f.append("audit_closure:unknown_dry_run_domain")
+    return DryRunAuditClosureValidationResult(not f, tuple(f))
+
+
+def validate_dry_run_closure_bundle(record: DryRunClosureBundle | Mapping[str, Any]) -> DryRunAuditClosureValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="closure_bundle:", status_field="bundle_status", statuses=BUNDLE_STATUSES, only_field="dry_run_closure_only", digest_fn=dry_run_closure_bundle_digest)
+    if p.get("closure_domain") not in CLOSURE_DOMAINS:
+        f.append("closure_bundle:unknown_closure_domain")
+    return DryRunAuditClosureValidationResult(not f, tuple(f))
+
+
+def summarize_dry_run_effect_verification(record: DryRunEffectVerification | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("verification_id", "source_dry_run_receipt_id", "dry_run_domain", "simulated_backend_class", "verification_status", "metadata_only", "dry_run_verification_only", "real_effect_receipt_created", "real_effect_performed", "real_backend_invoked", "host_mutation_performed", "digest")}
+
+
+def summarize_dry_run_postcondition_verification(record: DryRunPostconditionVerification | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("verification_id", "source_dry_run_receipt_id", "source_effect_verification_id", "dry_run_domain", "postcondition_status", "metadata_only", "dry_run_postcondition_only", "real_postcondition_check_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_dry_run_rollback_rehearsal(record: DryRunRollbackRehearsal | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("rehearsal_id", "source_dry_run_receipt_id", "source_effect_verification_id", "dry_run_domain", "rollback_status", "metadata_only", "dry_run_rollback_only", "real_rollback_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_dry_run_audit_closure_receipt(record: DryRunAuditClosureReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("receipt_id", "source_dry_run_receipt_id", "source_effect_verification_id", "source_postcondition_verification_id", "source_rollback_rehearsal_id", "dry_run_domain", "audit_closure_status", "metadata_only", "dry_run_audit_only", "production_audit_receipt_created", "real_effect_receipt_created", "real_postcondition_check_performed", "real_rollback_performed", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "provider_invocation_performed", "network_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_dry_run_closure_bundle(record: DryRunClosureBundle | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("bundle_id", "source_dry_run_receipt_id", "effect_verification_id", "postcondition_verification_id", "rollback_rehearsal_id", "audit_closure_receipt_id", "closure_domain", "bundle_status", "metadata_only", "dry_run_closure_only", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "digest")}
+
+
+def build_dry_run_audit_closure_wing(
+    dry_run_receipt: DryRunExecutionReceipt | Mapping[str, Any],
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> DryRunAuditClosureWingRecords:
+    effect = build_dry_run_effect_verification(dry_run_receipt, created_at=created_at)
+    postcondition = build_dry_run_postcondition_verification(dry_run_receipt, effect, created_at=created_at)
+    rollback = build_dry_run_rollback_rehearsal(dry_run_receipt, effect, created_at=created_at)
+    audit = build_dry_run_audit_closure_receipt(dry_run_receipt, effect, postcondition, rollback, created_at=created_at)
+    bundle = build_dry_run_closure_bundle(dry_run_receipt, effect, postcondition, rollback, audit, created_at=created_at)
+    return DryRunAuditClosureWingRecords(effect, postcondition, rollback, audit, bundle)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -50,6 +50,16 @@ from sentientos.dry_run_execution_harness import (
     summarize_dry_run_execution_result,
     summarize_simulated_backend_registry,
 )
+
+from sentientos.dry_run_audit_closure import (
+    build_dry_run_audit_closure_wing,
+    summarize_dry_run_audit_closure_receipt,
+    summarize_dry_run_closure_bundle,
+    summarize_dry_run_effect_verification,
+    summarize_dry_run_postcondition_verification,
+    summarize_dry_run_rollback_rehearsal,
+)
+
 from sentientos.local_authorization_grant import (
     build_local_authorization_grant_wing,
     build_operator_approval_evidence,
@@ -93,6 +103,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "fulfillment_authorization_posture",
         "executor_contract_posture",
         "dry_run_execution_posture",
+        "dry_run_audit_closure_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -119,6 +130,7 @@ BUNDLE_FILE_NAMES = {
     "fulfillment_authorization_posture": "fulfillment_authorization.json",
     "executor_contract_posture": "executor_contract.json",
     "dry_run_execution_posture": "dry_run_execution.json",
+    "dry_run_audit_closure_posture": "dry_run_audit_closure.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -140,6 +152,11 @@ DEFERRED_ACTION_LABELS = (
     "dry_run_execution_request",
     "dry_run_execution_result",
     "dry_run_execution_receipt",
+    "dry_run_effect_verification",
+    "dry_run_postcondition_verification",
+    "dry_run_rollback_rehearsal",
+    "dry_run_audit_closure_receipt",
+    "dry_run_closure_bundle",
     "real_backend_invocation",
     "real_effect_execution",
     "real_rollback_execution",
@@ -348,8 +365,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "7. `fulfillment_authorization.json` — metadata-only authorization consumption posture; consuming authorization is not fulfillment.",
             "8. `executor_contract.json` — metadata-only executor contract posture; it is not an executor.",
             "9. `dry_run_execution.json` — simulation-only dry-run harness posture; it is not fulfillment or an effect receipt.",
-            "10. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "11. `capability_registry_summary.json` — metadata-only capability posture.",
+            "10. `dry_run_audit_closure.json` — dry-run verification/audit closure posture; it is not a real effect receipt, real postcondition check, real rollback, or production audit receipt.",
+            "11. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "12. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -365,6 +383,7 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "- Local authorization grant records are authority metadata only; verification does not authorize fulfillment.",
             "- Executor contract records are readiness metadata only; they do not load backends, execute dry runs, grant control-plane admission, fulfill actions, or perform effects.",
             "- Dry-run execution runs only inert simulated in-process backends; dry_run_executed=true is simulation only, not fulfillment, not an effect receipt, and not host mutation proof.",
+            "- Dry-run audit closure verifies dry-run evidence only; it is not a real effect receipt, real host postcondition check, real rollback, or production audit receipt.",
             "- Fan/PWM writes, thermal writes, power mutation, service restart, cleanup, federation transport, and remote execution remain deferred or blocked.",
             "",
             f"Manifest ID: `{manifest_id}`",
@@ -453,6 +472,7 @@ def build_reviewer_proof_bundle_payload(
         requested_simulated_backend_class="cooling_backend_simulated",
         created_at=created_at,
     )
+    dry_run_audit_closure = build_dry_run_audit_closure_wing(dry_run_execution.receipt, created_at=created_at)
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
@@ -589,6 +609,40 @@ def build_reviewer_proof_bundle_payload(
                 "receipt": dry_run_execution.receipt.to_dict() if dry_run_execution.receipt else None,
             },
         }),
+        "dry_run_audit_closure_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "dry_run_audit_closure_only": True,
+            "proof_statement": "Dry-run audit closure verifies dry-run evidence only; it is not a real effect receipt, not a real host postcondition check, not real rollback, and not a production audit receipt.",
+            "effect_verification_summary": summarize_dry_run_effect_verification(dry_run_audit_closure.effect_verification),
+            "postcondition_verification_summary": summarize_dry_run_postcondition_verification(dry_run_audit_closure.postcondition_verification),
+            "rollback_rehearsal_summary": summarize_dry_run_rollback_rehearsal(dry_run_audit_closure.rollback_rehearsal),
+            "audit_closure_receipt_summary": summarize_dry_run_audit_closure_receipt(dry_run_audit_closure.audit_closure_receipt),
+            "closure_bundle_summary": summarize_dry_run_closure_bundle(dry_run_audit_closure.closure_bundle),
+            "real_effect_receipt_created": False,
+            "real_postcondition_check_performed": False,
+            "real_rollback_performed": False,
+            "production_audit_receipt_created": False,
+            "real_fulfillment_performed": False,
+            "real_effect_performed": False,
+            "host_mutation_performed": False,
+            "fan_pwm_write_performed": False,
+            "thermal_actuation_performed": False,
+            "power_profile_mutation_performed": False,
+            "service_restart_performed": False,
+            "file_cleanup_performed": False,
+            "network_performed": False,
+            "provider_invocation_performed": False,
+            "prompt_assembly_performed": False,
+            "real_actuation_deferred": True,
+            "records": {
+                "effect_verification": dry_run_audit_closure.effect_verification.to_dict(),
+                "postcondition_verification": dry_run_audit_closure.postcondition_verification.to_dict(),
+                "rollback_rehearsal": dry_run_audit_closure.rollback_rehearsal.to_dict(),
+                "audit_closure_receipt": dry_run_audit_closure.audit_closure_receipt.to_dict(),
+                "closure_bundle": dry_run_audit_closure.closure_bundle.to_dict(),
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -630,7 +684,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution, "dry_run_audit_closure": dry_run_audit_closure}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -194,3 +194,21 @@ def test_reviewer_proof_bundle_cli_writes_dry_run_execution_json(tmp_path) -> No
     assert payload["host_mutation_performed"] is False
     assert payload["fan_pwm_write_performed"] is False
     assert payload["thermal_actuation_performed"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_dry_run_audit_closure_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "dry_run_audit_closure.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["dry_run_audit_closure_only"] is True
+    assert payload["effect_verification_summary"]["real_effect_receipt_created"] is False
+    assert payload["postcondition_verification_summary"]["real_postcondition_check_performed"] is False
+    assert payload["rollback_rehearsal_summary"]["real_rollback_performed"] is False
+    assert payload["audit_closure_receipt_summary"]["production_audit_receipt_created"] is False
+    assert payload["real_fulfillment_performed"] is False
+    assert payload["host_mutation_performed"] is False
+    assert payload["fan_pwm_write_performed"] is False
+    assert payload["thermal_actuation_performed"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -556,3 +556,40 @@ def test_registry_update_from_dry_run_execution_receipt_preserves_real_action_de
     assert records["real_effect_execution"].status == "deferred"
     assert records["real_fan_pwm_control"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_dry_run_audit_closure_capabilities_are_dry_run_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["dry_run_effect_verification"].status == "implemented"
+    assert records["dry_run_effect_verification"].authority_level == "dry_run_verification_only"
+    assert records["dry_run_postcondition_verification"].authority_level == "dry_run_postcondition_only"
+    assert records["dry_run_rollback_rehearsal"].authority_level == "dry_run_rollback_only"
+    assert records["dry_run_audit_closure_receipt"].authority_level == "dry_run_audit_only"
+    assert records["dry_run_closure_bundle"].authority_level == "dry_run_closure_only"
+    for capability_id in ["real_effect_receipt_creation", "real_postcondition_check", "real_rollback_execution", "production_audit_receipt_for_host_effect", "fulfillment_execution", "real_effect_execution"]:
+        assert records[capability_id].status == "deferred"
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_registry_update_from_dry_run_audit_closure_preserves_real_action_deferral() -> None:
+    from sentientos.capability_registry import update_registry_from_dry_run_audit_closure
+    from sentientos.dry_run_audit_closure import build_dry_run_audit_closure_wing
+    from sentientos.dry_run_execution_harness import build_dry_run_execution_harness_wing
+    from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+    from tests.test_fulfillment_authorization import _wing, FIXED
+
+    executor = build_fulfillment_executor_contract_wing(_wing().consumption_receipt, created_at=FIXED)
+    dry_run = build_dry_run_execution_harness_wing(executor.readiness_receipt, created_at=FIXED)
+    closure = build_dry_run_audit_closure_wing(dry_run.receipt, created_at=FIXED)
+    registry = update_registry_from_dry_run_audit_closure(build_default_capability_registry(), closure)
+    records = registry.by_id()
+    assert records["dry_run_audit_closure_receipt"].status == "implemented"
+    assert records["dry_run_closure_bundle"].authority_level == "dry_run_closure_only"
+    assert records["real_effect_receipt_creation"].status == "deferred"
+    assert records["real_postcondition_check"].status == "deferred"
+    assert records["real_rollback_execution"].status == "deferred"
+    assert records["production_audit_receipt_for_host_effect"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"
+    assert validate_capability_registry(registry).ok

--- a/tests/test_dry_run_audit_closure.py
+++ b/tests/test_dry_run_audit_closure.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.dry_run_audit_closure import (
+    build_dry_run_audit_closure_wing,
+    dry_run_effect_verification_digest,
+    summarize_dry_run_audit_closure_receipt,
+    summarize_dry_run_closure_bundle,
+    summarize_dry_run_effect_verification,
+    summarize_dry_run_postcondition_verification,
+    summarize_dry_run_rollback_rehearsal,
+    validate_dry_run_audit_closure_receipt,
+    validate_dry_run_closure_bundle,
+    validate_dry_run_effect_verification,
+    validate_dry_run_postcondition_verification,
+    validate_dry_run_rollback_rehearsal,
+)
+from sentientos.dry_run_execution_harness import build_dry_run_execution_harness_wing, dry_run_execution_receipt_digest
+from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+from tests.test_fulfillment_authorization import FIXED
+from tests.test_fulfillment_executor_contract import _consumed_receipt
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _receipt(domain: str = "future_cooling_fulfillment_authorization", **changes):
+    executor = build_fulfillment_executor_contract_wing(_consumed_receipt(domain), created_at=FIXED)
+    dry_run = build_dry_run_execution_harness_wing(executor.readiness_receipt, created_at=FIXED)
+    assert dry_run.receipt is not None
+    receipt = dry_run.receipt
+    if changes:
+        receipt = replace(receipt, **changes)
+        if "digest" not in changes:
+            receipt = replace(receipt, digest=dry_run_execution_receipt_digest(receipt))
+    return receipt
+
+
+def test_recorded_dry_run_receipt_builds_metadata_only_closure_records() -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(), created_at=FIXED)
+    assert wing.effect_verification.verification_status in {"dry_run_verification_recorded", "dry_run_verification_recorded_with_warnings"}
+    assert wing.postcondition_verification.postcondition_status in {"dry_run_postcondition_verified", "dry_run_postcondition_verified_with_warnings"}
+    assert wing.rollback_rehearsal.rollback_status in {"dry_run_rollback_rehearsed", "dry_run_rollback_rehearsed_with_warnings"}
+    assert wing.audit_closure_receipt.audit_closure_status in {"dry_run_audit_closure_recorded", "dry_run_audit_closure_recorded_with_warnings"}
+    assert wing.closure_bundle.bundle_status in {"dry_run_closure_bundle_ready", "dry_run_closure_bundle_ready_with_warnings"}
+    assert wing.effect_verification.real_effect_receipt_created is False
+    assert wing.postcondition_verification.real_postcondition_check_performed is False
+    assert wing.rollback_rehearsal.real_rollback_performed is False
+    assert wing.audit_closure_receipt.production_audit_receipt_created is False
+    assert wing.closure_bundle.metadata_only is True
+    assert validate_dry_run_effect_verification(wing.effect_verification).ok
+    assert validate_dry_run_postcondition_verification(wing.postcondition_verification).ok
+    assert validate_dry_run_rollback_rehearsal(wing.rollback_rehearsal).ok
+    assert validate_dry_run_audit_closure_receipt(wing.audit_closure_receipt).ok
+    assert validate_dry_run_closure_bundle(wing.closure_bundle).ok
+
+
+@pytest.mark.parametrize(
+    ("receipt_status", "expected"),
+    [
+        ("dry_run_execution_receipt_blocked", "blocked"),
+        ("dry_run_execution_receipt_incomplete", "incomplete"),
+        ("dry_run_execution_receipt_contradicted", "contradicted"),
+    ],
+)
+def test_non_recorded_receipt_status_propagates_to_closure(receipt_status: str, expected: str) -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(receipt_status=receipt_status), created_at=FIXED)
+    assert wing.effect_verification.verification_status == f"dry_run_verification_{expected}"
+    assert wing.postcondition_verification.postcondition_status == f"dry_run_postcondition_{'verified' if expected == 'recorded' else expected}"
+    assert wing.rollback_rehearsal.rollback_status == f"dry_run_rollback_{'rehearsed' if expected == 'recorded' else expected}"
+    assert wing.audit_closure_receipt.audit_closure_status == f"dry_run_audit_closure_{expected}"
+    assert wing.closure_bundle.bundle_status == f"dry_run_closure_bundle_{expected}"
+
+
+def test_receipt_claiming_real_effect_fulfillment_or_host_mutation_is_contradicted() -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(real_effect_performed=True, real_fulfillment_performed=True, host_mutation_performed=True), created_at=FIXED)
+    assert wing.effect_verification.verification_status == "dry_run_verification_contradicted"
+    assert wing.audit_closure_receipt.audit_closure_status == "dry_run_audit_closure_contradicted"
+    assert wing.closure_bundle.bundle_status == "dry_run_closure_bundle_contradicted"
+
+
+@pytest.mark.parametrize(
+    ("domain", "blocked"),
+    [
+        ("future_cooling_fulfillment_authorization", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_fulfillment_authorization", {"power_profile_mutation"}),
+        ("future_cleanup_fulfillment_authorization", {"file_cleanup", "file_delete"}),
+        ("future_service_fulfillment_authorization", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_domain_specific_blocks_are_preserved(domain: str, blocked: set[str]) -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(domain), created_at=FIXED)
+    assert blocked <= set(wing.effect_verification.blocked_actions)
+    assert blocked <= set(wing.audit_closure_receipt.blocked_actions)
+    assert blocked <= set(wing.closure_bundle.blocked_actions)
+
+
+@pytest.mark.parametrize(
+    ("record_name", "flag", "validator"),
+    [
+        ("effect_verification", "real_effect_receipt_created", validate_dry_run_effect_verification),
+        ("postcondition_verification", "real_postcondition_check_performed", validate_dry_run_postcondition_verification),
+        ("rollback_rehearsal", "real_rollback_performed", validate_dry_run_rollback_rehearsal),
+        ("audit_closure_receipt", "production_audit_receipt_created", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "real_fulfillment_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "real_effect_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "host_mutation_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "fan_pwm_write_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "thermal_actuation_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "power_profile_mutation_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "service_restart_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "file_cleanup_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "network_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "provider_invocation_performed", validate_dry_run_audit_closure_receipt),
+        ("audit_closure_receipt", "prompt_assembly_performed", validate_dry_run_audit_closure_receipt),
+        ("closure_bundle", "real_fulfillment_performed", validate_dry_run_closure_bundle),
+    ],
+)
+def test_validation_rejects_forbidden_true_flags(record_name: str, flag: str, validator) -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(), created_at=FIXED)
+    record = getattr(wing, record_name)
+    bad = replace(record, **{flag: True})
+    result = validator(bad)
+    assert not result.ok
+    assert any(f"forbidden_flag:{flag}" in finding for finding in result.findings)
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    receipt = _receipt()
+    first = build_dry_run_audit_closure_wing(receipt, created_at=FIXED).effect_verification
+    second = build_dry_run_audit_closure_wing(receipt, created_at=FIXED).effect_verification
+    changed = replace(first, warning_codes=("new_warning",), digest="")
+    changed = replace(changed, digest=dry_run_effect_verification_digest(changed))
+    assert first.digest == second.digest
+    assert first.digest != changed.digest
+
+
+def test_summaries_are_metadata_only_and_non_effect() -> None:
+    wing = build_dry_run_audit_closure_wing(_receipt(), created_at=FIXED)
+    assert summarize_dry_run_effect_verification(wing.effect_verification)["real_effect_receipt_created"] is False
+    assert summarize_dry_run_postcondition_verification(wing.postcondition_verification)["real_postcondition_check_performed"] is False
+    assert summarize_dry_run_rollback_rehearsal(wing.rollback_rehearsal)["real_rollback_performed"] is False
+    assert summarize_dry_run_audit_closure_receipt(wing.audit_closure_receipt)["production_audit_receipt_created"] is False
+    assert summarize_dry_run_closure_bundle(wing.closure_bundle)["metadata_only"] is True

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -248,3 +248,19 @@ def test_default_reviewer_proof_bundle_includes_dry_run_execution_artifact() -> 
     assert dry_run["real_effect_performed"] is False
     assert dry_run["host_mutation_performed"] is False
     assert "dry_run_execution_posture" in {artifact.artifact_kind for artifact in payload["manifest"].artifact_records}
+
+
+def test_default_reviewer_proof_bundle_includes_dry_run_audit_closure_artifact() -> None:
+    payload = build_reviewer_proof_bundle_payload()
+    assert "dry_run_audit_closure_posture" in payload["artifacts"]
+    closure = json.loads(payload["artifacts"]["dry_run_audit_closure_posture"])
+    assert closure["dry_run_audit_closure_only"] is True
+    assert closure["effect_verification_summary"]["real_effect_receipt_created"] is False
+    assert closure["postcondition_verification_summary"]["real_postcondition_check_performed"] is False
+    assert closure["rollback_rehearsal_summary"]["real_rollback_performed"] is False
+    assert closure["audit_closure_receipt_summary"]["production_audit_receipt_created"] is False
+    assert closure["real_fulfillment_performed"] is False
+    assert closure["host_mutation_performed"] is False
+    assert "dry_run_audit_closure_posture" in {artifact.artifact_kind for artifact in payload["manifest"].artifact_records}
+    validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
+    assert validation.ok, validation.findings

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -493,3 +493,26 @@ def test_host_dry_run_execution_harness_doc_preserves_simulation_only_boundaries
     assert "Real actuation remains deferred" in doc
     assert "subprocess execution" in doc
     assert "network egress" in doc
+
+HOST_DRY_RUN_AUDIT_CLOSURE_WING = "docs/architecture/host_dry_run_audit_closure_wing.md"
+
+
+def test_navigation_links_to_host_dry_run_audit_closure_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    dry_run = _read(HOST_DRY_RUN_EXECUTION_HARNESS_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, dry_run, bundle, controlled, trajectory]:
+        assert HOST_DRY_RUN_AUDIT_CLOSURE_WING in text
+
+
+def test_host_dry_run_audit_closure_doc_preserves_dry_run_only_boundaries() -> None:
+    doc = _read(HOST_DRY_RUN_AUDIT_CLOSURE_WING)
+    assert "Dry-run effect verification is not a real effect receipt" in doc
+    assert "Dry-run postcondition verification is not a real host postcondition check" in doc
+    assert "Dry-run rollback rehearsal is not real rollback" in doc
+    assert "Dry-run audit closure is not a production audit receipt" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "No subprocess" in doc or "no subprocess" in doc


### PR DESCRIPTION
### Motivation

- Add a metadata-only verification and audit-closure layer that consumes `DryRunExecutionReceipt` records and produces simulated verification artifacts without performing any real host effects. 
- Provide deterministic, auditable records for simulated effect verification, simulated postcondition verification, simulated rollback rehearsal, an audit-closure receipt, and a closure bundle so reviewer tooling can reason about dry-run outcomes while preserving fail-closed real-action semantics. 
- Integrate the wing into existing proof packaging and capability posture so the repository can demonstrate a conservative dry-run verification posture in reviewer artifacts.

### Description

- New module `sentientos/dry_run_audit_closure.py` implements frozen dataclasses and builders for `DryRunAuditClosurePolicy`, `DryRunEffectVerification`, `DryRunPostconditionVerification`, `DryRunRollbackRehearsal`, `DryRunAuditClosureReceipt`, `DryRunClosureBundle`, deterministic digest helpers, validators, summarizers, and `build_dry_run_audit_closure_wing(...)` that accepts a `DryRunExecutionReceipt` and returns the set of closure records. 
- Reviewer-bundle integration: `sentientos/reviewer_proof_bundle.py` now includes `dry_run_audit_closure.json` (artifact kind `dry_run_audit_closure_posture`) and writes a metadata-only summary and full closure records into the default proof bundle. 
- Capability registry updates: `sentientos/capability_registry.py` adds dry-run-only capability records (`dry_run_effect_verification`, `dry_run_postcondition_verification`, `dry_run_rollback_rehearsal`, `dry_run_audit_closure_receipt`, `dry_run_closure_bundle`) and a helper `update_registry_from_dry_run_audit_closure(...)` that reflects closure posture while keeping all real-effect capabilities deferred/blocked. 
- Docs and tests: added `docs/architecture/host_dry_run_audit_closure_wing.md`, updated reviewer/doc links, and added focused tests (`tests/test_dry_run_audit_closure.py`) plus bundle and registry test updates to cover integration and validation rules.

### Testing

- Static checks: `python -m py_compile sentientos/dry_run_audit_closure.py sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py sentientos/capability_registry.py tests/test_dry_run_audit_closure.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` completed without syntax errors. 
- Unit tests: ran the focused test sets with `python -m scripts.run_tests -q` and the added/updated tests passed: `tests/test_dry_run_audit_closure.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py` all succeeded in the final run. 
- Integration checks: built a reviewer proof bundle with `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and verified `/tmp/sentientos-reviewer-proof/dry_run_audit_closure.json` exists and contains the expected metadata-only flags (no real-effect flags set). 
- Docs build and hygiene: docs bootstrapping and `python scripts/build_docs.py` were run successfully (initial `--check-deps` required `--bootstrap-docs`); `python scripts/verify_context_hygiene_prompt_boundaries.py` returned clean. 

All automated validation and tests described above completed successfully after the changes; generated artifacts preserve the invariant that dry-run closure records are metadata-only and do not claim or perform any real host effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06beaa35dc8320b26f5825451e8418)