### PR TITLE
[codex:transaction-ledger] add local effect transaction ledger wing

### DIFF
--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -86,3 +86,5 @@ See [Host Real Effect Capability Admission Wing](host_real_effect_capability_adm
 The authority ladder later reaches the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), the first explicit diagnostic artifact write effect.
 
 Later bounded real-effect proof organs include the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) and its [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); both remain explicit and narrow.
+
+The later [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) remains downstream of authorization, real-effect admission, the local diagnostic effect pilot, and exact rollback; it is metadata-only transaction integrity, not new authority.

--- a/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
@@ -56,3 +56,5 @@ The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effec
 - Tests: `tests/test_local_diagnostic_effect.py`, `tests/test_run_local_diagnostic_effect_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
 
 The matching exact-artifact rollback pilot is documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md); it deletes only the recorded diagnostic artifact when explicitly requested.
+
+Related: [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) records the diagnostic effect plus exact rollback lifecycle without adding a new host effect.

--- a/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
@@ -64,3 +64,5 @@ The capability registry marks `local_diagnostic_exact_rollback`, `local_diagnost
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_local_diagnostic_exact_rollback.py`, `tests/test_run_local_diagnostic_rollback_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+Next: [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) connects the effect, rollback, postcondition, and audit records into a metadata-only transaction lifecycle ledger.

--- a/docs/architecture/host_local_effect_transaction_ledger_wing.md
+++ b/docs/architecture/host_local_effect_transaction_ledger_wing.md
@@ -1,0 +1,60 @@
+# Host Local Effect Transaction Ledger Wing
+
+This wing follows the [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md). The exact rollback pilot proved that the first intentionally real local diagnostic artifact write can be reversed by an explicit, exact-artifact-only rollback. This wing connects those formerly loose records into a metadata-only transaction ledger.
+
+## Boundary
+
+The ledger does **not** introduce a new host effect. It does not run the diagnostic effect. It does not run rollback. It does not delete files except for the optional explicit write of one caller-supplied ledger JSON artifact path.
+
+It is not general cleanup and is not broader host control. It does not perform fan/PWM writes, thermal actuation, power profile mutation, service restart, process killing, package installation, driver installation, network egress, provider invocation, prompt assembly/export, subprocess execution, shell execution, OS-backend invocation, control-plane execution, federation transport/sync/adoption, or remote execution.
+
+## What the ledger records
+
+`sentientos/local_effect_transaction_ledger.py` creates immutable-style metadata records for the bounded local diagnostic lifecycle:
+
+- `LocalEffectTransactionEntry` records one source event, source record digest, previous entry digest, event kind, blocked actions, warnings, risks, and no-new-effect flags.
+- `LocalEffectTransactionLedger` orders entries into a digest chain and stores the current transaction status plus effect receipt, postcondition, production audit, rollback plan, rollback receipt, rollback postcondition, and rollback audit identifiers.
+- `LocalEffectTransactionLifecycleReport` classifies lifecycle posture from the ledger.
+- `LocalEffectTransactionLedgerArtifactReceipt` records the optional explicit ledger artifact write when a caller supplies an output path.
+
+## Lifecycle classification
+
+The wing detects and reports:
+
+- open or rollback-pending transactions when the effect, postcondition, audit, and rollback plan exist but no rollback receipt exists yet;
+- orphaned effects when an effect receipt is present without its postcondition or production audit;
+- incomplete rollback when rollback exists without rollback postcondition or rollback audit;
+- contradicted transactions when duplicate event kinds, digest mismatches, or forbidden host/network/provider/prompt/subprocess/shell/hardware/service/power/fan/thermal/general-cleanup claims appear;
+- closed transactions only when the effect receipt, effect postcondition, production audit, rollback plan, rollback receipt, rollback postcondition, and rollback audit are present and non-contradictory.
+
+## CLI
+
+Build a metadata-only ledger from explicit record files without running effect or rollback:
+
+```bash
+python scripts/build_local_effect_transaction_ledger.py --effect-receipt /tmp/sentientos-local-diagnostic-effect/effect_receipt.json --postcondition-check /tmp/sentientos-local-diagnostic-effect/postcondition_check.json --production-audit /tmp/sentientos-local-diagnostic-effect/production_audit.json --rollback-plan /tmp/sentientos-local-diagnostic-effect/rollback_plan.json --summary
+```
+
+After exact rollback, include rollback records for a closed transaction:
+
+```bash
+python scripts/build_local_effect_transaction_ledger.py --effect-receipt /tmp/sentientos-local-diagnostic-effect/effect_receipt.json --postcondition-check /tmp/sentientos-local-diagnostic-effect/postcondition_check.json --production-audit /tmp/sentientos-local-diagnostic-effect/production_audit.json --rollback-plan /tmp/sentientos-local-diagnostic-effect/rollback_plan.json --rollback-receipt /tmp/sentientos-local-diagnostic-effect/rollback_receipt.json --rollback-postcondition-check /tmp/sentientos-local-diagnostic-effect/rollback_postcondition_check.json --rollback-audit /tmp/sentientos-local-diagnostic-effect/rollback_audit.json --summary
+```
+
+`--output PATH` writes one deterministic ledger artifact only to that explicit file path. Directory and filesystem-root outputs are refused, and existing files require `--force`.
+
+## Reviewer proof bundle posture
+
+The reviewer proof bundle includes `local_effect_transaction_ledger_capability.json` and lists the CLI command in `proof_commands.json` as `proof_command_not_run`. Bundle generation does not run the diagnostic effect, rollback, or transaction ledger by default.
+
+## Capability registry posture
+
+The capability registry marks `local_effect_transaction_ledger`, `local_effect_lifecycle_report`, and `local_effect_transaction_ledger_artifact` as implemented bounded metadata surfaces. `general_effect_transaction_ledger` remains deferred. General cleanup, recursive delete, unrelated file delete, fan/PWM, thermal, power, service, package, driver, network, provider, prompt, federation, remote execution, subprocess, shell, OS backend, and control-plane execution remain blocked or deferred.
+
+## Implementation links
+
+- Module: `sentientos/local_effect_transaction_ledger.py`
+- CLI: `scripts/build_local_effect_transaction_ledger.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_local_effect_transaction_ledger.py`, `tests/test_build_local_effect_transaction_ledger_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -274,3 +274,5 @@ See [Host Real Effect Capability Admission Wing](host_real_effect_capability_adm
 For the first intentionally real but bounded effect, see the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md), which only writes one explicit local diagnostic artifact and is not run by reviewer bundles by default.
 
 Host embodiment proof now includes an explicit [local diagnostic effect pilot](host_local_diagnostic_effect_pilot_wing.md) and matching [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); reviewer bundles document but do not run either by default.
+
+The [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) (`docs/architecture/host_local_effect_transaction_ledger_wing.md`) adds metadata-only lifecycle integrity for the local diagnostic effect and exact rollback; it adds no new host effect and is not general cleanup or broader host control.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -120,3 +120,5 @@ See [Host Real Effect Capability Admission Wing](host_real_effect_capability_adm
 The bundle documents but does not run the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md); its optional CLI command is listed as not run by default.
 
 The proof bundle lists, but does not run, the exact-artifact rollback CLI documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md).
+
+The bundle also includes `local_effect_transaction_ledger_capability.json`; its ledger command is listed as `proof_command_not_run` and does not run effect or rollback by default. See [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md).

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -26,6 +26,9 @@ Capability Registry, Hardware/Sensor Inventory Manifest, and read-only Host
 Resource Governor scaffold. Privilege Broker and Actuation Fulfillment Layer
 remain future gates for any host action; direct fan/PWM control remains deferred. Phase 4 broker eligibility is documented in `docs/architecture/host_embodiment_substrate_phase4_privilege_broker.md` and still does not authorize or fulfill host action.
 
+
+The [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) (`docs/architecture/host_local_effect_transaction_ledger_wing.md`) records the local diagnostic effect plus exact rollback lifecycle, detects open/orphaned/incomplete/contradicted/closed transactions, and adds no new host effect.
+
 ## Current implemented proof surfaces
 
 ### Control plane / authority admission

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -424,3 +424,5 @@ See [Host Real Effect Capability Admission Wing](host_real_effect_capability_adm
 The first bounded real-effect pilot is the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md): one explicit local diagnostic artifact write, not hardware/service/power/cleanup control.
 
 The trajectory now includes a bounded [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md): the first real rollback, limited to the exact diagnostic artifact and not general cleanup.
+
+- [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md): metadata-only integrity ledger for the Tier-1 local diagnostic effect and exact rollback lifecycle before broader effect implementation.

--- a/scripts/build_local_effect_transaction_ledger.py
+++ b/scripts/build_local_effect_transaction_ledger.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Build a metadata-only local effect transaction ledger from record files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.local_effect_transaction_ledger import (  # noqa: E402
+    build_transaction_ledger_from_local_diagnostic_records,
+    summarize_local_effect_transaction_ledger,
+    summarize_local_effect_transaction_lifecycle_report,
+    summarize_local_effect_transaction_ledger_artifact_receipt,
+    validate_local_effect_transaction_ledger,
+    validate_local_effect_transaction_lifecycle_report,
+    write_local_effect_transaction_ledger_artifact,
+)
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+
+
+def _unsafe_output(path_text: str) -> str | None:
+    path = Path(path_text).expanduser()
+    if not str(path_text).strip():
+        return "output path is required"
+    if path == Path(path.anchor) or path.resolve() == Path(path.anchor).resolve():
+        return "refusing to write ledger artifact to filesystem root"
+    if path.exists() and path.is_dir():
+        return "refusing to write ledger artifact to a directory"
+    return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only local diagnostic effect transaction ledger")
+    parser.add_argument("--effect-receipt", required=True, help="path to effect_receipt.json")
+    parser.add_argument("--postcondition-check", required=True, help="path to postcondition_check.json")
+    parser.add_argument("--production-audit", required=True, help="path to production_audit.json")
+    parser.add_argument("--rollback-plan", required=True, help="path to rollback_plan.json")
+    parser.add_argument("--rollback-receipt", help="path to rollback_receipt.json")
+    parser.add_argument("--rollback-postcondition-check", help="path to rollback_postcondition_check.json")
+    parser.add_argument("--rollback-audit", help="path to rollback_audit.json")
+    parser.add_argument("--output", help="optional explicit local ledger artifact path")
+    parser.add_argument("--summary", action="store_true", help="print compact summary")
+    parser.add_argument("--force", action="store_true", help="overwrite --output if it already exists")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00", help="deterministic timestamp for records")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code or 0)
+
+    if args.output:
+        reason = _unsafe_output(args.output)
+        if reason:
+            print(reason, file=sys.stderr)
+            return 2
+
+    try:
+        bundle = build_transaction_ledger_from_local_diagnostic_records(
+            effect_receipt=_load_json(args.effect_receipt),
+            postcondition_check=_load_json(args.postcondition_check),
+            production_audit=_load_json(args.production_audit),
+            rollback_plan=_load_json(args.rollback_plan),
+            exact_rollback_receipt=_load_json(args.rollback_receipt) if args.rollback_receipt else None,
+            rollback_postcondition_check=_load_json(args.rollback_postcondition_check) if args.rollback_postcondition_check else None,
+            rollback_audit=_load_json(args.rollback_audit) if args.rollback_audit else None,
+            created_at=args.created_at,
+        )
+        ledger_validation = validate_local_effect_transaction_ledger(bundle.ledger)
+        report_validation = validate_local_effect_transaction_lifecycle_report(bundle.lifecycle_report)
+        if not ledger_validation.ok or not report_validation.ok:
+            print("local effect transaction ledger validation failed: " + ", ".join(ledger_validation.findings + report_validation.findings), file=sys.stderr)
+            return 2
+        artifact_receipt = None
+        if args.output:
+            artifact_receipt = write_local_effect_transaction_ledger_artifact(bundle.ledger, args.output, lifecycle_report=bundle.lifecycle_report, created_at=args.created_at, force=args.force)
+        payload: dict[str, Any]
+        if args.summary:
+            payload = {
+                "ledger": summarize_local_effect_transaction_ledger(bundle.ledger),
+                "lifecycle_report": summarize_local_effect_transaction_lifecycle_report(bundle.lifecycle_report),
+                "artifact_receipt": summarize_local_effect_transaction_ledger_artifact_receipt(artifact_receipt) if artifact_receipt else None,
+                "metadata_only": True,
+                "performs_no_new_effect": True,
+                "host_mutation_performed": False,
+                "network_performed": False,
+                "provider_invocation_performed": False,
+                "prompt_assembly_performed": False,
+                "subprocess_performed": False,
+                "shell_performed": False,
+            }
+        else:
+            payload = {
+                "ledger": bundle.ledger.to_dict(),
+                "lifecycle_report": bundle.lifecycle_report.to_dict(),
+                "artifact_receipt": artifact_receipt.to_dict() if artifact_receipt else None,
+            }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    except (OSError, json.JSONDecodeError, TypeError, ValueError, FileExistsError) as exc:
+        print(f"local effect transaction ledger failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_local_diagnostic_effect.py
+++ b/scripts/run_local_diagnostic_effect.py
@@ -84,6 +84,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run:
         output_dir = Path(args.output_dir).expanduser()
         (output_dir / "effect_receipt.json").write_text(json.dumps(records.receipt.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (output_dir / "postcondition_check.json").write_text(json.dumps(records.postcondition_check.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (output_dir / "production_audit.json").write_text(json.dumps(records.production_audit_receipt.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
         (output_dir / "rollback_plan.json").write_text(json.dumps(records.rollback_plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     payload = _compact_summary(summary, dry_run=args.dry_run) if args.summary else {
@@ -95,6 +97,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "rollback_receipt": records.rollback_receipt.to_dict(),
         "production_audit_receipt": records.production_audit_receipt.to_dict(),
         "effect_receipt_path": str(Path(args.output_dir).expanduser() / "effect_receipt.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
+        "postcondition_check_path": str(Path(args.output_dir).expanduser() / "postcondition_check.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
+        "production_audit_path": str(Path(args.output_dir).expanduser() / "production_audit.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
         "rollback_plan_path": str(Path(args.output_dir).expanduser() / "rollback_plan.json") if records.result.effect_status == "local_diagnostic_effect_performed" and not args.dry_run else None,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/run_local_diagnostic_rollback.py
+++ b/scripts/run_local_diagnostic_rollback.py
@@ -91,6 +91,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         dry_run=args.dry_run,
         created_at=args.created_at,
     )
+    if not args.dry_run:
+        output_dir = Path(args.output_dir_scope).expanduser()
+        (output_dir / "rollback_receipt.json").write_text(json.dumps(records.receipt.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (output_dir / "rollback_postcondition_check.json").write_text(json.dumps(records.postcondition_check.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (output_dir / "rollback_audit.json").write_text(json.dumps(records.audit_receipt.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
     summary = summarize_local_diagnostic_exact_rollback_wing(records)
     payload = _compact(summary, dry_run=args.dry_run) if args.summary else {
         "request": records.request.to_dict(),

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -48,6 +48,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "dry_run_audit_closure",
         "real_effect_admission",
         "local_diagnostic_effect",
+        "local_effect_transaction_ledger",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -106,6 +107,9 @@ AUTHORITY_LEVELS = frozenset(
         "exact_artifact_rollback_only",
         "exact_artifact_postcondition_only",
         "exact_artifact_rollback_audit_only",
+        "local_effect_transaction_ledger_only",
+        "local_effect_lifecycle_report_only",
+        "explicit_local_artifact_only",
         "candidate_only",
         "plan_scaffold_only",
         "block_receipt_only",
@@ -353,6 +357,18 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("local_diagnostic_exact_rollback", "local_diagnostic_effect", "implemented", "exact_artifact_rollback_only", source_paths=("sentientos/local_diagnostic_effect.py", "scripts/run_local_diagnostic_rollback.py"), proof_tests=("tests/test_local_diagnostic_exact_rollback.py", "tests/test_run_local_diagnostic_rollback_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_local_diagnostic_exact_rollback.py tests/test_run_local_diagnostic_rollback_script.py", "python scripts/run_local_diagnostic_rollback.py --effect-receipt <receipt.json> --rollback-plan <rollback-plan.json> --output-dir-scope /tmp/sentientos-local-effect --summary"), implemented_surfaces=("explicit exact-artifact rollback for local diagnostic artifact only", "path, digest, plan, receipt, and scope gated single Path.unlink"), deferred_surfaces=("general cleanup", "recursive delete", "wildcard delete", "unrelated file delete", "hardware control", "service control"), forbidden_implications=("exact diagnostic rollback is general cleanup", "exact diagnostic rollback deletes directories, siblings, wildcard matches, or unrelated files"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("local_diagnostic_rollback_postcondition_check", "local_diagnostic_effect", "implemented", "exact_artifact_postcondition_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_exact_rollback.py",), implemented_surfaces=("postcondition check verifies exact artifact path absence only",), deferred_surfaces=("broad filesystem checks",), forbidden_implications=("rollback postcondition scans broad filesystem")),
         _record("local_diagnostic_rollback_audit_receipt", "local_diagnostic_effect", "implemented", "exact_artifact_rollback_audit_only", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_exact_rollback.py",), implemented_surfaces=("audit receipt for exact local diagnostic artifact rollback only",), deferred_surfaces=("general rollback audits",), forbidden_implications=("rollback audit authorizes cleanup or unrelated deletion")),
+        _record("local_effect_transaction_ledger", "local_effect_transaction_ledger", "implemented", "local_effect_transaction_ledger_only", source_paths=("sentientos/local_effect_transaction_ledger.py", "scripts/build_local_effect_transaction_ledger.py"), proof_tests=("tests/test_local_effect_transaction_ledger.py", "tests/test_build_local_effect_transaction_ledger_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_local_effect_transaction_ledger.py tests/test_build_local_effect_transaction_ledger_script.py", "python scripts/build_local_effect_transaction_ledger.py --effect-receipt <effect_receipt.json> --postcondition-check <postcondition.json> --production-audit <audit.json> --rollback-plan <rollback_plan.json> --summary"), implemented_surfaces=("metadata-only transaction ledger for local diagnostic effect and exact rollback records", "digest-chain validation", "open/orphan/incomplete/contradicted/closed lifecycle classification"), deferred_surfaces=("broader effect transaction ledger", "general cleanup", "broader host control"), forbidden_implications=("transaction ledger performs host effects", "ledger authorizes cleanup or rollback"), requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("local_effect_lifecycle_report", "local_effect_transaction_ledger", "implemented", "local_effect_lifecycle_report_only", source_paths=("sentientos/local_effect_transaction_ledger.py",), proof_tests=("tests/test_local_effect_transaction_ledger.py",), implemented_surfaces=("metadata-only lifecycle status report for local diagnostic transactions",), deferred_surfaces=("general lifecycle enforcement",), forbidden_implications=("lifecycle report performs host mutation")),
+        _record("local_effect_transaction_ledger_artifact", "local_effect_transaction_ledger", "implemented", "explicit_local_artifact_only", source_paths=("sentientos/local_effect_transaction_ledger.py", "scripts/build_local_effect_transaction_ledger.py"), proof_tests=("tests/test_local_effect_transaction_ledger.py", "tests/test_build_local_effect_transaction_ledger_script.py"), implemented_surfaces=("optional explicit caller-supplied local JSON ledger artifact write",), deferred_surfaces=("default proof bundle execution", "implicit artifact writes"), forbidden_implications=("ledger artifact write runs effect or rollback")),
+        _record("general_effect_transaction_ledger", "local_effect_transaction_ledger", "deferred", "none", deferred_surfaces=("transaction ledgers for broader host effects",), forbidden_implications=("local diagnostic transaction ledger covers arbitrary host effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("general_cleanup", "execution_proof", "blocked", "none", deferred_surfaces=("general cleanup", "directory cleanup", "wildcard cleanup"), forbidden_implications=("exact artifact rollback is general cleanup"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("recursive_delete", "execution_proof", "blocked", "none", deferred_surfaces=("recursive delete",), forbidden_implications=("rollback uses recursive deletion"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("unrelated_file_delete", "execution_proof", "blocked", "none", deferred_surfaces=("unrelated file deletion",), forbidden_implications=("exact artifact rollback deletes siblings"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("package_install", "install_bootstrap", "blocked", "none", deferred_surfaces=("package installation",), forbidden_implications=("proof bundle or local effect installs packages"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("driver_install", "hardware_driver_awareness", "blocked", "none", deferred_surfaces=("driver installation",), forbidden_implications=("driver awareness installs drivers"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("network_egress", "local_model_chat", "blocked", "none", deferred_surfaces=("network egress",), forbidden_implications=("local ledgers open network connections")),
+        _record("prompt_assembly", "local_model_chat", "blocked", "none", deferred_surfaces=("prompt assembly", "prompt export"), forbidden_implications=("reviewer proof or local ledgers assemble prompts")),
+        _record("remote_execution", "federation_evidence", "blocked", "none", deferred_surfaces=("remote execution",), forbidden_implications=("federation evidence executes remotely"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("local_diagnostic_rollback_execution", "local_diagnostic_effect", "deferred", "none", source_paths=("sentientos/local_diagnostic_effect.py",), proof_tests=("tests/test_local_diagnostic_effect.py",), deferred_surfaces=("general rollback execution outside exact local diagnostic artifact"), forbidden_implications=("rollback scaffold performs deletion")),
         _record("real_backend_implementation", "real_effect_admission", "deferred", "none", deferred_surfaces=("real backend implementation", "OS backend implementation"), forbidden_implications=("real effect admission implements backends",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("real_effect_receipt_creation", "dry_run_audit_closure", "deferred", "none", deferred_surfaces=("real effect receipt creation",), forbidden_implications=("dry-run audit closure creates real effect receipts",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -1177,3 +1193,25 @@ def update_registry_from_local_diagnostic_rollback_receipt(registry: CapabilityR
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-local-diagnostic-exact-rollback-wing.v1")
+
+
+def update_registry_from_local_effect_transaction_ledger(registry: CapabilityRegistry, ledger: Any) -> CapabilityRegistry:
+    """Reflect the metadata-only local effect transaction ledger without widening host authority."""
+
+    payload = ledger.to_dict() if hasattr(ledger, "to_dict") else dict(ledger)
+    has_ledger = bool(payload.get("ledger_id"))
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "local_effect_transaction_ledger":
+            records.append(replace(record, status="implemented" if has_ledger else record.status, authority_level="local_effect_transaction_ledger_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_effect_lifecycle_report":
+            records.append(replace(record, status="implemented", authority_level="local_effect_lifecycle_report_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "local_effect_transaction_ledger_artifact":
+            records.append(replace(record, status="implemented", authority_level="explicit_local_artifact_only", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id == "general_effect_transaction_ledger":
+            records.append(replace(record, status="deferred", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in {"general_cleanup", "recursive_delete", "unrelated_file_delete", "real_file_cleanup", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install", "network_egress", "provider_invocation", "prompt_assembly", "federation_transport_sync_adoption", "remote_execution"}:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-local-effect-transaction-ledger-wing.v1")

--- a/sentientos/local_effect_transaction_ledger.py
+++ b/sentientos/local_effect_transaction_ledger.py
@@ -1,0 +1,757 @@
+"""Metadata-only local effect transaction ledger.
+
+This wing connects the bounded Tier-1 local diagnostic effect records and the
+exact-artifact rollback records into an integrity ledger. Building entries,
+ledgers, and lifecycle reports performs no new host effect. The only permitted
+mutation in this module is the optional explicit write of one caller-supplied
+ledger artifact path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping, NamedTuple, Sequence
+
+DEFAULT_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+TRANSACTION_STATUSES = frozenset({
+    "local_effect_transaction_open",
+    "local_effect_transaction_effect_recorded",
+    "local_effect_transaction_postcondition_passed",
+    "local_effect_transaction_audit_recorded",
+    "local_effect_transaction_rollback_available",
+    "local_effect_transaction_rollback_performed",
+    "local_effect_transaction_rollback_postcondition_passed",
+    "local_effect_transaction_rollback_audit_recorded",
+    "local_effect_transaction_closed",
+    "local_effect_transaction_orphaned",
+    "local_effect_transaction_incomplete",
+    "local_effect_transaction_contradicted",
+    "local_effect_transaction_invalid",
+})
+LEDGER_STATUSES = frozenset({
+    "local_effect_transaction_ledger_current",
+    "local_effect_transaction_ledger_current_with_warnings",
+    "local_effect_transaction_ledger_incomplete",
+    "local_effect_transaction_ledger_contradicted",
+    "local_effect_transaction_ledger_invalid",
+})
+LIFECYCLE_STATUSES = frozenset({
+    "local_effect_lifecycle_complete",
+    "local_effect_lifecycle_complete_with_rollback",
+    "local_effect_lifecycle_open",
+    "local_effect_lifecycle_orphaned_effect",
+    "local_effect_lifecycle_missing_postcondition",
+    "local_effect_lifecycle_missing_audit",
+    "local_effect_lifecycle_missing_rollback_plan",
+    "local_effect_lifecycle_rollback_pending",
+    "local_effect_lifecycle_rollback_incomplete",
+    "local_effect_lifecycle_contradicted",
+    "local_effect_lifecycle_invalid",
+})
+ARTIFACT_STATUSES = frozenset({
+    "local_effect_transaction_ledger_artifact_written",
+    "local_effect_transaction_ledger_artifact_blocked",
+    "local_effect_transaction_ledger_artifact_incomplete",
+    "local_effect_transaction_ledger_artifact_contradicted",
+})
+EVENT_KINDS = frozenset({
+    "diagnostic_effect_requested",
+    "diagnostic_effect_performed",
+    "diagnostic_effect_receipt_recorded",
+    "diagnostic_postcondition_passed",
+    "diagnostic_production_audit_recorded",
+    "diagnostic_rollback_plan_recorded",
+    "diagnostic_exact_rollback_requested",
+    "diagnostic_exact_rollback_performed",
+    "diagnostic_exact_rollback_receipt_recorded",
+    "diagnostic_rollback_postcondition_passed",
+    "diagnostic_rollback_audit_recorded",
+    "transaction_closed",
+    "transaction_blocked",
+    "transaction_contradicted",
+})
+BLOCKED_ACTION_LABELS = (
+    "general_cleanup",
+    "directory_cleanup",
+    "recursive_delete",
+    "wildcard_delete",
+    "unrelated_file_delete",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+    "hardware_control",
+)
+_FORBIDDEN_TRUE_FIELDS = (
+    "general_cleanup_performed",
+    "general_cleanup_requested",
+    "directory_cleanup_performed",
+    "directory_cleanup_requested",
+    "recursive_delete_performed",
+    "recursive_delete_requested",
+    "wildcard_delete_performed",
+    "wildcard_delete_requested",
+    "unrelated_file_delete_performed",
+    "unrelated_file_delete_requested",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "provider_invocation_performed",
+    "network_performed",
+    "prompt_assembly_performed",
+    "subprocess_performed",
+    "shell_performed",
+    "os_backend_invoked",
+    "os_backend_invocation_performed",
+    "control_plane_admission_execution_performed",
+    "hardware_control_performed",
+)
+_ALLOWED_ROLLBACK_TRUE_FIELDS = frozenset({"real_rollback_performed", "file_delete_performed", "host_mutation_performed"})
+
+
+@dataclass(frozen=True)
+class LocalEffectTransactionLedgerValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LocalEffectTransactionEntry:
+    entry_id: str
+    transaction_id: str
+    event_kind: str
+    source_record_id: str
+    source_record_digest: str
+    previous_entry_digest: str | None
+    transaction_status: str
+    output_path: str | None
+    artifact_digest: str | None
+    evidence_summary: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    ledger_entry_only: bool = True
+    performs_no_new_effect: bool = True
+    host_mutation_performed: bool = False
+    file_delete_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    subprocess_performed: bool = False
+    shell_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalEffectTransactionLedger:
+    ledger_id: str
+    transaction_id: str
+    entries: tuple[LocalEffectTransactionEntry, ...]
+    ledger_status: str
+    current_transaction_status: str
+    effect_receipt_id: str | None
+    postcondition_check_id: str | None
+    production_audit_id: str | None
+    rollback_plan_id: str | None
+    rollback_receipt_id: str | None
+    rollback_postcondition_check_id: str | None
+    rollback_audit_id: str | None
+    open_issue_codes: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    transaction_ledger_only: bool = True
+    performs_no_new_effect: bool = True
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["entries"] = [entry.to_dict() for entry in self.entries]
+        return payload
+
+
+@dataclass(frozen=True)
+class LocalEffectTransactionLifecycleReport:
+    report_id: str
+    ledger_id: str
+    transaction_id: str
+    lifecycle_status: str
+    present_event_kinds: tuple[str, ...]
+    missing_event_kinds: tuple[str, ...]
+    orphan_codes: tuple[str, ...]
+    contradiction_codes: tuple[str, ...]
+    closure_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    lifecycle_report_only: bool = True
+    performs_no_new_effect: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalEffectTransactionLedgerArtifactReceipt:
+    receipt_id: str
+    ledger_id: str
+    output_path: str
+    artifact_digest: str
+    byte_count: int
+    artifact_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    ledger_artifact_receipt_only: bool = True
+    local_file_write_performed: bool = False
+    host_mutation_performed: bool = False
+    network_performed: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class LocalEffectTransactionLedgerBundle(NamedTuple):
+    ledger: LocalEffectTransactionLedger
+    lifecycle_report: LocalEffectTransactionLifecycleReport
+
+
+def _source_payload(source: Any | None) -> dict[str, Any]:
+    if source is None:
+        return {}
+    if hasattr(source, "to_dict"):
+        return dict(source.to_dict())
+    return dict(source)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _without_digest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(payload)
+    data["digest"] = ""
+    return data
+
+
+def local_effect_transaction_digest(record_or_payload: Any) -> str:
+    payload = _source_payload(record_or_payload)
+    payload["digest"] = ""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+local_effect_transaction_entry_digest = local_effect_transaction_digest
+local_effect_transaction_ledger_digest = local_effect_transaction_digest
+local_effect_transaction_lifecycle_report_digest = local_effect_transaction_digest
+local_effect_transaction_ledger_artifact_receipt_digest = local_effect_transaction_digest
+
+
+def _digest_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    return prefix + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:16]
+
+
+def _tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return tuple(str(item) for item in value)
+
+
+def _record_digest(record: Any) -> str:
+    payload = _source_payload(record)
+    supplied = payload.get("digest")
+    if isinstance(supplied, str) and supplied.startswith("sha256:") and len(supplied) == 71:
+        return supplied
+    return "sha256:" + hashlib.sha256(_canonical_json(_without_digest(payload)).encode("utf-8")).hexdigest()
+
+
+def _record_id(record: Any, candidates: Sequence[str]) -> str:
+    payload = _source_payload(record)
+    for name in candidates:
+        if payload.get(name):
+            return str(payload[name])
+    return _digest_id("source-record-", payload)
+
+
+def _transaction_id_from_records(records: Sequence[Any]) -> str:
+    for record in records:
+        payload = _source_payload(record)
+        for name in ("source_effect_receipt_id", "effect_receipt_id", "receipt_id"):
+            value = payload.get(name)
+            if value:
+                return "local-effect-transaction-" + str(value).replace("local-diagnostic-effect-receipt-", "")
+    material = tuple(_record_digest(record) for record in records)
+    return _digest_id("local-effect-transaction-", {"records": material})
+
+
+def _blocked_actions_from_record(record: Any) -> tuple[str, ...]:
+    payload = _source_payload(record)
+    labels = set(_tuple(payload.get("blocked_actions")))
+    for field in _FORBIDDEN_TRUE_FIELDS:
+        if payload.get(field):
+            labels.add(field.replace("_performed", "").replace("_requested", ""))
+    return tuple(sorted(labels))
+
+
+def _contradiction_codes_for_record(event_kind: str, record: Any) -> tuple[str, ...]:
+    payload = _source_payload(record)
+    codes: list[str] = []
+    supplied = payload.get("digest")
+    if supplied and not (isinstance(supplied, str) and supplied.startswith("sha256:") and len(supplied) == 71):
+        codes.append(f"digest_mismatch:{event_kind}")
+    for field in _FORBIDDEN_TRUE_FIELDS:
+        if payload.get(field):
+            codes.append(f"forbidden_claim:{event_kind}:{field}")
+    return tuple(codes)
+
+
+def build_local_effect_transaction_entry(
+    *,
+    transaction_id: str,
+    event_kind: str,
+    source_record: Any,
+    transaction_status: str,
+    previous_entry_digest: str | None = None,
+    evidence_summary: Sequence[str] = (),
+    created_at: str | None = None,
+) -> LocalEffectTransactionEntry:
+    if event_kind not in EVENT_KINDS:
+        raise ValueError(f"unknown event kind: {event_kind}")
+    if transaction_status not in TRANSACTION_STATUSES:
+        raise ValueError(f"unknown transaction status: {transaction_status}")
+    payload = _source_payload(source_record)
+    id_candidates = ("receipt_id", "check_id", "audit_id", "plan_id", "result_id", "request_id")
+    if "postcondition" in event_kind:
+        id_candidates = ("check_id", "receipt_id", "audit_id", "plan_id", "result_id", "request_id")
+    elif "audit" in event_kind:
+        id_candidates = ("audit_id", "receipt_id", "check_id", "plan_id", "result_id", "request_id")
+    elif "plan" in event_kind:
+        id_candidates = ("plan_id", "receipt_id", "check_id", "audit_id", "result_id", "request_id")
+    elif event_kind.endswith("requested"):
+        id_candidates = ("request_id", "receipt_id", "check_id", "audit_id", "plan_id", "result_id")
+    elif event_kind.endswith("performed"):
+        id_candidates = ("result_id", "receipt_id", "check_id", "audit_id", "plan_id", "request_id")
+    entry_payload: dict[str, Any] = {
+        "entry_id": "",
+        "transaction_id": transaction_id,
+        "event_kind": event_kind,
+        "source_record_id": _record_id(source_record, id_candidates),
+        "source_record_digest": _record_digest(source_record),
+        "previous_entry_digest": previous_entry_digest,
+        "transaction_status": transaction_status,
+        "output_path": payload.get("output_path") or payload.get("expected_output_path"),
+        "artifact_digest": payload.get("artifact_digest") or payload.get("expected_artifact_digest") or payload.get("observed_artifact_digest"),
+        "evidence_summary": _tuple(evidence_summary or payload.get("evidence_summary") or (event_kind,)),
+        "blocked_actions": _blocked_actions_from_record(source_record) or BLOCKED_ACTION_LABELS,
+        "warning_codes": _tuple(payload.get("warning_codes")),
+        "risk_codes": _tuple(payload.get("risk_codes")),
+        "created_at": created_at or str(payload.get("created_at") or DEFAULT_CREATED_AT),
+        "digest": "",
+        "metadata_only": True,
+        "ledger_entry_only": True,
+        "performs_no_new_effect": True,
+        "host_mutation_performed": False,
+        "file_delete_performed": False,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+        "subprocess_performed": False,
+        "shell_performed": False,
+    }
+    entry_payload["entry_id"] = _digest_id("local-effect-transaction-entry-", entry_payload)
+    entry_payload["digest"] = local_effect_transaction_entry_digest(entry_payload)
+    return LocalEffectTransactionEntry(**entry_payload)
+
+
+def _entry_specs(**records: Any) -> tuple[tuple[str, Any, str, tuple[str, ...]], ...]:
+    specs = []
+    mapping = (
+        ("effect_request", "diagnostic_effect_requested", "local_effect_transaction_open", ("diagnostic effect request recorded",)),
+        ("effect_result", "diagnostic_effect_performed", "local_effect_transaction_effect_recorded", ("diagnostic effect result recorded",)),
+        ("effect_receipt", "diagnostic_effect_receipt_recorded", "local_effect_transaction_effect_recorded", ("real effect receipt recorded",)),
+        ("postcondition_check", "diagnostic_postcondition_passed", "local_effect_transaction_postcondition_passed", ("diagnostic postcondition passed",)),
+        ("production_audit", "diagnostic_production_audit_recorded", "local_effect_transaction_audit_recorded", ("production audit receipt recorded",)),
+        ("rollback_plan", "diagnostic_rollback_plan_recorded", "local_effect_transaction_rollback_available", ("exact artifact rollback plan recorded",)),
+        ("exact_rollback_request", "diagnostic_exact_rollback_requested", "local_effect_transaction_rollback_available", ("exact rollback request recorded",)),
+        ("exact_rollback_result", "diagnostic_exact_rollback_performed", "local_effect_transaction_rollback_performed", ("exact rollback result recorded",)),
+        ("exact_rollback_receipt", "diagnostic_exact_rollback_receipt_recorded", "local_effect_transaction_rollback_performed", ("exact rollback receipt recorded",)),
+        ("rollback_postcondition_check", "diagnostic_rollback_postcondition_passed", "local_effect_transaction_rollback_postcondition_passed", ("rollback postcondition passed",)),
+        ("rollback_audit", "diagnostic_rollback_audit_recorded", "local_effect_transaction_rollback_audit_recorded", ("rollback audit receipt recorded",)),
+    )
+    for key, event_kind, status, evidence in mapping:
+        if records.get(key) is not None:
+            specs.append((event_kind, records[key], status, evidence))
+    return tuple(specs)
+
+
+def _classify(events: Sequence[str], contradiction_codes: Sequence[str]) -> tuple[str, str, tuple[str, ...]]:
+    event_set = set(events)
+    issues: list[str] = []
+    if contradiction_codes or "transaction_contradicted" in event_set:
+        codes = tuple(contradiction_codes) or ("transaction_contradicted",)
+        return "local_effect_transaction_ledger_contradicted", "local_effect_transaction_contradicted", codes
+    if "diagnostic_effect_receipt_recorded" not in event_set:
+        return "local_effect_transaction_ledger_invalid", "local_effect_transaction_invalid", ("missing_effect_receipt",)
+    if "diagnostic_postcondition_passed" not in event_set:
+        issues.append("missing_postcondition")
+    if "diagnostic_production_audit_recorded" not in event_set:
+        issues.append("missing_production_audit")
+    if "diagnostic_rollback_plan_recorded" not in event_set:
+        issues.append("missing_rollback_plan")
+    has_rollback = "diagnostic_exact_rollback_receipt_recorded" in event_set
+    if not has_rollback:
+        issues.append("rollback_pending")
+    else:
+        if "diagnostic_rollback_postcondition_passed" not in event_set:
+            issues.append("missing_rollback_postcondition")
+        if "diagnostic_rollback_audit_recorded" not in event_set:
+            issues.append("missing_rollback_audit")
+    if issues:
+        status = "local_effect_transaction_orphaned" if issues[0] in {"missing_postcondition", "missing_production_audit"} else "local_effect_transaction_incomplete"
+        return "local_effect_transaction_ledger_incomplete", status, tuple(issues)
+    return "local_effect_transaction_ledger_current", "local_effect_transaction_closed", ()
+
+
+def build_local_effect_transaction_ledger(
+    entries: Sequence[LocalEffectTransactionEntry],
+    *,
+    transaction_id: str | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+    allow_duplicate_event_kinds: bool = False,
+) -> LocalEffectTransactionLedger:
+    entry_tuple = tuple(entries)
+    tx = transaction_id or (entry_tuple[0].transaction_id if entry_tuple else _digest_id("local-effect-transaction-", {"empty": True}))
+    events = [entry.event_kind for entry in entry_tuple]
+    contradiction_codes: list[str] = []
+    if len(set(events)) != len(events) and not allow_duplicate_event_kinds:
+        duplicates = sorted({event for event in events if events.count(event) > 1})
+        contradiction_codes.extend(f"duplicate_event_kind:{event}" for event in duplicates)
+    for index, entry in enumerate(entry_tuple):
+        validation = validate_local_effect_transaction_entry(entry)
+        contradiction_codes.extend(validation.findings)
+        if entry.event_kind == "transaction_contradicted":
+            contradiction_codes.extend(entry.evidence_summary or ("transaction_contradicted",))
+        expected_previous = entry_tuple[index - 1].digest if index else None
+        if entry.previous_entry_digest != expected_previous:
+            contradiction_codes.append(f"entry_digest_chain_mismatch:{entry.event_kind}")
+    ledger_status, current_status, issues = _classify(events, contradiction_codes)
+    ids = {entry.event_kind: entry.source_record_id for entry in entry_tuple}
+    payload: dict[str, Any] = {
+        "ledger_id": "",
+        "transaction_id": tx,
+        "entries": entry_tuple,
+        "ledger_status": ledger_status,
+        "current_transaction_status": current_status,
+        "effect_receipt_id": ids.get("diagnostic_effect_receipt_recorded"),
+        "postcondition_check_id": ids.get("diagnostic_postcondition_passed"),
+        "production_audit_id": ids.get("diagnostic_production_audit_recorded"),
+        "rollback_plan_id": ids.get("diagnostic_rollback_plan_recorded"),
+        "rollback_receipt_id": ids.get("diagnostic_exact_rollback_receipt_recorded"),
+        "rollback_postcondition_check_id": ids.get("diagnostic_rollback_postcondition_passed"),
+        "rollback_audit_id": ids.get("diagnostic_rollback_audit_recorded"),
+        "open_issue_codes": tuple(issues),
+        "blocked_actions": tuple(sorted(set().union(*(set(entry.blocked_actions) for entry in entry_tuple)))) if entry_tuple else BLOCKED_ACTION_LABELS,
+        "warning_codes": tuple(sorted(set().union(*(set(entry.warning_codes) for entry in entry_tuple), set(issues)))) if entry_tuple else tuple(issues),
+        "risk_codes": tuple(sorted(set().union(*(set(entry.risk_codes) for entry in entry_tuple), {"metadata_only_transaction_integrity_ledger"}))),
+        "created_at": created_at,
+        "digest": "",
+        "metadata_only": True,
+        "transaction_ledger_only": True,
+        "performs_no_new_effect": True,
+        "host_mutation_performed": False,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+    }
+    payload["ledger_id"] = _digest_id("local-effect-transaction-ledger-", {**payload, "entries": [entry.to_dict() for entry in entry_tuple]})
+    digest_payload = {**payload, "entries": [entry.to_dict() for entry in entry_tuple]}
+    payload["digest"] = local_effect_transaction_ledger_digest(digest_payload)
+    return LocalEffectTransactionLedger(**payload)
+
+
+def build_local_effect_transaction_lifecycle_report(ledger: LocalEffectTransactionLedger, *, created_at: str | None = None) -> LocalEffectTransactionLifecycleReport:
+    present = tuple(entry.event_kind for entry in ledger.entries)
+    present_set = set(present)
+    missing: list[str] = []
+    required = ("diagnostic_effect_receipt_recorded", "diagnostic_postcondition_passed", "diagnostic_production_audit_recorded", "diagnostic_rollback_plan_recorded")
+    for event in required:
+        if event not in present_set:
+            missing.append(event)
+    if "diagnostic_exact_rollback_receipt_recorded" in present_set:
+        for event in ("diagnostic_rollback_postcondition_passed", "diagnostic_rollback_audit_recorded"):
+            if event not in present_set:
+                missing.append(event)
+    contradiction_codes = tuple(code for code in ledger.open_issue_codes if "contradict" in code or "forbidden" in code or "duplicate_event_kind" in code or "digest_mismatch" in code or "chain_mismatch" in code)
+    orphan_codes: tuple[str, ...] = ()
+    closure_codes: tuple[str, ...] = ()
+    if ledger.ledger_status == "local_effect_transaction_ledger_invalid":
+        status = "local_effect_lifecycle_invalid"
+    elif ledger.ledger_status == "local_effect_transaction_ledger_contradicted" or contradiction_codes:
+        status = "local_effect_lifecycle_contradicted"
+    elif "diagnostic_postcondition_passed" not in present_set:
+        status = "local_effect_lifecycle_missing_postcondition"
+        orphan_codes = ("effect_receipt_without_postcondition",)
+    elif "diagnostic_production_audit_recorded" not in present_set:
+        status = "local_effect_lifecycle_missing_audit"
+        orphan_codes = ("effect_receipt_without_audit",)
+    elif "diagnostic_rollback_plan_recorded" not in present_set:
+        status = "local_effect_lifecycle_missing_rollback_plan"
+    elif "diagnostic_exact_rollback_receipt_recorded" not in present_set:
+        status = "local_effect_lifecycle_rollback_pending"
+    elif "diagnostic_rollback_postcondition_passed" not in present_set or "diagnostic_rollback_audit_recorded" not in present_set:
+        status = "local_effect_lifecycle_rollback_incomplete"
+    else:
+        status = "local_effect_lifecycle_complete_with_rollback"
+        closure_codes = ("effect_postcondition_audit_rollback_postcondition_and_audit_recorded",)
+    payload: dict[str, Any] = {
+        "report_id": "",
+        "ledger_id": ledger.ledger_id,
+        "transaction_id": ledger.transaction_id,
+        "lifecycle_status": status,
+        "present_event_kinds": present,
+        "missing_event_kinds": tuple(missing),
+        "orphan_codes": orphan_codes,
+        "contradiction_codes": contradiction_codes,
+        "closure_codes": closure_codes,
+        "warning_codes": ledger.warning_codes,
+        "risk_codes": ledger.risk_codes,
+        "created_at": created_at or ledger.created_at,
+        "digest": "",
+        "metadata_only": True,
+        "lifecycle_report_only": True,
+        "performs_no_new_effect": True,
+        "host_mutation_performed": False,
+    }
+    payload["report_id"] = _digest_id("local-effect-lifecycle-report-", payload)
+    payload["digest"] = local_effect_transaction_lifecycle_report_digest(payload)
+    return LocalEffectTransactionLifecycleReport(**payload)
+
+
+def build_transaction_ledger_from_local_diagnostic_records(
+    *,
+    effect_request: Any | None = None,
+    effect_result: Any | None = None,
+    effect_receipt: Any | None = None,
+    postcondition_check: Any | None = None,
+    production_audit: Any | None = None,
+    rollback_plan: Any | None = None,
+    exact_rollback_request: Any | None = None,
+    exact_rollback_result: Any | None = None,
+    exact_rollback_receipt: Any | None = None,
+    rollback_postcondition_check: Any | None = None,
+    rollback_audit: Any | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+    allow_duplicate_event_kinds: bool = False,
+) -> LocalEffectTransactionLedgerBundle:
+    supplied = tuple(record for record in (effect_request, effect_result, effect_receipt, postcondition_check, production_audit, rollback_plan, exact_rollback_request, exact_rollback_result, exact_rollback_receipt, rollback_postcondition_check, rollback_audit) if record is not None)
+    transaction_id = _transaction_id_from_records(supplied)
+    entries: list[LocalEffectTransactionEntry] = []
+    previous: str | None = None
+    contradiction_sources: list[str] = []
+    for event_kind, record, status, evidence in _entry_specs(
+        effect_request=effect_request,
+        effect_result=effect_result,
+        effect_receipt=effect_receipt,
+        postcondition_check=postcondition_check,
+        production_audit=production_audit,
+        rollback_plan=rollback_plan,
+        exact_rollback_request=exact_rollback_request,
+        exact_rollback_result=exact_rollback_result,
+        exact_rollback_receipt=exact_rollback_receipt,
+        rollback_postcondition_check=rollback_postcondition_check,
+        rollback_audit=rollback_audit,
+    ):
+        codes = _contradiction_codes_for_record(event_kind, record)
+        entry_status = "local_effect_transaction_contradicted" if codes else status
+        entry = build_local_effect_transaction_entry(transaction_id=transaction_id, event_kind=event_kind, source_record=record, transaction_status=entry_status, previous_entry_digest=previous, evidence_summary=evidence, created_at=created_at)
+        entries.append(entry)
+        previous = entry.digest
+        contradiction_sources.extend(codes)
+    if contradiction_sources:
+        marker = {"marker_id": "transaction-contradiction", "digest": hashlib.sha256("transaction-contradiction".encode("utf-8")).hexdigest(), "evidence_summary": tuple(contradiction_sources), "created_at": created_at}
+        entries.append(build_local_effect_transaction_entry(transaction_id=transaction_id, event_kind="transaction_contradicted", source_record=marker, transaction_status="local_effect_transaction_contradicted", previous_entry_digest=previous, evidence_summary=contradiction_sources, created_at=created_at))
+    ledger = build_local_effect_transaction_ledger(entries, transaction_id=transaction_id, created_at=created_at, allow_duplicate_event_kinds=allow_duplicate_event_kinds)
+    report = build_local_effect_transaction_lifecycle_report(ledger, created_at=created_at)
+    return LocalEffectTransactionLedgerBundle(ledger, report)
+
+
+def validate_local_effect_transaction_entry(entry: LocalEffectTransactionEntry | Mapping[str, Any]) -> LocalEffectTransactionLedgerValidationResult:
+    p = _source_payload(entry)
+    findings: list[str] = []
+    if p.get("event_kind") not in EVENT_KINDS:
+        findings.append("unknown_event_kind")
+    if p.get("transaction_status") not in TRANSACTION_STATUSES:
+        findings.append("unknown_transaction_status")
+    for flag in ("metadata_only", "ledger_entry_only", "performs_no_new_effect"):
+        if not p.get(flag):
+            findings.append(f"entry_missing_{flag}")
+    for flag in ("host_mutation_performed", "file_delete_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "subprocess_performed", "shell_performed"):
+        if p.get(flag):
+            findings.append(f"entry_forbidden_{flag}")
+    if p.get("digest") != local_effect_transaction_entry_digest(p):
+        findings.append("entry_digest_mismatch")
+    return LocalEffectTransactionLedgerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_effect_transaction_ledger(ledger: LocalEffectTransactionLedger | Mapping[str, Any]) -> LocalEffectTransactionLedgerValidationResult:
+    p = _source_payload(ledger)
+    findings: list[str] = []
+    if p.get("ledger_status") not in LEDGER_STATUSES:
+        findings.append("unknown_ledger_status")
+    if p.get("current_transaction_status") not in TRANSACTION_STATUSES:
+        findings.append("unknown_current_transaction_status")
+    for flag in ("metadata_only", "transaction_ledger_only", "performs_no_new_effect"):
+        if not p.get(flag):
+            findings.append(f"ledger_missing_{flag}")
+    for flag in ("host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"ledger_forbidden_{flag}")
+    digest_payload = dict(p)
+    digest_payload["entries"] = [entry.to_dict() if hasattr(entry, "to_dict") else dict(entry) for entry in p.get("entries", ())]
+    if p.get("digest") != local_effect_transaction_ledger_digest(digest_payload):
+        findings.append("ledger_digest_mismatch")
+    return LocalEffectTransactionLedgerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_effect_transaction_lifecycle_report(report: LocalEffectTransactionLifecycleReport | Mapping[str, Any]) -> LocalEffectTransactionLedgerValidationResult:
+    p = _source_payload(report)
+    findings: list[str] = []
+    if p.get("lifecycle_status") not in LIFECYCLE_STATUSES:
+        findings.append("unknown_lifecycle_status")
+    for flag in ("metadata_only", "lifecycle_report_only", "performs_no_new_effect"):
+        if not p.get(flag):
+            findings.append(f"report_missing_{flag}")
+    if p.get("host_mutation_performed"):
+        findings.append("report_forbidden_host_mutation")
+    if p.get("digest") != local_effect_transaction_lifecycle_report_digest(p):
+        findings.append("report_digest_mismatch")
+    return LocalEffectTransactionLedgerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def validate_local_effect_transaction_ledger_artifact_receipt(receipt: LocalEffectTransactionLedgerArtifactReceipt | Mapping[str, Any]) -> LocalEffectTransactionLedgerValidationResult:
+    p = _source_payload(receipt)
+    findings: list[str] = []
+    if p.get("artifact_status") not in ARTIFACT_STATUSES:
+        findings.append("unknown_artifact_status")
+    for flag in ("metadata_only", "ledger_artifact_receipt_only"):
+        if not p.get(flag):
+            findings.append(f"artifact_receipt_missing_{flag}")
+    for flag in ("network_performed", "provider_invocation_performed", "prompt_assembly_performed"):
+        if p.get(flag):
+            findings.append(f"artifact_receipt_forbidden_{flag}")
+    if p.get("digest") != local_effect_transaction_ledger_artifact_receipt_digest(p):
+        findings.append("artifact_receipt_digest_mismatch")
+    return LocalEffectTransactionLedgerValidationResult(ok=not findings, findings=tuple(findings))
+
+
+def _artifact_payload(ledger: LocalEffectTransactionLedger, report: LocalEffectTransactionLifecycleReport | None = None) -> dict[str, Any]:
+    return {
+        "metadata_only": True,
+        "local_effect_transaction_ledger_artifact": True,
+        "performs_no_new_effect": True,
+        "ledger": ledger.to_dict(),
+        "lifecycle_report": report.to_dict() if report else build_local_effect_transaction_lifecycle_report(ledger).to_dict(),
+    }
+
+
+def write_local_effect_transaction_ledger_artifact(
+    ledger: LocalEffectTransactionLedger,
+    output_path: str | Path,
+    *,
+    lifecycle_report: LocalEffectTransactionLifecycleReport | None = None,
+    created_at: str | None = None,
+    force: bool = False,
+) -> LocalEffectTransactionLedgerArtifactReceipt:
+    path = Path(output_path).expanduser()
+    if not str(output_path) or path == Path(path.anchor) or path.resolve() == Path(path.anchor).resolve():
+        raise ValueError("refusing unsafe ledger artifact output path")
+    if path.exists() and path.is_dir():
+        raise ValueError("ledger artifact output path must be a file, not a directory")
+    if path.exists() and not force:
+        raise FileExistsError("ledger artifact already exists; pass --force to overwrite")
+    content = json.dumps(_artifact_payload(ledger, lifecycle_report), indent=2, sort_keys=True) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    encoded = content.encode("utf-8")
+    artifact_digest = hashlib.sha256(encoded).hexdigest()
+    payload: dict[str, Any] = {
+        "receipt_id": "",
+        "ledger_id": ledger.ledger_id,
+        "output_path": str(path),
+        "artifact_digest": artifact_digest,
+        "byte_count": len(encoded),
+        "artifact_status": "local_effect_transaction_ledger_artifact_written" if ledger.ledger_status == "local_effect_transaction_ledger_current" else ("local_effect_transaction_ledger_artifact_contradicted" if ledger.ledger_status == "local_effect_transaction_ledger_contradicted" else "local_effect_transaction_ledger_artifact_incomplete"),
+        "warning_codes": ledger.warning_codes,
+        "risk_codes": tuple(sorted(set(ledger.risk_codes + ("explicit_local_ledger_artifact_write",)))),
+        "created_at": created_at or ledger.created_at,
+        "digest": "",
+        "metadata_only": True,
+        "ledger_artifact_receipt_only": True,
+        "local_file_write_performed": True,
+        "host_mutation_performed": True,
+        "network_performed": False,
+        "provider_invocation_performed": False,
+        "prompt_assembly_performed": False,
+    }
+    payload["receipt_id"] = _digest_id("local-effect-ledger-artifact-receipt-", payload)
+    payload["digest"] = local_effect_transaction_ledger_artifact_receipt_digest(payload)
+    return LocalEffectTransactionLedgerArtifactReceipt(**payload)
+
+
+def summarize_local_effect_transaction_entry(entry: LocalEffectTransactionEntry | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(entry)
+    return {k: p.get(k) for k in ("entry_id", "transaction_id", "event_kind", "source_record_id", "source_record_digest", "previous_entry_digest", "transaction_status", "output_path", "artifact_digest", "metadata_only", "performs_no_new_effect", "host_mutation_performed", "file_delete_performed", "digest")}
+
+
+def summarize_local_effect_transaction_ledger(ledger: LocalEffectTransactionLedger | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(ledger)
+    return {k: p.get(k) for k in ("ledger_id", "transaction_id", "ledger_status", "current_transaction_status", "effect_receipt_id", "postcondition_check_id", "production_audit_id", "rollback_plan_id", "rollback_receipt_id", "rollback_postcondition_check_id", "rollback_audit_id", "open_issue_codes", "metadata_only", "performs_no_new_effect", "host_mutation_performed", "digest")}
+
+
+def summarize_local_effect_transaction_lifecycle_report(report: LocalEffectTransactionLifecycleReport | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(report)
+    return {k: p.get(k) for k in ("report_id", "ledger_id", "transaction_id", "lifecycle_status", "present_event_kinds", "missing_event_kinds", "orphan_codes", "contradiction_codes", "closure_codes", "metadata_only", "performs_no_new_effect", "host_mutation_performed", "digest")}
+
+
+def summarize_local_effect_transaction_ledger_artifact_receipt(receipt: LocalEffectTransactionLedgerArtifactReceipt | Mapping[str, Any]) -> dict[str, Any]:
+    p = _source_payload(receipt)
+    return {k: p.get(k) for k in ("receipt_id", "ledger_id", "output_path", "artifact_digest", "byte_count", "artifact_status", "metadata_only", "local_file_write_performed", "host_mutation_performed", "network_performed", "provider_invocation_performed", "prompt_assembly_performed", "digest")}

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -115,6 +115,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "real_effect_admission_posture",
         "local_diagnostic_effect_capability",
         "local_diagnostic_rollback_capability",
+        "local_effect_transaction_ledger_capability",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -145,6 +146,7 @@ BUNDLE_FILE_NAMES = {
     "real_effect_admission_posture": "real_effect_admission.json",
     "local_diagnostic_effect_capability": "local_diagnostic_effect_capability.json",
     "local_diagnostic_rollback_capability": "local_diagnostic_rollback_capability.json",
+    "local_effect_transaction_ledger_capability": "local_effect_transaction_ledger_capability.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -314,6 +316,7 @@ def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord,
         (("python", "scripts/verify_context_hygiene_prompt_boundaries.py"), "Verify prompt/provider boundary hygiene."),
         (("python", "scripts/run_local_diagnostic_effect.py", "--output-dir", "/tmp/sentientos-local-effect", "--summary"), "Optional explicit Tier-1 local diagnostic effect pilot; listed for reviewer awareness and not run by proof bundle generation."),
         (("python", "scripts/run_local_diagnostic_rollback.py", "--effect-receipt", "<receipt.json>", "--rollback-plan", "<rollback-plan.json>", "--output-dir-scope", "/tmp/sentientos-local-effect", "--summary"), "Optional explicit exact-artifact rollback pilot; listed for reviewer awareness and not run by proof bundle generation."),
+        (("python", "scripts/build_local_effect_transaction_ledger.py", "--effect-receipt", "<effect_receipt.json>", "--postcondition-check", "<postcondition.json>", "--production-audit", "<audit.json>", "--rollback-plan", "<rollback_plan.json>", "--summary"), "Optional metadata-only local effect transaction ledger; listed for reviewer awareness and not run by proof bundle generation."),
     )
     return tuple(
         ReviewerProofCommandRecord(
@@ -738,6 +741,25 @@ def build_reviewer_proof_bundle_payload(
             "command": "python scripts/run_local_diagnostic_rollback.py --effect-receipt <receipt.json> --rollback-plan <rollback-plan.json> --output-dir-scope /tmp/sentientos-local-effect --summary",
             "not_general_cleanup": True,
             "no_directory_recursive_wildcard_or_unrelated_delete": True,
+            "no_fan_pwm_thermal_power_service_package_driver": True,
+            "no_network_provider_prompt_subprocess_shell_control_plane": True,
+        }),
+        "local_effect_transaction_ledger_capability": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "capability_available": True,
+            "explicit_command_required": True,
+            "run_by_reviewer_proof_bundle_default": False,
+            "proof_bundle_effect_performed": False,
+            "proof_bundle_rollback_performed": False,
+            "proof_bundle_ledger_built_by_default": False,
+            "proof_bundle_host_mutation_performed": False,
+            "transaction_ledger_exists": True,
+            "performs_no_new_host_effect_by_default": True,
+            "builds_from_explicit_effect_and_rollback_record_files": True,
+            "command": "python scripts/build_local_effect_transaction_ledger.py --effect-receipt <effect_receipt.json> --postcondition-check <postcondition.json> --production-audit <audit.json> --rollback-plan <rollback_plan.json> --summary",
+            "detects_open_orphaned_incomplete_contradicted_and_closed_transactions": True,
+            "general_cleanup_hardware_service_network_provider_prompt_remain_blocked": True,
             "no_fan_pwm_thermal_power_service_package_driver": True,
             "no_network_provider_prompt_subprocess_shell_control_plane": True,
         }),

--- a/tests/test_build_local_effect_transaction_ledger_script.py
+++ b/tests/test_build_local_effect_transaction_ledger_script.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import build_local_effect_transaction_ledger as script
+from sentientos.local_diagnostic_effect import run_local_diagnostic_effect_wing, run_local_diagnostic_exact_rollback_wing
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _write(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _record_files(tmp_path: Path) -> dict[str, Path]:
+    effect_dir = tmp_path / "effect"
+    records = run_local_diagnostic_effect_wing(output_dir=effect_dir)
+    return {
+        "effect": _write(tmp_path / "effect_receipt.json", records.receipt.to_dict()),
+        "post": _write(tmp_path / "postcondition_check.json", records.postcondition_check.to_dict()),
+        "audit": _write(tmp_path / "production_audit.json", records.production_audit_receipt.to_dict()),
+        "plan": _write(tmp_path / "rollback_plan.json", records.rollback_plan.to_dict()),
+    }
+
+
+def test_cli_requires_required_record_paths() -> None:
+    assert script.main([]) == 2
+
+
+def test_cli_builds_summary_from_record_files(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    files = _record_files(tmp_path)
+    assert script.main(["--effect-receipt", str(files["effect"]), "--postcondition-check", str(files["post"]), "--production-audit", str(files["audit"]), "--rollback-plan", str(files["plan"]), "--summary"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ledger"]["ledger_status"] == "local_effect_transaction_ledger_incomplete"
+    assert payload["lifecycle_report"]["lifecycle_status"] == "local_effect_lifecycle_rollback_pending"
+    assert payload["host_mutation_performed"] is False
+    assert payload["subprocess_performed"] is False
+    assert payload["shell_performed"] is False
+
+
+def test_cli_writes_explicit_output_only(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    files = _record_files(tmp_path)
+    output = tmp_path / "ledger.json"
+    before = set(tmp_path.rglob("*"))
+    assert script.main(["--effect-receipt", str(files["effect"]), "--postcondition-check", str(files["post"]), "--production-audit", str(files["audit"]), "--rollback-plan", str(files["plan"]), "--output", str(output), "--summary"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert output.exists()
+    assert set(tmp_path.rglob("*")) - before == {output}
+    assert payload["artifact_receipt"]["output_path"] == str(output)
+
+
+def test_cli_refuses_unsafe_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    files = _record_files(tmp_path)
+    assert script.main(["--effect-receipt", str(files["effect"]), "--postcondition-check", str(files["post"]), "--production-audit", str(files["audit"]), "--rollback-plan", str(files["plan"]), "--output", str(tmp_path)]) == 2
+    assert "directory" in capsys.readouterr().err
+
+
+def test_cli_full_rollback_records_close_transaction(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    effect_dir = tmp_path / "effect"
+    records = run_local_diagnostic_effect_wing(output_dir=effect_dir)
+    rollback = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=effect_dir)
+    paths = {
+        "effect": _write(tmp_path / "effect_receipt.json", records.receipt.to_dict()),
+        "post": _write(tmp_path / "postcondition_check.json", records.postcondition_check.to_dict()),
+        "audit": _write(tmp_path / "production_audit.json", records.production_audit_receipt.to_dict()),
+        "plan": _write(tmp_path / "rollback_plan.json", records.rollback_plan.to_dict()),
+        "rollback": _write(tmp_path / "rollback_receipt.json", rollback.receipt.to_dict()),
+        "rollback_post": _write(tmp_path / "rollback_postcondition_check.json", rollback.postcondition_check.to_dict()),
+        "rollback_audit": _write(tmp_path / "rollback_audit.json", rollback.audit_receipt.to_dict()),
+    }
+    assert script.main(["--effect-receipt", str(paths["effect"]), "--postcondition-check", str(paths["post"]), "--production-audit", str(paths["audit"]), "--rollback-plan", str(paths["plan"]), "--rollback-receipt", str(paths["rollback"]), "--rollback-postcondition-check", str(paths["rollback_post"]), "--rollback-audit", str(paths["rollback_audit"]), "--summary"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ledger"]["current_transaction_status"] == "local_effect_transaction_closed"

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -658,3 +658,17 @@ def test_local_diagnostic_exact_rollback_capabilities_are_exact_artifact_only() 
     for capability_id in ["real_file_cleanup", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "provider_invocation", "federation_transport_sync_adoption"]:
         assert records[capability_id].status in {"blocked", "deferred"}
     assert validate_capability_registry(build_default_capability_registry()).ok
+
+
+def test_local_effect_transaction_ledger_capabilities_are_bounded() -> None:
+    registry = build_default_capability_registry()
+    records = registry.by_id()
+    assert records["local_effect_transaction_ledger"].status == "implemented"
+    assert records["local_effect_transaction_ledger"].authority_level == "local_effect_transaction_ledger_only"
+    assert records["local_effect_lifecycle_report"].status == "implemented"
+    assert records["local_effect_lifecycle_report"].authority_level == "local_effect_lifecycle_report_only"
+    assert records["local_effect_transaction_ledger_artifact"].status == "implemented"
+    assert records["local_effect_transaction_ledger_artifact"].authority_level == "explicit_local_artifact_only"
+    assert records["general_effect_transaction_ledger"].status == "deferred"
+    for capability_id in ["general_cleanup", "recursive_delete", "unrelated_file_delete", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install", "network_egress", "provider_invocation", "prompt_assembly", "remote_execution"]:
+        assert records[capability_id].status == "blocked"

--- a/tests/test_local_effect_transaction_ledger.py
+++ b/tests/test_local_effect_transaction_ledger.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sentientos.local_diagnostic_effect import run_local_diagnostic_effect_wing, run_local_diagnostic_exact_rollback_wing
+from sentientos.local_effect_transaction_ledger import (
+    build_local_effect_transaction_lifecycle_report,
+    build_local_effect_transaction_ledger,
+    build_transaction_ledger_from_local_diagnostic_records,
+    local_effect_transaction_ledger_digest,
+    validate_local_effect_transaction_ledger,
+    validate_local_effect_transaction_lifecycle_report,
+    write_local_effect_transaction_ledger_artifact,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _effect_records(tmp_path: Path):
+    return run_local_diagnostic_effect_wing(output_dir=tmp_path / "effect")
+
+
+def test_ledger_builds_from_effect_records_and_marks_rollback_pending(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    bundle = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        postcondition_check=records.postcondition_check,
+        production_audit=records.production_audit_receipt,
+        rollback_plan=records.rollback_plan,
+    )
+    assert bundle.ledger.ledger_status == "local_effect_transaction_ledger_incomplete"
+    assert bundle.ledger.current_transaction_status == "local_effect_transaction_incomplete"
+    assert "rollback_pending" in bundle.ledger.open_issue_codes
+    assert bundle.lifecycle_report.lifecycle_status == "local_effect_lifecycle_rollback_pending"
+    assert bundle.ledger.host_mutation_performed is False
+    assert bundle.lifecycle_report.host_mutation_performed is False
+    assert validate_local_effect_transaction_ledger(bundle.ledger).ok
+    assert validate_local_effect_transaction_lifecycle_report(bundle.lifecycle_report).ok
+
+
+def test_full_effect_and_rollback_records_close_transaction(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    rollback = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=tmp_path / "effect")
+    bundle = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        postcondition_check=records.postcondition_check,
+        production_audit=records.production_audit_receipt,
+        rollback_plan=records.rollback_plan,
+        exact_rollback_receipt=rollback.receipt,
+        rollback_postcondition_check=rollback.postcondition_check,
+        rollback_audit=rollback.audit_receipt,
+    )
+    assert bundle.ledger.ledger_status == "local_effect_transaction_ledger_current"
+    assert bundle.ledger.current_transaction_status == "local_effect_transaction_closed"
+    assert bundle.lifecycle_report.lifecycle_status == "local_effect_lifecycle_complete_with_rollback"
+    assert bundle.lifecycle_report.closure_codes
+
+
+def test_missing_postcondition_and_audit_are_classified(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    missing_post = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        production_audit=records.production_audit_receipt,
+        rollback_plan=records.rollback_plan,
+    )
+    assert missing_post.lifecycle_report.lifecycle_status == "local_effect_lifecycle_missing_postcondition"
+    missing_audit = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        postcondition_check=records.postcondition_check,
+        rollback_plan=records.rollback_plan,
+    )
+    assert missing_audit.lifecycle_report.lifecycle_status == "local_effect_lifecycle_missing_audit"
+
+
+def test_missing_rollback_postcondition_and_audit_are_classified(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    rollback = run_local_diagnostic_exact_rollback_wing(records.receipt, records.rollback_plan, output_dir_scope=tmp_path / "effect")
+    missing_post = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        postcondition_check=records.postcondition_check,
+        production_audit=records.production_audit_receipt,
+        rollback_plan=records.rollback_plan,
+        exact_rollback_receipt=rollback.receipt,
+        rollback_audit=rollback.audit_receipt,
+    )
+    assert missing_post.lifecycle_report.lifecycle_status == "local_effect_lifecycle_rollback_incomplete"
+    assert "diagnostic_rollback_postcondition_passed" in missing_post.lifecycle_report.missing_event_kinds
+    missing_audit = build_transaction_ledger_from_local_diagnostic_records(
+        effect_receipt=records.receipt,
+        postcondition_check=records.postcondition_check,
+        production_audit=records.production_audit_receipt,
+        rollback_plan=records.rollback_plan,
+        exact_rollback_receipt=rollback.receipt,
+        rollback_postcondition_check=rollback.postcondition_check,
+    )
+    assert missing_audit.lifecycle_report.lifecycle_status == "local_effect_lifecycle_rollback_incomplete"
+    assert "diagnostic_rollback_audit_recorded" in missing_audit.lifecycle_report.missing_event_kinds
+
+
+def test_duplicate_event_kinds_and_digest_mismatch_are_contradictions(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    bundle = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=records.receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    duplicate = build_local_effect_transaction_ledger((bundle.ledger.entries[0], bundle.ledger.entries[0]), transaction_id=bundle.ledger.transaction_id)
+    assert duplicate.ledger_status == "local_effect_transaction_ledger_contradicted"
+    bad_receipt = {**records.receipt.to_dict(), "digest": "bad"}
+    mismatched = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=bad_receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    assert mismatched.ledger.ledger_status == "local_effect_transaction_ledger_contradicted"
+    assert any("digest_mismatch" in code for code in mismatched.lifecycle_report.contradiction_codes)
+
+
+def test_forbidden_flags_are_contradictions(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    bad_receipt = {**records.receipt.to_dict(), "network_performed": True, "provider_invocation_performed": True, "prompt_assembly_performed": True, "subprocess_performed": True, "shell_performed": True, "fan_pwm_write_performed": True}
+    bundle = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=bad_receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    assert bundle.ledger.ledger_status == "local_effect_transaction_ledger_contradicted"
+    assert bundle.lifecycle_report.lifecycle_status == "local_effect_lifecycle_contradicted"
+    assert any("forbidden_claim" in code for code in bundle.lifecycle_report.contradiction_codes)
+
+
+def test_digest_chain_and_record_digests_are_deterministic(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    first = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=records.receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    second = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=records.receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    assert [entry.digest for entry in first.ledger.entries] == [entry.digest for entry in second.ledger.entries]
+    assert first.ledger.entries[1].previous_entry_digest == first.ledger.entries[0].digest
+    assert first.ledger.digest == second.ledger.digest
+    assert first.lifecycle_report.digest == second.lifecycle_report.digest
+    changed = replace(first.ledger, warning_codes=first.ledger.warning_codes + ("changed",), digest="")
+    changed = replace(changed, digest=local_effect_transaction_ledger_digest(changed.to_dict()))
+    assert changed.digest != first.ledger.digest
+
+
+def test_optional_artifact_write_is_explicit_and_refuses_unsafe_paths(tmp_path: Path) -> None:
+    records = _effect_records(tmp_path)
+    bundle = build_transaction_ledger_from_local_diagnostic_records(effect_receipt=records.receipt, postcondition_check=records.postcondition_check, production_audit=records.production_audit_receipt, rollback_plan=records.rollback_plan)
+    before = set(tmp_path.rglob("*"))
+    output = tmp_path / "ledger.json"
+    receipt = write_local_effect_transaction_ledger_artifact(bundle.ledger, output, lifecycle_report=bundle.lifecycle_report)
+    after = set(tmp_path.rglob("*"))
+    assert output.exists()
+    assert after - before == {output}
+    assert receipt.local_file_write_performed is True
+    assert receipt.host_mutation_performed is True
+    with pytest.raises(ValueError):
+        write_local_effect_transaction_ledger_artifact(bundle.ledger, tmp_path)
+    with pytest.raises(ValueError):
+        write_local_effect_transaction_ledger_artifact(bundle.ledger, Path("/"))

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -63,6 +63,7 @@ def test_default_proof_commands_are_listed_and_not_run() -> None:
     rendered = [" ".join(command.command) for command in commands]
     assert "python scripts/build_host_embodiment_trace.py --validate-only" in rendered
     assert "python scripts/verify_context_hygiene_prompt_boundaries.py" in rendered
+    assert "python scripts/build_local_effect_transaction_ledger.py --effect-receipt <effect_receipt.json> --postcondition-check <postcondition.json> --production-audit <audit.json> --rollback-plan <rollback_plan.json> --summary" in rendered
 
 
 def test_bundle_includes_expected_artifacts_and_content() -> None:
@@ -77,6 +78,7 @@ def test_bundle_includes_expected_artifacts_and_content() -> None:
         "proof_command_manifest",
         "reviewer_readme",
         "bundle_manifest",
+        "local_effect_transaction_ledger_capability",
     ]:
         assert key in artifacts
     assert "fake/sample" in artifacts["trace_summary"]
@@ -84,6 +86,8 @@ def test_bundle_includes_expected_artifacts_and_content() -> None:
     assert "reviewer_proof_bundle" in artifacts["capability_registry_summary"]
     assert "real_fan_pwm_control" in artifacts["deferred_action_inventory"]
     assert "proof_command_not_run" in artifacts["proof_command_manifest"]
+    assert "performs_no_new_host_effect_by_default" in artifacts["local_effect_transaction_ledger_capability"]
+    assert "proof_bundle_ledger_built_by_default" in artifacts["local_effect_transaction_ledger_capability"]
 
 
 def test_deferred_actions_cover_non_mutating_boundary() -> None:

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -575,3 +575,20 @@ def test_exact_rollback_pilot_doc_is_linked_and_preserves_boundaries() -> None:
     assert "not general cleanup" in doc
     assert "proof bundle does not run" in doc
     assert "python scripts/run_local_diagnostic_rollback.py" in doc
+
+HOST_LOCAL_EFFECT_TRANSACTION_LEDGER_WING = "docs/architecture/host_local_effect_transaction_ledger_wing.md"
+
+
+def test_transaction_ledger_doc_is_linked_and_preserves_boundaries() -> None:
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    doc = _read(HOST_LOCAL_EFFECT_TRANSACTION_LEDGER_WING)
+    assert HOST_LOCAL_EFFECT_TRANSACTION_LEDGER_WING in overview
+    assert HOST_LOCAL_EFFECT_TRANSACTION_LEDGER_WING in index
+    assert "does **not** introduce a new host effect" in doc
+    assert "open or rollback-pending transactions" in doc
+    assert "orphaned effects" in doc
+    assert "incomplete rollback" in doc
+    assert "closed transactions" in doc
+    assert "not general cleanup" in doc
+    assert "python scripts/build_local_effect_transaction_ledger.py" in doc


### PR DESCRIPTION
### Motivation

- Ensure the Tier-1 local diagnostic effect and its exact-artifact rollback are not loose records by providing a metadata-only transaction ledger that proves lifecycle completeness or classifies open/orphaned/incomplete/contradicted transactions. 
- Provide deterministic digest-chained entries, lifecycle reports, and an optional explicit local ledger artifact write without introducing any new host effects.

### Description

- Add `sentientos/local_effect_transaction_ledger.py` implementing immutable dataclasses for `LocalEffectTransactionEntry`, `LocalEffectTransactionLedger`, `LocalEffectTransactionLifecycleReport`, and `LocalEffectTransactionLedgerArtifactReceipt`, deterministic digest helpers, validators, summarizers, and `build_transaction_ledger_from_local_diagnostic_records(...)` to assemble digest-chained ledgers and lifecycle reports from existing effect/rollback records. 
- Add CLI `scripts/build_local_effect_transaction_ledger.py` that ingests effect/rollback JSON records, builds the ledger + lifecycle report, validates them, prints JSON (or compact summary) and optionally writes one explicit ledger artifact to a caller-supplied file path with safe-path checks and `--force` overwrite. 
- Integrate with reviewer tooling by adding `local_effect_transaction_ledger_capability.json` entries into `sentientos/reviewer_proof_bundle.py` (proof command listed as `not_run`) and update the reviewer bundle artifacts/commands accordingly. 
- Update `sentientos/capability_registry.py` to add bounded capability records for `local_effect_transaction_ledger`, lifecycle report, and explicit artifact surface, plus `update_registry_from_local_effect_transaction_ledger(...)` to reflect ledger presence without widening authority, and add blocking/deferred entries for broader/forbidden actions. 
- Emit machine-readable record files from the existing CLIs: `scripts/run_local_diagnostic_effect.py` now writes `effect_receipt.json`, `postcondition_check.json`, `production_audit.json`, and `rollback_plan.json`; `scripts/run_local_diagnostic_rollback.py` now writes `rollback_receipt.json`, `rollback_postcondition_check.json`, and `rollback_audit.json` when not dry-run. 
- Add documentation `docs/architecture/host_local_effect_transaction_ledger_wing.md` and update several architecture docs to link and describe the wing and its boundaries. 
- Add tests `tests/test_local_effect_transaction_ledger.py` and `tests/test_build_local_effect_transaction_ledger_script.py` and update related reviewer/capability tests to assert the new capability and proof command entries. 
- All ledger/entry/ report constructors and validators are metadata-only and marked to prevent any new host effect; the only permitted mutation is the explicit single-file ledger artifact write invoked by the CLI or caller-provided API and guarded by path checks.

### Testing

- Ran `python -m py_compile` on the new and modified modules and CLIs without syntax errors. 
- Executed the targeted test suites with `python -m scripts.run_tests` including: `tests/test_local_effect_transaction_ledger.py`, `tests/test_build_local_effect_transaction_ledger_script.py`, `tests/test_local_diagnostic_exact_rollback.py`, `tests/test_run_local_diagnostic_rollback_script.py`, `tests/test_local_diagnostic_effect.py`, `tests/test_run_local_diagnostic_effect_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py`, plus broader proof suites (`tests/test_real_effect_admission.py`, `tests/test_dry_run_audit_closure.py`, `tests/test_dry_run_execution_harness.py`, `tests/test_fulfillment_executor_contract.py`, `tests/test_control_plane_kernel.py`, `tests/test_sentientosd_runtime_closure.py`). All modified and added tests passed in the final verification runs. 
- Performed docs build checks (`scripts/build_docs.py --check-deps` and `scripts/build_docs.py`) to ensure documentation pages generated and the new ledger doc is linked from the public overview and readiness index. 
- Ran a forbidden-ops scan for patterns (`socket`, `requests`, `subprocess`, `os.system`, `Popen`, `shell=True`, `unlink/delete`, `fan/pwm/thermal write`, etc.) across new/changed files; the only file-system mutation allowed is the single explicit ledger artifact write guarded by safe-path checks, and no subprocess/network/provider/prompt/control-plane/hardware mutations were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07ed77adec8320861e24c3d2bab9e8)