### PR TITLE
[codex:host-embodiment] record runner transaction ledger lifecycle

### DIFF
--- a/sentientos/builtin_runner_transaction_orchestrator.py
+++ b/sentientos/builtin_runner_transaction_orchestrator.py
@@ -727,6 +727,8 @@ def build_builtin_runner_transaction_receipt(request: BuiltinRunnerTransactionEx
 def build_builtin_runner_transaction_closure_report(receipt: BuiltinRunnerTransactionReceipt, *, result: BuiltinRunnerTransactionResult | None = None, lifecycle_report: Any | None = None, created_at: str | None = None) -> BuiltinRunnerTransactionClosureReport:
     warnings = list(receipt.warning_codes)
     lifecycle_status = _source_payload(lifecycle_report).get("lifecycle_status") if lifecycle_report else None
+    if lifecycle_status is None and receipt.ledger_id:
+        lifecycle_status = "local_effect_lifecycle_complete_with_rollback" if receipt.rollback_runner_receipt_id else "local_effect_lifecycle_rollback_pending"
     present = ["transaction_receipt"]
     missing: list[str] = []
     closure_codes: list[str] = []

--- a/tests/test_builtin_runner_transaction_orchestrator.py
+++ b/tests/test_builtin_runner_transaction_orchestrator.py
@@ -57,6 +57,7 @@ def test_write_with_ledger_builds_rollback_pending_ledger_without_artifact_by_de
     assert records.result.ledger_artifact_written is False
     assert records.closure_report is not None
     assert records.closure_report.closure_status == "builtin_runner_transaction_closed_after_write"
+    assert records.closure_report.lifecycle_status == "local_effect_lifecycle_rollback_pending"
     assert not (tmp_path / "out" / "transaction_ledger.json").exists()
 
 
@@ -69,6 +70,7 @@ def test_write_rollback_with_ledger_writes_explicit_ledger_artifact(tmp_path: Pa
     assert out.exists()
     assert records.closure_report is not None
     assert records.closure_report.closure_status == "builtin_runner_transaction_closed_after_rollback"
+    assert records.closure_report.lifecycle_status == "local_effect_lifecycle_complete_with_rollback"
 
 
 def test_unsupported_mode_blocks(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Ensure the bounded runner transaction orchestrator preserves and reports local-effect lifecycle state when a transaction ledger is built so reviewers and auditors can see ledger-backed lifecycle classification even if only the transaction receipt is present.
- Provide regression coverage that verifies ledger-backed closure lifecycle states for modes that build the ledger (rollback-pending and complete-with-rollback).

### Description

- Propagate ledger-backed lifecycle status into the transaction closure report when a ledger exists but no explicit lifecycle_report object was passed, choosing `local_effect_lifecycle_rollback_pending` or `local_effect_lifecycle_complete_with_rollback` as appropriate. (file: `sentientos/builtin_runner_transaction_orchestrator.py`).
- Add regression assertions to the transaction orchestrator tests to validate closure lifecycle classification for `diagnostic_write_with_ledger` and `diagnostic_write_rollback_with_ledger` modes. (file: `tests/test_builtin_runner_transaction_orchestrator.py`).
- Verified the module/CLI/wrapping wing, reviewer proof bundle integration, and capability-registry entries are present and remain bounded to the two allowed built-in runner actions and explicit ledger write semantics (no subprocess/shell/network/provider/prompt/hardware/service/power/general-cleanup authority). (files: `scripts/run_builtin_runner_transaction.py`, `sentientos/reviewer_proof_bundle.py`, `sentientos/capability_registry.py`, docs links updated).

### Testing

- Ran the requested compile check: `python -m py_compile ...` which succeeded for the changed modules and related artifacts. 
- Ran focused unit test suites: `python -m scripts.run_tests -q tests/test_builtin_runner_transaction_orchestrator.py tests/test_run_builtin_runner_transaction_script.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_capability_registry.py` and supporting suites; all tests passed in this environment.
- Performed CLI smoke checks for dry-run, write-only, write-with-rollback, and write-rollback-with-ledger modes and confirmed behavior (including explicit ledger write only when `--ledger-output` supplied); these checks succeeded.
- Built reviewer proof bundle and docs (with docs bootstrap) and ran the context-hygiene prompt-boundary scan; the proof artifact `builtin_runner_transaction_orchestrator_capability.json` is present and the prompt-boundary scan reported clean; docs build required `--bootstrap-docs` in this environment and then succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a090ec57cd0832094db09fea4197f13)