### PR TITLE
[codex:host-steward] add delegated runner boundary wing

### DIFF
--- a/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
+++ b/docs/architecture/host_embodiment_controlled_authorization_and_trace_wing.md
@@ -88,3 +88,5 @@ The authority ladder later reaches the [Host Local Diagnostic Effect Pilot Wing]
 Later bounded real-effect proof organs include the [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) and its [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); both remain explicit and narrow.
 
 The later [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) remains downstream of authorization, real-effect admission, the local diagnostic effect pilot, and exact rollback; it is metadata-only transaction integrity, not new authority.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_effect_pilot_wing.md
@@ -58,3 +58,5 @@ The capability registry marks `local_diagnostic_effect`, `local_diagnostic_effec
 The matching exact-artifact rollback pilot is documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md); it deletes only the recorded diagnostic artifact when explicitly requested.
 
 Related: [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) records the diagnostic effect plus exact rollback lifecycle without adding a new host effect.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
+++ b/docs/architecture/host_local_diagnostic_exact_rollback_pilot_wing.md
@@ -66,3 +66,5 @@ The capability registry marks `local_diagnostic_exact_rollback`, `local_diagnost
 - Tests: `tests/test_local_diagnostic_exact_rollback.py`, `tests/test_run_local_diagnostic_rollback_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
 
 Next: [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) connects the effect, rollback, postcondition, and audit records into a metadata-only transaction lifecycle ledger.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/host_local_effect_transaction_ledger_wing.md
+++ b/docs/architecture/host_local_effect_transaction_ledger_wing.md
@@ -58,3 +58,5 @@ The capability registry marks `local_effect_transaction_ledger`, `local_effect_l
 - Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
 - Capability registry integration: `sentientos/capability_registry.py`
 - Tests: `tests/test_local_effect_transaction_ledger.py`, `tests/test_build_local_effect_transaction_ledger_script.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/host_steward_delegated_runner_boundary_wing.md
+++ b/docs/architecture/host_steward_delegated_runner_boundary_wing.md
@@ -1,0 +1,78 @@
+# Host Steward / Delegated Runner Boundary Wing
+
+This wing follows the [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md). The local effect transaction ledger added integrity over the first local diagnostic effect and exact-artifact rollback lifecycle, but did not add a new host effect. This wing adds the next authority model: the boundary between broad top-level local host-steward authority and narrow delegated-runner authority.
+
+## Purpose
+
+SentientOS is intended to become a full local host stewardship runtime: a user-space runtime that can eventually operate the machine under explicit operator authority. The core host steward may eventually hold broad operator-delegated local authority.
+
+That broad host-steward authority is not inherited by every child action, generated script, plugin, backend adapter, federation artifact, external tool, or future runner. Delegated runners do not inherit ambient authority by default. Generated code, plugins, backend adapters, federation imports, and external tools must receive typed, scoped, revocable, auditable grants before any future effect path may consume authority.
+
+## What this wing implements
+
+`sentientos/host_steward_boundary.py` defines metadata-only records for:
+
+- `HostStewardAuthorityProfile`
+- `DelegatedRunnerBoundaryProfile`
+- `ExecutionContainmentProfile`
+- `BackendAdapterAuthorityDeclaration`
+- `RunnerCapabilityGrantScaffold`
+- `RunnerBoundaryAssessment`
+- `RunnerBoundaryViolationReceipt`
+
+These records are authority models and proof surfaces only. They are not runners, not execution permissions, not backend implementations, and not host effects.
+
+## Boundary rules
+
+- A host steward profile may state that the top-level SentientOS steward can eventually hold broad local operator-delegated authority.
+- Delegated runner boundary profiles explicitly deny ambient authority inheritance.
+- Execution containment profiles are declarations, not live sandbox execution.
+- Backend adapter declarations do not load or invoke backends.
+- Runner capability grant scaffolds do not issue live grants.
+- Runner boundary assessments do not authorize runner execution.
+- Runner boundary violation receipts record a blocked posture; they do not execute or mutate anything.
+
+## Current real-effect posture
+
+This wing does not spawn processes, use shell, use network, invoke providers, assemble prompts, mutate host state, call control-plane execution, or broaden current real effects.
+
+The current only real effects remain:
+
+1. the explicit local diagnostic artifact write; and
+2. the explicit exact-artifact rollback for that diagnostic artifact.
+
+Hardware control, service control, power control, cleanup, network egress, provider invocation, prompt assembly/export, subprocess execution, shell execution, fan/PWM writes, thermal actuation, OS backend invocation, federation transport/sync/adoption, remote execution, and uncontrolled runtime authority expansion remain blocked or deferred.
+
+## Reviewer proof bundle
+
+The reviewer proof bundle includes `host_steward_boundary.json`. It proves that:
+
+- delegated runners do not inherit ambient authority;
+- no runner executes by default;
+- containment profiles are not live sandbox execution;
+- backend declarations do not load or invoke backends;
+- grant scaffolds do not issue live runner grants; and
+- boundary assessments do not authorize runner execution.
+
+Bundle generation remains metadata-only and does not run the diagnostic effect, rollback, ledger builder, runner, backend, network, provider, prompt, shell, or subprocess path.
+
+## Capability registry posture
+
+The capability registry marks host-steward boundary surfaces as implemented metadata-only records:
+
+- `host_steward_authority_profile` is authority-profile-only.
+- `delegated_runner_boundary_profile` is boundary-profile-only.
+- `execution_containment_profile` is containment-profile-only.
+- `backend_adapter_authority_declaration` is declaration-only.
+- `runner_capability_grant_scaffold` is scaffold-only.
+- `runner_boundary_assessment` is assessment-only.
+- `runner_boundary_violation_receipt` is receipt-only.
+
+`live_runner_execution` remains deferred. Subprocess, shell, network, provider, prompt assembly, hardware control, service control, power control, cleanup, fan/PWM, and thermal runners remain blocked or deferred.
+
+## Implementation links
+
+- Module: `sentientos/host_steward_boundary.py`
+- Reviewer bundle integration: `sentientos/reviewer_proof_bundle.py`
+- Capability registry integration: `sentientos/capability_registry.py`
+- Tests: `tests/test_host_steward_boundary.py`, `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, `tests/test_reviewer_release_readiness_index.py`

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -276,3 +276,5 @@ For the first intentionally real but bounded effect, see the [Host Local Diagnos
 Host embodiment proof now includes an explicit [local diagnostic effect pilot](host_local_diagnostic_effect_pilot_wing.md) and matching [exact artifact rollback pilot](host_local_diagnostic_exact_rollback_pilot_wing.md); reviewer bundles document but do not run either by default.
 
 The [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md) (`docs/architecture/host_local_effect_transaction_ledger_wing.md`) adds metadata-only lifecycle integrity for the local diagnostic effect and exact rollback; it adds no new host effect and is not general cleanup or broader host control.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -122,3 +122,5 @@ The bundle documents but does not run the [Host Local Diagnostic Effect Pilot Wi
 The proof bundle lists, but does not run, the exact-artifact rollback CLI documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md).
 
 The bundle also includes `local_effect_transaction_ledger_capability.json`; its ledger command is listed as `proof_command_not_run` and does not run effect or rollback by default. See [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md).
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -278,3 +278,5 @@ See [Host Real Effect Capability Admission Wing](host_real_effect_capability_adm
 - [Host Local Diagnostic Effect Pilot Wing](host_local_diagnostic_effect_pilot_wing.md) — first intentionally real effect, explicit diagnostic artifact write only, reviewer bundle does not run it by default.
 
 The exact-artifact rollback proof is documented in [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md): it is the first real rollback and is exact diagnostic artifact only, not general cleanup.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -426,3 +426,5 @@ The first bounded real-effect pilot is the [Host Local Diagnostic Effect Pilot W
 The trajectory now includes a bounded [Host Local Diagnostic Exact Artifact Rollback Pilot Wing](host_local_diagnostic_exact_rollback_pilot_wing.md): the first real rollback, limited to the exact diagnostic artifact and not general cleanup.
 
 - [Host Local Effect Transaction Ledger Wing](host_local_effect_transaction_ledger_wing.md): metadata-only integrity ledger for the Tier-1 local diagnostic effect and exact rollback lifecycle before broader effect implementation.
+
+See also: [Host Steward / Delegated Runner Boundary Wing](host_steward_delegated_runner_boundary_wing.md) (`docs/architecture/host_steward_delegated_runner_boundary_wing.md`) for the next authority boundary after the local effect transaction ledger. It models broad top-level host-steward authority without granting delegated runners ambient authority.

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -49,6 +49,8 @@ CAPABILITY_CATEGORIES = frozenset(
         "real_effect_admission",
         "local_diagnostic_effect",
         "local_effect_transaction_ledger",
+        "host_steward_boundary",
+        "delegated_runner_boundary",
         "runtime_supervision",
         "audit_immutability",
         "self_amendment",
@@ -110,6 +112,11 @@ AUTHORITY_LEVELS = frozenset(
         "local_effect_transaction_ledger_only",
         "local_effect_lifecycle_report_only",
         "explicit_local_artifact_only",
+        "authority_profile_only",
+        "boundary_profile_only",
+        "containment_profile_only",
+        "grant_scaffold_only",
+        "violation_receipt_only",
         "candidate_only",
         "plan_scaffold_only",
         "block_receipt_only",
@@ -360,6 +367,23 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("local_effect_transaction_ledger", "local_effect_transaction_ledger", "implemented", "local_effect_transaction_ledger_only", source_paths=("sentientos/local_effect_transaction_ledger.py", "scripts/build_local_effect_transaction_ledger.py"), proof_tests=("tests/test_local_effect_transaction_ledger.py", "tests/test_build_local_effect_transaction_ledger_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_local_effect_transaction_ledger.py tests/test_build_local_effect_transaction_ledger_script.py", "python scripts/build_local_effect_transaction_ledger.py --effect-receipt <effect_receipt.json> --postcondition-check <postcondition.json> --production-audit <audit.json> --rollback-plan <rollback_plan.json> --summary"), implemented_surfaces=("metadata-only transaction ledger for local diagnostic effect and exact rollback records", "digest-chain validation", "open/orphan/incomplete/contradicted/closed lifecycle classification"), deferred_surfaces=("broader effect transaction ledger", "general cleanup", "broader host control"), forbidden_implications=("transaction ledger performs host effects", "ledger authorizes cleanup or rollback"), requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("local_effect_lifecycle_report", "local_effect_transaction_ledger", "implemented", "local_effect_lifecycle_report_only", source_paths=("sentientos/local_effect_transaction_ledger.py",), proof_tests=("tests/test_local_effect_transaction_ledger.py",), implemented_surfaces=("metadata-only lifecycle status report for local diagnostic transactions",), deferred_surfaces=("general lifecycle enforcement",), forbidden_implications=("lifecycle report performs host mutation")),
         _record("local_effect_transaction_ledger_artifact", "local_effect_transaction_ledger", "implemented", "explicit_local_artifact_only", source_paths=("sentientos/local_effect_transaction_ledger.py", "scripts/build_local_effect_transaction_ledger.py"), proof_tests=("tests/test_local_effect_transaction_ledger.py", "tests/test_build_local_effect_transaction_ledger_script.py"), implemented_surfaces=("optional explicit caller-supplied local JSON ledger artifact write",), deferred_surfaces=("default proof bundle execution", "implicit artifact writes"), forbidden_implications=("ledger artifact write runs effect or rollback")),
+        _record("host_steward_authority_profile", "host_steward_boundary", "implemented", "authority_profile_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only host steward authority profile", "top-level operator-delegated broad local authority model"), deferred_surfaces=("delegated runner execution",), forbidden_implications=("authority profile grants live runner authority",)),
+        _record("delegated_runner_boundary_profile", "delegated_runner_boundary", "implemented", "boundary_profile_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only delegated runner boundary profile", "ambient authority inheritance denial"), deferred_surfaces=("live runner implementation",), forbidden_implications=("boundary profile executes runner",)),
+        _record("execution_containment_profile", "delegated_runner_boundary", "implemented", "containment_profile_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only containment declaration",), deferred_surfaces=("live sandbox enforcement",), forbidden_implications=("containment declaration is live sandbox execution",)),
+        _record("backend_adapter_authority_declaration", "delegated_runner_boundary", "implemented", "declaration_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only backend adapter authority declaration",), deferred_surfaces=("backend loading", "backend invocation"), forbidden_implications=("declaration invokes backend",)),
+        _record("runner_capability_grant_scaffold", "delegated_runner_boundary", "implemented", "grant_scaffold_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only scoped revocable auditable grant scaffold",), deferred_surfaces=("live runner grant issuance",), forbidden_implications=("grant scaffold issues live runner grant",)),
+        _record("runner_boundary_assessment", "delegated_runner_boundary", "implemented", "assessment_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only runner boundary assessment",), deferred_surfaces=("execution authorization",), forbidden_implications=("boundary assessment authorizes execution",)),
+        _record("runner_boundary_violation_receipt", "delegated_runner_boundary", "implemented", "violation_receipt_only", source_paths=("sentientos/host_steward_boundary.py",), proof_tests=("tests/test_host_steward_boundary.py",), implemented_surfaces=("metadata-only runner boundary violation receipt",), deferred_surfaces=("runner execution", "host mutation"), forbidden_implications=("violation receipt authorizes execution",)),
+        _record("live_runner_execution", "delegated_runner_boundary", "deferred", "none", deferred_surfaces=("live delegated runner execution",), forbidden_implications=("host steward boundary wing implements runner execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("real_subprocess_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("subprocess runner",), forbidden_implications=("delegated runner subprocess execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("shell_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("shell runner",), forbidden_implications=("delegated runner shell execution",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("network_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("network runner",), forbidden_implications=("delegated runner network egress",), network_required=False),
+        _record("provider_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("provider runner",), forbidden_implications=("delegated runner provider invocation",), provider_required=False),
+        _record("prompt_assembly_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("prompt assembly runner",), forbidden_implications=("delegated runner prompt assembly",), prompt_assembly_required=False),
+        _record("hardware_control_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("hardware control runner",), forbidden_implications=("delegated runner hardware control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("service_control_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("service control runner",), forbidden_implications=("delegated runner service control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("power_control_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("power control runner",), forbidden_implications=("delegated runner power control",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True),
+        _record("cleanup_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("cleanup runner",), forbidden_implications=("delegated runner cleanup",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("general_effect_transaction_ledger", "local_effect_transaction_ledger", "deferred", "none", deferred_surfaces=("transaction ledgers for broader host effects",), forbidden_implications=("local diagnostic transaction ledger covers arbitrary host effects"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("general_cleanup", "execution_proof", "blocked", "none", deferred_surfaces=("general cleanup", "directory cleanup", "wildcard cleanup"), forbidden_implications=("exact artifact rollback is general cleanup"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("recursive_delete", "execution_proof", "blocked", "none", deferred_surfaces=("recursive delete",), forbidden_implications=("rollback uses recursive deletion"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -1215,3 +1239,42 @@ def update_registry_from_local_effect_transaction_ledger(registry: CapabilityReg
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-local-effect-transaction-ledger-wing.v1")
+
+
+def update_registry_from_host_steward_boundary(registry: CapabilityRegistry, wing: Any) -> CapabilityRegistry:
+    """Reflect metadata-only host steward boundary records without adding runner execution."""
+
+    payload = wing.to_dict() if hasattr(wing, "to_dict") else dict(wing)
+    has_profile = bool(payload.get("host_steward_profile"))
+    boundary_ids = {
+        "host_steward_authority_profile",
+        "delegated_runner_boundary_profile",
+        "execution_containment_profile",
+        "backend_adapter_authority_declaration",
+        "runner_capability_grant_scaffold",
+        "runner_boundary_assessment",
+        "runner_boundary_violation_receipt",
+    }
+    blocked_runner_ids = {
+        "live_runner_execution",
+        "real_subprocess_runner",
+        "shell_runner",
+        "network_runner",
+        "provider_runner",
+        "prompt_assembly_runner",
+        "hardware_control_runner",
+        "service_control_runner",
+        "power_control_runner",
+        "cleanup_runner",
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+    }
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id in boundary_ids:
+            records.append(replace(record, status="implemented" if has_profile else record.status, host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in blocked_runner_ids:
+            records.append(replace(record, status="deferred" if record.capability_id == "live_runner_execution" else "blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-steward-delegated-runner-boundary-wing.v1")

--- a/sentientos/host_steward_boundary.py
+++ b/sentientos/host_steward_boundary.py
@@ -1,0 +1,702 @@
+"""Metadata-only host steward / delegated runner authority boundary.
+
+This module models authority records only. It does not implement runners, load
+backends, execute processes, call providers, assemble prompts, use network
+transport, inspect privileged devices, or mutate host state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Mapping, Sequence
+
+HOST_STEWARD_PROFILE_STATUSES = frozenset({
+    "host_steward_authority_profile_ready",
+    "host_steward_authority_profile_ready_with_warnings",
+    "host_steward_authority_profile_blocked",
+    "host_steward_authority_profile_incomplete",
+    "host_steward_authority_profile_contradicted",
+})
+DELEGATED_RUNNER_BOUNDARY_STATUSES = frozenset({
+    "delegated_runner_boundary_ready",
+    "delegated_runner_boundary_ready_with_warnings",
+    "delegated_runner_boundary_blocked",
+    "delegated_runner_boundary_incomplete",
+    "delegated_runner_boundary_contradicted",
+})
+CONTAINMENT_STATUSES = frozenset({
+    "execution_containment_declared",
+    "execution_containment_declared_with_warnings",
+    "execution_containment_blocked",
+    "execution_containment_incomplete",
+    "execution_containment_contradicted",
+})
+BACKEND_AUTHORITY_STATUSES = frozenset({
+    "backend_adapter_authority_declared",
+    "backend_adapter_authority_declared_with_warnings",
+    "backend_adapter_authority_blocked",
+    "backend_adapter_authority_incomplete",
+    "backend_adapter_authority_contradicted",
+})
+RUNNER_GRANT_SCAFFOLD_STATUSES = frozenset({
+    "runner_capability_grant_scaffold_ready",
+    "runner_capability_grant_scaffold_ready_with_conditions",
+    "runner_capability_grant_scaffold_blocked",
+    "runner_capability_grant_scaffold_incomplete",
+    "runner_capability_grant_scaffold_contradicted",
+})
+BOUNDARY_ASSESSMENT_STATUSES = frozenset({
+    "runner_boundary_assessment_passed",
+    "runner_boundary_assessment_passed_with_warnings",
+    "runner_boundary_assessment_blocked",
+    "runner_boundary_assessment_incomplete",
+    "runner_boundary_assessment_contradicted",
+})
+VIOLATION_RECEIPT_STATUSES = frozenset({
+    "runner_boundary_violation_recorded",
+    "runner_boundary_violation_recorded_with_warnings",
+    "runner_boundary_violation_blocked",
+    "runner_boundary_violation_incomplete",
+    "runner_boundary_violation_contradicted",
+})
+
+AUTHORITY_MODES = frozenset({
+    "full_local_host_steward_mode",
+    "bounded_local_effect_mode",
+    "dry_run_only_mode",
+    "metadata_only_mode",
+    "delegated_runner_mode",
+    "offline_runner_mode",
+    "no_network_runner_mode",
+    "no_host_mutation_runner_mode",
+    "diagnostic_file_effect_mode",
+})
+RUNNER_TRUST_CLASSES = frozenset({
+    "trusted_core_runtime",
+    "bounded_builtin_runner",
+    "generated_code_runner",
+    "plugin_runner",
+    "backend_adapter_runner",
+    "federation_import_runner",
+    "external_tool_runner",
+    "unknown_runner",
+})
+CONTAINMENT_CLASSES = frozenset({
+    "metadata_only_containment",
+    "dry_run_simulation_containment",
+    "local_file_effect_containment",
+    "exact_artifact_rollback_containment",
+    "offline_no_network_containment",
+    "bounded_workspace_containment",
+    "future_os_sandbox_containment",
+    "future_privileged_backend_containment",
+})
+AUTHORITY_LABELS = frozenset({
+    "host_steward_may_hold_broad_local_authority",
+    "delegated_runners_do_not_inherit_ambient_authority",
+    "runner_authority_must_be_scoped",
+    "runner_authority_must_be_revocable",
+    "runner_authority_must_be_auditable",
+    "runner_authority_must_be_time_bounded",
+    "runner_must_have_explicit_capability_grant",
+    "runner_must_have_effect_receipt",
+    "runner_must_have_postcondition_check",
+    "runner_must_have_rollback_plan",
+    "runner_must_have_transaction_ledger",
+    "runner_must_not_use_network_by_default",
+    "runner_must_not_spawn_shell_by_default",
+    "runner_must_not_use_subprocess_by_default",
+    "runner_must_not_access_hardware_by_default",
+    "runner_must_not_mutate_services_by_default",
+    "runner_must_not_perform_cleanup_by_default",
+    "runner_must_not_use_provider_by_default",
+    "runner_must_not_assemble_prompt_by_default",
+})
+BLOCKED_ACTION_LABELS = frozenset({
+    "ambient_authority_inheritance",
+    "unscoped_runner_authority",
+    "unrevocable_runner_authority",
+    "unaudited_runner_authority",
+    "runner_network_egress",
+    "runner_provider_invocation",
+    "runner_prompt_assembly",
+    "runner_subprocess_execution",
+    "runner_shell_execution",
+    "runner_os_backend_invocation",
+    "runner_hardware_control",
+    "runner_service_control",
+    "runner_power_control",
+    "runner_cleanup",
+    "runner_recursive_delete",
+    "runner_unrelated_file_delete",
+    "runner_fan_pwm_write",
+    "runner_thermal_actuation",
+    "federation_authority_import",
+    "remote_execution",
+    "control_plane_admission_execution",
+})
+UNTRUSTED_RUNNER_CLASSES = frozenset({"generated_code_runner", "plugin_runner", "federation_import_runner", "external_tool_runner", "unknown_runner"})
+REQUIRED_RUNNER_DENIALS = tuple(sorted(label for label in AUTHORITY_LABELS if label.startswith("runner_must_not") or label == "delegated_runners_do_not_inherit_ambient_authority"))
+FORBIDDEN_TRUE_FLAGS = (
+    "grants_live_runner_authority",
+    "executes_runner",
+    "runner_implemented",
+    "runner_executed",
+    "host_mutation_performed",
+    "containment_enforced_live",
+    "backend_loaded",
+    "backend_invoked",
+    "live_runner_grant_issued",
+    "authorizes_runner_execution",
+    "network_performed",
+    "network_egress_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+    "subprocess_execution_performed",
+    "shell_execution_performed",
+    "hardware_control_performed",
+    "service_control_performed",
+    "power_control_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "cleanup_performed",
+    "control_plane_admission_execution_performed",
+)
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _digest_payload(payload: Mapping[str, Any]) -> str:
+    clean = {key: value for key, value in payload.items() if key != "digest"}
+    rendered = json.dumps(clean, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _with_digest(record: Any) -> Any:
+    return replace(record, digest=_digest_payload(asdict(record)))
+
+
+@dataclass(frozen=True)
+class HostStewardBoundaryValidationResult:
+    ok: bool
+    findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class HostStewardAuthorityPolicy:
+    policy_id: str
+    authority_modes: tuple[str, ...]
+    runner_trust_classes: tuple[str, ...]
+    containment_classes: tuple[str, ...]
+    authority_labels: tuple[str, ...]
+    blocked_action_labels: tuple[str, ...]
+    metadata_only: bool = True
+    policy_only: bool = True
+    digest: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostStewardAuthorityProfile:
+    profile_id: str
+    authority_mode: str
+    steward_identity_label: str
+    operator_delegation_labels: tuple[str, ...]
+    allowed_top_level_authority_labels: tuple[str, ...]
+    prohibited_delegation_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    required_revocation_labels: tuple[str, ...]
+    required_boundary_labels: tuple[str, ...]
+    profile_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    authority_profile_only: bool = True
+    grants_live_runner_authority: bool = False
+    executes_runner: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DelegatedRunnerBoundaryProfile:
+    boundary_id: str
+    runner_trust_class: str
+    containment_class: str
+    allowed_authority_labels: tuple[str, ...]
+    denied_authority_labels: tuple[str, ...]
+    required_grant_labels: tuple[str, ...]
+    required_receipt_labels: tuple[str, ...]
+    required_revocation_labels: tuple[str, ...]
+    required_audit_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    boundary_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    boundary_profile_only: bool = True
+    runner_implemented: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExecutionContainmentProfile:
+    containment_id: str
+    containment_class: str
+    writable_scope_labels: tuple[str, ...]
+    readable_scope_labels: tuple[str, ...]
+    network_posture_label: str
+    process_posture_label: str
+    hardware_posture_label: str
+    service_posture_label: str
+    provider_posture_label: str
+    prompt_posture_label: str
+    blocked_actions: tuple[str, ...]
+    containment_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    containment_profile_only: bool = True
+    containment_enforced_live: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BackendAdapterAuthorityDeclaration:
+    declaration_id: str
+    adapter_label: str
+    runner_trust_class: str
+    backend_domain_labels: tuple[str, ...]
+    required_capability_grant_labels: tuple[str, ...]
+    denied_authority_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    declaration_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    declaration_only: bool = True
+    backend_loaded: bool = False
+    backend_invoked: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RunnerCapabilityGrantScaffold:
+    scaffold_id: str
+    boundary_id: str
+    containment_id: str
+    backend_authority_declaration_id: str | None
+    runner_trust_class: str
+    containment_class: str
+    grant_scope_labels: tuple[str, ...]
+    grant_time_bound_labels: tuple[str, ...]
+    grant_revocation_labels: tuple[str, ...]
+    required_effect_receipt_labels: tuple[str, ...]
+    required_postcondition_labels: tuple[str, ...]
+    required_rollback_labels: tuple[str, ...]
+    required_transaction_ledger_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    scaffold_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    grant_scaffold_only: bool = True
+    live_runner_grant_issued: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RunnerBoundaryAssessment:
+    assessment_id: str
+    profile_id: str
+    boundary_id: str
+    containment_id: str
+    grant_scaffold_id: str | None
+    assessment_status: str
+    satisfied_boundary_labels: tuple[str, ...]
+    missing_boundary_labels: tuple[str, ...]
+    violation_codes: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    assessment_only: bool = True
+    authorizes_runner_execution: bool = False
+    live_runner_grant_issued: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RunnerBoundaryViolationReceipt:
+    receipt_id: str
+    assessment_id: str | None
+    runner_trust_class: str
+    containment_class: str
+    violation_status: str
+    violation_codes: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str = ""
+    metadata_only: bool = True
+    violation_receipt_only: bool = True
+    authorizes_runner_execution: bool = False
+    live_runner_grant_issued: bool = False
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HostStewardBoundaryWing:
+    policy: HostStewardAuthorityPolicy
+    host_steward_profile: HostStewardAuthorityProfile
+    delegated_runner_boundaries: tuple[DelegatedRunnerBoundaryProfile, ...]
+    containment_profiles: tuple[ExecutionContainmentProfile, ...]
+    backend_declarations: tuple[BackendAdapterAuthorityDeclaration, ...]
+    grant_scaffolds: tuple[RunnerCapabilityGrantScaffold, ...]
+    boundary_assessments: tuple[RunnerBoundaryAssessment, ...]
+    violation_receipts: tuple[RunnerBoundaryViolationReceipt, ...]
+    metadata_only: bool = True
+    wing_only: bool = True
+    runner_executed: bool = False
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_default_host_steward_authority_policy() -> HostStewardAuthorityPolicy:
+    return _with_digest(HostStewardAuthorityPolicy(
+        policy_id="host-steward-boundary-policy-v1",
+        authority_modes=tuple(sorted(AUTHORITY_MODES)),
+        runner_trust_classes=tuple(sorted(RUNNER_TRUST_CLASSES)),
+        containment_classes=tuple(sorted(CONTAINMENT_CLASSES)),
+        authority_labels=tuple(sorted(AUTHORITY_LABELS)),
+        blocked_action_labels=tuple(sorted(BLOCKED_ACTION_LABELS)),
+    ))
+
+
+def build_host_steward_authority_profile(*, profile_id: str = "default-host-steward-authority-profile", steward_identity_label: str = "sentientos_local_host_steward", created_at: str = "1970-01-01T00:00:00+00:00", authority_mode: str = "full_local_host_steward_mode") -> HostStewardAuthorityProfile:
+    return _with_digest(HostStewardAuthorityProfile(
+        profile_id=profile_id,
+        authority_mode=authority_mode,
+        steward_identity_label=steward_identity_label,
+        operator_delegation_labels=("explicit_operator_delegation_required", "local_operator_authority_preserved"),
+        allowed_top_level_authority_labels=("host_steward_may_hold_broad_local_authority",),
+        prohibited_delegation_labels=("delegated_runners_do_not_inherit_ambient_authority", "ambient_authority_inheritance"),
+        required_audit_labels=("runner_authority_must_be_auditable", "runner_must_have_effect_receipt", "runner_must_have_transaction_ledger"),
+        required_revocation_labels=("runner_authority_must_be_revocable", "runner_authority_must_be_time_bounded"),
+        required_boundary_labels=("runner_authority_must_be_scoped", "runner_must_have_explicit_capability_grant"),
+        profile_status="host_steward_authority_profile_ready",
+        warning_codes=(),
+        risk_codes=("broad_authority_must_remain_top_level_operator_delegated",),
+        created_at=created_at,
+    ))
+
+
+def _default_containment_for_runner(runner_trust_class: str, requested: str | None) -> str:
+    if requested:
+        return requested
+    if runner_trust_class in UNTRUSTED_RUNNER_CLASSES:
+        return "metadata_only_containment"
+    if runner_trust_class == "bounded_builtin_runner":
+        return "dry_run_simulation_containment"
+    return "metadata_only_containment"
+
+
+def build_delegated_runner_boundary_profile(*, boundary_id: str, runner_trust_class: str = "unknown_runner", containment_class: str | None = None, allowed_authority_labels: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> DelegatedRunnerBoundaryProfile:
+    final_containment = _default_containment_for_runner(runner_trust_class, containment_class)
+    allowed = _tuple(allowed_authority_labels)
+    if final_containment in {"local_file_effect_containment", "exact_artifact_rollback_containment"} and runner_trust_class != "bounded_builtin_runner":
+        allowed = ()
+        status = "delegated_runner_boundary_blocked"
+        risks = ("local_file_or_rollback_containment_requires_bounded_builtin_runner",)
+    else:
+        status = "delegated_runner_boundary_ready"
+        risks = ()
+    return _with_digest(DelegatedRunnerBoundaryProfile(
+        boundary_id=boundary_id,
+        runner_trust_class=runner_trust_class,
+        containment_class=final_containment,
+        allowed_authority_labels=allowed,
+        denied_authority_labels=REQUIRED_RUNNER_DENIALS,
+        required_grant_labels=("runner_must_have_explicit_capability_grant", "runner_authority_must_be_scoped", "runner_authority_must_be_time_bounded"),
+        required_receipt_labels=("runner_must_have_effect_receipt", "runner_must_have_postcondition_check", "runner_must_have_transaction_ledger"),
+        required_revocation_labels=("runner_authority_must_be_revocable",),
+        required_audit_labels=("runner_authority_must_be_auditable",),
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        boundary_status=status,
+        warning_codes=(),
+        risk_codes=risks,
+        created_at=created_at,
+    ))
+
+
+def build_execution_containment_profile(*, containment_id: str, containment_class: str = "metadata_only_containment", writable_scope_labels: Sequence[str] = (), readable_scope_labels: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> ExecutionContainmentProfile:
+    return _with_digest(ExecutionContainmentProfile(
+        containment_id=containment_id,
+        containment_class=containment_class,
+        writable_scope_labels=_tuple(writable_scope_labels),
+        readable_scope_labels=_tuple(readable_scope_labels),
+        network_posture_label="no_network_by_default",
+        process_posture_label="no_process_spawn_by_default",
+        hardware_posture_label="no_hardware_access_by_default",
+        service_posture_label="no_service_mutation_by_default",
+        provider_posture_label="no_provider_invocation_by_default",
+        prompt_posture_label="no_prompt_assembly_by_default",
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        containment_status="execution_containment_declared",
+        warning_codes=(),
+        risk_codes=("containment_profile_is_not_live_sandbox_execution",),
+        created_at=created_at,
+    ))
+
+
+def build_backend_adapter_authority_declaration(*, declaration_id: str, adapter_label: str, runner_trust_class: str = "backend_adapter_runner", backend_domain_labels: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> BackendAdapterAuthorityDeclaration:
+    return _with_digest(BackendAdapterAuthorityDeclaration(
+        declaration_id=declaration_id,
+        adapter_label=adapter_label,
+        runner_trust_class=runner_trust_class,
+        backend_domain_labels=_tuple(backend_domain_labels),
+        required_capability_grant_labels=("runner_must_have_explicit_capability_grant", "runner_authority_must_be_scoped"),
+        denied_authority_labels=REQUIRED_RUNNER_DENIALS,
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        declaration_status="backend_adapter_authority_declared",
+        warning_codes=(),
+        risk_codes=("backend_authority_declaration_is_not_backend_invocation",),
+        created_at=created_at,
+    ))
+
+
+def build_runner_capability_grant_scaffold(*, scaffold_id: str, boundary_id: str, containment_id: str, runner_trust_class: str = "unknown_runner", containment_class: str = "metadata_only_containment", backend_authority_declaration_id: str | None = None, grant_scope_labels: Sequence[str] = (), created_at: str = "1970-01-01T00:00:00+00:00") -> RunnerCapabilityGrantScaffold:
+    return _with_digest(RunnerCapabilityGrantScaffold(
+        scaffold_id=scaffold_id,
+        boundary_id=boundary_id,
+        containment_id=containment_id,
+        backend_authority_declaration_id=backend_authority_declaration_id,
+        runner_trust_class=runner_trust_class,
+        containment_class=containment_class,
+        grant_scope_labels=_tuple(grant_scope_labels) or ("metadata_scope_only",),
+        grant_time_bound_labels=("grant_must_have_not_before", "grant_must_have_not_after"),
+        grant_revocation_labels=("grant_must_be_revocable",),
+        required_effect_receipt_labels=("runner_must_have_effect_receipt",),
+        required_postcondition_labels=("runner_must_have_postcondition_check",),
+        required_rollback_labels=("runner_must_have_rollback_plan",),
+        required_transaction_ledger_labels=("runner_must_have_transaction_ledger",),
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        scaffold_status="runner_capability_grant_scaffold_ready",
+        warning_codes=(),
+        risk_codes=("grant_scaffold_is_not_live_runner_grant",),
+        created_at=created_at,
+    ))
+
+
+def assess_runner_boundary(profile: HostStewardAuthorityProfile, boundary: DelegatedRunnerBoundaryProfile, containment: ExecutionContainmentProfile, grant_scaffold: RunnerCapabilityGrantScaffold | None = None, *, assessment_id: str = "runner-boundary-assessment", created_at: str = "1970-01-01T00:00:00+00:00") -> RunnerBoundaryAssessment:
+    required = set(boundary.required_grant_labels + boundary.required_receipt_labels + boundary.required_revocation_labels + boundary.required_audit_labels + ("delegated_runners_do_not_inherit_ambient_authority",))
+    present = set(boundary.denied_authority_labels + boundary.required_grant_labels + boundary.required_receipt_labels + boundary.required_revocation_labels + boundary.required_audit_labels + profile.prohibited_delegation_labels)
+    missing = tuple(sorted(required - present))
+    violations = () if not missing and "ambient_authority_inheritance" in boundary.blocked_actions else ("ambient_authority_boundary_missing",)
+    status = "runner_boundary_assessment_passed" if not violations and not missing else "runner_boundary_assessment_blocked"
+    return _with_digest(RunnerBoundaryAssessment(
+        assessment_id=assessment_id,
+        profile_id=profile.profile_id,
+        boundary_id=boundary.boundary_id,
+        containment_id=containment.containment_id,
+        grant_scaffold_id=grant_scaffold.scaffold_id if grant_scaffold else None,
+        assessment_status=status,
+        satisfied_boundary_labels=tuple(sorted(required & present)),
+        missing_boundary_labels=missing,
+        violation_codes=violations,
+        blocked_actions=tuple(sorted(set(boundary.blocked_actions + containment.blocked_actions))),
+        warning_codes=(),
+        risk_codes=("assessment_does_not_authorize_runner_execution",),
+        created_at=created_at,
+    ))
+
+
+def build_runner_boundary_violation_receipt(*, receipt_id: str, runner_trust_class: str = "unknown_runner", containment_class: str = "metadata_only_containment", assessment_id: str | None = None, violation_codes: Sequence[str] = ("ambient_authority_inheritance_attempt",), created_at: str = "1970-01-01T00:00:00+00:00") -> RunnerBoundaryViolationReceipt:
+    return _with_digest(RunnerBoundaryViolationReceipt(
+        receipt_id=receipt_id,
+        assessment_id=assessment_id,
+        runner_trust_class=runner_trust_class,
+        containment_class=containment_class,
+        violation_status="runner_boundary_violation_recorded",
+        violation_codes=_tuple(violation_codes),
+        blocked_actions=tuple(sorted(BLOCKED_ACTION_LABELS)),
+        warning_codes=(),
+        risk_codes=("violation_receipt_is_not_execution_permission",),
+        created_at=created_at,
+    ))
+
+
+def _validate_common(record: Any, *, status_field: str, allowed_statuses: frozenset[str], required_true_flag: str | None = None, required_blocked_actions: bool = False) -> HostStewardBoundaryValidationResult:
+    payload = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+    findings: list[str] = []
+    if payload.get(status_field) not in allowed_statuses:
+        findings.append(f"unknown_status:{payload.get(status_field)}")
+    if payload.get("metadata_only") is not True:
+        findings.append("not_metadata_only")
+    if required_true_flag and payload.get(required_true_flag) is not True:
+        findings.append(f"missing_flag:{required_true_flag}")
+    for flag in FORBIDDEN_TRUE_FLAGS:
+        if payload.get(flag, False):
+            findings.append(f"forbidden_flag:{flag}")
+    if required_blocked_actions:
+        actions = set(payload.get("blocked_actions", ()) or ())
+        if "ambient_authority_inheritance" not in actions:
+            findings.append("missing_blocked_action:ambient_authority_inheritance")
+        dangerous = BLOCKED_ACTION_LABELS - actions
+        if dangerous:
+            findings.append("missing_blocked_actions:" + ",".join(sorted(dangerous)))
+    expected_digest = _digest_payload(payload)
+    if payload.get("digest") != expected_digest:
+        findings.append("digest_mismatch")
+    return HostStewardBoundaryValidationResult(not findings, tuple(findings))
+
+
+def validate_host_steward_authority_profile(profile: HostStewardAuthorityProfile | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    result = _validate_common(profile, status_field="profile_status", allowed_statuses=HOST_STEWARD_PROFILE_STATUSES, required_true_flag="authority_profile_only")
+    payload = profile.to_dict() if hasattr(profile, "to_dict") else dict(profile)
+    findings = list(result.findings)
+    if "host_steward_may_hold_broad_local_authority" not in payload.get("allowed_top_level_authority_labels", ()): findings.append("missing_broad_host_steward_label")
+    if "delegated_runners_do_not_inherit_ambient_authority" not in payload.get("prohibited_delegation_labels", ()): findings.append("missing_runner_ambient_denial")
+    return HostStewardBoundaryValidationResult(not findings, tuple(findings))
+
+
+def validate_delegated_runner_boundary_profile(boundary: DelegatedRunnerBoundaryProfile | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    result = _validate_common(boundary, status_field="boundary_status", allowed_statuses=DELEGATED_RUNNER_BOUNDARY_STATUSES, required_true_flag="boundary_profile_only", required_blocked_actions=True)
+    payload = boundary.to_dict() if hasattr(boundary, "to_dict") else dict(boundary)
+    findings = list(result.findings)
+    denied = set(payload.get("denied_authority_labels", ()) or ())
+    if "delegated_runners_do_not_inherit_ambient_authority" not in denied: findings.append("missing_denial:delegated_runners_do_not_inherit_ambient_authority")
+    if payload.get("runner_trust_class") in UNTRUSTED_RUNNER_CLASSES and payload.get("containment_class") not in {"metadata_only_containment", "dry_run_simulation_containment", "offline_no_network_containment"}:
+        findings.append("untrusted_runner_has_mutating_containment")
+    return HostStewardBoundaryValidationResult(not findings, tuple(findings))
+
+
+def validate_execution_containment_profile(containment: ExecutionContainmentProfile | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    return _validate_common(containment, status_field="containment_status", allowed_statuses=CONTAINMENT_STATUSES, required_true_flag="containment_profile_only", required_blocked_actions=True)
+
+
+def validate_backend_adapter_authority_declaration(declaration: BackendAdapterAuthorityDeclaration | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    return _validate_common(declaration, status_field="declaration_status", allowed_statuses=BACKEND_AUTHORITY_STATUSES, required_true_flag="declaration_only", required_blocked_actions=True)
+
+
+def validate_runner_capability_grant_scaffold(scaffold: RunnerCapabilityGrantScaffold | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    return _validate_common(scaffold, status_field="scaffold_status", allowed_statuses=RUNNER_GRANT_SCAFFOLD_STATUSES, required_true_flag="grant_scaffold_only", required_blocked_actions=True)
+
+
+def validate_runner_boundary_assessment(assessment: RunnerBoundaryAssessment | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    return _validate_common(assessment, status_field="assessment_status", allowed_statuses=BOUNDARY_ASSESSMENT_STATUSES, required_true_flag="assessment_only", required_blocked_actions=True)
+
+
+def validate_runner_boundary_violation_receipt(receipt: RunnerBoundaryViolationReceipt | Mapping[str, Any]) -> HostStewardBoundaryValidationResult:
+    return _validate_common(receipt, status_field="violation_status", allowed_statuses=VIOLATION_RECEIPT_STATUSES, required_true_flag="violation_receipt_only", required_blocked_actions=True)
+
+
+def host_steward_boundary_digest(record: Any) -> str:
+    payload = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+    return _digest_payload(payload)
+
+
+def _summary(record: Any, id_field: str, status_field: str) -> dict[str, Any]:
+    payload = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+    return {
+        id_field: payload.get(id_field),
+        "status": payload.get(status_field),
+        "metadata_only": payload.get("metadata_only"),
+        "runner_executed": payload.get("runner_executed", payload.get("executes_runner", False)),
+        "live_runner_grant_issued": payload.get("live_runner_grant_issued", payload.get("grants_live_runner_authority", False)),
+        "host_mutation_performed": payload.get("host_mutation_performed", False),
+        "blocked_actions": tuple(payload.get("blocked_actions", ()) or ()),
+        "digest": payload.get("digest"),
+    }
+
+
+def summarize_host_steward_authority_policy(policy: HostStewardAuthorityPolicy) -> dict[str, Any]: return {"policy_id": policy.policy_id, "metadata_only": policy.metadata_only, "policy_only": policy.policy_only, "blocked_action_count": len(policy.blocked_action_labels), "digest": policy.digest}
+def summarize_host_steward_authority_profile(profile: HostStewardAuthorityProfile) -> dict[str, Any]: return _summary(profile, "profile_id", "profile_status") | {"authority_mode": profile.authority_mode, "allowed_top_level_authority_labels": profile.allowed_top_level_authority_labels}
+def summarize_delegated_runner_boundary_profile(boundary: DelegatedRunnerBoundaryProfile) -> dict[str, Any]: return _summary(boundary, "boundary_id", "boundary_status") | {"runner_trust_class": boundary.runner_trust_class, "containment_class": boundary.containment_class, "denied_authority_labels": boundary.denied_authority_labels}
+def summarize_execution_containment_profile(containment: ExecutionContainmentProfile) -> dict[str, Any]: return _summary(containment, "containment_id", "containment_status") | {"containment_class": containment.containment_class, "containment_enforced_live": containment.containment_enforced_live}
+def summarize_backend_adapter_authority_declaration(declaration: BackendAdapterAuthorityDeclaration) -> dict[str, Any]: return _summary(declaration, "declaration_id", "declaration_status") | {"adapter_label": declaration.adapter_label, "backend_loaded": declaration.backend_loaded, "backend_invoked": declaration.backend_invoked}
+def summarize_runner_capability_grant_scaffold(scaffold: RunnerCapabilityGrantScaffold) -> dict[str, Any]: return _summary(scaffold, "scaffold_id", "scaffold_status") | {"grant_scaffold_only": scaffold.grant_scaffold_only}
+def summarize_runner_boundary_assessment(assessment: RunnerBoundaryAssessment) -> dict[str, Any]: return _summary(assessment, "assessment_id", "assessment_status") | {"authorizes_runner_execution": assessment.authorizes_runner_execution, "missing_boundary_labels": assessment.missing_boundary_labels}
+def summarize_runner_boundary_violation_receipt(receipt: RunnerBoundaryViolationReceipt) -> dict[str, Any]: return _summary(receipt, "receipt_id", "violation_status") | {"violation_codes": receipt.violation_codes, "authorizes_runner_execution": receipt.authorizes_runner_execution}
+
+
+def build_host_steward_boundary_wing(*, created_at: str = "1970-01-01T00:00:00+00:00") -> HostStewardBoundaryWing:
+    policy = build_default_host_steward_authority_policy()
+    profile = build_host_steward_authority_profile(created_at=created_at)
+    generated = build_delegated_runner_boundary_profile(boundary_id="generated-plugin-federation-external-runner-boundary", runner_trust_class="generated_code_runner", created_at=created_at)
+    plugin = build_delegated_runner_boundary_profile(boundary_id="plugin-runner-boundary", runner_trust_class="plugin_runner", created_at=created_at)
+    federation = build_delegated_runner_boundary_profile(boundary_id="federation-import-runner-boundary", runner_trust_class="federation_import_runner", created_at=created_at)
+    external = build_delegated_runner_boundary_profile(boundary_id="external-tool-runner-boundary", runner_trust_class="external_tool_runner", created_at=created_at)
+    diagnostic = build_delegated_runner_boundary_profile(boundary_id="local-diagnostic-bounded-runner-boundary", runner_trust_class="bounded_builtin_runner", containment_class="local_file_effect_containment", allowed_authority_labels=("diagnostic_file_effect_mode",), created_at=created_at)
+    containment = build_execution_containment_profile(containment_id="metadata-only-no-network-no-host-mutation-containment", created_at=created_at)
+    diagnostic_containment = build_execution_containment_profile(containment_id="local-diagnostic-file-effect-containment", containment_class="local_file_effect_containment", writable_scope_labels=("caller_supplied_diagnostic_output_directory_only",), readable_scope_labels=("effect_receipt_metadata_only",), created_at=created_at)
+    backend = build_backend_adapter_authority_declaration(declaration_id="future-backend-adapter-authority-declaration", adapter_label="future_metadata_only_backend_adapter", backend_domain_labels=("declaration_only_no_backend_load",), created_at=created_at)
+    scaffold = build_runner_capability_grant_scaffold(scaffold_id="metadata-only-runner-capability-grant-scaffold", boundary_id=generated.boundary_id, containment_id=containment.containment_id, runner_trust_class=generated.runner_trust_class, containment_class=containment.containment_class, backend_authority_declaration_id=backend.declaration_id, created_at=created_at)
+    assessment = assess_runner_boundary(profile, generated, containment, scaffold, assessment_id="metadata-only-runner-boundary-assessment", created_at=created_at)
+    violation = build_runner_boundary_violation_receipt(receipt_id="ambient-authority-inheritance-violation-receipt", assessment_id=assessment.assessment_id, runner_trust_class=generated.runner_trust_class, containment_class=containment.containment_class, created_at=created_at)
+    return HostStewardBoundaryWing(policy, profile, (generated, plugin, federation, external, diagnostic), (containment, diagnostic_containment), (backend,), (scaffold,), (assessment,), (violation,))
+
+
+def summarize_host_steward_boundary_wing(wing: HostStewardBoundaryWing) -> dict[str, Any]:
+    return {
+        "metadata_only": wing.metadata_only,
+        "wing_only": wing.wing_only,
+        "runner_executed": wing.runner_executed,
+        "host_mutation_performed": wing.host_mutation_performed,
+        "host_steward_profile": summarize_host_steward_authority_profile(wing.host_steward_profile),
+        "delegated_runner_boundaries": [summarize_delegated_runner_boundary_profile(item) for item in wing.delegated_runner_boundaries],
+        "containment_profiles": [summarize_execution_containment_profile(item) for item in wing.containment_profiles],
+        "backend_declarations": [summarize_backend_adapter_authority_declaration(item) for item in wing.backend_declarations],
+        "grant_scaffolds": [summarize_runner_capability_grant_scaffold(item) for item in wing.grant_scaffolds],
+        "boundary_assessments": [summarize_runner_boundary_assessment(item) for item in wing.boundary_assessments],
+        "violation_receipts": [summarize_runner_boundary_violation_receipt(item) for item in wing.violation_receipts],
+        "proof_delegated_runners_do_not_inherit_ambient_authority": all("ambient_authority_inheritance" in item.blocked_actions for item in wing.delegated_runner_boundaries),
+        "proof_no_runner_executes_by_default": not wing.runner_executed and all(not item.runner_executed for item in wing.delegated_runner_boundaries),
+    }

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -80,6 +80,10 @@ from sentientos.local_authorization_grant import (
     summarize_operator_approval_evidence,
     summarize_policy_approval_evidence,
 )
+from sentientos.host_steward_boundary import (
+    build_host_steward_boundary_wing,
+    summarize_host_steward_boundary_wing,
+)
 from sentientos.host_embodiment_trace_export import (
     serialize_host_embodiment_trace_json,
     serialize_host_embodiment_trace_markdown,
@@ -116,6 +120,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "local_diagnostic_effect_capability",
         "local_diagnostic_rollback_capability",
         "local_effect_transaction_ledger_capability",
+        "host_steward_boundary_posture",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -147,6 +152,7 @@ BUNDLE_FILE_NAMES = {
     "local_diagnostic_effect_capability": "local_diagnostic_effect_capability.json",
     "local_diagnostic_rollback_capability": "local_diagnostic_rollback_capability.json",
     "local_effect_transaction_ledger_capability": "local_effect_transaction_ledger_capability.json",
+    "host_steward_boundary_posture": "host_steward_boundary.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -192,6 +198,16 @@ DEFERRED_ACTION_LABELS = (
     "federation_transport_sync_adoption",
     "remote_execution",
     "local_diagnostic_effect_pilot_explicit_only",
+    "live_runner_execution",
+    "real_subprocess_runner",
+    "shell_runner",
+    "network_runner",
+    "provider_runner",
+    "prompt_assembly_runner",
+    "hardware_control_runner",
+    "service_control_runner",
+    "power_control_runner",
+    "cleanup_runner",
 )
 BLOCKED_ACTION_LABELS = (
     "fan_pwm_write",
@@ -205,6 +221,16 @@ BLOCKED_ACTION_LABELS = (
     "federation_transport_sync_adoption",
     "remote_execution",
     "local_diagnostic_effect_pilot_explicit_only",
+    "live_runner_execution",
+    "real_subprocess_runner",
+    "shell_runner",
+    "network_runner",
+    "provider_runner",
+    "prompt_assembly_runner",
+    "hardware_control_runner",
+    "service_control_runner",
+    "power_control_runner",
+    "cleanup_runner",
 )
 
 
@@ -501,6 +527,7 @@ def build_reviewer_proof_bundle_payload(
     )
     dry_run_audit_closure = build_dry_run_audit_closure_wing(dry_run_execution.receipt, created_at=created_at)
     real_effect_admission = build_real_effect_admission_wing(dry_run_audit_closure.closure_bundle, created_at=created_at)
+    host_steward_boundary = build_host_steward_boundary_wing(created_at=created_at)
     commands = tuple(proof_command_records) if proof_command_records is not None else build_default_reviewer_proof_commands()
     contents: dict[str, str] = {
         "trace_json": serialize_host_embodiment_trace_json(trace),
@@ -763,6 +790,33 @@ def build_reviewer_proof_bundle_payload(
             "no_fan_pwm_thermal_power_service_package_driver": True,
             "no_network_provider_prompt_subprocess_shell_control_plane": True,
         }),
+        "host_steward_boundary_posture": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "host_steward_boundary_only": True,
+            "proof_statement": "Host steward authority may be broad at the top level under operator delegation, but delegated runners do not inherit ambient authority.",
+            "delegated_runners_do_not_inherit_ambient_authority": True,
+            "no_runner_executes_by_default": True,
+            "containment_profiles_are_not_live_sandbox_execution": True,
+            "backend_declarations_do_not_load_or_invoke_backends": True,
+            "grant_scaffolds_do_not_issue_live_runner_grants": True,
+            "boundary_assessments_do_not_authorize_runner_execution": True,
+            "proof_bundle_effect_performed": False,
+            "proof_bundle_rollback_performed": False,
+            "proof_bundle_ledger_built_by_default": False,
+            "runner_executed": False,
+            "live_runner_grant_issued": False,
+            "backend_loaded": False,
+            "backend_invoked": False,
+            "host_mutation_performed": False,
+            "network_performed": False,
+            "provider_invocation_performed": False,
+            "prompt_assembly_performed": False,
+            "subprocess_execution_performed": False,
+            "shell_execution_performed": False,
+            "summary": summarize_host_steward_boundary_wing(host_steward_boundary),
+            "records": host_steward_boundary.to_dict(),
+        }),
         "reviewer_readme": _readme_text(manifest_id, trace.digest),
     }
     artifact_records = tuple(_artifact(kind, content) for kind, content in contents.items())
@@ -803,7 +857,7 @@ def build_reviewer_proof_bundle_payload(
     manifest = replace(manifest, artifact_records=artifact_records + (manifest_artifact,))
     manifest = replace(manifest, digest=reviewer_proof_bundle_manifest_digest(manifest))
     contents["bundle_manifest"] = _pretty_json(manifest.to_dict())
-    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution, "dry_run_audit_closure": dry_run_audit_closure, "real_effect_admission": real_effect_admission}
+    return {"manifest": manifest, "artifacts": contents, "trace": trace, "capability_registry": registry, "safety_gates": safety_gates, "live_grant_readiness": live_grant_readiness, "local_authorization": local_authorization, "fulfillment_authorization": fulfillment_authorization, "executor_contract": executor_contract, "dry_run_execution": dry_run_execution, "dry_run_audit_closure": dry_run_audit_closure, "real_effect_admission": real_effect_admission, "host_steward_boundary": host_steward_boundary}
 
 
 def validate_reviewer_proof_bundle_manifest(manifest: ReviewerProofBundleManifest | Mapping[str, Any]) -> ReviewerProofBundleValidationResult:

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -240,3 +240,14 @@ def test_reviewer_proof_bundle_cli_writes_local_diagnostic_capability_without_ru
     assert payload["proof_bundle_effect_performed"] is False
     commands = json.loads((output_dir / "proof_commands.json").read_text(encoding="utf-8"))["commands"]
     assert any("run_local_diagnostic_effect.py" in " ".join(record["command"]) and record["status"] == "proof_command_not_run" for record in commands)
+
+
+def test_script_writes_host_steward_boundary_artifact(tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(out), "--force"])
+    assert code == 0, stderr
+    assert "artifacts:" in stdout
+    assert (out / "host_steward_boundary.json").exists()
+    posture = json.loads((out / "host_steward_boundary.json").read_text(encoding="utf-8"))
+    assert posture["delegated_runners_do_not_inherit_ambient_authority"] is True
+    assert posture["no_runner_executes_by_default"] is True

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -672,3 +672,38 @@ def test_local_effect_transaction_ledger_capabilities_are_bounded() -> None:
     assert records["general_effect_transaction_ledger"].status == "deferred"
     for capability_id in ["general_cleanup", "recursive_delete", "unrelated_file_delete", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install", "network_egress", "provider_invocation", "prompt_assembly", "remote_execution"]:
         assert records[capability_id].status == "blocked"
+
+
+def test_host_steward_boundary_capabilities_are_metadata_only_and_runners_blocked() -> None:
+    records = build_default_capability_registry().by_id()
+    expected = {
+        "host_steward_authority_profile": "authority_profile_only",
+        "delegated_runner_boundary_profile": "boundary_profile_only",
+        "execution_containment_profile": "containment_profile_only",
+        "backend_adapter_authority_declaration": "declaration_only",
+        "runner_capability_grant_scaffold": "grant_scaffold_only",
+        "runner_boundary_assessment": "assessment_only",
+        "runner_boundary_violation_receipt": "violation_receipt_only",
+    }
+    for capability_id, authority_level in expected.items():
+        record = records[capability_id]
+        assert record.status == "implemented"
+        assert record.authority_level == authority_level
+        assert record.metadata_only is True
+        assert record.host_actuation_performed is False
+    assert records["live_runner_execution"].status == "deferred"
+    for capability_id in [
+        "real_subprocess_runner",
+        "shell_runner",
+        "network_runner",
+        "provider_runner",
+        "prompt_assembly_runner",
+        "hardware_control_runner",
+        "service_control_runner",
+        "power_control_runner",
+        "cleanup_runner",
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+    ]:
+        assert records[capability_id].status in {"blocked", "deferred"}
+        assert records[capability_id].host_actuation_performed is False

--- a/tests/test_host_steward_boundary.py
+++ b/tests/test_host_steward_boundary.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sentientos.host_steward_boundary import (
+    build_backend_adapter_authority_declaration,
+    build_delegated_runner_boundary_profile,
+    build_execution_containment_profile,
+    build_host_steward_authority_profile,
+    build_host_steward_boundary_wing,
+    build_runner_boundary_violation_receipt,
+    build_runner_capability_grant_scaffold,
+    host_steward_boundary_digest,
+    summarize_backend_adapter_authority_declaration,
+    summarize_delegated_runner_boundary_profile,
+    summarize_execution_containment_profile,
+    summarize_host_steward_authority_profile,
+    summarize_host_steward_boundary_wing,
+    summarize_runner_boundary_assessment,
+    summarize_runner_boundary_violation_receipt,
+    summarize_runner_capability_grant_scaffold,
+    assess_runner_boundary,
+    validate_backend_adapter_authority_declaration,
+    validate_delegated_runner_boundary_profile,
+    validate_execution_containment_profile,
+    validate_host_steward_authority_profile,
+    validate_runner_boundary_assessment,
+    validate_runner_boundary_violation_receipt,
+    validate_runner_capability_grant_scaffold,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+FIXED_CREATED_AT = "2025-07-30T00:00:00+00:00"
+
+
+def test_default_host_steward_profile_models_broad_authority_without_runner_grant() -> None:
+    profile = build_host_steward_authority_profile(created_at=FIXED_CREATED_AT)
+    assert profile.authority_mode == "full_local_host_steward_mode"
+    assert "host_steward_may_hold_broad_local_authority" in profile.allowed_top_level_authority_labels
+    assert "delegated_runners_do_not_inherit_ambient_authority" in profile.prohibited_delegation_labels
+    assert profile.grants_live_runner_authority is False
+    assert profile.executes_runner is False
+    assert profile.host_mutation_performed is False
+    assert validate_host_steward_authority_profile(profile).ok
+    assert summarize_host_steward_authority_profile(profile)["metadata_only"] is True
+
+
+@pytest.mark.parametrize("runner", ["generated_code_runner", "plugin_runner", "federation_import_runner", "external_tool_runner", "unknown_runner"])
+def test_untrusted_runner_defaults_no_network_no_host_mutation_metadata_or_dry_run(runner: str) -> None:
+    boundary = build_delegated_runner_boundary_profile(boundary_id=f"{runner}-boundary", runner_trust_class=runner, created_at=FIXED_CREATED_AT)
+    assert boundary.containment_class in {"metadata_only_containment", "dry_run_simulation_containment", "offline_no_network_containment"}
+    assert "ambient_authority_inheritance" in boundary.blocked_actions
+    assert "delegated_runners_do_not_inherit_ambient_authority" in boundary.denied_authority_labels
+    assert "runner_must_not_use_network_by_default" in boundary.denied_authority_labels
+    assert boundary.runner_executed is False
+    assert boundary.host_mutation_performed is False
+    assert validate_delegated_runner_boundary_profile(boundary).ok
+
+
+def test_local_diagnostic_runner_boundary_can_reference_file_effect_without_broadening() -> None:
+    boundary = build_delegated_runner_boundary_profile(
+        boundary_id="local-diagnostic",
+        runner_trust_class="bounded_builtin_runner",
+        containment_class="local_file_effect_containment",
+        allowed_authority_labels=("diagnostic_file_effect_mode",),
+        created_at=FIXED_CREATED_AT,
+    )
+    assert boundary.boundary_status == "delegated_runner_boundary_ready"
+    assert boundary.allowed_authority_labels == ("diagnostic_file_effect_mode",)
+    assert "runner_network_egress" in boundary.blocked_actions
+    assert "runner_shell_execution" in boundary.blocked_actions
+    assert validate_delegated_runner_boundary_profile(boundary).ok
+
+
+def test_containment_backend_grant_assessment_and_violation_are_metadata_only() -> None:
+    profile = build_host_steward_authority_profile(created_at=FIXED_CREATED_AT)
+    boundary = build_delegated_runner_boundary_profile(boundary_id="generated", runner_trust_class="generated_code_runner", created_at=FIXED_CREATED_AT)
+    containment = build_execution_containment_profile(containment_id="containment", created_at=FIXED_CREATED_AT)
+    backend = build_backend_adapter_authority_declaration(declaration_id="backend", adapter_label="future", created_at=FIXED_CREATED_AT)
+    scaffold = build_runner_capability_grant_scaffold(scaffold_id="scaffold", boundary_id=boundary.boundary_id, containment_id=containment.containment_id, backend_authority_declaration_id=backend.declaration_id, created_at=FIXED_CREATED_AT)
+    assessment = assess_runner_boundary(profile, boundary, containment, scaffold, created_at=FIXED_CREATED_AT)
+    violation = build_runner_boundary_violation_receipt(receipt_id="violation", assessment_id=assessment.assessment_id, created_at=FIXED_CREATED_AT)
+
+    assert containment.containment_enforced_live is False
+    assert backend.backend_loaded is False and backend.backend_invoked is False
+    assert scaffold.live_runner_grant_issued is False
+    assert assessment.authorizes_runner_execution is False
+    assert violation.authorizes_runner_execution is False
+    assert all(item.host_mutation_performed is False for item in (containment, backend, scaffold, assessment, violation))
+    assert validate_execution_containment_profile(containment).ok
+    assert validate_backend_adapter_authority_declaration(backend).ok
+    assert validate_runner_capability_grant_scaffold(scaffold).ok
+    assert validate_runner_boundary_assessment(assessment).ok
+    assert validate_runner_boundary_violation_receipt(violation).ok
+    assert summarize_execution_containment_profile(containment)["containment_enforced_live"] is False
+    assert summarize_backend_adapter_authority_declaration(backend)["backend_invoked"] is False
+    assert summarize_runner_capability_grant_scaffold(scaffold)["live_runner_grant_issued"] is False
+    assert summarize_runner_boundary_assessment(assessment)["authorizes_runner_execution"] is False
+    assert summarize_runner_boundary_violation_receipt(violation)["runner_executed"] is False
+
+
+@pytest.mark.parametrize(
+    "builder,validator,field",
+    [
+        (lambda: build_host_steward_authority_profile(), validate_host_steward_authority_profile, "executes_runner"),
+        (lambda: build_delegated_runner_boundary_profile(boundary_id="b"), validate_delegated_runner_boundary_profile, "runner_executed"),
+        (lambda: build_execution_containment_profile(containment_id="c"), validate_execution_containment_profile, "containment_enforced_live"),
+        (lambda: build_backend_adapter_authority_declaration(declaration_id="d", adapter_label="a"), validate_backend_adapter_authority_declaration, "backend_loaded"),
+        (lambda: build_backend_adapter_authority_declaration(declaration_id="d", adapter_label="a"), validate_backend_adapter_authority_declaration, "backend_invoked"),
+        (lambda: build_runner_capability_grant_scaffold(scaffold_id="s", boundary_id="b", containment_id="c"), validate_runner_capability_grant_scaffold, "live_runner_grant_issued"),
+    ],
+)
+def test_validation_rejects_forbidden_true_flags(builder, validator, field: str) -> None:
+    bad = replace(builder(), **{field: True})
+    result = validator(bad)
+    assert not result.ok
+    assert f"forbidden_flag:{field}" in result.findings
+
+
+def test_validation_rejects_host_mutation_and_missing_ambient_block() -> None:
+    boundary = build_delegated_runner_boundary_profile(boundary_id="b")
+    bad_mutation = replace(boundary, host_mutation_performed=True)
+    assert "forbidden_flag:host_mutation_performed" in validate_delegated_runner_boundary_profile(bad_mutation).findings
+    bad_block = replace(boundary, blocked_actions=tuple(action for action in boundary.blocked_actions if action != "ambient_authority_inheritance"))
+    assert "missing_blocked_action:ambient_authority_inheritance" in validate_delegated_runner_boundary_profile(bad_block).findings
+
+
+def test_digests_are_deterministic_and_change_on_meaningful_metadata() -> None:
+    first = build_delegated_runner_boundary_profile(boundary_id="b", runner_trust_class="plugin_runner", created_at=FIXED_CREATED_AT)
+    second = build_delegated_runner_boundary_profile(boundary_id="b", runner_trust_class="plugin_runner", created_at=FIXED_CREATED_AT)
+    changed = build_delegated_runner_boundary_profile(boundary_id="b2", runner_trust_class="plugin_runner", created_at=FIXED_CREATED_AT)
+    assert first.digest == second.digest == host_steward_boundary_digest(first)
+    assert first.digest != changed.digest
+    assert summarize_delegated_runner_boundary_profile(first)["metadata_only"] is True
+
+
+def test_host_steward_boundary_wing_proves_no_ambient_inheritance_or_execution() -> None:
+    wing = build_host_steward_boundary_wing(created_at=FIXED_CREATED_AT)
+    summary = summarize_host_steward_boundary_wing(wing)
+    assert summary["proof_delegated_runners_do_not_inherit_ambient_authority"] is True
+    assert summary["proof_no_runner_executes_by_default"] is True
+    assert wing.runner_executed is False
+    assert wing.host_mutation_performed is False
+    assert any(item.runner_trust_class == "federation_import_runner" for item in wing.delegated_runner_boundaries)

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -315,3 +315,23 @@ def test_reviewer_proof_bundle_lists_exact_rollback_but_does_not_run_it() -> Non
     rollback_commands = [record for record in commands if "run_local_diagnostic_rollback.py" in " ".join(record["command"])]
     assert rollback_commands
     assert all(record["status"] == "proof_command_not_run" and record["executed"] is False for record in rollback_commands)
+
+
+def test_bundle_includes_host_steward_boundary_posture_without_runner_execution() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    assert "host_steward_boundary_posture" in payload["artifacts"]
+    assert "host_steward_boundary.json" in payload["artifacts"]["bundle_manifest"]
+    posture = json.loads(payload["artifacts"]["host_steward_boundary_posture"])
+    assert posture["delegated_runners_do_not_inherit_ambient_authority"] is True
+    assert posture["no_runner_executes_by_default"] is True
+    assert posture["containment_profiles_are_not_live_sandbox_execution"] is True
+    assert posture["backend_declarations_do_not_load_or_invoke_backends"] is True
+    assert posture["grant_scaffolds_do_not_issue_live_runner_grants"] is True
+    assert posture["boundary_assessments_do_not_authorize_runner_execution"] is True
+    assert posture["proof_bundle_effect_performed"] is False
+    assert posture["proof_bundle_rollback_performed"] is False
+    assert posture["proof_bundle_ledger_built_by_default"] is False
+    assert posture["runner_executed"] is False
+    assert posture["host_mutation_performed"] is False
+    assert payload["host_steward_boundary"].runner_executed is False
+    assert validate_reviewer_proof_bundle_manifest(payload["manifest"]).ok

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -592,3 +592,20 @@ def test_transaction_ledger_doc_is_linked_and_preserves_boundaries() -> None:
     assert "closed transactions" in doc
     assert "not general cleanup" in doc
     assert "python scripts/build_local_effect_transaction_ledger.py" in doc
+
+HOST_STEWARD_BOUNDARY_WING = "docs/architecture/host_steward_delegated_runner_boundary_wing.md"
+
+
+def test_navigation_links_to_host_steward_delegated_runner_boundary_wing_doc() -> None:
+    for relative in [PUBLIC_OVERVIEW, READINESS_INDEX, TRAJECTORY_DOC]:
+        assert HOST_STEWARD_BOUNDARY_WING in _read(relative)
+
+
+def test_host_steward_boundary_doc_preserves_runner_boundary_limits() -> None:
+    doc = _read(HOST_STEWARD_BOUNDARY_WING)
+    assert "broad operator-delegated local authority" in doc
+    assert "Delegated runners do not inherit ambient authority by default" in doc
+    assert "Execution containment profiles are declarations, not live sandbox execution" in doc
+    assert "Backend adapter declarations do not load or invoke backends" in doc
+    assert "does not spawn processes, use shell, use network" in doc
+    assert "mutate host state" in doc


### PR DESCRIPTION
### Motivation

- Introduce a metadata-only authority model to separate broad top-level host-steward authority from explicit, scoped delegated-runner authority so ambient authority is not implicitly inherited by children or plugins.
- Provide deterministic proof surfaces and validation to ensure delegated runners are typed, scoped, revocable, auditable, and denied ambient authority by default.
- Integrate the new boundary wing into the reviewer proof flow and capability registry so reviewers can verify the posture without any live host effects.

### Description

- Added `sentientos/host_steward_boundary.py` implementing frozen dataclasses and builders for `HostStewardAuthorityPolicy`, `HostStewardAuthorityProfile`, `DelegatedRunnerBoundaryProfile`, `ExecutionContainmentProfile`, `BackendAdapterAuthorityDeclaration`, `RunnerCapabilityGrantScaffold`, `RunnerBoundaryAssessment`, `RunnerBoundaryViolationReceipt`, and `HostStewardBoundaryWing`, plus summaries, deterministic digests, and validation helpers; all records are `metadata_only` and forbidden true-flags (e.g., `executes_runner`, `backend_invoked`, `host_mutation_performed`) are rejected.
- Integrated the wing into the reviewer proof bundle by adding `host_steward_boundary.json` and including `host_steward_boundary` in `build_reviewer_proof_bundle_payload` so the proof bundle asserts no runner executes and that delegated runners do not inherit ambient authority (`sentientos/reviewer_proof_bundle.py`).
- Extended `sentientos/capability_registry.py` with new capability records for `host_steward_authority_profile`, `delegated_runner_boundary_profile`, `execution_containment_profile`, `backend_adapter_authority_declaration`, `runner_capability_grant_scaffold`, `runner_boundary_assessment`, and `runner_boundary_violation_receipt`, kept metadata-only and ensured live runner execution/subprocess/shell/network/provider/prompt/hardware/service/power/cleanup capabilities remain deferred or blocked.
- Added architecture doc `docs/architecture/host_steward_delegated_runner_boundary_wing.md` and updated related docs to link the new wing; updated tests to cover the wing and its reviewer-bundle and capability-registry integration (`tests/test_host_steward_boundary.py`, updates to `tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`, `tests/test_capability_registry.py`, and `tests/test_reviewer_release_readiness_index.py`).
- Implementation constraints: module explicitly models records only and does not load backends, spawn processes, call shell/subprocess, open network, invoke providers, assemble prompts, mutate host state, or broaden existing real effects (the only real pilots remain the explicit diagnostic file write and exact-artifact rollback).

### Testing

- Python compile checks: `python -m py_compile sentientos/host_steward_boundary.py sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py sentientos/capability_registry.py tests/test_host_steward_boundary.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py tests/test_reviewer_release_readiness_index.py` completed successfully.
- Unit/integration test runs: `python -m scripts.run_tests -q tests/test_host_steward_boundary.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py` and additional suites (`local_effect_transaction_ledger`, `local_diagnostic_exact_rollback`, `local_diagnostic_effect`, `real_effect_admission`, `dry_run_*`, `fulfillment_executor_contract`, `reviewer_release_readiness_index`, and control-plane kernel/runtime closure tests) were executed and passed in this environment (dots/progress shown in run log).
- Reviewer bundle CLI: `python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof --force` produced `/tmp/sentientos-reviewer-proof/host_steward_boundary.json` and the bundle validated with `validate_reviewer_proof_bundle_manifest`.
- Docs build: initial `--check-deps` prompted a bootstrap install for docs dependencies; `python scripts/build_docs.py --bootstrap-docs` then succeeded and `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` completed, generating the docs including the new wing.
- Forbidden-scan and hygiene checks: `rg` scans over modified files found only blocked-action labels, metadata flags, and validation guards; no forbidden runtime operations (no `socket`, `requests`, `subprocess`, `os.system`, `Popen`, `shell=True`, `admit_and_execute`, `unlink/delete` usage) were introduced in the new module or modified proof/registry code; `python scripts/verify_context_hygiene_prompt_boundaries.py` reported `boundary_clean`.

All automated tests and checks run for this PR passed in the environment, and docs were built after bootstrapping docs dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a082a3d290483209f421b5443b9a7fe)