### PR TITLE
[codex:workspace] add bounded workspace change-set execution wing, CLI, proof bundle & capability registry updates

### DIFF
--- a/docs/architecture/host_builtin_runner_transaction_orchestrator_wing.md
+++ b/docs/architecture/host_builtin_runner_transaction_orchestrator_wing.md
@@ -56,3 +56,7 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 ## Next workspace planning wing
 
 See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+
+## Workspace successor link
+
+Workspace-scoped multi-target execution is documented in [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md); it does not add general runner authority.

--- a/docs/architecture/host_workspace_change_set_execution_wing.md
+++ b/docs/architecture/host_workspace_change_set_execution_wing.md
@@ -1,0 +1,31 @@
+# Host Workspace Change Set Transaction Execution Pilot Wing
+
+This wing follows the [Host Workspace Change Set Preflight / Planning Wing](host_workspace_change_set_preflight_wing.md). It is the first bounded multi-target workspace execution layer in SentientOS: preflight made multi-target reasoning possible, and this wing makes bounded multi-target execution possible only after a passed preflight report and a ready transaction plan.
+
+## What it executes
+
+The execution wing consumes the explicit Workspace Change Set Manifest, Workspace Change Set Preflight Report, Workspace Change Set Rollback Plan, and Workspace Change Set Transaction Plan produced by the preflight/planning wing. It refuses execution unless preflight is passed or passed-with-warnings and the transaction plan is ready or ready-with-warnings.
+
+Targets execute strictly in planned order. Each target must already be declared in the manifest as an explicit relative path inside one explicit workspace root. The wing rechecks preflight digest posture before writing so drift since preflight blocks execution.
+
+## How it executes
+
+The wing does not introduce a general filesystem API. For each target it delegates to the existing single-target workspace file effect helper in `sentientos/workspace_file_effect.py`. Per-target execution records capture the workspace effect receipt, postcondition check, exact-target rollback plan, production audit receipt, before/after digests, and target status.
+
+## Rollback and partial-state visibility
+
+Rollback is optional and exact-target-only. Rollback runs in reverse execution order and delegates to the existing workspace file exact rollback helper. Rollback can occur after a successful execution when explicitly requested, or after a later target failure when rollback-on-failure is enabled.
+
+Partial state is never hidden. Applied, failed, skipped, and rolled-back target identifiers are recorded in the execution result, execution receipt, rollback result, transaction ledger, and closure report.
+
+## Ledger and closure report
+
+The transaction ledger and closure report are metadata-only. They perform no additional target effects. A caller may request one explicit ledger artifact at a safe caller-supplied path inside the workspace root after execution and rollback state are known.
+
+## Non-authorities
+
+This wing is not general filesystem access. It is not cleanup. It is not recursive deletion, wildcard deletion, unrelated file deletion, service control, power control, hardware control, fan/PWM control, thermal actuation, package/driver installation, subprocess execution, shell execution, generated-code execution, plugin execution, federation import execution, external tool execution, network egress, provider invocation, prompt assembly/export, remote execution, or uncontrolled runtime authority expansion.
+
+## Reviewer proof posture
+
+The reviewer proof bundle documents `workspace_change_set_execution_capability.json` but does not run workspace change-set execution by default. The listed proof command is `proof_command_not_run` so reviewers can explicitly invoke the bounded pilot if desired.

--- a/docs/architecture/host_workspace_change_set_preflight_wing.md
+++ b/docs/architecture/host_workspace_change_set_preflight_wing.md
@@ -42,4 +42,8 @@ The reviewer proof bundle documents `workspace_change_set_preflight_capability.j
 
 ## Future work remains deferred
 
-Future workspace change-set transaction execution, multi-file runner actions, and bulk rollback remain deferred behind new authority, safety, audit, rollback, and operator approval gates.
+Workspace change-set transaction execution now follows in the bounded execution pilot wing; multi-file runner actions and bulk cleanup rollback remain deferred behind new authority, safety, audit, rollback, and operator approval gates.
+
+## Next wing
+
+The bounded successor is [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md), which consumes passed preflight and ready transaction plans before delegating each explicit target to the single-target workspace file helper.

--- a/docs/architecture/host_workspace_file_effect_pilot_wing.md
+++ b/docs/architecture/host_workspace_file_effect_pilot_wing.md
@@ -76,3 +76,7 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 ## Next workspace planning wing
 
 See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+
+## Successor link
+
+The file effect pilot remains the single-target machinery used by [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md).

--- a/docs/architecture/host_workspace_file_runner_transaction_wing.md
+++ b/docs/architecture/host_workspace_file_runner_transaction_wing.md
@@ -30,3 +30,7 @@ Built-in transaction orchestrator integration for workspace file modes is now im
 ## Next workspace planning wing
 
 See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+
+## Successor link
+
+The runner transaction wing remains single-target; bounded multi-target workspace execution is documented in [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md).

--- a/docs/architecture/host_workspace_file_transaction_orchestrator_wing.md
+++ b/docs/architecture/host_workspace_file_transaction_orchestrator_wing.md
@@ -40,3 +40,7 @@ digests, paths, and warnings so partial state is visible to reviewers.
 ## Next workspace planning wing
 
 See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+
+## Successor link
+
+The workspace file transaction orchestrator remains single-target; bounded multi-target execution is introduced by [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md).

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -293,4 +293,7 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 
 ## Next workspace planning wing
 
-See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and is followed by bounded change-set transaction execution in the execution pilot wing.
+
+
+Workspace change-set transaction execution is documented in [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md) (`docs/architecture/host_workspace_change_set_execution_wing.md`): it is the first bounded multi-target workspace execution layer, consumes passed preflight/transaction plans, uses existing single-target helpers, records partial state visibly, and does not grant general filesystem access or cleanup authority.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -141,4 +141,8 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 
 ## Next workspace planning wing
 
-See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and is followed by the bounded change-set transaction execution pilot wing.
+
+## Workspace change-set execution proof artifact
+
+The bundle includes `workspace_change_set_execution_capability.json` for [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md). It documents the bounded capability but does not run execution by default.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -310,4 +310,7 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 
 ## Next workspace planning wing
 
-See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and is followed by bounded change-set transaction execution in the execution pilot wing.
+
+
+The [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md) (`docs/architecture/host_workspace_change_set_execution_wing.md`) adds the first bounded multi-target workspace execution layer after preflight/planning. It consumes passed preflight/transaction plans, uses existing single-target helpers, records partial state visibly, and the reviewer proof bundle documents but does not run it by default.

--- a/docs/architecture/sentientos_trajectory_and_missing_organs.md
+++ b/docs/architecture/sentientos_trajectory_and_missing_organs.md
@@ -446,3 +446,6 @@ See also: [Host Workspace File Runner / Transaction Integration Wing](host_works
 ## Next workspace planning wing
 
 See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_change_set_preflight_wing.md) (`docs/architecture/host_workspace_change_set_preflight_wing.md`) for the metadata-only layer that prepares bounded multi-target workspace changes but does not execute them, reads only explicitly declared target metadata/digests, performs no target writes, performs no rollback, invokes no runner/orchestrator, and leaves future change-set execution deferred.
+
+
+Workspace change-set transaction execution now exists as a bounded pilot in [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md). It narrows multi-target workspace execution to explicit manifest targets and leaves general filesystem access, cleanup, services, power, hardware, fan/PWM, thermal, network, provider, prompt, subprocess, and shell authority blocked or deferred.

--- a/scripts/run_workspace_change_set_transaction.py
+++ b/scripts/run_workspace_change_set_transaction.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Run bounded workspace change-set preflight and optional transaction execution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.workspace_change_set_execution import (  # noqa: E402
+    EXECUTION_MODES,
+    WorkspaceChangeSetExecutionPolicy,
+    run_workspace_change_set_execution_wing,
+    summarize_workspace_change_set_execution_closure_report,
+    summarize_workspace_change_set_execution_ledger,
+    summarize_workspace_change_set_execution_receipt,
+    summarize_workspace_change_set_execution_result,
+    summarize_workspace_change_set_rollback_execution_result,
+)
+from sentientos.workspace_change_set_preflight import (  # noqa: E402
+    CHANGE_OPERATIONS,
+    WorkspaceChangeSetPolicy,
+    build_workspace_change_set_manifest,
+    build_workspace_change_set_preflight_report,
+    build_workspace_change_set_rollback_plan,
+    build_workspace_change_set_transaction_plan,
+    build_workspace_change_target_declaration,
+    preflight_workspace_change_target,
+    run_workspace_change_set_preflight_wing,
+)
+
+
+def _parse_target(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("target must use PATH=PAYLOAD")
+    path, payload = value.split("=", 1)
+    if not path:
+        raise argparse.ArgumentTypeError("target path is required")
+    return path, payload
+
+
+def _jsonify(value: object) -> object:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()  # type: ignore[no-any-return]
+    if isinstance(value, tuple):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonify(item) for key, item in value.items()}
+    return value
+
+
+def _summary_text(payload: dict[str, object]) -> str:
+    if payload.get("dry_run"):
+        summary = payload["preflight"]["summary"]  # type: ignore[index]
+        report = summary["preflight_report"]  # type: ignore[index]
+        manifest = summary["manifest"]  # type: ignore[index]
+        transaction = summary["transaction_plan"]  # type: ignore[index]
+        return "\n".join([
+            "SentientOS Workspace Change Set Transaction (dry-run)",
+            f"manifest_status: {manifest['manifest_status']}",
+            f"report_status: {report['report_status']}",
+            f"transaction_plan_status: {transaction['transaction_plan_status']}",
+            f"target_count: {manifest['target_count']}",
+            "target_writes: false",
+            "rollback_performed: false",
+            "ledger_artifact_written: false",
+        ])
+    execution = payload["execution_summary"]  # type: ignore[index]
+    receipt = payload["execution_receipt_summary"]  # type: ignore[index]
+    rollback = payload["rollback_summary"]  # type: ignore[index]
+    closure = payload["closure_summary"]  # type: ignore[index]
+    ledger = payload.get("ledger_summary")
+    artifact = payload.get("ledger_artifact") or {}
+    return "\n".join([
+        "SentientOS Workspace Change Set Transaction",
+        f"execution_status: {execution['execution_status']}",
+        f"receipt_status: {receipt['receipt_status']}",
+        f"applied_target_ids: {list(execution['applied_target_ids'])}",
+        f"failed_target_ids: {list(execution['failed_target_ids'])}",
+        f"skipped_target_ids: {list(execution['skipped_target_ids'])}",
+        f"rollback_status: {rollback['rollback_status']}",
+        f"rollback_target_order: {list(rollback['rollback_target_order'])}",
+        f"closure_status: {closure['closure_status']}",
+        f"ledger_status: {ledger['lifecycle_status'] if ledger else 'not_requested'}",
+        f"ledger_artifact_written: {bool(artifact.get('artifact_written'))}",
+        "bounded_change_set_execution_only: true",
+        "general_filesystem_access_performed: false",
+        "cleanup_performed: false",
+        "subprocess_shell_network_provider_prompt: false",
+    ])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace-root", required=True)
+    parser.add_argument("--target", action="append", type=_parse_target, required=True, help="PATH=PAYLOAD; may be supplied multiple times")
+    parser.add_argument("--operation", choices=sorted(CHANGE_OPERATIONS), default="create_file")
+    parser.add_argument("--mode", choices=sorted(EXECUTION_MODES), default="change_set_execute_full_guarded")
+    parser.add_argument("--ledger-output")
+    rollback_group = parser.add_mutually_exclusive_group()
+    rollback_group.add_argument("--rollback-on-failure", dest="rollback_on_failure", action="store_true", default=None)
+    rollback_group.add_argument("--no-rollback-on-failure", dest="rollback_on_failure", action="store_false")
+    parser.add_argument("--rollback-after-execute", action="store_true")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00")
+    parser.add_argument("--max-targets", type=int, default=8)
+    parser.add_argument("--max-payload-bytes", type=int, default=65536)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    targets = tuple(
+        build_workspace_change_target_declaration(
+            relative_target_path=path,
+            operation=args.operation,
+            payload_text=payload,
+            allow_replace=True,
+            allow_create=True,
+            created_at=args.created_at,
+        )
+        for path, payload in args.target
+    )
+    preflight_policy = WorkspaceChangeSetPolicy(max_targets=args.max_targets, max_payload_bytes_per_target=args.max_payload_bytes)
+    manifest = build_workspace_change_set_manifest(workspace_root=args.workspace_root, targets=targets, policy=preflight_policy, created_at=args.created_at)
+    target_preflights = tuple(preflight_workspace_change_target(workspace_root=args.workspace_root, target=target, policy=preflight_policy, created_at=args.created_at) for target in targets)
+    preflight_report = build_workspace_change_set_preflight_report(manifest=manifest, target_preflights=target_preflights, created_at=args.created_at)
+    rollback_plan = build_workspace_change_set_rollback_plan(manifest=manifest, preflight_report=preflight_report, target_preflights=target_preflights, created_at=args.created_at)
+    transaction_plan = build_workspace_change_set_transaction_plan(manifest=manifest, preflight_report=preflight_report, rollback_plan=rollback_plan, created_at=args.created_at)
+    preflight = run_workspace_change_set_preflight_wing(workspace_root=args.workspace_root, targets=targets, policy=preflight_policy, created_at=args.created_at)
+    if args.dry_run:
+        payload = {
+            "dry_run": True,
+            "metadata_only": True,
+            "preflight_planning_only": True,
+            "target_write_performed": False,
+            "rollback_performed": False,
+            "ledger_artifact_written": False,
+            "preflight": preflight,
+        }
+        print(_summary_text(payload) if args.summary else json.dumps(_jsonify(payload), indent=2, sort_keys=True))
+        return 0 if preflight["preflight_report"]["report_status"] in {"workspace_change_set_preflight_passed", "workspace_change_set_preflight_passed_with_warnings"} else 2
+
+    execution_policy = WorkspaceChangeSetExecutionPolicy(max_targets=args.max_targets)
+    wing = run_workspace_change_set_execution_wing(
+        manifest=manifest,
+        preflight_report=preflight_report,
+        rollback_plan=rollback_plan,
+        transaction_plan=transaction_plan,
+        execution_mode=args.mode,
+        rollback_on_failure=args.rollback_on_failure,
+        rollback_after_execute=args.rollback_after_execute,
+        write_ledger=bool(args.ledger_output) or args.mode in {"change_set_execute_with_ledger", "change_set_execute_rollback_with_ledger", "change_set_execute_full_guarded"},
+        ledger_output_path=args.ledger_output,
+        policy=execution_policy,
+        created_at=args.created_at,
+    )
+    artifact = None
+    if args.ledger_output and wing.ledger is not None:
+        # The wing writes the artifact; this records expected posture for CLI output.
+        artifact = {"artifact_written": Path(args.ledger_output).exists(), "path": args.ledger_output}
+    payload = {
+        "dry_run": False,
+        "request": wing.request,
+        "execution_result": wing.execution_result,
+        "execution_receipt": wing.execution_receipt,
+        "rollback_result": wing.rollback_result,
+        "rollback_receipt": wing.rollback_receipt,
+        "ledger": wing.ledger,
+        "closure_report": wing.closure_report,
+        "ledger_artifact": artifact,
+        "execution_summary": summarize_workspace_change_set_execution_result(wing.execution_result),
+        "execution_receipt_summary": summarize_workspace_change_set_execution_receipt(wing.execution_receipt),
+        "rollback_summary": summarize_workspace_change_set_rollback_execution_result(wing.rollback_result),
+        "ledger_summary": summarize_workspace_change_set_execution_ledger(wing.ledger) if wing.ledger else None,
+        "closure_summary": summarize_workspace_change_set_execution_closure_report(wing.closure_report),
+    }
+    print(_summary_text(payload) if args.summary else json.dumps(_jsonify(payload), indent=2, sort_keys=True))
+    return 0 if wing.execution_result.execution_status in {"workspace_change_set_execution_performed", "workspace_change_set_execution_performed_with_warnings", "workspace_change_set_execution_partially_performed"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -53,6 +53,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "workspace_file_transaction_ledger",
         "workspace_file_transaction_orchestrator",
         "workspace_change_set_preflight",
+        "workspace_change_set_execution",
         "host_steward_boundary",
         "delegated_runner_boundary",
         "runtime_supervision",
@@ -423,10 +424,17 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("workspace_change_set_rollback_plan", "workspace_change_set_preflight", "implemented", "metadata-plan-only", source_paths=("sentientos/workspace_change_set_preflight.py",), proof_tests=("tests/test_workspace_change_set_preflight.py",), implemented_surfaces=("metadata-only rollback strategy entries",), deferred_surfaces=("bulk rollback execution",), forbidden_implications=("rollback plan performs rollback"), requires_rollback_receipt=True),
         _record("workspace_change_set_transaction_plan", "workspace_change_set_preflight", "implemented", "metadata-plan-only", source_paths=("sentientos/workspace_change_set_preflight.py",), proof_tests=("tests/test_workspace_change_set_preflight.py",), implemented_surfaces=("metadata-only future transaction order and strategy",), deferred_surfaces=("workspace change-set transaction execution",), forbidden_implications=("transaction plan executes multi-file writes")),
         _record("workspace_change_set_preflight_artifact", "workspace_change_set_preflight", "implemented", "explicit-local-artifact-only", source_paths=("scripts/preflight_workspace_change_set.py",), proof_tests=("tests/test_preflight_workspace_change_set_script.py",), implemented_surfaces=("optional exact caller-supplied preflight/plan JSON artifact",), deferred_surfaces=("implicit artifact writes", "target writes"), forbidden_implications=("artifact output writes target payloads")),
-        _record("workspace_change_set_execution", "workspace_change_set_preflight", "deferred", "none", deferred_surfaces=("workspace change-set execution", "multi-target writes"), forbidden_implications=("preflight wing implements future executor"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("workspace_change_set_transaction_execution", "workspace_change_set_preflight", "deferred", "none", deferred_surfaces=("workspace change-set transaction execution",), forbidden_implications=("transaction plan is transaction execution"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("workspace_change_set_multi_file_runner", "workspace_change_set_preflight", "deferred", "none", deferred_surfaces=("multi-file built-in runner",), forbidden_implications=("preflight adds runner actions"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
-        _record("workspace_change_set_bulk_rollback", "workspace_change_set_preflight", "deferred", "none", deferred_surfaces=("bulk rollback execution",), forbidden_implications=("rollback plan performs bulk rollback"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_execution", "workspace_change_set_execution", "implemented", "explicit_local_artifact_only", source_paths=("sentientos/workspace_change_set_execution.py", "scripts/run_workspace_change_set_transaction.py"), proof_tests=("tests/test_workspace_change_set_execution.py", "tests/test_run_workspace_change_set_transaction_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_workspace_change_set_execution.py tests/test_run_workspace_change_set_transaction_script.py", "python scripts/run_workspace_change_set_transaction.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --target docs-demo.txt=docs --summary"), implemented_surfaces=("bounded explicit-target workspace change-set execution after passed preflight and ready transaction plan", "planned-order delegation to single-target workspace file effect helper"), deferred_surfaces=("unbounded change-set execution", "bulk cleanup", "general filesystem access"), forbidden_implications=("change-set execution is ambient filesystem authority", "change-set execution runs shell, subprocess, network, provider, prompt, hardware, service, power, fan, or thermal actions"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_execution_request", "workspace_change_set_execution", "implemented", "request_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("explicit execution request tied to manifest, preflight report, rollback plan, and transaction plan",), forbidden_implications=("request alone grants general filesystem authority")),
+        _record("workspace_change_target_execution_result", "workspace_change_set_execution", "implemented", "real_effect_receipt_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("per-target receipt-backed execution result with postcondition, rollback plan, and audit digests",), forbidden_implications=("per-target result hides failed or skipped targets"), requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_rollback_execution", "workspace_change_set_execution", "implemented", "exact_artifact_rollback_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("reverse-order exact-target rollback through workspace_file_effect rollback helper",), deferred_surfaces=("bulk cleanup", "recursive delete", "wildcard delete", "unrelated file delete"), forbidden_implications=("change-set rollback deletes unrelated files"), requires_rollback_receipt=True),
+        _record("workspace_change_set_execution_ledger", "workspace_change_set_execution", "implemented", "metadata_ledger_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("metadata-only change-set transaction ledger", "optional explicit caller-supplied ledger artifact"), forbidden_implications=("ledger build performs target effects")),
+        _record("workspace_change_set_execution_closure_report", "workspace_change_set_execution", "implemented", "report_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("metadata-only closure report classifying open, partial, failed, execute-closed, and rollback-closed states",), forbidden_implications=("closure report mutates workspace")),
+        _record("workspace_change_set_transaction_execution", "workspace_change_set_execution", "implemented", "explicit_local_artifact_only", source_paths=("sentientos/workspace_change_set_execution.py", "scripts/run_workspace_change_set_transaction.py"), proof_tests=("tests/test_workspace_change_set_execution.py", "tests/test_run_workspace_change_set_transaction_script.py"), implemented_surfaces=("bounded multi-target workspace transaction execution",), deferred_surfaces=("unbounded execution",), forbidden_implications=("transaction execution skips passed preflight requirement"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_multi_file_runner", "workspace_change_set_execution", "deferred", "none", deferred_surfaces=("multi-file built-in runner",), forbidden_implications=("change-set execution adds broad runner actions"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_bulk_rollback", "workspace_change_set_execution", "deferred", "none", deferred_surfaces=("bulk cleanup rollback",), forbidden_implications=("exact-target rollback is bulk cleanup"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
+        _record("workspace_change_set_unbounded_execution", "workspace_change_set_execution", "blocked", "none", deferred_surfaces=("unbounded workspace change-set execution",), forbidden_implications=("bounded pilot permits ambient targets")),
+        _record("workspace_change_set_bulk_cleanup", "workspace_change_set_execution", "blocked", "none", deferred_surfaces=("bulk cleanup",), forbidden_implications=("bounded pilot permits cleanup")),
         _record("general_filesystem_runner", "delegated_runner_boundary", "blocked", "none", deferred_surfaces=("general filesystem runner",), forbidden_implications=("workspace runner actions grant general filesystem runner authority",), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("builtin_runner_transaction_orchestrator", "delegated_runner_boundary", "implemented", "bounded-orchestrator", source_paths=("sentientos/builtin_runner_transaction_orchestrator.py", "scripts/run_builtin_runner_transaction.py"), proof_tests=("tests/test_builtin_runner_transaction_orchestrator.py", "tests/test_run_builtin_runner_transaction_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_builtin_runner_transaction_orchestrator.py tests/test_run_builtin_runner_transaction_script.py", "python scripts/run_builtin_runner_transaction.py --output-dir /tmp/sentientos-builtin-runner-transaction --mode diagnostic_write_rollback_with_ledger --ledger-output /tmp/sentientos-builtin-runner-transaction/transaction_ledger.json --summary"), implemented_surfaces=("bounded transaction orchestration of built-in diagnostic write and exact rollback",), deferred_surfaces=("general runner orchestration",), forbidden_implications=("transaction orchestrator is general runner framework", "transaction orchestrator widens delegated authority"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("builtin_runner_transaction_write_only", "delegated_runner_boundary", "implemented", "bounded diagnostic write orchestration", source_paths=("sentientos/builtin_runner_transaction_orchestrator.py",), proof_tests=("tests/test_builtin_runner_transaction_orchestrator.py",), implemented_surfaces=("orchestrates existing bounded local diagnostic artifact write",), forbidden_implications=("write-only orchestration is new effect class",), requires_operator_approval=True, requires_audit_receipt=True),
@@ -1501,3 +1509,53 @@ def update_registry_from_workspace_change_set_preflight(registry: CapabilityRegi
         else:
             records.append(record)
     return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-preflight-wing.v1")
+
+
+def update_registry_from_workspace_change_set_execution(registry: CapabilityRegistry, wing: Any) -> CapabilityRegistry:
+    """Reflect bounded change-set execution without broadening workspace authority."""
+
+    payload = wing.to_dict() if hasattr(wing, "to_dict") else dict(wing) if isinstance(wing, Mapping) else {}
+    has_execution = bool(payload.get("execution_receipt") or payload.get("execution_result") or payload.get("request"))
+    implemented_ids = {
+        "workspace_change_set_execution",
+        "workspace_change_set_execution_request",
+        "workspace_change_target_execution_result",
+        "workspace_change_set_rollback_execution",
+        "workspace_change_set_execution_ledger",
+        "workspace_change_set_execution_closure_report",
+        "workspace_change_set_transaction_execution",
+    }
+    blocked_ids = {
+        "general_filesystem_access",
+        "general_cleanup",
+        "recursive_delete",
+        "wildcard_delete",
+        "unrelated_file_delete",
+        "workspace_change_set_unbounded_execution",
+        "workspace_change_set_bulk_cleanup",
+        "real_file_cleanup",
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+        "real_power_profile_mutation",
+        "real_service_restart",
+        "package_install",
+        "driver_install",
+        "network_egress",
+        "provider_invocation",
+        "prompt_assembly",
+        "subprocess_runner",
+        "shell_runner",
+        "real_subprocess_runner",
+        "hardware_control_runner",
+        "service_control_runner",
+        "power_control_runner",
+    }
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id in implemented_ids:
+            records.append(replace(record, status="implemented" if has_execution else record.status, host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in blocked_ids:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-execution-wing.v1")

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -127,6 +127,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "workspace_file_runner_transaction_capability",
         "workspace_file_transaction_orchestrator_capability",
         "workspace_change_set_preflight_capability",
+        "workspace_change_set_execution_capability",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -165,6 +166,7 @@ BUNDLE_FILE_NAMES = {
     "workspace_file_runner_transaction_capability": "workspace_file_runner_transaction_capability.json",
     "workspace_file_transaction_orchestrator_capability": "workspace_file_transaction_orchestrator_capability.json",
     "workspace_change_set_preflight_capability": "workspace_change_set_preflight_capability.json",
+    "workspace_change_set_execution_capability": "workspace_change_set_execution_capability.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -371,6 +373,7 @@ def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord,
         (("python", "scripts/build_workspace_file_transaction_ledger.py", "--effect-receipt", "<workspace_effect_receipt.json>", "--preimage", "<workspace_preimage.json>", "--postcondition-check", "<workspace_postcondition_check.json>", "--production-audit", "<workspace_production_audit.json>", "--rollback-plan", "<workspace_rollback_plan.json>", "--summary"), "Optional explicit workspace file transaction ledger build; listed for reviewer awareness and not run by proof bundle generation."),
         (("python", "scripts/run_builtin_runner_transaction.py", "--mode", "workspace_file_update_rollback_with_ledger", "--workspace-root", "/tmp/sentientos-workspace-transaction", "--target", "demo.txt", "--payload", "hello", "--ledger-output", "/tmp/sentientos-workspace-transaction/workspace_transaction_ledger.json", "--summary"), "Optional explicit workspace file transaction orchestrator; listed for reviewer awareness and not run by proof bundle generation."),
         (("python", "scripts/preflight_workspace_change_set.py", "--workspace-root", "/tmp/sentientos-workspace-change-set", "--target", "demo.txt=hello", "--summary"), "Optional explicit workspace change-set preflight/planning command; listed for reviewer awareness and not run by proof bundle generation."),
+        (("python", "scripts/run_workspace_change_set_transaction.py", "--workspace-root", "/tmp/sentientos-workspace-change-set", "--target", "demo.txt=hello", "--target", "docs-demo.txt=docs", "--summary"), "Optional explicit bounded workspace change-set execution command; listed for reviewer awareness and not run by proof bundle generation."),
     )
     return tuple(
         ReviewerProofCommandRecord(
@@ -789,7 +792,30 @@ def build_reviewer_proof_bundle_payload(
             "unrelated_file_delete_remains_blocked": True,
             "subprocess_shell_network_provider_prompt_control_plane_execution": False,
             "hardware_service_power_fan_thermal_blocked_deferred": True,
-            "future_change_set_execution_deferred": True,
+            "future_change_set_execution_deferred": False,
+        }),
+        "workspace_change_set_execution_capability": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "capability_available": True,
+            "bounded_change_set_execution_exists": True,
+            "consumes_passed_preflight_and_transaction_plans": True,
+            "executes_explicit_targets_only": True,
+            "uses_single_target_workspace_file_effect_helpers": True,
+            "rollback_is_reverse_order_exact_target_only": True,
+            "partial_state_is_visible": True,
+            "run_by_reviewer_proof_bundle_default": False,
+            "proof_bundle_execution_performed": False,
+            "proof_bundle_rollback_performed": False,
+            "proof_bundle_ledger_built_by_default": False,
+            "proof_bundle_host_mutation_performed": False,
+            "general_filesystem_access_remains_blocked": True,
+            "cleanup_remains_blocked": True,
+            "recursive_wildcard_unrelated_delete_remain_blocked": True,
+            "no_subprocess_shell_network_provider_prompt_control_plane_execution": True,
+            "hardware_service_power_fan_thermal_remain_blocked_deferred": True,
+            "proof_command_status": "proof_command_not_run",
+            "proof_command": "python scripts/run_workspace_change_set_transaction.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --target docs-demo.txt=docs --summary",
         }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "local_diagnostic_effect_capability": _pretty_json({

--- a/sentientos/workspace_change_set_execution.py
+++ b/sentientos/workspace_change_set_execution.py
@@ -1,0 +1,1357 @@
+"""Bounded workspace change-set transaction execution.
+
+This wing consumes a passed Workspace Change Set preflight/transaction plan and
+executes only the explicit relative targets declared in that manifest. Each
+write is delegated to :mod:`sentientos.workspace_file_effect`, preserving the
+existing single-target workspace guardrails and exact-target rollback machinery.
+
+It is not general filesystem access, not cleanup, not recursive or wildcard
+operation, and it never invokes subprocesses, shells, network/provider/prompt
+machinery, services, power, hardware, fan/PWM, thermal, plugins, generated code,
+or federation transports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from sentientos.workspace_change_set_preflight import (
+    DEFAULT_CREATED_AT,
+    WorkspaceChangeSetManifest,
+    WorkspaceChangeSetPreflightReport,
+    WorkspaceChangeSetRollbackPlan,
+    WorkspaceChangeSetTransactionPlan,
+    WorkspaceChangeTargetDeclaration,
+)
+from sentientos.workspace_file_effect import (
+    WorkspaceFileEffectWingResult,
+    WorkspaceFileRollbackPlan,
+    WorkspaceFileRollbackWingResult,
+    bytes_digest,
+    run_workspace_file_effect_wing,
+    run_workspace_file_rollback_wing,
+)
+
+EXECUTION_MODES = frozenset({
+    "change_set_execute_only",
+    "change_set_execute_with_ledger",
+    "change_set_execute_with_rollback_after",
+    "change_set_execute_rollback_with_ledger",
+    "change_set_execute_with_rollback_on_failure",
+    "change_set_execute_full_guarded",
+})
+REQUEST_STATUSES = frozenset({
+    "workspace_change_set_execution_requested",
+    "workspace_change_set_execution_blocked",
+    "workspace_change_set_execution_incomplete",
+    "workspace_change_set_execution_contradicted",
+})
+TARGET_EXECUTION_STATUSES = frozenset({
+    "workspace_change_target_execution_created",
+    "workspace_change_target_execution_updated",
+    "workspace_change_target_execution_blocked",
+    "workspace_change_target_execution_failed",
+    "workspace_change_target_execution_skipped_after_failure",
+    "workspace_change_target_execution_contradicted",
+})
+CHANGE_SET_EXECUTION_STATUSES = frozenset({
+    "workspace_change_set_execution_performed",
+    "workspace_change_set_execution_performed_with_warnings",
+    "workspace_change_set_execution_partially_performed",
+    "workspace_change_set_execution_blocked",
+    "workspace_change_set_execution_failed",
+    "workspace_change_set_execution_incomplete",
+    "workspace_change_set_execution_contradicted",
+})
+ROLLBACK_EXECUTION_STATUSES = frozenset({
+    "workspace_change_set_rollback_performed",
+    "workspace_change_set_rollback_performed_with_warnings",
+    "workspace_change_set_rollback_partially_performed",
+    "workspace_change_set_rollback_not_requested",
+    "workspace_change_set_rollback_blocked",
+    "workspace_change_set_rollback_failed",
+    "workspace_change_set_rollback_incomplete",
+    "workspace_change_set_rollback_contradicted",
+})
+RECEIPT_STATUSES = frozenset({
+    "workspace_change_set_execution_receipt_recorded",
+    "workspace_change_set_execution_receipt_recorded_with_warnings",
+    "workspace_change_set_execution_receipt_blocked",
+    "workspace_change_set_execution_receipt_failed",
+    "workspace_change_set_execution_receipt_incomplete",
+    "workspace_change_set_execution_receipt_contradicted",
+})
+CLOSURE_STATUSES = frozenset({
+    "workspace_change_set_execution_closed_after_execute",
+    "workspace_change_set_execution_closed_after_rollback",
+    "workspace_change_set_execution_open",
+    "workspace_change_set_execution_partially_open",
+    "workspace_change_set_execution_rollback_pending",
+    "workspace_change_set_execution_rollback_incomplete",
+    "workspace_change_set_execution_failed",
+    "workspace_change_set_execution_contradicted",
+})
+PASSED_PREFLIGHT_STATUSES = frozenset({
+    "workspace_change_set_preflight_passed",
+    "workspace_change_set_preflight_passed_with_warnings",
+})
+READY_TRANSACTION_STATUSES = frozenset({
+    "workspace_change_set_transaction_plan_ready",
+    "workspace_change_set_transaction_plan_ready_with_warnings",
+})
+READY_ROLLBACK_PLAN_STATUSES = frozenset({
+    "workspace_change_set_rollback_plan_ready",
+    "workspace_change_set_rollback_plan_ready_with_warnings",
+})
+BLOCKED_ACTION_LABELS = (
+    "general_filesystem_access",
+    "directory_cleanup",
+    "recursive_delete",
+    "wildcard_delete",
+    "unrelated_file_delete",
+    "path_traversal",
+    "absolute_target_path",
+    "target_outside_workspace",
+    "symlink_target_write",
+    "directory_target_write",
+    "fan_pwm_write",
+    "thermal_actuation",
+    "power_profile_mutation",
+    "process_kill",
+    "service_restart",
+    "package_install",
+    "driver_install",
+    "provider_invocation",
+    "network_egress",
+    "prompt_assembly",
+    "federation_transport",
+    "remote_execution",
+    "subprocess_execution",
+    "shell_execution",
+    "os_backend_invocation",
+    "control_plane_admission_execution",
+    "hardware_control",
+)
+FORBIDDEN_TRUE_FIELDS = (
+    "general_filesystem_access_requested",
+    "general_filesystem_access_performed",
+    "cleanup_requested",
+    "cleanup_performed",
+    "directory_cleanup_performed",
+    "general_cleanup_performed",
+    "recursive_delete_requested",
+    "recursive_delete_performed",
+    "wildcard_delete_requested",
+    "wildcard_delete_performed",
+    "unrelated_file_delete_performed",
+    "subprocess_used",
+    "shell_used",
+    "network_used",
+    "network_performed",
+    "provider_invocation_performed",
+    "prompt_assembly_performed",
+    "fan_pwm_write_performed",
+    "thermal_actuation_performed",
+    "power_profile_mutation_performed",
+    "process_kill_performed",
+    "service_restart_performed",
+    "package_install_performed",
+    "driver_install_performed",
+    "hardware_control_performed",
+    "control_plane_admission_execution_performed",
+)
+_ALLOWED_MUTATION_TRUE_FIELDS = frozenset({
+    "change_set_execution_requested",
+    "target_write_performed",
+    "host_mutation_performed",
+    "local_file_write_performed",
+    "change_set_execution_performed",
+    "all_targets_applied",
+    "partial_state_visible",
+    "change_set_execution_receipt_created",
+    "rollback_performed",
+    "exact_target_rollback_only",
+    "change_set_rollback_receipt_created",
+    "metadata_only",
+    "execution_ledger_only",
+    "closure_report_only",
+    "performs_no_new_effect",
+})
+
+
+def _tuple(value: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(str(item) for item in (value or ()))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def deterministic_digest(prefix: str, payload: Mapping[str, Any]) -> str:
+    data = dict(payload)
+    data["digest"] = ""
+    return "sha256:" + hashlib.sha256((prefix + _canonical_json(data)).encode("utf-8")).hexdigest()
+
+
+def _target_digest(path: Path) -> str | None:
+    if not path.exists() or path.is_symlink() or not path.is_file():
+        return None
+    return bytes_digest(path.read_bytes())
+
+
+def _normalize_relative(path_text: str) -> str:
+    text = path_text.replace("\\", "/")
+    pure = PurePosixPath(text)
+    parts: list[str] = []
+    for part in pure.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            else:
+                parts.append("..")
+        else:
+            parts.append(part)
+    return "/".join(parts)
+
+
+def _inside_workspace(root: Path, target: Path) -> bool:
+    try:
+        target.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionValidationResult:
+    ok: bool
+    status: str
+    findings: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionPolicy:
+    require_passed_preflight: bool = True
+    require_transaction_plan: bool = True
+    max_targets: int = 8
+    execute_in_planned_order: bool = True
+    rollback_in_reverse_order: bool = True
+    stop_on_first_failure: bool = True
+    rollback_on_failure_default: bool = True
+    require_digest_still_matches_preflight: bool = True
+    require_parent_exists: bool = True
+    allow_replace: bool = True
+    allow_create: bool = True
+    write_ledger_default: bool = False
+    mutation_allowed: bool = True
+    blocked_actions: tuple[str, ...] = BLOCKED_ACTION_LABELS
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionRequest:
+    request_id: str
+    source_manifest_id: str
+    source_preflight_report_id: str
+    source_rollback_plan_id: str
+    source_transaction_plan_id: str
+    workspace_root: str
+    execution_mode: str
+    target_order: tuple[str, ...]
+    rollback_on_failure: bool
+    rollback_after_execute: bool
+    write_ledger: bool
+    ledger_output_path: str | None
+    required_execution_labels: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    request_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    change_set_execution_requested: bool = True
+    general_filesystem_access_requested: bool = False
+    cleanup_requested: bool = False
+    recursive_delete_requested: bool = False
+    wildcard_delete_requested: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeTargetExecutionResult:
+    result_id: str
+    request_id: str
+    target_id: str
+    relative_target_path: str
+    operation: str
+    target_execution_status: str
+    workspace_effect_receipt_id: str | None
+    workspace_effect_receipt_digest: str | None
+    workspace_postcondition_check_id: str | None
+    workspace_postcondition_check_digest: str | None
+    workspace_rollback_plan_id: str | None
+    workspace_rollback_plan_digest: str | None
+    workspace_production_audit_id: str | None
+    workspace_production_audit_digest: str | None
+    target_path: str
+    before_digest: str | None
+    after_digest: str | None
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    target_write_performed: bool = False
+    host_mutation_performed: bool = False
+    local_file_write_performed: bool = False
+    rollback_performed: bool = False
+    general_filesystem_access_performed: bool = False
+    directory_cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    fan_pwm_write_performed: bool = False
+    thermal_actuation_performed: bool = False
+    power_profile_mutation_performed: bool = False
+    process_kill_performed: bool = False
+    service_restart_performed: bool = False
+    package_install_performed: bool = False
+    driver_install_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionResult:
+    result_id: str
+    request_id: str
+    workspace_root: str
+    execution_mode: str
+    target_results: tuple[WorkspaceChangeTargetExecutionResult, ...]
+    applied_target_ids: tuple[str, ...]
+    failed_target_ids: tuple[str, ...]
+    skipped_target_ids: tuple[str, ...]
+    produced_record_ids: tuple[str, ...]
+    produced_record_digests: tuple[str, ...]
+    produced_paths: tuple[str, ...]
+    execution_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    change_set_execution_performed: bool = False
+    all_targets_applied: bool = False
+    partial_state_visible: bool = False
+    host_mutation_performed: bool = False
+    target_write_performed: bool = False
+    rollback_performed: bool = False
+    general_filesystem_access_performed: bool = False
+    cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        return data
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionReceipt:
+    receipt_id: str
+    request_id: str
+    result_id: str
+    workspace_root: str
+    execution_mode: str
+    receipt_status: str
+    evidence_summary: tuple[str, ...]
+    applied_target_ids: tuple[str, ...]
+    failed_target_ids: tuple[str, ...]
+    skipped_target_ids: tuple[str, ...]
+    produced_record_ids: tuple[str, ...]
+    produced_record_digests: tuple[str, ...]
+    produced_paths: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    change_set_execution_receipt_created: bool = True
+    host_mutation_performed: bool = False
+    target_write_performed: bool = False
+    general_filesystem_access_performed: bool = False
+    cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetRollbackExecutionResult:
+    rollback_result_id: str
+    source_execution_result_id: str
+    workspace_root: str
+    rollback_target_order: tuple[str, ...]
+    rollback_target_ids: tuple[str, ...]
+    rollback_status_by_target: tuple[dict[str, str], ...]
+    rollback_receipt_ids: tuple[str, ...]
+    rollback_receipt_digests: tuple[str, ...]
+    rollback_postcondition_check_ids: tuple[str, ...]
+    rollback_postcondition_check_digests: tuple[str, ...]
+    rollback_audit_ids: tuple[str, ...]
+    rollback_audit_digests: tuple[str, ...]
+    rollback_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    rollback_performed: bool = False
+    host_mutation_performed: bool = False
+    exact_target_rollback_only: bool = True
+    general_cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetRollbackReceipt:
+    receipt_id: str
+    source_execution_receipt_id: str
+    rollback_result_id: str
+    workspace_root: str
+    rollback_status: str
+    evidence_summary: tuple[str, ...]
+    rollback_target_order: tuple[str, ...]
+    rollback_receipt_ids: tuple[str, ...]
+    rollback_receipt_digests: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    change_set_rollback_receipt_created: bool = True
+    rollback_performed: bool = False
+    exact_target_rollback_only: bool = True
+    general_cleanup_performed: bool = False
+    recursive_delete_performed: bool = False
+    wildcard_delete_performed: bool = False
+    unrelated_file_delete_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionLedger:
+    ledger_id: str
+    request_id: str
+    execution_receipt_id: str
+    rollback_receipt_id: str | None
+    target_event_entries: tuple[dict[str, Any], ...]
+    execution_status: str
+    rollback_status: str | None
+    lifecycle_status: str
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    execution_ledger_only: bool = True
+    performs_no_new_effect: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionClosureReport:
+    report_id: str
+    ledger_id: str | None
+    execution_receipt_id: str
+    rollback_receipt_id: str | None
+    closure_status: str
+    applied_target_ids: tuple[str, ...]
+    rolled_back_target_ids: tuple[str, ...]
+    open_target_ids: tuple[str, ...]
+    failed_target_ids: tuple[str, ...]
+    skipped_target_ids: tuple[str, ...]
+    open_issue_codes: tuple[str, ...]
+    closure_codes: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    risk_codes: tuple[str, ...]
+    created_at: str
+    digest: str
+    metadata_only: bool = True
+    closure_report_only: bool = True
+    performs_no_new_effect: bool = True
+    host_mutation_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class WorkspaceChangeSetExecutionWingResult(NamedTuple):
+    request: WorkspaceChangeSetExecutionRequest
+    execution_result: WorkspaceChangeSetExecutionResult
+    execution_receipt: WorkspaceChangeSetExecutionReceipt
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult
+    rollback_receipt: WorkspaceChangeSetRollbackReceipt | None
+    ledger: WorkspaceChangeSetExecutionLedger | None
+    closure_report: WorkspaceChangeSetExecutionClosureReport
+
+
+def build_default_workspace_change_set_execution_policy() -> WorkspaceChangeSetExecutionPolicy:
+    return WorkspaceChangeSetExecutionPolicy()
+
+
+def build_workspace_change_set_execution_request(
+    *,
+    manifest: WorkspaceChangeSetManifest,
+    preflight_report: WorkspaceChangeSetPreflightReport,
+    rollback_plan: WorkspaceChangeSetRollbackPlan,
+    transaction_plan: WorkspaceChangeSetTransactionPlan,
+    execution_mode: str = "change_set_execute_full_guarded",
+    rollback_on_failure: bool | None = None,
+    rollback_after_execute: bool = False,
+    write_ledger: bool | None = None,
+    ledger_output_path: str | None = None,
+    policy: WorkspaceChangeSetExecutionPolicy | None = None,
+    request_id: str | None = None,
+    required_execution_labels: Sequence[str] = ("passed_workspace_change_set_preflight", "ready_workspace_change_set_transaction_plan", "explicit_workspace_root", "explicit_manifest_targets"),
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetExecutionRequest:
+    policy = policy or build_default_workspace_change_set_execution_policy()
+    findings: list[str] = []
+    if execution_mode not in EXECUTION_MODES:
+        findings.append("unknown_execution_mode")
+    if len(transaction_plan.planned_target_order) > policy.max_targets:
+        findings.append("target_count_over_limit")
+    if policy.require_passed_preflight and preflight_report.report_status not in PASSED_PREFLIGHT_STATUSES:
+        findings.append("preflight_not_passed")
+    if policy.require_transaction_plan and transaction_plan.transaction_plan_status not in READY_TRANSACTION_STATUSES:
+        findings.append("transaction_plan_not_ready")
+    if rollback_plan.rollback_plan_status not in READY_ROLLBACK_PLAN_STATUSES:
+        findings.append("rollback_plan_not_ready")
+    if manifest.manifest_id != preflight_report.manifest_id or manifest.manifest_id != transaction_plan.manifest_id or manifest.manifest_id != rollback_plan.manifest_id:
+        findings.append("source_manifest_mismatch")
+    if preflight_report.report_id != transaction_plan.preflight_report_id or preflight_report.report_id != rollback_plan.preflight_report_id:
+        findings.append("source_preflight_report_mismatch")
+    if rollback_plan.plan_id != transaction_plan.rollback_plan_id:
+        findings.append("source_rollback_plan_mismatch")
+    if tuple(target.target_id for target in manifest.targets) != tuple(transaction_plan.planned_target_order):
+        findings.append("transaction_order_not_manifest_order")
+    status = "workspace_change_set_execution_requested"
+    if findings:
+        status = "workspace_change_set_execution_blocked"
+    if any("contradict" in item for item in findings) or preflight_report.report_status.endswith("contradicted") or transaction_plan.transaction_plan_status.endswith("contradicted"):
+        status = "workspace_change_set_execution_contradicted"
+    mode_requests_ledger = execution_mode in {"change_set_execute_with_ledger", "change_set_execute_rollback_with_ledger", "change_set_execute_full_guarded"}
+    mode_requests_rollback_after = execution_mode in {"change_set_execute_with_rollback_after", "change_set_execute_rollback_with_ledger"}
+    record = WorkspaceChangeSetExecutionRequest(
+        request_id=request_id or "workspace-change-set-execution-request-" + hashlib.sha256(f"{manifest.manifest_id}\0{transaction_plan.plan_id}\0{created_at}".encode("utf-8")).hexdigest()[:16],
+        source_manifest_id=manifest.manifest_id,
+        source_preflight_report_id=preflight_report.report_id,
+        source_rollback_plan_id=rollback_plan.plan_id,
+        source_transaction_plan_id=transaction_plan.plan_id,
+        workspace_root=str(manifest.workspace_root),
+        execution_mode=execution_mode,
+        target_order=tuple(transaction_plan.planned_target_order),
+        rollback_on_failure=policy.rollback_on_failure_default if rollback_on_failure is None else bool(rollback_on_failure),
+        rollback_after_execute=bool(rollback_after_execute or mode_requests_rollback_after),
+        write_ledger=policy.write_ledger_default if write_ledger is None else bool(write_ledger or mode_requests_ledger or ledger_output_path),
+        ledger_output_path=str(ledger_output_path) if ledger_output_path else None,
+        required_execution_labels=_tuple(required_execution_labels),
+        blocked_actions=tuple(sorted(set(policy.blocked_actions))),
+        request_status=status,
+        warning_codes=(),
+        risk_codes=tuple(sorted(set(findings + list(manifest.risk_codes) + list(preflight_report.risk_codes) + list(transaction_plan.risk_codes)))),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-request-", record.to_dict()))
+
+
+def _forbidden_true_findings(record: Any) -> list[str]:
+    payload = record.to_dict() if hasattr(record, "to_dict") else asdict(record)
+    findings: list[str] = []
+    for field in FORBIDDEN_TRUE_FIELDS:
+        if payload.get(field) is True:
+            findings.append(f"contradiction:{field}_true")
+    return findings
+
+
+def validate_workspace_change_set_execution_request(record: WorkspaceChangeSetExecutionRequest) -> WorkspaceChangeSetExecutionValidationResult:
+    findings = _forbidden_true_findings(record)
+    if record.request_status not in REQUEST_STATUSES:
+        findings.append("unknown_request_status")
+    if record.execution_mode not in EXECUTION_MODES:
+        findings.append("unknown_execution_mode")
+    if not record.change_set_execution_requested:
+        findings.append("change_set_execution_not_requested")
+    status = record.request_status if not findings else "workspace_change_set_execution_contradicted"
+    return WorkspaceChangeSetExecutionValidationResult(not findings and record.request_status == "workspace_change_set_execution_requested", status, tuple(sorted(set(findings + list(record.risk_codes if record.request_status != "workspace_change_set_execution_requested" else ())))))
+
+
+def _blocked_result(request: WorkspaceChangeSetExecutionRequest, findings: Sequence[str], created_at: str) -> WorkspaceChangeSetExecutionResult:
+    record = WorkspaceChangeSetExecutionResult(
+        result_id=f"workspace-change-set-execution-result-{request.request_id}",
+        request_id=request.request_id,
+        workspace_root=request.workspace_root,
+        execution_mode=request.execution_mode,
+        target_results=(),
+        applied_target_ids=(),
+        failed_target_ids=(),
+        skipped_target_ids=tuple(request.target_order),
+        produced_record_ids=(),
+        produced_record_digests=(),
+        produced_paths=(),
+        execution_status="workspace_change_set_execution_contradicted" if any("contradict" in item for item in findings) else "workspace_change_set_execution_blocked",
+        warning_codes=tuple(findings),
+        risk_codes=tuple(sorted(set(findings))),
+        created_at=created_at,
+        digest="",
+        partial_state_visible=False,
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-result-", record.to_dict()))
+
+
+def _target_result_from_effect(
+    *,
+    request: WorkspaceChangeSetExecutionRequest,
+    target: WorkspaceChangeTargetDeclaration,
+    wing: WorkspaceFileEffectWingResult | None,
+    status: str,
+    before_digest: str | None,
+    after_digest: str | None,
+    warning_codes: Sequence[str] = (),
+    created_at: str,
+) -> WorkspaceChangeTargetExecutionResult:
+    receipt = wing.receipt if wing else None
+    postcondition = wing.postcondition if wing else None
+    rollback_plan = wing.rollback_plan if wing else None
+    audit = wing.production_audit if wing else None
+    succeeded = status in {"workspace_change_target_execution_created", "workspace_change_target_execution_updated"}
+    record = WorkspaceChangeTargetExecutionResult(
+        result_id=f"workspace-change-target-execution-result-{request.request_id}-{target.target_id}",
+        request_id=request.request_id,
+        target_id=target.target_id,
+        relative_target_path=target.relative_target_path,
+        operation=target.operation,
+        target_execution_status=status,
+        workspace_effect_receipt_id=receipt.receipt_id if receipt else None,
+        workspace_effect_receipt_digest=receipt.digest if receipt else None,
+        workspace_postcondition_check_id=postcondition.check_id if postcondition else None,
+        workspace_postcondition_check_digest=postcondition.digest if postcondition else None,
+        workspace_rollback_plan_id=rollback_plan.plan_id if rollback_plan else None,
+        workspace_rollback_plan_digest=rollback_plan.digest if rollback_plan else None,
+        workspace_production_audit_id=audit.audit_id if audit else None,
+        workspace_production_audit_digest=audit.digest if audit else None,
+        target_path=receipt.target_path if receipt else str(Path(request.workspace_root) / _normalize_relative(target.relative_target_path)),
+        before_digest=before_digest,
+        after_digest=after_digest,
+        warning_codes=_tuple(warning_codes),
+        risk_codes=tuple(sorted(set(_tuple(warning_codes) + target.risk_codes))),
+        created_at=created_at,
+        digest="",
+        target_write_performed=succeeded,
+        host_mutation_performed=succeeded,
+        local_file_write_performed=succeeded,
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-target-execution-result-", record.to_dict()))
+
+
+def _skipped_target_result(request: WorkspaceChangeSetExecutionRequest, target: WorkspaceChangeTargetDeclaration, created_at: str) -> WorkspaceChangeTargetExecutionResult:
+    return _target_result_from_effect(
+        request=request,
+        target=target,
+        wing=None,
+        status="workspace_change_target_execution_skipped_after_failure",
+        before_digest=None,
+        after_digest=None,
+        warning_codes=("skipped_after_prior_target_failure",),
+        created_at=created_at,
+    )
+
+
+def _digest_drift_findings(manifest: WorkspaceChangeSetManifest, rollback_plan: WorkspaceChangeSetRollbackPlan) -> tuple[str, ...]:
+    root = Path(manifest.workspace_root).expanduser()
+    target_by_id = {target.target_id: target for target in manifest.targets}
+    findings: list[str] = []
+    for entry in rollback_plan.target_rollback_entries:
+        target_id = str(entry.get("target_id", ""))
+        target = target_by_id.get(target_id)
+        if target is None:
+            findings.append(f"target_not_in_manifest:{target_id}")
+            continue
+        normalized = _normalize_relative(target.relative_target_path)
+        path = root / normalized
+        if not _inside_workspace(root, path):
+            findings.append(f"target_outside_workspace:{target_id}")
+            continue
+        if path.is_symlink():
+            findings.append(f"symlink_target_write:{target_id}")
+            continue
+        if path.exists() and path.is_dir():
+            findings.append(f"directory_target_write:{target_id}")
+            continue
+        existed_before = bool(entry.get("existed_before"))
+        expected_digest = entry.get("existing_digest")
+        if existed_before:
+            current = _target_digest(path)
+            if current != expected_digest:
+                findings.append(f"preflight_digest_drift:{target_id}")
+        elif path.exists():
+            findings.append(f"preflight_absent_target_now_exists:{target_id}")
+        if not path.parent.exists():
+            findings.append(f"parent_missing_since_preflight:{target_id}")
+    return tuple(findings)
+
+
+def execute_workspace_change_set(
+    *,
+    request: WorkspaceChangeSetExecutionRequest,
+    manifest: WorkspaceChangeSetManifest,
+    preflight_report: WorkspaceChangeSetPreflightReport,
+    rollback_plan: WorkspaceChangeSetRollbackPlan,
+    transaction_plan: WorkspaceChangeSetTransactionPlan,
+    policy: WorkspaceChangeSetExecutionPolicy | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+    effect_runner: Any = run_workspace_file_effect_wing,
+) -> tuple[WorkspaceChangeSetExecutionResult, tuple[WorkspaceFileEffectWingResult, ...]]:
+    policy = policy or build_default_workspace_change_set_execution_policy()
+    validation = validate_workspace_change_set_execution_request(request)
+    findings = list(validation.findings)
+    if not validation.ok:
+        findings.append("execution_request_not_valid")
+    if preflight_report.report_status not in PASSED_PREFLIGHT_STATUSES:
+        findings.append("preflight_not_passed")
+    if transaction_plan.transaction_plan_status not in READY_TRANSACTION_STATUSES:
+        findings.append("transaction_plan_not_ready")
+    if policy.require_digest_still_matches_preflight:
+        findings.extend(_digest_drift_findings(manifest, rollback_plan))
+    if findings:
+        return _blocked_result(request, findings, created_at), ()
+
+    root = Path(request.workspace_root).expanduser()
+    target_by_id = {target.target_id: target for target in manifest.targets}
+    target_results: list[WorkspaceChangeTargetExecutionResult] = []
+    applied: list[str] = []
+    failed: list[str] = []
+    skipped: list[str] = []
+    produced_ids: list[str] = []
+    produced_digests: list[str] = []
+    produced_paths: list[str] = []
+    effect_wings: list[WorkspaceFileEffectWingResult] = []
+    failure_seen = False
+    warning_codes: list[str] = []
+
+    for target_id in request.target_order:
+        target = target_by_id.get(target_id)
+        if target is None:
+            failed.append(target_id)
+            warning_codes.append(f"target_not_in_manifest:{target_id}")
+            failure_seen = True
+            continue
+        if failure_seen and policy.stop_on_first_failure:
+            skipped.append(target_id)
+            target_results.append(_skipped_target_result(request, target, created_at))
+            continue
+        target_path = root / _normalize_relative(target.relative_target_path)
+        before_digest = _target_digest(target_path)
+        try:
+            wing = effect_runner(
+                workspace_root=request.workspace_root,
+                relative_target_path=target.relative_target_path,
+                payload_text=target.payload_text,
+                request_id=f"{request.request_id}-{target.target_id}",
+                force_create=(target.operation == "create_file"),
+                allow_replace=target.allow_replace and policy.allow_replace,
+                dry_run=False,
+                created_at=created_at,
+            )
+        except Exception as exc:  # fail-stop visibility; exception is captured, not retried or hidden.
+            failed.append(target_id)
+            failure_seen = True
+            warning = f"target_effect_exception:{type(exc).__name__}"
+            warning_codes.append(warning)
+            target_results.append(_target_result_from_effect(request=request, target=target, wing=None, status="workspace_change_target_execution_failed", before_digest=before_digest, after_digest=_target_digest(target_path), warning_codes=(warning,), created_at=created_at))
+            continue
+        after_digest = _target_digest(Path(wing.receipt.target_path))
+        if wing.receipt.real_effect_performed and wing.postcondition.postcondition_status == "workspace_file_postcondition_passed":
+            status = "workspace_change_target_execution_created" if wing.receipt.created_new_file else "workspace_change_target_execution_updated"
+            applied.append(target_id)
+            effect_wings.append(wing)
+            produced_ids.extend([wing.receipt.receipt_id, wing.postcondition.check_id, wing.rollback_plan.plan_id, wing.production_audit.audit_id])
+            produced_digests.extend([wing.receipt.digest, wing.postcondition.digest, wing.rollback_plan.digest, wing.production_audit.digest])
+            produced_paths.append(wing.receipt.target_path)
+        else:
+            status = "workspace_change_target_execution_blocked" if wing.result.effect_status == "workspace_file_effect_blocked" else "workspace_change_target_execution_failed"
+            failed.append(target_id)
+            failure_seen = True
+            warning_codes.extend(wing.result.warning_codes)
+        target_results.append(_target_result_from_effect(request=request, target=target, wing=wing, status=status, before_digest=before_digest, after_digest=after_digest, warning_codes=wing.result.warning_codes, created_at=created_at))
+
+    all_applied = len(applied) == len(request.target_order) and not failed and not skipped
+    any_applied = bool(applied)
+    partial = any_applied and (bool(failed) or bool(skipped) or len(applied) != len(request.target_order))
+    if all_applied and warning_codes:
+        status = "workspace_change_set_execution_performed_with_warnings"
+    elif all_applied:
+        status = "workspace_change_set_execution_performed"
+    elif any_applied:
+        status = "workspace_change_set_execution_partially_performed"
+    elif failed:
+        status = "workspace_change_set_execution_failed"
+    else:
+        status = "workspace_change_set_execution_incomplete"
+    record = WorkspaceChangeSetExecutionResult(
+        result_id=f"workspace-change-set-execution-result-{request.request_id}",
+        request_id=request.request_id,
+        workspace_root=request.workspace_root,
+        execution_mode=request.execution_mode,
+        target_results=tuple(target_results),
+        applied_target_ids=tuple(applied),
+        failed_target_ids=tuple(failed),
+        skipped_target_ids=tuple(skipped),
+        produced_record_ids=tuple(produced_ids),
+        produced_record_digests=tuple(produced_digests),
+        produced_paths=tuple(produced_paths),
+        execution_status=status,
+        warning_codes=tuple(sorted(set(warning_codes))),
+        risk_codes=tuple(sorted(set(manifest.risk_codes + preflight_report.risk_codes + tuple(warning_codes)))),
+        created_at=created_at,
+        digest="",
+        change_set_execution_performed=any_applied,
+        all_targets_applied=all_applied,
+        partial_state_visible=partial,
+        host_mutation_performed=any_applied,
+        target_write_performed=any_applied,
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-result-", record.to_dict())), tuple(effect_wings)
+
+
+def build_workspace_change_set_execution_receipt(
+    request: WorkspaceChangeSetExecutionRequest,
+    result: WorkspaceChangeSetExecutionResult,
+    *,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetExecutionReceipt:
+    if result.execution_status == "workspace_change_set_execution_contradicted":
+        status = "workspace_change_set_execution_receipt_contradicted"
+    elif result.execution_status == "workspace_change_set_execution_blocked":
+        status = "workspace_change_set_execution_receipt_blocked"
+    elif result.execution_status in {"workspace_change_set_execution_failed", "workspace_change_set_execution_partially_performed"}:
+        status = "workspace_change_set_execution_receipt_failed"
+    elif result.warning_codes:
+        status = "workspace_change_set_execution_receipt_recorded_with_warnings"
+    elif result.change_set_execution_performed:
+        status = "workspace_change_set_execution_receipt_recorded"
+    else:
+        status = "workspace_change_set_execution_receipt_incomplete"
+    record = WorkspaceChangeSetExecutionReceipt(
+        receipt_id=f"workspace-change-set-execution-receipt-{result.result_id}",
+        request_id=request.request_id,
+        result_id=result.result_id,
+        workspace_root=result.workspace_root,
+        execution_mode=result.execution_mode,
+        receipt_status=status,
+        evidence_summary=tuple(str(item) for item in summarize_workspace_change_set_execution_result(result).items()),
+        applied_target_ids=result.applied_target_ids,
+        failed_target_ids=result.failed_target_ids,
+        skipped_target_ids=result.skipped_target_ids,
+        produced_record_ids=result.produced_record_ids,
+        produced_record_digests=result.produced_record_digests,
+        produced_paths=result.produced_paths,
+        blocked_actions=request.blocked_actions,
+        warning_codes=result.warning_codes,
+        risk_codes=result.risk_codes,
+        created_at=created_at,
+        digest="",
+        host_mutation_performed=result.host_mutation_performed,
+        target_write_performed=result.target_write_performed,
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-receipt-", record.to_dict()))
+
+
+def _rollback_not_requested(execution_result: WorkspaceChangeSetExecutionResult, created_at: str) -> WorkspaceChangeSetRollbackExecutionResult:
+    record = WorkspaceChangeSetRollbackExecutionResult(
+        rollback_result_id=f"workspace-change-set-rollback-result-{execution_result.result_id}",
+        source_execution_result_id=execution_result.result_id,
+        workspace_root=execution_result.workspace_root,
+        rollback_target_order=(),
+        rollback_target_ids=(),
+        rollback_status_by_target=(),
+        rollback_receipt_ids=(),
+        rollback_receipt_digests=(),
+        rollback_postcondition_check_ids=(),
+        rollback_postcondition_check_digests=(),
+        rollback_audit_ids=(),
+        rollback_audit_digests=(),
+        rollback_status="workspace_change_set_rollback_not_requested",
+        warning_codes=("rollback_not_requested",),
+        risk_codes=(),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-rollback-result-", record.to_dict()))
+
+
+def execute_workspace_change_set_rollback(
+    *,
+    execution_result: WorkspaceChangeSetExecutionResult,
+    target_effects: Sequence[WorkspaceFileEffectWingResult],
+    rollback_target_ids: Sequence[str] | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+    rollback_runner: Any = run_workspace_file_rollback_wing,
+) -> tuple[WorkspaceChangeSetRollbackExecutionResult, tuple[WorkspaceFileRollbackWingResult, ...]]:
+    if not target_effects:
+        return _rollback_not_requested(execution_result, created_at), ()
+    ids_by_plan = {wing.rollback_plan.plan_id: target_id for wing, target_id in zip(target_effects, execution_result.applied_target_ids)}
+    selected = list(target_effects)
+    if rollback_target_ids is not None:
+        selected_ids = set(rollback_target_ids)
+        selected = [wing for wing in selected if ids_by_plan.get(wing.rollback_plan.plan_id) in selected_ids]
+    selected = list(reversed(selected))
+    status_entries: list[dict[str, str]] = []
+    receipt_ids: list[str] = []
+    receipt_digests: list[str] = []
+    post_ids: list[str] = []
+    post_digests: list[str] = []
+    audit_ids: list[str] = []
+    audit_digests: list[str] = []
+    performed_ids: list[str] = []
+    warnings: list[str] = []
+    rollback_wings: list[WorkspaceFileRollbackWingResult] = []
+    for wing in selected:
+        target_id = ids_by_plan.get(wing.rollback_plan.plan_id, wing.receipt.relative_target_path)
+        try:
+            rollback = rollback_runner(effect_receipt=wing.receipt, rollback_plan=wing.rollback_plan, created_at=created_at)
+        except Exception as exc:
+            status_entries.append({"target_id": target_id, "rollback_status": "workspace_file_rollback_failed"})
+            warnings.append(f"rollback_exception:{type(exc).__name__}:{target_id}")
+            continue
+        rollback_wings.append(rollback)
+        status_entries.append({"target_id": target_id, "rollback_status": rollback.rollback_result.rollback_status})
+        receipt_ids.append(rollback.rollback_receipt.receipt_id)
+        receipt_digests.append(rollback.rollback_receipt.digest)
+        post_ids.append(rollback.rollback_postcondition.check_id)
+        post_digests.append(rollback.rollback_postcondition.digest)
+        audit_ids.append(rollback.production_audit.audit_id)
+        audit_digests.append(rollback.production_audit.digest)
+        if rollback.rollback_result.real_rollback_performed:
+            performed_ids.append(target_id)
+        else:
+            warnings.extend(rollback.rollback_result.warning_codes)
+    if performed_ids and len(performed_ids) == len(selected) and not warnings:
+        status = "workspace_change_set_rollback_performed"
+    elif performed_ids and len(performed_ids) == len(selected):
+        status = "workspace_change_set_rollback_performed_with_warnings"
+    elif performed_ids:
+        status = "workspace_change_set_rollback_partially_performed"
+    else:
+        status = "workspace_change_set_rollback_failed"
+    record = WorkspaceChangeSetRollbackExecutionResult(
+        rollback_result_id=f"workspace-change-set-rollback-result-{execution_result.result_id}",
+        source_execution_result_id=execution_result.result_id,
+        workspace_root=execution_result.workspace_root,
+        rollback_target_order=tuple(entry["target_id"] for entry in status_entries),
+        rollback_target_ids=tuple(performed_ids),
+        rollback_status_by_target=tuple(status_entries),
+        rollback_receipt_ids=tuple(receipt_ids),
+        rollback_receipt_digests=tuple(receipt_digests),
+        rollback_postcondition_check_ids=tuple(post_ids),
+        rollback_postcondition_check_digests=tuple(post_digests),
+        rollback_audit_ids=tuple(audit_ids),
+        rollback_audit_digests=tuple(audit_digests),
+        rollback_status=status,
+        warning_codes=tuple(sorted(set(warnings))),
+        risk_codes=execution_result.risk_codes,
+        created_at=created_at,
+        digest="",
+        rollback_performed=bool(performed_ids),
+        host_mutation_performed=bool(performed_ids),
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-rollback-result-", record.to_dict())), tuple(rollback_wings)
+
+
+def build_workspace_change_set_rollback_receipt(
+    execution_receipt: WorkspaceChangeSetExecutionReceipt,
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult,
+    *,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetRollbackReceipt:
+    record = WorkspaceChangeSetRollbackReceipt(
+        receipt_id=f"workspace-change-set-rollback-receipt-{rollback_result.rollback_result_id}",
+        source_execution_receipt_id=execution_receipt.receipt_id,
+        rollback_result_id=rollback_result.rollback_result_id,
+        workspace_root=rollback_result.workspace_root,
+        rollback_status=rollback_result.rollback_status,
+        evidence_summary=tuple(str(item) for item in summarize_workspace_change_set_rollback_execution_result(rollback_result).items()),
+        rollback_target_order=rollback_result.rollback_target_order,
+        rollback_receipt_ids=rollback_result.rollback_receipt_ids,
+        rollback_receipt_digests=rollback_result.rollback_receipt_digests,
+        blocked_actions=execution_receipt.blocked_actions,
+        warning_codes=rollback_result.warning_codes,
+        risk_codes=rollback_result.risk_codes,
+        created_at=created_at,
+        digest="",
+        rollback_performed=rollback_result.rollback_performed,
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-rollback-receipt-", record.to_dict()))
+
+
+def build_workspace_change_set_execution_ledger(
+    *,
+    request: WorkspaceChangeSetExecutionRequest,
+    execution_receipt: WorkspaceChangeSetExecutionReceipt,
+    execution_result: WorkspaceChangeSetExecutionResult,
+    rollback_receipt: WorkspaceChangeSetRollbackReceipt | None = None,
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetExecutionLedger:
+    rollback_status_by_target = {entry["target_id"]: entry["rollback_status"] for entry in (rollback_result.rollback_status_by_target if rollback_result else ())}
+    entries: list[dict[str, Any]] = []
+    for index, target in enumerate(execution_result.target_results):
+        entries.append({
+            "index": index,
+            "target_id": target.target_id,
+            "relative_target_path": target.relative_target_path,
+            "operation": target.operation,
+            "target_execution_status": target.target_execution_status,
+            "workspace_effect_receipt_id": target.workspace_effect_receipt_id,
+            "workspace_rollback_plan_id": target.workspace_rollback_plan_id,
+            "rollback_status": rollback_status_by_target.get(target.target_id),
+            "target_write_performed": target.target_write_performed,
+        })
+    lifecycle = "workspace_change_set_execution_closed_after_rollback" if rollback_receipt and rollback_receipt.rollback_performed else "workspace_change_set_execution_closed_after_execute" if execution_result.all_targets_applied else "workspace_change_set_execution_partially_open" if execution_result.partial_state_visible else "workspace_change_set_execution_open"
+    record = WorkspaceChangeSetExecutionLedger(
+        ledger_id=f"workspace-change-set-execution-ledger-{execution_receipt.receipt_id}",
+        request_id=request.request_id,
+        execution_receipt_id=execution_receipt.receipt_id,
+        rollback_receipt_id=rollback_receipt.receipt_id if rollback_receipt else None,
+        target_event_entries=tuple(entries),
+        execution_status=execution_result.execution_status,
+        rollback_status=rollback_result.rollback_status if rollback_result else None,
+        lifecycle_status=lifecycle,
+        warning_codes=tuple(sorted(set(execution_result.warning_codes + (rollback_result.warning_codes if rollback_result else ())))),
+        risk_codes=tuple(sorted(set(execution_result.risk_codes + (rollback_result.risk_codes if rollback_result else ())))),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-ledger-", record.to_dict()))
+
+
+def build_workspace_change_set_execution_closure_report(
+    *,
+    execution_receipt: WorkspaceChangeSetExecutionReceipt,
+    execution_result: WorkspaceChangeSetExecutionResult,
+    ledger: WorkspaceChangeSetExecutionLedger | None = None,
+    rollback_receipt: WorkspaceChangeSetRollbackReceipt | None = None,
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetExecutionClosureReport:
+    rolled_back = tuple(rollback_result.rollback_target_ids if rollback_result else ())
+    open_ids = tuple(target_id for target_id in execution_result.applied_target_ids if target_id not in set(rolled_back))
+    issues: list[str] = []
+    if execution_result.failed_target_ids:
+        issues.append("failed_targets_visible")
+    if execution_result.skipped_target_ids:
+        issues.append("skipped_targets_visible")
+    if open_ids and execution_result.failed_target_ids:
+        status = "workspace_change_set_execution_partially_open"
+        issues.append("partial_state_visible")
+    elif open_ids and execution_result.all_targets_applied and not rollback_result:
+        status = "workspace_change_set_execution_closed_after_execute"
+    elif open_ids and rollback_result and rollback_result.rollback_performed:
+        status = "workspace_change_set_execution_rollback_incomplete"
+        issues.append("rollback_incomplete")
+    elif not open_ids and rollback_result and rollback_result.rollback_performed:
+        status = "workspace_change_set_execution_closed_after_rollback"
+    elif execution_result.failed_target_ids and not execution_result.applied_target_ids:
+        status = "workspace_change_set_execution_failed"
+    elif execution_result.applied_target_ids and not rollback_result and not execution_result.all_targets_applied:
+        status = "workspace_change_set_execution_rollback_pending"
+        issues.append("rollback_pending")
+    else:
+        status = "workspace_change_set_execution_open"
+    record = WorkspaceChangeSetExecutionClosureReport(
+        report_id=f"workspace-change-set-execution-closure-{execution_receipt.receipt_id}",
+        ledger_id=ledger.ledger_id if ledger else None,
+        execution_receipt_id=execution_receipt.receipt_id,
+        rollback_receipt_id=rollback_receipt.receipt_id if rollback_receipt else None,
+        closure_status=status,
+        applied_target_ids=execution_result.applied_target_ids,
+        rolled_back_target_ids=rolled_back,
+        open_target_ids=open_ids,
+        failed_target_ids=execution_result.failed_target_ids,
+        skipped_target_ids=execution_result.skipped_target_ids,
+        open_issue_codes=tuple(sorted(set(issues))),
+        closure_codes=(status,),
+        warning_codes=tuple(sorted(set(execution_result.warning_codes + (rollback_result.warning_codes if rollback_result else ())))),
+        risk_codes=tuple(sorted(set(execution_result.risk_codes + (rollback_result.risk_codes if rollback_result else ())))),
+        created_at=created_at,
+        digest="",
+    )
+    return replace(record, digest=deterministic_digest("workspace-change-set-execution-closure-", record.to_dict()))
+
+
+def _validate_record(record: Any, statuses: frozenset[str], status_field: str, contradicted_status: str) -> WorkspaceChangeSetExecutionValidationResult:
+    payload = record.to_dict() if hasattr(record, "to_dict") else asdict(record)
+    findings = _forbidden_true_findings(record)
+    status = str(payload.get(status_field, ""))
+    if status not in statuses:
+        findings.append(f"unknown_{status_field}")
+    return WorkspaceChangeSetExecutionValidationResult(not findings, status if not findings else contradicted_status, tuple(sorted(set(findings))))
+
+
+def validate_workspace_change_target_execution_result(record: WorkspaceChangeTargetExecutionResult) -> WorkspaceChangeSetExecutionValidationResult:
+    return _validate_record(record, TARGET_EXECUTION_STATUSES, "target_execution_status", "workspace_change_target_execution_contradicted")
+
+
+def validate_workspace_change_set_execution_result(record: WorkspaceChangeSetExecutionResult) -> WorkspaceChangeSetExecutionValidationResult:
+    return _validate_record(record, CHANGE_SET_EXECUTION_STATUSES, "execution_status", "workspace_change_set_execution_contradicted")
+
+
+def validate_workspace_change_set_execution_receipt(record: WorkspaceChangeSetExecutionReceipt) -> WorkspaceChangeSetExecutionValidationResult:
+    return _validate_record(record, RECEIPT_STATUSES, "receipt_status", "workspace_change_set_execution_receipt_contradicted")
+
+
+def validate_workspace_change_set_rollback_execution_result(record: WorkspaceChangeSetRollbackExecutionResult) -> WorkspaceChangeSetExecutionValidationResult:
+    return _validate_record(record, ROLLBACK_EXECUTION_STATUSES, "rollback_status", "workspace_change_set_rollback_contradicted")
+
+
+def validate_workspace_change_set_rollback_receipt(record: WorkspaceChangeSetRollbackReceipt) -> WorkspaceChangeSetExecutionValidationResult:
+    return _validate_record(record, ROLLBACK_EXECUTION_STATUSES, "rollback_status", "workspace_change_set_rollback_contradicted")
+
+
+def validate_workspace_change_set_execution_ledger(record: WorkspaceChangeSetExecutionLedger) -> WorkspaceChangeSetExecutionValidationResult:
+    findings = _forbidden_true_findings(record)
+    if not record.metadata_only or not record.execution_ledger_only or not record.performs_no_new_effect or record.host_mutation_performed:
+        findings.append("contradiction:ledger_effect_claim")
+    return WorkspaceChangeSetExecutionValidationResult(not findings, record.lifecycle_status if not findings else "workspace_change_set_execution_contradicted", tuple(sorted(set(findings))))
+
+
+def validate_workspace_change_set_execution_closure_report(record: WorkspaceChangeSetExecutionClosureReport) -> WorkspaceChangeSetExecutionValidationResult:
+    findings = _forbidden_true_findings(record)
+    if record.closure_status not in CLOSURE_STATUSES:
+        findings.append("unknown_closure_status")
+    if not record.metadata_only or not record.closure_report_only or not record.performs_no_new_effect or record.host_mutation_performed:
+        findings.append("contradiction:closure_report_effect_claim")
+    return WorkspaceChangeSetExecutionValidationResult(not findings, record.closure_status if not findings else "workspace_change_set_execution_contradicted", tuple(sorted(set(findings))))
+
+
+def summarize_workspace_change_target_execution_result(result: WorkspaceChangeTargetExecutionResult) -> dict[str, Any]:
+    return {
+        "target_id": result.target_id,
+        "relative_target_path": result.relative_target_path,
+        "status": result.target_execution_status,
+        "target_write_performed": result.target_write_performed,
+        "workspace_effect_receipt_id": result.workspace_effect_receipt_id,
+        "workspace_rollback_plan_id": result.workspace_rollback_plan_id,
+        "general_filesystem_access_performed": False,
+    }
+
+
+def summarize_workspace_change_set_execution_result(result: WorkspaceChangeSetExecutionResult) -> dict[str, Any]:
+    return {
+        "result_id": result.result_id,
+        "execution_status": result.execution_status,
+        "applied_target_ids": result.applied_target_ids,
+        "failed_target_ids": result.failed_target_ids,
+        "skipped_target_ids": result.skipped_target_ids,
+        "partial_state_visible": result.partial_state_visible,
+        "bounded_change_set_execution_only": True,
+        "general_filesystem_access_performed": False,
+    }
+
+
+def summarize_workspace_change_set_execution_receipt(receipt: WorkspaceChangeSetExecutionReceipt) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt.receipt_id,
+        "receipt_status": receipt.receipt_status,
+        "applied_target_ids": receipt.applied_target_ids,
+        "failed_target_ids": receipt.failed_target_ids,
+        "skipped_target_ids": receipt.skipped_target_ids,
+        "uses_single_target_workspace_file_helpers": True,
+        "not_general_filesystem_access": True,
+    }
+
+
+def summarize_workspace_change_set_rollback_execution_result(result: WorkspaceChangeSetRollbackExecutionResult) -> dict[str, Any]:
+    return {
+        "rollback_result_id": result.rollback_result_id,
+        "rollback_status": result.rollback_status,
+        "rollback_target_order": result.rollback_target_order,
+        "rolled_back_target_ids": result.rollback_target_ids,
+        "exact_target_rollback_only": result.exact_target_rollback_only,
+        "recursive_delete_performed": False,
+        "wildcard_delete_performed": False,
+        "unrelated_file_delete_performed": False,
+    }
+
+
+def summarize_workspace_change_set_rollback_receipt(receipt: WorkspaceChangeSetRollbackReceipt) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt.receipt_id,
+        "rollback_status": receipt.rollback_status,
+        "rollback_target_order": receipt.rollback_target_order,
+        "exact_target_rollback_only": True,
+        "general_cleanup_performed": False,
+    }
+
+
+def summarize_workspace_change_set_execution_ledger(ledger: WorkspaceChangeSetExecutionLedger) -> dict[str, Any]:
+    return {
+        "ledger_id": ledger.ledger_id,
+        "execution_status": ledger.execution_status,
+        "rollback_status": ledger.rollback_status,
+        "lifecycle_status": ledger.lifecycle_status,
+        "target_event_count": len(ledger.target_event_entries),
+        "metadata_only": True,
+        "performs_no_new_effect": True,
+    }
+
+
+def summarize_workspace_change_set_execution_closure_report(report: WorkspaceChangeSetExecutionClosureReport) -> dict[str, Any]:
+    return {
+        "report_id": report.report_id,
+        "closure_status": report.closure_status,
+        "open_target_ids": report.open_target_ids,
+        "failed_target_ids": report.failed_target_ids,
+        "skipped_target_ids": report.skipped_target_ids,
+        "metadata_only": True,
+        "performs_no_new_effect": True,
+    }
+
+
+def _ledger_output_path_is_safe(path_text: str, workspace_root: str) -> tuple[bool, str]:
+    if not path_text or path_text.strip() == "":
+        return False, "ledger_output_path_required"
+    path = Path(path_text).expanduser()
+    root = Path(workspace_root).expanduser()
+    if path.resolve(strict=False) == Path(path.anchor or "/").resolve(strict=False):
+        return False, "ledger_output_path_is_root"
+    if path.exists() and path.is_dir():
+        return False, "ledger_output_path_is_directory"
+    if path.is_symlink():
+        return False, "ledger_output_path_is_symlink"
+    if not path.parent.exists():
+        return False, "ledger_output_parent_missing"
+    if not _inside_workspace(root, path):
+        return False, "ledger_output_outside_workspace"
+    return True, ""
+
+
+def write_workspace_change_set_execution_ledger_artifact(ledger: WorkspaceChangeSetExecutionLedger, closure_report: WorkspaceChangeSetExecutionClosureReport, *, output_path: str, workspace_root: str) -> dict[str, Any]:
+    ok, reason = _ledger_output_path_is_safe(output_path, workspace_root)
+    if not ok:
+        return {"artifact_written": False, "status": "workspace_change_set_ledger_artifact_blocked", "reason": reason, "path": output_path}
+    payload = {
+        "metadata_only": True,
+        "explicit_ledger_artifact_only": True,
+        "performs_no_new_effect": True,
+        "host_mutation_performed": False,
+        "ledger": ledger.to_dict(),
+        "closure_report": closure_report.to_dict(),
+    }
+    Path(output_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {"artifact_written": True, "status": "workspace_change_set_ledger_artifact_written", "path": output_path, "digest": bytes_digest(json.dumps(payload, sort_keys=True).encode("utf-8"))}
+
+
+def run_workspace_change_set_execution_wing(
+    *,
+    manifest: WorkspaceChangeSetManifest,
+    preflight_report: WorkspaceChangeSetPreflightReport,
+    rollback_plan: WorkspaceChangeSetRollbackPlan,
+    transaction_plan: WorkspaceChangeSetTransactionPlan,
+    execution_mode: str = "change_set_execute_full_guarded",
+    rollback_on_failure: bool | None = None,
+    rollback_after_execute: bool = False,
+    write_ledger: bool | None = None,
+    ledger_output_path: str | None = None,
+    policy: WorkspaceChangeSetExecutionPolicy | None = None,
+    created_at: str = DEFAULT_CREATED_AT,
+) -> WorkspaceChangeSetExecutionWingResult:
+    policy = policy or build_default_workspace_change_set_execution_policy()
+    request = build_workspace_change_set_execution_request(
+        manifest=manifest,
+        preflight_report=preflight_report,
+        rollback_plan=rollback_plan,
+        transaction_plan=transaction_plan,
+        execution_mode=execution_mode,
+        rollback_on_failure=rollback_on_failure,
+        rollback_after_execute=rollback_after_execute,
+        write_ledger=write_ledger,
+        ledger_output_path=ledger_output_path,
+        policy=policy,
+        created_at=created_at,
+    )
+    execution_result, effect_wings = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=preflight_report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, policy=policy, created_at=created_at)
+    execution_receipt = build_workspace_change_set_execution_receipt(request, execution_result, created_at=created_at)
+    rollback_result = _rollback_not_requested(execution_result, created_at)
+    rollback_receipt: WorkspaceChangeSetRollbackReceipt | None = None
+    should_rollback = (request.rollback_after_execute and execution_result.applied_target_ids) or (request.rollback_on_failure and execution_result.failed_target_ids and execution_result.applied_target_ids)
+    if should_rollback:
+        rollback_result, _rollback_wings = execute_workspace_change_set_rollback(execution_result=execution_result, target_effects=effect_wings, created_at=created_at)
+        rollback_receipt = build_workspace_change_set_rollback_receipt(execution_receipt, rollback_result, created_at=created_at)
+    ledger = None
+    if request.write_ledger:
+        ledger = build_workspace_change_set_execution_ledger(request=request, execution_receipt=execution_receipt, execution_result=execution_result, rollback_receipt=rollback_receipt, rollback_result=rollback_result if rollback_result.rollback_status != "workspace_change_set_rollback_not_requested" else None, created_at=created_at)
+    closure = build_workspace_change_set_execution_closure_report(execution_receipt=execution_receipt, execution_result=execution_result, ledger=ledger, rollback_receipt=rollback_receipt, rollback_result=rollback_result if rollback_result.rollback_status != "workspace_change_set_rollback_not_requested" else None, created_at=created_at)
+    if ledger and ledger_output_path:
+        artifact = write_workspace_change_set_execution_ledger_artifact(ledger, closure, output_path=ledger_output_path, workspace_root=request.workspace_root)
+        if not artifact.get("artifact_written"):
+            ledger = replace(ledger, warning_codes=tuple(sorted(set(ledger.warning_codes + (str(artifact.get("reason")),)))), digest="")
+            ledger = replace(ledger, digest=deterministic_digest("workspace-change-set-execution-ledger-", ledger.to_dict()))
+    return WorkspaceChangeSetExecutionWingResult(request, execution_result, execution_receipt, rollback_result, rollback_receipt, ledger, closure)

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -320,3 +320,16 @@ def test_reviewer_proof_bundle_cli_writes_workspace_change_set_preflight_capabil
     assert payload["run_by_reviewer_proof_bundle_default"] is False
     assert payload["target_writes_occur"] is False
     assert payload["rollback_occurs"] is False
+
+
+def test_reviewer_proof_bundle_cli_writes_workspace_change_set_execution_capability(tmp_path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir), "--force"])
+    assert code == 0, (stdout, stderr)
+    path = output_dir / "workspace_change_set_execution_capability.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["bounded_change_set_execution_exists"] is True
+    assert payload["run_by_reviewer_proof_bundle_default"] is False
+    assert payload["proof_bundle_execution_performed"] is False
+    assert payload["general_filesystem_access_remains_blocked"] is True

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -849,10 +849,17 @@ def test_workspace_change_set_preflight_capabilities_are_read_only_and_bounded(t
     assert records["workspace_change_target_preflight"].authority_level == "explicit-target-read-only"
     assert records["workspace_change_set_rollback_plan"].authority_level == "metadata-plan-only"
     assert records["workspace_change_set_transaction_plan"].authority_level == "metadata-plan-only"
-    assert records["workspace_change_set_execution"].status == "deferred"
-    assert records["workspace_change_set_transaction_execution"].status == "deferred"
+    assert records["workspace_change_set_execution"].status == "implemented"
+    assert records["workspace_change_set_execution_request"].authority_level == "request_only"
+    assert records["workspace_change_target_execution_result"].status == "implemented"
+    assert records["workspace_change_set_rollback_execution"].implemented_surfaces
+    assert records["workspace_change_set_execution_ledger"].authority_level == "metadata_ledger_only"
+    assert records["workspace_change_set_execution_closure_report"].authority_level == "report_only"
+    assert records["workspace_change_set_transaction_execution"].status == "implemented"
     assert records["workspace_change_set_multi_file_runner"].status == "deferred"
     assert records["workspace_change_set_bulk_rollback"].status == "deferred"
+    assert records["workspace_change_set_unbounded_execution"].status == "blocked"
+    assert records["workspace_change_set_bulk_cleanup"].status == "blocked"
     for capability_id in ["general_filesystem_access", "general_cleanup", "recursive_delete", "wildcard_delete", "unrelated_file_delete"]:
         assert records[capability_id].status in {"blocked", "deferred"}
     for capability_id in ["real_service_restart", "real_power_profile_mutation", "real_fan_pwm_control", "real_thermal_actuation", "package_install", "driver_install", "network_egress", "provider_invocation", "prompt_assembly", "subprocess_runner", "shell_runner"]:
@@ -864,3 +871,18 @@ def test_workspace_change_set_preflight_capabilities_are_read_only_and_bounded(t
     assert updated["workspace_change_set_preflight"].status == "implemented"
     assert updated["general_filesystem_access"].status == "blocked"
     assert updated["real_fan_pwm_control"].status == "blocked"
+
+
+def test_workspace_change_set_execution_registry_helper_marks_blocked_surfaces(tmp_path) -> None:
+    from sentientos.capability_registry import update_registry_from_workspace_change_set_execution
+
+    updated = update_registry_from_workspace_change_set_execution(
+        build_default_capability_registry(),
+        {"request": {"request_id": "r"}, "execution_result": {"result_id": "x"}, "execution_receipt": {"receipt_id": "e"}},
+    ).by_id()
+    assert updated["workspace_change_set_execution"].status == "implemented"
+    assert updated["workspace_change_set_rollback_execution"].status == "implemented"
+    assert updated["workspace_change_set_execution_ledger"].status == "implemented"
+    assert updated["workspace_change_set_execution_closure_report"].status == "implemented"
+    for capability_id in ["general_filesystem_access", "general_cleanup", "recursive_delete", "wildcard_delete", "unrelated_file_delete", "workspace_change_set_unbounded_execution", "workspace_change_set_bulk_cleanup", "network_egress", "provider_invocation", "prompt_assembly", "subprocess_runner", "shell_runner", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install"]:
+        assert updated[capability_id].status in {"blocked", "deferred"}

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -435,3 +435,25 @@ def test_bundle_includes_workspace_change_set_preflight_artifact_and_not_run_com
     rendered = [" ".join(command["command"]) for command in commands]
     assert "python scripts/preflight_workspace_change_set.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --summary" in rendered
     assert all(command.status == "proof_command_not_run" for command in payload["manifest"].proof_command_records)
+
+
+def test_bundle_includes_workspace_change_set_execution_artifact_and_not_run_command() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    artifacts = payload["artifacts"]
+    assert "workspace_change_set_execution_capability" in artifacts
+    capability = json.loads(artifacts["workspace_change_set_execution_capability"])
+    assert capability["bounded_change_set_execution_exists"] is True
+    assert capability["consumes_passed_preflight_and_transaction_plans"] is True
+    assert capability["executes_explicit_targets_only"] is True
+    assert capability["uses_single_target_workspace_file_effect_helpers"] is True
+    assert capability["rollback_is_reverse_order_exact_target_only"] is True
+    assert capability["partial_state_is_visible"] is True
+    assert capability["run_by_reviewer_proof_bundle_default"] is False
+    assert capability["proof_bundle_execution_performed"] is False
+    assert capability["general_filesystem_access_remains_blocked"] is True
+    assert capability["cleanup_remains_blocked"] is True
+    assert capability["proof_command_status"] == "proof_command_not_run"
+    commands = json.loads(artifacts["proof_command_manifest"])["commands"]
+    rendered = [" ".join(command["command"]) for command in commands]
+    assert "python scripts/run_workspace_change_set_transaction.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --target docs-demo.txt=docs --summary" in rendered
+    assert all(command.status == "proof_command_not_run" for command in payload["manifest"].proof_command_records)

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -671,4 +671,22 @@ def test_workspace_change_set_preflight_doc_is_linked_and_preserves_boundaries()
     assert "reads only explicitly declared target metadata/digests" in doc
     assert "no target files are written" in doc
     assert "no built-in runner or transaction orchestrator is invoked" in doc
-    assert "Future workspace change-set execution remains deferred" in doc
+    assert "bounded successor" in doc
+    assert "passed preflight and ready transaction plans" in doc
+
+
+HOST_WORKSPACE_CHANGE_SET_EXECUTION = "docs/architecture/host_workspace_change_set_execution_wing.md"
+
+def test_workspace_change_set_execution_doc_is_linked_and_preserves_boundaries() -> None:
+    doc = _read(HOST_WORKSPACE_CHANGE_SET_EXECUTION)
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    assert HOST_WORKSPACE_CHANGE_SET_EXECUTION in overview
+    assert HOST_WORKSPACE_CHANGE_SET_EXECUTION in index
+    assert "first bounded multi-target workspace execution layer" in doc
+    assert "consumes the explicit Workspace Change Set Manifest" in doc
+    assert "single-target workspace file effect helper" in doc
+    assert "Partial state is never hidden" in doc
+    assert "not general filesystem access" in doc
+    assert "not cleanup" in doc
+    assert "does not run workspace change-set execution by default" in doc

--- a/tests/test_run_workspace_change_set_transaction_script.py
+++ b/tests/test_run_workspace_change_set_transaction_script.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from scripts import run_workspace_change_set_transaction as cli
+
+
+def test_requires_workspace_root_and_target(capsys):
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+
+def test_dry_run_writes_no_targets(tmp_path, capsys):
+    code = cli.main(['--workspace-root', str(tmp_path), '--target', 'demo.txt=hello', '--dry-run', '--summary'])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert 'dry-run' in out
+    assert not (tmp_path / 'demo.txt').exists()
+
+
+def test_default_guarded_mode_executes_and_builds_ledger_posture(tmp_path, capsys):
+    code = cli.main(['--workspace-root', str(tmp_path), '--target', 'demo.txt=hello', '--target', 'docs.txt=docs', '--summary'])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert (tmp_path / 'demo.txt').read_text() == 'hello'
+    assert 'ledger_status: workspace_change_set_execution_closed_after_execute' in out
+    assert 'general_filesystem_access_performed: false' in out
+
+
+def test_rollback_after_execute_removes_created_targets(tmp_path, capsys):
+    code = cli.main(['--workspace-root', str(tmp_path), '--target', 'demo.txt=hello', '--rollback-after-execute', '--summary'])
+    assert code == 0
+    assert not (tmp_path / 'demo.txt').exists()
+    assert 'closed_after_rollback' in capsys.readouterr().out
+
+
+def test_ledger_output_writes_one_explicit_artifact(tmp_path):
+    output = tmp_path / 'ledger.json'
+    code = cli.main(['--workspace-root', str(tmp_path), '--target', 'demo.txt=hello', '--ledger-output', str(output)])
+    assert code == 0
+    assert output.exists()
+    payload = json.loads(output.read_text())
+    assert payload['explicit_ledger_artifact_only'] is True
+    assert payload['host_mutation_performed'] is False
+    assert (tmp_path / 'demo.txt').exists()
+
+
+def test_unsafe_target_path_rejected(tmp_path):
+    code = cli.main(['--workspace-root', str(tmp_path), '--target', '../escape.txt=bad', '--summary'])
+    assert code == 2
+    assert not (tmp_path.parent / 'escape.txt').exists()

--- a/tests/test_workspace_change_set_execution.py
+++ b/tests/test_workspace_change_set_execution.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.workspace_change_set_execution import (
+    build_workspace_change_set_execution_closure_report,
+    build_workspace_change_set_execution_ledger,
+    build_workspace_change_set_execution_receipt,
+    build_workspace_change_set_execution_request,
+    execute_workspace_change_set,
+    run_workspace_change_set_execution_wing,
+    summarize_workspace_change_set_execution_result,
+    validate_workspace_change_set_execution_result,
+    validate_workspace_change_target_execution_result,
+)
+from sentientos.workspace_change_set_preflight import (
+    build_workspace_change_set_manifest,
+    build_workspace_change_set_preflight_report,
+    build_workspace_change_set_rollback_plan,
+    build_workspace_change_set_transaction_plan,
+    build_workspace_change_target_declaration,
+    preflight_workspace_change_target,
+)
+
+
+def _plans(root, specs=(('a.txt', 'alpha'), ('b.txt', 'beta'))):
+    targets = tuple(
+        build_workspace_change_target_declaration(relative_target_path=path, payload_text=payload)
+        for path, payload in specs
+    )
+    manifest = build_workspace_change_set_manifest(workspace_root=root, targets=targets)
+    preflights = tuple(preflight_workspace_change_target(workspace_root=root, target=t) for t in targets)
+    report = build_workspace_change_set_preflight_report(manifest=manifest, target_preflights=preflights)
+    rollback_plan = build_workspace_change_set_rollback_plan(manifest=manifest, preflight_report=report, target_preflights=preflights)
+    transaction_plan = build_workspace_change_set_transaction_plan(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan)
+    return targets, manifest, report, rollback_plan, transaction_plan
+
+
+def test_execution_refuses_failed_preflight(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path / 'missing')
+    request = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan)
+    result, effects = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan)
+    assert effects == ()
+    assert result.execution_status == 'workspace_change_set_execution_blocked'
+    assert 'preflight_not_passed' in result.risk_codes
+
+
+def test_execution_refuses_non_ready_transaction_plan(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    bad_plan = replace(transaction_plan, transaction_plan_status='workspace_change_set_transaction_plan_blocked')
+    request = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=bad_plan)
+    result, _effects = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=bad_plan)
+    assert result.execution_status == 'workspace_change_set_execution_blocked'
+    assert 'transaction_plan_not_ready' in result.risk_codes
+
+
+def test_executes_two_explicit_targets_and_captures_receipts(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    assert (tmp_path / 'a.txt').read_text() == 'alpha'
+    assert (tmp_path / 'b.txt').read_text() == 'beta'
+    assert wing.execution_result.execution_status == 'workspace_change_set_execution_performed'
+    assert wing.execution_result.applied_target_ids == tuple(t.target_id for t in targets)
+    assert all(r.workspace_effect_receipt_id for r in wing.execution_result.target_results)
+    assert all(r.workspace_postcondition_check_id for r in wing.execution_result.target_results)
+    assert all(r.workspace_rollback_plan_id for r in wing.execution_result.target_results)
+    assert all(r.workspace_production_audit_id for r in wing.execution_result.target_results)
+    assert wing.ledger is not None
+    assert wing.ledger.metadata_only and wing.ledger.performs_no_new_effect
+    assert summarize_workspace_change_set_execution_result(wing.execution_result)['bounded_change_set_execution_only'] is True
+
+
+def test_rollback_after_execute_is_reverse_exact_target_and_preserves_sibling(tmp_path):
+    (tmp_path / 'sibling.txt').write_text('keep')
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, rollback_after_execute=True, write_ledger=True)
+    assert wing.rollback_result.rollback_performed is True
+    assert wing.rollback_result.rollback_target_order == tuple(reversed([t.target_id for t in targets]))
+    assert not (tmp_path / 'a.txt').exists()
+    assert not (tmp_path / 'b.txt').exists()
+    assert (tmp_path / 'sibling.txt').read_text() == 'keep'
+    assert wing.closure_report.closure_status == 'workspace_change_set_execution_closed_after_rollback'
+    assert wing.rollback_result.recursive_delete_performed is False
+    assert wing.rollback_result.wildcard_delete_performed is False
+    assert wing.rollback_result.unrelated_file_delete_performed is False
+
+
+def test_digest_drift_since_preflight_blocks_execution(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    (tmp_path / 'a.txt').write_text('drift')
+    request = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan)
+    result, _effects = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan)
+    assert result.execution_status == 'workspace_change_set_execution_blocked'
+    assert any(code.startswith('preflight_absent_target_now_exists') for code in result.risk_codes)
+
+
+def test_rollback_on_failure_rolls_back_applied_targets_and_records_skipped(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path, (('a.txt', 'alpha'), ('b.txt', 'beta'), ('c.txt', 'gamma')))
+    calls = {'count': 0}
+    from sentientos.workspace_file_effect import run_workspace_file_effect_wing
+
+    def failing_runner(**kwargs):
+        calls['count'] += 1
+        if calls['count'] == 2:
+            raise RuntimeError('boom')
+        return run_workspace_file_effect_wing(**kwargs)
+
+    request = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, rollback_on_failure=True)
+    result, effects = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, effect_runner=failing_runner)
+    receipt = build_workspace_change_set_execution_receipt(request, result)
+    assert result.execution_status == 'workspace_change_set_execution_partially_performed'
+    assert result.partial_state_visible is True
+    assert result.applied_target_ids == (targets[0].target_id,)
+    assert result.failed_target_ids == (targets[1].target_id,)
+    assert result.skipped_target_ids == (targets[2].target_id,)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, rollback_on_failure=True)
+    # Standalone partial result validates forbidden flags remain false.
+    assert validate_workspace_change_set_execution_result(result).ok
+    assert validate_workspace_change_target_execution_result(result.target_results[0]).ok
+    assert receipt.general_filesystem_access_performed is False
+
+
+def test_validation_rejects_forbidden_flags(tmp_path):
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan)
+    bad = replace(wing.execution_result, subprocess_used=True)
+    validation = validate_workspace_change_set_execution_result(bad)
+    assert not validation.ok
+    assert 'contradiction:subprocess_used_true' in validation.findings
+
+
+def test_closure_report_classifications(tmp_path):
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    report1 = wing.closure_report
+    assert report1.closure_status == 'workspace_change_set_execution_closed_after_execute'
+    ledger2 = build_workspace_change_set_execution_ledger(request=wing.request, execution_receipt=wing.execution_receipt, execution_result=replace(wing.execution_result, all_targets_applied=False, failed_target_ids=('x',), partial_state_visible=True))
+    report2 = build_workspace_change_set_execution_closure_report(execution_receipt=wing.execution_receipt, execution_result=replace(wing.execution_result, all_targets_applied=False, failed_target_ids=('x',), partial_state_visible=True), ledger=ledger2)
+    assert report2.closure_status in {'workspace_change_set_execution_partially_open', 'workspace_change_set_execution_rollback_pending'}
+
+
+def test_digests_deterministic_and_change_on_metadata(tmp_path):
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    req1 = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, execution_mode='change_set_execute_only')
+    req2 = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, execution_mode='change_set_execute_only')
+    req3 = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, execution_mode='change_set_execute_with_ledger')
+    assert req1.digest == req2.digest
+    assert req1.digest != req3.digest


### PR DESCRIPTION
### Motivation
- Provide the first bounded multi-target execution layer that consumes a passed preflight/transaction plan and performs only the explicit per-manifest target writes using the existing single-target file-effect helpers. 
- Keep strong deny-by-default safety: no general filesystem authority or subprocess/network/provider/prompt/hardware/service/power/fan/thermal effects are introduced and partial state is visible and auditable.

### Description
- Add `sentientos/workspace_change_set_execution.py` implementing immutable dataclasses and helpers for execution policy, execution request, per-target execution result, execution result, receipts, rollback result/receipt, ledger and closure-report types, deterministic digest helpers, validators, and `run_workspace_change_set_execution_wing(...)` which delegates all file writes/rollbacks to `sentientos.workspace_file_effect` helpers and enforces preflight/transaction/ledger/rollback behavior and safety checks.
- Add `scripts/run_workspace_change_set_transaction.py` CLI to perform preflight (or dry-run) and execute a bounded change-set in planned order with options for rollback-on-failure, rollback-after-execute, ledger output path, summary/dry-run and safety checks for ledger artifact path.
- Integrate reviewer proof bundle by updating `sentientos/reviewer_proof_bundle.py` to list the new `workspace_change_set_execution_capability` artifact and to include a not-run proof command that documents the new CLI invocation (bundle still does not run execution by default).
- Update `sentientos/capability_registry.py` to declare the new implemented/deferred/blocked capability records and to add `update_registry_from_workspace_change_set_execution(...)` logic that reflects bounded execution without widening workspace authority.
- Keep all mutation delegated to existing `workspace_file_effect` API and its rollback helpers; ledger/report building is metadata-only unless a safe caller-supplied output path is given (the CLI/write helper enforces path safety and workspace scoping).

### Testing
- Performed syntax/compile checks with `python -m py_compile` for new/modified modules and scripts and they compiled successfully.
- Ran the new CLI end-to-end in a temporary workspace: `scripts/run_workspace_change_set_transaction.py --workspace-root $TMP --target a.txt=hello --target b.txt=docs --summary` and observed successful execution with both targets created and a summary showing `workspace_change_set_execution_performed` (created files `a.txt`/`b.txt`).
- Verified the CLI dry-run path and ledger artifact safety checks during development (dry-run returns preflight/plan only; ledger write path validated and guarded); these behaviors succeeded in manual runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a6cd1f2f08320941878b2e4b333c1)