### PR TITLE
[codex:docs] harden docs build dependency path

### DIFF
--- a/docs/REVIEWER_QUICKSTART.md
+++ b/docs/REVIEWER_QUICKSTART.md
@@ -22,6 +22,18 @@ federation posture using the current command surface.
    python -m sentientos.ops node health --json
    python -m sentientos.ops constitution verify --json
    ```
+6. Bootstrap and build public documentation from the explicit docs dependency
+   surface:
+   ```bash
+   python scripts/build_docs.py --check-deps
+   python scripts/build_docs.py --bootstrap-docs
+   python scripts/build_docs.py --check-deps
+   python scripts/build_docs.py
+   ```
+
+   `--bootstrap-docs` installs the same minimal docs requirements declared in
+   `pyproject.toml` under the `docs` extra. Reviewers who prefer one install
+   command may run `pip install -e .[docs]` instead.
 
 For terminology translation between public engineering language and internal
 codenames, see [PUBLIC_LANGUAGE_BRIDGE.md](PUBLIC_LANGUAGE_BRIDGE.md).

--- a/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
+++ b/docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md
@@ -90,6 +90,8 @@ python -m scripts.run_tests -q tests/test_host_resource_policy.py tests/test_hos
 python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py
 python scripts/verify_context_hygiene_prompt_boundaries.py
 python scripts/build_docs.py --check-deps
+python scripts/build_docs.py --bootstrap-docs
+python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 ```
 

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -132,7 +132,9 @@ expand runtime authority.
 Run from the repository root. Expected posture for each command is successful
 completion unless the local environment is missing an explicitly declared docs or
 test dependency, in which case the failure should be treated as a bootstrap issue
-and fixed through the documented wrapper path.
+and fixed through the documented wrapper path. Docs validation uses the
+`pyproject.toml` `docs` extra and the mirrored `scripts/build_docs.py` minimal
+bootstrap path; missing MkDocs is not a silent skip.
 
 ```bash
 # Test-runner bootstrap and docs tooling smoke coverage.
@@ -166,7 +168,9 @@ python scripts/verify_audits.py --strict
 # Immutable manifest verification.
 python scripts/audit_immutability_verifier.py --manifest vow/immutable_manifest.json
 
-# Docs dependency check and docs build.
+# Docs dependency check, explicit docs bootstrap, and docs build.
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py --bootstrap-docs
 python scripts/build_docs.py --check-deps
 python scripts/build_docs.py
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,5 +18,24 @@ api/index
 experimental_features
 ```
 
+## Documentation build dependency contract
+
+The MkDocs build is intentionally kept out of the runtime dependency set. For a
+clean reviewer environment, install or verify the explicit docs toolchain before
+running the build:
+
+```bash
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py --bootstrap-docs
+python scripts/build_docs.py --check-deps
+python scripts/build_docs.py
+```
+
+The equivalent project-extra install is `pip install -e .[docs]`. Missing docs
+dependencies are bootstrap failures, not skipped documentation validation. The
+current docs dependency surface is the `docs` optional dependency group in
+`pyproject.toml`, mirrored by `scripts/build_docs.py` for the minimal bootstrap
+path.
+
 SentientOS prioritizes operator accountability, auditability, and safe
 shutdown.

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 """Sanctuary Privilege Ritual: Do not remove. See doctrine for details."""
-from sentientos.privilege import require_admin_banner, require_lumos_approval
-require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
-require_lumos_approval()
+
 import argparse
 import importlib.util
 import subprocess
@@ -11,8 +9,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-DOCS_DEPENDENCY_IMPORTS = ("mkdocs",)
-DOCS_PIP_REQUIREMENTS = ("mkdocs>=1.6,<2", "watchdog>=2,<3")
+from sentientos.privilege import require_admin_banner, require_lumos_approval
+
+require_admin_banner()  # Enforced: Sanctuary Privilege Ritual—do not remove. See doctrine.
+require_lumos_approval()
+
+DOCS_DEPENDENCIES: tuple[tuple[str, str, str], ...] = (
+    ("mkdocs", "mkdocs>=1.6,<2", "MkDocs static site generator"),
+    ("watchdog.observers", "watchdog>=2,<3", "file watching support used by MkDocs tooling"),
+)
+DOCS_DEPENDENCY_IMPORTS = tuple(import_name for import_name, _requirement, _purpose in DOCS_DEPENDENCIES)
+DOCS_PIP_REQUIREMENTS = tuple(requirement for _import_name, requirement, _purpose in DOCS_DEPENDENCIES)
 DOCS_BOOTSTRAP_COMMAND = "python scripts/build_docs.py --bootstrap-docs"
 DOCS_EXTRA_INSTALL_COMMAND = "pip install -e .[docs]"
 DOCS_DEPENDENCY_MESSAGE = (
@@ -21,17 +28,34 @@ DOCS_DEPENDENCY_MESSAGE = (
 )
 
 
+def _import_available(import_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
 def missing_docs_dependencies() -> list[str]:
     """Return docs build dependency imports unavailable in this environment."""
 
-    return [name for name in DOCS_DEPENDENCY_IMPORTS if importlib.util.find_spec(name) is None]
+    return [name for name in DOCS_DEPENDENCY_IMPORTS if not _import_available(name)]
+
+
+def _dependency_requirement(import_name: str) -> str:
+    for candidate_import, requirement, _purpose in DOCS_DEPENDENCIES:
+        if candidate_import == import_name:
+            return requirement
+    return import_name
 
 
 def _emit_missing_dependency_message(missing: list[str]) -> None:
     joined = ", ".join(missing)
+    requirement_list = ", ".join(_dependency_requirement(name) for name in missing)
     print(
         "ENVIRONMENT/BOOTSTRAP ERROR: "
-        f"{DOCS_DEPENDENCY_MESSAGE}\nMissing Python import(s): {joined}",
+        f"{DOCS_DEPENDENCY_MESSAGE}\n"
+        f"Missing Python import(s): {joined}\n"
+        f"Missing docs package requirement(s): {requirement_list}",
         file=sys.stderr,
     )
 
@@ -57,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--bootstrap-docs",
         action="store_true",
-        help="install the minimal docs dependency set before building",
+        help="install the minimal docs dependency set without building",
     )
     args = parser.parse_args(argv)
 
@@ -67,15 +91,21 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     missing = missing_docs_dependencies()
-    if missing and args.bootstrap_docs:
-        if not bootstrap_docs_dependencies():
-            print(
-                "ENVIRONMENT/BOOTSTRAP ERROR: Docs dependency bootstrap failed. "
-                f"Tried: pip install {' '.join(DOCS_PIP_REQUIREMENTS)}",
-                file=sys.stderr,
-            )
+    if args.bootstrap_docs:
+        if missing:
+            if not bootstrap_docs_dependencies():
+                print(
+                    "ENVIRONMENT/BOOTSTRAP ERROR: Docs dependency bootstrap failed. "
+                    f"Tried: pip install {' '.join(DOCS_PIP_REQUIREMENTS)}",
+                    file=sys.stderr,
+                )
+                return 2
+            missing = missing_docs_dependencies()
+        if missing:
+            _emit_missing_dependency_message(missing)
             return 2
-        missing = missing_docs_dependencies()
+        print("Docs build dependencies bootstrapped and available.")
+        return 0
     if missing:
         _emit_missing_dependency_message(missing)
         return 2

--- a/tests/test_build_docs_tooling.py
+++ b/tests/test_build_docs_tooling.py
@@ -4,6 +4,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import yaml
+
 import pytest
 
 from scripts import build_docs
@@ -28,6 +30,13 @@ def test_docs_extra_declares_mkdocs() -> None:
     assert not any(dep.startswith("mkdocs") for dep in pyproject["project"]["dependencies"])
 
 
+def test_mkdocs_config_does_not_require_undeclared_plugins_or_theme() -> None:
+    config = yaml.safe_load(Path("mkdocs.yml").read_text(encoding="utf-8"))
+
+    assert config.get("theme") == "readthedocs"
+    assert config.get("plugins", []) in ([], None)
+
+
 def test_missing_docs_dependency_fails_actionably(monkeypatch, tmp_path, capsys) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "mkdocs.yml").write_text("site_name: Test\n", encoding="utf-8")
@@ -41,7 +50,35 @@ def test_missing_docs_dependency_fails_actionably(monkeypatch, tmp_path, capsys)
     assert "Docs build dependencies missing. Run:" in captured.err
     assert "python scripts/build_docs.py --bootstrap-docs" in captured.err
     assert "pip install -e .[docs]" in captured.err
-    assert "Missing Python import(s): mkdocs" in captured.err
+    assert "Missing Python import(s): mkdocs, watchdog.observers" in captured.err
+    assert "Missing docs package requirement(s): mkdocs>=1.6,<2, watchdog>=2,<3" in captured.err
+
+
+def test_bootstrap_docs_flag_installs_and_exits_without_building(monkeypatch, tmp_path, capsys) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "mkdocs.yml").write_text("site_name: Test\n", encoding="utf-8")
+
+    missing_values = [["mkdocs"], []]
+
+    def fake_missing() -> list[str]:
+        return missing_values.pop(0)
+
+    def fake_run(cmd, check=False):
+        commands.append(cmd)
+        return _Completed(0)
+
+    monkeypatch.setattr(build_docs, "missing_docs_dependencies", fake_missing)
+    monkeypatch.setattr(build_docs.subprocess, "run", fake_run)
+
+    code = build_docs.main(["--bootstrap-docs"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert commands == [
+        [sys.executable, "-m", "pip", "install", *build_docs.DOCS_PIP_REQUIREMENTS]
+    ]
+    assert "Docs build dependencies bootstrapped and available." in captured.out
 
 
 def test_build_docs_uses_current_python_mkdocs_module(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
### Motivation
- The MkDocs build toolchain is intentionally provided as a docs-only optional extra, which caused undocumented failures when running the docs build in a clean environment because `mkdocs` (and its related runtime import `watchdog.observers`) were not installed. 
- The fix makes the docs dependency contract explicit and actionably bootstrappable so reviewers and CI can reproduce the docs build sequence without guessing an environment gap.

### Description
- `scripts/build_docs.py` now defines an explicit `DOCS_DEPENDENCIES` mapping (import name → package requirement → purpose), mirrors the `pyproject.toml` `docs` extra for the minimal bootstrap path, and reports both missing imports and the corresponding installable package requirements. 
- The script adds a robust import-availability probe, improved actionable error text, and a non-destructive `--bootstrap-docs` mode that installs the minimal docs toolchain and exits successfully without implicitly running a build. 
- Tests in `tests/test_build_docs_tooling.py` were extended to assert docs dependency declaration, MkDocs config sanity (no undeclared plugins/theme), clear missing-dependency messages, and `--bootstrap-docs` behavior. 
- Reviewer-facing documentation was updated to document the reproducible sequence `--check-deps`, `--bootstrap-docs`, re-check, and `build`; files changed are `scripts/build_docs.py`, `tests/test_build_docs_tooling.py`, `docs/index.md`, `docs/REVIEWER_QUICKSTART.md`, `docs/architecture/reviewer_release_readiness_index.md`, and `docs/architecture/host_embodiment_substrate_phase3_policy_receipts.md`.

### Testing
- Ran `python scripts/build_docs.py --check-deps` in a clean environment and observed an actionable `ENVIRONMENT/BOOTSTRAP ERROR` listing missing imports and package requirements (exit code 2). 
- Ran `python scripts/build_docs.py --bootstrap-docs` which invoked `pip install` for the minimal docs requirements (`mkdocs>=1.6,<2`, `watchdog>=2,<3`) and exited 0, after which `python scripts/build_docs.py --check-deps` reported dependencies available. 
- Ran `python scripts/build_docs.py` and confirmed the build completed and printed generated pages. 
- Executed the focused test run `python -m scripts.run_tests -q tests/test_build_docs_tooling.py tests/test_reviewer_release_readiness_index.py` as well as `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`, and all automated checks referenced above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0abb4b63d483209b015d3dc186638e)