### PR TITLE
[codex:host-embodiment] add exact artifact rollback pilot

### DIFF
--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -84,3 +84,5 @@ Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
 
 The authority ladder later reaches the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), the first explicit diagnostic artifact write effect.
+
+Later bounded real-effect proof organs include the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) and its [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); both remain explicit and narrow.

--- a/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
@@ -14,7 +14,7 @@ This is not general host control. It does not create general host executors, OS 
 - **LocalDiagnosticEffectResult** records the artifact path, artifact digest, byte count, and real-effect flags. `real_effect_performed=true`, `local_file_write_performed=true`, and `host_mutation_performed=true` only when the file write succeeds.
 - **LocalDiagnosticEffectReceipt** records a real effect receipt for the diagnostic file write only. Fan/PWM, thermal, power, process, service, package, driver, cleanup/delete, network, provider, and prompt flags remain false.
 - **LocalDiagnosticPostconditionCheck** reads back only the artifact path written by the pilot, compares digest and byte count, and performs no host mutation.
-- **LocalDiagnosticRollbackPlan** and **LocalDiagnosticRollbackReceipt** are plan/receipt scaffolds by default. Rollback execution and deletion are deferred; no automatic deletion is performed.
+- **LocalDiagnosticRollbackPlan** and **LocalDiagnosticRollbackReceipt** remain plan/receipt scaffolds during the effect pilot itself. The separate exact-artifact rollback pilot may delete only this recorded artifact when explicitly requested through its API/CLI.
 - **LocalDiagnosticProductionAuditReceipt** records production audit evidence for this local diagnostic effect only and performs no additional host mutation.
 
 ## CLI
@@ -45,7 +45,7 @@ The reviewer proof bundle documents this capability in `local_diagnostic_effect_
 
 ## Capability registry posture
 
-The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effect_receipt`, `local_diagnostic_postcondition_check`, `local_diagnostic_production_audit_receipt`, and `local_diagnostic_rollback_plan` as implemented for this diagnostic artifact only. `local_diagnostic_rollback_execution` remains deferred unless a future exact-artifact rollback implementation is explicitly added. General real backends, real backend invocation, general fulfillment execution, fan/PWM, thermal, power, service, and unrelated cleanup actions remain deferred or blocked.
+The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effect_receipt`, `local_diagnostic_postcondition_check`, `local_diagnostic_production_audit_receipt`, and `local_diagnostic_rollback_plan` as implemented for this diagnostic artifact only. `local_diagnostic_exact_rollback`, `local_diagnostic_rollback_postcondition_check`, and `local_diagnostic_rollback_audit_receipt` are implemented as exact-artifact-only surfaces in the separate rollback wing. General cleanup, recursive delete, wildcard delete, unrelated delete, real backends, real backend invocation, fan/PWM, thermal, power, service, and unrelated cleanup actions remain deferred or blocked.
 
 ## Implementation links
 
@@ -54,3 +54,5 @@ The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effec
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_local_diagnostic_effect.py`, `tests/test_run_local_diagnostic_effect_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+The matching exact-artifact rollback pilot is documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md); it deletes only the recorded diagnostic artifact when explicitly requested.

--- a/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
@@ -1,0 +1,66 @@
+# Host Local Diagnostic Exact Artifact Rollback Pilot Wing
+
+This wing follows the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md). The previous wing proved one bounded real local artifact write. This wing proves the matching bounded rollback for that exact artifact only.
+
+## Boundary
+
+This is the first intentionally real rollback pilot. Its only allowed real effect is deleting the exact diagnostic artifact created by `sentientos/local_diagnostic_effect.py` and recorded by the local diagnostic effect receipt plus rollback plan.
+
+It is not general cleanup. It is not directory cleanup. It is not recursive deletion. It is not wildcard deletion. It is not unrelated file deletion. It does not delete siblings, parent directories, temporary directories, or any path other than the exact recorded artifact path.
+
+Before `Path.unlink()` is reached, the rollback verifies all of the following:
+
+- the source effect receipt succeeded;
+- the rollback plan references the same receipt and output path;
+- the output path is inside the explicit `--output-dir-scope`;
+- the scope is not filesystem root;
+- the target path is not root, not a directory, and not a symlink;
+- the observed artifact digest matches the expected digest from the effect receipt.
+
+Hardware, service, power, process, package, driver, network, provider, prompt, subprocess, shell, OS-backend, control-plane, federation transport/sync/adoption, and remote execution actions remain forbidden.
+
+## Records
+
+- **LocalDiagnosticExactRollbackRequest** records the source effect receipt, source rollback plan, expected artifact path/digest, explicit output scope, blocked actions, and false network/provider/prompt/subprocess/shell flags.
+- **LocalDiagnosticExactRollbackResult** records whether exact artifact deletion happened. `real_rollback_performed=true`, `file_delete_performed=true`, and `host_mutation_performed=true` only when the exact artifact path is deleted.
+- **LocalDiagnosticExactRollbackReceipt** records exact-artifact-only rollback evidence and keeps general cleanup, directory cleanup, recursive delete, wildcard delete, unrelated delete, hardware, service, network, provider, and prompt flags false.
+- **LocalDiagnosticRollbackPostconditionCheck** verifies the exact artifact path is absent and performs no host mutation.
+- **LocalDiagnosticRollbackAuditReceipt** records production rollback audit evidence for the exact local diagnostic artifact only.
+
+## CLI
+
+First run the explicit diagnostic effect pilot so the receipt and rollback plan files are written:
+
+```bash
+python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary --force
+```
+
+Dry-run rollback validates the exact path and digest but does not delete:
+
+```bash
+python scripts/run_local_diagnostic_rollback.py --effect-receipt /tmp/sentientos-local-diagnostic-effect/effect_receipt.json --rollback-plan /tmp/sentientos-local-diagnostic-effect/rollback_plan.json --output-dir-scope /tmp/sentientos-local-diagnostic-effect --dry-run --summary
+```
+
+Real rollback is explicit and deletes only the exact diagnostic artifact:
+
+```bash
+python scripts/run_local_diagnostic_rollback.py --effect-receipt /tmp/sentientos-local-diagnostic-effect/effect_receipt.json --rollback-plan /tmp/sentientos-local-diagnostic-effect/rollback_plan.json --output-dir-scope /tmp/sentientos-local-diagnostic-effect --summary
+```
+
+`--allow-missing-artifact` records that no deletion was performed when the exact artifact is already absent. It does not widen scope and does not become cleanup.
+
+## Reviewer proof bundle posture
+
+The reviewer proof bundle documents this capability in `local_diagnostic_rollback_capability.json` and lists the rollback CLI in `proof_commands.json` as `proof_command_not_run`. The proof bundle does not run the effect or rollback by default and remains no-real-effect/no-host-mutation by default.
+
+## Capability registry posture
+
+The capability registry marks `local_diagnostic_exact_rollback`, `local_diagnostic_rollback_postcondition_check`, and `local_diagnostic_rollback_audit_receipt` as implemented exact-artifact-only surfaces. General file cleanup, recursive delete, unrelated delete, fan/PWM control, thermal actuation, power mutation, service restart, package/driver install, provider/network/prompt/federation/remote execution remain blocked or deferred.
+
+## Implementation links
+
+- Module: `sentientos/local_diagnostic_effect.py`
+- CLI: `scripts/run_local_diagnostic_rollback.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_local_diagnostic_exact_rollback.py`, `tests/test_run_local_diagnostic_rollback_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/host_real_effect_capability_admission_wing.md
+++ b/docs/architecture/host_real_effect_capability_admission_wing.md
@@ -43,3 +43,5 @@ The reviewer proof bundle includes `real_effect_admission.json`. The artifact sh
 - Tests: `tests/test_real_effect_admission.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
 
 After admission, the first intentionally real low-risk effect is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), limited to an explicit diagnostic artifact write only.
+
+The next bounded real-effect organ is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), followed by the [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md) for exact-artifact-only rollback.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -272,3 +272,5 @@ See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_a
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
 
 For the first intentionally real but bounded effect, see the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), which only writes one explicit local diagnostic artifact and is not run by reviewer bundles by default.
+
+Host embodiment proof now includes an explicit [local diagnostic effect pilot](host_local_diagnostic_effect_pilot_wing.md) and matching [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); reviewer bundles document but do not run either by default.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -118,3 +118,5 @@ Proof path: docs/architecture/host_dry_run_audit_closure_wing.md
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
 
 The bundle documents but does not run the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md); its optional CLI command is listed as not run by default.
+
+The proof bundle lists, but does not run, the exact-artifact rollback CLI documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md).

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -273,3 +273,5 @@ See also: [Host Dry-Run Effect Verification / Audit Closure Wing](host_dry_run_a
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
 
 - [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) — first intentionally real effect, explicit diagnostic artifact write only, reviewer bundle does not run it by default.
+
+The exact-artifact rollback proof is documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md): it is the first real rollback and is exact diagnostic artifact only, not general cleanup.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -422,3 +422,5 @@ See also: [Host Dry-Run Execution Harness Wing](host_dry_run_execution_harness_w
 See [Host Real Effect Capability Admission Wing](host_real_effect_capability_admission_wing.md) (`docs/architecture/host_real_effect_capability_admission_wing.md`): dry-run closure does not automatically permit real effects; real effect admission is not implementation, the admission decision does not authorize implementation or execution, the plan scaffold does not start implementation, cooling/hardware control remains blocked by default, and real actuation remains deferred.
 
 The first bounded real-effect pilot is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md): one explicit local diagnostic artifact write, not hardware/service/power/cleanup control.
+
+The trajectory now includes a bounded [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md): the first real rollback, limited to the exact diagnostic artifact and not general cleanup.

--- a/scripts/run_local_diagnostic_effect.py
+++ b/scripts/run_local_diagnostic_effect.py
@@ -81,6 +81,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         created_at=args.created_at,
     )
     summary = summarize_local_diagnostic_effect_wing(records)
+    if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run:
+        output_dir = Path(args.output_dir).expanduser()
+        (output_dir / "effect_receipt.json").write_text(json.dumps(records.receipt.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (output_dir / "rollback_plan.json").write_text(json.dumps(records.rollback_plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
     payload = _compact_summary(summary, dry_run=args.dry_run) if args.summary else {
         "request": records.request.to_dict(),
         "result": records.result.to_dict(),
@@ -89,6 +94,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "rollback_plan": records.rollback_plan.to_dict(),
         "rollback_receipt": records.rollback_receipt.to_dict(),
         "production_audit_receipt": records.production_audit_receipt.to_dict(),
+        "effect_receipt_path": str(Path(args.output_dir).expanduser() / "effect_receipt.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
+        "rollback_plan_path": str(Path(args.output_dir).expanduser() / "rollback_plan.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
     if records.result.effect_status == "local_diagnostic_effect_performed" or args.dry_run:

--- a/scripts/run_local_diagnostic_rollback.py
+++ b/scripts/run_local_diagnostic_rollback.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Run the explicit exact-artifact local diagnostic rollback pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.local_diagnostic_effect import (  # noqa: E402
+    build_local_diagnostic_exact_rollback_request,
+    perform_local_diagnostic_exact_rollback,
+    build_local_diagnostic_exact_rollback_receipt,
+    perform_local_diagnostic_rollback_postcondition_check,
+    build_local_diagnostic_rollback_audit_receipt,
+    run_local_diagnostic_exact_rollback_wing,
+    summarize_local_diagnostic_exact_rollback_wing,
+    validate_local_diagnostic_exact_rollback_request,
+)
+
+
+def _load_json(path: str) -> dict[str, object]:
+    return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+
+
+def _compact(summary: dict[str, object], *, dry_run: bool) -> dict[str, object]:
+    request = summary["request"]  # type: ignore[index]
+    result = summary["result"]  # type: ignore[index]
+    receipt = summary["receipt"]  # type: ignore[index]
+    postcondition = summary["postcondition_check"]  # type: ignore[index]
+    audit = summary["rollback_audit_receipt"]  # type: ignore[index]
+    return {
+        "dry_run": dry_run,
+        "request_status": request["request_status"],
+        "output_path": result["output_path"],
+        "would_delete_exact_artifact": dry_run and request["request_status"] == "local_diagnostic_exact_rollback_requested",
+        "rollback_status": result["rollback_status"],
+        "real_rollback_performed": result["real_rollback_performed"],
+        "file_delete_performed": result["file_delete_performed"],
+        "host_mutation_performed": result["host_mutation_performed"],
+        "exact_artifact_only": receipt["exact_artifact_only"],
+        "general_cleanup_performed": receipt["general_cleanup_performed"],
+        "directory_cleanup_performed": receipt["directory_cleanup_performed"],
+        "recursive_delete_performed": receipt["recursive_delete_performed"],
+        "wildcard_delete_performed": receipt["wildcard_delete_performed"],
+        "unrelated_file_delete_performed": receipt["unrelated_file_delete_performed"],
+        "postcondition_status": postcondition["postcondition_status"],
+        "observed_exists": postcondition["observed_exists"],
+        "audit_status": audit["audit_status"],
+        "audit_for_exact_local_diagnostic_artifact_only": audit["audit_for_exact_local_diagnostic_artifact_only"],
+        "network_performed": receipt["network_performed"],
+        "provider_invocation_performed": receipt["provider_invocation_performed"],
+        "prompt_assembly_performed": receipt["prompt_assembly_performed"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Delete only the exact local diagnostic artifact proven by receipt and rollback plan")
+    parser.add_argument("--effect-receipt", required=True, help="path to effect_receipt.json from the local diagnostic effect pilot")
+    parser.add_argument("--rollback-plan", required=True, help="path to rollback_plan.json from the local diagnostic effect pilot")
+    parser.add_argument("--output-dir-scope", required=True, help="explicit directory scope containing the exact artifact")
+    parser.add_argument("--allow-missing-artifact", action="store_true", help="record no deletion if the exact artifact is already absent")
+    parser.add_argument("--summary", action="store_true", help="print compact summary instead of full rollback records")
+    parser.add_argument("--dry-run", action="store_true", help="validate and report the exact artifact path without deleting it")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00", help="deterministic timestamp for records")
+    args = parser.parse_args(argv)
+
+    effect_receipt = _load_json(args.effect_receipt)
+    rollback_plan = _load_json(args.rollback_plan)
+    request = build_local_diagnostic_exact_rollback_request(
+        effect_receipt,
+        rollback_plan,
+        output_dir_scope=args.output_dir_scope,
+        allow_missing_artifact=args.allow_missing_artifact,
+        created_at=args.created_at,
+    )
+    validation = validate_local_diagnostic_exact_rollback_request(request)
+    if not validation.ok:
+        print("local diagnostic exact rollback request rejected: " + ", ".join(validation.findings), file=sys.stderr)
+        return 2
+
+    records = run_local_diagnostic_exact_rollback_wing(
+        effect_receipt,
+        rollback_plan,
+        output_dir_scope=args.output_dir_scope,
+        allow_missing_artifact=args.allow_missing_artifact,
+        dry_run=args.dry_run,
+        created_at=args.created_at,
+    )
+    summary = summarize_local_diagnostic_exact_rollback_wing(records)
+    payload = _compact(summary, dry_run=args.dry_run) if args.summary else {
+        "request": records.request.to_dict(),
+        "result": records.result.to_dict(),
+        "receipt": records.receipt.to_dict(),
+        "postcondition_check": records.postcondition_check.to_dict(),
+        "rollback_audit_receipt": records.audit_receipt.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if args.dry_run:
+        return 0
+    if records.result.rollback_status in {"local_diagnostic_exact_rollback_performed", "local_diagnostic_exact_rollback_missing_artifact"} and (records.result.real_rollback_performed or args.allow_missing_artifact):
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -103,6 +103,9 @@ AUTHORITY_LEVELS = frozenset(
         "real_effect_receipt_only",
         "real_postcondition_check_only",
         "production_audit_only",
+        "exact_artifact_rollback_only",
+        "exact_artifact_postcondition_only",
+        "exact_artifact_rollback_audit_only",
         "candidate_only",
         "plan_scaffold_only",
         "block_receipt_only",
@@ -347,7 +350,10 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("local_diagnostic_postcondition_check", "local_diagnostic_effect", "implemented", "real_postcondition_check_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("readback postcondition check for the exact diagnostic artifact only",), deferred_surfaces=("general host postcondition checks",), forbidden_implications=("postcondition readback scans broad filesystem")),
         _record("local_diagnostic_production_audit_receipt", "local_diagnostic_effect", "implemented", "production_audit_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("production audit receipt for local diagnostic artifact effect only",), deferred_surfaces=("production audits for general host effects",), forbidden_implications=("diagnostic audit authorizes broader effects")),
         _record("local_diagnostic_rollback_plan", "local_diagnostic_effect", "implemented", "plan_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), implemented_surfaces=("rollback plan and non-executed rollback receipt scaffold",), deferred_surfaces=("automatic exact-artifact rollback execution"), forbidden_implications=("rollback plan deletes files"), requires_rollback_receipt=True),
-        _record("local_diagnostic_rollback_execution", "local_diagnostic_effect", "deferred", "none", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), deferred_surfaces=("exact-artifact rollback deletion requires explicit future implementation"), forbidden_implications=("rollback scaffold performs deletion")),
+        _record("local_diagnostic_exact_rollback", "local_diagnostic_effect", "implemented", "exact_artifact_rollback_only", source_paths=("sentientos/local_diagnostic_effect.py", "scripts/run_local_diagnostic_rollback.py"), proof_tests=("tests/test_local_diagnostic_exact_rollback.py", "tests/test_run_local_diagnostic_rollback_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_local_diagnostic_exact_rollback.py tests/test_run_local_diagnostic_rollback_script.py", "python scripts/run_local_diagnostic_rollback.py --effect-receipt <receipt.json> --rollback-plan <rollback-plan.json> --output-dir-scope /tmp/sentientos-local-effect --summary"), implemented_surfaces=("explicit exact-artifact rollback for local diagnostic artifact only", "path, digest, plan, receipt, and scope gated single Path.unlink"), deferred_surfaces=("general cleanup", "recursive delete", "wildcard delete", "unrelated file delete", "hardware control", "service control"), forbidden_implications=("exact diagnostic rollback is general cleanup", "exact diagnostic rollback deletes directories, siblings, wildcard matches, or unrelated files"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("local_diagnostic_rollback_postcondition_check", "local_diagnostic_effect", "implemented", "exact_artifact_postcondition_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_exact_rollback.py",), implemented_surfaces=("postcondition check verifies exact artifact path absence only",), deferred_surfaces=("broad filesystem checks",), forbidden_implications=("rollback postcondition scans broad filesystem")),
+        _record("local_diagnostic_rollback_audit_receipt", "local_diagnostic_effect", "implemented", "exact_artifact_rollback_audit_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_exact_rollback.py",), implemented_surfaces=("audit receipt for exact local diagnostic artifact rollback only",), deferred_surfaces=("general rollback audits",), forbidden_implications=("rollback audit authorizes cleanup or unrelated deletion")),
+        _record("local_diagnostic_rollback_execution", "local_diagnostic_effect", "deferred", "none", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), deferred_surfaces=("general rollback execution outside exact local diagnostic artifact"), forbidden_implications=("rollback scaffold performs deletion")),
         _record("real_backend_implementation", "real_effect_admission", "deferred", "none", deferred_surfaces=("real backend implementation", "OS backend implementation"), forbidden_implications=("real effect admission implements backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_receipt_creation", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real effect receipt creation",), forbidden_implications=("dry-run audit closure creates real effect receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_postcondition_check", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real host postcondition checking",), forbidden_implications=("dry-run audit closure checks real host postconditions",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -1151,3 +1157,23 @@ def update_registry_from_executor_contract_readiness(registry: CapabilityRegistr
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-fulfillment-executor-contract-wing.v1")
+
+
+def update_registry_from_local_diagnostic_rollback_receipt(registry: CapabilityRegistry, receipt: Any) -> CapabilityRegistry:
+    """Reflect exact local diagnostic artifact rollback without widening cleanup authority."""
+
+    payload = receipt.to_dict() if hasattr(receipt, "to_dict") else dict(receipt)
+    performed = bool(payload.get("real_rollback_performed")) and bool(payload.get("exact_artifact_only"))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "local_diagnostic_exact_rollback":
+            records.append(replace(record, status="implemented", authority_level="exact_artifact_rollback_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_diagnostic_rollback_postcondition_check":
+            records.append(replace(record, status="implemented", authority_level="exact_artifact_postcondition_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_diagnostic_rollback_audit_receipt":
+            records.append(replace(record, status="implemented", authority_level="exact_artifact_rollback_audit_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"real_file_cleanup", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "provider_invocation", "federation_transport_sync_adoption"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-local-diagnostic-exact-rollback-wing.v1")

--- a/sentientos/local_diagnostic_effect.py
+++ b/sentientos/local_diagnostic_effect.py
@@ -838,3 +838,661 @@ def run_local_diagnostic_effect_wing(
     rollback_receipt = build_local_diagnostic_rollback_receipt(rollback_plan, created_at=created_at)
     audit = build_local_diagnostic_production_audit_receipt(receipt, postcondition, rollback_plan, rollback_receipt, created_at=created_at)
     return LocalDiagnosticEffectWingRecords(request, result, receipt, postcondition, rollback_plan, rollback_receipt, audit)
+
+
+# Host Embodiment Exact Artifact Rollback Pilot Wing -----------------------
+# This deliberately narrow wing is the first intentionally real rollback pilot:
+# it may remove only the exact diagnostic artifact path proven by the local
+# diagnostic effect receipt and rollback plan.
+
+EXACT_ROLLBACK_REQUEST_STATUSES = frozenset({
+    "local_diagnostic_exact_rollback_requested",
+    "local_diagnostic_exact_rollback_blocked",
+    "local_diagnostic_exact_rollback_incomplete",
+    "local_diagnostic_exact_rollback_contradicted",
+})
+EXACT_ROLLBACK_RESULT_STATUSES = frozenset({
+    "local_diagnostic_exact_rollback_performed",
+    "local_diagnostic_exact_rollback_blocked",
+    "local_diagnostic_exact_rollback_missing_artifact",
+    "local_diagnostic_exact_rollback_digest_mismatch",
+    "local_diagnostic_exact_rollback_scope_mismatch",
+    "local_diagnostic_exact_rollback_incomplete",
+    "local_diagnostic_exact_rollback_contradicted",
+})
+EXACT_ROLLBACK_RECEIPT_STATUSES = frozenset({
+    "local_diagnostic_exact_rollback_receipt_recorded",
+    "local_diagnostic_exact_rollback_receipt_recorded_with_warnings",
+    "local_diagnostic_exact_rollback_receipt_blocked",
+    "local_diagnostic_exact_rollback_receipt_incomplete",
+    "local_diagnostic_exact_rollback_receipt_contradicted",
+})
+ROLLBACK_POSTCONDITION_STATUSES = frozenset({
+    "local_diagnostic_rollback_postcondition_passed",
+    "local_diagnostic_rollback_postcondition_failed",
+    "local_diagnostic_rollback_postcondition_blocked",
+    "local_diagnostic_rollback_postcondition_incomplete",
+    "local_diagnostic_rollback_postcondition_contradicted",
+})
+ROLLBACK_AUDIT_STATUSES = frozenset({
+    "local_diagnostic_rollback_audit_recorded",
+    "local_diagnostic_rollback_audit_recorded_with_warnings",
+    "local_diagnostic_rollback_audit_blocked",
+    "local_diagnostic_rollback_audit_incomplete",
+    "local_diagnostic_rollback_audit_contradicted",
+})
+EXACT_ROLLBACK_BLOCKED_ACTION_LABELS = (
+    "directory_cleanup",
+    "recursive_delete",
+    "wildcard_delete",
+    "unrelated_file_delete",
+    "file_delete_outside_artifact_scope",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+    "hardware_control",
+)
+_EXACT_ROLLBACK_FORBIDDEN_RESULT_FLAGS = (
+    "directory_cleanup_performed",
+    "recursive_delete_performed",
+    "wildcard_delete_performed",
+    "unrelated_file_delete_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+)
+_EXACT_ROLLBACK_FORBIDDEN_REQUEST_FLAGS = (
+    "general_cleanup_requested",
+    "recursive_delete_requested",
+    "wildcard_delete_requested",
+    "network_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+    "subprocess_performed",
+    "shell_performed",
+)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticExactRollbackValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticExactRollbackRequest:
+    request_id: str
+    source_effect_receipt_id: str
+    source_effect_receipt_digest: str
+    source_rollback_plan_id: str
+    source_rollback_plan_digest: str
+    expected_output_path: str
+    expected_artifact_digest: str
+    output_dir_scope: str
+    allow_missing_artifact: bool
+    request_status: str
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    exact_artifact_rollback_requested: bool = True
+    general_cleanup_requested: bool = False
+    recursive_delete_requested: bool = False
+    wildcard_delete_requested: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    subprocess_performed: bool = False
+    shell_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticExactRollbackResult:
+    result_id: str
+    request_id: str
+    output_path: str
+    expected_artifact_digest: str
+    observed_artifact_digest: str | None
+    rollback_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_rollback_performed: bool = False
+    file_delete_performed: bool = False
+    host_mutation_performed: bool = False
+    directory_cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticExactRollbackReceipt:
+    receipt_id: str
+    request_id: str
+    result_id: str
+    source_effect_receipt_id: str
+    source_rollback_plan_id: str
+    output_path: str
+    expected_artifact_digest: str
+    observed_artifact_digest: str | None
+    rollback_status: str
+    evidence_summary: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_rollback_receipt_created: bool = False
+    real_rollback_performed: bool = False
+    file_delete_performed: bool = False
+    host_mutation_performed: bool = False
+    exact_artifact_only: bool = True
+    general_cleanup_performed: bool = False
+    directory_cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+    provider_invocation_performed: bool = False
+    network_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticRollbackPostconditionCheck:
+    check_id: str
+    rollback_receipt_id: str
+    output_path: str
+    expected_absent: bool
+    observed_exists: bool
+    postcondition_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    real_rollback_postcondition_check_performed: bool = True
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalDiagnosticRollbackAuditReceipt:
+    audit_id: str
+    rollback_receipt_id: str
+    rollback_postcondition_check_id: str
+    source_effect_receipt_id: str
+    audit_status: str
+    evidence_summary: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    production_rollback_audit_receipt_created: bool = True
+    audit_for_exact_local_diagnostic_artifact_only: bool = True
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class LocalDiagnosticExactRollbackWingRecords(NamedTuple):
+    request: LocalDiagnosticExactRollbackRequest
+    result: LocalDiagnosticExactRollbackResult
+    receipt: LocalDiagnosticExactRollbackReceipt
+    postcondition_check: LocalDiagnosticRollbackPostconditionCheck
+    audit_receipt: LocalDiagnosticRollbackAuditReceipt
+
+
+local_diagnostic_exact_rollback_request_digest = local_diagnostic_effect_digest
+local_diagnostic_exact_rollback_result_digest = local_diagnostic_effect_digest
+local_diagnostic_exact_rollback_receipt_digest = local_diagnostic_effect_digest
+local_diagnostic_rollback_postcondition_check_digest = local_diagnostic_effect_digest
+local_diagnostic_rollback_audit_receipt_digest = local_diagnostic_effect_digest
+
+
+def _is_root_path(path: Path) -> bool:
+    resolved = path.expanduser().resolve(strict=False)
+    return str(resolved) == resolved.anchor
+
+
+def _path_inside_scope(path: Path, scope: Path) -> bool:
+    resolved_path = path.expanduser().resolve(strict=False)
+    resolved_scope = scope.expanduser().resolve(strict=False)
+    try:
+        resolved_path.relative_to(resolved_scope)
+    except ValueError:
+        return False
+    return True
+
+
+def _exact_rollback_common_findings(request: LocalDiagnosticExactRollbackRequest | Mapping[str, Any]) -> list[str]:
+    p = _source_payload(request)
+    findings: list[str] = []
+    output = Path(str(p.get("expected_output_path", ""))).expanduser()
+    scope = Path(str(p.get("output_dir_scope", ""))).expanduser()
+    if not str(p.get("expected_output_path", "")).strip():
+        findings.append("missing_expected_output_path")
+    if not str(p.get("output_dir_scope", "")).strip():
+        findings.append("missing_output_dir_scope")
+    elif _is_root_path(scope):
+        findings.append("output_dir_scope_is_filesystem_root")
+    if str(p.get("expected_output_path", "")).strip() and str(p.get("output_dir_scope", "")).strip() and not _path_inside_scope(output, scope):
+        findings.append("output_path_outside_scope")
+    if str(p.get("expected_output_path", "")).strip() and _is_root_path(output):
+        findings.append("output_path_is_filesystem_root")
+    if p.get("request_status") not in EXACT_ROLLBACK_REQUEST_STATUSES:
+        findings.append("unknown_request_status")
+    if not p.get("exact_artifact_rollback_requested"):
+        findings.append("exact_artifact_rollback_not_requested")
+    for flag in _EXACT_ROLLBACK_FORBIDDEN_REQUEST_FLAGS:
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    blocked = tuple(p.get("blocked_actions", ()))
+    missing_blocked = tuple(label for label in EXACT_ROLLBACK_BLOCKED_ACTION_LABELS if label not in blocked)
+    if missing_blocked:
+        findings.append("missing_blocked_action_labels")
+    return findings
+
+
+def build_local_diagnostic_exact_rollback_request(
+    effect_receipt: LocalDiagnosticEffectReceipt | Mapping[str, Any],
+    rollback_plan: LocalDiagnosticRollbackPlan | Mapping[str, Any],
+    *,
+    output_dir_scope: str | Path,
+    allow_missing_artifact: bool = False,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> LocalDiagnosticExactRollbackRequest:
+    receipt = _source_payload(effect_receipt)
+    plan = _source_payload(rollback_plan)
+    warnings: list[str] = []
+    status = "local_diagnostic_exact_rollback_requested"
+    if not receipt.get("real_effect_performed") or receipt.get("effect_status") != "local_diagnostic_effect_performed":
+        warnings.append("source_effect_receipt_not_successful")
+    if not receipt.get("digest"):
+        warnings.append("source_effect_receipt_digest_missing")
+    if not plan.get("digest"):
+        warnings.append("source_rollback_plan_digest_missing")
+    if plan.get("receipt_id") != receipt.get("receipt_id"):
+        warnings.append("rollback_plan_receipt_mismatch")
+    if str(plan.get("output_path", "")) != str(receipt.get("output_path", "")):
+        warnings.append("rollback_plan_output_path_mismatch")
+    expected_path = str(receipt.get("output_path", ""))
+    expected_digest = str(receipt.get("artifact_digest", ""))
+    payload = {
+        "request_id": "",
+        "source_effect_receipt_id": str(receipt.get("receipt_id", "")),
+        "source_effect_receipt_digest": str(receipt.get("digest", "")),
+        "source_rollback_plan_id": str(plan.get("plan_id", "")),
+        "source_rollback_plan_digest": str(plan.get("digest", "")),
+        "expected_output_path": expected_path,
+        "expected_artifact_digest": expected_digest,
+        "output_dir_scope": str(output_dir_scope),
+        "allow_missing_artifact": bool(allow_missing_artifact),
+        "request_status": status,
+        "blocked_actions": EXACT_ROLLBACK_BLOCKED_ACTION_LABELS,
+        "warning_codes": tuple(warnings),
+        "risk_codes": tuple(receipt.get("risk_codes", ())) + ("tier1_exact_artifact_rollback_is_real_host_mutation",),
+        "created_at": created_at,
+        "digest": "",
+        "exact_artifact_rollback_requested": True,
+        "general_cleanup_requested": False,
+        "recursive_delete_requested": False,
+        "wildcard_delete_requested": False,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+        "subprocess_performed": False,
+        "shell_performed": False,
+    }
+    preliminary = dict(payload)
+    preliminary["request_status"] = "local_diagnostic_exact_rollback_blocked" if warnings else status
+    common_findings = _exact_rollback_common_findings(preliminary)
+    if common_findings:
+        warnings.extend(item for item in common_findings if item not in warnings)
+    payload["warning_codes"] = tuple(warnings)
+    payload["request_status"] = "local_diagnostic_exact_rollback_requested" if not warnings else "local_diagnostic_exact_rollback_blocked"
+    payload["request_id"] = _digest_id("local-diagnostic-exact-rollback-request-", payload)
+    payload["digest"] = local_diagnostic_exact_rollback_request_digest(payload)
+    return LocalDiagnosticExactRollbackRequest(**payload)
+
+
+def validate_local_diagnostic_exact_rollback_request(request: LocalDiagnosticExactRollbackRequest | Mapping[str, Any]) -> LocalDiagnosticExactRollbackValidationResult:
+    p = _source_payload(request)
+    findings = _exact_rollback_common_findings(request)
+    if not p.get("source_effect_receipt_id"):
+        findings.append("missing_source_effect_receipt_id")
+    if not p.get("source_rollback_plan_id"):
+        findings.append("missing_source_rollback_plan_id")
+    ok = not findings and p.get("request_status") == "local_diagnostic_exact_rollback_requested"
+    return LocalDiagnosticExactRollbackValidationResult(ok=ok, findings=tuple(findings))
+
+
+def _rollback_result_payload(
+    request: LocalDiagnosticExactRollbackRequest,
+    *,
+    status: str,
+    observed_digest: str | None,
+    warnings: Sequence[str],
+    created_at: str,
+    performed: bool = False,
+) -> dict[str, Any]:
+    payload = {
+        "result_id": "",
+        "request_id": request.request_id,
+        "output_path": request.expected_output_path,
+        "expected_artifact_digest": request.expected_artifact_digest,
+        "observed_artifact_digest": observed_digest,
+        "rollback_status": status,
+        "warning_codes": tuple(warnings),
+        "risk_codes": request.risk_codes,
+        "created_at": created_at,
+        "digest": "",
+        "real_rollback_performed": performed,
+        "file_delete_performed": performed,
+        "host_mutation_performed": performed,
+    }
+    payload["result_id"] = _digest_id("local-diagnostic-exact-rollback-result-", payload)
+    payload["digest"] = local_diagnostic_exact_rollback_result_digest(payload)
+    return payload
+
+
+def perform_local_diagnostic_exact_rollback(
+    request: LocalDiagnosticExactRollbackRequest,
+    *,
+    dry_run: bool = False,
+    created_at: str | None = None,
+) -> LocalDiagnosticExactRollbackResult:
+    created = created_at or request.created_at
+    validation = validate_local_diagnostic_exact_rollback_request(request)
+    if not validation.ok:
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_blocked", observed_digest=None, warnings=validation.findings, created_at=created))
+    output = Path(request.expected_output_path).expanduser()
+    scope = Path(request.output_dir_scope).expanduser()
+    if _is_root_path(scope):
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_scope_mismatch", observed_digest=None, warnings=("output_dir_scope_is_filesystem_root",), created_at=created))
+    if _is_root_path(output):
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_scope_mismatch", observed_digest=None, warnings=("output_path_is_filesystem_root",), created_at=created))
+    if not _path_inside_scope(output, scope):
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_scope_mismatch", observed_digest=None, warnings=("output_path_outside_scope",), created_at=created))
+    if output.is_symlink():
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_blocked", observed_digest=None, warnings=("output_path_is_symlink",), created_at=created))
+    if not output.exists():
+        status = "local_diagnostic_exact_rollback_missing_artifact"
+        warnings = ("artifact_missing_no_deletion_performed",)
+        if request.allow_missing_artifact:
+            warnings = ("artifact_already_absent_no_deletion_performed",)
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status=status, observed_digest=None, warnings=warnings, created_at=created))
+    if output.is_dir():
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_blocked", observed_digest=None, warnings=("output_path_is_directory",), created_at=created))
+    data = output.read_bytes()
+    observed = _artifact_digest(data)
+    if observed != request.expected_artifact_digest:
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_digest_mismatch", observed_digest=observed, warnings=("artifact_digest_mismatch",), created_at=created))
+    if dry_run:
+        return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_blocked", observed_digest=observed, warnings=("dry_run_no_delete_performed",), created_at=created))
+    output.unlink()
+    return LocalDiagnosticExactRollbackResult(**_rollback_result_payload(request, status="local_diagnostic_exact_rollback_performed", observed_digest=observed, warnings=(), created_at=created, performed=True))
+
+
+def validate_local_diagnostic_exact_rollback_result(result: LocalDiagnosticExactRollbackResult | Mapping[str, Any]) -> LocalDiagnosticExactRollbackValidationResult:
+    p = _source_payload(result)
+    findings = []
+    if p.get("rollback_status") not in EXACT_ROLLBACK_RESULT_STATUSES:
+        findings.append("unknown_rollback_status")
+    performed = p.get("rollback_status") == "local_diagnostic_exact_rollback_performed"
+    for flag in ("real_rollback_performed", "file_delete_performed", "host_mutation_performed"):
+        if bool(p.get(flag)) != performed:
+            findings.append(f"{flag}_mismatch")
+    for flag in _EXACT_ROLLBACK_FORBIDDEN_RESULT_FLAGS:
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticExactRollbackValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def build_local_diagnostic_exact_rollback_receipt(
+    request: LocalDiagnosticExactRollbackRequest,
+    result: LocalDiagnosticExactRollbackResult,
+    *,
+    created_at: str | None = None,
+) -> LocalDiagnosticExactRollbackReceipt:
+    success = result.rollback_status == "local_diagnostic_exact_rollback_performed"
+    status = "local_diagnostic_exact_rollback_receipt_recorded" if success else "local_diagnostic_exact_rollback_receipt_recorded_with_warnings"
+    if result.rollback_status in {"local_diagnostic_exact_rollback_blocked", "local_diagnostic_exact_rollback_scope_mismatch", "local_diagnostic_exact_rollback_digest_mismatch"}:
+        status = "local_diagnostic_exact_rollback_receipt_blocked"
+    evidence = ("exact diagnostic artifact path deleted after receipt, plan, scope, and digest validation",) if success else ("no exact artifact deletion performed",)
+    payload = {
+        "receipt_id": "",
+        "request_id": request.request_id,
+        "result_id": result.result_id,
+        "source_effect_receipt_id": request.source_effect_receipt_id,
+        "source_rollback_plan_id": request.source_rollback_plan_id,
+        "output_path": result.output_path,
+        "expected_artifact_digest": result.expected_artifact_digest,
+        "observed_artifact_digest": result.observed_artifact_digest,
+        "rollback_status": status,
+        "evidence_summary": evidence,
+        "blocked_actions": request.blocked_actions,
+        "warning_codes": result.warning_codes,
+        "risk_codes": result.risk_codes,
+        "created_at": created_at or result.created_at,
+        "digest": "",
+        "real_rollback_receipt_created": success,
+        "real_rollback_performed": success,
+        "file_delete_performed": success,
+        "host_mutation_performed": success,
+        "exact_artifact_only": True,
+    }
+    payload["receipt_id"] = _digest_id("local-diagnostic-exact-rollback-receipt-", payload)
+    payload["digest"] = local_diagnostic_exact_rollback_receipt_digest(payload)
+    return LocalDiagnosticExactRollbackReceipt(**payload)
+
+
+def validate_local_diagnostic_exact_rollback_receipt(receipt: LocalDiagnosticExactRollbackReceipt | Mapping[str, Any]) -> LocalDiagnosticExactRollbackValidationResult:
+    p = _source_payload(receipt)
+    findings = []
+    if p.get("rollback_status") not in EXACT_ROLLBACK_RECEIPT_STATUSES:
+        findings.append("unknown_rollback_receipt_status")
+    success = p.get("rollback_status") == "local_diagnostic_exact_rollback_receipt_recorded"
+    for flag in ("real_rollback_receipt_created", "real_rollback_performed", "file_delete_performed", "host_mutation_performed"):
+        if bool(p.get(flag)) != success:
+            findings.append(f"{flag}_mismatch")
+    if not p.get("exact_artifact_only"):
+        findings.append("not_exact_artifact_only")
+    for flag in ("general_cleanup_performed",) + _EXACT_ROLLBACK_FORBIDDEN_RESULT_FLAGS:
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticExactRollbackValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def perform_local_diagnostic_rollback_postcondition_check(
+    rollback_receipt: LocalDiagnosticExactRollbackReceipt,
+    *,
+    created_at: str | None = None,
+) -> LocalDiagnosticRollbackPostconditionCheck:
+    exists = Path(rollback_receipt.output_path).expanduser().exists()
+    status = "local_diagnostic_rollback_postcondition_passed" if not exists else "local_diagnostic_rollback_postcondition_failed"
+    payload = {
+        "check_id": "",
+        "rollback_receipt_id": rollback_receipt.receipt_id,
+        "output_path": rollback_receipt.output_path,
+        "expected_absent": True,
+        "observed_exists": exists,
+        "postcondition_status": status,
+        "warning_codes": () if not exists else ("artifact_still_exists",),
+        "risk_codes": rollback_receipt.risk_codes,
+        "created_at": created_at or rollback_receipt.created_at,
+        "digest": "",
+        "real_rollback_postcondition_check_performed": True,
+        "host_mutation_performed": False,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+    }
+    payload["check_id"] = _digest_id("local-diagnostic-rollback-postcondition-", payload)
+    payload["digest"] = local_diagnostic_rollback_postcondition_check_digest(payload)
+    return LocalDiagnosticRollbackPostconditionCheck(**payload)
+
+
+def validate_local_diagnostic_rollback_postcondition_check(check: LocalDiagnosticRollbackPostconditionCheck | Mapping[str, Any]) -> LocalDiagnosticExactRollbackValidationResult:
+    p = _source_payload(check)
+    findings = []
+    if p.get("postcondition_status") not in ROLLBACK_POSTCONDITION_STATUSES:
+        findings.append("unknown_postcondition_status")
+    for flag in ("host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticExactRollbackValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def build_local_diagnostic_rollback_audit_receipt(
+    rollback_receipt: LocalDiagnosticExactRollbackReceipt,
+    postcondition_check: LocalDiagnosticRollbackPostconditionCheck,
+    *,
+    created_at: str | None = None,
+) -> LocalDiagnosticRollbackAuditReceipt:
+    ok = rollback_receipt.rollback_status == "local_diagnostic_exact_rollback_receipt_recorded" and postcondition_check.postcondition_status == "local_diagnostic_rollback_postcondition_passed"
+    status = "local_diagnostic_rollback_audit_recorded" if ok else "local_diagnostic_rollback_audit_recorded_with_warnings"
+    payload = {
+        "audit_id": "",
+        "rollback_receipt_id": rollback_receipt.receipt_id,
+        "rollback_postcondition_check_id": postcondition_check.check_id,
+        "source_effect_receipt_id": rollback_receipt.source_effect_receipt_id,
+        "audit_status": status,
+        "evidence_summary": ("exact artifact rollback receipt recorded", "postcondition confirms exact artifact path absent", "no cleanup, recursive, wildcard, sibling, hardware, service, network, provider, prompt, shell, subprocess, OS, or control-plane action recorded"),
+        "warning_codes": tuple(rollback_receipt.warning_codes + postcondition_check.warning_codes),
+        "risk_codes": rollback_receipt.risk_codes,
+        "created_at": created_at or rollback_receipt.created_at,
+        "digest": "",
+        "production_rollback_audit_receipt_created": True,
+        "audit_for_exact_local_diagnostic_artifact_only": True,
+        "host_mutation_performed": False,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+    }
+    payload["audit_id"] = _digest_id("local-diagnostic-rollback-audit-", payload)
+    payload["digest"] = local_diagnostic_rollback_audit_receipt_digest(payload)
+    return LocalDiagnosticRollbackAuditReceipt(**payload)
+
+
+def validate_local_diagnostic_rollback_audit_receipt(receipt: LocalDiagnosticRollbackAuditReceipt | Mapping[str, Any]) -> LocalDiagnosticExactRollbackValidationResult:
+    p = _source_payload(receipt)
+    findings = []
+    if p.get("audit_status") not in ROLLBACK_AUDIT_STATUSES:
+        findings.append("unknown_audit_status")
+    if not p.get("production_rollback_audit_receipt_created"):
+        findings.append("missing_production_rollback_audit_receipt")
+    if not p.get("audit_for_exact_local_diagnostic_artifact_only"):
+        findings.append("not_exact_local_diagnostic_artifact_only")
+    for flag in ("host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"forbidden_{flag}")
+    return LocalDiagnosticExactRollbackValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def summarize_local_diagnostic_exact_rollback_request(record: LocalDiagnosticExactRollbackRequest | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("request_id", "source_effect_receipt_id", "source_rollback_plan_id", "expected_output_path", "expected_artifact_digest", "output_dir_scope", "allow_missing_artifact", "request_status", "exact_artifact_rollback_requested", "general_cleanup_requested", "recursive_delete_requested", "wildcard_delete_requested", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "subprocess_performed", "shell_performed", "digest")}
+
+
+def summarize_local_diagnostic_exact_rollback_result(record: LocalDiagnosticExactRollbackResult | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("result_id", "request_id", "output_path", "expected_artifact_digest", "observed_artifact_digest", "rollback_status", "real_rollback_performed", "file_delete_performed", "host_mutation_performed", "directory_cleanup_performed", "recursive_delete_performed", "wildcard_delete_performed", "unrelated_file_delete_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "package_install_performed", "driver_install_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_exact_rollback_receipt(record: LocalDiagnosticExactRollbackReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("receipt_id", "request_id", "result_id", "source_effect_receipt_id", "source_rollback_plan_id", "output_path", "expected_artifact_digest", "observed_artifact_digest", "rollback_status", "real_rollback_receipt_created", "real_rollback_performed", "file_delete_performed", "host_mutation_performed", "exact_artifact_only", "general_cleanup_performed", "directory_cleanup_performed", "recursive_delete_performed", "wildcard_delete_performed", "unrelated_file_delete_performed", "fan_pwm_write_performed", "thermal_actuation_performed", "power_profile_mutation_performed", "service_restart_performed", "package_install_performed", "driver_install_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_rollback_postcondition_check(record: LocalDiagnosticRollbackPostconditionCheck | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("check_id", "rollback_receipt_id", "output_path", "expected_absent", "observed_exists", "postcondition_status", "real_rollback_postcondition_check_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_rollback_audit_receipt(record: LocalDiagnosticRollbackAuditReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(record)
+    return {k: p.get(k) for k in ("audit_id", "rollback_receipt_id", "rollback_postcondition_check_id", "source_effect_receipt_id", "audit_status", "production_rollback_audit_receipt_created", "audit_for_exact_local_diagnostic_artifact_only", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}
+
+
+def summarize_local_diagnostic_exact_rollback_wing(records: LocalDiagnosticExactRollbackWingRecords) -> dict[str, Any]:
+    return {
+        "request": summarize_local_diagnostic_exact_rollback_request(records.request),
+        "result": summarize_local_diagnostic_exact_rollback_result(records.result),
+        "receipt": summarize_local_diagnostic_exact_rollback_receipt(records.receipt),
+        "postcondition_check": summarize_local_diagnostic_rollback_postcondition_check(records.postcondition_check),
+        "rollback_audit_receipt": summarize_local_diagnostic_rollback_audit_receipt(records.audit_receipt),
+    }
+
+
+def run_local_diagnostic_exact_rollback_wing(
+    effect_receipt: LocalDiagnosticEffectReceipt | Mapping[str, Any],
+    rollback_plan: LocalDiagnosticRollbackPlan | Mapping[str, Any],
+    *,
+    output_dir_scope: str | Path,
+    allow_missing_artifact: bool = False,
+    dry_run: bool = False,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> LocalDiagnosticExactRollbackWingRecords:
+    request = build_local_diagnostic_exact_rollback_request(effect_receipt, rollback_plan, output_dir_scope=output_dir_scope, allow_missing_artifact=allow_missing_artifact, created_at=created_at)
+    result = perform_local_diagnostic_exact_rollback(request, dry_run=dry_run, created_at=created_at)
+    receipt = build_local_diagnostic_exact_rollback_receipt(request, result, created_at=created_at)
+    postcondition = perform_local_diagnostic_rollback_postcondition_check(receipt, created_at=created_at)
+    audit = build_local_diagnostic_rollback_audit_receipt(receipt, postcondition, created_at=created_at)
+    return LocalDiagnosticExactRollbackWingRecords(request, result, receipt, postcondition, audit)

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -114,6 +114,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "dry_run_audit_closure_posture",
         "real_effect_admission_posture",
         "local_diagnostic_effect_capability",
+        "local_diagnostic_rollback_capability",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -143,6 +144,7 @@ BUNDLE_FILE_NAMES = {
     "dry_run_audit_closure_posture": "dry_run_audit_closure.json",
     "real_effect_admission_posture": "real_effect_admission.json",
     "local_diagnostic_effect_capability": "local_diagnostic_effect_capability.json",
+    "local_diagnostic_rollback_capability": "local_diagnostic_rollback_capability.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -311,6 +313,7 @@ def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord,
         (("python", "scripts/build_docs.py"), "Build documentation locally."),
         (("python", "scripts/verify_context_hygiene_prompt_boundaries.py"), "Verify prompt/provider boundary hygiene."),
         (("python", "scripts/run_local_diagnostic_effect.py", "--output-dir", "/tmp/sentientos-local-effect", "--summary"), "Optional explicit Tier-1 local diagnostic effect pilot; listed for reviewer awareness and not run by proof bundle generation."),
+        (("python", "scripts/run_local_diagnostic_rollback.py", "--effect-receipt", "<receipt.json>", "--rollback-plan", "<rollback-plan.json>", "--output-dir-scope", "/tmp/sentientos-local-effect", "--summary"), "Optional explicit exact-artifact rollback pilot; listed for reviewer awareness and not run by proof bundle generation."),
     )
     return tuple(
         ReviewerProofCommandRecord(
@@ -719,7 +722,24 @@ def build_reviewer_proof_bundle_payload(
             "command": "python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-effect --summary",
             "no_fan_pwm_thermal_power_service_cleanup": True,
             "no_network_provider_prompt_subprocess_shell_control_plane": True,
-            "rollback_execution_deferred_by_default": True,
+            "rollback_execution_deferred_by_default": False,
+            "matching_exact_artifact_rollback_available_by_explicit_command_only": True,
+        }),
+        "local_diagnostic_rollback_capability": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "capability_available": True,
+            "explicit_command_required": True,
+            "run_by_reviewer_proof_bundle_default": False,
+            "proof_bundle_rollback_performed": False,
+            "proof_bundle_host_mutation_performed": False,
+            "first_intentionally_real_rollback_pilot": True,
+            "only_real_rollback_when_explicitly_run": "delete the exact diagnostic artifact proven by receipt, rollback plan, scope, and digest",
+            "command": "python scripts/run_local_diagnostic_rollback.py --effect-receipt <receipt.json> --rollback-plan <rollback-plan.json> --output-dir-scope /tmp/sentientos-local-effect --summary",
+            "not_general_cleanup": True,
+            "no_directory_recursive_wildcard_or_unrelated_delete": True,
+            "no_fan_pwm_thermal_power_service_package_driver": True,
+            "no_network_provider_prompt_subprocess_shell_control_plane": True,
         }),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -640,3 +640,21 @@ def test_local_diagnostic_effect_registry_records_are_narrow_and_general_effects
         assert records[capability_id].status == "deferred"
     for capability_id in ["real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "real_file_cleanup"]:
         assert records[capability_id].status == "blocked"
+
+
+def test_local_diagnostic_exact_rollback_capabilities_are_exact_artifact_only() -> None:
+    records = build_default_capability_registry().by_id()
+    rollback = records["local_diagnostic_exact_rollback"]
+    postcondition = records["local_diagnostic_rollback_postcondition_check"]
+    audit = records["local_diagnostic_rollback_audit_receipt"]
+    assert rollback.status == "implemented"
+    assert rollback.authority_level == "exact_artifact_rollback_only"
+    assert "explicit exact-artifact rollback for local diagnostic artifact only" in rollback.implemented_surfaces
+    assert {"general cleanup", "recursive delete", "wildcard delete", "unrelated file delete"}.issubset(set(rollback.deferred_surfaces))
+    assert postcondition.status == "implemented"
+    assert postcondition.authority_level == "exact_artifact_postcondition_only"
+    assert audit.status == "implemented"
+    assert audit.authority_level == "exact_artifact_rollback_audit_only"
+    for capability_id in ["real_file_cleanup", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "provider_invocation", "federation_transport_sync_adoption"]:
+        assert records[capability_id].status in {"blocked", "deferred"}
+    assert validate_capability_registry(build_default_capability_registry()).ok

--- a/tests/test_local_diagnostic_exact_rollback.py
+++ b/tests/test_local_diagnostic_exact_rollback.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sentientos.local_diagnostic_effect import (
+    build_local_diagnostic_exact_rollback_request,
+    local_diagnostic_exact_rollback_request_digest,
+    perform_local_diagnostic_exact_rollback,
+    run_local_diagnostic_effect_wing,
+    run_local_diagnostic_exact_rollback_wing,
+    summarize_local_diagnostic_exact_rollback_result,
+    summarize_local_diagnostic_exact_rollback_receipt,
+    validate_local_diagnostic_exact_rollback_receipt,
+    validate_local_diagnostic_exact_rollback_request,
+    validate_local_diagnostic_exact_rollback_result,
+    validate_local_diagnostic_rollback_audit_receipt,
+    validate_local_diagnostic_rollback_postcondition_check,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _effect(tmp_path: Path):
+    return run_local_diagnostic_effect_wing(output_dir=tmp_path / "effect")
+
+
+def test_request_validation_rejects_root_and_outside_scope(tmp_path: Path) -> None:
+    records = _effect(tmp_path)
+    root = build_local_diagnostic_exact_rollback_request(records.receipt, records.rollback_plan, output_dir_scope="/")
+    assert not validate_local_diagnostic_exact_rollback_request(root).ok
+    assert "output_dir_scope_is_filesystem_root" in root.warning_codes
+    outside = build_local_diagnostic_exact_rollback_request(records.receipt, records.rollback_plan, output_dir_scope=tmp_path / "other")
+    assert not validate_local_diagnostic_exact_rollback_request(outside).ok
+    assert "output_path_outside_scope" in outside.warning_codes
+
+
+def test_rejects_directory_target_symlink_digest_mismatch_and_bad_plan(tmp_path: Path) -> None:
+    records = _effect(tmp_path)
+    artifact = Path(records.receipt.output_path)
+    artifact.unlink()
+    artifact.mkdir()
+    request = build_local_diagnostic_exact_rollback_request(records.receipt, records.rollback_plan, output_dir_scope=artifact.parent)
+    result = perform_local_diagnostic_exact_rollback(request)
+    assert result.rollback_status == "local_diagnostic_exact_rollback_blocked"
+    assert "output_path_is_directory" in result.warning_codes
+    artifact.rmdir()
+    sibling = artifact.parent / "sibling.txt"
+    sibling.write_text("keep", encoding="utf-8")
+    artifact.symlink_to(sibling)
+    result = perform_local_diagnostic_exact_rollback(request)
+    assert result.rollback_status == "local_diagnostic_exact_rollback_blocked"
+    assert "output_path_is_symlink" in result.warning_codes
+    artifact.unlink()
+    artifact.write_text("changed", encoding="utf-8")
+    result = perform_local_diagnostic_exact_rollback(request)
+    assert result.rollback_status == "local_diagnostic_exact_rollback_digest_mismatch"
+    bad_plan = records.rollback_plan.to_dict() | {"receipt_id": "other", "output_path": str(artifact.parent / "other.json")}
+    bad_request = build_local_diagnostic_exact_rollback_request(records.receipt, bad_plan, output_dir_scope=artifact.parent)
+    assert not validate_local_diagnostic_exact_rollback_request(bad_request).ok
+    assert "rollback_plan_receipt_mismatch" in bad_request.warning_codes
+    assert "rollback_plan_output_path_mismatch" in bad_request.warning_codes
+
+
+def test_dry_run_deletes_nothing_but_real_rollback_deletes_only_artifact(tmp_path: Path) -> None:
+    records = _effect(tmp_path)
+    artifact = Path(records.receipt.output_path)
+    sibling = artifact.parent / "sibling.txt"
+    child_dir = artifact.parent / "kept-dir"
+    sibling.write_text("keep", encoding="utf-8")
+    child_dir.mkdir()
+    dry = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=artifact.parent, dry_run=True)
+    assert dry.result.real_rollback_performed is False
+    assert artifact.exists()
+    real = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=artifact.parent)
+    assert not artifact.exists()
+    assert sibling.read_text(encoding="utf-8") == "keep"
+    assert child_dir.is_dir()
+    result_summary = summarize_local_diagnostic_exact_rollback_result(real.result)
+    assert result_summary["real_rollback_performed"] is True
+    assert result_summary["file_delete_performed"] is True
+    assert result_summary["host_mutation_performed"] is True
+    for flag in ["directory_cleanup_performed", "recursive_delete_performed", "wildcard_delete_performed", "unrelated_file_delete_performed"]:
+        assert result_summary[flag] is False
+    receipt_summary = summarize_local_diagnostic_exact_rollback_receipt(real.receipt)
+    assert receipt_summary["exact_artifact_only"] is True
+    assert real.postcondition_check.postcondition_status == "local_diagnostic_rollback_postcondition_passed"
+    assert real.postcondition_check.observed_exists is False
+    assert real.audit_receipt.audit_for_exact_local_diagnostic_artifact_only is True
+
+
+def test_allow_missing_records_no_deletion(tmp_path: Path) -> None:
+    records = _effect(tmp_path)
+    artifact = Path(records.receipt.output_path)
+    artifact.unlink()
+    rollback = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=artifact.parent, allow_missing_artifact=True)
+    assert rollback.result.rollback_status == "local_diagnostic_exact_rollback_missing_artifact"
+    assert rollback.result.real_rollback_performed is False
+    assert rollback.result.file_delete_performed is False
+    assert rollback.postcondition_check.postcondition_status == "local_diagnostic_rollback_postcondition_passed"
+
+
+def test_validation_rejects_forbidden_claims_and_digest_changes(tmp_path: Path) -> None:
+    records = _effect(tmp_path)
+    request = build_local_diagnostic_exact_rollback_request(records.receipt, records.rollback_plan, output_dir_scope=Path(records.receipt.output_path).parent)
+    same = build_local_diagnostic_exact_rollback_request(records.receipt, records.rollback_plan, output_dir_scope=Path(records.receipt.output_path).parent)
+    changed = replace(request, allow_missing_artifact=True, digest="")
+    assert request.digest == same.digest
+    assert request.digest == local_diagnostic_exact_rollback_request_digest(request)
+    assert request.digest != local_diagnostic_exact_rollback_request_digest(changed)
+    result = perform_local_diagnostic_exact_rollback(request, dry_run=True)
+    assert validate_local_diagnostic_exact_rollback_result(result).ok
+    for flag in [
+        "directory_cleanup_performed",
+        "recursive_delete_performed",
+        "wildcard_delete_performed",
+        "unrelated_file_delete_performed",
+        "fan_pwm_write_performed",
+        "thermal_actuation_performed",
+        "power_profile_mutation_performed",
+        "service_restart_performed",
+        "package_install_performed",
+        "driver_install_performed",
+        "network_performed",
+        "provider_invocation_performed",
+        "prompt_assembly_performed",
+    ]:
+        bad = result.to_dict() | {flag: True}
+        assert not validate_local_diagnostic_exact_rollback_result(bad).ok
+    real = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=Path(records.receipt.output_path).parent)
+    assert validate_local_diagnostic_exact_rollback_receipt(real.receipt).ok
+    assert validate_local_diagnostic_rollback_postcondition_check(real.postcondition_check).ok
+    assert validate_local_diagnostic_rollback_audit_receipt(real.audit_receipt).ok
+    assert not validate_local_diagnostic_exact_rollback_receipt(real.receipt.to_dict() | {"recursive_delete_performed": True}).ok

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -296,3 +296,18 @@ def test_reviewer_proof_bundle_lists_local_diagnostic_effect_but_does_not_run_it
     local_commands = [record for record in commands if "run_local_diagnostic_effect.py" in " ".join(record["command"])]
     assert local_commands
     assert all(record["status"] == "proof_command_not_run" and record["executed"] is False for record in local_commands)
+
+
+def test_reviewer_proof_bundle_lists_exact_rollback_but_does_not_run_it() -> None:
+    payload = build_reviewer_proof_bundle_payload()
+    artifacts = payload["artifacts"]
+    capability = json.loads(artifacts["local_diagnostic_rollback_capability"])
+    assert capability["explicit_command_required"] is True
+    assert capability["run_by_reviewer_proof_bundle_default"] is False
+    assert capability["proof_bundle_rollback_performed"] is False
+    assert capability["proof_bundle_host_mutation_performed"] is False
+    assert capability["not_general_cleanup"] is True
+    commands = json.loads(artifacts["proof_command_manifest"])["commands"]
+    rollback_commands = [record for record in commands if "run_local_diagnostic_rollback.py" in " ".join(record["command"])]
+    assert rollback_commands
+    assert all(record["status"] == "proof_command_not_run" and record["executed"] is False for record in rollback_commands)

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -560,3 +560,18 @@ def test_local_diagnostic_effect_pilot_doc_is_linked_and_preserves_boundaries() 
     assert "network egress" in doc and "provider invocation" in doc and "prompt assembly" in doc
     assert "subprocess execution" in doc and "shell execution" in doc
     assert "python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary" in doc
+
+HOST_LOCAL_DIAGNOSTIC_EXACT_ROLLBACK = "docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md"
+
+
+def test_exact_rollback_pilot_doc_is_linked_and_preserves_boundaries() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    doc = _read(HOST_LOCAL_DIAGNOSTIC_EXACT_ROLLBACK)
+    assert "host_local_diagnostic_exact_rollback_pilot_wing.md" in overview
+    assert "host_local_diagnostic_exact_rollback_pilot_wing.md" in index
+    assert "first intentionally real rollback pilot" in doc
+    assert "exact diagnostic artifact" in doc
+    assert "not general cleanup" in doc
+    assert "proof bundle does not run" in doc
+    assert "python scripts/run_local_diagnostic_rollback.py" in doc

--- a/tests/test_run_local_diagnostic_rollback_script.py
+++ b/tests/test_run_local_diagnostic_rollback_script.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_local_diagnostic_effect as effect_script
+from scripts import run_local_diagnostic_rollback as rollback_script
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO(); stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            code = rollback_script.main(args)
+        except SystemExit as exc:
+            code = int(exc.code or 0)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def _effect(tmp_path: Path) -> tuple[Path, Path, Path]:
+    code = effect_script.main(["--output-dir", str(tmp_path), "--summary", "--force"])
+    assert code == 0
+    return tmp_path / "effect_receipt.json", tmp_path / "rollback_plan.json", tmp_path / "sentientos_local_diagnostic_effect.json"
+
+
+def test_requires_receipt_plan_and_scope() -> None:
+    code, _out, err = _run([])
+    assert code != 0
+    assert "effect-receipt" in err
+
+
+def test_dry_run_deletes_nothing_and_summary_is_compact(tmp_path: Path) -> None:
+    receipt, plan, artifact = _effect(tmp_path)
+    code, out, err = _run(["--effect-receipt", str(receipt), "--rollback-plan", str(plan), "--output-dir-scope", str(tmp_path), "--dry-run", "--summary"])
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["dry_run"] is True
+    assert payload["would_delete_exact_artifact"] is True
+    assert payload["real_rollback_performed"] is False
+    assert artifact.exists()
+
+
+def test_default_deletes_exact_artifact_and_keeps_sibling(tmp_path: Path) -> None:
+    receipt, plan, artifact = _effect(tmp_path)
+    sibling = tmp_path / "sibling.txt"
+    sibling.write_text("keep", encoding="utf-8")
+    code, out, err = _run(["--effect-receipt", str(receipt), "--rollback-plan", str(plan), "--output-dir-scope", str(tmp_path), "--summary"])
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["real_rollback_performed"] is True
+    assert payload["file_delete_performed"] is True
+    assert payload["exact_artifact_only"] is True
+    assert payload["general_cleanup_performed"] is False
+    assert payload["recursive_delete_performed"] is False
+    assert payload["wildcard_delete_performed"] is False
+    assert payload["unrelated_file_delete_performed"] is False
+    assert not artifact.exists()
+    assert sibling.read_text(encoding="utf-8") == "keep"
+
+
+def test_refuses_digest_mismatch_outside_scope_and_directory(tmp_path: Path) -> None:
+    receipt, plan, artifact = _effect(tmp_path)
+    artifact.write_text("changed", encoding="utf-8")
+    code, _out, _err = _run(["--effect-receipt", str(receipt), "--rollback-plan", str(plan), "--output-dir-scope", str(tmp_path), "--summary"])
+    assert code == 1
+    artifact.write_text("x", encoding="utf-8")
+    code, _out, err = _run(["--effect-receipt", str(receipt), "--rollback-plan", str(plan), "--output-dir-scope", str(tmp_path / "other"), "--summary"])
+    assert code == 2
+    assert "output_path_outside_scope" in err
+    artifact.unlink()
+    artifact.mkdir()
+    code, _out, _err = _run(["--effect-receipt", str(receipt), "--rollback-plan", str(plan), "--output-dir-scope", str(tmp_path), "--summary"])
+    assert code == 1


### PR DESCRIPTION
### Motivation

- Provide a narrowly-scoped, auditable rollback that can remove only the exact diagnostic artifact produced by the Tier-1 local diagnostic effect and emit matching rollback/postcondition/audit evidence. 
- Ensure rollback remains strictly narrower than general cleanup by gating deletion on receipt/plan identity, explicit output scope, no-symlink/no-directory target, and digest match; forbid any hardware/service/network/provider/prompt/subprocess/shell/control-plane actions.

### Description

- Add exact-artifact rollback types, validators, deterministic digests, summaries, and the wing runner to `sentientos/local_diagnostic_effect.py`, including `LocalDiagnosticExactRollbackRequest`, `LocalDiagnosticExactRollbackResult`, `LocalDiagnosticExactRollbackReceipt`, `LocalDiagnosticRollbackPostconditionCheck`, `LocalDiagnosticRollbackAuditReceipt`, `perform_local_diagnostic_exact_rollback(...)`, and `run_local_diagnostic_exact_rollback_wing(...)`, with a single `Path.unlink()` call reachable only after all scope/digest/symlink/directory validations. 
- Add explicit CLI `scripts/run_local_diagnostic_rollback.py` (required `--effect-receipt`, `--rollback-plan`, `--output-dir-scope`; optional `--dry-run`, `--allow-missing-artifact`, `--summary`) and extend `scripts/run_local_diagnostic_effect.py` to write `effect_receipt.json` and `rollback_plan.json` when the effect runs so the reviewer path is explicit. 
- Integrate reviewer/proof surfaces and capability posture: add `local_diagnostic_rollback_capability` entry in `sentientos/reviewer_proof_bundle.py` (listed but not run by default) and add exact-artifact rollback/postcondition/audit entries plus `update_registry_from_local_diagnostic_rollback_receipt(...)` to `sentientos/capability_registry.py` while keeping general cleanup, recursive/wildcard/unrelated delete, and hardware/service/provider/network/prompt actions blocked or deferred. 
- Add documentation `docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md` and tests `tests/test_local_diagnostic_exact_rollback.py` and `tests/test_run_local_diagnostic_rollback_script.py`, and update reviewer/bundle/registry tests to cover listing and non-execution by default.

### Testing

- Static checks: compiled updated modules with `python -m py_compile` (including `sentientos/local_diagnostic_effect.py`, `scripts/run_local_diagnostic_rollback.py`, `sentientos/reviewer_proof_bundle.py`, `sentientos/capability_registry.py`) and succeeded. 
- Unit tests: ran focused and integration suites with `python -m scripts.run_tests -q` for the new and related tests, e.g. `tests/test_local_diagnostic_exact_rollback.py`, `tests/test_run_local_diagnostic_rollback_script.py`, `tests/test_local_diagnostic_effect.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_capability_registry.py`, and the broader readiness suites; all test runs in the environment completed successfully. 
- CLI/behavioral checks: exercised the end-to-end path: `python scripts/run_local_diagnostic_effect.py --output-dir /tmp/sentientos-local-diagnostic-effect --summary --force` then `python scripts/run_local_diagnostic_rollback.py --effect-receipt /tmp/sentientos-local-diagnostic-effect/effect_receipt.json --rollback-plan /tmp/sentientos-local-diagnostic-effect/rollback_plan.json --output-dir-scope /tmp/sentientos-local-diagnostic-effect --dry-run --summary` (dry-run left the artifact intact) and the non-dry run (deleted only the exact artifact); outputs and summaries from the runs match the exact-artifact-only guarantees. 
- Docs: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` completed in the environment after bootstrapping; `python scripts/verify_context_hygiene_prompt_boundaries.py` returned no forbidden findings. 

If you want, I can (a) produce a short reviewer checklist showing the exact CLI invocations and sample output JSON, or (b) split some of the long validation helpers into a small dedicated module for clarity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07a82311c48320b7b8ce07bc9c2823)