### PR TITLE
[codex:host-embodiment] add real effect admission wing

### DIFF
--- a/docs/architecture/host_dry_run_audit_closure_wing.md
+++ b/docs/architecture/host_dry_run_audit_closure_wing.md
@@ -26,7 +26,7 @@ Any record claiming real fulfillment, real effect, host mutation, fan/PWM write,
 
 ## Authority ladder
 
-observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → dry-run execution harness → dry-run verification/audit closure → fulfill → effect receipt → postcondition check → audit → rollback.
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → dry-run execution harness → dry-run verification/audit closure → real effect capability admission → implement real backend → fulfill → effect receipt → postcondition check → audit → rollback.
 
 This wing covers **dry-run verification and audit closure only**.
 
@@ -41,3 +41,8 @@ The reviewer proof bundle includes `dry_run_audit_closure.json`. The artifact is
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_dry_run_audit_closure.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/host_dry_run_execution_harness_wing.md
+++ b/docs/architecture/host_dry_run_execution_harness_wing.md
@@ -47,3 +47,8 @@ The reviewer proof bundle includes `dry_run_execution.json`. The artifact is rev
 Next wing: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). It verifies dry-run evidence only; dry-run effect verification is not a real effect receipt, dry-run postcondition verification is not a real host postcondition check, dry-run rollback rehearsal is not real rollback, and dry-run audit closure is not a production audit receipt.
 
 Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -77,3 +77,8 @@ See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_w
 Downstream dry-run proof link: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). It preserves the boundary that dry-run closure is not fulfillment, effect receipt, real host postcondition check, rollback, production audit, or actuation.
 
 Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/host_real_effect_capability_admission_wing.md
+++ b/docs/architecture/host_real_effect_capability_admission_wing.md
@@ -1,0 +1,43 @@
+# Host Real Effect Capability Admission Wing
+
+This wing follows the [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). Dry-run audit closure verifies simulated evidence only; it does **not** automatically permit real effects. Real effect capability admission is metadata-only implementation planning posture, not implementation.
+
+## Boundary
+
+Real effect capability admission is not implementation. The admission decision does not authorize implementation or execution. The implementation plan scaffold does not start implementation. The block/deferral receipt does not mutate host state.
+
+This wing does not implement a real backend, load a backend, invoke a backend, fulfill a host action, execute a real effect, create a real effect receipt, perform a real host postcondition check, execute rollback, create a production audit receipt, actuate hardware, write fan/PWM controls, perform thermal actuation, mutate power profiles, restart services, kill processes, clean or delete files, install packages or drivers, call the OS, perform network egress, invoke providers, assemble prompts, transport federation changes, execute remotely, spawn subprocess execution, run shell execution, or call control-plane admission/execution.
+
+## Records
+
+- **RealEffectCapabilityCandidate** records a dry-run closure-backed candidate and keeps `metadata_only=true`, `candidate_only=true`, `implementation_not_started=true`, `real_backend_implemented=false`, `real_fulfillment_performed=false`, `real_effect_performed=false`, and `host_mutation_performed=false`.
+- **RealEffectCapabilityAdmissionDecision** classifies the candidate as eligible for implementation planning, eligible with conditions, blocked, incomplete, or contradicted. It keeps `authorizes_implementation=false` and `authorizes_execution=false`.
+- **RealEffectImplementationPlanScaffold** names future design work only. It keeps `plan_scaffold_only=true`, `implementation_not_started=true`, `backend_loaded=false`, `backend_invoked=false`, `real_fulfillment_performed=false`, `real_effect_performed=false`, and `host_mutation_performed=false`.
+- **RealEffectCapabilityBlockReceipt** records why a capability remains blocked/deferred and keeps `block_receipt_only=true`, `implementation_not_started=true`, `real_backend_implemented=false`, `real_fulfillment_performed=false`, and `host_mutation_performed=false`.
+- **RealEffectAdmissionBundle** packages candidate, decision, and plan-or-block posture while keeping `authorizes_implementation=false`, `authorizes_execution=false`, and all real-action flags false.
+
+## Domain posture
+
+Lower-risk domains such as diagnostics, operator review, and resource pressure may become implementation-planning candidates. Conditional domains must still satisfy explicit planning, operator, and security review labels.
+
+Cooling/hardware control remains blocked by default. Real fan/PWM, thermal, power, service, and cleanup actions remain blocked/deferred. Future cooling preserves `fan_pwm_write` and `thermal_actuation` blocked actions. Future power preserves `power_profile_mutation`. Future service preserves `service_restart` and `process_kill`. Future cleanup preserves `file_cleanup` and `file_delete`.
+
+Real fulfillment remains deferred. Real effect receipts remain deferred. Real postcondition checks remain deferred. Real rollback remains deferred. Production audit remains deferred. Real actuation remains deferred.
+
+## Authority ladder
+
+observe → model → propose → broker eligibility → rehearse → readiness → authorization review → controlled grant contract → safety gates → live-grant readiness → local authorization grant → fulfillment authorization consumption → executor contract → dry-run execution harness → dry-run verification/audit closure → real effect capability admission → implement real backend → fulfill → effect receipt → postcondition check → audit → rollback.
+
+This wing covers **real effect capability admission and implementation planning only**.
+
+## Reviewer proof bundle integration
+
+The reviewer proof bundle includes `real_effect_admission.json`. The artifact shows that a dry-run closure can be evaluated for future implementation planning while no implementation starts, no backend loads, no backend invokes, no real fulfillment occurs, no real effect occurs, and no host mutation occurs.
+
+## Implementation links
+
+- Module: `sentientos/real_effect_admission.py`
+- Dry-run closure source: `sentientos/dry_run_audit_closure.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_real_effect_admission.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -265,3 +265,8 @@ Reviewer map: [Host Fulfillment Executor Contract Wing](host_fulfillment_executo
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
 
 See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md) (`docs/architecture/host_dry_run_audit_closure_wing.md`), which verifies dry-run evidence only; it is not a real effect receipt, not a real host postcondition check, not real rollback, not a production audit receipt, and real actuation remains deferred.
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -111,3 +111,8 @@ See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_w
 The bundle also includes `dry_run_audit_closure.json`; see [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md). Dry-run audit closure verifies dry-run evidence only and is not a real effect receipt, not a real host postcondition check, not real rollback, and not a production audit receipt.
 
 Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -266,3 +266,8 @@ The [Host Fulfillment Authorization Consumption Wing](host_fulfillment_authoriza
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
 
 See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_audit_closure_wing.md) (`docs/architecture/host_dry_run_audit_closure_wing.md`). Dry-run effect verification is not a real effect receipt; dry-run postcondition verification is not real host postcondition check; dry-run rollback rehearsal is not real rollback; dry-run audit closure is not production audit receipt; real actuation remains deferred.
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -415,3 +415,8 @@ Proof path: `docs/architecture/host_fulfillment_executor_contract_wing.md`.
 See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_wing.md) (`docs/architecture/host_dry_run_execution_harness_wing.md`), which is simulation-only; dry-run execution is not real fulfillment, dry-run result is not an effect receipt, dry-run receipt is not proof of host mutation, and real actuation remains deferred.
 
 - Host Dry-Run Effect Verification / Audit Closure Wing: `docs/architecture/host_dry_run_audit_closure_wing.md`. Dry-run effect verification is not a real effect receipt; dry-run postcondition verification is not a real host postcondition check; dry-run rollback rehearsal is not real rollback; dry-run audit closure is not a production audit receipt; real actuation remains deferred.
+
+
+## Real effect capability admission link
+
+See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -46,6 +46,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "fulfillment_executor_contract",
         "dry_run_execution_harness",
         "dry_run_audit_closure",
+        "real_effect_admission",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -96,6 +97,10 @@ AUTHORITY_LEVELS = frozenset(
         "dry_run_rollback_only",
         "dry_run_audit_only",
         "dry_run_closure_only",
+        "admission_planning_only",
+        "candidate_only",
+        "plan_scaffold_only",
+        "block_receipt_only",
         "telemetry_readiness_only",
         "gated_host_interaction",
         "privileged_host_action",
@@ -328,10 +333,15 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("dry_run_rollback_rehearsal", "dry_run_audit_closure", "implemented", "dry_run_rollback_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only rollback rehearsal records",), deferred_surfaces=("real rollback execution",), forbidden_implications=("dry-run rollback rehearsal executes rollback",)),
         _record("dry_run_audit_closure_receipt", "dry_run_audit_closure", "implemented", "dry_run_audit_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only dry-run audit closure receipts",), deferred_surfaces=("production audit receipt for host effects",), forbidden_implications=("dry-run audit closure is a production audit receipt",)),
         _record("dry_run_closure_bundle", "dry_run_audit_closure", "implemented", "dry_run_closure_only", source_paths=("sentientos/dry_run_audit_closure.py",), proof_tests=("tests/test_dry_run_audit_closure.py",), implemented_surfaces=("metadata-only dry-run closure bundles",), deferred_surfaces=("real fulfillment", "real effect receipt", "real postcondition check", "real rollback"), forbidden_implications=("dry-run closure bundle fulfills host actions",)),
+        _record("real_effect_capability_admission", "real_effect_admission", "implemented", "admission_planning_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("metadata-only real effect capability admission decisions",), deferred_surfaces=("real backend implementation", "real fulfillment execution", "real effect execution", "host mutation"), forbidden_implications=("real effect admission is implementation", "admission authorizes execution")),
+        _record("real_effect_capability_candidate", "real_effect_admission", "implemented", "candidate_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("metadata-only capability candidate records",), deferred_surfaces=("implementation start", "backend loading"), forbidden_implications=("candidate record implements backend",)),
+        _record("real_effect_implementation_plan_scaffold", "real_effect_admission", "implemented", "plan_scaffold_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("implementation plan scaffolds only",), deferred_surfaces=("real backend implementation", "backend invocation", "effect receipt creation"), forbidden_implications=("plan scaffold starts implementation",)),
+        _record("real_effect_capability_block_receipt", "real_effect_admission", "implemented", "block_receipt_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("real effect capability block and deferral receipts",), deferred_surfaces=("blocked host action", "host mutation"), forbidden_implications=("block receipt mutates host state",)),
+        _record("real_backend_implementation", "real_effect_admission", "deferred", "none", deferred_surfaces=("real backend implementation", "OS backend implementation"), forbidden_implications=("real effect admission implements backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_receipt_creation", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real effect receipt creation",), forbidden_implications=("dry-run audit closure creates real effect receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_postcondition_check", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real host postcondition checking",), forbidden_implications=("dry-run audit closure checks real host postconditions",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("production_audit_receipt_for_host_effect", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("production audit receipts for real host effects",), forbidden_implications=("dry-run audit closure emits production audit receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("real_backend_invocation", "dry_run_execution_harness", "deferred", "none", deferred_surfaces=("real backend invocation", "OS backend invocation", "control-plane execution"), forbidden_implications=("dry-run harness invokes real backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("real_backend_invocation", "real_effect_admission", "deferred", "none", deferred_surfaces=("real backend invocation", "OS backend invocation", "control-plane execution"), forbidden_implications=("real effect admission invokes real backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("fulfillment_execution", "fulfillment_authorization", "deferred", "none", deferred_surfaces=("future fulfillment executor", "host mutation", "effect receipt from real action"), forbidden_implications=("fulfillment authorization wing implements execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("live_host_trace_collection", "host_embodiment_trace", "deferred", "none", deferred_surfaces=("live host trace collection", "privileged probing"), forbidden_implications=("reviewer demo default collects live host data",)),
         _record("live_authorization_grant", "controlled_authorization", "deferred", "none", deferred_surfaces=("live controlled authorization grant", "runtime authority token"), forbidden_implications=("controlled authorization wing implements live grants",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -348,9 +358,9 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("federation_evidence_custody", "federation_evidence", "implemented", "federation_evidence", source_paths=("sentientos/federation/",), proof_tests=("tests/test_federated_improvement_candidate.py", "tests/test_federated_improvement_intake_receipt.py", "tests/test_federated_improvement_custody_runway.py"), implemented_surfaces=("federated evidence/receipt custody",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "execution"), forbidden_implications=("federation receipts transport or adopt changes")),
         _record("federation_transport_sync_adoption", "federation_evidence", "blocked", "none", source_paths=("sentientos/federation/",), deferred_surfaces=("transport", "sync", "adoption", "merge", "apply", "install", "remote execution"), forbidden_implications=("evidence custody is adoption")),
         _record("provider_invocation", "local_model_chat", "blocked", "none", source_paths=("docs/architecture/reviewer_release_readiness_index.md",), proof_commands=("python scripts/verify_context_hygiene_prompt_boundaries.py",), deferred_surfaces=("provider invocation", "provider SDK", "network egress", "prompt export"), forbidden_implications=("provider runtime authority exists")),
-        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/host_fulfillment_executor_contract_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
+        _record("docs_proof", "docs_proof", "implemented", "observation", source_paths=("docs/architecture/host_embodiment_substrate_phase1.md", "docs/architecture/host_embodiment_substrate_phase2_read_only_discovery.md", "docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md", "docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md", "docs/architecture/host_embodiment_substrate_phase5_actuation_fulfillment_scaffold.md", "docs/architecture/host_embodiment_execution_proof_wing.md", "docs/architecture/host_embodiment_authorization_review_wing.md", "docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md", "docs/architecture/host_local_authorization_grant_wing.md", "docs/architecture/host_fulfillment_authorization_consumption_wing.md", "docs/architecture/host_fulfillment_executor_contract_wing.md", "docs/architecture/host_real_effect_capability_admission_wing.md", "docs/architecture/sentientos_trajectory_and_missing_organs.md", "docs/architecture/public_technical_overview.md", "docs/architecture/reviewer_release_readiness_index.md"), proof_tests=("tests/test_reviewer_release_readiness_index.py",), proof_commands=("python scripts/build_docs.py --check-deps", "python scripts/build_docs.py"), implemented_surfaces=("public proof maps and docs build",)),
     )
-    return CapabilityRegistry(registry_id="sentientos-host-embodiment-dry-run-audit-closure-wing", schema_version="host-dry-run-audit-closure-wing.v1", records=records)
+    return CapabilityRegistry(registry_id="sentientos-host-real-effect-capability-admission-wing", schema_version="host-real-effect-capability-admission-wing.v1", records=records)
 
 
 
@@ -642,6 +652,33 @@ def update_registry_from_dry_run_audit_closure(registry: CapabilityRegistry, clo
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-dry-run-audit-closure-wing.v1")
+
+
+def update_registry_from_real_effect_admission(registry: CapabilityRegistry, admission_wing: Any) -> CapabilityRegistry:
+    """Reflect real-effect admission planning without claiming implementation."""
+
+    has_candidate = bool(getattr(getattr(admission_wing, "candidate", None), "candidate_id", "")) or bool(getattr(admission_wing, "candidate_id", ""))
+    has_decision = bool(getattr(getattr(admission_wing, "decision", None), "decision_id", "")) or bool(getattr(admission_wing, "decision_id", ""))
+    plan_or_block = getattr(admission_wing, "plan_or_block_receipt", None)
+    has_plan = bool(getattr(plan_or_block, "plan_id", "")) or bool(getattr(admission_wing, "plan_id", ""))
+    has_block = bool(getattr(plan_or_block, "receipt_id", "")) or bool(getattr(admission_wing, "block_receipt_id", ""))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "real_effect_capability_admission":
+            records.append(replace(record, status="implemented" if has_decision else record.status, authority_level="admission_planning_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "real_effect_capability_candidate":
+            records.append(replace(record, status="implemented" if has_candidate else record.status, authority_level="candidate_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "real_effect_implementation_plan_scaffold":
+            records.append(replace(record, status="implemented" if has_plan else record.status, authority_level="plan_scaffold_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "real_effect_capability_block_receipt":
+            records.append(replace(record, status="implemented" if has_block else record.status, authority_level="block_receipt_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_backend_implementation", "real_backend_invocation", "fulfillment_execution", "real_effect_execution", "real_effect_receipt_creation", "real_postcondition_check", "real_rollback_execution", "production_audit_receipt_for_host_effect", "real_actuation_fulfillment"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup", "direct_fan_pwm_thermal_control"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-real-effect-capability-admission-wing.v1")
 
 def update_registry_from_actuation_fulfillment_plan(registry: CapabilityRegistry, plan: Any) -> CapabilityRegistry:
     """Reflect a Phase 5 rehearsal plan without claiming real fulfillment."""

--- a/sentientos/real_effect_admission.py
+++ b/sentientos/real_effect_admission.py
@@ -1,0 +1,742 @@
+"""Metadata-only real effect capability admission records.
+
+This wing follows dry-run audit closure and decides whether future real-effect
+capability domains may enter implementation planning. It does not implement,
+load, invoke, execute, fulfill, mutate host state, write fan/PWM controls,
+change thermal or power settings, kill processes, restart services, install
+packages or drivers, delete or clean files, perform network calls, invoke
+providers, assemble prompts, spawn subprocess execution, run shell execution,
+invoke OS backends, or call control-plane admission/execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.dry_run_audit_closure import DryRunClosureBundle
+
+ADMISSION_STATUSES = frozenset({
+    "real_effect_admission_eligible_for_planning",
+    "real_effect_admission_eligible_with_conditions",
+    "real_effect_admission_blocked",
+    "real_effect_admission_incomplete",
+    "real_effect_admission_contradicted",
+})
+CANDIDATE_STATUSES = frozenset({
+    "real_effect_candidate_recorded",
+    "real_effect_candidate_recorded_with_warnings",
+    "real_effect_candidate_blocked",
+    "real_effect_candidate_incomplete",
+    "real_effect_candidate_contradicted",
+})
+PLAN_STATUSES = frozenset({
+    "real_effect_implementation_plan_scaffold_ready",
+    "real_effect_implementation_plan_scaffold_ready_with_conditions",
+    "real_effect_implementation_plan_scaffold_blocked",
+    "real_effect_implementation_plan_scaffold_incomplete",
+    "real_effect_implementation_plan_scaffold_contradicted",
+})
+BLOCK_RECEIPT_STATUSES = frozenset({
+    "real_effect_block_receipt_recorded",
+    "real_effect_block_receipt_recorded_with_warnings",
+    "real_effect_block_receipt_incomplete",
+    "real_effect_block_receipt_contradicted",
+})
+ADMISSION_DOMAINS = frozenset({
+    "diagnostics_real_effect_candidate",
+    "operator_review_real_effect_candidate",
+    "resource_pressure_real_effect_candidate",
+    "thermal_safety_real_effect_candidate",
+    "future_cleanup_real_effect_candidate",
+    "future_service_real_effect_candidate",
+    "future_power_real_effect_candidate",
+    "future_cooling_real_effect_candidate",
+})
+IMPLEMENTATION_TIERS = frozenset({
+    "tier0_observation_only",
+    "tier1_metadata_only",
+    "tier2_dry_run_only",
+    "tier3_local_low_risk_effect_future",
+    "tier4_privileged_host_effect_future",
+    "tier5_hardware_control_effect_future",
+})
+REQUIRED_PLANNING_LABELS = (
+    "dry_run_closure_bundle_required",
+    "dry_run_effect_verification_required",
+    "dry_run_postcondition_verification_required",
+    "dry_run_rollback_rehearsal_required",
+    "dry_run_audit_closure_required",
+    "safety_gate_satisfaction_required",
+    "local_authorization_required",
+    "fulfillment_authorization_consumption_required",
+    "executor_contract_readiness_required",
+    "implementation_scope_required",
+    "backend_design_required",
+    "effect_receipt_design_required",
+    "postcondition_check_design_required",
+    "rollback_design_required",
+    "production_audit_design_required",
+    "operator_review_required",
+    "security_review_required",
+)
+BLOCKED_ACTION_LABELS = (
+    "real_fulfillment_execution",
+    "real_effect_execution",
+    "real_effect_receipt_creation",
+    "real_postcondition_check",
+    "real_rollback_execution",
+    "production_audit_receipt",
+    "host_mutation",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup",
+    "file_delete",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+)
+_LOW_RISK_DOMAINS = frozenset({
+    "diagnostics_real_effect_candidate",
+    "operator_review_real_effect_candidate",
+    "resource_pressure_real_effect_candidate",
+})
+_CONDITIONAL_DOMAINS = frozenset({"thermal_safety_real_effect_candidate"})
+_DEFAULT_BLOCKED_DOMAINS = frozenset({
+    "future_cleanup_real_effect_candidate",
+    "future_service_real_effect_candidate",
+    "future_power_real_effect_candidate",
+    "future_cooling_real_effect_candidate",
+})
+_DOMAIN_BLOCKS = {
+    "future_cooling_real_effect_candidate": ("fan_pwm_write", "thermal_actuation"),
+    "thermal_safety_real_effect_candidate": ("thermal_actuation",),
+    "future_power_real_effect_candidate": ("power_profile_mutation",),
+    "future_cleanup_real_effect_candidate": ("file_cleanup", "file_delete"),
+    "future_service_real_effect_candidate": ("service_restart", "process_kill"),
+}
+_CLOSURE_TO_ADMISSION_DOMAIN = {
+    "diagnostics_dry_run_closure": "diagnostics_real_effect_candidate",
+    "operator_review_dry_run_closure": "operator_review_real_effect_candidate",
+    "resource_pressure_dry_run_closure": "resource_pressure_real_effect_candidate",
+    "thermal_safety_dry_run_closure": "thermal_safety_real_effect_candidate",
+    "future_cleanup_dry_run_closure": "future_cleanup_real_effect_candidate",
+    "future_service_dry_run_closure": "future_service_real_effect_candidate",
+    "future_power_dry_run_closure": "future_power_real_effect_candidate",
+    "future_cooling_dry_run_closure": "future_cooling_real_effect_candidate",
+}
+_FORBIDDEN_TRUE_FLAGS = (
+    "authorizes_implementation",
+    "authorizes_execution",
+    "real_backend_implemented",
+    "backend_loaded",
+    "backend_invoked",
+    "real_fulfillment_performed",
+    "real_effect_performed",
+    "host_mutation_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "file_delete_performed",
+    "network_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+    "subprocess_execution_performed",
+    "shell_execution_performed",
+    "os_backend_invoked",
+    "control_plane_admission_execution_performed",
+    "real_effect_receipt_created",
+    "real_postcondition_check_performed",
+    "real_rollback_performed",
+    "production_audit_receipt_created",
+)
+
+
+@dataclass(frozen=True)
+class RealEffectAdmissionPolicy:
+    policy_id: str
+    supported_admission_domains: tuple[str, ...]
+    eligible_for_planning_domains: tuple[str, ...]
+    conditional_domains: tuple[str, ...]
+    default_blocked_domains: tuple[str, ...]
+    low_risk_max_tier: str
+    conditional_max_tier: str
+    required_planning_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...] = ()
+    risk_codes: tuple[str, ...] = ("real_effect_admission_is_not_implementation",)
+    metadata_only: bool = True
+    admission_policy_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectCapabilityCandidate:
+    candidate_id: str
+    source_dry_run_closure_bundle_id: str
+    source_dry_run_closure_bundle_digest: str
+    admission_domain: str
+    requested_implementation_tier: str
+    candidate_status: str
+    candidate_scope_labels: tuple[str, ...]
+    required_planning_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    candidate_only: bool = True
+    implementation_not_started: bool = True
+    real_backend_implemented: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectCapabilityAdmissionDecision:
+    decision_id: str
+    candidate_id: str
+    source_dry_run_closure_bundle_id: str
+    admission_domain: str
+    implementation_tier: str
+    admission_status: str
+    satisfied_planning_labels: tuple[str, ...]
+    missing_planning_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    admission_only: bool = True
+    authorizes_implementation: bool = False
+    authorizes_execution: bool = False
+    real_backend_implemented: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectImplementationPlanScaffold:
+    plan_id: str
+    decision_id: str
+    candidate_id: str
+    admission_domain: str
+    implementation_tier: str
+    plan_status: str
+    proposed_backend_labels: tuple[str, ...]
+    proposed_effect_receipt_labels: tuple[str, ...]
+    proposed_postcondition_labels: tuple[str, ...]
+    proposed_rollback_labels: tuple[str, ...]
+    proposed_audit_labels: tuple[str, ...]
+    proposed_security_review_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    plan_scaffold_only: bool = True
+    implementation_not_started: bool = True
+    backend_loaded: bool = False
+    backend_invoked: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectCapabilityBlockReceipt:
+    receipt_id: str
+    candidate_id: str
+    decision_id: str | None
+    admission_domain: str
+    block_status: str
+    block_reason_codes: tuple[str, ...]
+    missing_planning_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    block_receipt_only: bool = True
+    implementation_not_started: bool = True
+    real_backend_implemented: bool = False
+    real_fulfillment_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectAdmissionBundle:
+    bundle_id: str
+    candidate_id: str
+    decision_id: str
+    plan_id: str | None
+    block_receipt_id: str | None
+    admission_domain: str
+    bundle_status: str
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    admission_bundle_only: bool = True
+    implementation_not_started: bool = True
+    authorizes_implementation: bool = False
+    authorizes_execution: bool = False
+    real_backend_implemented: bool = False
+    real_fulfillment_performed: bool = False
+    real_effect_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealEffectAdmissionValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+class RealEffectAdmissionWingRecords(NamedTuple):
+    candidate: RealEffectCapabilityCandidate
+    decision: RealEffectCapabilityAdmissionDecision
+    plan_or_block_receipt: RealEffectImplementationPlanScaffold | RealEffectCapabilityBlockReceipt
+    admission_bundle: RealEffectAdmissionBundle
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = dict(_source_payload(record_or_payload))
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def real_effect_admission_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+real_effect_capability_candidate_digest = real_effect_admission_digest
+real_effect_capability_admission_decision_digest = real_effect_admission_digest
+real_effect_implementation_plan_scaffold_digest = real_effect_admission_digest
+real_effect_capability_block_receipt_digest = real_effect_admission_digest
+real_effect_admission_bundle_digest = real_effect_admission_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def _blocked_actions(domain: str, extra: Sequence[str] | None = None) -> tuple[str, ...]:
+    return tuple(sorted(set(BLOCKED_ACTION_LABELS) | set(_DOMAIN_BLOCKS.get(domain, ())) | set(_tuple(extra))))
+
+
+def _domain_from_closure(closure: Mapping[str, Any], override: str | None) -> str:
+    if override:
+        return override if override in ADMISSION_DOMAINS else "operator_review_real_effect_candidate"
+    closure_domain = str(closure.get("closure_domain", ""))
+    return _CLOSURE_TO_ADMISSION_DOMAIN.get(closure_domain, "operator_review_real_effect_candidate")
+
+
+def _closure_base_status(closure: Mapping[str, Any]) -> str:
+    if any(closure.get(flag, False) for flag in _FORBIDDEN_TRUE_FLAGS if flag in closure):
+        return "contradicted"
+    status = str(closure.get("bundle_status", ""))
+    if status == "dry_run_closure_bundle_ready":
+        return "ready"
+    if status == "dry_run_closure_bundle_ready_with_warnings":
+        return "ready_with_warnings"
+    if status == "dry_run_closure_bundle_blocked":
+        return "blocked"
+    if status == "dry_run_closure_bundle_incomplete":
+        return "incomplete"
+    if status == "dry_run_closure_bundle_contradicted":
+        return "contradicted"
+    return "incomplete"
+
+
+def build_default_real_effect_admission_policy() -> RealEffectAdmissionPolicy:
+    return RealEffectAdmissionPolicy(
+        policy_id="real-effect-admission-policy-v1",
+        supported_admission_domains=tuple(sorted(ADMISSION_DOMAINS)),
+        eligible_for_planning_domains=tuple(sorted(_LOW_RISK_DOMAINS)),
+        conditional_domains=tuple(sorted(_CONDITIONAL_DOMAINS)),
+        default_blocked_domains=tuple(sorted(_DEFAULT_BLOCKED_DOMAINS)),
+        low_risk_max_tier="tier3_local_low_risk_effect_future",
+        conditional_max_tier="tier2_dry_run_only",
+        required_planning_labels=REQUIRED_PLANNING_LABELS,
+        blocked_actions=BLOCKED_ACTION_LABELS,
+    )
+
+
+def build_real_effect_capability_candidate(
+    dry_run_closure_bundle: DryRunClosureBundle | Mapping[str, Any],
+    *,
+    admission_domain: str | None = None,
+    requested_implementation_tier: str | None = None,
+    policy: RealEffectAdmissionPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectCapabilityCandidate:
+    closure = _source_payload(dry_run_closure_bundle)
+    policy = policy or build_default_real_effect_admission_policy()
+    domain = _domain_from_closure(closure, admission_domain)
+    tier = requested_implementation_tier or "tier1_metadata_only"
+    if tier not in IMPLEMENTATION_TIERS:
+        tier = "tier1_metadata_only"
+    base = _closure_base_status(closure)
+    warnings = _tuple(closure.get("warning_codes"))
+    if base == "ready":
+        status = "real_effect_candidate_recorded"
+    elif base == "ready_with_warnings":
+        status = "real_effect_candidate_recorded_with_warnings"
+    elif base == "blocked":
+        status = "real_effect_candidate_blocked"
+    elif base == "contradicted":
+        status = "real_effect_candidate_contradicted"
+    else:
+        status = "real_effect_candidate_incomplete"
+    risks = tuple(sorted(set(_tuple(closure.get("risk_codes"))) | set(policy.risk_codes) | {"dry_run_closure_does_not_authorize_real_effects"}))
+    provisional = RealEffectCapabilityCandidate(
+        _digest_id("real-effect-candidate-", {"bundle": closure.get("bundle_id"), "domain": domain, "tier": tier, "status": status}),
+        str(closure.get("bundle_id", "")),
+        str(closure.get("digest", "")),
+        domain,
+        tier,
+        status,
+        ("metadata_only_admission_candidate", domain, tier),
+        policy.required_planning_labels,
+        _blocked_actions(domain, closure.get("blocked_actions")),
+        warnings,
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=real_effect_capability_candidate_digest(provisional))
+
+
+def evaluate_real_effect_capability_admission(
+    candidate: RealEffectCapabilityCandidate | Mapping[str, Any],
+    *,
+    policy: RealEffectAdmissionPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectCapabilityAdmissionDecision:
+    c = _source_payload(candidate)
+    policy = policy or build_default_real_effect_admission_policy()
+    domain = str(c.get("admission_domain", ""))
+    tier = str(c.get("requested_implementation_tier", "tier1_metadata_only"))
+    candidate_status = str(c.get("candidate_status", ""))
+    missing = tuple(label for label in policy.required_planning_labels if label not in ("dry_run_closure_bundle_required", "dry_run_effect_verification_required", "dry_run_postcondition_verification_required", "dry_run_rollback_rehearsal_required", "dry_run_audit_closure_required"))
+    satisfied = tuple(label for label in policy.required_planning_labels if label not in missing)
+    reasons: tuple[str, ...]
+    if candidate_status.endswith("contradicted"):
+        status = "real_effect_admission_contradicted"
+        reasons = ("dry_run_closure_or_candidate_contradicted",)
+    elif candidate_status.endswith("incomplete"):
+        status = "real_effect_admission_incomplete"
+        reasons = ("dry_run_closure_or_candidate_incomplete",)
+    elif candidate_status.endswith("blocked"):
+        status = "real_effect_admission_blocked"
+        reasons = ("dry_run_closure_or_candidate_blocked",)
+    elif domain in _DEFAULT_BLOCKED_DOMAINS or tier == "tier5_hardware_control_effect_future":
+        status = "real_effect_admission_blocked"
+        reasons = ("domain_blocked_by_default_for_real_effect_planning",)
+    elif domain in _CONDITIONAL_DOMAINS or tier == "tier4_privileged_host_effect_future":
+        status = "real_effect_admission_eligible_with_conditions"
+        reasons = ("eligible_only_with_unmet_real_effect_planning_conditions",)
+    elif domain in _LOW_RISK_DOMAINS:
+        status = "real_effect_admission_eligible_for_planning"
+        reasons = ("lower_risk_domain_eligible_for_implementation_planning_only",)
+    else:
+        status = "real_effect_admission_incomplete"
+        reasons = ("unknown_or_unsupported_admission_domain",)
+    if status == "real_effect_admission_eligible_for_planning":
+        missing = ()
+    warnings = _tuple(c.get("warning_codes"))
+    risks = tuple(sorted(set(_tuple(c.get("risk_codes"))) | {"admission_decision_does_not_authorize_implementation_or_execution"}))
+    provisional = RealEffectCapabilityAdmissionDecision(
+        _digest_id("real-effect-admission-decision-", {"candidate": c.get("candidate_id"), "status": status}),
+        str(c.get("candidate_id", "")),
+        str(c.get("source_dry_run_closure_bundle_id", "")),
+        domain,
+        tier,
+        status,
+        satisfied,
+        missing,
+        _blocked_actions(domain, c.get("blocked_actions")),
+        reasons,
+        warnings,
+        risks,
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=real_effect_capability_admission_decision_digest(provisional))
+
+
+def build_real_effect_implementation_plan_scaffold(
+    decision: RealEffectCapabilityAdmissionDecision | Mapping[str, Any],
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectImplementationPlanScaffold:
+    d = _source_payload(decision)
+    status_map = {
+        "real_effect_admission_eligible_for_planning": "real_effect_implementation_plan_scaffold_ready",
+        "real_effect_admission_eligible_with_conditions": "real_effect_implementation_plan_scaffold_ready_with_conditions",
+        "real_effect_admission_blocked": "real_effect_implementation_plan_scaffold_blocked",
+        "real_effect_admission_incomplete": "real_effect_implementation_plan_scaffold_incomplete",
+        "real_effect_admission_contradicted": "real_effect_implementation_plan_scaffold_contradicted",
+    }
+    domain = str(d.get("admission_domain", ""))
+    provisional = RealEffectImplementationPlanScaffold(
+        _digest_id("real-effect-plan-scaffold-", {"decision": d.get("decision_id"), "status": d.get("admission_status")}),
+        str(d.get("decision_id", "")),
+        str(d.get("candidate_id", "")),
+        domain,
+        str(d.get("implementation_tier", "")),
+        status_map.get(str(d.get("admission_status")), "real_effect_implementation_plan_scaffold_incomplete"),
+        ("backend_design_required_before_implementation", "no_backend_loaded"),
+        ("effect_receipt_design_required", "real_effect_receipt_creation_blocked"),
+        ("postcondition_check_design_required", "real_postcondition_check_blocked"),
+        ("rollback_design_required", "real_rollback_execution_blocked"),
+        ("production_audit_design_required", "production_audit_receipt_blocked"),
+        ("operator_review_required", "security_review_required"),
+        _blocked_actions(domain, d.get("blocked_actions")),
+        _tuple(d.get("warning_codes")),
+        tuple(sorted(set(_tuple(d.get("risk_codes"))) | {"plan_scaffold_does_not_start_implementation"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=real_effect_implementation_plan_scaffold_digest(provisional))
+
+
+def build_real_effect_capability_block_receipt(
+    candidate: RealEffectCapabilityCandidate | Mapping[str, Any],
+    decision: RealEffectCapabilityAdmissionDecision | Mapping[str, Any] | None = None,
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectCapabilityBlockReceipt:
+    c = _source_payload(candidate)
+    d = _source_payload(decision) if decision is not None else {}
+    domain = str(d.get("admission_domain", c.get("admission_domain", "")))
+    admission_status = str(d.get("admission_status", "real_effect_admission_blocked"))
+    if admission_status == "real_effect_admission_contradicted":
+        block_status = "real_effect_block_receipt_contradicted"
+    elif admission_status == "real_effect_admission_incomplete":
+        block_status = "real_effect_block_receipt_incomplete"
+    elif d.get("warning_codes") or c.get("warning_codes"):
+        block_status = "real_effect_block_receipt_recorded_with_warnings"
+    else:
+        block_status = "real_effect_block_receipt_recorded"
+    provisional = RealEffectCapabilityBlockReceipt(
+        _digest_id("real-effect-block-receipt-", {"candidate": c.get("candidate_id"), "decision": d.get("decision_id"), "status": block_status}),
+        str(c.get("candidate_id", "")),
+        str(d.get("decision_id")) if d.get("decision_id") is not None else None,
+        domain,
+        block_status,
+        _tuple(d.get("reason_codes")) or ("real_effect_capability_deferred_or_blocked",),
+        _tuple(d.get("missing_planning_labels")) or _tuple(c.get("required_planning_labels")),
+        _blocked_actions(domain, d.get("blocked_actions") or c.get("blocked_actions")),
+        tuple(sorted(set(_tuple(c.get("warning_codes"))) | set(_tuple(d.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | set(_tuple(d.get("risk_codes"))) | {"block_receipt_does_not_mutate_host"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=real_effect_capability_block_receipt_digest(provisional))
+
+
+def build_real_effect_admission_bundle(
+    candidate: RealEffectCapabilityCandidate | Mapping[str, Any],
+    decision: RealEffectCapabilityAdmissionDecision | Mapping[str, Any],
+    plan_or_block_receipt: RealEffectImplementationPlanScaffold | RealEffectCapabilityBlockReceipt | Mapping[str, Any],
+    *,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectAdmissionBundle:
+    c = _source_payload(candidate)
+    d = _source_payload(decision)
+    p = _source_payload(plan_or_block_receipt)
+    admission_status = str(d.get("admission_status", ""))
+    if admission_status.endswith("contradicted"):
+        status = "real_effect_admission_contradicted"
+    elif admission_status.endswith("incomplete"):
+        status = "real_effect_admission_incomplete"
+    elif admission_status.endswith("blocked"):
+        status = "real_effect_admission_blocked"
+    else:
+        status = admission_status
+    plan_id = p.get("plan_id") if "plan_id" in p else None
+    block_id = p.get("receipt_id") if "receipt_id" in p else None
+    domain = str(d.get("admission_domain", c.get("admission_domain", "")))
+    provisional = RealEffectAdmissionBundle(
+        _digest_id("real-effect-admission-bundle-", {"candidate": c.get("candidate_id"), "decision": d.get("decision_id"), "posture": status}),
+        str(c.get("candidate_id", "")),
+        str(d.get("decision_id", "")),
+        str(plan_id) if plan_id is not None else None,
+        str(block_id) if block_id is not None else None,
+        domain,
+        status,
+        _blocked_actions(domain, d.get("blocked_actions")),
+        tuple(sorted(set(_tuple(c.get("warning_codes"))) | set(_tuple(d.get("warning_codes"))) | set(_tuple(p.get("warning_codes"))))),
+        tuple(sorted(set(_tuple(c.get("risk_codes"))) | set(_tuple(d.get("risk_codes"))) | set(_tuple(p.get("risk_codes"))) | {"real_effect_admission_bundle_is_not_implementation"})),
+        created_at,
+        "",
+    )
+    return replace(provisional, digest=real_effect_admission_bundle_digest(provisional))
+
+
+def _validate_common(payload: Mapping[str, Any], *, prefix: str, status_field: str, statuses: frozenset[str], only_field: str, digest_fn: Any) -> list[str]:
+    findings: list[str] = []
+    if not payload.get("metadata_only", False):
+        findings.append(prefix + "not_metadata_only")
+    if not payload.get(only_field, False):
+        findings.append(prefix + f"missing_{only_field}")
+    if payload.get(status_field) not in statuses:
+        findings.append(prefix + f"unknown_{status_field}")
+    for flag in _FORBIDDEN_TRUE_FLAGS:
+        if payload.get(flag, False):
+            findings.append(prefix + f"forbidden_flag:{flag}")
+    if payload.get("implementation_not_started") is False:
+        findings.append(prefix + "implementation_started")
+    if payload.get("digest") and payload.get("digest") != digest_fn(payload):
+        findings.append(prefix + "digest_mismatch")
+    return findings
+
+
+def validate_real_effect_capability_candidate(record: RealEffectCapabilityCandidate | Mapping[str, Any]) -> RealEffectAdmissionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="candidate:", status_field="candidate_status", statuses=CANDIDATE_STATUSES, only_field="candidate_only", digest_fn=real_effect_capability_candidate_digest)
+    if p.get("admission_domain") not in ADMISSION_DOMAINS:
+        f.append("candidate:unknown_admission_domain")
+    if p.get("requested_implementation_tier") not in IMPLEMENTATION_TIERS:
+        f.append("candidate:unknown_requested_implementation_tier")
+    return RealEffectAdmissionValidationResult(not f, tuple(f))
+
+
+def validate_real_effect_capability_admission_decision(record: RealEffectCapabilityAdmissionDecision | Mapping[str, Any]) -> RealEffectAdmissionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="decision:", status_field="admission_status", statuses=ADMISSION_STATUSES, only_field="admission_only", digest_fn=real_effect_capability_admission_decision_digest)
+    if p.get("admission_domain") not in ADMISSION_DOMAINS:
+        f.append("decision:unknown_admission_domain")
+    return RealEffectAdmissionValidationResult(not f, tuple(f))
+
+
+def validate_real_effect_implementation_plan_scaffold(record: RealEffectImplementationPlanScaffold | Mapping[str, Any]) -> RealEffectAdmissionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="plan_scaffold:", status_field="plan_status", statuses=PLAN_STATUSES, only_field="plan_scaffold_only", digest_fn=real_effect_implementation_plan_scaffold_digest)
+    if p.get("admission_domain") not in ADMISSION_DOMAINS:
+        f.append("plan_scaffold:unknown_admission_domain")
+    return RealEffectAdmissionValidationResult(not f, tuple(f))
+
+
+def validate_real_effect_capability_block_receipt(record: RealEffectCapabilityBlockReceipt | Mapping[str, Any]) -> RealEffectAdmissionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="block_receipt:", status_field="block_status", statuses=BLOCK_RECEIPT_STATUSES, only_field="block_receipt_only", digest_fn=real_effect_capability_block_receipt_digest)
+    if p.get("admission_domain") not in ADMISSION_DOMAINS:
+        f.append("block_receipt:unknown_admission_domain")
+    return RealEffectAdmissionValidationResult(not f, tuple(f))
+
+
+def validate_real_effect_admission_bundle(record: RealEffectAdmissionBundle | Mapping[str, Any]) -> RealEffectAdmissionValidationResult:
+    p = _source_payload(record)
+    f = _validate_common(p, prefix="admission_bundle:", status_field="bundle_status", statuses=ADMISSION_STATUSES, only_field="admission_bundle_only", digest_fn=real_effect_admission_bundle_digest)
+    if p.get("admission_domain") not in ADMISSION_DOMAINS:
+        f.append("admission_bundle:unknown_admission_domain")
+    return RealEffectAdmissionValidationResult(not f, tuple(f))
+
+
+def summarize_real_effect_capability_candidate(record: RealEffectCapabilityCandidate | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("candidate_id", "source_dry_run_closure_bundle_id", "admission_domain", "requested_implementation_tier", "candidate_status", "metadata_only", "candidate_only", "implementation_not_started", "real_backend_implemented", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_real_effect_capability_admission_decision(record: RealEffectCapabilityAdmissionDecision | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("decision_id", "candidate_id", "admission_domain", "implementation_tier", "admission_status", "missing_planning_labels", "metadata_only", "admission_only", "authorizes_implementation", "authorizes_execution", "real_backend_implemented", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_real_effect_implementation_plan_scaffold(record: RealEffectImplementationPlanScaffold | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("plan_id", "decision_id", "candidate_id", "admission_domain", "implementation_tier", "plan_status", "metadata_only", "plan_scaffold_only", "implementation_not_started", "backend_loaded", "backend_invoked", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_real_effect_capability_block_receipt(record: RealEffectCapabilityBlockReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("receipt_id", "candidate_id", "decision_id", "admission_domain", "block_status", "metadata_only", "block_receipt_only", "implementation_not_started", "real_backend_implemented", "real_fulfillment_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_real_effect_admission_bundle(record: RealEffectAdmissionBundle | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("bundle_id", "candidate_id", "decision_id", "plan_id", "block_receipt_id", "admission_domain", "bundle_status", "metadata_only", "admission_bundle_only", "implementation_not_started", "authorizes_implementation", "authorizes_execution", "real_backend_implemented", "real_fulfillment_performed", "real_effect_performed", "host_mutation_performed", "digest")}
+
+
+def build_real_effect_admission_wing(
+    dry_run_closure_bundle: DryRunClosureBundle | Mapping[str, Any],
+    *,
+    admission_domain: str | None = None,
+    requested_implementation_tier: str | None = None,
+    policy: RealEffectAdmissionPolicy | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> RealEffectAdmissionWingRecords:
+    policy = policy or build_default_real_effect_admission_policy()
+    candidate = build_real_effect_capability_candidate(
+        dry_run_closure_bundle,
+        admission_domain=admission_domain,
+        requested_implementation_tier=requested_implementation_tier,
+        policy=policy,
+        created_at=created_at,
+    )
+    decision = evaluate_real_effect_capability_admission(candidate, policy=policy, created_at=created_at)
+    if decision.admission_status in {"real_effect_admission_eligible_for_planning", "real_effect_admission_eligible_with_conditions"}:
+        plan_or_block = build_real_effect_implementation_plan_scaffold(decision, created_at=created_at)
+    else:
+        plan_or_block = build_real_effect_capability_block_receipt(candidate, decision, created_at=created_at)
+    bundle = build_real_effect_admission_bundle(candidate, decision, plan_or_block, created_at=created_at)
+    return RealEffectAdmissionWingRecords(candidate, decision, plan_or_block, bundle)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -59,6 +59,14 @@ from sentientos.dry_run_audit_closure import (
     summarize_dry_run_postcondition_verification,
     summarize_dry_run_rollback_rehearsal,
 )
+from sentientos.real_effect_admission import (
+    build_real_effect_admission_wing,
+    summarize_real_effect_admission_bundle,
+    summarize_real_effect_capability_admission_decision,
+    summarize_real_effect_capability_block_receipt,
+    summarize_real_effect_capability_candidate,
+    summarize_real_effect_implementation_plan_scaffold,
+)
 
 from sentientos.local_authorization_grant import (
     build_local_authorization_grant_wing,
@@ -104,6 +112,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "executor_contract_posture",
         "dry_run_execution_posture",
         "dry_run_audit_closure_posture",
+        "real_effect_admission_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -131,6 +140,7 @@ BUNDLE_FILE_NAMES = {
     "executor_contract_posture": "executor_contract.json",
     "dry_run_execution_posture": "dry_run_execution.json",
     "dry_run_audit_closure_posture": "dry_run_audit_closure.json",
+    "real_effect_admission_posture": "real_effect_admission.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -157,6 +167,11 @@ DEFERRED_ACTION_LABELS = (
     "dry_run_rollback_rehearsal",
     "dry_run_audit_closure_receipt",
     "dry_run_closure_bundle",
+    "real_effect_capability_admission",
+    "real_effect_capability_candidate",
+    "real_effect_implementation_plan_scaffold",
+    "real_effect_capability_block_receipt",
+    "real_backend_implementation",
     "real_backend_invocation",
     "real_effect_execution",
     "real_rollback_execution",
@@ -366,8 +381,9 @@ def _readme_text(manifest_id: str, trace_digest: str) -> str:
             "8. `executor_contract.json` — metadata-only executor contract posture; it is not an executor.",
             "9. `dry_run_execution.json` — simulation-only dry-run harness posture; it is not fulfillment or an effect receipt.",
             "10. `dry_run_audit_closure.json` — dry-run verification/audit closure posture; it is not a real effect receipt, real postcondition check, real rollback, or production audit receipt.",
-            "11. `proof_commands.json` — bounded local proof commands listed but not run by default.",
-            "12. `capability_registry_summary.json` — metadata-only capability posture.",
+            "11. `real_effect_admission.json` — metadata-only real-effect capability admission posture; admission is not implementation or execution.",
+            "12. `proof_commands.json` — bounded local proof commands listed but not run by default.",
+            "13. `capability_registry_summary.json` — metadata-only capability posture.",
             "",
             "## Safety posture",
             "",
@@ -473,6 +489,7 @@ def build_reviewer_proof_bundle_payload(
         created_at=created_at,
     )
     dry_run_audit_closure = build_dry_run_audit_closure_wing(dry_run_execution.receipt, created_at=created_at)
+    real_effect_admission = build_real_effect_admission_wing(dry_run_audit_closure.closure_bundle, created_at=created_at)
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
@@ -643,6 +660,46 @@ def build_reviewer_proof_bundle_payload(
                 "closure_bundle": dry_run_audit_closure.closure_bundle.to_dict(),
             },
         }),
+
+        "real_effect_admission_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "real_effect_admission_only": True,
+            "proof_statement": "Dry-run audit closure does not automatically permit real effects; real-effect admission is implementation planning metadata only, not implementation, backend loading, execution, fulfillment, effect receipt creation, postcondition checking, rollback, production audit, or host mutation.",
+            "candidate_summary": summarize_real_effect_capability_candidate(real_effect_admission.candidate),
+            "decision_summary": summarize_real_effect_capability_admission_decision(real_effect_admission.decision),
+            "plan_scaffold_summary": summarize_real_effect_implementation_plan_scaffold(real_effect_admission.plan_or_block_receipt) if hasattr(real_effect_admission.plan_or_block_receipt, "plan_id") else None,
+            "block_receipt_summary": summarize_real_effect_capability_block_receipt(real_effect_admission.plan_or_block_receipt) if hasattr(real_effect_admission.plan_or_block_receipt, "receipt_id") else None,
+            "admission_bundle_summary": summarize_real_effect_admission_bundle(real_effect_admission.admission_bundle),
+            "authorizes_implementation": False,
+            "authorizes_execution": False,
+            "implementation_not_started": True,
+            "backend_loaded": False,
+            "backend_invoked": False,
+            "real_backend_implemented": False,
+            "real_fulfillment_performed": False,
+            "real_effect_performed": False,
+            "real_effect_receipt_created": False,
+            "real_postcondition_check_performed": False,
+            "real_rollback_performed": False,
+            "production_audit_receipt_created": False,
+            "host_mutation_performed": False,
+            "fan_pwm_write_performed": False,
+            "thermal_actuation_performed": False,
+            "power_profile_mutation_performed": False,
+            "service_restart_performed": False,
+            "file_cleanup_performed": False,
+            "network_performed": False,
+            "provider_invocation_performed": False,
+            "prompt_assembly_performed": False,
+            "blocked_actions": real_effect_admission.admission_bundle.blocked_actions,
+            "records": {
+                "candidate": real_effect_admission.candidate.to_dict(),
+                "decision": real_effect_admission.decision.to_dict(),
+                "plan_or_block_receipt": real_effect_admission.plan_or_block_receipt.to_dict(),
+                "admission_bundle": real_effect_admission.admission_bundle.to_dict(),
+            },
+        }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
@@ -684,7 +741,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution, "dry_run_audit_closure": dry_run_audit_closure}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution, "dry_run_audit_closure": dry_run_audit_closure, "real_effect_admission": real_effect_admission}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -212,3 +212,19 @@ def test_reviewer_proof_bundle_cli_writes_dry_run_audit_closure_json(tmp_path) -
     assert payload["host_mutation_performed"] is False
     assert payload["fan_pwm_write_performed"] is False
     assert payload["thermal_actuation_performed"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_real_effect_admission_json(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "real_effect_admission.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["real_effect_admission_only"] is True
+    assert payload["decision_summary"]["authorizes_implementation"] is False
+    assert payload["decision_summary"]["authorizes_execution"] is False
+    assert payload["implementation_not_started"] is True
+    assert payload["backend_loaded"] is False
+    assert payload["backend_invoked"] is False
+    assert payload["host_mutation_performed"] is False

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -593,3 +593,33 @@ def test_registry_update_from_dry_run_audit_closure_preserves_real_action_deferr
     assert records["production_audit_receipt_for_host_effect"].status == "deferred"
     assert records["real_fan_pwm_control"].status == "blocked"
     assert validate_capability_registry(registry).ok
+
+
+def test_real_effect_admission_registry_records_are_planning_only_and_real_actions_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["real_effect_capability_admission"].status == "implemented"
+    assert records["real_effect_capability_admission"].authority_level == "admission_planning_only"
+    assert records["real_effect_capability_candidate"].authority_level == "candidate_only"
+    assert records["real_effect_implementation_plan_scaffold"].authority_level == "plan_scaffold_only"
+    assert records["real_effect_capability_block_receipt"].authority_level == "block_receipt_only"
+    for capability_id in ["real_backend_implementation", "real_backend_invocation", "fulfillment_execution", "real_effect_execution", "real_effect_receipt_creation", "real_postcondition_check", "real_rollback_execution", "production_audit_receipt_for_host_effect"]:
+        assert records[capability_id].status == "deferred"
+        assert records[capability_id].host_actuation_performed is False
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"
+        assert records[capability_id].host_actuation_performed is False
+    assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_update_registry_from_real_effect_admission_preserves_deferred_real_backends() -> None:
+    from sentientos.capability_registry import update_registry_from_real_effect_admission
+    from sentientos.real_effect_admission import build_real_effect_admission_wing
+    from tests.test_real_effect_admission import _closure
+
+    wing = build_real_effect_admission_wing(_closure(), created_at="2025-07-30T00:00:00+00:00")
+    records = update_registry_from_real_effect_admission(build_default_capability_registry(), wing).by_id()
+    assert records["real_effect_capability_admission"].status == "implemented"
+    assert records["real_backend_implementation"].status == "deferred"
+    assert records["real_backend_invocation"].status == "deferred"
+    assert records["real_effect_execution"].status == "deferred"
+    assert records["real_fan_pwm_control"].status == "blocked"

--- a/tests/test_real_effect_admission.py
+++ b/tests/test_real_effect_admission.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.dry_run_audit_closure import build_dry_run_audit_closure_wing, dry_run_closure_bundle_digest
+from sentientos.dry_run_execution_harness import build_dry_run_execution_harness_wing
+from sentientos.fulfillment_executor_contract import build_fulfillment_executor_contract_wing
+from sentientos.real_effect_admission import (
+    RealEffectAdmissionBundle,
+    build_real_effect_admission_wing,
+    real_effect_capability_candidate_digest,
+    summarize_real_effect_admission_bundle,
+    summarize_real_effect_capability_admission_decision,
+    summarize_real_effect_capability_block_receipt,
+    summarize_real_effect_capability_candidate,
+    summarize_real_effect_implementation_plan_scaffold,
+    validate_real_effect_admission_bundle,
+    validate_real_effect_capability_admission_decision,
+    validate_real_effect_capability_block_receipt,
+    validate_real_effect_capability_candidate,
+    validate_real_effect_implementation_plan_scaffold,
+)
+from tests.test_fulfillment_authorization import FIXED
+from tests.test_fulfillment_executor_contract import _consumed_receipt
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _closure(domain: str = "resource_pressure_fulfillment_authorization", **changes):
+    executor = build_fulfillment_executor_contract_wing(_consumed_receipt(domain), created_at=FIXED)
+    dry_run = build_dry_run_execution_harness_wing(executor.readiness_receipt, created_at=FIXED)
+    assert dry_run.receipt is not None
+    wing = build_dry_run_audit_closure_wing(dry_run.receipt, created_at=FIXED)
+    bundle = wing.closure_bundle
+    if changes:
+        bundle = replace(bundle, **changes)
+        if "digest" not in changes:
+            bundle = replace(bundle, digest=dry_run_closure_bundle_digest(bundle))
+    return bundle
+
+
+def test_ready_dry_run_closure_builds_candidate_decision_plan_and_bundle() -> None:
+    wing = build_real_effect_admission_wing(_closure("resource_pressure_fulfillment_authorization"), admission_domain="resource_pressure_real_effect_candidate", created_at=FIXED)
+    assert wing.candidate.candidate_status in {"real_effect_candidate_recorded", "real_effect_candidate_recorded_with_warnings"}
+    assert wing.decision.admission_status == "real_effect_admission_eligible_for_planning"
+    assert hasattr(wing.plan_or_block_receipt, "plan_id")
+    assert wing.admission_bundle.bundle_status == "real_effect_admission_eligible_for_planning"
+    assert wing.decision.authorizes_implementation is False
+    assert wing.decision.authorizes_execution is False
+    assert wing.plan_or_block_receipt.implementation_not_started is True
+    assert wing.plan_or_block_receipt.backend_loaded is False
+    assert wing.plan_or_block_receipt.backend_invoked is False
+    assert validate_real_effect_capability_candidate(wing.candidate).ok
+    assert validate_real_effect_capability_admission_decision(wing.decision).ok
+    assert validate_real_effect_implementation_plan_scaffold(wing.plan_or_block_receipt).ok
+    assert validate_real_effect_admission_bundle(wing.admission_bundle).ok
+
+
+@pytest.mark.parametrize("domain", ["diagnostics_real_effect_candidate", "resource_pressure_real_effect_candidate"])
+def test_low_risk_domains_can_become_eligible_for_planning(domain: str) -> None:
+    wing = build_real_effect_admission_wing(_closure(), admission_domain=domain, requested_implementation_tier="tier3_local_low_risk_effect_future", created_at=FIXED)
+    assert wing.decision.admission_status == "real_effect_admission_eligible_for_planning"
+    assert wing.decision.authorizes_implementation is False
+    assert wing.decision.authorizes_execution is False
+
+
+@pytest.mark.parametrize(
+    ("bundle_status", "expected"),
+    [
+        ("dry_run_closure_bundle_blocked", "real_effect_admission_blocked"),
+        ("dry_run_closure_bundle_incomplete", "real_effect_admission_incomplete"),
+        ("dry_run_closure_bundle_contradicted", "real_effect_admission_contradicted"),
+    ],
+)
+def test_non_ready_dry_run_closure_produces_non_ready_admission(bundle_status: str, expected: str) -> None:
+    wing = build_real_effect_admission_wing(_closure(bundle_status=bundle_status), created_at=FIXED)
+    assert wing.decision.admission_status == expected
+    assert hasattr(wing.plan_or_block_receipt, "receipt_id")
+    assert wing.plan_or_block_receipt.host_mutation_performed is False
+    assert validate_real_effect_capability_block_receipt(wing.plan_or_block_receipt).ok
+
+
+def test_dry_run_closure_claiming_real_effect_or_host_mutation_is_contradicted() -> None:
+    wing = build_real_effect_admission_wing(_closure(real_effect_performed=True, host_mutation_performed=True), created_at=FIXED)
+    assert wing.candidate.candidate_status == "real_effect_candidate_contradicted"
+    assert wing.decision.admission_status == "real_effect_admission_contradicted"
+
+
+@pytest.mark.parametrize(
+    ("domain", "blocked"),
+    [
+        ("future_cooling_real_effect_candidate", {"fan_pwm_write", "thermal_actuation"}),
+        ("future_power_real_effect_candidate", {"power_profile_mutation"}),
+        ("future_cleanup_real_effect_candidate", {"file_cleanup", "file_delete"}),
+        ("future_service_real_effect_candidate", {"service_restart", "process_kill"}),
+    ],
+)
+def test_future_high_risk_domains_remain_blocked_by_default(domain: str, blocked: set[str]) -> None:
+    wing = build_real_effect_admission_wing(_closure(), admission_domain=domain, requested_implementation_tier="tier5_hardware_control_effect_future", created_at=FIXED)
+    assert wing.decision.admission_status == "real_effect_admission_blocked"
+    assert blocked <= set(wing.decision.blocked_actions)
+    assert blocked <= set(wing.admission_bundle.blocked_actions)
+    assert hasattr(wing.plan_or_block_receipt, "receipt_id")
+    assert wing.plan_or_block_receipt.host_mutation_performed is False
+
+
+@pytest.mark.parametrize(
+    ("record_name", "flag", "validator"),
+    [
+        ("decision", "authorizes_implementation", validate_real_effect_capability_admission_decision),
+        ("decision", "authorizes_execution", validate_real_effect_capability_admission_decision),
+        ("decision", "real_backend_implemented", validate_real_effect_capability_admission_decision),
+        ("decision", "real_fulfillment_performed", validate_real_effect_capability_admission_decision),
+        ("decision", "real_effect_performed", validate_real_effect_capability_admission_decision),
+        ("decision", "host_mutation_performed", validate_real_effect_capability_admission_decision),
+        ("plan_or_block_receipt", "backend_loaded", validate_real_effect_implementation_plan_scaffold),
+        ("plan_or_block_receipt", "backend_invoked", validate_real_effect_implementation_plan_scaffold),
+        ("plan_or_block_receipt", "real_fulfillment_performed", validate_real_effect_implementation_plan_scaffold),
+        ("plan_or_block_receipt", "real_effect_performed", validate_real_effect_implementation_plan_scaffold),
+        ("plan_or_block_receipt", "host_mutation_performed", validate_real_effect_implementation_plan_scaffold),
+    ],
+)
+def test_validation_rejects_forbidden_true_fields(record_name: str, flag: str, validator) -> None:
+    wing = build_real_effect_admission_wing(_closure(), admission_domain="resource_pressure_real_effect_candidate", created_at=FIXED)
+    record = getattr(wing, record_name)
+    bad = replace(record, **{flag: True})
+    assert not validator(bad).ok
+
+
+@pytest.mark.parametrize("flag", ["fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "subprocess_execution_performed", "shell_execution_performed", "control_plane_admission_execution_performed"])
+def test_validation_rejects_forbidden_mapping_flags(flag: str) -> None:
+    wing = build_real_effect_admission_wing(_closure(), created_at=FIXED)
+    payload = wing.decision.to_dict()
+    payload[flag] = True
+    assert not validate_real_effect_capability_admission_decision(payload).ok
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    first = build_real_effect_admission_wing(_closure(), created_at=FIXED).candidate
+    second = build_real_effect_admission_wing(_closure(), created_at=FIXED).candidate
+    assert first.digest == second.digest
+    changed = replace(first, admission_domain="operator_review_real_effect_candidate", digest="")
+    assert real_effect_capability_candidate_digest(first) != real_effect_capability_candidate_digest(changed)
+
+
+def test_summaries_are_metadata_only_and_non_authorizing() -> None:
+    wing = build_real_effect_admission_wing(_closure(), created_at=FIXED)
+    summaries = (
+        summarize_real_effect_capability_candidate(wing.candidate),
+        summarize_real_effect_capability_admission_decision(wing.decision),
+        summarize_real_effect_implementation_plan_scaffold(wing.plan_or_block_receipt),
+        summarize_real_effect_admission_bundle(wing.admission_bundle),
+    )
+    for summary in summaries:
+        assert summary["metadata_only"] is True
+    assert summaries[1]["authorizes_implementation"] is False
+    assert summaries[1]["authorizes_execution"] is False
+    blocked = build_real_effect_admission_wing(_closure(), admission_domain="future_cooling_real_effect_candidate", created_at=FIXED)
+    assert summarize_real_effect_capability_block_receipt(blocked.plan_or_block_receipt)["host_mutation_performed"] is False
+
+
+def test_bundle_validation_rejects_authorization_claim() -> None:
+    wing = build_real_effect_admission_wing(_closure(), created_at=FIXED)
+    bad = replace(wing.admission_bundle, authorizes_execution=True)
+    assert not validate_real_effect_admission_bundle(bad).ok

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -264,3 +264,21 @@ def test_default_reviewer_proof_bundle_includes_dry_run_audit_closure_artifact()
     assert "dry_run_audit_closure_posture" in {artifact.artifact_kind for artifact in payload["manifest"].artifact_records}
     validation = validate_reviewer_proof_bundle_manifest(payload["manifest"])
     assert validation.ok, validation.findings
+
+
+def test_bundle_includes_real_effect_admission_posture_and_remains_non_mutating() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "real_effect_admission_posture" in payload["artifacts"]
+    admission = json.loads(payload["artifacts"]["real_effect_admission_posture"])
+    assert admission["real_effect_admission_only"] is True
+    assert admission["authorizes_implementation"] is False
+    assert admission["authorizes_execution"] is False
+    assert admission["implementation_not_started"] is True
+    assert admission["backend_loaded"] is False
+    assert admission["backend_invoked"] is False
+    assert admission["real_backend_implemented"] is False
+    assert admission["real_fulfillment_performed"] is False
+    assert admission["real_effect_performed"] is False
+    assert admission["host_mutation_performed"] is False
+    assert "fan_pwm_write" in admission["blocked_actions"]
+    assert "thermal_actuation" in admission["blocked_actions"]

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -516,3 +516,32 @@ def test_host_dry_run_audit_closure_doc_preserves_dry_run_only_boundaries() -> N
     assert "Dry-run audit closure is not a production audit receipt" in doc
     assert "Real actuation remains deferred" in doc
     assert "No subprocess" in doc or "no subprocess" in doc
+
+HOST_REAL_EFFECT_CAPABILITY_ADMISSION_WING = "docs/architecture/host_real_effect_capability_admission_wing.md"
+
+
+def test_navigation_links_to_host_real_effect_capability_admission_wing_doc() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    dry_run = _read(HOST_DRY_RUN_EXECUTION_HARNESS_WING)
+    closure = _read(HOST_DRY_RUN_AUDIT_CLOSURE_WING)
+    bundle = _read(REVIEWER_FIRST_RUN_PROOF_BUNDLE)
+    controlled = _read(HOST_EMBODIMENT_CONTROLLED_AUTHORIZATION_TRACE_WING)
+    trajectory = _read(TRAJECTORY_DOC)
+    for text in [overview, index, dry_run, closure, bundle, controlled, trajectory]:
+        assert HOST_REAL_EFFECT_CAPABILITY_ADMISSION_WING in text
+
+
+def test_host_real_effect_capability_admission_doc_preserves_planning_only_boundaries() -> None:
+    doc = _read(HOST_REAL_EFFECT_CAPABILITY_ADMISSION_WING)
+    assert "Dry-run audit closure verifies simulated evidence only" in doc
+    assert "Real effect capability admission is not implementation" in doc
+    assert "admission decision does not authorize implementation or execution" in doc
+    assert "implementation plan scaffold does not start implementation" in doc
+    assert "Cooling/hardware control remains blocked by default" in doc
+    assert "Real actuation remains deferred" in doc
+    assert "Real fulfillment remains deferred" in doc
+    assert "Real effect receipts remain deferred" in doc
+    assert "Real postcondition checks remain deferred" in doc
+    assert "Real rollback remains deferred" in doc
+    assert "Production audit remains deferred" in doc


### PR DESCRIPTION
### Motivation

- Introduce a conservative, metadata-only admission layer that evaluates dry-run audit closure evidence and decides whether real-effect capability domains may enter implementation planning while strictly preventing any real host mutation or execution. 
- Preserve existing dry-run / rehearsal / audit boundaries and ensure reviewer artifacts, capability registry entries, and docs reflect planning-only posture (admission ≠ implementation).

### Description

- Add `sentientos/real_effect_admission.py` implementing immutable dataclasses and helpers for `RealEffectAdmissionPolicy`, `RealEffectCapabilityCandidate`, `RealEffectCapabilityAdmissionDecision`, `RealEffectImplementationPlanScaffold`, `RealEffectCapabilityBlockReceipt`, `RealEffectAdmissionBundle`, validation, summaries, deterministic digests, and `build_real_effect_admission_wing(...)`; all records are metadata-only and explicitly forbid real backend/load/invoke/execution/host mutation. 
- Integrate admission posture into reviewer bundles by extending `sentientos/reviewer_proof_bundle.py` to include `real_effect_admission_posture` (artifact `real_effect_admission.json`) and produce non-authorizing, non-mutating summaries and records. 
- Extend `sentientos/capability_registry.py` additively with admission/candidate/plan/block capability records and `update_registry_from_real_effect_admission(...)`, keeping all real backend/fill/execute/postcondition/rollback/audit effects deferred and fan/PWM/thermal/power/service/cleanup blocked. 
- Add architecture doc `docs/architecture/host_real_effect_capability_admission_wing.md` and update reviewer-facing docs to link the new wing and clarify admission vs implementation boundaries. 
- Add tests: `tests/test_real_effect_admission.py` and updates to bundle/CLI/registry/doc tests to validate non-mutating admission posture and registry integration; ensure validation rejects any forbidden true flags or claims of implementation/authorization.

### Testing

- Static/compile checks: ran `python -m py_compile` on modified modules; OK. 
- Unit & integration tests: ran `python -m scripts.run_tests -q` for these suites and files and they passed: `tests/test_real_effect_admission.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`, plus dependent suites used during iteration (`tests/test_dry_run_audit_closure.py`, `tests/test_dry_run_execution_harness.py`, `tests/test_fulfillment_executor_contract.py`, `tests/test_fulfillment_authorization.py`, `tests/test_local_authorization_grant.py`, `tests/test_live_grant_readiness.py`, `tests/test_host_actuation_safety.py`, `tests/test_controlled_authorization.py`, `tests/test_control_plane_kernel.py`, `tests/test_sentientosd_runtime_closure.py`). All executed runs completed successfully after iterative fixes. 
- Reviewer bundle CLI: ran `scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` and verified `/tmp/sentientos-reviewer-proof/real_effect_admission.json` exists and contains metadata-only, non-authorizing fields. 
- Docs: ran `python scripts/build_docs.py --bootstrap-docs` and `python scripts/build_docs.py --check-deps` then `python scripts/build_docs.py`; docs built successfully and new wing appears in generated docs. 
- Forbidden-scan and context-hygiene: ran a scan for forbidden runtime operations and `scripts/verify_context_hygiene_prompt_boundaries.py`; no prohibited runtime operations were introduced and no prompt/provider boundary issues were found.

Files changed (high level): `sentientos/real_effect_admission.py`, updates to `sentientos/reviewer_proof_bundle.py` and `sentientos/capability_registry.py`, new docs `docs/architecture/host_real_effect_capability_admission_wing.md` and reviewer-doc links, new tests `tests/test_real_effect_admission.py` and small test updates. All changes preserve the repository invariant that admission records are planning-only and do not authorize or execute real host effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06ed208b4c8320be8d636b6a68493b)