### PR TITLE
[codex:workspace-change-set] add execution verification replay audit

### DIFF
--- a/docs/architecture/host_workspace_change_set_execution_verification_wing.md
+++ b/docs/architecture/host_workspace_change_set_execution_verification_wing.md
@@ -1,0 +1,52 @@
+# Host Workspace Change Set Execution Verification / Replay Audit Wing
+
+This wing sits after the [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md). It is an independent metadata/read-only verification and replay-audit layer for completed workspace change-set executions.
+
+## What it verifies
+
+The verifier consumes existing workspace change-set manifest, preflight report, rollback plan, transaction plan, execution request, execution result, execution receipt, optional rollback result/receipt, optional execution ledger, and optional closure report evidence. It does not create a new truth source and does not duplicate provenance into a mutable store.
+
+It verifies:
+
+- execution request/result/receipt identity and digest consistency;
+- per-target execution evidence and produced record ID/digest consistency;
+- planned target order preservation;
+- optional rollback order preservation and rollback preimage/absence evidence;
+- optional ledger status/order/source consistency;
+- optional closure report source and open/failed/skipped target consistency;
+- current digest state for explicitly declared manifest targets only;
+- visible partial-state classifications for failed, skipped, open, and rolled-back targets;
+- unknown or outside-manifest target evidence.
+
+## Verification statuses
+
+The deterministic overall statuses are:
+
+- `verified_clean`
+- `verified_with_partial_state`
+- `verified_rolled_back`
+- `verification_failed`
+- `verification_blocked`
+- `insufficient_evidence`
+
+Per-target records distinguish postcondition verification, rollback preimage verification, rollback-created-file absence, failed/skipped visibility, failed verification, blocked verification, and insufficient evidence.
+
+## Read-only boundary
+
+The verifier reads only the relative target paths declared in the workspace change-set manifest. It recomputes digests for those declared targets only. It does not recurse directories, expand wildcards, infer undeclared targets, execute target payloads, invoke the change-set execution wing, invoke workspace file effect helpers, invoke rollback helpers, perform cleanup, delete files, call subprocess/shell/network/provider/prompt paths, run external tools, control services, control power, control fan/PWM or thermal state, install packages/drivers, execute plugins/generated code, or perform federation import execution.
+
+The only permitted write is one optional caller-supplied verification/audit artifact path. That artifact records verifier metadata and the verification result; it is not a target mutation, rollback, cleanup, scheduler, or orchestration layer.
+
+## CLI
+
+The optional CLI is `scripts/verify_workspace_change_set_execution.py`. It accepts a JSON evidence bundle containing the preflight/planning and execution evidence and prints either JSON or a compact summary:
+
+```bash
+python scripts/verify_workspace_change_set_execution.py --evidence <workspace_change_set_execution_evidence.json> --summary
+```
+
+The CLI is verification-only. It does not build fresh preflight, does not execute a transaction, does not rollback, and does not run by default in the reviewer proof bundle.
+
+## Reviewer proof posture
+
+The reviewer proof bundle documents `workspace_change_set_execution_verification_capability.json` but does not run verification by default. The listed proof command is `proof_command_not_run` for reviewers who explicitly want to replay-audit completed evidence.

--- a/docs/architecture/public_technical_overview.md
+++ b/docs/architecture/public_technical_overview.md
@@ -297,3 +297,6 @@ See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_chang
 
 
 Workspace change-set transaction execution is documented in [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md) (`docs/architecture/host_workspace_change_set_execution_wing.md`): it is the first bounded multi-target workspace execution layer, consumes passed preflight/transaction plans, uses existing single-target helpers, records partial state visibly, and does not grant general filesystem access or cleanup authority.
+
+
+Workspace change-set execution verification is documented in [Host Workspace Change Set Execution Verification / Replay Audit Wing](host_workspace_change_set_execution_verification_wing.md) (`docs/architecture/host_workspace_change_set_execution_verification_wing.md`): it is a read-only replay-audit layer for completed change-set executions, reads only declared manifest targets, checks receipt/ledger/closure and optional rollback evidence, may write one caller-supplied verification artifact, and does not execute, rollback, cleanup, schedule, scan undeclared files, or invoke subprocess/shell/network/provider/prompt/hardware/service/power/fan/thermal paths.

--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -146,3 +146,6 @@ See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_chang
 ## Workspace change-set execution proof artifact
 
 The bundle includes `workspace_change_set_execution_capability.json` for [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md). It documents the bounded capability but does not run execution by default.
+
+
+The [Host Workspace Change Set Execution Verification / Replay Audit Wing](host_workspace_change_set_execution_verification_wing.md) (`docs/architecture/host_workspace_change_set_execution_verification_wing.md`) adds a read-only replay-audit layer for completed change-set executions. It reads only declared manifest targets, checks receipt/ledger/closure and optional rollback evidence, may write one caller-supplied verification artifact, and does not execute, rollback, cleanup, schedule, scan undeclared files, or invoke subprocess/shell/network/provider/prompt/hardware/service/power/fan/thermal paths.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -314,3 +314,6 @@ See [`Host Workspace Change Set Preflight / Planning Wing`](host_workspace_chang
 
 
 The [Host Workspace Change Set Transaction Execution Pilot Wing](host_workspace_change_set_execution_wing.md) (`docs/architecture/host_workspace_change_set_execution_wing.md`) adds the first bounded multi-target workspace execution layer after preflight/planning. It consumes passed preflight/transaction plans, uses existing single-target helpers, records partial state visibly, and the reviewer proof bundle documents but does not run it by default.
+
+
+The [Host Workspace Change Set Execution Verification / Replay Audit Wing](host_workspace_change_set_execution_verification_wing.md) (`docs/architecture/host_workspace_change_set_execution_verification_wing.md`) adds a read-only replay-audit layer for completed change-set executions. It reads only declared manifest targets, checks receipt/ledger/closure and optional rollback evidence, may write one caller-supplied verification artifact, and does not execute, rollback, cleanup, schedule, scan undeclared files, or invoke subprocess/shell/network/provider/prompt/hardware/service/power/fan/thermal paths.

--- a/scripts/verify_workspace_change_set_execution.py
+++ b/scripts/verify_workspace_change_set_execution.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify/replay-audit completed workspace change-set execution evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sentientos.workspace_change_set_execution_verification import (  # noqa: E402
+    load_verification_evidence,
+    summarize_workspace_change_set_execution_verification_result,
+    verify_workspace_change_set_execution,
+)
+
+
+def _jsonify(value: object) -> object:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, tuple):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonify(item) for key, item in value.items()}
+    return value
+
+
+def _summary_text(payload: dict[str, object]) -> str:
+    summary = cast(Mapping[str, object], payload["verification_summary"])
+    return "\n".join([
+        "SentientOS Workspace Change Set Execution Verification / Replay Audit",
+        f"verification_status: {summary['verification_status']}",
+        f"target_count: {summary['target_count']}",
+        f"postcondition_digest_agreement: {summary['postcondition_digest_agreement']}",
+        f"rollback_digest_agreement: {summary['rollback_digest_agreement']}",
+        f"partial_state_visible: {summary['partial_state_visible']}",
+        f"unknown_target_ids: {list(cast(Iterable[object], summary['unknown_target_ids']))}",
+        f"finding_codes: {list(cast(Iterable[object], summary['finding_codes']))}",
+        "verification_only: true",
+        "read_only_except_optional_audit_artifact: true",
+        "execution_invoked: false",
+        "rollback_invoked: false",
+        "cleanup_performed: false",
+        "subprocess_shell_network_provider_prompt: false",
+    ])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", required=True, help="JSON evidence containing manifest, preflight_report, rollback_plan, transaction_plan, execution result/receipt, and optional rollback/ledger/closure records")
+    parser.add_argument("--audit-output", help="Optional explicit verification/audit artifact output path")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    evidence = load_verification_evidence(args.evidence)
+    wing = verify_workspace_change_set_execution(**evidence, audit_output_path=args.audit_output, created_at=args.created_at)
+    payload = {
+        "request": wing.request,
+        "verification_result": wing.verification_result,
+        "verification_summary": summarize_workspace_change_set_execution_verification_result(wing.verification_result),
+    }
+    print(_summary_text(payload) if args.summary else json.dumps(_jsonify(payload), indent=2, sort_keys=True))
+    return 0 if wing.verification_result.verification_status in {"verified_clean", "verified_with_partial_state", "verified_rolled_back"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -131,6 +131,7 @@ AUTHORITY_LEVELS = frozenset(
         "metadata-plan-only",
         "explicit-target-read-only",
         "read-only/preflight-only",
+        "read-only-verification",
         "bounded_workspace_file_orchestration",
         "single_target_workspace_update_orchestration",
         "single_target_workspace_update_exact_rollback_orchestration",
@@ -430,6 +431,7 @@ def build_default_capability_registry() -> CapabilityRegistry:
         _record("workspace_change_set_rollback_execution", "workspace_change_set_execution", "implemented", "exact_artifact_rollback_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("reverse-order exact-target rollback through workspace_file_effect rollback helper",), deferred_surfaces=("bulk cleanup", "recursive delete", "wildcard delete", "unrelated file delete"), forbidden_implications=("change-set rollback deletes unrelated files"), requires_rollback_receipt=True),
         _record("workspace_change_set_execution_ledger", "workspace_change_set_execution", "implemented", "metadata_ledger_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("metadata-only change-set transaction ledger", "optional explicit caller-supplied ledger artifact"), forbidden_implications=("ledger build performs target effects")),
         _record("workspace_change_set_execution_closure_report", "workspace_change_set_execution", "implemented", "report_only", source_paths=("sentientos/workspace_change_set_execution.py",), proof_tests=("tests/test_workspace_change_set_execution.py",), implemented_surfaces=("metadata-only closure report classifying open, partial, failed, execute-closed, and rollback-closed states",), forbidden_implications=("closure report mutates workspace")),
+        _record("workspace_change_set_execution_verification", "workspace_change_set_execution", "implemented", "read-only-verification", source_paths=("sentientos/workspace_change_set_execution_verification.py", "scripts/verify_workspace_change_set_execution.py"), proof_tests=("tests/test_workspace_change_set_execution_verification.py", "tests/test_verify_workspace_change_set_execution_script.py"), proof_commands=("python -m scripts.run_tests -q tests/test_workspace_change_set_execution_verification.py tests/test_verify_workspace_change_set_execution_script.py", "python scripts/verify_workspace_change_set_execution.py --evidence <workspace_change_set_execution_evidence.json> --summary"), implemented_surfaces=("read-only explicit-target replay audit of completed workspace change-set execution evidence", "optional single caller-supplied verification artifact"), deferred_surfaces=("execution", "rollback", "cleanup", "scheduling"), forbidden_implications=("verification invokes execution or rollback helpers", "verification scans undeclared targets", "verification grants broader workspace authority"), requires_audit_receipt=True),
         _record("workspace_change_set_transaction_execution", "workspace_change_set_execution", "implemented", "explicit_local_artifact_only", source_paths=("sentientos/workspace_change_set_execution.py", "scripts/run_workspace_change_set_transaction.py"), proof_tests=("tests/test_workspace_change_set_execution.py", "tests/test_run_workspace_change_set_transaction_script.py"), implemented_surfaces=("bounded multi-target workspace transaction execution",), deferred_surfaces=("unbounded execution",), forbidden_implications=("transaction execution skips passed preflight requirement"), requires_operator_approval=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("workspace_change_set_multi_file_runner", "workspace_change_set_execution", "deferred", "none", deferred_surfaces=("multi-file built-in runner",), forbidden_implications=("change-set execution adds broad runner actions"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
         _record("workspace_change_set_bulk_rollback", "workspace_change_set_execution", "deferred", "none", deferred_surfaces=("bulk cleanup rollback",), forbidden_implications=("exact-target rollback is bulk cleanup"), requires_control_plane_admission=True, requires_operator_approval=True, requires_panic_stop=True, requires_audit_receipt=True, requires_rollback_receipt=True),
@@ -1511,6 +1513,43 @@ def update_registry_from_workspace_change_set_preflight(registry: CapabilityRegi
     return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-preflight-wing.v1")
 
 
+
+def update_registry_from_workspace_change_set_execution_verification(registry: CapabilityRegistry, wing: Any) -> CapabilityRegistry:
+    """Reflect read-only change-set execution verification without adding authority."""
+
+    payload = wing.to_dict() if hasattr(wing, "to_dict") else dict(wing) if isinstance(wing, Mapping) else {}
+    has_verification = bool(payload.get("verification_result") or payload.get("request"))
+    blocked_ids = {
+        "general_filesystem_access",
+        "general_cleanup",
+        "recursive_delete",
+        "wildcard_delete",
+        "unrelated_file_delete",
+        "workspace_change_set_unbounded_execution",
+        "workspace_change_set_bulk_cleanup",
+        "real_file_cleanup",
+        "real_fan_pwm_control",
+        "real_thermal_actuation",
+        "real_power_profile_mutation",
+        "real_service_restart",
+        "package_install",
+        "driver_install",
+        "network_egress",
+        "provider_invocation",
+        "prompt_assembly",
+        "subprocess_runner",
+        "shell_runner",
+    }
+    records: list[CapabilityRecord] = []
+    for record in registry.records:
+        if record.capability_id == "workspace_change_set_execution_verification":
+            records.append(replace(record, status="implemented" if has_verification else record.status, authority_level="read-only-verification", host_actuation_performed=False, metadata_only=True))
+        elif record.capability_id in blocked_ids:
+            records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
+        else:
+            records.append(record)
+    return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-execution-verification-wing.v1")
+
 def update_registry_from_workspace_change_set_execution(registry: CapabilityRegistry, wing: Any) -> CapabilityRegistry:
     """Reflect bounded change-set execution without broadening workspace authority."""
 
@@ -1524,6 +1563,7 @@ def update_registry_from_workspace_change_set_execution(registry: CapabilityRegi
         "workspace_change_set_execution_ledger",
         "workspace_change_set_execution_closure_report",
         "workspace_change_set_transaction_execution",
+        "workspace_change_set_execution_verification",
     }
     blocked_ids = {
         "general_filesystem_access",
@@ -1558,4 +1598,4 @@ def update_registry_from_workspace_change_set_execution(registry: CapabilityRegi
             records.append(replace(record, status="blocked", authority_level="none", host_actuation_performed=False, metadata_only=True))
         else:
             records.append(record)
-    return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-execution-wing.v1")
+    return replace(registry, records=tuple(records), schema_version="host-workspace-change-set-execution-verification-wing.v1")

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -128,6 +128,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "workspace_file_transaction_orchestrator_capability",
         "workspace_change_set_preflight_capability",
         "workspace_change_set_execution_capability",
+        "workspace_change_set_execution_verification_capability",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -167,6 +168,7 @@ BUNDLE_FILE_NAMES = {
     "workspace_file_transaction_orchestrator_capability": "workspace_file_transaction_orchestrator_capability.json",
     "workspace_change_set_preflight_capability": "workspace_change_set_preflight_capability.json",
     "workspace_change_set_execution_capability": "workspace_change_set_execution_capability.json",
+    "workspace_change_set_execution_verification_capability": "workspace_change_set_execution_verification_capability.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -374,6 +376,7 @@ def build_default_reviewer_proof_commands() -> tuple[ReviewerProofCommandRecord,
         (("python", "scripts/run_builtin_runner_transaction.py", "--mode", "workspace_file_update_rollback_with_ledger", "--workspace-root", "/tmp/sentientos-workspace-transaction", "--target", "demo.txt", "--payload", "hello", "--ledger-output", "/tmp/sentientos-workspace-transaction/workspace_transaction_ledger.json", "--summary"), "Optional explicit workspace file transaction orchestrator; listed for reviewer awareness and not run by proof bundle generation."),
         (("python", "scripts/preflight_workspace_change_set.py", "--workspace-root", "/tmp/sentientos-workspace-change-set", "--target", "demo.txt=hello", "--summary"), "Optional explicit workspace change-set preflight/planning command; listed for reviewer awareness and not run by proof bundle generation."),
         (("python", "scripts/run_workspace_change_set_transaction.py", "--workspace-root", "/tmp/sentientos-workspace-change-set", "--target", "demo.txt=hello", "--target", "docs-demo.txt=docs", "--summary"), "Optional explicit bounded workspace change-set execution command; listed for reviewer awareness and not run by proof bundle generation."),
+        (("python", "scripts/verify_workspace_change_set_execution.py", "--evidence", "<workspace_change_set_execution_evidence.json>", "--summary"), "Optional read-only workspace change-set execution verification/replay-audit command; listed for reviewer awareness and not run by proof bundle generation."),
     )
     return tuple(
         ReviewerProofCommandRecord(
@@ -816,6 +819,31 @@ def build_reviewer_proof_bundle_payload(
             "hardware_service_power_fan_thermal_remain_blocked_deferred": True,
             "proof_command_status": "proof_command_not_run",
             "proof_command": "python scripts/run_workspace_change_set_transaction.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --target docs-demo.txt=docs --summary",
+        }),
+        "workspace_change_set_execution_verification_capability": _pretty_json({
+            "metadata_only": True,
+            "reviewer_proof_only": True,
+            "capability_available": True,
+            "read_only_verification_exists": True,
+            "verifies_completed_change_set_execution_evidence": True,
+            "reads_only_explicitly_declared_targets": True,
+            "recomputes_declared_target_digests_only": True,
+            "checks_receipt_ledger_closure_consistency": True,
+            "checks_optional_rollback_preimage_or_absence": True,
+            "partial_state_replay_audit_visible": True,
+            "optional_audit_artifact_only_when_caller_supplies_path": True,
+            "run_by_reviewer_proof_bundle_default": False,
+            "proof_bundle_verification_run": False,
+            "proof_bundle_execution_performed": False,
+            "proof_bundle_rollback_performed": False,
+            "proof_bundle_cleanup_performed": False,
+            "general_filesystem_access_remains_blocked": True,
+            "cleanup_remains_blocked": True,
+            "recursive_wildcard_unrelated_delete_remain_blocked": True,
+            "no_subprocess_shell_network_provider_prompt_control_plane_execution": True,
+            "hardware_service_power_fan_thermal_remain_blocked_deferred": True,
+            "proof_command_status": "proof_command_not_run",
+            "proof_command": "python scripts/verify_workspace_change_set_execution.py --evidence <workspace_change_set_execution_evidence.json> --summary",
         }),
         "proof_command_manifest": _pretty_json({"metadata_only": True, "reviewer_proof_only": True, "default_execution": "not_run", "commands": [record.to_dict() for record in commands]}),
         "local_diagnostic_effect_capability": _pretty_json({

--- a/sentientos/workspace_change_set_execution_verification.py
+++ b/sentientos/workspace_change_set_execution_verification.py
@@ -1,0 +1,678 @@
+"""Read-only verification and replay audit for workspace change-set executions.
+
+This wing consumes existing change-set manifest/preflight/transaction/execution
+and optional rollback/ledger/closure evidence. It recomputes digests only for the
+explicit manifest targets and never invokes execution, rollback, cleanup,
+subprocess, shell, network, provider, prompt, service, power, fan/PWM, thermal,
+plugin, generated-code, federation, or external-tool paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, fields, is_dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping, NamedTuple, Sequence, TypeVar, get_args, get_origin, cast, get_type_hints
+
+from sentientos.workspace_change_set_execution import (
+    BLOCKED_ACTION_LABELS,
+    CLOSURE_STATUSES,
+    ROLLBACK_EXECUTION_STATUSES,
+    WorkspaceChangeSetExecutionClosureReport,
+    WorkspaceChangeSetExecutionLedger,
+    WorkspaceChangeSetExecutionReceipt,
+    WorkspaceChangeSetExecutionRequest,
+    WorkspaceChangeSetExecutionResult,
+    WorkspaceChangeSetRollbackExecutionResult,
+    WorkspaceChangeSetRollbackReceipt,
+    WorkspaceChangeTargetExecutionResult,
+    deterministic_digest,
+    validate_workspace_change_set_execution_closure_report,
+    validate_workspace_change_set_execution_ledger,
+    validate_workspace_change_set_execution_receipt,
+    validate_workspace_change_set_execution_request,
+    validate_workspace_change_set_execution_result,
+    validate_workspace_change_set_rollback_execution_result,
+    validate_workspace_change_set_rollback_receipt,
+    validate_workspace_change_target_execution_result,
+)
+from sentientos.workspace_change_set_preflight import (
+    WorkspaceChangeSetManifest,
+    WorkspaceChangeSetPreflightReport,
+    WorkspaceChangeSetRollbackPlan,
+    WorkspaceChangeSetTransactionPlan,
+    WorkspaceChangeTargetDeclaration,
+    file_digest,
+)
+
+VERIFICATION_STATUSES = frozenset({
+    "verified_clean",
+    "verified_with_partial_state",
+    "verified_rolled_back",
+    "verification_failed",
+    "verification_blocked",
+    "insufficient_evidence",
+})
+TARGET_VERIFICATION_STATUSES = frozenset({
+    "target_verified_postcondition",
+    "target_verified_rollback_preimage",
+    "target_verified_rollback_absence",
+    "target_verified_failed_visible",
+    "target_verified_skipped_visible",
+    "target_verification_failed",
+    "target_verification_blocked",
+    "target_insufficient_evidence",
+})
+FORBIDDEN_VERIFIER_ACTIONS = tuple(sorted(set(BLOCKED_ACTION_LABELS + (
+    "workspace_change_set_execution",
+    "workspace_change_set_rollback_execution",
+    "workspace_file_effect_wing",
+    "workspace_file_rollback_wing",
+    "cleanup",
+    "target_payload_execution",
+    "directory_recursion",
+    "wildcard_expansion",
+))))
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionVerificationRequest:
+    request_id: str
+    source_manifest_id: str
+    source_execution_request_id: str
+    source_execution_result_id: str
+    source_execution_receipt_id: str
+    workspace_root: str
+    declared_target_ids: tuple[str, ...]
+    planned_target_order: tuple[str, ...]
+    rollback_target_order: tuple[str, ...]
+    audit_output_path: str | None = None
+    verification_only: bool = True
+    read_only_except_optional_audit_artifact: bool = True
+    explicit_targets_only: bool = True
+    does_not_execute: bool = True
+    does_not_rollback: bool = True
+    does_not_cleanup: bool = True
+    blocked_actions: tuple[str, ...] = FORBIDDEN_VERIFIER_ACTIONS
+    created_at: str = "1970-01-01T00:00:00+00:00"
+    digest: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeTargetVerificationRecord:
+    target_id: str
+    relative_target_path: str
+    target_verification_status: str
+    expected_digest: str | None
+    observed_digest: str | None
+    expected_absent: bool
+    observed_exists: bool
+    execution_status: str | None
+    rollback_status: str | None
+    basis: tuple[str, ...]
+    finding_codes: tuple[str, ...]
+    read_only: bool = True
+    target_write_performed: bool = False
+    rollback_performed: bool = False
+    cleanup_performed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkspaceChangeSetExecutionVerificationResult:
+    verification_id: str
+    request_id: str
+    verification_status: str
+    basis: tuple[str, ...]
+    target_records: tuple[WorkspaceChangeTargetVerificationRecord, ...]
+    receipt_consistency: tuple[str, ...]
+    ledger_consistency: tuple[str, ...]
+    closure_consistency: tuple[str, ...]
+    postcondition_digest_agreement: bool
+    rollback_digest_agreement: bool | None
+    partial_state_visible: bool
+    unknown_target_ids: tuple[str, ...]
+    finding_codes: tuple[str, ...]
+    audit_artifact_path: str | None
+    audit_artifact_digest: str | None
+    verification_only: bool = True
+    read_only_except_optional_audit_artifact: bool = True
+    explicit_targets_only: bool = True
+    execution_invoked: bool = False
+    rollback_invoked: bool = False
+    cleanup_performed: bool = False
+    subprocess_used: bool = False
+    shell_used: bool = False
+    network_used: bool = False
+    provider_invocation_performed: bool = False
+    prompt_assembly_performed: bool = False
+    digest: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class WorkspaceChangeSetExecutionVerificationWingResult(NamedTuple):
+    request: WorkspaceChangeSetExecutionVerificationRequest
+    verification_result: WorkspaceChangeSetExecutionVerificationResult
+
+
+def _digest(prefix: str, payload: Mapping[str, Any]) -> str:
+    return deterministic_digest(prefix, payload)
+
+
+def build_workspace_change_set_execution_verification_request(
+    *,
+    manifest: WorkspaceChangeSetManifest,
+    execution_request: WorkspaceChangeSetExecutionRequest,
+    execution_result: WorkspaceChangeSetExecutionResult,
+    execution_receipt: WorkspaceChangeSetExecutionReceipt,
+    transaction_plan: WorkspaceChangeSetTransactionPlan,
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult | None = None,
+    audit_output_path: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> WorkspaceChangeSetExecutionVerificationRequest:
+    rollback_order = tuple(rollback_result.rollback_target_order if rollback_result else ())
+    record = WorkspaceChangeSetExecutionVerificationRequest(
+        request_id=f"workspace-change-set-execution-verification-request-{execution_result.result_id}",
+        source_manifest_id=manifest.manifest_id,
+        source_execution_request_id=execution_request.request_id,
+        source_execution_result_id=execution_result.result_id,
+        source_execution_receipt_id=execution_receipt.receipt_id,
+        workspace_root=manifest.workspace_root,
+        declared_target_ids=tuple(target.target_id for target in manifest.targets),
+        planned_target_order=tuple(transaction_plan.planned_target_order),
+        rollback_target_order=rollback_order,
+        audit_output_path=audit_output_path,
+        created_at=created_at,
+    )
+    return replace(record, digest=_digest("workspace-change-set-execution-verification-request-", record.to_dict()))
+
+
+def _normalize_relative(path_text: str) -> str:
+    parts = [part for part in str(path_text).replace("\\", "/").split("/") if part not in {"", "."}]
+    return "/".join(parts)
+
+
+def _target_path(root: Path, relative: str) -> Path:
+    return root / _normalize_relative(relative)
+
+
+def _rollback_entries_by_id(plan: WorkspaceChangeSetRollbackPlan) -> dict[str, Mapping[str, Any]]:
+    return {str(entry.get("target_id")): entry for entry in plan.target_rollback_entries if isinstance(entry, Mapping) and entry.get("target_id")}
+
+
+def _status_by_rollback_target(rollback_result: WorkspaceChangeSetRollbackExecutionResult | None) -> dict[str, str]:
+    if not rollback_result:
+        return {}
+    statuses: dict[str, str] = {}
+    for entry in rollback_result.rollback_status_by_target:
+        if isinstance(entry, Mapping) and entry.get("target_id"):
+            statuses[str(entry["target_id"])] = str(entry.get("rollback_status", ""))
+    return statuses
+
+
+def _collect_target_ids(*values: Any) -> set[str]:
+    ids: set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            ids.add(value)
+        elif isinstance(value, Mapping):
+            for key in ("target_id",):
+                if value.get(key):
+                    ids.add(str(value[key]))
+        elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            ids.update(_collect_target_ids(*value))
+        elif hasattr(value, "target_id"):
+            ids.add(str(value.target_id))
+    return ids
+
+
+def _validate_digest(record: Any, prefix: str) -> tuple[bool, str]:
+    payload = record.to_dict() if hasattr(record, "to_dict") else asdict(record)
+    expected = _digest(prefix, payload)
+    observed = str(payload.get("digest", ""))
+    return observed == expected, observed
+
+
+def _append_validation(findings: list[str], label: str, validation: Any) -> None:
+    if not getattr(validation, "ok", False):
+        findings.extend(f"{label}:{item}" for item in getattr(validation, "findings", ()))
+
+
+def _safe_audit_output(path_text: str, declared_paths: set[Path]) -> tuple[bool, str]:
+    path = Path(path_text).expanduser()
+    if not path_text or path_text.strip() == "":
+        return False, "audit_output_path_required"
+    if path.exists() and path.is_dir():
+        return False, "audit_output_path_is_directory"
+    if path.is_symlink():
+        return False, "audit_output_path_is_symlink"
+    if not path.parent.exists():
+        return False, "audit_output_parent_missing"
+    resolved = path.resolve(strict=False)
+    if any(resolved == declared.resolve(strict=False) for declared in declared_paths):
+        return False, "audit_output_matches_declared_target"
+    return True, ""
+
+
+def _write_audit_artifact(result: WorkspaceChangeSetExecutionVerificationResult, request: WorkspaceChangeSetExecutionVerificationRequest, declared_paths: set[Path]) -> tuple[str | None, str | None, tuple[str, ...]]:
+    if not request.audit_output_path:
+        return None, None, ()
+    ok, reason = _safe_audit_output(request.audit_output_path, declared_paths)
+    if not ok:
+        return None, None, (reason,)
+    payload = {
+        "metadata_only": True,
+        "workspace_change_set_execution_verification_only": True,
+        "read_only_except_this_explicit_artifact": True,
+        "request": request.to_dict(),
+        "verification_result": result.to_dict(),
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    Path(request.audit_output_path).write_text(text, encoding="utf-8")
+    return request.audit_output_path, "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest(), ()
+
+
+def _target_record(
+    *,
+    root: Path,
+    target: WorkspaceChangeTargetDeclaration,
+    rollback_entry: Mapping[str, Any] | None,
+    execution_record: WorkspaceChangeTargetExecutionResult | None,
+    applied: set[str],
+    failed: set[str],
+    skipped: set[str],
+    rolled_back: set[str],
+    rollback_status_by_target: Mapping[str, str],
+) -> WorkspaceChangeTargetVerificationRecord:
+    findings: list[str] = []
+    basis: list[str] = ["manifest_declared_target"]
+    path = _target_path(root, target.relative_target_path)
+    observed_exists = path.exists()
+    observed_digest: str | None = None
+    if observed_exists and path.is_file() and not path.is_symlink():
+        observed_digest, _size = file_digest(path)
+        basis.append("declared_target_digest_recomputed")
+    elif observed_exists:
+        findings.append("declared_target_not_plain_file")
+
+    tid = target.target_id
+    execution_status = execution_record.target_execution_status if execution_record else None
+    rollback_status = rollback_status_by_target.get(tid)
+    expected_digest: str | None = None
+    expected_absent = False
+
+    if execution_record is None:
+        findings.append("missing_per_target_execution_record")
+        status = "target_insufficient_evidence"
+    elif tid in rolled_back:
+        basis.append("rollback_evidence_visible")
+        existed_before = bool(rollback_entry.get("existed_before")) if rollback_entry else False
+        existing_digest = str(rollback_entry.get("existing_digest")) if rollback_entry and rollback_entry.get("existing_digest") else None
+        if existed_before:
+            expected_digest = existing_digest
+            if not expected_digest:
+                findings.append("missing_rollback_preimage_digest")
+            elif observed_digest != expected_digest:
+                findings.append("rollback_preimage_digest_mismatch")
+        else:
+            expected_absent = True
+            if observed_exists:
+                findings.append("rollback_expected_absent_target_exists")
+        status = "target_verified_rollback_preimage" if existed_before else "target_verified_rollback_absence"
+    elif tid in applied:
+        basis.append("postcondition_evidence_visible")
+        expected_digest = str(rollback_entry.get("expected_post_write_digest")) if rollback_entry and rollback_entry.get("expected_post_write_digest") else target.digest
+        if not observed_exists:
+            findings.append("applied_target_missing")
+        elif observed_digest != expected_digest:
+            findings.append("postcondition_digest_mismatch")
+        status = "target_verified_postcondition"
+    elif tid in failed:
+        basis.append("failed_target_visible")
+        status = "target_verified_failed_visible"
+    elif tid in skipped:
+        basis.append("skipped_target_visible")
+        status = "target_verified_skipped_visible"
+    else:
+        findings.append("target_not_classified_by_execution_evidence")
+        status = "target_insufficient_evidence"
+
+    if findings and status not in {"target_insufficient_evidence", "target_verification_blocked"}:
+        status = "target_verification_failed"
+    return WorkspaceChangeTargetVerificationRecord(
+        target_id=tid,
+        relative_target_path=target.relative_target_path,
+        target_verification_status=status,
+        expected_digest=expected_digest,
+        observed_digest=observed_digest,
+        expected_absent=expected_absent,
+        observed_exists=observed_exists,
+        execution_status=execution_status,
+        rollback_status=rollback_status,
+        basis=tuple(basis),
+        finding_codes=tuple(sorted(set(findings))),
+    )
+
+
+def verify_workspace_change_set_execution(
+    *,
+    manifest: WorkspaceChangeSetManifest,
+    preflight_report: WorkspaceChangeSetPreflightReport,
+    rollback_plan: WorkspaceChangeSetRollbackPlan,
+    transaction_plan: WorkspaceChangeSetTransactionPlan,
+    execution_request: WorkspaceChangeSetExecutionRequest,
+    execution_result: WorkspaceChangeSetExecutionResult,
+    execution_receipt: WorkspaceChangeSetExecutionReceipt,
+    rollback_result: WorkspaceChangeSetRollbackExecutionResult | None = None,
+    rollback_receipt: WorkspaceChangeSetRollbackReceipt | None = None,
+    ledger: WorkspaceChangeSetExecutionLedger | None = None,
+    closure_report: WorkspaceChangeSetExecutionClosureReport | None = None,
+    audit_output_path: str | None = None,
+    created_at: str = "1970-01-01T00:00:00+00:00",
+) -> WorkspaceChangeSetExecutionVerificationWingResult:
+    request = build_workspace_change_set_execution_verification_request(
+        manifest=manifest,
+        execution_request=execution_request,
+        execution_result=execution_result,
+        execution_receipt=execution_receipt,
+        transaction_plan=transaction_plan,
+        rollback_result=rollback_result,
+        audit_output_path=audit_output_path,
+        created_at=created_at,
+    )
+    findings: list[str] = []
+    basis: list[str] = ["metadata_evidence_supplied", "read_only_declared_target_digest_replay"]
+    receipt_consistency: list[str] = []
+    ledger_consistency: list[str] = []
+    closure_consistency: list[str] = []
+
+    declared_ids = tuple(target.target_id for target in manifest.targets)
+    declared_set = set(declared_ids)
+    root = Path(manifest.workspace_root).expanduser()
+    target_by_id = {target.target_id: target for target in manifest.targets}
+    execution_by_id = {record.target_id: record for record in execution_result.target_results}
+    rollback_entries = _rollback_entries_by_id(rollback_plan)
+    rollback_status_by_target = _status_by_rollback_target(rollback_result)
+
+    if preflight_report.manifest_id != manifest.manifest_id:
+        findings.append("preflight_manifest_mismatch")
+    if rollback_plan.manifest_id != manifest.manifest_id or rollback_plan.preflight_report_id != preflight_report.report_id:
+        findings.append("rollback_plan_source_mismatch")
+    if transaction_plan.manifest_id != manifest.manifest_id or transaction_plan.rollback_plan_id != rollback_plan.plan_id:
+        findings.append("transaction_plan_source_mismatch")
+    if execution_request.source_manifest_id != manifest.manifest_id or execution_request.source_transaction_plan_id != transaction_plan.plan_id:
+        findings.append("execution_request_source_mismatch")
+    if execution_result.request_id != execution_request.request_id or execution_receipt.request_id != execution_request.request_id or execution_receipt.result_id != execution_result.result_id:
+        findings.append("execution_receipt_result_request_mismatch")
+
+    if tuple(execution_request.target_order) != tuple(transaction_plan.planned_target_order):
+        findings.append("planned_target_order_not_preserved")
+    if tuple(transaction_plan.planned_target_order) != declared_ids:
+        findings.append("planned_target_order_differs_from_manifest_order")
+
+    for label, record, prefix in (
+        ("execution_request", execution_request, "workspace-change-set-execution-request-"),
+        ("execution_result", execution_result, "workspace-change-set-execution-result-"),
+        ("execution_receipt", execution_receipt, "workspace-change-set-execution-receipt-"),
+    ):
+        ok, _observed = _validate_digest(record, prefix)
+        if not ok:
+            findings.append(f"{label}_digest_mismatch")
+    for target_execution_record in execution_result.target_results:
+        ok, _observed = _validate_digest(target_execution_record, "workspace-change-target-execution-result-")
+        if not ok:
+            findings.append(f"target_execution_digest_mismatch:{target_execution_record.target_id}")
+
+    _append_validation(findings, "execution_request", validate_workspace_change_set_execution_request(execution_request))
+    _append_validation(findings, "execution_result", validate_workspace_change_set_execution_result(execution_result))
+    _append_validation(findings, "execution_receipt", validate_workspace_change_set_execution_receipt(execution_receipt))
+    for target_execution_record in execution_result.target_results:
+        _append_validation(findings, f"target:{target_execution_record.target_id}", validate_workspace_change_target_execution_result(target_execution_record))
+
+    receipt_expected = {
+        "applied": tuple(execution_result.applied_target_ids),
+        "failed": tuple(execution_result.failed_target_ids),
+        "skipped": tuple(execution_result.skipped_target_ids),
+        "produced_record_ids": tuple(execution_result.produced_record_ids),
+        "produced_record_digests": tuple(execution_result.produced_record_digests),
+        "produced_paths": tuple(execution_result.produced_paths),
+    }
+    receipt_observed = {
+        "applied": tuple(execution_receipt.applied_target_ids),
+        "failed": tuple(execution_receipt.failed_target_ids),
+        "skipped": tuple(execution_receipt.skipped_target_ids),
+        "produced_record_ids": tuple(execution_receipt.produced_record_ids),
+        "produced_record_digests": tuple(execution_receipt.produced_record_digests),
+        "produced_paths": tuple(execution_receipt.produced_paths),
+    }
+    if receipt_expected == receipt_observed:
+        receipt_consistency.append("execution_receipt_matches_result_lists")
+    else:
+        findings.append("execution_receipt_lists_mismatch")
+
+    if len(execution_result.produced_record_ids) != len(execution_result.produced_record_digests):
+        findings.append("produced_record_id_digest_count_mismatch")
+    if any(not item for item in execution_result.produced_record_ids + execution_result.produced_record_digests):
+        findings.append("missing_produced_record_id_or_digest")
+
+    applied = set(execution_result.applied_target_ids)
+    failed = set(execution_result.failed_target_ids)
+    skipped = set(execution_result.skipped_target_ids)
+    rolled_back = set(rollback_result.rollback_target_ids if rollback_result else ())
+
+    evidence_ids = set(execution_by_id) | applied | failed | skipped | set(rollback_entries) | rolled_back | set(rollback_status_by_target)
+    if ledger:
+        evidence_ids |= _collect_target_ids(ledger.target_event_entries)
+    if closure_report:
+        evidence_ids |= set(closure_report.applied_target_ids + closure_report.rolled_back_target_ids + closure_report.open_target_ids + closure_report.failed_target_ids + closure_report.skipped_target_ids)
+    unknown_ids = tuple(sorted(evidence_ids - declared_set))
+    if unknown_ids:
+        findings.append("unknown_target_evidence")
+    missing_execution_records = tuple(target_id for target_id in declared_ids if target_id not in execution_by_id)
+    if missing_execution_records:
+        findings.append("missing_declared_target_execution_record")
+
+    if rollback_result:
+        _append_validation(findings, "rollback_result", validate_workspace_change_set_rollback_execution_result(rollback_result))
+        ok, _observed = _validate_digest(rollback_result, "workspace-change-set-rollback-result-")
+        if not ok:
+            findings.append("rollback_result_digest_mismatch")
+        if rollback_result.rollback_performed and tuple(rollback_result.rollback_target_order) != tuple(reversed(execution_result.applied_target_ids)):
+            findings.append("rollback_order_not_reverse_applied_order")
+        if rollback_receipt:
+            _append_validation(findings, "rollback_receipt", validate_workspace_change_set_rollback_receipt(rollback_receipt))
+            ok, _observed = _validate_digest(rollback_receipt, "workspace-change-set-rollback-receipt-")
+            if not ok:
+                findings.append("rollback_receipt_digest_mismatch")
+            if tuple(rollback_receipt.rollback_target_order) != tuple(rollback_result.rollback_target_order):
+                findings.append("rollback_receipt_order_mismatch")
+        elif rollback_result.rollback_performed:
+            findings.append("missing_rollback_receipt")
+    elif rollback_receipt:
+        findings.append("rollback_receipt_without_rollback_result")
+
+    target_records = tuple(
+        _target_record(
+            root=root,
+            target=target,
+            rollback_entry=rollback_entries.get(target.target_id),
+            execution_record=execution_by_id.get(target.target_id),
+            applied=applied,
+            failed=failed,
+            skipped=skipped,
+            rolled_back=rolled_back,
+            rollback_status_by_target=rollback_status_by_target,
+        )
+        for target in manifest.targets
+    )
+    for target_record in target_records:
+        findings.extend(f"{target_record.target_id}:{code}" for code in target_record.finding_codes)
+
+    if ledger:
+        _append_validation(findings, "ledger", validate_workspace_change_set_execution_ledger(ledger))
+        ok, _observed = _validate_digest(ledger, "workspace-change-set-execution-ledger-")
+        if not ok:
+            findings.append("ledger_digest_mismatch")
+        if ledger.request_id != execution_request.request_id or ledger.execution_receipt_id != execution_receipt.receipt_id:
+            findings.append("ledger_source_mismatch")
+        if ledger.execution_status != execution_result.execution_status:
+            findings.append("ledger_execution_status_stale")
+        expected_rb_status = rollback_result.rollback_status if rollback_result and rollback_result.rollback_status != "workspace_change_set_rollback_not_requested" else None
+        if ledger.rollback_status != expected_rb_status:
+            findings.append("ledger_rollback_status_stale")
+        ledger_order = tuple(str(entry.get("target_id")) for entry in ledger.target_event_entries if isinstance(entry, Mapping) and entry.get("target_id"))
+        if ledger_order == tuple(record.target_id for record in execution_result.target_results):
+            ledger_consistency.append("ledger_target_order_matches_execution_result")
+        else:
+            findings.append("ledger_target_order_mismatch")
+    else:
+        ledger_consistency.append("ledger_not_supplied")
+
+    if closure_report:
+        _append_validation(findings, "closure_report", validate_workspace_change_set_execution_closure_report(closure_report))
+        ok, _observed = _validate_digest(closure_report, "workspace-change-set-execution-closure-")
+        if not ok:
+            findings.append("closure_report_digest_mismatch")
+        if closure_report.execution_receipt_id != execution_receipt.receipt_id:
+            findings.append("closure_report_receipt_mismatch")
+        expected_open = tuple(target_id for target_id in execution_result.applied_target_ids if target_id not in rolled_back)
+        if tuple(closure_report.open_target_ids) != expected_open:
+            findings.append("closure_open_targets_contradict_evidence")
+        if tuple(closure_report.failed_target_ids) != tuple(execution_result.failed_target_ids) or tuple(closure_report.skipped_target_ids) != tuple(execution_result.skipped_target_ids):
+            findings.append("closure_failed_skipped_targets_contradict_evidence")
+        if closure_report.closure_status not in CLOSURE_STATUSES:
+            findings.append("closure_status_unknown")
+        closure_consistency.append("closure_report_checked")
+    else:
+        closure_consistency.append("closure_report_not_supplied")
+
+    post_ok = all(record.target_verification_status != "target_verification_failed" for record in target_records if record.target_id in applied - rolled_back)
+    rollback_ok: bool | None = None
+    if rollback_result and rollback_result.rollback_performed:
+        rollback_ok = all(record.target_verification_status in {"target_verified_rollback_preimage", "target_verified_rollback_absence"} for record in target_records if record.target_id in rolled_back)
+
+    insufficient = any(record.target_verification_status == "target_insufficient_evidence" for record in target_records) or any(code.startswith("missing_") and "target_missing" not in code for code in findings)
+    blocked = execution_request.request_status == "workspace_change_set_execution_blocked" or execution_result.execution_status == "workspace_change_set_execution_blocked"
+    failed_verification = bool(findings) and not (insufficient or blocked)
+    partial_visible = bool(execution_result.partial_state_visible or failed or skipped or (closure_report and closure_report.open_issue_codes))
+
+    if blocked:
+        status = "verification_blocked"
+    elif insufficient:
+        status = "insufficient_evidence"
+    elif failed_verification:
+        status = "verification_failed"
+    elif rollback_result and rollback_result.rollback_performed and not (set(execution_result.applied_target_ids) - rolled_back):
+        status = "verified_rolled_back"
+    elif partial_visible:
+        status = "verified_with_partial_state"
+    else:
+        status = "verified_clean"
+
+    result = WorkspaceChangeSetExecutionVerificationResult(
+        verification_id=f"workspace-change-set-execution-verification-{execution_result.result_id}",
+        request_id=request.request_id,
+        verification_status=status,
+        basis=tuple(sorted(set(basis))),
+        target_records=target_records,
+        receipt_consistency=tuple(receipt_consistency),
+        ledger_consistency=tuple(ledger_consistency),
+        closure_consistency=tuple(closure_consistency),
+        postcondition_digest_agreement=post_ok,
+        rollback_digest_agreement=rollback_ok,
+        partial_state_visible=partial_visible,
+        unknown_target_ids=unknown_ids,
+        finding_codes=tuple(sorted(set(findings))),
+        audit_artifact_path=None,
+        audit_artifact_digest=None,
+    )
+    result = replace(result, digest=_digest("workspace-change-set-execution-verification-result-", result.to_dict()))
+    artifact_path, artifact_digest, artifact_findings = _write_audit_artifact(result, request, {_target_path(root, target.relative_target_path) for target in manifest.targets})
+    if artifact_findings:
+        findings.extend(artifact_findings)
+        result = replace(result, verification_status="verification_failed", finding_codes=tuple(sorted(set(findings))))
+    if artifact_path:
+        result = replace(result, audit_artifact_path=artifact_path, audit_artifact_digest=artifact_digest)
+    result = replace(result, digest="")
+    result = replace(result, digest=_digest("workspace-change-set-execution-verification-result-", result.to_dict()))
+    return WorkspaceChangeSetExecutionVerificationWingResult(request, result)
+
+
+def summarize_workspace_change_set_execution_verification_result(result: WorkspaceChangeSetExecutionVerificationResult) -> dict[str, Any]:
+    return {
+        "verification_id": result.verification_id,
+        "verification_status": result.verification_status,
+        "target_count": len(result.target_records),
+        "postcondition_digest_agreement": result.postcondition_digest_agreement,
+        "rollback_digest_agreement": result.rollback_digest_agreement,
+        "partial_state_visible": result.partial_state_visible,
+        "unknown_target_ids": result.unknown_target_ids,
+        "finding_codes": result.finding_codes,
+        "verification_only": True,
+        "read_only_except_optional_audit_artifact": True,
+        "execution_invoked": False,
+        "rollback_invoked": False,
+        "cleanup_performed": False,
+    }
+
+
+T = TypeVar("T")
+
+
+def _coerce_value(annotation: Any, value: Any) -> Any:
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is tuple and args:
+        inner = args[0]
+        return tuple(_coerce_value(inner, item) for item in (value or ()))
+    if origin is list and args:
+        inner = args[0]
+        return [_coerce_value(inner, item) for item in (value or ())]
+    if origin is dict:
+        return dict(value or {})
+    if isinstance(annotation, type) and is_dataclass(annotation) and isinstance(value, Mapping):
+        return dataclass_from_dict(annotation, value)
+    return value
+
+
+def dataclass_from_dict(cls: type[T], payload: Mapping[str, Any]) -> T:
+    kwargs: dict[str, Any] = {}
+    type_hints = get_type_hints(cls)
+    for field in fields(cast(Any, cls)):
+        if field.name in payload:
+            kwargs[field.name] = _coerce_value(type_hints.get(field.name, field.type), payload[field.name])
+    return cls(**kwargs)
+
+
+def verification_evidence_from_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "manifest": dataclass_from_dict(WorkspaceChangeSetManifest, payload["manifest"]),
+        "preflight_report": dataclass_from_dict(WorkspaceChangeSetPreflightReport, payload["preflight_report"]),
+        "rollback_plan": dataclass_from_dict(WorkspaceChangeSetRollbackPlan, payload["rollback_plan"]),
+        "transaction_plan": dataclass_from_dict(WorkspaceChangeSetTransactionPlan, payload["transaction_plan"]),
+        "execution_request": dataclass_from_dict(WorkspaceChangeSetExecutionRequest, payload.get("execution_request", payload.get("request", {}))),
+        "execution_result": dataclass_from_dict(WorkspaceChangeSetExecutionResult, payload["execution_result"]),
+        "execution_receipt": dataclass_from_dict(WorkspaceChangeSetExecutionReceipt, payload["execution_receipt"]),
+        "rollback_result": dataclass_from_dict(WorkspaceChangeSetRollbackExecutionResult, payload["rollback_result"]) if payload.get("rollback_result") else None,
+        "rollback_receipt": dataclass_from_dict(WorkspaceChangeSetRollbackReceipt, payload["rollback_receipt"]) if payload.get("rollback_receipt") else None,
+        "ledger": dataclass_from_dict(WorkspaceChangeSetExecutionLedger, payload["ledger"]) if payload.get("ledger") else None,
+        "closure_report": dataclass_from_dict(WorkspaceChangeSetExecutionClosureReport, payload["closure_report"]) if payload.get("closure_report") else None,
+    }
+
+
+def load_verification_evidence(path: str | Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if "preflight" in payload and isinstance(payload["preflight"], Mapping):
+        preflight = payload["preflight"]
+        payload = {**payload, "manifest": preflight.get("manifest"), "preflight_report": preflight.get("preflight_report"), "rollback_plan": preflight.get("rollback_plan"), "transaction_plan": preflight.get("transaction_plan")}
+    return verification_evidence_from_mapping(payload)

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -886,3 +886,20 @@ def test_workspace_change_set_execution_registry_helper_marks_blocked_surfaces(t
     assert updated["workspace_change_set_execution_closure_report"].status == "implemented"
     for capability_id in ["general_filesystem_access", "general_cleanup", "recursive_delete", "wildcard_delete", "unrelated_file_delete", "workspace_change_set_unbounded_execution", "workspace_change_set_bulk_cleanup", "network_egress", "provider_invocation", "prompt_assembly", "subprocess_runner", "shell_runner", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install"]:
         assert updated[capability_id].status in {"blocked", "deferred"}
+
+
+def test_workspace_change_set_execution_verification_registry_helper_marks_read_only_and_blocks_broader_authority() -> None:
+    from sentientos.capability_registry import update_registry_from_workspace_change_set_execution_verification
+
+    records = build_default_capability_registry().by_id()
+    assert records["workspace_change_set_execution_verification"].status == "implemented"
+    assert records["workspace_change_set_execution_verification"].authority_level == "read-only-verification"
+    assert "sentientos/workspace_change_set_execution_verification.py" in records["workspace_change_set_execution_verification"].source_paths
+    updated = update_registry_from_workspace_change_set_execution_verification(
+        build_default_capability_registry(),
+        {"request": {"request_id": "v"}, "verification_result": {"verification_status": "verified_clean"}},
+    ).by_id()
+    assert updated["workspace_change_set_execution_verification"].status == "implemented"
+    assert updated["workspace_change_set_execution_verification"].metadata_only is True
+    for capability_id in ["general_filesystem_access", "general_cleanup", "recursive_delete", "wildcard_delete", "unrelated_file_delete", "workspace_change_set_unbounded_execution", "workspace_change_set_bulk_cleanup", "network_egress", "provider_invocation", "prompt_assembly", "subprocess_runner", "shell_runner", "real_fan_pwm_control", "real_thermal_actuation", "real_power_profile_mutation", "real_service_restart", "package_install", "driver_install"]:
+        assert updated[capability_id].status in {"blocked", "deferred"}

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -457,3 +457,25 @@ def test_bundle_includes_workspace_change_set_execution_artifact_and_not_run_com
     rendered = [" ".join(command["command"]) for command in commands]
     assert "python scripts/run_workspace_change_set_transaction.py --workspace-root /tmp/sentientos-workspace-change-set --target demo.txt=hello --target docs-demo.txt=docs --summary" in rendered
     assert all(command.status == "proof_command_not_run" for command in payload["manifest"].proof_command_records)
+
+
+def test_bundle_includes_workspace_change_set_execution_verification_artifact_and_not_run_command() -> None:
+    payload = build_reviewer_proof_bundle_payload(created_at=FIXED_CREATED_AT)
+    artifacts = payload["artifacts"]
+    assert "workspace_change_set_execution_verification_capability" in artifacts
+    capability = json.loads(artifacts["workspace_change_set_execution_verification_capability"])
+    assert capability["read_only_verification_exists"] is True
+    assert capability["verifies_completed_change_set_execution_evidence"] is True
+    assert capability["reads_only_explicitly_declared_targets"] is True
+    assert capability["checks_receipt_ledger_closure_consistency"] is True
+    assert capability["optional_audit_artifact_only_when_caller_supplies_path"] is True
+    assert capability["run_by_reviewer_proof_bundle_default"] is False
+    assert capability["proof_bundle_verification_run"] is False
+    assert capability["proof_bundle_execution_performed"] is False
+    assert capability["proof_bundle_rollback_performed"] is False
+    assert capability["proof_bundle_cleanup_performed"] is False
+    assert capability["proof_command_status"] == "proof_command_not_run"
+    commands = json.loads(artifacts["proof_command_manifest"])["commands"]
+    rendered = [" ".join(command["command"]) for command in commands]
+    assert "python scripts/verify_workspace_change_set_execution.py --evidence <workspace_change_set_execution_evidence.json> --summary" in rendered
+    assert all(command.status == "proof_command_not_run" for command in payload["manifest"].proof_command_records)

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -690,3 +690,18 @@ def test_workspace_change_set_execution_doc_is_linked_and_preserves_boundaries()
     assert "not general filesystem access" in doc
     assert "not cleanup" in doc
     assert "does not run workspace change-set execution by default" in doc
+
+HOST_WORKSPACE_CHANGE_SET_EXECUTION_VERIFICATION = "docs/architecture/host_workspace_change_set_execution_verification_wing.md"
+
+
+def test_workspace_change_set_execution_verification_doc_is_linked_and_preserves_boundaries() -> None:
+    doc = _read(HOST_WORKSPACE_CHANGE_SET_EXECUTION_VERIFICATION)
+    overview = _read(PUBLIC_OVERVIEW)
+    index = _read(READINESS_INDEX)
+    assert HOST_WORKSPACE_CHANGE_SET_EXECUTION_VERIFICATION in overview
+    assert HOST_WORKSPACE_CHANGE_SET_EXECUTION_VERIFICATION in index
+    assert "read-only verification and replay-audit layer" in doc
+    assert "reads only the relative target paths declared" in doc
+    assert "does not recurse directories" in doc
+    assert "does not execute" in doc
+    assert "does not run by default in the reviewer proof bundle" in doc

--- a/tests/test_verify_workspace_change_set_execution_script.py
+++ b/tests/test_verify_workspace_change_set_execution_script.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from scripts import verify_workspace_change_set_execution as cli
+from sentientos.workspace_change_set_execution import run_workspace_change_set_execution_wing
+from sentientos.workspace_change_set_preflight import (
+    build_workspace_change_set_manifest,
+    build_workspace_change_set_preflight_report,
+    build_workspace_change_set_rollback_plan,
+    build_workspace_change_set_transaction_plan,
+    build_workspace_change_target_declaration,
+    preflight_workspace_change_target,
+)
+
+
+def _evidence(path: Path) -> Path:
+    targets = (build_workspace_change_target_declaration(relative_target_path='a.txt', payload_text='alpha'),)
+    manifest = build_workspace_change_set_manifest(workspace_root=path, targets=targets)
+    preflights = tuple(preflight_workspace_change_target(workspace_root=path, target=target) for target in targets)
+    report = build_workspace_change_set_preflight_report(manifest=manifest, target_preflights=preflights)
+    rollback_plan = build_workspace_change_set_rollback_plan(manifest=manifest, preflight_report=report, target_preflights=preflights)
+    transaction_plan = build_workspace_change_set_transaction_plan(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    payload = {
+        'manifest': manifest.to_dict(),
+        'preflight_report': report.to_dict(),
+        'rollback_plan': rollback_plan.to_dict(),
+        'transaction_plan': transaction_plan.to_dict(),
+        'request': wing.request.to_dict(),
+        'execution_result': wing.execution_result.to_dict(),
+        'execution_receipt': wing.execution_receipt.to_dict(),
+        'rollback_result': wing.rollback_result.to_dict(),
+        'rollback_receipt': None,
+        'ledger': wing.ledger.to_dict(),
+        'closure_report': wing.closure_report.to_dict(),
+    }
+    evidence = path / 'evidence.json'
+    evidence.write_text(json.dumps(payload), encoding='utf-8')
+    return evidence
+
+
+def test_cli_verification_summary_works(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    evidence = _evidence(tmp_path)
+    assert cli.main(['--evidence', str(evidence), '--summary']) == 0
+    out = capsys.readouterr().out
+    assert 'verification_status: verified_clean' in out
+    assert 'execution_invoked: false' in out
+    assert 'rollback_invoked: false' in out
+
+
+def test_cli_optional_audit_artifact_works(tmp_path: Path) -> None:
+    evidence = _evidence(tmp_path)
+    audit = tmp_path / 'verification.json'
+    assert cli.main(['--evidence', str(evidence), '--audit-output', str(audit)]) == 0
+    payload = json.loads(audit.read_text(encoding='utf-8'))
+    assert payload['workspace_change_set_execution_verification_only'] is True

--- a/tests/test_workspace_change_set_execution_verification.py
+++ b/tests/test_workspace_change_set_execution_verification.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.workspace_change_set_execution import (
+    build_workspace_change_set_execution_closure_report,
+    build_workspace_change_set_execution_ledger,
+    build_workspace_change_set_execution_receipt,
+    build_workspace_change_set_execution_request,
+    deterministic_digest,
+    execute_workspace_change_set,
+    run_workspace_change_set_execution_wing,
+)
+from sentientos.workspace_change_set_execution_verification import (
+    VERIFICATION_STATUSES,
+    summarize_workspace_change_set_execution_verification_result,
+    verify_workspace_change_set_execution,
+)
+from sentientos.workspace_change_set_preflight import (
+    build_workspace_change_set_manifest,
+    build_workspace_change_set_preflight_report,
+    build_workspace_change_set_rollback_plan,
+    build_workspace_change_set_transaction_plan,
+    build_workspace_change_target_declaration,
+    preflight_workspace_change_target,
+)
+
+
+def _plans(root: Path, specs=(('a.txt', 'alpha'), ('b.txt', 'beta'))):
+    targets = tuple(build_workspace_change_target_declaration(relative_target_path=path, payload_text=payload) for path, payload in specs)
+    manifest = build_workspace_change_set_manifest(workspace_root=root, targets=targets)
+    preflights = tuple(preflight_workspace_change_target(workspace_root=root, target=target) for target in targets)
+    report = build_workspace_change_set_preflight_report(manifest=manifest, target_preflights=preflights)
+    rollback_plan = build_workspace_change_set_rollback_plan(manifest=manifest, preflight_report=report, target_preflights=preflights)
+    transaction_plan = build_workspace_change_set_transaction_plan(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan)
+    return targets, manifest, report, rollback_plan, transaction_plan
+
+
+def _verify(manifest, report, rollback_plan, transaction_plan, wing, **kwargs):
+    return verify_workspace_change_set_execution(
+        manifest=manifest,
+        preflight_report=report,
+        rollback_plan=rollback_plan,
+        transaction_plan=transaction_plan,
+        execution_request=wing.request,
+        execution_result=wing.execution_result,
+        execution_receipt=wing.execution_receipt,
+        rollback_result=wing.rollback_result,
+        rollback_receipt=wing.rollback_receipt,
+        ledger=wing.ledger,
+        closure_report=wing.closure_report,
+        **kwargs,
+    )
+
+
+def test_clean_execution_verifies(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    result = verified.verification_result
+    assert result.verification_status == 'verified_clean'
+    assert result.postcondition_digest_agreement is True
+    assert result.unknown_target_ids == ()
+    assert all(record.target_verification_status == 'target_verified_postcondition' for record in result.target_records)
+    assert summarize_workspace_change_set_execution_verification_result(result)['execution_invoked'] is False
+
+
+def test_rollback_after_execute_verifies_against_preimages_or_absence(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, rollback_after_execute=True, write_ledger=True)
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    assert verified.verification_result.verification_status == 'verified_rolled_back'
+    assert verified.verification_result.rollback_digest_agreement is True
+    assert {record.target_verification_status for record in verified.verification_result.target_records} == {'target_verified_rollback_absence'}
+
+
+def test_partial_failure_remains_visible_and_verifies_as_partial_state(tmp_path: Path) -> None:
+    targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path, (('a.txt', 'alpha'), ('b.txt', 'beta'), ('c.txt', 'gamma')))
+    calls = {'count': 0}
+
+    def failing_runner(**kwargs):
+        from sentientos.workspace_file_effect import run_workspace_file_effect_wing
+        calls['count'] += 1
+        if calls['count'] == 2:
+            raise RuntimeError('boom')
+        return run_workspace_file_effect_wing(**kwargs)
+
+    request = build_workspace_change_set_execution_request(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, rollback_on_failure=False)
+    execution_result, _effects = execute_workspace_change_set(request=request, manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, effect_runner=failing_runner)
+    receipt = build_workspace_change_set_execution_receipt(request, execution_result)
+    ledger = build_workspace_change_set_execution_ledger(request=request, execution_receipt=receipt, execution_result=execution_result)
+    closure = build_workspace_change_set_execution_closure_report(execution_receipt=receipt, execution_result=execution_result, ledger=ledger)
+    wing = type('Wing', (), {'request': request, 'execution_result': execution_result, 'execution_receipt': receipt, 'rollback_result': None, 'rollback_receipt': None, 'ledger': ledger, 'closure_report': closure})()
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    assert verified.verification_result.verification_status == 'verified_with_partial_state'
+    assert verified.verification_result.partial_state_visible is True
+    statuses = {record.target_id: record.target_verification_status for record in verified.verification_result.target_records}
+    assert statuses[targets[0].target_id] == 'target_verified_postcondition'
+    assert statuses[targets[1].target_id] == 'target_verified_failed_visible'
+    assert statuses[targets[2].target_id] == 'target_verified_skipped_visible'
+
+
+def test_digest_mismatch_fails_verification(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    (tmp_path / 'a.txt').write_text('tampered')
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    assert verified.verification_result.verification_status == 'verification_failed'
+    assert any('postcondition_digest_mismatch' in code for code in verified.verification_result.finding_codes)
+
+
+def test_missing_applied_declared_target_fails_verification(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    (tmp_path / 'a.txt').unlink()
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    assert verified.verification_result.verification_status == 'verification_failed'
+    assert any('applied_target_missing' in code for code in verified.verification_result.finding_codes)
+
+
+def test_unknown_target_evidence_fails_verification(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    unknown = replace(wing.execution_result.target_results[0], target_id='unknown-target', digest='')
+    unknown = replace(unknown, digest=deterministic_digest('workspace-change-target-execution-result-', unknown.to_dict()))
+    execution_result = replace(wing.execution_result, target_results=wing.execution_result.target_results + (unknown,), digest='')
+    execution_result = replace(execution_result, digest=deterministic_digest('workspace-change-set-execution-result-', execution_result.to_dict()))
+    verified = verify_workspace_change_set_execution(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, execution_request=wing.request, execution_result=execution_result, execution_receipt=wing.execution_receipt, rollback_result=wing.rollback_result, rollback_receipt=wing.rollback_receipt, ledger=wing.ledger, closure_report=wing.closure_report)
+    assert verified.verification_result.verification_status == 'verification_failed'
+    assert verified.verification_result.unknown_target_ids == ('unknown-target',)
+
+
+def test_stale_or_contradictory_ledger_receipt_closure_fails(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    bad_ledger = replace(wing.ledger, execution_status='workspace_change_set_execution_failed')
+    bad_receipt = replace(wing.execution_receipt, applied_target_ids=())
+    bad_closure = replace(wing.closure_report, open_target_ids=('ghost',))
+    verified = verify_workspace_change_set_execution(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, execution_request=wing.request, execution_result=wing.execution_result, execution_receipt=bad_receipt, rollback_result=wing.rollback_result, rollback_receipt=wing.rollback_receipt, ledger=bad_ledger, closure_report=bad_closure)
+    assert verified.verification_result.verification_status == 'verification_failed'
+    assert {'ledger_execution_status_stale', 'execution_receipt_lists_mismatch', 'closure_open_targets_contradict_evidence'} <= set(verified.verification_result.finding_codes)
+
+
+def test_verifier_reads_only_declared_targets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / 'unrelated.txt').write_text('do not read')
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    reads: list[Path] = []
+    original = Path.read_bytes
+
+    def recording_read_bytes(self: Path) -> bytes:
+        reads.append(self.resolve())
+        return original(self)
+
+    monkeypatch.setattr(Path, 'read_bytes', recording_read_bytes)
+    _verify(manifest, report, rollback_plan, transaction_plan, wing)
+    assert set(reads) == {(tmp_path / 'a.txt').resolve(), (tmp_path / 'b.txt').resolve()}
+
+
+def test_verifier_performs_no_writes_except_optional_audit_artifact(tmp_path: Path) -> None:
+    _targets, manifest, report, rollback_plan, transaction_plan = _plans(tmp_path)
+    wing = run_workspace_change_set_execution_wing(manifest=manifest, preflight_report=report, rollback_plan=rollback_plan, transaction_plan=transaction_plan, write_ledger=True)
+    mtimes = {path: path.stat().st_mtime_ns for path in (tmp_path / 'a.txt', tmp_path / 'b.txt')}
+    audit_path = tmp_path / 'verification_audit.json'
+    verified = _verify(manifest, report, rollback_plan, transaction_plan, wing, audit_output_path=str(audit_path))
+    assert audit_path.exists()
+    assert verified.verification_result.audit_artifact_path == str(audit_path)
+    assert {path: path.stat().st_mtime_ns for path in mtimes} == mtimes
+
+
+def test_verifier_does_not_import_execution_or_rollback_helpers() -> None:
+    import sentientos.workspace_change_set_execution_verification as verifier
+    assert not hasattr(verifier, 'run_workspace_file_effect_wing')
+    assert not hasattr(verifier, 'run_workspace_file_rollback_wing')
+    assert VERIFICATION_STATUSES == {'verified_clean', 'verified_with_partial_state', 'verified_rolled_back', 'verification_failed', 'verification_blocked', 'insufficient_evidence'}


### PR DESCRIPTION
### Motivation
- Provide an independent, read-only verification and replay-audit layer for completed workspace change-set executions so reviewers and operators can deterministically validate execution evidence without any execution/rollback authority. 
- Preserve existing bounded/forbidden authority posture by only reading explicitly declared manifest targets and by optionally writing a single caller-supplied audit artifact. 

### Description
- Added a new verifier module `sentientos/workspace_change_set_execution_verification.py` implementing `WorkspaceChangeSetExecutionVerificationRequest`, `WorkspaceChangeSetExecutionVerificationResult`, per-target records, deterministic digests, receipt/ledger/closure/rollback consistency checks, declared-target digest replay, unknown-target detection, and optional audit-artifact writing. 
- Added an optional verification-only CLI `scripts/verify_workspace_change_set_execution.py` that consumes a JSON evidence bundle, prints JSON or a compact summary, and can write one explicit caller-supplied audit artifact via `--audit-output`. 
- Integrated the verifier into reviewer surfaces and capability registry by adding `workspace_change_set_execution_verification` capability and `workspace_change_set_execution_verification_capability.json` to the reviewer proof bundle; registry helper `update_registry_from_workspace_change_set_execution_verification` marks the verifier implemented and keeps broader authorities blocked/metadata-only. 
- Updated architecture docs and reviewer indexes with a new page `docs/architecture/host_workspace_change_set_execution_verification_wing.md` describing statuses, read-only boundaries, and CLI usage. 
- Added focused tests covering clean verification, rollback verification, partial-state visibility, digest mismatch, missing/unknown target evidence, stale/contradictory ledger/receipt/closure evidence, declared-target-only reads, single audit-artifact write, CLI behavior, proof-bundle and registry reflections, and a safety assertion that the verifier does not import execution/rollback helpers. 

Files changed
- docs/architecture/host_workspace_change_set_execution_verification_wing.md (new)
- docs/architecture/public_technical_overview.md (updated)
- docs/architecture/reviewer_first_run_proof_bundle.md (updated)
- docs/architecture/reviewer_release_readiness_index.md (updated)
- sentientos/workspace_change_set_execution_verification.py (new verifier module)
- scripts/verify_workspace_change_set_execution.py (new CLI)
- sentientos/capability_registry.py (updated to register verifier and helper)
- sentientos/reviewer_proof_bundle.py (updated to include verifier artifact and proof command)
- tests/test_workspace_change_set_execution_verification.py (new)
- tests/test_verify_workspace_change_set_execution_script.py (new)
- tests/test_capability_registry.py (updated)
- tests/test_reviewer_proof_bundle.py (updated)
- tests/test_reviewer_release_readiness_index.py (updated)

Verification statuses implemented
- Overall: `verified_clean`, `verified_with_partial_state`, `verified_rolled_back`, `verification_failed`, `verification_blocked`, `insufficient_evidence`.
- Per-target: `target_verified_postcondition`, `target_verified_rollback_preimage`, `target_verified_rollback_absence`, `target_verified_failed_visible`, `target_verified_skipped_visible`, `target_verification_failed`, `target_verification_blocked`, `target_insufficient_evidence`.

Safety / boundary proofs included
- The verifier only recomputes digests for manifest-declared relative target paths and does not recurse, expand wildcards, infer undeclared targets, execute payloads, call execution/rollback helpers, perform cleanup, delete files, or call subprocess/shell/network/provider/prompt/hardware/service/power/fan/thermal paths, and this is enforced in code and validated by tests. 
- Tests prove only declared files are read (monkeypatched `Path.read_bytes`), no target files are written except the explicit caller-supplied audit artifact, and the verification module does not import or expose execution/rollback helpers. 

### Testing
- Unit/test suite: ran `python -m scripts.run_tests -q tests/test_workspace_change_set_preflight.py tests/test_preflight_workspace_change_set_script.py tests/test_workspace_change_set_execution.py tests/test_run_workspace_change_set_transaction_script.py tests/test_workspace_change_set_execution_verification.py tests/test_verify_workspace_change_set_execution_script.py tests/test_capability_registry.py tests/test_reviewer_proof_bundle.py tests/test_reviewer_release_readiness_index.py`, and the targeted tests introduced by this PR passed in the execution environment. 
- CLI smoke: ran the new CLI `scripts/verify_workspace_change_set_execution.py` against generated evidence and validated summary and audit artifact behaviors (tests passed). 
- Docs: ran `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py --bootstrap-docs && python scripts/build_docs.py` successfully to update documentation artifacts. 
- Audit immutability: ran `python scripts/audit_immutability_verifier.py` which passed (artifact-dependent check). 
- Capability registry and proof-bundle checks: updated tests asserting the new capability is documented and listed as `proof_command_not_run`, and these tests passed. 

Known limitations / unresolved risks
- `mypy scripts/ sentientos/` was run and the repository still contains pre-existing, broad typing issues; the new verifier and CLI were py-compiled and adjusted to minimize type issues, but a full repo-wide mypy pass remains blocked by unrelated existing type errors. 
- `verify_audits --strict` was not available in PATH in the environment at one point; `audit_immutability_verifier.py` was used and passed. 

If you want, I can (a) split the verifier into smaller helper units, (b) add more doc examples for the evidence JSON shape, or (c) produce the explicit `workspace_change_set_execution_verification_capability.json` artifact content for the reviewer bundle output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a7289b3408320a3e600d8013337d4)