### PR TITLE
[codex:embodiment] add Tier-1 local diagnostic effect pilot (bounded local file write, receipts & CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ For technical reviewers, start here: [`docs/architecture/public_technical_overvi
 
 To generate a local reviewer proof bundle, run `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof` (metadata-only; fake/sample host telemetry by default).
 
+The first bounded real-effect pilot is documented at [`docs/architecture/host_local_diagnostic_effect_pilot_wing.md`](docs/architecture/host_local_diagnostic_effect_pilot_wing.md).
+
 > ⚠️ **Codex-first builds.** Do not run local host builds—use the Codex CI workflow or open the repository inside the provided VS Code Dev Container.
 
 [![Docker Pull](https://img.shields.io/static/v1?label=Docker%20Pull&message=ghcr.io/zombinator85/sentientos&color=blue)](https://github.com/zombinator85/sentientos/pkgs/container/sentientos)

--- a/docs/architecture/host_dry_run_audit_closure_wing.md
+++ b/docs/architecture/host_dry_run_audit_closure_wing.md
@@ -46,3 +46,5 @@ The reviewer proof bundle includes `dry_run_audit_closure.json`. The artifact is
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+Dry-run closure feeds real-effect admission; the first narrow real-effect successor is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md).

--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -82,3 +82,5 @@ Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+The authority ladder later reaches the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), the first explicit diagnostic artifact write effect.

--- a/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
@@ -1,0 +1,56 @@
+# Host Local Diagnostic Effect Pilot Wing
+
+This wing follows the [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md). It is the first intentionally real effect pilot after real-effect admission: a deliberately narrow, explicit, local-only diagnostic artifact write.
+
+## Boundary
+
+The only real effect is writing one deterministic metadata/diagnostic artifact to an explicit caller-supplied local output directory. The write is optional, happens only through `sentientos/local_diagnostic_effect.py` APIs or the explicit CLI, and is not performed at import time or during reviewer proof bundle generation.
+
+This is not general host control. It does not create general host executors, OS backends, provider paths, network paths, prompt export paths, federation transport, remote execution, subprocess execution, shell execution, fan/PWM control, thermal actuation, power profile mutation, service restart, process killing, package installation, driver installation, or cleanup of unrelated files. In direct terms: no network egress, no provider invocation, and no prompt assembly occur.
+
+## Records
+
+- **LocalDiagnosticEffectRequest** records the explicit output directory, single artifact name, low-risk local-file effect domain, blocked action labels, source real-effect admission bundle reference when provided, and false network/provider/prompt/subprocess/shell flags.
+- **LocalDiagnosticEffectResult** records the artifact path, artifact digest, byte count, and real-effect flags. `real_effect_performed=true`, `local_file_write_performed=true`, and `host_mutation_performed=true` only when the file write succeeds.
+- **LocalDiagnosticEffectReceipt** records a real effect receipt for the diagnostic file write only. Fan/PWM, thermal, power, process, service, package, driver, cleanup/delete, network, provider, and prompt flags remain false.
+- **LocalDiagnosticPostconditionCheck** reads back only the artifact path written by the pilot, compares digest and byte count, and performs no host mutation.
+- **LocalDiagnosticRollbackPlan** and **LocalDiagnosticRollbackReceipt** are plan/receipt scaffolds by default. Rollback execution and deletion are deferred; no automatic deletion is performed.
+- **LocalDiagnosticProductionAuditReceipt** records production audit evidence for this local diagnostic effect only and performs no additional host mutation.
+
+## CLI
+
+Run the pilot explicitly:
+
+```bash
+python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary
+```
+
+Dry-run validation does not write the artifact:
+
+```bash
+python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --dry-run --summary
+```
+
+Use `--force` only to overwrite the named target artifact:
+
+```bash
+python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary --force
+```
+
+The default artifact name is `sentientos_local_diagnostic_effect.json`. The CLI refuses root/empty output directories, absolute artifact names, path traversal, artifact names containing path separators, and overwrites without `--force`.
+
+## Reviewer proof bundle posture
+
+The reviewer proof bundle documents this capability in `local_diagnostic_effect_capability.json` and lists the optional command in `proof_commands.json` as `proof_command_not_run`. The reviewer proof bundle does not run this effect by default and remains no-real-effect/no-host-mutation by default.
+
+## Capability registry posture
+
+The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effect_receipt`, `local_diagnostic_postcondition_check`, `local_diagnostic_production_audit_receipt`, and `local_diagnostic_rollback_plan` as implemented for this diagnostic artifact only. `local_diagnostic_rollback_execution` remains deferred unless a future exact-artifact rollback implementation is explicitly added. General real backends, real backend invocation, general fulfillment execution, fan/PWM, thermal, power, service, and unrelated cleanup actions remain deferred or blocked.
+
+## Implementation links
+
+- Module: `sentientos/local_diagnostic_effect.py`
+- CLI: `scripts/run_local_diagnostic_effect.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_local_diagnostic_effect.py`, `tests/test_run_local_diagnostic_effect_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_real_effect_capability_admission_wing.md
+++ b/docs/architecture/host_real_effect_capability_admission_wing.md
@@ -41,3 +41,5 @@ The reviewer proof bundle includes `real_effect_admission.json`. The artifact sh
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_real_effect_admission.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+After admission, the first intentionally real low-risk effect is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), limited to an explicit diagnostic artifact write only.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -270,3 +270,5 @@ See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_a
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+For the first intentionally real but bounded effect, see the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), which only writes one explicit local diagnostic artifact and is not run by reviewer bundles by default.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -116,3 +116,5 @@ Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+The bundle documents but does not run the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md); its optional CLI command is listed as not run by default.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -271,3 +271,5 @@ See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_a
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+- [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) — first intentionally real effect, explicit diagnostic artifact write only, reviewer bundle does not run it by default.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -420,3 +420,5 @@ See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_w
 ## Real effect capability admission link
 
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
+
+The first bounded real-effect pilot is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md): one explicit local diagnostic artifact write, not hardware/service/power/cleanup control.

--- a/scripts/run_local_diagnostic_effect.py
+++ b/scripts/run_local_diagnostic_effect.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Run the explicit Tier-1 local diagnostic effect pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.local_diagnostic_effect import (  # noqa: E402
+    DEFAULT_ARTIFACT_NAME,
+    build_local_diagnostic_effect_request,
+    run_local_diagnostic_effect_wing,
+    summarize_local_diagnostic_effect_wing,
+    validate_local_diagnostic_effect_request,
+)
+
+
+def _compact_summary(summary: dict[str, object], *, dry_run: bool) -> dict[str, object]:
+    result = summary["result"]  # type: ignore[index]
+    receipt = summary["receipt"]  # type: ignore[index]
+    postcondition = summary["postcondition_check"]  # type: ignore[index]
+    rollback = summary["rollback_receipt"]  # type: ignore[index]
+    audit = summary["production_audit_receipt"]  # type: ignore[index]
+    return {
+        "dry_run": dry_run,
+        "effect_status": result["effect_status"],
+        "output_path": result["output_path"],
+        "artifact_digest": result["artifact_digest"],
+        "byte_count": result["byte_count"],
+        "real_effect_performed": result["real_effect_performed"],
+        "local_file_write_performed": result["local_file_write_performed"],
+        "host_mutation_performed": result["host_mutation_performed"],
+        "real_effect_receipt_created": receipt["real_effect_receipt_created"],
+        "postcondition_status": postcondition["postcondition_status"],
+        "rollback_status": rollback["rollback_status"],
+        "real_rollback_performed": rollback["real_rollback_performed"],
+        "file_delete_performed": rollback["file_delete_performed"],
+        "audit_status": audit["audit_status"],
+        "fan_pwm_write_performed": receipt["fan_pwm_write_performed"],
+        "thermal_actuation_performed": receipt["thermal_actuation_performed"],
+        "power_profile_mutation_performed": receipt["power_profile_mutation_performed"],
+        "service_restart_performed": receipt["service_restart_performed"],
+        "file_cleanup_performed": receipt["file_cleanup_performed"],
+        "network_performed": receipt["network_performed"],
+        "provider_invocation_performed": receipt["provider_invocation_performed"],
+        "prompt_assembly_performed": receipt["prompt_assembly_performed"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Write one explicit local diagnostic artifact and emit auditable receipts")
+    parser.add_argument("--output-dir", required=True, help="explicit local output directory for the diagnostic artifact")
+    parser.add_argument("--artifact-name", default=DEFAULT_ARTIFACT_NAME, help="single artifact filename, not a path")
+    parser.add_argument("--force", action="store_true", help="allow overwriting only the named target artifact")
+    parser.add_argument("--summary", action="store_true", help="print compact summary instead of full wing records")
+    parser.add_argument("--dry-run", action="store_true", help="validate and summarize without writing the artifact")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00", help="deterministic timestamp for records")
+    args = parser.parse_args(argv)
+
+    request = build_local_diagnostic_effect_request(
+        output_dir=args.output_dir,
+        artifact_name=args.artifact_name,
+        force_overwrite=args.force,
+        created_at=args.created_at,
+    )
+    validation = validate_local_diagnostic_effect_request(request)
+    if not validation.ok:
+        print("local diagnostic effect request rejected: " + ", ".join(validation.findings), file=sys.stderr)
+        return 2
+
+    records = run_local_diagnostic_effect_wing(
+        output_dir=args.output_dir,
+        artifact_name=args.artifact_name,
+        force_overwrite=args.force,
+        dry_run=args.dry_run,
+        created_at=args.created_at,
+    )
+    summary = summarize_local_diagnostic_effect_wing(records)
+    payload = _compact_summary(summary, dry_run=args.dry_run) if args.summary else {
+        "request": records.request.to_dict(),
+        "result": records.result.to_dict(),
+        "receipt": records.receipt.to_dict(),
+        "postcondition_check": records.postcondition_check.to_dict(),
+        "rollback_plan": records.rollback_plan.to_dict(),
+        "rollback_receipt": records.rollback_receipt.to_dict(),
+        "production_audit_receipt": records.production_audit_receipt.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if records.result.effect_status == "local_diagnostic_effect_performed" or args.dry_run:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -47,6 +47,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "dry_run_execution_harness",
         "dry_run_audit_closure",
         "real_effect_admission",
+        "local_diagnostic_effect",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -98,6 +99,10 @@ AUTHORITY_LEVELS = frozenset(
         "dry_run_audit_only",
         "dry_run_closure_only",
         "admission_planning_only",
+        "local_diagnostic_effect_only",
+        "real_effect_receipt_only",
+        "real_postcondition_check_only",
+        "production_audit_only",
         "candidate_only",
         "plan_scaffold_only",
         "block_receipt_only",
@@ -337,6 +342,12 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("real_effect_capability_candidate", "real_effect_admission", "implemented", "candidate_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("metadata-only capability candidate records",), deferred_surfaces=("implementation start", "backend loading"), forbidden_implications=("candidate record implements backend",)),
         _record("real_effect_implementation_plan_scaffold", "real_effect_admission", "implemented", "plan_scaffold_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("implementation plan scaffolds only",), deferred_surfaces=("real backend implementation", "backend invocation", "effect receipt creation"), forbidden_implications=("plan scaffold starts implementation",)),
         _record("real_effect_capability_block_receipt", "real_effect_admission", "implemented", "block_receipt_only", source_paths=("sentientos/real_effect_admission.py",), proof_tests=("tests/test_real_effect_admission.py",), implemented_surfaces=("real effect capability block and deferral receipts",), deferred_surfaces=("blocked host action", "host mutation"), forbidden_implications=("block receipt mutates host state",)),
+        _record("local_diagnostic_effect", "local_diagnostic_effect", "implemented", "local_diagnostic_effect_only", source_paths=("sentientos/local_diagnostic_effect.py", "scripts/run_local_diagnostic_effect.py"), proof_tests=("tests/test_local_diagnostic_effect.py", "tests/test_run_local_diagnostic_effect_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_local_diagnostic_effect.py tests/test_run_local_diagnostic_effect_script.py", "python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-effect --summary"), implemented_surfaces=("explicit optional low-risk local diagnostic file write", "single caller-supplied output directory artifact"), deferred_surfaces=("general host effects", "hardware control", "service control", "cleanup outside exact artifact rollback"), forbidden_implications=("local diagnostic effect is general host backend", "diagnostic artifact write grants hardware control"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("local_diagnostic_effect_receipt", "local_diagnostic_effect", "implemented", "real_effect_receipt_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("real effect receipt for diagnostic artifact write only",), deferred_surfaces=("general real effect receipt creation", "privileged host action receipts"), forbidden_implications=("diagnostic receipt covers fan/PWM, thermal, power, service, cleanup, provider, network, prompt, subprocess, shell, or control-plane execution"), requires_audit_receipt=True),
+        _record("local_diagnostic_postcondition_check", "local_diagnostic_effect", "implemented", "real_postcondition_check_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("readback postcondition check for the exact diagnostic artifact only",), deferred_surfaces=("general host postcondition checks",), forbidden_implications=("postcondition readback scans broad filesystem")),
+        _record("local_diagnostic_production_audit_receipt", "local_diagnostic_effect", "implemented", "production_audit_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("production audit receipt for local diagnostic artifact effect only",), deferred_surfaces=("production audits for general host effects",), forbidden_implications=("diagnostic audit authorizes broader effects")),
+        _record("local_diagnostic_rollback_plan", "local_diagnostic_effect", "implemented", "plan_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("rollback plan and non-executed rollback receipt scaffold",), deferred_surfaces=("automatic exact-artifact rollback execution"), forbidden_implications=("rollback plan deletes files"), requires_rollback_receipt=True),
+        _record("local_diagnostic_rollback_execution", "local_diagnostic_effect", "deferred", "none", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), deferred_surfaces=("exact-artifact rollback deletion requires explicit future implementation"), forbidden_implications=("rollback scaffold performs deletion")),
         _record("real_backend_implementation", "real_effect_admission", "deferred", "none", deferred_surfaces=("real backend implementation", "OS backend implementation"), forbidden_implications=("real effect admission implements backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_receipt_creation", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real effect receipt creation",), forbidden_implications=("dry-run audit closure creates real effect receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_postcondition_check", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real host postcondition checking",), forbidden_implications=("dry-run audit closure checks real host postconditions",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -653,6 +664,35 @@ def update_registry_from_dry_run_audit_closure(registry: CapabilityRegistry, clo
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-dry-run-audit-closure-wing.v1")
 
+
+def update_registry_from_local_diagnostic_effect_receipt(registry: CapabilityRegistry, receipt: Any) -> CapabilityRegistry:
+    """Reflect the explicit Tier-1 local diagnostic effect without broadening host authority."""
+
+    has_receipt = bool(getattr(receipt, "receipt_id", "")) or bool(isinstance(receipt, Mapping) and receipt.get("receipt_id"))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id in {"local_diagnostic_effect", "local_diagnostic_effect_receipt", "local_diagnostic_postcondition_check", "local_diagnostic_production_audit_receipt", "local_diagnostic_rollback_plan"}:
+            records.append(
+                replace(
+                    record,
+                    status="implemented" if has_receipt else record.status,
+                    source_paths=tuple(sorted(set(record.source_paths + ("sentientos/local_diagnostic_effect.py", "scripts/run_local_diagnostic_effect.py")))),
+                    proof_tests=tuple(sorted(set(record.proof_tests + ("tests/test_local_diagnostic_effect.py", "tests/test_run_local_diagnostic_effect_script.py")))),
+                    implemented_surfaces=tuple(sorted(set(record.implemented_surfaces + ("Tier-1 explicit local diagnostic artifact effect",)))),
+                    forbidden_implications=tuple(sorted(set(record.forbidden_implications + ("local diagnostic effect grants general host control",)))),
+                    host_actuation_performed=False,
+                    metadata_only=True,
+                )
+            )
+        elif record.capability_id == "local_diagnostic_rollback_execution":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_backend_implementation", "real_backend_invocation", "fulfillment_execution", "real_effect_execution", "real_fulfillment_execution"}:
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-local-diagnostic-effect-pilot-wing.v1")
 
 def update_registry_from_real_effect_admission(registry: CapabilityRegistry, admission_wing: Any) -> CapabilityRegistry:
     """Reflect real-effect admission planning without claiming implementation."""

--- a/sentientos/local_diagnostic_effect.py
+++ b/sentientos/local_diagnostic_effect.py
@@ -1,0 +1,840 @@
+"""Tier-1 local diagnostic effect pilot.
+
+This module implements exactly one deliberately narrow real effect: writing one
+metadata-only diagnostic artifact to an explicit caller-supplied local output
+directory. It does not perform hardware control, service control, cleanup,
+network egress, provider invocation, prompt assembly, subprocess execution,
+shell execution, OS backend invocation, or control-plane execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping, NamedTuple, Sequence
+
+EFFECT_STATUSES = frozenset({
+    "local_diagnostic_effect_requested",
+    "local_diagnostic_effect_performed",
+    "local_diagnostic_effect_blocked",
+    "local_diagnostic_effect_incomplete",
+    "local_diagnostic_effect_contradicted",
+})
+POSTCONDITION_STATUSES = frozenset({
+    "local_diagnostic_postcondition_passed",
+    "local_diagnostic_postcondition_passed_with_warnings",
+    "local_diagnostic_postcondition_failed",
+    "local_diagnostic_postcondition_blocked",
+    "local_diagnostic_postcondition_incomplete",
+    "local_diagnostic_postcondition_contradicted",
+})
+ROLLBACK_STATUSES = frozenset({
+    "local_diagnostic_rollback_plan_ready",
+    "local_diagnostic_rollback_plan_ready_with_warnings",
+    "local_diagnostic_rollback_performed",
+    "local_diagnostic_rollback_blocked",
+    "local_diagnostic_rollback_incomplete",
+    "local_diagnostic_rollback_contradicted",
+})
+AUDIT_STATUSES = frozenset({
+    "local_diagnostic_production_audit_recorded",
+    "local_diagnostic_production_audit_recorded_with_warnings",
+    "local_diagnostic_production_audit_blocked",
+    "local_diagnostic_production_audit_incomplete",
+    "local_diagnostic_production_audit_contradicted",
+})
+EFFECT_DOMAINS = frozenset({
+    "diagnostics_local_file_effect",
+    "resource_pressure_local_file_effect",
+    "operator_review_local_file_effect",
+})
+LOW_RISK_ADMISSION_DOMAINS = frozenset({
+    "diagnostics_real_effect_candidate",
+    "resource_pressure_real_effect_candidate",
+    "operator_review_real_effect_candidate",
+})
+BLOCKING_ADMISSION_STATUSES = frozenset({
+    "real_effect_admission_blocked",
+    "real_effect_admission_incomplete",
+    "real_effect_admission_contradicted",
+})
+BLOCKED_ACTION_LABELS = (
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "file_cleanup_unrelated",
+    "file_delete_unrelated",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+    "hardware_control",
+)
+FORBIDDEN_PERFORMED_FLAGS = (
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "file_cleanup_performed",
+    "file_delete_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+    "subprocess_performed",
+    "shell_performed",
+    "os_backend_invoked",
+    "control_plane_admission_execution_performed",
+)
+DEFAULT_ARTIFACT_NAME = "sentientos_local_diagnostic_effect.json"
+DEFAULT_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticEffectValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticEffectPolicy:
+    policy_id: str
+    allowed_effect_domains: tuple[str, ...]
+    low_risk_source_admission_domains: tuple[str, ...]
+    required_scope_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    default_artifact_media_type: str = "application/json"
+    warning_codes: tuple[str, ...] = ()
+    risk_codes: tuple[str, ...] = ("tier1_local_file_write_is_real_host_mutation",)
+    local_only: bool = True
+    diagnostic_only: bool = True
+    exact_artifact_rollback_deferred: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticEffectRequest:
+    request_id: str
+    source_real_effect_admission_bundle_id: str | None
+    source_real_effect_admission_bundle_digest: str | None
+    effect_domain: str
+    output_dir: str
+    artifact_name: str
+    artifact_media_type: str
+    artifact_payload_summary: str
+    force_overwrite: bool
+    required_scope_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    request_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    local_effect_requested: bool = True
+    diagnostic_only: bool = True
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    subprocess_performed: bool = False
+    shell_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticEffectResult:
+    result_id: str
+    request_id: str
+    output_path: str
+    artifact_digest: str
+    byte_count: int
+    effect_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_effect_performed: bool = False
+    local_file_write_performed: bool = False
+    host_mutation_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    file_delete_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticEffectReceipt:
+    receipt_id: str
+    request_id: str
+    result_id: str
+    effect_domain: str
+    output_path: str
+    artifact_digest: str
+    byte_count: int
+    effect_status: str
+    evidence_summary: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_effect_receipt_created: bool = False
+    real_effect_performed: bool = False
+    local_file_write_performed: bool = False
+    host_mutation_performed: bool = False
+    diagnostic_only: bool = True
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    file_cleanup_performed: bool = False
+    file_delete_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticPostconditionCheck:
+    check_id: str
+    receipt_id: str
+    output_path: str
+    expected_artifact_digest: str
+    observed_artifact_digest: str
+    expected_byte_count: int
+    observed_byte_count: int
+    postcondition_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_postcondition_check_performed: bool = True
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticRollbackPlan:
+    plan_id: str
+    receipt_id: str
+    output_path: str
+    rollback_strategy_labels: tuple[str, ...]
+    rollback_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    rollback_plan_only: bool = True
+    real_rollback_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticRollbackReceipt:
+    receipt_id: str
+    plan_id: str
+    output_path: str
+    rollback_status: str
+    rollback_reason_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    rollback_receipt_only: bool = True
+    real_rollback_performed: bool = False
+    host_mutation_performed: bool = False
+    file_delete_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticProductionAuditReceipt:
+    audit_id: str
+    effect_receipt_id: str
+    postcondition_check_id: str
+    rollback_plan_id: str
+    rollback_receipt_id: str | None
+    audit_status: str
+    evidence_summary: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    production_audit_receipt_created: bool = True
+    audit_for_local_diagnostic_effect_only: bool = True
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class LocalDiagnosticEffectWingRecords(NamedTuple):
+    request: LocalDiagnosticEffectRequest
+    result: LocalDiagnosticEffectResult
+    receipt: LocalDiagnosticEffectReceipt
+    postcondition_check: LocalDiagnosticPostconditionCheck
+    rollback_plan: LocalDiagnosticRollbackPlan
+    rollback_receipt: LocalDiagnosticRollbackReceipt
+    production_audit_receipt: LocalDiagnosticProductionAuditReceipt
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _source_payload(source: Any) -> Mapping[str, Any]:
+    return source.to_dict() if hasattr(source, "to_dict") else dict(source)
+
+
+def _payload(record_or_payload: Any) -> dict[str, Any]:
+    payload = dict(_source_payload(record_or_payload))
+    payload["digest"] = ""
+    return payload
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def local_diagnostic_effect_digest(record_or_payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(_payload(record_or_payload)).encode("utf-8")).hexdigest()
+
+
+local_diagnostic_effect_request_digest = local_diagnostic_effect_digest
+local_diagnostic_effect_result_digest = local_diagnostic_effect_digest
+local_diagnostic_effect_receipt_digest = local_diagnostic_effect_digest
+local_diagnostic_postcondition_check_digest = local_diagnostic_effect_digest
+local_diagnostic_rollback_plan_digest = local_diagnostic_effect_digest
+local_diagnostic_rollback_receipt_digest = local_diagnostic_effect_digest
+local_diagnostic_production_audit_receipt_digest = local_diagnostic_effect_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:24]
+
+
+def _artifact_bytes(request: LocalDiagnosticEffectRequest, payload: Mapping[str, Any] | None = None) -> bytes:
+    artifact = {
+        "schema_version": "sentientos.local_diagnostic_effect.v1",
+        "effect_domain": request.effect_domain,
+        "request_id": request.request_id,
+        "created_at": request.created_at,
+        "artifact_payload_summary": request.artifact_payload_summary,
+        "diagnostic_only": True,
+        "local_only": True,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+        "subprocess_performed": False,
+        "shell_performed": False,
+        "blocked_actions": tuple(request.blocked_actions),
+        "payload": dict(payload or {}),
+    }
+    return (_canonical_json(artifact) + "\n").encode("utf-8")
+
+
+def _artifact_digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def build_default_local_diagnostic_effect_policy() -> LocalDiagnosticEffectPolicy:
+    return LocalDiagnosticEffectPolicy(
+        policy_id="local-diagnostic-effect-policy-v1",
+        allowed_effect_domains=tuple(sorted(EFFECT_DOMAINS)),
+        low_risk_source_admission_domains=tuple(sorted(LOW_RISK_ADMISSION_DOMAINS)),
+        required_scope_labels=("explicit_output_dir_required", "single_artifact_name_required", "diagnostic_metadata_only", "local_file_write_only"),
+        blocked_actions=BLOCKED_ACTION_LABELS,
+    )
+
+
+def _output_dir_findings(output_dir: str) -> list[str]:
+    findings: list[str] = []
+    if not str(output_dir).strip():
+        findings.append("empty_output_dir")
+        return findings
+    path = Path(output_dir).expanduser()
+    if path == path.anchor or str(path.resolve()) == path.anchor:
+        findings.append("output_dir_is_filesystem_root")
+    return findings
+
+
+def _artifact_name_findings(artifact_name: str) -> list[str]:
+    findings: list[str] = []
+    if not artifact_name or not artifact_name.strip():
+        findings.append("empty_artifact_name")
+    candidate = Path(artifact_name)
+    if candidate.is_absolute():
+        findings.append("absolute_artifact_name")
+    if any(sep and sep in artifact_name for sep in ("/", os.sep, os.altsep)):
+        findings.append("artifact_name_contains_path_separator")
+    if ".." in candidate.parts or artifact_name in {".", ".."}:
+        findings.append("artifact_name_path_traversal")
+    return findings
+
+
+def _source_admission_findings(source: Any | None, policy: LocalDiagnosticEffectPolicy) -> tuple[list[str], tuple[str | None, str | None]]:
+    if source is None:
+        return [], (None, None)
+    payload = _source_payload(source)
+    findings: list[str] = []
+    bundle_id = payload.get("bundle_id")
+    digest = payload.get("digest")
+    if payload.get("bundle_status") in BLOCKING_ADMISSION_STATUSES:
+        findings.append("source_real_effect_admission_not_eligible")
+    if payload.get("admission_domain") not in policy.low_risk_source_admission_domains:
+        findings.append("source_real_effect_admission_domain_not_low_risk")
+    return findings, (str(bundle_id) if bundle_id else None, str(digest) if digest else None)
+
+
+def build_local_diagnostic_effect_request(
+    *,
+    output_dir: str | Path,
+    artifact_name: str = DEFAULT_ARTIFACT_NAME,
+    artifact_media_type: str = "application/json",
+    artifact_payload_summary: str = "deterministic local diagnostic metadata artifact",
+    effect_domain: str = "diagnostics_local_file_effect",
+    force_overwrite: bool = False,
+    required_scope_labels: Sequence[str] | None = None,
+    blocked_actions: Sequence[str] | None = None,
+    source_real_effect_admission_bundle: Any | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+    policy: LocalDiagnosticEffectPolicy | None = None,
+) -> LocalDiagnosticEffectRequest:
+    policy = policy or build_default_local_diagnostic_effect_policy()
+    warnings: list[str] = []
+    risks = list(policy.risk_codes)
+    source_findings, (source_id, source_digest) = _source_admission_findings(source_real_effect_admission_bundle, policy)
+    findings = _output_dir_findings(str(output_dir)) + _artifact_name_findings(artifact_name) + source_findings
+    if effect_domain not in policy.allowed_effect_domains:
+        findings.append("unsupported_effect_domain")
+    status = "local_diagnostic_effect_requested" if not findings else "local_diagnostic_effect_blocked"
+    warnings.extend(findings)
+    payload = {
+        "request_id": "",
+        "source_real_effect_admission_bundle_id": source_id,
+        "source_real_effect_admission_bundle_digest": source_digest,
+        "effect_domain": effect_domain,
+        "output_dir": str(output_dir),
+        "artifact_name": artifact_name,
+        "artifact_media_type": artifact_media_type,
+        "artifact_payload_summary": artifact_payload_summary,
+        "force_overwrite": bool(force_overwrite),
+        "required_scope_labels": tuple(required_scope_labels or policy.required_scope_labels),
+        "blocked_actions": tuple(blocked_actions or policy.blocked_actions),
+        "request_status": status,
+        "warning_codes": tuple(warnings),
+        "risk_codes": tuple(risks),
+        "created_at": created_at,
+        "digest": "",
+        "local_effect_requested": True,
+        "diagnostic_only": True,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+        "subprocess_performed": False,
+        "shell_performed": False,
+    }
+    payload["request_id"] = _digest_id("local-diagnostic-effect-request-", payload)
+    payload["digest"] = local_diagnostic_effect_request_digest(payload)
+    return LocalDiagnosticEffectRequest(**payload)
+
+
+def _output_path(request: LocalDiagnosticEffectRequest) -> Path:
+    return Path(request.output_dir).expanduser() / request.artifact_name
+
+
+def validate_local_diagnostic_effect_request(request: LocalDiagnosticEffectRequest | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(request)
+    findings = _output_dir_findings(str(p.get("output_dir", ""))) + _artifact_name_findings(str(p.get("artifact_name", "")))
+    if p.get("effect_domain") not in EFFECT_DOMAINS:
+        findings.append("unsupported_effect_domain")
+    if p.get("request_status") not in EFFECT_STATUSES:
+        findings.append("unknown_request_status")
+    for flag in ("network_performed", "provider_invocation_performed", "prompt_assembly_performed", "subprocess_performed", "shell_performed"):
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticEffectValidationResult(ok=not findings and p.get("request_status") == "local_diagnostic_effect_requested", findings=tuple(findings))
+
+
+def _blocked_result(request: LocalDiagnosticEffectRequest, status: str, warnings: Sequence[str], created_at: str) -> LocalDiagnosticEffectResult:
+    out = str(_output_path(request))
+    payload = {
+        "result_id": "",
+        "request_id": request.request_id,
+        "output_path": out,
+        "artifact_digest": "",
+        "byte_count": 0,
+        "effect_status": status,
+        "warning_codes": tuple(warnings),
+        "risk_codes": request.risk_codes,
+        "created_at": created_at,
+        "digest": "",
+        "real_effect_performed": False,
+        "local_file_write_performed": False,
+        "host_mutation_performed": False,
+    }
+    payload["result_id"] = _digest_id("local-diagnostic-effect-result-", payload)
+    payload["digest"] = local_diagnostic_effect_result_digest(payload)
+    return LocalDiagnosticEffectResult(**payload)
+
+
+def perform_local_diagnostic_effect(
+    request: LocalDiagnosticEffectRequest,
+    *,
+    artifact_payload: Mapping[str, Any] | None = None,
+    dry_run: bool = False,
+    created_at: str | None = None,
+) -> LocalDiagnosticEffectResult:
+    created = created_at or request.created_at
+    validation = validate_local_diagnostic_effect_request(request)
+    if not validation.ok:
+        return _blocked_result(request, "local_diagnostic_effect_blocked", validation.findings, created)
+    out_dir = Path(request.output_dir).expanduser()
+    out_path = _output_path(request)
+    resolved_dir = out_dir.resolve(strict=False)
+    resolved_out = out_path.resolve(strict=False)
+    if resolved_out.parent != resolved_dir:
+        return _blocked_result(request, "local_diagnostic_effect_contradicted", ("output_path_escapes_output_dir",), created)
+    data = _artifact_bytes(request, artifact_payload)
+    digest = _artifact_digest(data)
+    if dry_run:
+        return _blocked_result(request, "local_diagnostic_effect_requested", ("dry_run_no_write_performed",), created)
+    if out_path.exists() and not request.force_overwrite:
+        return _blocked_result(request, "local_diagnostic_effect_blocked", ("artifact_exists_without_force",), created)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = out_dir / f".{request.artifact_name}.{request.request_id}.tmp"
+    with tmp_path.open("xb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, out_path)
+    payload = {
+        "result_id": "",
+        "request_id": request.request_id,
+        "output_path": str(out_path),
+        "artifact_digest": digest,
+        "byte_count": len(data),
+        "effect_status": "local_diagnostic_effect_performed",
+        "warning_codes": (),
+        "risk_codes": request.risk_codes,
+        "created_at": created,
+        "digest": "",
+        "real_effect_performed": True,
+        "local_file_write_performed": True,
+        "host_mutation_performed": True,
+    }
+    payload["result_id"] = _digest_id("local-diagnostic-effect-result-", payload)
+    payload["digest"] = local_diagnostic_effect_result_digest(payload)
+    return LocalDiagnosticEffectResult(**payload)
+
+
+def build_local_diagnostic_effect_receipt(request: LocalDiagnosticEffectRequest, result: LocalDiagnosticEffectResult, *, created_at: str | None = None) -> LocalDiagnosticEffectReceipt:
+    success = result.effect_status == "local_diagnostic_effect_performed"
+    payload = {
+        "receipt_id": "",
+        "request_id": request.request_id,
+        "result_id": result.result_id,
+        "effect_domain": request.effect_domain,
+        "output_path": result.output_path,
+        "artifact_digest": result.artifact_digest,
+        "byte_count": result.byte_count,
+        "effect_status": result.effect_status,
+        "evidence_summary": ("single deterministic diagnostic artifact write to explicit output directory",) if success else ("effect not performed",),
+        "blocked_actions": request.blocked_actions,
+        "warning_codes": result.warning_codes,
+        "risk_codes": result.risk_codes,
+        "created_at": created_at or result.created_at,
+        "digest": "",
+        "real_effect_receipt_created": success,
+        "real_effect_performed": success,
+        "local_file_write_performed": success,
+        "host_mutation_performed": success,
+    }
+    payload["receipt_id"] = _digest_id("local-diagnostic-effect-receipt-", payload)
+    payload["digest"] = local_diagnostic_effect_receipt_digest(payload)
+    return LocalDiagnosticEffectReceipt(**payload)
+
+
+def perform_local_diagnostic_postcondition_check(receipt: LocalDiagnosticEffectReceipt, *, created_at: str | None = None) -> LocalDiagnosticPostconditionCheck:
+    warnings: tuple[str, ...] = ()
+    observed_digest = ""
+    observed_count = 0
+    status = "local_diagnostic_postcondition_blocked"
+    if receipt.real_effect_performed and receipt.output_path:
+        try:
+            data = Path(receipt.output_path).read_bytes()
+            observed_digest = _artifact_digest(data)
+            observed_count = len(data)
+            status = "local_diagnostic_postcondition_passed" if observed_digest == receipt.artifact_digest and observed_count == receipt.byte_count else "local_diagnostic_postcondition_failed"
+        except OSError:
+            warnings = ("artifact_readback_failed",)
+            status = "local_diagnostic_postcondition_failed"
+    payload = {
+        "check_id": "",
+        "receipt_id": receipt.receipt_id,
+        "output_path": receipt.output_path,
+        "expected_artifact_digest": receipt.artifact_digest,
+        "observed_artifact_digest": observed_digest,
+        "expected_byte_count": receipt.byte_count,
+        "observed_byte_count": observed_count,
+        "postcondition_status": status,
+        "warning_codes": warnings,
+        "risk_codes": receipt.risk_codes,
+        "created_at": created_at or receipt.created_at,
+        "digest": "",
+    }
+    payload["check_id"] = _digest_id("local-diagnostic-postcondition-", payload)
+    payload["digest"] = local_diagnostic_postcondition_check_digest(payload)
+    return LocalDiagnosticPostconditionCheck(**payload)
+
+
+def build_local_diagnostic_rollback_plan(receipt: LocalDiagnosticEffectReceipt, *, created_at: str | None = None) -> LocalDiagnosticRollbackPlan:
+    warnings = ("exact_artifact_rollback_execution_deferred",)
+    payload = {
+        "plan_id": "",
+        "receipt_id": receipt.receipt_id,
+        "output_path": receipt.output_path,
+        "rollback_strategy_labels": ("exact_artifact_path_known", "manual_operator_removal_possible", "automatic_deletion_not_performed_by_default"),
+        "rollback_status": "local_diagnostic_rollback_plan_ready_with_warnings",
+        "warning_codes": warnings,
+        "risk_codes": receipt.risk_codes,
+        "created_at": created_at or receipt.created_at,
+        "digest": "",
+    }
+    payload["plan_id"] = _digest_id("local-diagnostic-rollback-plan-", payload)
+    payload["digest"] = local_diagnostic_rollback_plan_digest(payload)
+    return LocalDiagnosticRollbackPlan(**payload)
+
+
+def build_local_diagnostic_rollback_receipt(plan: LocalDiagnosticRollbackPlan, *, created_at: str | None = None) -> LocalDiagnosticRollbackReceipt:
+    payload = {
+        "receipt_id": "",
+        "plan_id": plan.plan_id,
+        "output_path": plan.output_path,
+        "rollback_status": "local_diagnostic_rollback_incomplete",
+        "rollback_reason_codes": ("rollback_execution_deferred_no_deletion_performed",),
+        "warning_codes": plan.warning_codes,
+        "risk_codes": plan.risk_codes,
+        "created_at": created_at or plan.created_at,
+        "digest": "",
+    }
+    payload["receipt_id"] = _digest_id("local-diagnostic-rollback-receipt-", payload)
+    payload["digest"] = local_diagnostic_rollback_receipt_digest(payload)
+    return LocalDiagnosticRollbackReceipt(**payload)
+
+
+def build_local_diagnostic_production_audit_receipt(
+    receipt: LocalDiagnosticEffectReceipt,
+    postcondition_check: LocalDiagnosticPostconditionCheck,
+    rollback_plan: LocalDiagnosticRollbackPlan,
+    rollback_receipt: LocalDiagnosticRollbackReceipt | None = None,
+    *,
+    created_at: str | None = None,
+) -> LocalDiagnosticProductionAuditReceipt:
+    ok = receipt.real_effect_receipt_created and postcondition_check.postcondition_status.startswith("local_diagnostic_postcondition_passed")
+    payload = {
+        "audit_id": "",
+        "effect_receipt_id": receipt.receipt_id,
+        "postcondition_check_id": postcondition_check.check_id,
+        "rollback_plan_id": rollback_plan.plan_id,
+        "rollback_receipt_id": rollback_receipt.receipt_id if rollback_receipt else None,
+        "audit_status": "local_diagnostic_production_audit_recorded" if ok else "local_diagnostic_production_audit_recorded_with_warnings",
+        "evidence_summary": ("effect receipt recorded", "postcondition readback limited to artifact path", "rollback plan recorded", "rollback execution deferred"),
+        "warning_codes": tuple(receipt.warning_codes + postcondition_check.warning_codes + rollback_plan.warning_codes + (rollback_receipt.warning_codes if rollback_receipt else ())),
+        "risk_codes": receipt.risk_codes,
+        "created_at": created_at or receipt.created_at,
+        "digest": "",
+    }
+    payload["audit_id"] = _digest_id("local-diagnostic-production-audit-", payload)
+    payload["digest"] = local_diagnostic_production_audit_receipt_digest(payload)
+    return LocalDiagnosticProductionAuditReceipt(**payload)
+
+
+def _validate_forbidden_false(payload: Mapping[str, Any]) -> list[str]:
+    return [f"forbidden_{flag}" for flag in FORBIDDEN_PERFORMED_FLAGS if payload.get(flag)]
+
+
+def validate_local_diagnostic_effect_result(result: LocalDiagnosticEffectResult | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(result)
+    findings = _validate_forbidden_false(p)
+    if p.get("effect_status") not in EFFECT_STATUSES:
+        findings.append("unknown_effect_status")
+    if p.get("real_effect_performed") != (p.get("effect_status") == "local_diagnostic_effect_performed"):
+        findings.append("real_effect_flag_mismatch")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_diagnostic_effect_receipt(receipt: LocalDiagnosticEffectReceipt | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(receipt)
+    findings = _validate_forbidden_false(p)
+    if not p.get("diagnostic_only"):
+        findings.append("receipt_not_diagnostic_only")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_diagnostic_postcondition_check(check: LocalDiagnosticPostconditionCheck | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(check)
+    findings = []
+    if p.get("postcondition_status") not in POSTCONDITION_STATUSES:
+        findings.append("unknown_postcondition_status")
+    for flag in ("host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_diagnostic_rollback_plan(plan: LocalDiagnosticRollbackPlan | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(plan)
+    findings = []
+    if p.get("rollback_status") not in ROLLBACK_STATUSES:
+        findings.append("unknown_rollback_status")
+    if not p.get("rollback_plan_only") or p.get("real_rollback_performed") or p.get("host_mutation_performed"):
+        findings.append("rollback_plan_claims_execution")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_diagnostic_rollback_receipt(receipt: LocalDiagnosticRollbackReceipt | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(receipt)
+    findings = []
+    if p.get("rollback_status") not in ROLLBACK_STATUSES:
+        findings.append("unknown_rollback_status")
+    if p.get("real_rollback_performed") or p.get("host_mutation_performed") or p.get("file_delete_performed"):
+        findings.append("rollback_receipt_claims_deletion")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_diagnostic_production_audit_receipt(receipt: LocalDiagnosticProductionAuditReceipt | Mapping[str, Any]) -> LocalDiagnosticEffectValidationResult:
+    p = _source_payload(receipt)
+    findings = []
+    if p.get("audit_status") not in AUDIT_STATUSES:
+        findings.append("unknown_audit_status")
+    for flag in ("host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    if not p.get("audit_for_local_diagnostic_effect_only"):
+        findings.append("audit_scope_not_local_diagnostic_only")
+    return LocalDiagnosticEffectValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def summarize_local_diagnostic_effect_request(record: LocalDiagnosticEffectRequest | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("request_id", "source_real_effect_admission_bundle_id", "effect_domain", "output_dir", "artifact_name", "force_overwrite", "request_status", "local_effect_requested", "diagnostic_only", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "subprocess_performed", "shell_performed", "digest")}
+
+
+def summarize_local_diagnostic_effect_result(record: LocalDiagnosticEffectResult | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("result_id", "request_id", "output_path", "artifact_digest", "byte_count", "effect_status", "real_effect_performed", "local_file_write_performed", "host_mutation_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_effect_receipt(record: LocalDiagnosticEffectReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "result_id", "effect_domain", "output_path", "artifact_digest", "byte_count", "effect_status", "real_effect_receipt_created", "real_effect_performed", "local_file_write_performed", "host_mutation_performed", "diagnostic_only", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_postcondition_check(record: LocalDiagnosticPostconditionCheck | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("check_id", "receipt_id", "output_path", "expected_artifact_digest", "observed_artifact_digest", "expected_byte_count", "observed_byte_count", "postcondition_status", "real_postcondition_check_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_rollback_plan(record: LocalDiagnosticRollbackPlan | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("plan_id", "receipt_id", "output_path", "rollback_strategy_labels", "rollback_status", "rollback_plan_only", "real_rollback_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_local_diagnostic_rollback_receipt(record: LocalDiagnosticRollbackReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("receipt_id", "plan_id", "output_path", "rollback_status", "rollback_reason_codes", "rollback_receipt_only", "real_rollback_performed", "host_mutation_performed", "file_delete_performed", "digest")}
+
+
+def summarize_local_diagnostic_production_audit_receipt(record: LocalDiagnosticProductionAuditReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("audit_id", "effect_receipt_id", "postcondition_check_id", "rollback_plan_id", "rollback_receipt_id", "audit_status", "production_audit_receipt_created", "audit_for_local_diagnostic_effect_only", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "host_mutation_performed", "digest")}
+
+
+def summarize_local_diagnostic_effect_wing(records: LocalDiagnosticEffectWingRecords) -> dict[str, Any]:
+    return {
+        "request": summarize_local_diagnostic_effect_request(records.request),
+        "result": summarize_local_diagnostic_effect_result(records.result),
+        "receipt": summarize_local_diagnostic_effect_receipt(records.receipt),
+        "postcondition_check": summarize_local_diagnostic_postcondition_check(records.postcondition_check),
+        "rollback_plan": summarize_local_diagnostic_rollback_plan(records.rollback_plan),
+        "rollback_receipt": summarize_local_diagnostic_rollback_receipt(records.rollback_receipt),
+        "production_audit_receipt": summarize_local_diagnostic_production_audit_receipt(records.production_audit_receipt),
+    }
+
+
+def run_local_diagnostic_effect_wing(
+    *,
+    output_dir: str | Path,
+    artifact_name: str = DEFAULT_ARTIFACT_NAME,
+    effect_domain: str = "diagnostics_local_file_effect",
+    artifact_payload_summary: str = "deterministic local diagnostic metadata artifact",
+    artifact_payload: Mapping[str, Any] | None = None,
+    force_overwrite: bool = False,
+    dry_run: bool = False,
+    source_real_effect_admission_bundle: Any | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> LocalDiagnosticEffectWingRecords:
+    request = build_local_diagnostic_effect_request(
+        output_dir=output_dir,
+        artifact_name=artifact_name,
+        effect_domain=effect_domain,
+        artifact_payload_summary=artifact_payload_summary,
+        force_overwrite=force_overwrite,
+        source_real_effect_admission_bundle=source_real_effect_admission_bundle,
+        created_at=created_at,
+    )
+    result = perform_local_diagnostic_effect(request, artifact_payload=artifact_payload, dry_run=dry_run, created_at=created_at)
+    receipt = build_local_diagnostic_effect_receipt(request, result, created_at=created_at)
+    postcondition = perform_local_diagnostic_postcondition_check(receipt, created_at=created_at)
+    rollback_plan = build_local_diagnostic_rollback_plan(receipt, created_at=created_at)
+    rollback_receipt = build_local_diagnostic_rollback_receipt(rollback_plan, created_at=created_at)
+    audit = build_local_diagnostic_production_audit_receipt(receipt, postcondition, rollback_plan, rollback_receipt, created_at=created_at)
+    return LocalDiagnosticEffectWingRecords(request, result, receipt, postcondition, rollback_plan, rollback_receipt, audit)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -113,6 +113,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "dry_run_execution_posture",
         "dry_run_audit_closure_posture",
         "real_effect_admission_posture",
+        "local_diagnostic_effect_capability",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -141,6 +142,7 @@ BUNDLE_FILE_NAMES = {
     "dry_run_execution_posture": "dry_run_execution.json",
     "dry_run_audit_closure_posture": "dry_run_audit_closure.json",
     "real_effect_admission_posture": "real_effect_admission.json",
+    "local_diagnostic_effect_capability": "local_diagnostic_effect_capability.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -185,6 +187,7 @@ DEFERRED_ACTION_LABELS = (
     "prompt_assembly_export",
     "federation_transport_sync_adoption",
     "remote_execution",
+    "local_diagnostic_effect_pilot_explicit_only",
 )
 BLOCKED_ACTION_LABELS = (
     "fan_pwm_write",
@@ -197,6 +200,7 @@ BLOCKED_ACTION_LABELS = (
     "prompt_assembly_export",
     "federation_transport_sync_adoption",
     "remote_execution",
+    "local_diagnostic_effect_pilot_explicit_only",
 )
 
 
@@ -306,6 +310,7 @@ def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord,
         (("python", "scripts/build_docs.py", "--check-deps"), "Check documentation build dependencies."),
         (("python", "scripts/build_docs.py"), "Build documentation locally."),
         (("python", "scripts/verify_context_hygiene_prompt_boundaries.py"), "Verify prompt/provider boundary hygiene."),
+        (("python", "scripts/run_local_diagnostic_effect.py", "--output-dir", "/tmp/sentientos-local-effect", "--summary"), "Optional explicit Tier-1 local diagnostic effect pilot; listed for reviewer awareness and not run by proof bundle generation."),
     )
     return tuple(
         ReviewerProofCommandRecord(
@@ -701,6 +706,21 @@ def build_reviewer_proof_bundle_payload(
             },
         }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
+        "local_diagnostic_effect_capability": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "capability_available": True,
+            "explicit_command_required": True,
+            "run_by_reviewer_proof_bundle_default": False,
+            "proof_bundle_effect_performed": False,
+            "proof_bundle_host_mutation_performed": False,
+            "first_intentionally_real_effect_pilot": True,
+            "only_real_effect_when_explicitly_run": "write one deterministic diagnostic artifact to caller-supplied local output directory",
+            "command": "python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-effect --summary",
+            "no_fan_pwm_thermal_power_service_cleanup": True,
+            "no_network_provider_prompt_subprocess_shell_control_plane": True,
+            "rollback_execution_deferred_by_default": True,
+        }),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
     artifact_records = tuple(_artifact(kind, content) for kind, content in contents.items())

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -228,3 +228,15 @@ def test_reviewer_proof_bundle_cli_writes_real_effect_admission_json(tmp_path) -
     assert payload["backend_loaded"] is False
     assert payload["backend_invoked"] is False
     assert payload["host_mutation_performed"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_local_diagnostic_capability_without_running_effect(tmp_path: Path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir)])
+    assert code == 0, (stdout, stderr)
+    payload = json.loads((output_dir / "local_diagnostic_effect_capability.json").read_text(encoding="utf-8"))
+    assert payload["explicit_command_required"] is True
+    assert payload["run_by_reviewer_proof_bundle_default"] is False
+    assert payload["proof_bundle_effect_performed"] is False
+    commands = json.loads((output_dir / "proof_commands.json").read_text(encoding="utf-8"))["commands"]
+    assert any("run_local_diagnostic_effect.py" in " ".join(record["command"]) and record["status"] == "proof_command_not_run" for record in commands)

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -623,3 +623,20 @@ def test_update_registry_from_real_effect_admission_preserves_deferred_real_back
     assert records["real_backend_invocation"].status == "deferred"
     assert records["real_effect_execution"].status == "deferred"
     assert records["real_fan_pwm_control"].status == "blocked"
+
+
+def test_local_diagnostic_effect_registry_records_are_narrow_and_general_effects_deferred() -> None:
+    records = build_default_capability_registry().by_id()
+    assert records["local_diagnostic_effect"].status == "implemented"
+    assert records["local_diagnostic_effect"].authority_level == "local_diagnostic_effect_only"
+    assert "explicit optional low-risk local diagnostic file write" in records["local_diagnostic_effect"].implemented_surfaces
+    assert records["local_diagnostic_effect_receipt"].status == "implemented"
+    assert records["local_diagnostic_effect_receipt"].authority_level == "real_effect_receipt_only"
+    assert records["local_diagnostic_postcondition_check"].authority_level == "real_postcondition_check_only"
+    assert records["local_diagnostic_production_audit_receipt"].authority_level == "production_audit_only"
+    assert records["local_diagnostic_rollback_plan"].status == "implemented"
+    assert records["local_diagnostic_rollback_execution"].status == "deferred"
+    for capability_id in ["real_backend_implementation", "real_backend_invocation", "fulfillment_execution", "real_effect_execution"]:
+        assert records[capability_id].status == "deferred"
+    for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
+        assert records[capability_id].status == "blocked"

--- a/tests/test_local_diagnostic_effect.py
+++ b/tests/test_local_diagnostic_effect.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sentientos.local_diagnostic_effect import (
+    build_local_diagnostic_effect_receipt,
+    build_local_diagnostic_effect_request,
+    build_local_diagnostic_rollback_plan,
+    build_local_diagnostic_rollback_receipt,
+    build_local_diagnostic_production_audit_receipt,
+    local_diagnostic_effect_request_digest,
+    perform_local_diagnostic_effect,
+    perform_local_diagnostic_postcondition_check,
+    run_local_diagnostic_effect_wing,
+    summarize_local_diagnostic_effect_receipt,
+    summarize_local_diagnostic_effect_result,
+    summarize_local_diagnostic_rollback_plan,
+    validate_local_diagnostic_effect_receipt,
+    validate_local_diagnostic_effect_request,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def test_request_validation_rejects_unsafe_output_and_names(tmp_path: Path) -> None:
+    cases = [
+        {"output_dir": "", "artifact_name": "ok.json", "finding": "empty_output_dir"},
+        {"output_dir": "/", "artifact_name": "ok.json", "finding": "output_dir_is_filesystem_root"},
+        {"output_dir": tmp_path, "artifact_name": "nested/name.json", "finding": "artifact_name_contains_path_separator"},
+        {"output_dir": tmp_path, "artifact_name": "/tmp/name.json", "finding": "absolute_artifact_name"},
+        {"output_dir": tmp_path, "artifact_name": "..", "finding": "artifact_name_path_traversal"},
+    ]
+    for case in cases:
+        req = build_local_diagnostic_effect_request(output_dir=case["output_dir"], artifact_name=case["artifact_name"])
+        validation = validate_local_diagnostic_effect_request(req)
+        assert not validation.ok
+        assert case["finding"] in validation.findings
+
+
+def test_dry_run_does_not_write_artifact(tmp_path: Path) -> None:
+    records = run_local_diagnostic_effect_wing(output_dir=tmp_path, dry_run=True)
+    assert records.result.effect_status == "local_diagnostic_effect_requested"
+    assert records.result.real_effect_performed is False
+    assert not (tmp_path / "sentientos_local_diagnostic_effect.json").exists()
+
+
+def test_real_mode_writes_one_artifact_and_receipts_are_narrow(tmp_path: Path) -> None:
+    out = tmp_path / "effect-out"
+    records = run_local_diagnostic_effect_wing(output_dir=out)
+    target = out / "sentientos_local_diagnostic_effect.json"
+    assert target.exists()
+    assert [p.name for p in out.iterdir()] == ["sentientos_local_diagnostic_effect.json"]
+    result_summary = summarize_local_diagnostic_effect_result(records.result)
+    assert result_summary["real_effect_performed"] is True
+    assert result_summary["local_file_write_performed"] is True
+    assert result_summary["host_mutation_performed"] is True
+    receipt_summary = summarize_local_diagnostic_effect_receipt(records.receipt)
+    assert receipt_summary["real_effect_receipt_created"] is True
+    for flag in [
+        "fan_pwm_write_performed",
+        "thermal_actuation_performed",
+        "power_profile_mutation_performed",
+        "service_restart_performed",
+        "file_cleanup_performed",
+        "network_performed",
+        "provider_invocation_performed",
+        "prompt_assembly_performed",
+    ]:
+        assert receipt_summary[flag] is False
+    assert records.postcondition_check.postcondition_status == "local_diagnostic_postcondition_passed"
+    assert records.postcondition_check.output_path == str(target)
+    assert records.rollback_plan.rollback_plan_only is True
+    assert records.rollback_receipt.real_rollback_performed is False
+    assert records.rollback_receipt.file_delete_performed is False
+    assert target.exists()
+    assert records.production_audit_receipt.production_audit_receipt_created is True
+    assert records.production_audit_receipt.audit_for_local_diagnostic_effect_only is True
+
+
+def test_overwrite_requires_force_and_force_only_targets_artifact(tmp_path: Path) -> None:
+    first = run_local_diagnostic_effect_wing(output_dir=tmp_path)
+    unrelated = tmp_path / "unrelated.txt"
+    unrelated.write_text("keep", encoding="utf-8")
+    second = run_local_diagnostic_effect_wing(output_dir=tmp_path)
+    assert second.result.effect_status == "local_diagnostic_effect_blocked"
+    assert second.result.real_effect_performed is False
+    forced = run_local_diagnostic_effect_wing(output_dir=tmp_path, force_overwrite=True)
+    assert forced.result.effect_status == "local_diagnostic_effect_performed"
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+    assert first.result.output_path == forced.result.output_path
+
+
+def test_source_admission_blocks_bad_status_and_non_low_risk(tmp_path: Path) -> None:
+    blocked = {"bundle_id": "b", "digest": "sha256:x", "bundle_status": "real_effect_admission_blocked", "admission_domain": "diagnostics_real_effect_candidate"}
+    req = build_local_diagnostic_effect_request(output_dir=tmp_path, source_real_effect_admission_bundle=blocked)
+    assert req.request_status == "local_diagnostic_effect_blocked"
+    assert "source_real_effect_admission_not_eligible" in req.warning_codes
+    non_low = {"bundle_id": "b", "digest": "sha256:x", "bundle_status": "real_effect_admission_eligible_for_planning", "admission_domain": "future_cooling_real_effect_candidate"}
+    req2 = build_local_diagnostic_effect_request(output_dir=tmp_path, source_real_effect_admission_bundle=non_low)
+    assert req2.request_status == "local_diagnostic_effect_blocked"
+    assert "source_real_effect_admission_domain_not_low_risk" in req2.warning_codes
+
+
+def test_digests_are_deterministic_and_change_on_metadata(tmp_path: Path) -> None:
+    a = build_local_diagnostic_effect_request(output_dir=tmp_path, artifact_payload_summary="a")
+    b = build_local_diagnostic_effect_request(output_dir=tmp_path, artifact_payload_summary="a")
+    c = build_local_diagnostic_effect_request(output_dir=tmp_path, artifact_payload_summary="c")
+    assert a.digest == b.digest
+    assert local_diagnostic_effect_request_digest(a) == a.digest
+    assert a.digest != c.digest
+
+
+def test_validators_accept_success_records_and_reject_forbidden_claims(tmp_path: Path) -> None:
+    request = build_local_diagnostic_effect_request(output_dir=tmp_path)
+    result = perform_local_diagnostic_effect(request)
+    receipt = build_local_diagnostic_effect_receipt(request, result)
+    check = perform_local_diagnostic_postcondition_check(receipt)
+    plan = build_local_diagnostic_rollback_plan(receipt)
+    rollback = build_local_diagnostic_rollback_receipt(plan)
+    audit = build_local_diagnostic_production_audit_receipt(receipt, check, plan, rollback)
+    assert validate_local_diagnostic_effect_request(request).ok
+    assert validate_local_diagnostic_effect_receipt(receipt).ok
+    assert summarize_local_diagnostic_rollback_plan(plan)["rollback_plan_only"] is True
+    bad = receipt.to_dict() | {"network_performed": True}
+    assert not validate_local_diagnostic_effect_receipt(bad).ok
+    assert audit.host_mutation_performed is False

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -282,3 +282,17 @@ def test_bundle_includes_real_effect_admission_posture_and_remains_non_mutating(
     assert admission["host_mutation_performed"] is False
     assert "fan_pwm_write" in admission["blocked_actions"]
     assert "thermal_actuation" in admission["blocked_actions"]
+
+
+def test_reviewer_proof_bundle_lists_local_diagnostic_effect_but_does_not_run_it() -> None:
+    payload = build_reviewer_proof_bundle_payload()
+    artifacts = payload["artifacts"]
+    capability = json.loads(artifacts["local_diagnostic_effect_capability"])
+    assert capability["explicit_command_required"] is True
+    assert capability["run_by_reviewer_proof_bundle_default"] is False
+    assert capability["proof_bundle_effect_performed"] is False
+    assert capability["proof_bundle_host_mutation_performed"] is False
+    commands = json.loads(artifacts["proof_command_manifest"])["commands"]
+    local_commands = [record for record in commands if "run_local_diagnostic_effect.py" in " ".join(record["command"])]
+    assert local_commands
+    assert all(record["status"] == "proof_command_not_run" and record["executed"] is False for record in local_commands)

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -545,3 +545,18 @@ def test_host_real_effect_capability_admission_doc_preserves_planning_only_bound
     assert "Real postcondition checks remain deferred" in doc
     assert "Real rollback remains deferred" in doc
     assert "Production audit remains deferred" in doc
+
+
+def test_local_diagnostic_effect_pilot_doc_is_linked_and_preserves_boundaries() -> None:
+    doc = Path("docs/architecture/host_local_diagnostic_effect_pilot_wing.md").read_text(encoding="utf-8")
+    public = Path("docs/architecture/public_technical_overview.md").read_text(encoding="utf-8")
+    index = Path("docs/architecture/reviewer_release_readiness_index.md").read_text(encoding="utf-8")
+    assert "host_local_diagnostic_effect_pilot_wing.md" in public
+    assert "host_local_diagnostic_effect_pilot_wing.md" in index
+    assert "first intentionally real effect pilot" in doc
+    assert "one deterministic metadata/diagnostic artifact" in doc
+    assert "does not run this effect by default" in doc
+    assert "fan/PWM control" in doc and "thermal actuation" in doc and "service restart" in doc
+    assert "network egress" in doc and "provider invocation" in doc and "prompt assembly" in doc
+    assert "subprocess execution" in doc and "shell execution" in doc
+    assert "python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary" in doc

--- a/tests/test_run_local_diagnostic_effect_script.py
+++ b/tests/test_run_local_diagnostic_effect_script.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_local_diagnostic_effect as script
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO(); stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            code = script.main(args)
+        except SystemExit as exc:
+            code = int(exc.code or 0)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_requires_output_dir() -> None:
+    code, _out, err = _run([])
+    assert code != 0
+    assert "output-dir" in err
+
+
+def test_dry_run_writes_nothing_and_summary_is_safe(tmp_path: Path) -> None:
+    code, out, err = _run(["--output-dir", str(tmp_path), "--dry-run", "--summary"])
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["dry_run"] is True
+    assert payload["real_effect_performed"] is False
+    assert payload["network_performed"] is False
+    assert not (tmp_path / "sentientos_local_diagnostic_effect.json").exists()
+
+
+def test_default_writes_and_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    code, out, err = _run(["--output-dir", str(tmp_path), "--summary"])
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["real_effect_performed"] is True
+    assert (tmp_path / "sentientos_local_diagnostic_effect.json").exists()
+    code, out, _err = _run(["--output-dir", str(tmp_path), "--summary"])
+    assert code == 1
+    payload = json.loads(out)
+    assert payload["effect_status"] == "local_diagnostic_effect_blocked"
+
+
+def test_force_overwrites_target_and_summary_proves_forbidden_flags_false(tmp_path: Path) -> None:
+    assert _run(["--output-dir", str(tmp_path), "--summary"])[0] == 0
+    code, out, err = _run(["--output-dir", str(tmp_path), "--summary", "--force"])
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["local_file_write_performed"] is True
+    for flag in ["fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "file_cleanup_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"]:
+        assert payload[flag] is False
+
+
+def test_invalid_artifact_name_exits_nonzero(tmp_path: Path) -> None:
+    code, _out, err = _run(["--output-dir", str(tmp_path), "--artifact-name", "bad/name.json"])
+    assert code == 2
+    assert "artifact_name_contains_path_separator" in err


### PR DESCRIPTION
### Motivation
- Provide a single, deliberately narrow real-effect pilot that proves we can emit a bounded, auditable local host mutation (one diagnostic artifact file) without opening broader host control paths.
- Keep the pilot scoped to metadata/diagnostic output only, with deterministic artifact content, atomic write semantics, postcondition verification, a rollback-plan scaffold, and a production-audit receipt.

### Description
- Add a new effect wing implementation `sentientos/local_diagnostic_effect.py` with frozen dataclasses, deterministic digests, helpers, and `run_local_diagnostic_effect_wing(...)` that: validates requests, writes one artifact atomically (unless `--dry-run`), builds result/receipt/postcondition/rollback/audit records, and preserves forbidden-action flags as false.
- Add CLI `scripts/run_local_diagnostic_effect.py` that exposes the effect (required `--output-dir`), supports `--dry-run`, `--force`, `--summary`, and enforces safety checks (no path traversal, no root writes, no overwrite without `--force`).
- Integrate the capability into reviewer proof bundle by adding a documented capability artifact (listed but not run) and an explicit optional proof command entry so the bundle remains non-mutating by default (`sentientos/reviewer_proof_bundle.py`).
- Update capability registry (`sentientos/capability_registry.py`) additively to describe the new `local_diagnostic_*` records and a helper `update_registry_from_local_diagnostic_effect_receipt(...)` that reflects issuance without broadening authority; general real backends and dangerous actions remain deferred/blocked.
- Add docs `docs/architecture/host_local_diagnostic_effect_pilot_wing.md` and wire short links into the public/reviewer docs and README to declare boundaries and run instructions.
- Add focused tests: `tests/test_local_diagnostic_effect.py` and `tests/test_run_local_diagnostic_effect_script.py`, plus updates to reviewer/bundle/registry tests to assert the capability is listed but not executed by default.

### Testing
- Performed static compile checks with `python -m py_compile` on the new/modified modules and scripts; compilation succeeded.
- Ran focused pytest suites via the repo test harness: `tests/test_local_diagnostic_effect.py`, `tests/test_run_local_diagnostic_effect_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`, and the related real-effect/dry-run proof tests (`tests/test_real_effect_admission.py`, `tests/test_dry_run_audit_closure.py`, `tests/test_dry_run_execution_harness.py`, `tests/test_fulfillment_executor_contract.py`); all executed and passed in this environment.
- Executed CLI smoke runs: `scripts/run_local_diagnostic_effect.py --dry-run --summary` (no write) and `scripts/run_local_diagnostic_effect.py --summary --force` (wrote artifact), and built a reviewer proof bundle with `scripts/build_reviewer_proof_bundle.py --output-dir ... --force`; those invocations completed successfully and produced the expected receipts and non-mutating reviewer bundle artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07621147248320bfc1ad627ee6d5d7)