### PR TITLE
[codex:typing] add mypy baseline ratchet

### DIFF
--- a/docs/REVIEWER_QUICKSTART.md
+++ b/docs/REVIEWER_QUICKSTART.md
@@ -22,7 +22,15 @@ federation posture using the current command surface.
    python -m sentientos.ops node health --json
    python -m sentientos.ops constitution verify --json
    ```
-6. Bootstrap and build public documentation from the explicit docs dependency
+6. Check the repo-wide mypy baseline ratchet and the focused workspace typed surface:
+   ```bash
+   python scripts/check_mypy_baseline.py
+   python -m mypy --follow-imports=skip --hide-error-context --no-color-output --show-column-numbers --show-error-codes sentientos/workspace_change_set_admission.py scripts/admit_workspace_change_set.py sentientos/workspace_change_set_preflight.py scripts/preflight_workspace_change_set.py sentientos/workspace_change_set_execution.py scripts/run_workspace_change_set_transaction.py sentientos/workspace_change_set_execution_verification.py scripts/verify_workspace_change_set_execution.py sentientos/workspace_change_set_lifecycle_closure.py scripts/build_workspace_change_set_lifecycle_closure.py sentientos/workspace_change_set_lifecycle_orchestrator.py scripts/run_workspace_change_set_lifecycle.py
+   ```
+
+   The baseline/ratchet contract is documented in [mypy_baseline_ratchet.md](architecture/mypy_baseline_ratchet.md).
+
+7. Bootstrap and build public documentation from the explicit docs dependency
    surface:
    ```bash
    python scripts/build_docs.py --check-deps

--- a/docs/architecture/mypy_baseline_ratchet.md
+++ b/docs/architecture/mypy_baseline_ratchet.md
@@ -1,0 +1,116 @@
+# Mypy Baseline Ratchet and Typed Surface Gate
+
+This document defines the bounded type-governance layer for repository-wide
+mypy debt. It makes the existing broad mypy failure surface explicit without
+suppressing errors globally, weakening targeted checks, or changing runtime
+authority.
+
+## Baseline artifact
+
+The deterministic baseline artifact is:
+
+```text
+vow/mypy_baseline.json
+```
+
+The manifest format is JSON with sorted keys and a stable `generated_at`
+placeholder. It contains:
+
+- `schema_version`: manifest schema version.
+- `generated_at`: stable placeholder for reproducible refreshes.
+- `generator`: `scripts.build_mypy_baseline`.
+- `mypy_command`: command used to capture the baseline.
+- `mypy_version`: best-effort `python -m mypy --version` result.
+- `total_error_count`: normalized error count.
+- `affected_file_count`: number of files with normalized errors.
+- `per_file_counts`: deterministic map of file path to error count.
+- `digest`: SHA-256 digest of normalized error records.
+- `errors`: sorted records with `path`, `line`, `column`, `code`, and
+  normalized `message`.
+
+The default capture command is:
+
+```bash
+python -m mypy --hide-error-context --no-color-output --show-column-numbers --show-error-codes scripts/ sentientos/
+```
+
+## Refreshing the baseline explicitly
+
+Refresh is an explicit reviewer-visible action:
+
+```bash
+python scripts/build_mypy_baseline.py
+```
+
+The builder parses current mypy output, rewrites `vow/mypy_baseline.json`, and
+prints a compact JSON summary with the new error count, affected file count, and
+digest. New files do not silently enter the debt ledger during checking; they
+enter only when this refresh command is run and the resulting manifest is
+reviewed.
+
+For deterministic parser reviews or tests, the builder can consume captured
+output instead of invoking mypy:
+
+```bash
+python scripts/build_mypy_baseline.py --mypy-output-file /tmp/mypy-output.txt --output /tmp/mypy_baseline.json
+```
+
+## Ratchet check
+
+Run the baseline ratchet check with:
+
+```bash
+python scripts/check_mypy_baseline.py
+```
+
+The checker validates the manifest digest and compares current normalized mypy
+errors with baseline records. It allows matching existing debt, reports retired
+errors as improvement, and fails on new errors. The compact reviewer summary
+contains:
+
+- `matched_existing_errors`
+- `new_errors`
+- `retired_errors`
+- `affected_new_files`
+- `status`
+
+Statuses are deterministic:
+
+- `mypy_baseline_clean`
+- `mypy_baseline_matches_existing_debt`
+- `mypy_baseline_regression_detected`
+- `mypy_baseline_improved`
+- `mypy_baseline_missing`
+- `mypy_baseline_invalid`
+
+Regression mode exits non-zero only when new errors are present or when the
+baseline is missing/invalid. Retired errors remain visible so reviewers can
+choose whether to refresh the baseline downward.
+
+## Targeted typed surface gate
+
+The repo-wide baseline is not a substitute for focused typed-surface checks on
+new bounded workspace change-set modules and CLIs. Run the targeted gate with:
+
+```bash
+python -m mypy --follow-imports=skip --hide-error-context --no-color-output --show-column-numbers --show-error-codes sentientos/workspace_change_set_admission.py scripts/admit_workspace_change_set.py sentientos/workspace_change_set_preflight.py scripts/preflight_workspace_change_set.py sentientos/workspace_change_set_execution.py scripts/run_workspace_change_set_transaction.py sentientos/workspace_change_set_execution_verification.py scripts/verify_workspace_change_set_execution.py sentientos/workspace_change_set_lifecycle_closure.py scripts/build_workspace_change_set_lifecycle_closure.py sentientos/workspace_change_set_lifecycle_orchestrator.py scripts/run_workspace_change_set_lifecycle.py
+```
+
+This targeted command stays stricter than the repo-wide baseline posture: it is
+intended to remain green for the selected workspace change-set surface even
+while older repository-wide debt remains ratcheted.
+
+## Reviewer interpretation
+
+- `mypy_baseline_matches_existing_debt`: current repo-wide debt matches the
+  baseline and introduces no new normalized errors.
+- `mypy_baseline_improved`: some baseline records disappeared; review may
+  refresh the baseline downward.
+- `mypy_baseline_regression_detected`: new errors or new files are outside the
+  baseline and must be fixed or explicitly baselined through a reviewed refresh.
+- `mypy_baseline_missing` / `mypy_baseline_invalid`: the governance artifact is
+  absent or corrupted and the check is not authoritative.
+
+This layer is build tooling only. It does not add runtime execution authority,
+workspace orchestration, provider invocation, prompt export, network egress, or
+host actuation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ operator-directed automation.
 - [PUBLIC_LANGUAGE_BRIDGE.md](PUBLIC_LANGUAGE_BRIDGE.md) — normalized public terminology policy.
 - [GLOSSARY.md](GLOSSARY.md) — canonical terminology definitions.
 - [REVIEWER_QUICKSTART.md](REVIEWER_QUICKSTART.md) — fast verification workflow.
+- [architecture/mypy_baseline_ratchet.md](architecture/mypy_baseline_ratchet.md) — repo-wide mypy debt baseline and targeted typed-surface gate.
 
 ```{toctree}
 :maxdepth: 2

--- a/scripts/build_mypy_baseline.py
+++ b/scripts/build_mypy_baseline.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.mypy_baseline_common import BASELINE_PATH, DEFAULT_MYPY_COMMAND, build_manifest, manifest_to_text, parse_mypy_output
+
+
+def _run_command(command: list[str]) -> tuple[int, str]:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    output = completed.stdout
+    if completed.stderr:
+        output = f"{output}\n{completed.stderr}" if output else completed.stderr
+    return completed.returncode, output
+
+
+def _mypy_version() -> str:
+    completed = subprocess.run([sys.executable, "-m", "mypy", "--version"], check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        return "unknown"
+    return completed.stdout.strip() or "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build or refresh the deterministic repo-wide mypy baseline manifest.")
+    parser.add_argument("--output", type=Path, default=BASELINE_PATH, help="Baseline manifest path to write.")
+    parser.add_argument("--mypy-output-file", type=Path, help="Read existing mypy output instead of invoking mypy.")
+    parser.add_argument("--print", action="store_true", help="Print the manifest instead of writing it.")
+    parser.add_argument("targets", nargs="*", help="Override mypy targets/flags after 'python -m mypy'.")
+    args = parser.parse_args(argv)
+
+    if args.mypy_output_file is not None:
+        output = args.mypy_output_file.read_text(encoding="utf-8")
+        command = list(DEFAULT_MYPY_COMMAND if not args.targets else ("python", "-m", "mypy", *args.targets))
+    else:
+        command = list(DEFAULT_MYPY_COMMAND if not args.targets else (sys.executable, "-m", "mypy", *args.targets))
+        _, output = _run_command(command)
+
+    manifest = build_manifest(records=parse_mypy_output(output), mypy_command=command, mypy_version=_mypy_version())
+    text = manifest_to_text(manifest)
+    if args.print:
+        print(text, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+        summary = {
+            "status": "mypy_baseline_refreshed",
+            "baseline": str(args.output),
+            "total_error_count": manifest["total_error_count"],
+            "affected_file_count": manifest["affected_file_count"],
+            "digest": manifest["digest"],
+        }
+        print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_mypy_baseline.py
+++ b/scripts/check_mypy_baseline.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.mypy_baseline_common import (
+    BASELINE_PATH,
+    DEFAULT_MYPY_COMMAND,
+    STATUS_INVALID,
+    STATUS_MISSING,
+    compare_records,
+    load_manifest,
+    manifest_records,
+    parse_mypy_output,
+)
+
+
+def _run_command(command: list[str]) -> str:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    output = completed.stdout
+    if completed.stderr:
+        output = f"{output}\n{completed.stderr}" if output else completed.stderr
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare current repo-wide mypy output against the deterministic baseline.")
+    parser.add_argument("--baseline", type=Path, default=BASELINE_PATH, help="Baseline manifest path to read.")
+    parser.add_argument("--current-output-file", type=Path, help="Read current mypy output instead of invoking mypy.")
+    parser.add_argument("--summary", type=Path, help="Optional path for reviewer summary JSON.")
+    parser.add_argument("targets", nargs="*", help="Override mypy targets/flags after 'python -m mypy'.")
+    args = parser.parse_args(argv)
+
+    if not args.baseline.exists():
+        summary = {"status": STATUS_MISSING, "baseline": str(args.baseline)}
+        print(json.dumps(summary, sort_keys=True))
+        return 2
+    try:
+        manifest = load_manifest(args.baseline)
+    except ValueError as exc:
+        summary = {"status": STATUS_INVALID, "baseline": str(args.baseline), "reason": str(exc)}
+        print(json.dumps(summary, sort_keys=True))
+        return 2
+
+    command = list(DEFAULT_MYPY_COMMAND if not args.targets else (sys.executable, "-m", "mypy", *args.targets))
+    output = args.current_output_file.read_text(encoding="utf-8") if args.current_output_file is not None else _run_command(command)
+    result = compare_records(baseline_records=manifest_records(manifest), current_records=parse_mypy_output(output))
+    summary = {
+        "status": result["status"],
+        "baseline": str(args.baseline),
+        "baseline_digest": manifest["digest"],
+        "mypy_command": manifest.get("mypy_command", list(DEFAULT_MYPY_COMMAND)),
+        "matched_existing_errors": result["matched_existing_errors"],
+        "new_errors": result["new_errors"],
+        "retired_errors": result["retired_errors"],
+        "affected_new_files": result["affected_new_files"],
+    }
+    if result["new_errors"]:
+        summary["new_error_records"] = result["new_error_records"]
+    if result["retired_errors"]:
+        summary["retired_error_records"] = result["retired_error_records"]
+    text = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    print(text, end="")
+    if args.summary is not None:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(text, encoding="utf-8")
+    return 1 if result["new_errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mypy_baseline_common.py
+++ b/scripts/mypy_baseline_common.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterable, Sequence
+
+BASELINE_PATH = Path("vow/mypy_baseline.json")
+DEFAULT_MYPY_COMMAND = (
+    "python",
+    "-m",
+    "mypy",
+    "--hide-error-context",
+    "--no-color-output",
+    "--show-column-numbers",
+    "--show-error-codes",
+    "scripts/",
+    "sentientos/",
+)
+STABLE_GENERATED_AT = "stable-baseline-refresh"
+SCHEMA_VERSION = 1
+STATUS_CLEAN = "mypy_baseline_clean"
+STATUS_MATCHES = "mypy_baseline_matches_existing_debt"
+STATUS_REGRESSION = "mypy_baseline_regression_detected"
+STATUS_IMPROVED = "mypy_baseline_improved"
+STATUS_MISSING = "mypy_baseline_missing"
+STATUS_INVALID = "mypy_baseline_invalid"
+
+_ERROR_RE = re.compile(
+    r"^(?P<path>[^:\n]+):(?P<line>\d+)"
+    r"(?::(?P<column>\d+))?:\s+"
+    r"(?P<severity>error|note):\s+"
+    r"(?P<message>.+?)"
+    r"(?:\s+\[(?P<code>[^\]]+)\])?$"
+)
+_NON_POSITION_ERROR_RE = re.compile(
+    r"^(?P<path>[^:\n]+):\s+"
+    r"(?P<severity>error|note):\s+"
+    r"(?P<message>.+?)"
+    r"(?:\s+\[(?P<code>[^\]]+)\])?$"
+)
+
+
+@dataclass(frozen=True, order=True)
+class MypyErrorRecord:
+    path: str
+    line: int | None
+    column: int | None
+    code: str | None
+    message: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "column": self.column,
+            "code": self.code,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_json(cls, payload: Any) -> "MypyErrorRecord":
+        if not isinstance(payload, dict):
+            raise ValueError("error record must be an object")
+        path = payload.get("path")
+        message = payload.get("message")
+        if not isinstance(path, str) or not path:
+            raise ValueError("error record path must be a non-empty string")
+        if not isinstance(message, str) or not message:
+            raise ValueError("error record message must be a non-empty string")
+        return cls(
+            path=normalize_path(path),
+            line=_optional_int(payload.get("line")),
+            column=_optional_int(payload.get("column")),
+            code=_optional_str(payload.get("code")),
+            message=normalize_message(message),
+        )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("optional integer field must be an integer or null")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("optional string field must be a string or null")
+    return value or None
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def normalize_message(message: str) -> str:
+    return " ".join(message.strip().split())
+
+
+def parse_mypy_output(output: str) -> list[MypyErrorRecord]:
+    records: list[MypyErrorRecord] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _ERROR_RE.match(line) or _NON_POSITION_ERROR_RE.match(line)
+        if match is None or match.group("severity") != "error":
+            continue
+        raw_line_number = match.groupdict().get("line")
+        raw_column = match.groupdict().get("column")
+        records.append(
+            MypyErrorRecord(
+                path=normalize_path(match.group("path")),
+                line=int(raw_line_number) if raw_line_number is not None else None,
+                column=int(raw_column) if raw_column is not None else None,
+                code=match.group("code") or None,
+                message=normalize_message(match.group("message")),
+            )
+        )
+    return normalize_records(records)
+
+
+def normalize_records(records: Iterable[MypyErrorRecord]) -> list[MypyErrorRecord]:
+    return sorted(records, key=lambda record: (record.path, record.line or -1, record.column or -1, record.code or "", record.message))
+
+
+def records_digest(records: Iterable[MypyErrorRecord]) -> str:
+    payload = [record.to_json() for record in normalize_records(records)]
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_manifest(*, records: Sequence[MypyErrorRecord], mypy_command: Sequence[str], mypy_version: str | None) -> dict[str, Any]:
+    normalized = normalize_records(records)
+    per_file = Counter(record.path for record in normalized)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": STABLE_GENERATED_AT,
+        "generator": "scripts.build_mypy_baseline",
+        "mypy_command": list(mypy_command),
+        "mypy_version": mypy_version or "unknown",
+        "total_error_count": len(normalized),
+        "affected_file_count": len(per_file),
+        "per_file_counts": {path: per_file[path] for path in sorted(per_file)},
+        "digest": records_digest(normalized),
+        "errors": [record.to_json() for record in normalized],
+    }
+
+
+def manifest_to_text(manifest: dict[str, Any]) -> str:
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"baseline not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"baseline is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("baseline manifest must be a JSON object")
+    validate_manifest(payload)
+    return payload
+
+
+def manifest_records(manifest: dict[str, Any]) -> list[MypyErrorRecord]:
+    errors = manifest.get("errors")
+    if not isinstance(errors, list):
+        raise ValueError("baseline errors must be a list")
+    return normalize_records(MypyErrorRecord.from_json(error) for error in errors)
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported mypy baseline schema_version")
+    records = manifest_records(manifest)
+    expected_digest = records_digest(records)
+    if manifest.get("digest") != expected_digest:
+        raise ValueError("baseline digest does not match normalized error records")
+    if manifest.get("total_error_count") != len(records):
+        raise ValueError("baseline total_error_count does not match errors")
+    affected = len({record.path for record in records})
+    if manifest.get("affected_file_count") != affected:
+        raise ValueError("baseline affected_file_count does not match errors")
+    per_file_counts = Counter(record.path for record in records)
+    expected_counts = {path: per_file_counts[path] for path in sorted(per_file_counts)}
+    if manifest.get("per_file_counts") != expected_counts:
+        raise ValueError("baseline per_file_counts does not match errors")
+
+
+def compare_records(*, baseline_records: Sequence[MypyErrorRecord], current_records: Sequence[MypyErrorRecord]) -> dict[str, Any]:
+    baseline = Counter(normalize_records(baseline_records))
+    current = Counter(normalize_records(current_records))
+    matched_count = sum((baseline & current).values())
+    new_counter = current - baseline
+    retired_counter = baseline - current
+    new_records = list(new_counter.elements())
+    retired_records = list(retired_counter.elements())
+    baseline_paths = {record.path for record in baseline}
+    affected_new_files = sorted({record.path for record in new_records if record.path not in baseline_paths})
+    status = _status_for(matched_count=matched_count, new_records=new_records, retired_records=retired_records, current_records=current_records)
+    return {
+        "status": status,
+        "matched_existing_errors": matched_count,
+        "new_errors": len(new_records),
+        "retired_errors": len(retired_records),
+        "affected_new_files": affected_new_files,
+        "current_error_count": len(current_records),
+        "baseline_error_count": len(baseline_records),
+        "new_error_records": [record.to_json() for record in normalize_records(new_records)[:50]],
+        "retired_error_records": [record.to_json() for record in normalize_records(retired_records)[:50]],
+    }
+
+
+def _status_for(*, matched_count: int, new_records: Sequence[MypyErrorRecord], retired_records: Sequence[MypyErrorRecord], current_records: Sequence[MypyErrorRecord]) -> str:
+    if new_records:
+        return STATUS_REGRESSION
+    if retired_records:
+        return STATUS_IMPROVED
+    if not current_records and matched_count == 0:
+        return STATUS_CLEAN
+    return STATUS_MATCHES

--- a/scripts/preflight_workspace_change_set.py
+++ b/scripts/preflight_workspace_change_set.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence, cast
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -45,11 +45,11 @@ def _output_path_is_safe(path_text: str) -> tuple[bool, str]:
 
 
 def _summary_text(payload: dict[str, object]) -> str:
-    summary = payload["summary"]  # type: ignore[index]
-    report = summary["preflight_report"]  # type: ignore[index]
-    manifest = summary["manifest"]  # type: ignore[index]
-    rollback = summary["rollback_plan"]  # type: ignore[index]
-    transaction = summary["transaction_plan"]  # type: ignore[index]
+    summary = cast(Mapping[str, Mapping[str, object]], payload["summary"])
+    report = summary["preflight_report"]
+    manifest = summary["manifest"]
+    rollback = summary["rollback_plan"]
+    transaction = summary["transaction_plan"]
     return "\n".join(
         [
             "SentientOS Workspace Change Set Preflight",

--- a/scripts/run_workspace_change_set_transaction.py
+++ b/scripts/run_workspace_change_set_transaction.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Iterable, Mapping, Sequence, cast
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -45,7 +45,7 @@ def _parse_target(value: str) -> tuple[str, str]:
 
 def _jsonify(value: object) -> object:
     if hasattr(value, "to_dict"):
-        return value.to_dict()  # type: ignore[no-any-return]
+        return cast(object, value.to_dict())
     if isinstance(value, tuple):
         return [_jsonify(item) for item in value]
     if isinstance(value, list):
@@ -55,12 +55,18 @@ def _jsonify(value: object) -> object:
     return value
 
 
+def _object_list(value: object) -> list[object]:
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, dict)):
+        return list(value)
+    return []
+
 def _summary_text(payload: dict[str, object]) -> str:
     if payload.get("dry_run"):
-        summary = payload["preflight"]["summary"]  # type: ignore[index]
-        report = summary["preflight_report"]  # type: ignore[index]
-        manifest = summary["manifest"]  # type: ignore[index]
-        transaction = summary["transaction_plan"]  # type: ignore[index]
+        preflight = cast(Mapping[str, Mapping[str, Mapping[str, object]]], payload["preflight"])
+        summary = preflight["summary"]
+        report = summary["preflight_report"]
+        manifest = summary["manifest"]
+        transaction = summary["transaction_plan"]
         return "\n".join([
             "SentientOS Workspace Change Set Transaction (dry-run)",
             f"manifest_status: {manifest['manifest_status']}",
@@ -71,21 +77,21 @@ def _summary_text(payload: dict[str, object]) -> str:
             "rollback_performed: false",
             "ledger_artifact_written: false",
         ])
-    execution = payload["execution_summary"]  # type: ignore[index]
-    receipt = payload["execution_receipt_summary"]  # type: ignore[index]
-    rollback = payload["rollback_summary"]  # type: ignore[index]
-    closure = payload["closure_summary"]  # type: ignore[index]
-    ledger = payload.get("ledger_summary")
-    artifact = payload.get("ledger_artifact") or {}
+    execution = cast(Mapping[str, object], payload["execution_summary"])
+    receipt = cast(Mapping[str, object], payload["execution_receipt_summary"])
+    rollback = cast(Mapping[str, object], payload["rollback_summary"])
+    closure = cast(Mapping[str, object], payload["closure_summary"])
+    ledger = cast(Mapping[str, object] | None, payload.get("ledger_summary"))
+    artifact = cast(Mapping[str, object], payload.get("ledger_artifact") or {})
     return "\n".join([
         "SentientOS Workspace Change Set Transaction",
         f"execution_status: {execution['execution_status']}",
         f"receipt_status: {receipt['receipt_status']}",
-        f"applied_target_ids: {list(execution['applied_target_ids'])}",
-        f"failed_target_ids: {list(execution['failed_target_ids'])}",
-        f"skipped_target_ids: {list(execution['skipped_target_ids'])}",
+        f"applied_target_ids: {_object_list(execution['applied_target_ids'])}",
+        f"failed_target_ids: {_object_list(execution['failed_target_ids'])}",
+        f"skipped_target_ids: {_object_list(execution['skipped_target_ids'])}",
         f"rollback_status: {rollback['rollback_status']}",
-        f"rollback_target_order: {list(rollback['rollback_target_order'])}",
+        f"rollback_target_order: {_object_list(rollback['rollback_target_order'])}",
         f"closure_status: {closure['closure_status']}",
         f"ledger_status: {ledger['lifecycle_status'] if ledger else 'not_requested'}",
         f"ledger_artifact_written: {bool(artifact.get('artifact_written'))}",

--- a/sentientos/workspace_change_set_execution.py
+++ b/sentientos/workspace_change_set_execution.py
@@ -200,7 +200,8 @@ def deterministic_digest(prefix: str, payload: Mapping[str, Any]) -> str:
 def _target_digest(path: Path) -> str | None:
     if not path.exists() or path.is_symlink() or not path.is_file():
         return None
-    return bytes_digest(path.read_bytes())
+    digest = bytes_digest(path.read_bytes())
+    return digest if isinstance(digest, str) else str(digest)
 
 
 def _normalize_relative(path_text: str) -> str:

--- a/sentientos/workspace_change_set_lifecycle_orchestrator.py
+++ b/sentientos/workspace_change_set_lifecycle_orchestrator.py
@@ -213,11 +213,11 @@ class WorkspaceChangeSetLifecycleOrchestrationWing(NamedTuple):
         return {
             "request": self.request.to_dict(),
             "result": self.result.to_dict(),
-            "admission": self.admission_wing.to_dict() if hasattr(self.admission_wing, "to_dict") else self.admission_wing,
+            "admission": _jsonable(self.admission_wing),
             "preflight": self.preflight_wing,
-            "execution": self.execution_wing._asdict() if hasattr(self.execution_wing, "_asdict") else self.execution_wing,
-            "verification": self.verification_wing._asdict() if hasattr(self.verification_wing, "_asdict") else self.verification_wing,
-            "closure": self.closure_wing._asdict() if hasattr(self.closure_wing, "_asdict") else self.closure_wing,
+            "execution": _jsonable(self.execution_wing),
+            "verification": _jsonable(self.verification_wing),
+            "closure": _jsonable(self.closure_wing),
         }
 
 
@@ -306,17 +306,18 @@ def build_workspace_change_set_lifecycle_orchestration_request(
 ) -> WorkspaceChangeSetLifecycleOrchestrationRequest:
     if mode not in LIFECYCLE_MODES:
         raise ValueError(f"unsupported lifecycle mode: {mode}")
-    body = {
+    proposal_digest = _digest("workspace-change-set-lifecycle-proposal-", _admission_metadata(proposal))
+    body: dict[str, str | None] = {
         "mode": mode,
         "workspace_root": str(workspace_root) if workspace_root is not None else None,
-        "proposal_digest": _digest("workspace-change-set-lifecycle-proposal-", _admission_metadata(proposal)),
+        "proposal_digest": proposal_digest,
         "created_at": created_at,
     }
     record = WorkspaceChangeSetLifecycleOrchestrationRequest(
         request_id="workspace-change-set-lifecycle-orchestration-" + hashlib.sha256(_canonical_json(body).encode("utf-8")).hexdigest()[:16],
         mode=mode,
         workspace_root=str(workspace_root) if workspace_root is not None else None,
-        proposal_digest=body["proposal_digest"],
+        proposal_digest=proposal_digest,
         proposed_target_count=len(_targets_payload(proposal)),
         stages_requested=MODE_STAGES[mode],
         admission_artifact_output_path=str(admission_artifact_output_path) if admission_artifact_output_path else None,

--- a/tests/test_mypy_baseline.py
+++ b/tests/test_mypy_baseline.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.mypy_baseline_common import (
+    DEFAULT_MYPY_COMMAND,
+    MypyErrorRecord,
+    STATUS_IMPROVED,
+    STATUS_INVALID,
+    STATUS_MATCHES,
+    STATUS_MISSING,
+    STATUS_REGRESSION,
+    build_manifest,
+    compare_records,
+    load_manifest,
+    manifest_to_text,
+    parse_mypy_output,
+    records_digest,
+)
+from scripts import build_mypy_baseline, check_mypy_baseline
+
+
+pytestmark = pytest.mark.no_legacy_skip
+
+WORKSPACE_TYPED_SURFACE_COMMAND = (
+    "python -m mypy --follow-imports=skip --hide-error-context --no-color-output --show-column-numbers "
+    "--show-error-codes sentientos/workspace_change_set_admission.py "
+    "scripts/admit_workspace_change_set.py sentientos/workspace_change_set_preflight.py "
+    "scripts/preflight_workspace_change_set.py sentientos/workspace_change_set_execution.py "
+    "scripts/run_workspace_change_set_transaction.py sentientos/workspace_change_set_execution_verification.py "
+    "scripts/verify_workspace_change_set_execution.py sentientos/workspace_change_set_lifecycle_closure.py "
+    "scripts/build_workspace_change_set_lifecycle_closure.py sentientos/workspace_change_set_lifecycle_orchestrator.py "
+    "scripts/run_workspace_change_set_lifecycle.py"
+)
+
+
+def test_parser_handles_normal_mypy_error_lines() -> None:
+    records = parse_mypy_output('sentientos/example.py:12: error: Incompatible return value type [return-value]\n')
+    assert records == [
+        MypyErrorRecord(
+            path="sentientos/example.py",
+            line=12,
+            column=None,
+            code="return-value",
+            message="Incompatible return value type",
+        )
+    ]
+
+
+def test_parser_handles_error_codes_and_columns() -> None:
+    records = parse_mypy_output('scripts/tool.py:7:9: error: Need type annotation for "x" [var-annotated]\n')
+    assert records[0].column == 9
+    assert records[0].code == "var-annotated"
+
+
+def test_parser_ignores_summary_notes_and_noise_lines() -> None:
+    output = "note: this is not an error\nFound 1 error in 1 file (checked 2 source files)\nscripts/tool.py:7:9: note: Revealed type is Any\n"
+    assert parse_mypy_output(output) == []
+
+
+def test_baseline_manifest_is_deterministic() -> None:
+    records = [
+        MypyErrorRecord("b.py", 2, None, "arg-type", "B"),
+        MypyErrorRecord("a.py", 1, 3, None, "A"),
+    ]
+    first = manifest_to_text(build_manifest(records=records, mypy_command=DEFAULT_MYPY_COMMAND, mypy_version="mypy 1.x"))
+    second = manifest_to_text(build_manifest(records=list(reversed(records)), mypy_command=DEFAULT_MYPY_COMMAND, mypy_version="mypy 1.x"))
+    assert first == second
+
+
+def test_digest_changes_when_normalized_errors_change() -> None:
+    first = records_digest([MypyErrorRecord("a.py", 1, None, None, "A")])
+    second = records_digest([MypyErrorRecord("a.py", 1, None, None, "B")])
+    assert first != second
+
+
+def test_check_passes_when_current_output_matches_baseline() -> None:
+    record = MypyErrorRecord("a.py", 1, None, "attr-defined", "A")
+    result = compare_records(baseline_records=[record], current_records=[record])
+    assert result["status"] == STATUS_MATCHES
+    assert result["new_errors"] == 0
+    assert result["matched_existing_errors"] == 1
+
+
+def test_check_reports_retired_errors_when_current_output_improves() -> None:
+    record = MypyErrorRecord("a.py", 1, None, "attr-defined", "A")
+    result = compare_records(baseline_records=[record], current_records=[])
+    assert result["status"] == STATUS_IMPROVED
+    assert result["retired_errors"] == 1
+
+
+def test_check_fails_when_new_errors_appear() -> None:
+    baseline = [MypyErrorRecord("a.py", 1, None, "attr-defined", "A")]
+    current = [*baseline, MypyErrorRecord("new_file.py", 2, 4, "return-value", "B")]
+    result = compare_records(baseline_records=baseline, current_records=current)
+    assert result["status"] == STATUS_REGRESSION
+    assert result["new_errors"] == 1
+    assert result["affected_new_files"] == ["new_file.py"]
+
+
+def test_check_fails_when_baseline_missing(tmp_path: Path, capsys) -> None:
+    exit_code = check_mypy_baseline.main(["--baseline", str(tmp_path / "missing.json"), "--current-output-file", str(tmp_path / "unused.txt")])
+    out = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert out["status"] == STATUS_MISSING
+
+
+def test_check_fails_when_baseline_invalid(tmp_path: Path, capsys) -> None:
+    baseline = tmp_path / "baseline.json"
+    current = tmp_path / "current.txt"
+    baseline.write_text('{"schema_version": 1, "digest": "bad", "errors": [], "total_error_count": 0, "affected_file_count": 0, "per_file_counts": {}}\n', encoding="utf-8")
+    current.write_text("", encoding="utf-8")
+    exit_code = check_mypy_baseline.main(["--baseline", str(baseline), "--current-output-file", str(current)])
+    out = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert out["status"] == STATUS_INVALID
+
+
+def test_explicit_baseline_refresh_updates_records_and_digest(tmp_path: Path) -> None:
+    output_file = tmp_path / "mypy.txt"
+    baseline = tmp_path / "baseline.json"
+    output_file.write_text("a.py:1: error: A [misc]\n", encoding="utf-8")
+    assert build_mypy_baseline.main(["--mypy-output-file", str(output_file), "--output", str(baseline)]) == 0
+    first = load_manifest(baseline)
+    output_file.write_text("a.py:1: error: B [misc]\n", encoding="utf-8")
+    assert build_mypy_baseline.main(["--mypy-output-file", str(output_file), "--output", str(baseline)]) == 0
+    second = load_manifest(baseline)
+    assert first["digest"] != second["digest"]
+    assert second["errors"][0]["message"] == "B"
+
+
+def test_reviewer_summary_is_compact_and_deterministic(tmp_path: Path, capsys) -> None:
+    output_file = tmp_path / "mypy.txt"
+    baseline = tmp_path / "baseline.json"
+    output_file.write_text("a.py:1: error: A [misc]\n", encoding="utf-8")
+    build_mypy_baseline.main(["--mypy-output-file", str(output_file), "--output", str(baseline)])
+    capsys.readouterr()
+    exit_code = check_mypy_baseline.main(["--baseline", str(baseline), "--current-output-file", str(output_file)])
+    summary = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert list(summary) == sorted(summary)
+    assert summary["status"] == STATUS_MATCHES
+    assert summary["matched_existing_errors"] == 1
+
+
+def test_targeted_typed_surface_command_remains_documented() -> None:
+    docs = Path("docs/architecture/mypy_baseline_ratchet.md").read_text(encoding="utf-8")
+    for token in WORKSPACE_TYPED_SURFACE_COMMAND.split():
+        assert token in docs
+
+
+def test_reviewer_index_links_are_updated() -> None:
+    index = Path("docs/index.md").read_text(encoding="utf-8")
+    quickstart = Path("docs/REVIEWER_QUICKSTART.md").read_text(encoding="utf-8")
+    assert "mypy_baseline_ratchet.md" in index
+    assert "mypy_baseline_ratchet.md" in quickstart

--- a/vow/mypy_baseline.json
+++ b/vow/mypy_baseline.json
@@ -1,0 +1,17787 @@
+{
+  "affected_file_count": 417,
+  "digest": "7ef587170d96b06edbfb222358970f6a3b88badb140a68ce7dde6f572abf117f",
+  "errors": [
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 101,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "admin_utils.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 72,
+      "line": 18,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "agents/forms/archive_util.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 22,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/browser_plan.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 37,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "agents/forms/browser_plan.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 12,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 16,
+      "message": "Function is missing a return type annotation",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 19,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 50,
+      "line": 25,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 39,
+      "line": 31,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 29,
+      "line": 37,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/oracle_session.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 17,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 18,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 19,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 21,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 22,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 23,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 48,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 53,
+      "message": "Function is missing a return type annotation",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 15,
+      "line": 60,
+      "message": "Call to untyped function \"_load_pdf\" in typed context",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 70,
+      "message": "Function is missing a return type annotation",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 73,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 49,
+      "line": 73,
+      "message": "Variable \"agents.forms.pdf_prep.PdfDict\" is not valid as a type",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 83,
+      "message": "Returning Any from function declared to return \"Iterable[PdfDict?]\"",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 46,
+      "line": 85,
+      "message": "Variable \"agents.forms.pdf_prep.PdfDict\" is not valid as a type",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 90,
+      "message": "PdfDict? has no attribute \"update\"",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 38,
+      "line": 92,
+      "message": "Variable \"agents.forms.pdf_prep.PdfDict\" is not valid as a type",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 93,
+      "message": "PdfDict? has no attribute \"get\"",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 155,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "agents/forms/pdf_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 17,
+      "message": "Function is missing a return type annotation",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 28,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 31,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 55,
+      "message": "Returning Any from function declared to return \"list[dict[Any, Any]]\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 39,
+      "line": 59,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 35,
+      "line": 65,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 68,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 45,
+      "line": 76,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/review_bundle.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 16,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "agents/forms/screenshot_plan.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "agents/forms/screenshot_plan.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 85,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "agents/forms/ssa_disability_agent.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 78,
+      "message": "Incompatible return value type (got \"str | None\", expected \"str\")",
+      "path": "avatar_state.py"
+    },
+    {
+      "code": "assignment",
+      "column": 33,
+      "line": 145,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 38,
+      "line": 777,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"candidate_id\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 20,
+      "line": 894,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"proposal\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 46,
+      "line": 895,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"candidate_id\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 938,
+      "message": "Returning Any from function declared to return \"AmendmentProposal\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 988,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 1004,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 1093,
+      "message": "\"SpecAmender\" has no attribute \"_update_preferences\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 1113,
+      "message": "\"SpecAmender\" has no attribute \"_update_preferences\"",
+      "path": "codex/amendments.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 293,
+      "message": "Unused \"type: ignore\" comment, use narrower [method-assign] instead of [assignment] code",
+      "path": "codex/autogenesis.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 294,
+      "message": "Unused \"type: ignore\" comment, use narrower [method-assign] instead of [assignment] code",
+      "path": "codex/autogenesis.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 222,
+      "message": "Returning Any from function declared to return \"Mapping[str, object]\"",
+      "path": "codex/gap_seeker.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 375,
+      "message": "Argument 1 to \"update\" of \"MutableMapping\" has incompatible type \"Mapping[str, object]\"; expected \"SupportsKeysAndGetItem[str, Collection[str]]\"",
+      "path": "codex/gap_seeker.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 74,
+      "line": 376,
+      "message": "Argument \"details\" to \"log\" of \"RecoveryLedger\" has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object] | None\"",
+      "path": "codex/gap_seeker.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 234,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", variable has type \"str\")",
+      "path": "codex/governance.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 34,
+      "line": 266,
+      "message": "Item \"None\" of \"CodexMetaStrategy | None\" has no attribute \"metadata\"",
+      "path": "codex/governance.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 64,
+      "line": 502,
+      "message": "Argument 2 to \"load_version\" of \"Implementor\" has incompatible type \"str | None\"; expected \"str\"",
+      "path": "codex/implementations.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 19,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "codex/integrity_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 129,
+      "message": "Argument \"required_fields\" to \"ProofVerifier\" has incompatible type \"set[str]\"; expected \"Sequence[str] | None\"",
+      "path": "codex/integrity_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 130,
+      "message": "Argument \"forbidden_statuses\" to \"ProofVerifier\" has incompatible type \"set[str]\"; expected \"Sequence[str] | None\"",
+      "path": "codex/integrity_daemon.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 537,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "codex/integrity_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 221,
+      "message": "Argument 1 to \"int\" has incompatible type \"Any | None\"; expected \"str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc\"",
+      "path": "codex/narratives.py"
+    },
+    {
+      "code": "assignment",
+      "column": 28,
+      "line": 291,
+      "message": "Incompatible types in assignment (expression has type \"StrategyConflict | None\", variable has type \"StrategyConflict\")",
+      "path": "codex/orchestrator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 13,
+      "line": 20,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type Module)",
+      "path": "codex/proof_budget_governor.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 13,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "codex/proof_verifier.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 144,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "codex/proof_verifier.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 16,
+      "message": "Unused \"type: ignore[misc]\" comment",
+      "path": "codex/scaffolds.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 55,
+      "line": 173,
+      "message": "Argument 1 to \"draft_from_scaffold\" of \"Implementor\" has incompatible type \"codex.scaffolds.SupportsSpecProposal\"; expected \"codex.implementations.SupportsSpecProposal\"",
+      "path": "codex/scaffolds.py"
+    },
+    {
+      "code": "assignment",
+      "column": 30,
+      "line": 234,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/scaffolds.py"
+    },
+    {
+      "code": "assignment",
+      "column": 33,
+      "line": 123,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/specs.py"
+    },
+    {
+      "code": "assignment",
+      "column": 42,
+      "line": 266,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, str]\", target has type \"str | None\")",
+      "path": "codex/specs.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 385,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/specs.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 27,
+      "line": 233,
+      "message": "Dict entry 0 has incompatible type \"str\": \"dict[str, Any]\"; expected \"str\": \"str | None\"",
+      "path": "codex/strategy.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 482,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any]\", target has type \"str\")",
+      "path": "codex/strategy.py"
+    },
+    {
+      "code": "assignment",
+      "column": 48,
+      "line": 634,
+      "message": "Incompatible types in assignment (expression has type \"str\", target has type \"bool\")",
+      "path": "codex/strategy.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 54,
+      "message": "Argument 2 to \"append_json\" has incompatible type \"MutableMapping[str, object]\"; expected \"dict[str, Any]\"",
+      "path": "control_plane/task_admission.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 37,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 38,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 28,
+      "line": 59,
+      "message": "\"object\" has no attribute \"review\"",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "operator",
+      "column": 13,
+      "line": 106,
+      "message": "Unsupported left operand type for + (\"object\")",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 55,
+      "line": 108,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "operator",
+      "column": 13,
+      "line": 109,
+      "message": "Unsupported left operand type for + (\"object\")",
+      "path": "curiosity_executor.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 28,
+      "line": 75,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 45,
+      "line": 76,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 101,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "assignment",
+      "column": 40,
+      "line": 110,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"Iterable[str]\")",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 160,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 189,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 243,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 246,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 255,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 256,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 68,
+      "line": 261,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 263,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 264,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 265,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "curiosity_goal_helper.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 29,
+      "message": "Unused \"type: ignore[misc]\" comment",
+      "path": "daemon_autonomy_supervisor.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 69,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "daemon_autonomy_supervisor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 17,
+      "line": 317,
+      "message": "Item \"None\" of \"AutonomyRuntime | None\" has no attribute \"record_readiness_success\"",
+      "path": "daemon_autonomy_supervisor.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 22,
+      "line": 331,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "daemon_autonomy_supervisor.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 21,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 23,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 26,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 28,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 31,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 33,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 36,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 38,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 88,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 69,
+      "line": 88,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 97,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, Any]\"; expected \"Turn\"",
+      "path": "demo_recorder.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 190,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 191,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 193,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "misc",
+      "column": 5,
+      "line": 193,
+      "message": "Cannot assign to a type",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "assignment",
+      "column": 16,
+      "line": 193,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"type[InotifyObserver]\")",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 194,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "misc",
+      "column": 5,
+      "line": 194,
+      "message": "Cannot assign to a type",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "assignment",
+      "column": 30,
+      "line": 194,
+      "message": "Incompatible types in assignment (expression has type \"type[object]\", variable has type \"type[FileSystemEventHandler]\")",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 203,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 203,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 11,
+      "line": 206,
+      "message": "Call to untyped function \"InotifyObserver\" in typed context",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 13,
+      "line": 212,
+      "message": "Call to untyped function \"schedule\" in typed context",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 5,
+      "line": 213,
+      "message": "Call to untyped function \"start\" in typed context",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 233,
+      "message": "\"object\" has no attribute \"stop\"",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 234,
+      "message": "\"object\" has no attribute \"join\"",
+      "path": "doctrine.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 71,
+      "line": 9,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "drift_report.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 124,
+      "message": "Incompatible return value type (got \"object\", expected \"int | None\")",
+      "path": "embodiment/silhouette.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 83,
+      "line": 196,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "embodiment/silhouette.py"
+    },
+    {
+      "code": "assignment",
+      "column": 5,
+      "line": 223,
+      "message": "Incompatible types in assignment (expression has type \"Mapping[str, object]\", variable has type \"dict[Any, Any]\")",
+      "path": "embodiment/silhouette.py"
+    },
+    {
+      "code": "assignment",
+      "column": 5,
+      "line": 231,
+      "message": "Incompatible types in assignment (expression has type \"Mapping[str, object]\", variable has type \"dict[Any, Any]\")",
+      "path": "embodiment/silhouette.py"
+    },
+    {
+      "code": "import-untyped",
+      "column": 1,
+      "line": 11,
+      "message": "Library stubs not installed for \"yaml\"",
+      "path": "emotion_fallback.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 35,
+      "message": "Returning Any from function declared to return \"list[dict[str, Any]]\"",
+      "path": "experiment_tracker.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 38,
+      "message": "Incompatible return value type (got \"Path | None\", expected \"Path\")",
+      "path": "final_approval.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 44,
+      "message": "Incompatible return value type (got \"Path | None\", expected \"Path\")",
+      "path": "final_approval.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 18,
+      "line": 122,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "godot_avatar_receiver.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 127,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "godot_avatar_receiver.py"
+    },
+    {
+      "code": "assignment",
+      "column": 21,
+      "line": 64,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type Module)",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "assignment",
+      "column": 22,
+      "line": 313,
+      "message": "Incompatible types in assignment (expression has type \"SentinelPolicy\", variable has type \"dict[str, object]\")",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 314,
+      "message": "\"dict[str, object]\" has no attribute \"enabled\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 315,
+      "message": "Argument 1 to \"save_policy\" of \"ContractSentinel\" has incompatible type \"dict[str, object]\"; expected \"SentinelPolicy\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "assignment",
+      "column": 22,
+      "line": 319,
+      "message": "Incompatible types in assignment (expression has type \"SentinelPolicy\", variable has type \"dict[str, object]\")",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 320,
+      "message": "\"dict[str, object]\" has no attribute \"enabled\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 321,
+      "message": "Argument 1 to \"save_policy\" of \"ContractSentinel\" has incompatible type \"dict[str, object]\"; expected \"SentinelPolicy\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "assignment",
+      "column": 22,
+      "line": 331,
+      "message": "Incompatible types in assignment (expression has type \"CompletedProcess[str]\", variable has type \"dict[str, Any]\")",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 332,
+      "message": "\"dict[str, Any]\" has no attribute \"stdout\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 38,
+      "line": 332,
+      "message": "\"dict[str, Any]\" has no attribute \"stderr\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 17,
+      "line": 373,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 11,
+      "line": 374,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 375,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 19,
+      "line": 377,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 392,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 393,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 394,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 32,
+      "line": 401,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 31,
+      "line": 402,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 21,
+      "line": 431,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 17,
+      "line": 435,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 436,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "assignment",
+      "column": 18,
+      "line": 483,
+      "message": "Incompatible types in assignment (expression has type \"CompletedProcess[str]\", variable has type \"dict[str, Any]\")",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 484,
+      "message": "\"dict[str, Any]\" has no attribute \"stdout\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 34,
+      "line": 484,
+      "message": "\"dict[str, Any]\" has no attribute \"stderr\"",
+      "path": "gui/cathedral_gui.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 10,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "gui/wdm_panel.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 12,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "gui/wdm_panel.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 35,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "hf_intake/classifier.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 59,
+      "line": 48,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "hf_intake/discovery.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 27,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "hf_intake/manifest.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 103,
+      "line": 102,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "hf_intake/manifest.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 27,
+      "line": 145,
+      "message": "Need type annotation for \"impacts\"",
+      "path": "integration_memory.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 79,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 43,
+      "line": 89,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 41,
+      "line": 120,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 125,
+      "message": "Returning Any from function declared to return \"dict[Any, Any] | None\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 45,
+      "line": 130,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 83,
+      "line": 135,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 35,
+      "line": 159,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 163,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 43,
+      "line": 174,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 25,
+      "line": 186,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 11,
+      "line": 201,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 15,
+      "line": 205,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 226,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 31,
+      "line": 304,
+      "message": "Incompatible types in assignment (expression has type \"bool\", target has type \"Collection[str]\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 31,
+      "line": 310,
+      "message": "Incompatible types in assignment (expression has type \"float\", target has type \"Collection[str]\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 31,
+      "line": 312,
+      "message": "Incompatible types in assignment (expression has type \"float\", target has type \"Collection[str]\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 29,
+      "line": 313,
+      "message": "Incompatible types in assignment (expression has type \"int\", target has type \"Collection[str]\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 315,
+      "message": "Argument 1 to \"add_emotion\" has incompatible type \"Collection[str]\"; expected \"dict[str, float]\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 322,
+      "message": "Function is missing a return type annotation",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 322,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "operator",
+      "column": 15,
+      "line": 375,
+      "message": "Unsupported left operand type for * (\"object\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "misc",
+      "column": 16,
+      "line": 376,
+      "message": "Generator has incompatible item type \"float | Any | str\"; expected \"bool\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "operator",
+      "column": 16,
+      "line": 376,
+      "message": "Unsupported operand types for * (\"float\" and \"str\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "operator",
+      "column": 16,
+      "line": 376,
+      "message": "Unsupported operand types for * (\"str\" and \"float\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "operator",
+      "column": 16,
+      "line": 376,
+      "message": "Unsupported operand types for * (\"str\" and \"str\")",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 380,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 31,
+      "line": 687,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 61,
+      "line": 726,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 741,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 50,
+      "line": 769,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 46,
+      "line": 811,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 833,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 17,
+      "line": 844,
+      "message": "Returning Any from function declared to return \"str | None\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 62,
+      "line": 851,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 12,
+      "line": 857,
+      "message": "Need type annotation for \"tags\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 45,
+      "line": 879,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 30,
+      "line": 880,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 889,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 911,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 946,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 13,
+      "line": 1031,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 13,
+      "line": 1032,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 11,
+      "line": 1123,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 15,
+      "line": 1127,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 1188,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 1191,
+      "message": "Returning Any from function declared to return \"list[dict[Any, Any]]\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 29,
+      "line": 1197,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 13,
+      "line": 1205,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 6,
+      "line": 1210,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 1233,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 31,
+      "line": 1250,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 20,
+      "line": 1257,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 15,
+      "line": 1261,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 51,
+      "line": 1282,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "memory_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 25,
+      "message": "Returning Any from function declared to return \"dict[str, list[dict[str, Any]]]\"",
+      "path": "notification.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 17,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"MappingProxyType\"",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 17,
+      "line": 46,
+      "message": "Missing type arguments for generic type \"MappingProxyType\"",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 191,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 194,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 199,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 202,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 214,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "misc",
+      "column": 9,
+      "line": 217,
+      "message": "Cannot assign to a type",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 218,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 219,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 220,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 221,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 231,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 234,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 235,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 243,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "misc",
+      "column": 9,
+      "line": 246,
+      "message": "Cannot assign to a type",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 247,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 254,
+      "message": "Function is missing a type annotation",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 257,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 571,
+      "message": "Argument 1 to \"run\" of \"BasePlugin\" has incompatible type \"MappingProxyType[str, Any]\"; expected \"dict[str, Any]\"",
+      "path": "plugin_framework.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 42,
+      "message": "Function is missing a return type annotation",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 51,
+      "message": "Function is missing a return type annotation",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 118,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 9,
+      "line": 177,
+      "message": "Call to untyped function \"_intent_record_module\" in typed context",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 29,
+      "line": 182,
+      "message": "Call to untyped function \"_affective_context_module\" in typed context",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "name-defined",
+      "column": 9,
+      "line": 297,
+      "message": "Name \"ac\" is not defined",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "name-defined",
+      "column": 9,
+      "line": 307,
+      "message": "Name \"ac\" is not defined",
+      "path": "policy_engine.py"
+    },
+    {
+      "code": "import-untyped",
+      "column": 1,
+      "line": 7,
+      "message": "Library stubs not installed for \"yaml\"",
+      "path": "privilege_lint/reporting/format_engines.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 51,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "privilege_lint/reporting/format_engines.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 72,
+      "message": "\"object\" has no attribute \"format_name\"",
+      "path": "privilege_lint/reporting/report_router.py"
+    },
+    {
+      "code": "misc",
+      "column": 38,
+      "line": 72,
+      "message": "Value expression in dictionary comprehension has incompatible type \"object\"; expected type \"FormatEngine\"",
+      "path": "privilege_lint/reporting/report_router.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 69,
+      "line": 495,
+      "message": "Argument 2 to \"request_approval\" has incompatible type \"**dict[str, list[str]]\"; expected \"str | None\"",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 68,
+      "line": 532,
+      "message": "Argument 2 to \"request_approval\" has incompatible type \"**dict[str, list[str]]\"; expected \"str | None\"",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 618,
+      "message": "Returning Any from function declared to return \"list[dict[str, Any]]\"",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 670,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 681,
+      "message": "Incompatible types in assignment (expression has type \"FileChangeTrigger\", variable has type \"IntervalTrigger\")",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 683,
+      "message": "Incompatible types in assignment (expression has type \"OnDemandTrigger\", variable has type \"IntervalTrigger\")",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 691,
+      "message": "Incompatible types in assignment (expression has type \"ConditionalTrigger\", variable has type \"IntervalTrigger\")",
+      "path": "reflex_manager.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 17,
+      "line": 85,
+      "message": "Returning Any from function declared to return \"dict[str, Any] | None\"",
+      "path": "relationship_log.py"
+    },
+    {
+      "code": "exit-return",
+      "column": 5,
+      "line": 129,
+      "message": "\"bool\" is invalid as return type for \"__exit__\" that always returns False",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 129,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 442,
+      "message": "Argument 1 to \"detect_drift\" has incompatible type \"list[dict[str, object]]\"; expected \"list[Mapping[str, object]] | None\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 470,
+      "message": "Argument 1 to \"_track_epoch_fields\" of \"ResidentKernel\" has incompatible type \"dict_keys[str, object]\"; expected \"tuple[str, ...] | list[str] | set[str]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 484,
+      "message": "Argument 1 to \"_track_epoch_fields\" of \"ResidentKernel\" has incompatible type \"dict_keys[str, object]\"; expected \"tuple[str, ...] | list[str] | set[str]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 9,
+      "line": 533,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"paused\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 9,
+      "line": 537,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"paused\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 545,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 41,
+      "line": 550,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 554,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 41,
+      "line": 557,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 561,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 37,
+      "line": 564,
+      "message": "Item \"None\" of \"_EpochSessionState | None\" has no attribute \"epoch_id\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 654,
+      "message": "Argument 1 to \"_hash_checkpoint_payload\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"str\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 655,
+      "message": "Argument 2 to \"_hash_checkpoint_payload\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 656,
+      "message": "Argument 3 to \"_hash_checkpoint_payload\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 663,
+      "message": "Argument 1 to \"_validate_checkpoint_payload\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 664,
+      "message": "Argument 2 to \"_validate_checkpoint_payload\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 666,
+      "message": "Argument 1 to \"_validate_restore_epoch\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"int\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "operator",
+      "column": 28,
+      "line": 706,
+      "message": "Unsupported operand types for < (\"int\" and \"object\")",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "operator",
+      "column": 28,
+      "line": 708,
+      "message": "Unsupported operand types for + (\"object\" and \"int\")",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 23,
+      "line": 718,
+      "message": "No overload variant of \"get\" of \"dict\" matches argument types \"object\", \"set[Never]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "operator",
+      "column": 26,
+      "line": 738,
+      "message": "Unsupported operand types for < (\"int\" and \"object\")",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 740,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 755,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str\")",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "assignment",
+      "column": 26,
+      "line": 758,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str\")",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 846,
+      "message": "Argument 1 to \"_validate_checkpoint_sensor_health\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, bool]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 847,
+      "message": "Argument 2 to \"_validate_checkpoint_sensor_health\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, bool]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 850,
+      "message": "Argument 1 to \"_validate_checkpoint_actuator_state\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, bool]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 851,
+      "message": "Argument 2 to \"_validate_checkpoint_actuator_state\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"str\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 78,
+      "line": 965,
+      "message": "Missing type arguments for generic type \"set\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 974,
+      "message": "Missing type arguments for generic type \"set\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 1055,
+      "message": "Argument 1 to \"_validate_sensor_health\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, bool]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 1062,
+      "message": "Argument 1 to \"_validate_actuator_state\" of \"ResidentKernel\" has incompatible type \"object\"; expected \"Mapping[str, bool]\"",
+      "path": "resident_kernel.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 173,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "ritual.py"
+    },
+    {
+      "code": "type-var",
+      "column": 20,
+      "line": 194,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"Any | None\"",
+      "path": "ritual.py"
+    },
+    {
+      "code": "type-var",
+      "column": 22,
+      "line": 195,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"Any | None\"",
+      "path": "ritual.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 197,
+      "message": "Argument 1 to \"join\" of \"str\" has incompatible type \"list[Any | None]\"; expected \"Iterable[str]\"",
+      "path": "ritual.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 199,
+      "message": "Argument 1 to \"join\" of \"str\" has incompatible type \"list[Any | None]\"; expected \"Iterable[str]\"",
+      "path": "ritual.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 82,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/apply_audit_repairs.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 287,
+      "message": "Argument \"status\" to \"render_result\" has incompatible type \"str\"; expected \"Literal['passed', 'failed', 'skipped', 'error', 'missing']\"",
+      "path": "scripts/audit_immutability_verifier.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 17,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/avatar_reflex.py"
+    },
+    {
+      "code": "assignment",
+      "column": 13,
+      "line": 19,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"Callable[[str, str | None, str | None, dict[str, float] | None, str | None], str | None]\")",
+      "path": "scripts/avatar_reflex.py"
+    },
+    {
+      "code": "truthy-function",
+      "column": 8,
+      "line": 31,
+      "message": "Function \"speak\" could always be true in boolean context",
+      "path": "scripts/avatar_reflex.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 33,
+      "message": "Argument 1 to \"iter_data_files\" has incompatible type \"list[str] | None\"; expected \"Iterable[str]\"",
+      "path": "scripts/benchmark_lint.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 221,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "scripts/bootstrap_trust_restore.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 27,
+      "message": "Function is missing a return type annotation",
+      "path": "scripts/build_host_embodiment_trace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 33,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/build_host_embodiment_trace.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 26,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/build_local_effect_transaction_ledger.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 25,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/build_workspace_file_transaction_ledger.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 119,
+      "message": "Argument 1 to \"_issues_by_code\" has incompatible type \"dict[str, list[AuditIssue]]\"; expected \"dict[str, list[dict[str, Any]]]\"",
+      "path": "scripts/capture_audit_baseline.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 122,
+      "message": "Argument 1 to \"_issue_tuples\" has incompatible type \"dict[str, list[AuditIssue]]\"; expected \"dict[str, list[dict[str, Any]]]\"",
+      "path": "scripts/capture_audit_baseline.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 39,
+      "message": "Returning Any from function declared to return \"Mapping[str, str]\"",
+      "path": "scripts/check_governance_drift.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 41,
+      "message": "Argument 1 to \"sorted\" has incompatible type \"list[AuditIssue]\"; expected \"Iterable[dict[str, Any]]\"",
+      "path": "scripts/converge_audits.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 69,
+      "message": "Argument 1 to \"_issue_tuples\" has incompatible type \"dict[str, list[AuditIssue]]\"; expected \"dict[str, list[dict[str, Any]]]\"",
+      "path": "scripts/detect_audit_drift.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 18,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/detect_federation_identity_drift.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 18,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/detect_perception_schema_drift.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 18,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/detect_pulse_schema_drift.py"
+    },
+    {
+      "code": "type-var",
+      "column": 25,
+      "line": 46,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"dict[str, Any]\"",
+      "path": "scripts/detect_pulse_schema_drift.py"
+    },
+    {
+      "code": "type-var",
+      "column": 27,
+      "line": 47,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"dict[str, Any]\"",
+      "path": "scripts/detect_pulse_schema_drift.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 18,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "scripts/detect_self_model_drift.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 62,
+      "message": "Returning Any from function declared to return \"dict[str, Any] | None\"",
+      "path": "scripts/editable_install.py"
+    },
+    {
+      "code": "redundant-cast",
+      "column": 12,
+      "line": 84,
+      "message": "Redundant cast to \"dict[str, Any]\"",
+      "path": "scripts/emit_baseline_verification_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 325,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 28,
+      "line": 326,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 354,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 355,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 37,
+      "line": 356,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 358,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 359,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 362,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 365,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 470,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 57,
+      "line": 471,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 472,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 22,
+      "line": 481,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 482,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 38,
+      "line": 508,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/emit_contract_status.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 88,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/emit_stability_doctrine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 102,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/expand_mode_sandbox.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 102,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/expand_mode_sandbox.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 255,
+      "message": "\"object\" has no attribute \"rstrip\"",
+      "path": "scripts/expand_mode_sandbox.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 32,
+      "message": "Returning Any from function declared to return \"dict[str, Any] | None\"",
+      "path": "scripts/export_manual_audit_issues.py"
+    },
+    {
+      "code": "import-untyped",
+      "column": 1,
+      "line": 14,
+      "message": "Library stubs not installed for \"yaml\"",
+      "path": "scripts/federation_puller.py"
+    },
+    {
+      "code": "import-untyped",
+      "column": 1,
+      "line": 13,
+      "message": "Library stubs not installed for \"yaml\"",
+      "path": "scripts/federation_stream_relay.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 29,
+      "message": "Name \"resolve_repo_root\" already defined (possibly by an import)",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "assignment",
+      "column": 21,
+      "line": 80,
+      "message": "Incompatible types in assignment (expression has type \"StrategicVerifyResult\", variable has type \"VerifyResult\")",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 163,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 261,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 287,
+      "message": "Returning Any from function declared to return \"int\"",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 12,
+      "line": 287,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/forge_replay.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 26,
+      "message": "Name \"resolve_repo_root\" already defined (possibly by an import)",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 180,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 181,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 37,
+      "line": 189,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 71,
+      "line": 195,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "index",
+      "column": 48,
+      "line": 253,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 315,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 330,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 331,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "index",
+      "column": 13,
+      "line": 371,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 379,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 395,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 396,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 413,
+      "message": "Returning Any from function declared to return \"int\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 12,
+      "line": 413,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/forge_status.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 26,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/formal_check.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 124,
+      "message": "Module \"sentientos.constitutional_mutation_fabric\" does not explicitly export attribute \"get_control_plane_kernel\"",
+      "path": "scripts/generate_immutable_manifest.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 37,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "scripts/generate_sbom.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 44,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "scripts/generate_sbom.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 75,
+      "message": "Argument 2 to \"_write_bom\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "scripts/generate_sbom.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 24,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "scripts/goal_progress.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 93,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "scripts/invariant_lint.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 191,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "scripts/invariant_lint.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 41,
+      "line": 15,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "scripts/migrate_embeddings.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 16,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "scripts/migrate_embeddings.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 88,
+      "message": "Returning Any from function declared to return \"int | None\"",
+      "path": "scripts/mypy_baseline_common.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 129,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/perception/screen_adapter.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 130,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/perception/screen_adapter.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 131,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/perception/screen_adapter.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 93,
+      "message": "Argument 1 to \"extend\" of \"list\" has incompatible type \"list[AuditIssue]\"; expected \"Iterable[dict[str, str]]\"",
+      "path": "scripts/plan_audit_repairs.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 99,
+      "message": "Argument 2 to \"_repair_for_path\" has incompatible type \"list[AuditIssue]\"; expected \"list[dict[str, str]]\"",
+      "path": "scripts/plan_audit_repairs.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 208,
+      "message": "Returning Any from function declared to return \"bool\"",
+      "path": "scripts/prepare_secondary_build.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 29,
+      "line": 339,
+      "message": "Item \"None\" of \"IO[str] | None\" has no attribute \"__iter__\" (not iterable)",
+      "path": "scripts/prepare_secondary_build.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 17,
+      "line": 344,
+      "message": "Item \"None\" of \"IO[str] | None\" has no attribute \"close\"",
+      "path": "scripts/prepare_secondary_build.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 518,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 520,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 522,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 524,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 16,
+      "line": 542,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "assignment",
+      "column": 37,
+      "line": 674,
+      "message": "Incompatible types in assignment (expression has type \"Any | None\", variable has type \"dict[str, int]\")",
+      "path": "scripts/protected_corridor.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 41,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 53,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 56,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 63,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 66,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 92,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 95,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 119,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "scripts/pytest_collection_reporter.py"
+    },
+    {
+      "code": "index",
+      "column": 13,
+      "line": 119,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "scripts/quarantine_clear.py"
+    },
+    {
+      "code": "index",
+      "column": 13,
+      "line": 122,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "scripts/quarantine_clear.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 31,
+      "line": 226,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"to_dict\"",
+      "path": "scripts/quarantine_clear.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 66,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 67,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 68,
+      "message": "\"object\" has no attribute \"findings\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 69,
+      "message": "\"object\" has no attribute \"findings\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 14,
+      "line": 70,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 8,
+      "line": 71,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 72,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 90,
+      "line": 73,
+      "message": "\"object\" has no attribute \"artifacts_written\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 107,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 155,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 57,
+      "line": 160,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 161,
+      "message": "\"object\" has no attribute \"status\"",
+      "path": "scripts/reconcile_audits.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 31,
+      "line": 30,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 106,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 38,
+      "line": 109,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 112,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 51,
+      "line": 152,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "assignment",
+      "column": 19,
+      "line": 193,
+      "message": "Incompatible types in assignment (expression has type \"Path\", variable has type \"str | None\")",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "operator",
+      "column": 24,
+      "line": 194,
+      "message": "Unsupported operand types for / (\"Path\" and \"None\")",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 199,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 46,
+      "line": 213,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 36,
+      "line": 215,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "scripts/remote_probe.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 26,
+      "line": 35,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "scripts/rotate_pulse_keys.py"
+    },
+    {
+      "code": "assignment",
+      "column": 62,
+      "line": 71,
+      "message": "Incompatible types in assignment (expression has type \"bool\", target has type \"dict[str, Any] | None\")",
+      "path": "scripts/run_builtin_runner_transaction.py"
+    },
+    {
+      "code": "assignment",
+      "column": 42,
+      "line": 72,
+      "message": "Incompatible types in assignment (expression has type \"str\", target has type \"dict[str, Any] | None\")",
+      "path": "scripts/run_builtin_runner_transaction.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 24,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 25,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 26,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 27,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 28,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 26,
+      "line": 31,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 24,
+      "line": 32,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 33,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 23,
+      "line": 34,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 34,
+      "line": 35,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 39,
+      "line": 36,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 36,
+      "line": 37,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 40,
+      "line": 38,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 33,
+      "line": 39,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 40,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 36,
+      "line": 41,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 34,
+      "line": 42,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 25,
+      "line": 43,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 36,
+      "line": 44,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 40,
+      "line": 45,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 45,
+      "line": 46,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 38,
+      "line": 47,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 35,
+      "line": 48,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 30,
+      "line": 49,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 42,
+      "line": 50,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "index",
+      "column": 38,
+      "line": 51,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_effect.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 27,
+      "message": "Returning Any from function declared to return \"dict[str, object]\"",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 31,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 32,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 33,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 34,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 35,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 38,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 24,
+      "line": 39,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 52,
+      "line": 40,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 41,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 36,
+      "line": 42,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 34,
+      "line": 43,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 36,
+      "line": 44,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 32,
+      "line": 45,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 38,
+      "line": 46,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 40,
+      "line": 47,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 39,
+      "line": 48,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 38,
+      "line": 49,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 44,
+      "line": 50,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 33,
+      "line": 51,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 52,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 25,
+      "line": 53,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 59,
+      "line": 54,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 30,
+      "line": 55,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 42,
+      "line": 56,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "index",
+      "column": 38,
+      "line": 57,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/run_local_diagnostic_rollback.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 82,
+      "message": "Argument 2 to \"append_task_record\" has incompatible type \"dict[str, list[dict[str, object]] | str]\"; expected \"dict[str, object]\"",
+      "path": "scripts/run_recovery_task.py"
+    },
+    {
+      "code": "assignment",
+      "column": 25,
+      "line": 810,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"Path\")",
+      "path": "scripts/run_tests.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 1027,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"Path\")",
+      "path": "scripts/run_tests.py"
+    },
+    {
+      "code": "assignment",
+      "column": 31,
+      "line": 1029,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"Path\")",
+      "path": "scripts/run_tests.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 27,
+      "line": 37,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "scripts/sign_strategic.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 25,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "scripts/strategic_propose.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 39,
+      "line": 26,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "scripts/strategic_propose.py"
+    },
+    {
+      "code": "index",
+      "column": 22,
+      "line": 34,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "scripts/strategic_propose.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 12,
+      "message": "Unused \"type: ignore\" comment, use narrower [import-untyped] instead of [import] code",
+      "path": "scripts/test_cathedral_boot.py"
+    },
+    {
+      "code": "redundant-cast",
+      "column": 12,
+      "line": 571,
+      "message": "Redundant cast to \"Literal['passed', 'failed', 'skipped', 'error', 'missing']\"",
+      "path": "scripts/tooling_status.py"
+    },
+    {
+      "code": "redundant-cast",
+      "column": 27,
+      "line": 1583,
+      "message": "Redundant cast to \"Literal['ACCEPT', 'WARN', 'REJECT']\"",
+      "path": "scripts/tooling_status.py"
+    },
+    {
+      "code": "redundant-cast",
+      "column": 14,
+      "line": 1703,
+      "message": "Redundant cast to \"Literal['overall_status', 'producer_type', 'redaction_profile', 'advisory_issues']\"",
+      "path": "scripts/tooling_status.py"
+    },
+    {
+      "code": "redundant-cast",
+      "column": 17,
+      "line": 1704,
+      "message": "Redundant cast to \"Literal['match', 'warn', 'reject']\"",
+      "path": "scripts/tooling_status.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 35,
+      "message": "Name \"resolve_repo_root\" already defined (possibly by an import)",
+      "path": "scripts/verify_audits.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 218,
+      "message": "Module \"audit_immutability\" does not explicitly export attribute \"_hash_entry\"",
+      "path": "scripts/verify_audits.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 72,
+      "line": 540,
+      "message": "Argument \"status\" to \"render_result\" has incompatible type \"str\"; expected \"Literal['passed', 'failed', 'skipped', 'error', 'missing']\"",
+      "path": "scripts/verify_audits.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 1254,
+      "message": "Argument 1 to \"_display_path\" has incompatible type \"Path | None\"; expected \"Path\"",
+      "path": "scripts/verify_context_hygiene_prompt_boundaries.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 11,
+      "message": "Name \"HASH_ALGO\" already defined (possibly by an import)",
+      "path": "scripts/verify_pressure_state_chain.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 11,
+      "message": "Name \"canonical_json_bytes\" already defined (possibly by an import)",
+      "path": "scripts/verify_pressure_state_chain.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 23,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "semantic_embeddings.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 25,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "semantic_embeddings.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 28,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "semantic_embeddings.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 76,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "semantic_embeddings.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 79,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/__main__.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 123,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/__main__.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 105,
+      "message": "Argument \"pressure_reason\" to \"log\" of \"AutonomyActionLogger\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/actuators/gui_control.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 106,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/actuators/gui_control.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 106,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"Sequence[str] | None\"",
+      "path": "sentientos/actuators/gui_control.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 106,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"float\"",
+      "path": "sentientos/actuators/gui_control.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 85,
+      "line": 10,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 17,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 31,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 32,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 42,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 46,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 11,
+      "line": 80,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 20,
+      "line": 88,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 89,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/adjudication/truth_tribunal.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 102,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/admin_utils.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 55,
+      "message": "\"object\" has no attribute \"open\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 61,
+      "message": "\"object\" has no attribute \"click\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 70,
+      "message": "\"object\" has no attribute \"type\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 79,
+      "message": "\"object\" has no attribute \"type\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 132,
+      "message": "Argument \"pressure_reason\" to \"log\" of \"AutonomyActionLogger\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 133,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 133,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"Sequence[str] | None\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 133,
+      "message": "Argument 11 to \"log\" of \"AutonomyActionLogger\" has incompatible type \"**dict[str, object]\"; expected \"float\"",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 21,
+      "line": 174,
+      "message": "Incompatible types in assignment (expression has type \"tuple[str, str, str]\", variable has type \"tuple[str, str]\")",
+      "path": "sentientos/agents/browser_automator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 46,
+      "line": 180,
+      "message": "Argument 3 to \"_evaluate_rule\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 196,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 204,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 207,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 223,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 237,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 255,
+      "message": "\"object\" has no attribute \"ok\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 256,
+      "message": "\"object\" has no attribute \"message\"",
+      "path": "sentientos/alerts.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 15,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/analysis/pattern_volatility.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 30,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/analysis/pattern_volatility.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 74,
+      "line": 49,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/analysis/pattern_volatility.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 18,
+      "line": 50,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/analysis/pattern_volatility.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 23,
+      "message": "Argument 2 to \"_write_status\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 24,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], None]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 28,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", variable has type \"dict[str, str | None]\")",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 30,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", variable has type \"dict[str, str | None]\")",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 31,
+      "message": "Argument 2 to \"_write_status\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 34,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], str]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 35,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], None]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/anchor_witness.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 89,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 100,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 131,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 19,
+      "line": 132,
+      "message": "Argument \"links\" to \"append_catalog_entry\" has incompatible type \"object\"; expected \"dict[str, object] | None\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 133,
+      "message": "Argument \"summary\" to \"append_catalog_entry\" has incompatible type \"object\"; expected \"dict[str, object] | None\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 85,
+      "line": 148,
+      "message": "Argument 1 to \"_safe_ts\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 165,
+      "message": "Argument 2 to \"normalize\" has incompatible type \"str | None\"; expected \"str\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 34,
+      "line": 257,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 299,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/artifact_catalog.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 74,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/attestation_snapshot.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 140,
+      "message": "Argument 1 to \"safe_ts\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/attestation_snapshot.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 31,
+      "line": 168,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/attestation_snapshot.py"
+    },
+    {
+      "code": "index",
+      "column": 16,
+      "line": 232,
+      "message": "Value of type \"str | None\" is not indexable",
+      "path": "sentientos/attestation_snapshot.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 31,
+      "message": "Incompatible return value type (got \"str\", expected \"Literal['baseline', 'runtime', 'both']\")",
+      "path": "sentientos/audit_sink.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 50,
+      "message": "Incompatible return value type (got \"dict[str, Collection[Collection[str]]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 72,
+      "message": "Incompatible return value type (got \"dict[str, Collection[Collection[str]]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 163,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 184,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 36,
+      "line": 184,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 208,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 36,
+      "line": 208,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 216,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 36,
+      "line": 216,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 307,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 313,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 316,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 36,
+      "line": 316,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 335,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "return-value",
+      "column": 36,
+      "line": 335,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 364,
+      "message": "Argument 1 to \"update\" of \"set\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 366,
+      "message": "Argument 1 to \"update\" of \"set\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 379,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 380,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 396,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 397,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 398,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 23,
+      "line": 401,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/authority_surface.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 96,
+      "line": 78,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/auto_remediation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 13,
+      "line": 98,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/auto_remediation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 71,
+      "line": 152,
+      "message": "\"AuditChainVerification\" has no attribute \"valid\"",
+      "path": "sentientos/auto_remediation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 73,
+      "line": 157,
+      "message": "\"ReceiptChainVerification\" has no attribute \"valid\"",
+      "path": "sentientos/auto_remediation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 74,
+      "line": 162,
+      "message": "\"AnchorVerification\" has no attribute \"valid\"",
+      "path": "sentientos/auto_remediation.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 221,
+      "message": "Item \"object\" of \"object | Any\" has no attribute \"get\"",
+      "path": "sentientos/autonomy/audit.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 57,
+      "line": 223,
+      "message": "Argument 1 to \"float\" has incompatible type \"object | Any\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/autonomy/audit.py"
+    },
+    {
+      "code": "assignment",
+      "column": 33,
+      "line": 301,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", target has type \"list[str] | str\")",
+      "path": "sentientos/autonomy/audit.py"
+    },
+    {
+      "code": "valid-type",
+      "column": null,
+      "line": 29,
+      "message": "Bracketed expression \"[...]\" is not valid as a type",
+      "path": "sentientos/autonomy/conversation_triggers.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 16,
+      "line": 29,
+      "message": "Function \"builtins.callable\" is not valid as a type",
+      "path": "sentientos/autonomy/conversation_triggers.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 13,
+      "line": 58,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/autonomy/rehearsal.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 94,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 108,
+      "message": "Argument \"mood\" to \"ContinuitySnapshot\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 109,
+      "message": "Argument \"readiness\" to \"ContinuitySnapshot\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 29,
+      "line": 110,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 32,
+      "line": 111,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 112,
+      "message": "Argument \"last_readiness_ts\" to \"ContinuitySnapshot\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/autonomy/state.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 114,
+      "message": "\"type[CodexHealer]\" has no attribute \"monitor\"",
+      "path": "sentientos/boot_ceremony.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 129,
+      "message": "\"type[IntegrityDaemon]\" has no attribute \"guard\"",
+      "path": "sentientos/boot_ceremony.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 133,
+      "message": "\"type[CodexHealer]\" has no attribute \"monitor\"",
+      "path": "sentientos/boot_ceremony.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 9,
+      "line": 137,
+      "message": "Missing positional arguments \"self\", \"telemetry_streams\", \"vows\" in call to \"expand\" of \"GenesisForge\"",
+      "path": "sentientos/boot_ceremony.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 87,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/boot_chronicler.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 143,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/boot_chronicler.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 284,
+      "message": "Name \"wildcard_delete_performed\" already defined on line 272",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 369,
+      "message": "Returning Any from function declared to return \"Mapping[str, Any]\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 371,
+      "message": "Returning Any from function declared to return \"Mapping[str, Any]\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 374,
+      "message": "Returning Any from function declared to return \"Mapping[str, Any]\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 404,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 19,
+      "line": 661,
+      "message": "Incompatible types in assignment (expression has type \"LocalDiagnosticExactRollbackWingRecords\", variable has type \"LocalDiagnosticEffectWingRecords\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 12,
+      "line": 663,
+      "message": "\"LocalDiagnosticEffectResult\" has no attribute \"rollback_status\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 667,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"audit_receipt\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 670,
+      "message": "Incompatible types in assignment (expression has type \"tuple[LocalDiagnosticEffectReceipt, LocalDiagnosticPostconditionCheck, Any]\", variable has type \"tuple[LocalDiagnosticEffectReceipt, LocalDiagnosticPostconditionCheck, LocalDiagnosticProductionAuditReceipt, LocalDiagnosticRollbackPlan]\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 67,
+      "line": 670,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"audit_receipt\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 671,
+      "message": "\"LocalDiagnosticEffectResult\" has no attribute \"rollback_status\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 101,
+      "line": 671,
+      "message": "\"LocalDiagnosticEffectResult\" has no attribute \"real_rollback_performed\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 19,
+      "line": 677,
+      "message": "Incompatible types in assignment (expression has type \"WorkspaceFileEffectWingResult\", variable has type \"LocalDiagnosticEffectWingRecords\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 44,
+      "line": 690,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"preimage\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 693,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"postcondition\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 52,
+      "line": 695,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"production_audit\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 698,
+      "message": "Incompatible types in assignment (expression has type \"tuple[Any, LocalDiagnosticEffectReceipt, Any, Any, LocalDiagnosticRollbackPlan]\", variable has type \"tuple[LocalDiagnosticEffectReceipt, LocalDiagnosticPostconditionCheck, LocalDiagnosticProductionAuditReceipt, LocalDiagnosticRollbackPlan]\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 698,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"preimage\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 698,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"postcondition\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 79,
+      "line": 698,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"production_audit\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 288,
+      "line": 701,
+      "message": "\"LocalDiagnosticEffectResult\" has no attribute \"target_path\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 26,
+      "line": 710,
+      "message": "Incompatible types in assignment (expression has type \"WorkspaceFileEffectReceipt\", variable has type \"dict[str, Any]\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 25,
+      "line": 711,
+      "message": "Incompatible types in assignment (expression has type \"WorkspaceFileRollbackPlan\", variable has type \"dict[str, Any]\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 19,
+      "line": 712,
+      "message": "Incompatible types in assignment (expression has type \"WorkspaceFileRollbackWingResult\", variable has type \"LocalDiagnosticEffectWingRecords\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 712,
+      "message": "Argument \"effect_receipt\" to \"run_workspace_file_rollback_wing\" has incompatible type \"dict[str, Any]\"; expected \"WorkspaceFileEffectReceipt\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 97,
+      "line": 712,
+      "message": "Argument \"rollback_plan\" to \"run_workspace_file_rollback_wing\" has incompatible type \"dict[str, Any]\"; expected \"WorkspaceFileRollbackPlan\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 12,
+      "line": 713,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 51,
+      "line": 715,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 64,
+      "line": 717,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_postcondition\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 50,
+      "line": 718,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"production_audit\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 721,
+      "message": "Incompatible types in assignment (expression has type \"tuple[Any, LocalDiagnosticRollbackReceipt, Any, Any]\", variable has type \"tuple[LocalDiagnosticEffectReceipt, LocalDiagnosticPostconditionCheck, LocalDiagnosticProductionAuditReceipt, LocalDiagnosticRollbackPlan]\")",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 721,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 72,
+      "line": 721,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_postcondition\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 104,
+      "line": 721,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"production_audit\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 722,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 214,
+      "line": 724,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 165,
+      "line": 726,
+      "message": "\"LocalDiagnosticEffectWingRecords\" has no attribute \"rollback_result\"",
+      "path": "sentientos/builtin_local_effect_runner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 425,
+      "message": "Returning Any from function declared to return \"dict[str, Any] | None\"",
+      "path": "sentientos/builtin_runner_transaction_orchestrator.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 71,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/cathedral/amendment.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 79,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/cathedral/amendment.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 79,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "sentientos/cathedral/amendment.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 87,
+      "message": "Argument 3 to \"_record_hold\" of \"AmendmentSentinel\" has incompatible type \"CouncilVote\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/cathedral/amendment_sentinel.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 192,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/cathedral/apply.py"
+    },
+    {
+      "code": "index",
+      "column": 21,
+      "line": 230,
+      "message": "Unsupported target for indexed assignment (\"Mapping[Any, Any]\")",
+      "path": "sentientos/cathedral/apply.py"
+    },
+    {
+      "code": "index",
+      "column": 21,
+      "line": 238,
+      "message": "Unsupported target for indexed assignment (\"Mapping[Any, Any]\")",
+      "path": "sentientos/cathedral/apply.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 52,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/cathedral/federation_guard.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 9,
+      "line": 108,
+      "message": "Name \"errors\" already defined on line 74",
+      "path": "sentientos/cathedral/rollback.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 244,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/cathedral/rollback.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 166,
+      "message": "Argument 1 to \"_contains_raw_code\" has incompatible type \"Any | None\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/cathedral/validator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 169,
+      "message": "Argument 1 to \"_validate_change_grammar\" has incompatible type \"Any | None\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/cathedral/validator.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 32,
+      "line": 171,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "sentientos/cathedral/validator.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 172,
+      "message": "Item \"None\" of \"Any | None\" has no attribute \"get\"",
+      "path": "sentientos/cathedral/validator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 51,
+      "line": 352,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"dict[str, object] | None\")",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 423,
+      "message": "Incompatible types in assignment (expression has type \"TransactionSnapshot\", variable has type \"CiBaselineSnapshot | None\")",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 42,
+      "line": 424,
+      "message": "Item \"CiBaselineSnapshot\" of \"CiBaselineSnapshot | None\" has no attribute \"ci_baseline\"",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 42,
+      "line": 424,
+      "message": "Item \"None\" of \"CiBaselineSnapshot | None\" has no attribute \"ci_baseline\"",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 442,
+      "message": "Argument 1 to \"compare_snapshots\" has incompatible type \"TransactionSnapshot | None\"; expected \"TransactionSnapshot\"",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 443,
+      "message": "Argument 2 to \"compare_snapshots\" has incompatible type \"CiBaselineSnapshot | None\"; expected \"TransactionSnapshot\"",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 68,
+      "line": 565,
+      "message": "Argument 1 to \"snapshot_to_report_dict\" has incompatible type \"CiBaselineSnapshot | None\"; expected \"TransactionSnapshot | None\"",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "assignment",
+      "column": 51,
+      "line": 586,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"dict[str, object] | None\")",
+      "path": "sentientos/cathedral_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 215,
+      "message": "Argument 1 to \"_parse_iso_timestamp\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 220,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 38,
+      "line": 221,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 235,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 236,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 245,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 247,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 362,
+      "message": "Returning Any from function declared to return \"MutableMapping[str, object]\"",
+      "path": "sentientos/change_narrator.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 19,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "sentientos/chaos.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 95,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "sentientos/chaos.py"
+    },
+    {
+      "code": "assignment",
+      "column": 24,
+      "line": 21,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"ChangeNarrator\")",
+      "path": "sentientos/chat_service.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 72,
+      "message": "Returning Any from function declared to return \"dict[str, object]\"",
+      "path": "sentientos/cli/ois_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 43,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/cli/trace_cli.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 54,
+      "message": "Incompatible return value type (got \"dict[str, int]\", expected \"dict[str, object]\")",
+      "path": "sentientos/codex/codex_context_pruner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 85,
+      "line": 12,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/retraining_prep.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 19,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/retraining_prep.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 32,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/codex/retraining_prep.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 6,
+      "line": 56,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/retraining_prep.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 65,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/retraining_prep.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 34,
+      "line": 38,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/scorekeeper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 93,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/scorekeeper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 48,
+      "line": 109,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/scorekeeper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 110,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/scorekeeper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 58,
+      "line": 123,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/scorekeeper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 9,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 12,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 86,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 17,
+      "line": 25,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 68,
+      "line": 49,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 61,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 62,
+      "line": 95,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 109,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 114,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 121,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 55,
+      "line": 138,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 46,
+      "line": 144,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/codex/self_training_daemon.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 59,
+      "message": "Incompatible return value type (got \"dict[str, Collection[str]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/codex_healer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 57,
+      "line": 116,
+      "message": "Argument 1 to \"_extract_proof_summary\" of \"RecoveryLedger\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/codex_healer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 77,
+      "line": 117,
+      "message": "Argument 1 to \"_extract_canonical_admission_linkage\" of \"RecoveryLedger\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/codex_healer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 406,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/codex_healer.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 21,
+      "line": 210,
+      "message": "Returning Any from function declared to return \"str | None\"",
+      "path": "sentientos/codex_startup_guard.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 250,
+      "message": "Argument 1 to \"int\" has incompatible type \"str | None\"; expected \"str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc\"",
+      "path": "sentientos/config.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 22,
+      "line": 261,
+      "message": "Argument 1 to \"float\" has incompatible type \"str | None\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/config.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 64,
+      "message": "Missing type arguments for generic type \"tuple\"",
+      "path": "sentientos/consciousness/attention_arbitrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 54,
+      "line": 140,
+      "message": "Argument 1 to \"get\" of \"dict\" has incompatible type \"str | None\"; expected \"str\"",
+      "path": "sentientos/consciousness/attention_arbitrator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 33,
+      "line": 212,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str | None\")",
+      "path": "sentientos/consciousness/attention_arbitrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 16,
+      "line": 110,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/consciousness/cognitive_posture.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 140,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/consciousness/cognitive_posture.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 140,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/consciousness/cognitive_state.py"
+    },
+    {
+      "code": "return-value",
+      "column": 50,
+      "line": 140,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/consciousness/cognitive_state.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 156,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/consciousness/cognitive_state.py"
+    },
+    {
+      "code": "return-value",
+      "column": 45,
+      "line": 156,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/consciousness/cognitive_state.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 202,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/consciousness/cognitive_state.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 21,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/consciousness/cycle_gate.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 201,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/consciousness/inner_narrator.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 40,
+      "line": 37,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 28,
+      "line": 43,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 110,
+      "message": "Argument \"path\" to \"build_forget_pressure_snapshot\" has incompatible type \"object\"; expected \"Path | str\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 147,
+      "message": "Incompatible return value type (got \"Mapping[Any, Any] | None\", expected \"dict[str, object] | None\")",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 170,
+      "message": "Incompatible return value type (got \"Mapping[Any, Any] | None\", expected \"dict[str, object] | None\")",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 183,
+      "message": "Argument 1 to \"_coerce_mapping\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 184,
+      "message": "Argument 1 to \"_coerce_mapping\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 201,
+      "message": "Returning Any from function declared to return \"str | None\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 202,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 202,
+      "message": "Returning Any from function declared to return \"str | None\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 28,
+      "line": 270,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/consciousness/integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 29,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/consciousness/recursion_guard.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 23,
+      "line": 60,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 65,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 95,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 96,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 152,
+      "message": "Argument \"path\" to \"update\" has incompatible type \"str | None\"; expected \"Path | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 162,
+      "message": "Argument \"path\" to \"load\" has incompatible type \"str | None\"; expected \"Path | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 178,
+      "message": "Argument \"attention_hint\" to \"_update_self_model\" of \"SentienceKernel\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 179,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 186,
+      "message": "\"object\" has no attribute \"update\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 197,
+      "message": "Argument \"attention_hint\" to \"_update_self_model\" of \"SentienceKernel\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 198,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 206,
+      "message": "Argument 2 to \"emit_goal_event\" of \"SentienceKernel\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 213,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 218,
+      "message": "Argument \"attention_hint\" to \"_update_self_model\" of \"SentienceKernel\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 22,
+      "line": 224,
+      "message": "Argument \"goal\" to \"KernelProposal\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 226,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/consciousness/sentience_kernel.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 28,
+      "message": "Returning Any from function declared to return \"bool\"",
+      "path": "sentientos/context_hygiene/pollution_guard.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 82,
+      "line": 439,
+      "message": "Argument 1 to \"external_security_review_packet_ready_for_review\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 72,
+      "line": 510,
+      "message": "Argument 1 to \"compute_external_security_review_packet_digest\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 63,
+      "line": 521,
+      "message": "Argument 1 to \"external_security_review_packet_ready_for_review\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 77,
+      "line": 523,
+      "message": "Argument 1 to \"external_security_review_packet_is_metadata_only\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 88,
+      "line": 525,
+      "message": "Argument 1 to \"external_security_review_packet_preserves_invocation_denial\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 84,
+      "line": 527,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_prompt_text\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 80,
+      "line": 529,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_secrets\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 82,
+      "line": 531,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_endpoints\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 80,
+      "line": 533,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_clients\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 88,
+      "line": 535,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_network_handles\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 90,
+      "line": 537,
+      "message": "Argument 1 to \"external_security_review_packet_contains_no_runtime_authority\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 118,
+      "line": 605,
+      "message": "Argument 1 to \"external_security_review_packet_preserves_invocation_denial\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 616,
+      "message": "Argument 44 to \"ExternalAuditExportReceipt\" has incompatible type \"**dict[str, bool]\"; expected \"str\"",
+      "path": "sentientos/context_hygiene/prompt_external_audit_export.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 115,
+      "line": 845,
+      "message": "Argument 1 to \"provider_invocation_denial_review_remains_metadata_only\" has incompatible type \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_external_security_review.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 851,
+      "message": "Argument 39 to \"ExternalSecurityReviewPacket\" has incompatible type \"**dict[str, bool]\"; expected \"str\"",
+      "path": "sentientos/context_hygiene/prompt_external_security_review.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 852,
+      "message": "Argument 40 to \"ExternalSecurityReviewPacket\" has incompatible type \"**dict[str, bool]\"; expected \"str\"",
+      "path": "sentientos/context_hygiene/prompt_external_security_review.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 112,
+      "message": "Returning Any from function declared to return \"Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_handoff_manifest.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 455,
+      "message": "Argument 1 to \"policy_decision_requires_operator_review\" has incompatible type \"Any | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_internal_candidate.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 63,
+      "line": 458,
+      "message": "Argument 1 to \"policy_decision_allows_internal_candidate_no_llm\" has incompatible type \"Any | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_internal_candidate.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 109,
+      "line": 620,
+      "message": "Argument 1 to \"_review_required\" has incompatible type \"Collection[str]\"; expected \"Mapping[str, Any] | str\"",
+      "path": "sentientos/context_hygiene/prompt_materialization_policy.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 478,
+      "message": "Argument 1 to \"internal_prompt_candidate_is_operator_visible_only\" has incompatible type \"InternalPromptCandidate | Mapping[str, Any] | None\"; expected \"InternalPromptCandidate | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 480,
+      "message": "Argument 1 to \"internal_prompt_candidate_is_no_llm\" has incompatible type \"InternalPromptCandidate | Mapping[str, Any] | None\"; expected \"InternalPromptCandidate | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 482,
+      "message": "Argument 1 to \"internal_prompt_candidate_contains_no_raw_payloads\" has incompatible type \"InternalPromptCandidate | Mapping[str, Any] | None\"; expected \"InternalPromptCandidate | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 484,
+      "message": "Argument 1 to \"internal_prompt_candidate_has_no_runtime_authority\" has incompatible type \"InternalPromptCandidate | Mapping[str, Any] | None\"; expected \"InternalPromptCandidate | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 486,
+      "message": "Argument 1 to \"internal_prompt_candidate_has_no_tool_or_action_capability\" has incompatible type \"InternalPromptCandidate | Mapping[str, Any] | None\"; expected \"InternalPromptCandidate | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 509,
+      "message": "Argument 1 to \"validate_internal_prompt_display_receipt\" has incompatible type \"InternalPromptDisplayReceipt | Mapping[str, Any] | None\"; expected \"InternalPromptDisplayReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 59,
+      "line": 511,
+      "message": "Argument 1 to \"internal_prompt_candidate_may_be_displayed\" has incompatible type \"InternalPromptDisplayReceipt | Mapping[str, Any] | None\"; expected \"InternalPromptDisplayReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 513,
+      "message": "Argument 1 to \"internal_prompt_display_preserves_candidate_digest\" has incompatible type \"InternalPromptDisplayReceipt | Mapping[str, Any] | None\"; expected \"InternalPromptDisplayReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 60,
+      "line": 515,
+      "message": "Argument 1 to \"internal_prompt_display_has_no_model_egress\" has incompatible type \"InternalPromptDisplayReceipt | Mapping[str, Any] | None\"; expected \"InternalPromptDisplayReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 65,
+      "line": 517,
+      "message": "Argument 1 to \"internal_prompt_display_has_no_runtime_authority\" has incompatible type \"InternalPromptDisplayReceipt | Mapping[str, Any] | None\"; expected \"InternalPromptDisplayReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 65,
+      "line": 523,
+      "message": "Argument 1 to \"policy_decision_allows_internal_candidate_no_llm\" has incompatible type \"PromptMaterializationPolicyDecision | Mapping[str, Any] | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 57,
+      "line": 531,
+      "message": "Argument 1 to \"audit_receipt_allows_shadow_materializer\" has incompatible type \"PromptMaterializationAuditReceipt | Mapping[str, Any] | None\"; expected \"PromptMaterializationAuditReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_model_call_preflight.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 71,
+      "line": 413,
+      "message": "Argument 1 to \"external_security_review_packet_ready_for_review\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 86,
+      "line": 414,
+      "message": "Argument 1 to \"provider_invocation_denial_review_affirms_forbidden_invocation\" has incompatible type \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 415,
+      "message": "Argument 1 to \"provider_invocation_readiness_forbids_invocation\" has incompatible type \"ProviderInvocationReadinessManifest | Mapping[str, Any] | None\"; expected \"ProviderInvocationReadinessManifest | ProviderInvocationReadinessPreflight | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 84,
+      "line": 418,
+      "message": "Argument 1 to \"external_audit_export_receipt_ready_for_export_review\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 71,
+      "line": 481,
+      "message": "Argument 1 to \"compute_external_audit_export_receipt_digest\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 144,
+      "line": 488,
+      "message": "Argument 1 to \"external_audit_export_receipt_ready_for_export_review\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 76,
+      "line": 490,
+      "message": "Argument 1 to \"external_audit_export_receipt_is_metadata_only\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 492,
+      "message": "Argument 1 to \"external_audit_export_receipt_does_not_export\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 87,
+      "line": 494,
+      "message": "Argument 1 to \"external_audit_export_receipt_preserves_invocation_denial\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 83,
+      "line": 496,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_prompt_text\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 79,
+      "line": 498,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_secrets\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 81,
+      "line": 500,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_endpoints\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 79,
+      "line": 502,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_clients\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 87,
+      "line": 504,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_network_handles\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 89,
+      "line": 506,
+      "message": "Argument 1 to \"external_audit_export_receipt_contains_no_runtime_authority\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 98,
+      "line": 518,
+      "message": "Argument 1 to \"external_security_review_packet_ready_for_review\" has incompatible type \"ExternalSecurityReviewPacket | Mapping[str, Any] | None\"; expected \"ExternalSecurityReviewPacket | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 122,
+      "line": 520,
+      "message": "Argument 1 to \"provider_invocation_denial_review_affirms_forbidden_invocation\" has incompatible type \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialReviewReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 94,
+      "line": 522,
+      "message": "Argument 1 to \"provider_invocation_readiness_forbids_invocation\" has incompatible type \"ProviderInvocationReadinessManifest | Mapping[str, Any] | None\"; expected \"ProviderInvocationReadinessManifest | ProviderInvocationReadinessPreflight | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 117,
+      "line": 575,
+      "message": "Argument 1 to \"external_audit_export_receipt_preserves_invocation_denial\" has incompatible type \"ExternalAuditExportReceipt | Mapping[str, Any] | None\"; expected \"ExternalAuditExportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 596,
+      "message": "Argument 47 to \"ProviderInvocationDenialAttestation\" has incompatible type \"**dict[str, bool]\"; expected \"str\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 307,
+      "message": "Argument 1 to \"asdict\" has incompatible type \"DataclassInstance | type[DataclassInstance]\"; expected \"DataclassInstance\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 327,
+      "message": "Argument 1 to \"asdict\" has incompatible type \"DataclassInstance | type[DataclassInstance]\"; expected \"DataclassInstance\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 84,
+      "line": 505,
+      "message": "Argument 1 to \"compute_provider_invocation_denial_attestation_digest\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 106,
+      "line": 520,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_ready\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 72,
+      "line": 522,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_is_metadata_only\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 73,
+      "line": 524,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_denies_invocation\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 71,
+      "line": 526,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_does_not_export\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 79,
+      "line": 528,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_prompt_text\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 530,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_secrets\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 77,
+      "line": 532,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_endpoints\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 534,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_clients\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 83,
+      "line": 536,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_network_handles\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 85,
+      "line": 538,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_contains_no_runtime_authority\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 120,
+      "line": 648,
+      "message": "Argument 1 to \"provider_invocation_denial_attestation_denies_invocation\" has incompatible type \"ProviderInvocationDenialAttestation | Mapping[str, Any] | None\"; expected \"ProviderInvocationDenialAttestation | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 668,
+      "message": "Argument 59 to \"ProviderInvocationDenialClosureManifest\" has incompatible type \"**dict[str, bool]\"; expected \"str\"",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py"
+    },
+    {
+      "code": "assignment",
+      "column": 9,
+      "line": 904,
+      "message": "Incompatible types in assignment (expression has type \"tuple[str, str, str]\", variable has type \"tuple[str, str]\")",
+      "path": "sentientos/context_hygiene/prompt_provider_invocation_denial_review.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 11,
+      "line": 827,
+      "message": "Argument 46 to \"ProviderNullTransportReceipt\" has incompatible type \"**dict[str, bool]\"; expected \"ProviderNullTransportBoundary\"",
+      "path": "sentientos/context_hygiene/prompt_provider_null_transport.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 80,
+      "line": 950,
+      "message": "Argument 1 to \"provider_network_egress_review_approves_future_null_transport_gate\" has incompatible type \"ProviderNetworkEgressReviewReceipt | Mapping[str, Any] | None\"; expected \"ProviderNetworkEgressReviewReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_null_transport.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 363,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/context_hygiene/prompt_provider_simulation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 372,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/context_hygiene/prompt_provider_simulation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 374,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/context_hygiene/prompt_provider_simulation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 375,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/context_hygiene/prompt_provider_simulation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 62,
+      "line": 603,
+      "message": "Argument 1 to \"provider_null_transport_sent_nothing\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 64,
+      "line": 605,
+      "message": "Argument 1 to \"provider_null_transport_has_no_network\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 77,
+      "line": 607,
+      "message": "Argument 1 to \"provider_null_transport_has_no_provider_credentials\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 65,
+      "line": 609,
+      "message": "Argument 1 to \"provider_null_transport_has_no_endpoint\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 72,
+      "line": 611,
+      "message": "Argument 1 to \"provider_null_transport_has_no_provider_client\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 74,
+      "line": 613,
+      "message": "Argument 1 to \"provider_null_transport_has_no_runtime_authority\" has incompatible type \"ProviderNullTransportReceipt | Mapping[str, Any] | None\"; expected \"ProviderNullTransportReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 96,
+      "line": 783,
+      "message": "Argument 1 to \"compute_provider_transport_registry_digest\" has incompatible type \"ProviderTransportRegistryManifest | Mapping[str, Any] | None\"; expected \"ProviderTransportRegistryManifest | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_provider_transport_registry.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 60,
+      "line": 405,
+      "message": "Argument 1 to \"policy_decision_allows_synthetic_materializer\" has incompatible type \"Any | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_synthetic_materializer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 406,
+      "message": "Argument 1 to \"policy_decision_requires_operator_review\" has incompatible type \"Any | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_synthetic_materializer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 64,
+      "line": 409,
+      "message": "Argument 1 to \"operator_review_satisfies_policy_decision\" has incompatible type \"Any | None\"; expected \"PromptMaterializationPolicyDecision | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_synthetic_materializer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 55,
+      "line": 418,
+      "message": "Argument 1 to \"audit_receipt_allows_shadow_materializer\" has incompatible type \"Any | None\"; expected \"PromptMaterializationAuditReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/context_hygiene/prompt_synthetic_materializer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 355,
+      "message": "\"OutcomeSummary\" has no attribute \"transaction_status\"",
+      "path": "sentientos/contract_sentinel.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 22,
+      "line": 483,
+      "message": "Need type annotation for \"essentials\"",
+      "path": "sentientos/contract_sentinel.py"
+    },
+    {
+      "code": "assignment",
+      "column": 5,
+      "line": 508,
+      "message": "Incompatible types in assignment (expression has type \"ControlledAuthorizationRevocationRecord\", variable has type \"ControlledAuthorizationGrantRecord\")",
+      "path": "sentientos/controlled_authorization.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 68,
+      "line": 509,
+      "message": "Argument 1 to \"validate_controlled_authorization_revocation_record\" has incompatible type \"ControlledAuthorizationGrantRecord\"; expected \"ControlledAuthorizationRevocationRecord\"",
+      "path": "sentientos/controlled_authorization.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 131,
+      "line": 509,
+      "message": "\"ControlledAuthorizationGrantRecord\" has no attribute \"revocation_id\"",
+      "path": "sentientos/controlled_authorization.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 345,
+      "message": "Argument \"key\" to \"sorted\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/cor.py"
+    },
+    {
+      "code": "return-value",
+      "column": 57,
+      "line": 345,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/cor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 388,
+      "message": "Argument 1 to \"append\" of \"deque\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/cor.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 19,
+      "line": 44,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/council/governance_council.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 29,
+      "line": 45,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/council/governance_council.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 34,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 70,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 111,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 120,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 210,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 291,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/curiosity_scheduler.py"
+    },
+    {
+      "code": "assignment",
+      "column": 23,
+      "line": 697,
+      "message": "Incompatible types in assignment (expression has type \"set[str]\", variable has type \"list[str]\")",
+      "path": "sentientos/daemons/driver_manager.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 704,
+      "message": "\"list[str]\" has no attribute \"add\"; maybe \"append\" or \"extend\"?",
+      "path": "sentientos/daemons/driver_manager.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 711,
+      "message": "\"list[str]\" has no attribute \"add\"; maybe \"append\" or \"extend\"?",
+      "path": "sentientos/daemons/driver_manager.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 35,
+      "line": 21,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/identity_continuity_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 57,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/identity_continuity_daemon.py"
+    },
+    {
+      "code": "operator",
+      "column": 48,
+      "line": 79,
+      "message": "Unsupported operand types for < (\"float\" and \"str\")",
+      "path": "sentientos/daemons/integrity_daemon.py"
+    },
+    {
+      "code": "operator",
+      "column": 48,
+      "line": 79,
+      "message": "Unsupported operand types for < (\"str\" and \"float\")",
+      "path": "sentientos/daemons/integrity_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 44,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/memory_persona_linter.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/memory_persona_linter.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 407,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/daemons/monitoring_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 130,
+      "message": "Argument \"epitaph\" to \"_handle_expired\" of \"NarrativeReaper\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/daemons/narrative_reaper.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 133,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/daemons/narrative_reaper.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 277,
+      "message": "Returning Any from function declared to return \"dict[str, object]\"",
+      "path": "sentientos/daemons/narrative_reaper.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 39,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_anomaly_forecaster.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 53,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_anomaly_forecaster.py"
+    },
+    {
+      "code": "misc",
+      "column": 5,
+      "line": 17,
+      "message": "Cannot assign to a type",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "assignment",
+      "column": 25,
+      "line": 17,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"type[IntegrationMemory]\")",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 25,
+      "line": 30,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 76,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 79,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 49,
+      "line": 91,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 40,
+      "line": 95,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 177,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 47,
+      "line": 212,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 44,
+      "line": 224,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 228,
+      "message": "Returning Any from function declared to return \"dict[str, dict[Any, Any]]\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 47,
+      "line": 232,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 83,
+      "line": 236,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 73,
+      "line": 247,
+      "message": "Argument 3 to \"mark_suppressed\" of \"ReflexStateIndex\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/daemons/reflex_guard.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 59,
+      "line": 54,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "sentientos/daemons/witness_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 60,
+      "line": 63,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "sentientos/daemons/witness_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 47,
+      "line": 73,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "sentientos/daemons/witness_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 53,
+      "line": 77,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "sentientos/daemons/witness_daemon.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 80,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/daemons/witness_daemon.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 36,
+      "line": 146,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/delegated_judgment_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 47,
+      "line": 147,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/delegated_judgment_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 44,
+      "line": 148,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/delegated_judgment_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 35,
+      "line": 149,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/delegated_judgment_fabric.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 26,
+      "message": "Argument 1 to \"int\" has incompatible type \"str | None\"; expected \"str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc\"",
+      "path": "sentientos/determinism.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 50,
+      "line": 57,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/diagnostics/error_frame.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 63,
+      "line": 75,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/diagnostics/error_frame.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 34,
+      "line": 104,
+      "message": "Missing type arguments for generic type \"OrderedDict\"",
+      "path": "sentientos/diagnostics/error_frame.py"
+    },
+    {
+      "code": "assignment",
+      "column": 37,
+      "line": 273,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", target has type \"Sequence[str]\")",
+      "path": "sentientos/diagnostics/error_frame.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 275,
+      "message": "Incompatible types in assignment (expression has type \"Any | None\", target has type \"Sequence[str]\")",
+      "path": "sentientos/diagnostics/error_frame.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 299,
+      "message": "Dict entry 0 has incompatible type \"str\": \"MissingInstallDirectoryRecoveryLadder\"; expected \"str\": \"RecoveryLadder\"",
+      "path": "sentientos/diagnostics/recovery.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 300,
+      "message": "Dict entry 1 has incompatible type \"str\": \"OptionalModuleIsolationRecoveryLadder\"; expected \"str\": \"RecoveryLadder\"",
+      "path": "sentientos/diagnostics/recovery.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 52,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/doctrine_identity.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 73,
+      "line": 79,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/doctrine_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 55,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/embodiment/consent.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 183,
+      "message": "Incompatible return value type (got \"dict[str, str]\", expected \"dict[str, object]\")",
+      "path": "sentientos/embodiment/consent.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 273,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/embodiment/contracts.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 52,
+      "line": 144,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/embodiment/embodiment_digest.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 145,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/embodiment/embodiment_digest.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 76,
+      "line": 161,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/embodiment/embodiment_digest.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 11,
+      "line": 178,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/embodiment/embodiment_digest.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 182,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/embodiment/embodiment_digest.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 58,
+      "line": 220,
+      "message": "Argument 2 to \"_tags_for_memory_class\" has incompatible type \"Collection[str]\"; expected \"Sequence[str]\"",
+      "path": "sentientos/embodiment/simulation.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 221,
+      "message": "Incompatible return value type (got \"dict[str, Collection[str]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/embodiment/simulation.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 33,
+      "line": 32,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/embodiment_ingress.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 36,
+      "line": 35,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/embodiment_ingress.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 20,
+      "line": 69,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/embodiment_proposal_diagnostic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 100,
+      "message": "Argument 1 to \"float\" has incompatible type \"Any | None\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/embodiment_proposal_diagnostic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 194,
+      "message": "Argument 1 to \"summarize_recent_embodied_proposals\" has incompatible type \"list[dict[str, Any]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/embodiment_proposal_diagnostic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 75,
+      "line": 194,
+      "message": "Argument \"review_receipts\" to \"summarize_recent_embodied_proposals\" has incompatible type \"list[dict[str, Any]]\"; expected \"list[Mapping[str, Any]] | None\"",
+      "path": "sentientos/embodiment_proposal_diagnostic.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 12,
+      "line": 146,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/embodiment_proposal_review.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 3,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/ethics/__init__.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 23,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 105,
+      "line": 33,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 41,
+      "line": 39,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 57,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 60,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 63,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/consent_memory_vault.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 87,
+      "line": 39,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 40,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 57,
+      "line": 61,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 64,
+      "message": "Argument 1 to \"_render_section\" of \"CovenantDigestDaemon\" has incompatible type \"list[dict[Any, Any]]\"; expected \"list[Mapping[str, object]]\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 67,
+      "message": "Argument 1 to \"_render_section\" of \"CovenantDigestDaemon\" has incompatible type \"list[dict[Any, Any]]\"; expected \"list[Mapping[str, object]]\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 70,
+      "message": "Argument 1 to \"_render_section\" of \"CovenantDigestDaemon\" has incompatible type \"list[dict[Any, Any]]\"; expected \"list[Mapping[str, object]]\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 73,
+      "message": "Argument 1 to \"_render_section\" of \"CovenantDigestDaemon\" has incompatible type \"list[dict[Any, Any]]\"; expected \"list[Mapping[str, object]]\"",
+      "path": "sentientos/ethics/covenant_digest_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 78,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/ethics/ethics_critic_daemon.py"
+    },
+    {
+      "code": "return-value",
+      "column": 38,
+      "line": 78,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/ethics/ethics_critic_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 85,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/ethics/ethics_critic_daemon.py"
+    },
+    {
+      "code": "type-var",
+      "column": 20,
+      "line": 52,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"max\" cannot be \"object\"",
+      "path": "sentientos/ethics/semantic_scanner_daemon.py"
+    },
+    {
+      "code": "operator",
+      "column": 31,
+      "line": 53,
+      "message": "Unsupported operand types for <= (\"float\" and \"object\")",
+      "path": "sentientos/ethics/semantic_scanner_daemon.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 25,
+      "line": 57,
+      "message": "No overload variant of \"round\" matches argument types \"object\", \"int\"",
+      "path": "sentientos/ethics/semantic_scanner_daemon.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 18,
+      "line": 47,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/ethics/symbolic_hygiene_monitor.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 6,
+      "line": 8,
+      "message": "Dict entry 0 has incompatible type \"str\": \"str\"; expected \"str\": \"int\"",
+      "path": "sentientos/ethics_core.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 6,
+      "line": 9,
+      "message": "Dict entry 0 has incompatible type \"str\": \"str\"; expected \"str\": \"int\"",
+      "path": "sentientos/ethics_core.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 6,
+      "line": 10,
+      "message": "Dict entry 0 has incompatible type \"str\": \"str\"; expected \"str\": \"int\"",
+      "path": "sentientos/ethics_core.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 6,
+      "line": 11,
+      "message": "Dict entry 0 has incompatible type \"str\": \"str\"; expected \"str\": \"int\"",
+      "path": "sentientos/ethics_core.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 58,
+      "line": 34,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/ethics_core.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 67,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/experiments/chain.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 69,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/experiments/chain.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 70,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/experiments/chain.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 204,
+      "message": "Argument \"name\" to \"Identifier\" has incompatible type \"str | int | float | bool\"; expected \"str\"",
+      "path": "sentientos/experiments/criteria_dsl.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 114,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 16,
+      "line": 127,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 130,
+      "message": "Argument 1 to \"int\" has incompatible type \"object | Any\"; expected \"str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc\"",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 141,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 142,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 29,
+      "line": 158,
+      "message": "Call to untyped function \"_deepcopy_if_needed\" in typed context",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 29,
+      "line": 160,
+      "message": "Call to untyped function \"_deepcopy_if_needed\" in typed context",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 200,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 17,
+      "line": 220,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 259,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/experiments/demo_gallery.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 57,
+      "line": 8,
+      "message": "Argument 2 to \"register_adapter\" has incompatible type \"type[FilesystemAdapter]\"; expected \"type[ExternalAdapter]\"",
+      "path": "sentientos/external_adapters/__init__.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 53,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/external_adapters/filesystem_adapter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 65,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/external_adapters/filesystem_adapter.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 193,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/external_adapters/runtime.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 238,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/external_adapters/runtime.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 266,
+      "message": "Argument 2 to \"append_json\" has incompatible type \"MutableMapping[str, object]\"; expected \"dict[str, Any]\"",
+      "path": "sentientos/external_adapters/runtime.py"
+    },
+    {
+      "code": "index",
+      "column": 31,
+      "line": 276,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/federation_mutation_control_preflight.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 28,
+      "line": 290,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/federation_mutation_control_preflight.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 83,
+      "line": 16,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 17,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 65,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 34,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 42,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 44,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/feedback/feedback_attributor.py"
+    },
+    {
+      "code": "import-untyped",
+      "column": 1,
+      "line": 9,
+      "message": "Library stubs not installed for \"yaml\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 134,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, str]\", variable has type \"dict[str, object] | None\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 9,
+      "line": 140,
+      "message": "Name \"summary\" already defined on line 133",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 30,
+      "line": 168,
+      "message": "Incompatible types in assignment (expression has type \"list[dict[str, object]]\", target has type \"str\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 28,
+      "line": 171,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", target has type \"str\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 33,
+      "line": 174,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", target has type \"str\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 29,
+      "line": 183,
+      "message": "Incompatible types in assignment (expression has type \"list[dict[str, Sequence[str]]]\", target has type \"str\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 189,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 30,
+      "line": 201,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, str]\", variable has type \"dict[str, object] | None\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 230,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 290,
+      "message": "\"object\" has no attribute \"strip\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 294,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 26,
+      "line": 295,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 325,
+      "message": "\"object\" has no attribute \"strip\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 351,
+      "message": "Incompatible return value type (got \"dict[str, Collection[str]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 409,
+      "message": "Argument 1 has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/first_boot.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 197,
+      "message": "Argument \"has_drift\" to \"mark_finished\" of \"ForgeQueue\" has incompatible type \"object\"; expected \"bool | None\"",
+      "path": "sentientos/forge_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 198,
+      "message": "Argument \"drift_domains\" to \"mark_finished\" of \"ForgeQueue\" has incompatible type \"object\"; expected \"list[str] | None\"",
+      "path": "sentientos/forge_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 201,
+      "message": "Argument \"contract_alert_counts\" to \"mark_finished\" of \"ForgeQueue\" has incompatible type \"object\"; expected \"dict[str, int] | None\"",
+      "path": "sentientos/forge_daemon.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 202,
+      "message": "Argument \"contract_row_summary_counts\" to \"mark_finished\" of \"ForgeQueue\" has incompatible type \"object\"; expected \"dict[str, int] | None\"",
+      "path": "sentientos/forge_daemon.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 10,
+      "message": "Name \"tomllib\" already defined (by an import)",
+      "path": "sentientos/forge_env.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 26,
+      "message": "Returning Any from function declared to return \"ForgeEnv\"",
+      "path": "sentientos/forge_env.py"
+    },
+    {
+      "code": "name-defined",
+      "column": 69,
+      "line": 34,
+      "message": "Name \"ForgeEnv\" is not defined",
+      "path": "sentientos/forge_env_cache.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 125,
+      "message": "Argument \"key\" to \"sorted\" has incompatible type \"Callable[[tuple[Path, ForgeEnvCacheEntry | None]], datetime | None]\"; expected \"Callable[[tuple[Path, ForgeEnvCacheEntry | None]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/forge_env_cache.py"
+    },
+    {
+      "code": "return-value",
+      "column": 26,
+      "line": 125,
+      "message": "Incompatible return value type (got \"datetime | None\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/forge_env_cache.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 26,
+      "line": 49,
+      "message": "Argument 1 to \"_digest\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 51,
+      "message": "Argument \"nodeid\" to \"FailureSignature\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 52,
+      "message": "Argument \"file\" to \"FailureSignature\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 53,
+      "message": "Argument \"line\" to \"FailureSignature\" has incompatible type \"object\"; expected \"int | None\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 54,
+      "message": "Argument \"test_name\" to \"FailureSignature\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 55,
+      "message": "Argument \"error_type\" to \"FailureSignature\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 63,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/forge_failures.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 186,
+      "line": 142,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 119,
+      "line": 159,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 36,
+      "line": 164,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 42,
+      "line": 192,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 70,
+      "line": 193,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 127,
+      "line": 206,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 31,
+      "line": 224,
+      "message": "Item \"None\" of \"dict[str, object] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 390,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 34,
+      "line": 419,
+      "message": "Item \"None\" of \"dict[str, object] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 743,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 779,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/forge_index.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 1,
+      "line": 29,
+      "message": "Module \"sentientos.github_artifacts\" does not explicitly export attribute \"DoctrineIdentity\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 147,
+      "message": "Argument 1 to \"TrainPolicy\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 147,
+      "message": "Argument 1 to \"TrainPolicy\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 147,
+      "message": "Argument 1 to \"TrainPolicy\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 202,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 203,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 28,
+      "line": 206,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 207,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 462,
+      "message": "No overload variant of \"reversed\" matches argument type \"object\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 57,
+      "line": 809,
+      "message": "Argument 1 to \"_audit_integrity_failures\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 64,
+      "line": 810,
+      "message": "Argument 1 to \"_contract_doctrine_failures\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 48,
+      "line": 828,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 47,
+      "line": 829,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 830,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 1069,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 1073,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 1077,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "misc",
+      "column": 25,
+      "line": 1124,
+      "message": "Generator has incompatible item type \"int\"; expected \"bool\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "operator",
+      "column": 85,
+      "line": 1124,
+      "message": "Unsupported operand types for <= (\"datetime\" and \"None\")",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "misc",
+      "column": 24,
+      "line": 1125,
+      "message": "Generator has incompatible item type \"int\"; expected \"bool\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "operator",
+      "column": 84,
+      "line": 1125,
+      "message": "Unsupported operand types for <= (\"datetime\" and \"None\")",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 1259,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 1277,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 23,
+      "line": 1278,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 10,
+      "line": 1284,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 23,
+      "line": 1285,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/forge_merge_train.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 32,
+      "line": 44,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 31,
+      "line": 45,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 40,
+      "line": 52,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 44,
+      "line": 54,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 62,
+      "line": 81,
+      "message": "Argument 1 to \"_infer_no_improvement_streak\" has incompatible type \"Any | list[Any] | None\"; expected \"list[Any]\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 72,
+      "line": 84,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/forge_outcomes.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 314,
+      "message": "Argument \"has_drift\" to \"ForgeReceipt\" has incompatible type \"object\"; expected \"bool | None\"",
+      "path": "sentientos/forge_queue.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 13,
+      "line": 41,
+      "message": "Dict entry 2 has incompatible type \"str\": \"bool\"; expected \"str\": \"dict[str, Any]\"",
+      "path": "sentientos/forge_transaction.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 53,
+      "message": "Returning Any from function declared to return \"dict[str, object]\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 26,
+      "line": 65,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 66,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 67,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 82,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "index",
+      "column": 23,
+      "line": 310,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 13,
+      "line": 311,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 411,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/formal_verification.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 23,
+      "line": 403,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 516,
+      "message": "Argument 1 to \"dict\" has incompatible type \"Mapping[str, object]\"; expected \"SupportsKeysAndGetItem[str, str]\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "assignment",
+      "column": 40,
+      "line": 595,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", target has type \"str\")",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 596,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 676,
+      "message": "Argument \"details\" to \"log\" of \"RecoveryLedger\" has incompatible type \"Mapping[str, object]\"; expected \"dict[str, object] | None\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "misc",
+      "column": 29,
+      "line": 751,
+      "message": "List comprehension has incompatible type List[tuple[str, object]]; expected List[tuple[str, IntegrityEvaluationA]]",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "misc",
+      "column": 26,
+      "line": 771,
+      "message": "List comprehension has incompatible type List[tuple[str, object]]; expected List[tuple[str, IntegrityEvaluationA]]",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 775,
+      "message": "\"object\" has no attribute \"probe\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 55,
+      "line": 799,
+      "message": "Argument 1 to \"rank_stage_a\" has incompatible type \"object\"; expected \"IntegrityEvaluationA\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 54,
+      "line": 804,
+      "message": "\"object\" has no attribute \"reason_codes_a\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 61,
+      "line": 805,
+      "message": "Argument 1 to \"score_evaluation_a\" has incompatible type \"object\"; expected \"IntegrityEvaluationA\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "misc",
+      "column": 43,
+      "line": 811,
+      "message": "Generator has incompatible item type \"int\"; expected \"bool\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 90,
+      "line": 811,
+      "message": "\"object\" has no attribute \"valid_a\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 46,
+      "line": 823,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"candidate_id\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 849,
+      "message": "\"object\" has no attribute \"valid_a\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 52,
+      "line": 850,
+      "message": "\"object\" has no attribute \"reason_codes_a\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 74,
+      "line": 851,
+      "message": "\"object\" has no attribute \"violations_a\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 59,
+      "line": 852,
+      "message": "Argument 1 to \"score_evaluation_a\" has incompatible type \"object\"; expected \"IntegrityEvaluationA\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 853,
+      "message": "Argument 1 to \"rank_stage_a\" has incompatible type \"object\"; expected \"IntegrityEvaluationA\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 52,
+      "line": 854,
+      "message": "\"object\" has no attribute \"ledger_entry\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 59,
+      "line": 858,
+      "message": "Argument 1 to \"rank_stage_a\" has incompatible type \"object\"; expected \"IntegrityEvaluationA\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 28,
+      "line": 929,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"proposal\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 61,
+      "line": 930,
+      "message": "Item \"None\" of \"CandidateResult | None\" has no attribute \"candidate_id\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 1040,
+      "message": "Argument \"details\" to \"log\" of \"RecoveryLedger\" has incompatible type \"Mapping[str, object]\"; expected \"dict[str, object] | None\"",
+      "path": "sentientos/genesis_forge.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 59,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 98,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 99,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 140,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 187,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 192,
+      "message": "Dict entry 0 has incompatible type \"str\": \"_ForgeLastRunOkCheck\"; expected \"str\": \"CompletionCheck\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 193,
+      "message": "Dict entry 1 has incompatible type \"str\": \"_IntegrityBaselineCheck\"; expected \"str\": \"CompletionCheck\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 194,
+      "message": "Dict entry 2 has incompatible type \"str\": \"_FederationCheck\"; expected \"str\": \"CompletionCheck\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 195,
+      "message": "Dict entry 3 has incompatible type \"str\": \"_WitnessesCheck\"; expected \"str\": \"CompletionCheck\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 5,
+      "line": 196,
+      "message": "Dict entry 4 has incompatible type \"str\": \"_MypyForgeCheck\"; expected \"str\": \"CompletionCheck\"",
+      "path": "sentientos/goal_completion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 147,
+      "message": "Argument 2 to \"_deterministic_progress\" has incompatible type \"list[CompletionResult]\"; expected \"list[object]\"",
+      "path": "sentientos/goal_executor.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 21,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 22,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 46,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 78,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 44,
+      "line": 46,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 53,
+      "line": 64,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 57,
+      "line": 72,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 73,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 48,
+      "line": 90,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 91,
+      "message": "Missing type arguments for generic type \"Counter\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 141,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 150,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 38,
+      "line": 159,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 166,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/governance/council_bias_analyzer.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 23,
+      "line": 113,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/governance_reducer.py"
+    },
+    {
+      "code": "assignment",
+      "column": 41,
+      "line": 378,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", variable has type \"str\")",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 19,
+      "line": 446,
+      "message": "Need type annotation for \"payload\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 464,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"object\"; expected \"Iterable[Never]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 467,
+      "message": "Argument 1 to \"_sorted_hashes\" has incompatible type \"list[dict[str, object]]\"; expected \"Iterable[Mapping[str, str]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 477,
+      "message": "Argument \"request\" to \"ForgetDiff\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Mapping[str, str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 482,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 483,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 484,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 485,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, object]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 486,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, str]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 487,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, str]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 488,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, str]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 26,
+      "line": 489,
+      "message": "Argument \"state_hashes\" to \"ForgetDiff\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Mapping[str, str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 490,
+      "message": "Argument \"invariant_status\" to \"ForgetDiff\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"str\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 491,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, str]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 492,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, object]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 493,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, object]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 494,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"list[dict[str, object]] | dict[str, str] | list[dict[str, str]] | tuple[Any, ...] | list[str] | dict[str, object] | str | None\"; expected \"Iterable[dict[str, object]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "assignment",
+      "column": 13,
+      "line": 710,
+      "message": "Incompatible types in assignment (expression has type \"str\", variable has type \"tuple[str | None, str, str | None, str | None]\")",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "type-var",
+      "column": 19,
+      "line": 1294,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 1299,
+      "message": "Argument \"subsystem\" to \"ForgetBoundaryPreview\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 1305,
+      "message": "Argument 1 to \"set\" has incompatible type \"list[object]\"; expected \"Iterable[str]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 1406,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, object]], object]\"; expected \"Callable[[dict[str, object]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "return-value",
+      "column": 49,
+      "line": 1406,
+      "message": "Incompatible return value type (got \"object\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 1781,
+      "message": "Incompatible return value type (got \"list[dict[str, bool | str]]\", expected \"list[dict[str, object]]\")",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 1848,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 27,
+      "line": 1853,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 32,
+      "line": 1857,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 38,
+      "line": 1874,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 1875,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 46,
+      "line": 1876,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 51,
+      "line": 1882,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 48,
+      "line": 1884,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 1886,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "type-var",
+      "column": 18,
+      "line": 1920,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "type-var",
+      "column": 18,
+      "line": 1968,
+      "message": "Value of type variable \"SupportsRichComparisonT\" of \"sorted\" cannot be \"object\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 63,
+      "line": 1978,
+      "message": "Argument \"subsystem\" to \"_append_pressure_budget_event\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 2037,
+      "message": "Incompatible return value type (got \"dict[str, Sequence[str]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/governance/intentional_forgetting.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 132,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 133,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 134,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 135,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 33,
+      "line": 136,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 49,
+      "line": 137,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 23,
+      "line": 138,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 146,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 150,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 17,
+      "line": 153,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 34,
+      "line": 157,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 33,
+      "line": 160,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 162,
+      "message": "Argument \"time_window\" to \"RoutineDefinition\" has incompatible type \"tuple[Never, ...] | None\"; expected \"tuple[str, str] | None\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 162,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"object\"; expected \"Iterable[Never]\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 169,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 376,
+      "message": "Argument 1 to \"from_dict\" of \"RoutineDefinition\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 382,
+      "message": "Argument 1 to \"from_dict\" of \"RoutineDefinition\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/governance/routine_delegation.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 46,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/sanction_engine.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 30,
+      "line": 49,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/sanction_engine.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 29,
+      "line": 50,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/sanction_engine.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 25,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/vote_justifier.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 26,
+      "line": 34,
+      "message": "Argument 1 to \"update\" of \"MutableMapping\" has incompatible type \"Mapping[str, object]\"; expected \"SupportsKeysAndGetItem[str, Sequence[str]]\"",
+      "path": "sentientos/governance/vote_justifier.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 34,
+      "line": 38,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/vote_justifier.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 39,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/governance/vote_justifier.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 45,
+      "line": 147,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 49,
+      "line": 149,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 52,
+      "line": 150,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 49,
+      "line": 152,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "assignment",
+      "column": 32,
+      "line": 154,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"dict[str, object] | None\")",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 56,
+      "line": 162,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/governance_trace.py"
+    },
+    {
+      "code": "misc",
+      "column": 1,
+      "line": 78,
+      "message": "Type of __all__ must be \"Sequence[str]\", not \"Iterable[str]\"",
+      "path": "sentientos/gradient_contract.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 10,
+      "message": "Module \"agents.forms.ssa_disability_agent\" does not explicitly export attribute \"SSA827Prefill\"",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 18,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 20,
+      "message": "Returning Any from function declared to return \"dict[Any, Any]\"",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 35,
+      "line": 23,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 32,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 33,
+      "message": "Module \"agents.forms.ssa_disability_agent\" does not explicitly export attribute \"SSA827Prefill\"",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 45,
+      "line": 45,
+      "message": "Call to untyped function \"_load_ssa_symbols\" in typed context",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 76,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 45,
+      "line": 78,
+      "message": "Call to untyped function \"_load_ssa_symbols\" in typed context",
+      "path": "sentientos/helpers/__init__.py"
+    },
+    {
+      "code": "assignment",
+      "column": 34,
+      "line": 195,
+      "message": "Incompatible types in assignment (expression has type \"float | None\", target has type \"int\")",
+      "path": "sentientos/host_collectors.py"
+    },
+    {
+      "code": "assignment",
+      "column": 32,
+      "line": 196,
+      "message": "Incompatible types in assignment (expression has type \"str\", target has type \"int\")",
+      "path": "sentientos/host_collectors.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 322,
+      "message": "Incompatible types in assignment (expression has type \"tuple[str] | tuple[()]\", variable has type \"tuple[str]\")",
+      "path": "sentientos/host_collectors.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 364,
+      "message": "Incompatible types in assignment (expression has type \"tuple[str] | tuple[()]\", variable has type \"tuple[str]\")",
+      "path": "sentientos/host_collectors.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 89,
+      "message": "Argument 1 to \"asdict\" has incompatible type \"DataclassInstance | type[DataclassInstance]\"; expected \"DataclassInstance\"",
+      "path": "sentientos/host_embodiment_trace_export.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 28,
+      "line": 261,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 262,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 263,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 264,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 265,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 266,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 267,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 268,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 129,
+      "line": 274,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"status\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 19,
+      "line": 295,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"status\"",
+      "path": "sentientos/host_inventory.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 285,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 286,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 287,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 288,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 289,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 290,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 27,
+      "line": 291,
+      "message": "Item \"None\" of \"HostCollectorResult | None\" has no attribute \"values\"",
+      "path": "sentientos/host_resource_governor.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 413,
+      "message": "Returning Any from function declared to return \"HostStewardAuthorityPolicy\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 424,
+      "message": "Returning Any from function declared to return \"HostStewardAuthorityProfile\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "assignment",
+      "column": 17,
+      "line": 460,
+      "message": "Incompatible types in assignment (expression has type \"tuple[()]\", variable has type \"tuple[str]\")",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 461,
+      "message": "Returning Any from function declared to return \"DelegatedRunnerBoundaryProfile\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 480,
+      "message": "Returning Any from function declared to return \"ExecutionContainmentProfile\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 500,
+      "message": "Returning Any from function declared to return \"BackendAdapterAuthorityDeclaration\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 516,
+      "message": "Returning Any from function declared to return \"RunnerCapabilityGrantScaffold\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 544,
+      "message": "Returning Any from function declared to return \"RunnerBoundaryAssessment\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 562,
+      "message": "Returning Any from function declared to return \"RunnerBoundaryViolationReceipt\"",
+      "path": "sentientos/host_steward_boundary.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 190,
+      "message": "Returning Any from function declared to return \"dict[str, object]\"",
+      "path": "sentientos/immutability.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 227,
+      "message": "Argument 3 to \"_sign_manifest\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/immutability.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 156,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 161,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "assignment",
+      "column": 19,
+      "line": 161,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"float | None\")",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 163,
+      "message": "Argument 1 to \"float\" has incompatible type \"float | None\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 173,
+      "message": "Argument 1 to \"enforce\" of \"ConstraintRegistrationGate\" has incompatible type \"str | None\"; expected \"str\"",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 206,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 20,
+      "line": 206,
+      "message": "Item \"None\" of \"ConstraintEngagementEngine | None\" has no attribute \"record_signal\"",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 13,
+      "line": 207,
+      "message": "Argument 1 to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"str | None\"; expected \"str\"",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 210,
+      "message": "Argument \"affective_context\" to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"Mapping[str, object] | None\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 225,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "misc",
+      "column": 27,
+      "line": 225,
+      "message": "\"None\" not callable",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 298,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 303,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/innervation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 46,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/autobio_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 49,
+      "message": "Argument 1 to \"deepcopy\" has incompatible type \"Mapping[str, Any]\"; expected \"dict[str, Any]\"",
+      "path": "sentientos/innerworld/autobio_compressor.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 29,
+      "line": 16,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/history.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 18,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/history.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 47,
+      "line": 23,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/history.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 31,
+      "line": 32,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/history.py"
+    },
+    {
+      "code": "misc",
+      "column": 34,
+      "line": 104,
+      "message": "Generator has incompatible item type \"object\"; expected \"str\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 86,
+      "line": 114,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 149,
+      "message": "Argument \"ethical_report\" to \"generate\" of \"CognitiveReportGenerator\" has incompatible type \"object\"; expected \"dict[str, Any] | None\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 150,
+      "message": "Argument \"simulation_report\" to \"generate\" of \"CognitiveReportGenerator\" has incompatible type \"object\"; expected \"dict[str, Any] | None\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 153,
+      "message": "Argument 1 to \"update_chapter\" of \"SelfNarrativeEngine\" has incompatible type \"object\"; expected \"dict[Any, Any]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 156,
+      "message": "Argument \"qualia\" to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"object\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 157,
+      "message": "Argument \"meta_notes\" to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"object\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 158,
+      "message": "Argument \"ethics\" to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"object\"; expected \"Mapping[str, Any] | None\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 34,
+      "line": 160,
+      "message": "Call to untyped function \"get_identity_summary\" in typed context",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 166,
+      "message": "Argument \"cognitive_report\" to \"generate\" of \"InnerDialogueEngine\" has incompatible type \"object\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 170,
+      "message": "Argument \"ethics\" to \"record_cycle\" of \"ValueDriftSentinel\" has incompatible type \"object\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 34,
+      "line": 171,
+      "message": "Call to untyped function \"get_identity_summary\" in typed context",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 26,
+      "line": 177,
+      "message": "Argument \"chapters\" to \"compress\" of \"AutobiographicalCompressor\" has incompatible type \"list[dict[Any, Any]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 34,
+      "line": 179,
+      "message": "Call to untyped function \"get_identity_summary\" in typed context",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 32,
+      "line": 188,
+      "message": "Call to untyped function \"get_identity_summary\" in typed context",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 202,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 237,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 240,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 243,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 247,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 250,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/orchestrator.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 15,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 46,
+      "line": 26,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 40,
+      "message": "Argument 1 to \"_classify_trend\" of \"CycleReflectionEngine\" has incompatible type \"list[int]\"; expected \"list[float]\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 46,
+      "line": 43,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 45,
+      "line": 92,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "assignment",
+      "column": 30,
+      "line": 100,
+      "message": "Incompatible types in assignment (expression has type \"Any | None\", variable has type \"dict[Any, Any]\")",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 52,
+      "line": 119,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 38,
+      "line": 141,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/reflection.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 48,
+      "line": 24,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 56,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 61,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 88,
+      "message": "Argument 1 to \"_dominant_theme\" of \"SelfNarrativeEngine\" has incompatible type \"list[Any | None]\"; expected \"list[str]\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 89,
+      "message": "Argument 1 to \"_dominant_theme\" of \"SelfNarrativeEngine\" has incompatible type \"list[Any | None]\"; expected \"list[str]\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 91,
+      "message": "Argument 1 to \"_dominant_theme\" of \"SelfNarrativeEngine\" has incompatible type \"list[Any | None]\"; expected \"list[str]\"",
+      "path": "sentientos/innerworld/self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 19,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/value_drift.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 100,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/innerworld/value_drift.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 80,
+      "line": 223,
+      "message": "\"ReceiptChainVerification\" has no attribute \"reason\"",
+      "path": "sentientos/integrity_controller.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 82,
+      "line": 232,
+      "message": "\"AnchorVerification\" has no attribute \"reason\"",
+      "path": "sentientos/integrity_controller.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 78,
+      "line": 241,
+      "message": "\"AuditChainVerification\" has no attribute \"reason\"",
+      "path": "sentientos/integrity_controller.py"
+    },
+    {
+      "code": "comparison-overlap",
+      "column": 12,
+      "line": 23,
+      "message": "Non-overlapping container check (element type: \"Path\", container item type: \"str\")",
+      "path": "sentientos/integrity_metrics.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 140,
+      "message": "Argument 1 to \"IntegrityPressureState\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/integrity_pressure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 140,
+      "message": "Argument 1 to \"IntegrityPressureState\" has incompatible type \"**dict[str, object]\"; expected \"str | None\"",
+      "path": "sentientos/integrity_pressure.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 140,
+      "message": "Argument 1 to \"IntegrityPressureState\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/integrity_pressure.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 51,
+      "line": 242,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/integrity_snapshot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 16,
+      "line": 298,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", variable has type \"str\")",
+      "path": "sentientos/integrity_snapshot.py"
+    },
+    {
+      "code": "assignment",
+      "column": 17,
+      "line": 299,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", variable has type \"str\")",
+      "path": "sentientos/integrity_snapshot.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 111,
+      "message": "Argument 2 to \"append_json\" has incompatible type \"MutableMapping[str, object]\"; expected \"dict[str, Any]\"",
+      "path": "sentientos/intent_record.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 34,
+      "line": 44,
+      "message": "Missing type arguments for generic type \"OrderedDict\"",
+      "path": "sentientos/introspection/spine.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 46,
+      "line": 55,
+      "message": "Item \"None\" of \"dict[str, object] | None\" has no attribute \"get\"",
+      "path": "sentientos/jurisprudence_consumption.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 44,
+      "line": 56,
+      "message": "Item \"None\" of \"dict[str, object] | None\" has no attribute \"get\"",
+      "path": "sentientos/jurisprudence_consumption.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 52,
+      "line": 385,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 42,
+      "line": 401,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 402,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/kernel_admission_provenance.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 10,
+      "line": 133,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/contradiction_policy.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 532,
+      "message": "Argument 2 to \"write_json\" has incompatible type \"dict[str, object] | dict[str, int]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/lab/federation_lab.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 337,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 495,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 34,
+      "line": 497,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 504,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 26,
+      "line": 506,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 507,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 45,
+      "line": 508,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "assignment",
+      "column": 5,
+      "line": 644,
+      "message": "Incompatible types in assignment (expression has type \"Mapping[str, object]\", variable has type \"dict[str, object]\")",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "assignment",
+      "column": 16,
+      "line": 715,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"Popen[str]\")",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 762,
+      "message": "Argument \"check\" to \"classify_remote_preflight\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 763,
+      "message": "Argument \"mkdir\" to \"classify_remote_preflight\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "index",
+      "column": 13,
+      "line": 792,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 832,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 833,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 834,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "assignment",
+      "column": 9,
+      "line": 1030,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"Path\")",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 90,
+      "line": 1048,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 86,
+      "line": 1050,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 14,
+      "line": 1053,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 1057,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 1150,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 1151,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 1153,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 1154,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 35,
+      "line": 1155,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "misc",
+      "column": 55,
+      "line": 1214,
+      "message": "Generator has incompatible item type \"int\"; expected \"bool\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 59,
+      "line": 1214,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/lab/wan_federation.py"
+    },
+    {
+      "code": "comparison-overlap",
+      "column": 8,
+      "line": 403,
+      "message": "Non-overlapping equality check (left operand type: \"Path\", right operand type: \"str\")",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 486,
+      "message": "Argument 1 to \"LocalDiagnosticEffectRequest\" has incompatible type \"**dict[str, tuple[str, ...] | bool | str | None]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 486,
+      "message": "Argument 1 to \"LocalDiagnosticEffectRequest\" has incompatible type \"**dict[str, tuple[str, ...] | bool | str | None]\"; expected \"str | None\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 486,
+      "message": "Argument 1 to \"LocalDiagnosticEffectRequest\" has incompatible type \"**dict[str, tuple[str, ...] | bool | str | None]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 486,
+      "message": "Argument 1 to \"LocalDiagnosticEffectRequest\" has incompatible type \"**dict[str, tuple[str, ...] | bool | str | None]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 525,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 525,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 525,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 525,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 575,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 575,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 575,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 575,
+      "message": "Argument 1 to \"LocalDiagnosticEffectResult\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 602,
+      "message": "Argument 1 to \"LocalDiagnosticEffectReceipt\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 602,
+      "message": "Argument 1 to \"LocalDiagnosticEffectReceipt\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 602,
+      "message": "Argument 1 to \"LocalDiagnosticEffectReceipt\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 602,
+      "message": "Argument 1 to \"LocalDiagnosticEffectReceipt\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 635,
+      "message": "Argument 1 to \"LocalDiagnosticPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 635,
+      "message": "Argument 1 to \"LocalDiagnosticPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 635,
+      "message": "Argument 1 to \"LocalDiagnosticPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 635,
+      "message": "Argument 1 to \"LocalDiagnosticPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 653,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPlan\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 653,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPlan\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 653,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPlan\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 670,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackReceipt\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 670,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackReceipt\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 670,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackReceipt\" has incompatible type \"**dict[str, Sequence[str]]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 697,
+      "message": "Argument 1 to \"LocalDiagnosticProductionAuditReceipt\" has incompatible type \"**dict[str, tuple[str, ...] | str | None]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 697,
+      "message": "Argument 1 to \"LocalDiagnosticProductionAuditReceipt\" has incompatible type \"**dict[str, tuple[str, ...] | str | None]\"; expected \"str | None\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 697,
+      "message": "Argument 1 to \"LocalDiagnosticProductionAuditReceipt\" has incompatible type \"**dict[str, tuple[str, ...] | str | None]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 697,
+      "message": "Argument 1 to \"LocalDiagnosticProductionAuditReceipt\" has incompatible type \"**dict[str, tuple[str, ...] | str | None]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1212,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackRequest\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1212,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackRequest\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1212,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackRequest\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1343,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackReceipt\" has incompatible type \"**dict[str, bool | tuple[str, ...] | str | None]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1343,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackReceipt\" has incompatible type \"**dict[str, bool | tuple[str, ...] | str | None]\"; expected \"str | None\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1343,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackReceipt\" has incompatible type \"**dict[str, bool | tuple[str, ...] | str | None]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1343,
+      "message": "Argument 1 to \"LocalDiagnosticExactRollbackReceipt\" has incompatible type \"**dict[str, bool | tuple[str, ...] | str | None]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 1389,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 1389,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 1389,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackPostconditionCheck\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1431,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackAuditReceipt\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1431,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackAuditReceipt\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 1431,
+      "message": "Argument 1 to \"LocalDiagnosticRollbackAuditReceipt\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/local_diagnostic_effect.py"
+    },
+    {
+      "code": "name-defined",
+      "column": 31,
+      "line": 130,
+      "message": "Name \"torch.dtype\" is not defined",
+      "path": "sentientos/local_model.py"
+    },
+    {
+      "code": "assignment",
+      "column": 37,
+      "line": 338,
+      "message": "Incompatible types in assignment (expression has type \"_ModelBackend\", variable has type \"_NullBackend\")",
+      "path": "sentientos/local_model.py"
+    },
+    {
+      "code": "dict-item",
+      "column": 13,
+      "line": 354,
+      "message": "Dict entry 2 has incompatible type \"str\": \"list[str]\"; expected \"str\": \"str\"",
+      "path": "sentientos/local_model.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 403,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "sentientos/local_model.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 61,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 67,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 31,
+      "line": 67,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 73,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 79,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 32,
+      "line": 79,
+      "message": "Missing type arguments for generic type \"list\"",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 85,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 39,
+      "line": 85,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 91,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 44,
+      "line": 91,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 97,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 41,
+      "line": 97,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/logging/events.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 17,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 17,
+      "message": "Name \"BaseHTTPMiddleware\" already defined on line 13",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 18,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 21,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 21,
+      "message": "Name \"Request\" already defined on line 14",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 31,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 31,
+      "message": "Name \"Response\" already defined on line 15",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "misc",
+      "column": 34,
+      "line": 38,
+      "message": "Invalid base class \"BaseHTTPMiddleware\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 34,
+      "line": 38,
+      "message": "Variable \"sentientos.logging_middleware.BaseHTTPMiddleware\" is not valid as a type",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 41,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 39,
+      "line": 46,
+      "message": "Variable \"sentientos.logging_middleware.Request\" is not valid as a type",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "valid-type",
+      "column": 89,
+      "line": 46,
+      "message": "Variable \"sentientos.logging_middleware.Response\" is not valid as a type",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 52,
+      "message": "Request? has no attribute \"url\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 52,
+      "message": "Request? has no attribute \"method\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 59,
+      "message": "Request? has no attribute \"url\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 34,
+      "line": 59,
+      "message": "Request? has no attribute \"method\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 50,
+      "line": 59,
+      "message": "Response? has no attribute \"status_code\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 61,
+      "message": "Request? has no attribute \"headers\"",
+      "path": "sentientos/logging_middleware.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 20,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/dream_loop.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 34,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 96,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 136,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 185,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 212,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 249,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 289,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 313,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/memory/pulse_view.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 199,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/memory_economics.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 219,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/memory_economics.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 392,
+      "message": "Incompatible return value type (got \"list[dict[str, str]]\", expected \"list[dict[str, object]]\")",
+      "path": "sentientos/memory_economics.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 410,
+      "message": "Incompatible return value type (got \"list[dict[str, str]]\", expected \"list[dict[str, object]]\")",
+      "path": "sentientos/memory_economics.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 33,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/ambiguity_resolver.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 38,
+      "line": 39,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/ambiguity_resolver.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 38,
+      "line": 40,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/ambiguity_resolver.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 64,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/ambiguity_resolver.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 26,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/narrative_genealogy.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 38,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/narrative_genealogy.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 23,
+      "line": 46,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/narrative_genealogy.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 90,
+      "line": 62,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/narrative_genealogy.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 17,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 32,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "assignment",
+      "column": 40,
+      "line": 60,
+      "message": "Incompatible types in assignment (expression has type \"bool\", target has type \"Collection[Any]\")",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 15,
+      "line": 70,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 71,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 85,
+      "line": 96,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 97,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 10,
+      "line": 110,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 95,
+      "line": 117,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 124,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/meta/reflection_loop.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 93,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/metrics.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 76,
+      "line": 53,
+      "message": "Argument 1 to \"list\" has incompatible type \"Any | list[Any] | None\"; expected \"Iterable[Any]\"",
+      "path": "sentientos/narrative/narrative_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 65,
+      "message": "Argument \"key\" to \"sort\" of \"list\" has incompatible type \"Callable[[dict[str, Sequence[str]]], Sequence[str]]\"; expected \"Callable[[dict[str, Sequence[str]]], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/narrative/narrative_compressor.py"
+    },
+    {
+      "code": "return-value",
+      "column": 44,
+      "line": 65,
+      "message": "Incompatible return value type (got \"Sequence[str]\", expected \"SupportsDunderLT[Any] | SupportsDunderGT[Any]\")",
+      "path": "sentientos/narrative/narrative_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 21,
+      "message": "Argument 1 to \"_flatten_text\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/narrative/persona_decay_audit.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 22,
+      "message": "Argument 1 to \"_flatten_text\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/narrative/persona_decay_audit.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 33,
+      "message": "Argument 1 to \"_flatten_text\" has incompatible type \"ValuesView[object]\"; expected \"Iterable[str]\"",
+      "path": "sentientos/narrative/persona_decay_audit.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 6,
+      "line": 65,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/narrative/persona_decay_audit.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 52,
+      "line": 83,
+      "message": "Argument \"key\" to \"max\" has incompatible type overloaded function; expected \"Callable[[str], SupportsDunderLT[Any] | SupportsDunderGT[Any]]\"",
+      "path": "sentientos/narrative/persona_decay_audit.py"
+    },
+    {
+      "code": "misc",
+      "column": 41,
+      "line": 100,
+      "message": "Generator has incompatible item type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 54,
+      "line": 103,
+      "message": "Argument 2 to \"log_narrative_generated\" has incompatible type \"Collection[Collection[str]] | None\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 104,
+      "message": "Incompatible return value type (got \"dict[str, Collection[Collection[str]]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "misc",
+      "column": 41,
+      "line": 124,
+      "message": "Generator has incompatible item type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 47,
+      "line": 126,
+      "message": "Argument 2 to \"log_narrative_generated\" has incompatible type \"Collection[Collection[str]] | None\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 127,
+      "message": "Incompatible return value type (got \"dict[str, Collection[Collection[str]]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 151,
+      "message": "Argument 2 to \"log_narrative_generated\" has incompatible type \"object\"; expected \"Mapping[str, object] | None\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 193,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 194,
+      "message": "No overload variant of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 51,
+      "line": 228,
+      "message": "Module has no attribute \"ADMISSION_LOG_PATH\"; maybe \"_ADMISSION_LOG_PATH\"?",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 277,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 313,
+      "message": "\"object\" has no attribute \"add\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 320,
+      "message": "\"object\" has no attribute \"add\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 323,
+      "message": "\"object\" has no attribute \"add\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 342,
+      "message": "\"object\" has no attribute \"add\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 25,
+      "line": 351,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 352,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 353,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 30,
+      "line": 354,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 376,
+      "message": "\"object\" has no attribute \"add\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "operator",
+      "column": 13,
+      "line": 379,
+      "message": "Unsupported operand types for + (\"object\" and \"int\")",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "operator",
+      "column": 17,
+      "line": 381,
+      "message": "Unsupported operand types for + (\"object\" and \"int\")",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "operator",
+      "column": 17,
+      "line": 383,
+      "message": "Unsupported operand types for + (\"object\" and \"int\")",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 395,
+      "message": "No overload variant of \"sorted\" matches argument type \"object\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 435,
+      "message": "Argument 1 to \"_count_change_types\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 8,
+      "line": 437,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 440,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 441,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 458,
+      "message": "Argument 1 to \"_extract_entity_ids\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 464,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 465,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 466,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 8,
+      "line": 502,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "index",
+      "column": 15,
+      "line": 504,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 8,
+      "line": 506,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "index",
+      "column": 21,
+      "line": 507,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 12,
+      "line": 508,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 509,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 513,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 515,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 523,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 525,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 543,
+      "message": "Argument 1 to \"_extract_log_ids\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 544,
+      "message": "Argument 1 to \"_extract_log_ids\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 53,
+      "line": 545,
+      "message": "Argument 1 to \"_extract_log_ids\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 546,
+      "message": "Argument 1 to \"_extract_log_ids\" has incompatible type \"object\"; expected \"Iterable[Mapping[str, object]]\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 32,
+      "line": 560,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 598,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 599,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 609,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 610,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 611,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 29,
+      "line": 59,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 76,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "index",
+      "column": 24,
+      "line": 84,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "index",
+      "column": 33,
+      "line": 146,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "index",
+      "column": 34,
+      "line": 147,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "index",
+      "column": 32,
+      "line": 148,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 149,
+      "message": "Argument 1 to \"join\" of \"str\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 30,
+      "line": 154,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 254,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 277,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "assignment",
+      "column": 5,
+      "line": 336,
+      "message": "Incompatible types in assignment (expression has type \"str\", variable has type \"Path\")",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 337,
+      "message": "Argument 2 to \"_bounded_jsonl\" has incompatible type \"Path\"; expected \"str\"",
+      "path": "sentientos/node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 46,
+      "line": 74,
+      "message": "Module has no attribute \"ADMISSION_LOG_PATH\"; maybe \"_ADMISSION_LOG_PATH\"?",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 82,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 278,
+      "message": "Incompatible return value type (got \"dict[str, list[dict[str, object]]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 377,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 378,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 379,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 416,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 421,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 426,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 433,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 442,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 448,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 17,
+      "line": 456,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 508,
+      "message": "Module has no attribute \"ADMISSION_LOG_PATH\"; maybe \"_ADMISSION_LOG_PATH\"?",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 22,
+      "line": 721,
+      "message": "Argument \"kind\" to \"Step\" has incompatible type \"str\"; expected \"Literal['noop', 'shell', 'python', 'mesh', 'adapter']\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 730,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"object\"; expected \"Iterable[str]\"",
+      "path": "sentientos/ois.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 31,
+      "line": 79,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/operator_report_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 318,
+      "message": "Argument 3 to \"Anomaly\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 824,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 1000,
+      "message": "Item \"None\" of \"CIChecker | None\" has no attribute \"evaluate\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 24,
+      "line": 1021,
+      "message": "Item \"None\" of \"MergeGate | None\" has no attribute \"attempt\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 1234,
+      "message": "Argument 1 to \"_parse_timestamp\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 1297,
+      "message": "Returning Any from function declared to return \"MutableMapping[str, object]\"",
+      "path": "sentientos/oracle_cycle.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 401,
+      "message": "\"None\" has no attribute \"chromium\"",
+      "path": "sentientos/oracle_relay.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 402,
+      "message": "\"None\" has no attribute \"new_context\"",
+      "path": "sentientos/oracle_relay.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 22,
+      "line": 403,
+      "message": "\"None\" has no attribute \"new_page\"",
+      "path": "sentientos/oracle_relay.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 406,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/oracle_relay.py"
+    },
+    {
+      "code": "assignment",
+      "column": 18,
+      "line": 1640,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, Any] | None\", variable has type \"dict[str, Any]\")",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 1881,
+      "message": "Argument 2 to \"_recent_external_fulfillment_summary\" has incompatible type \"list[dict[str, Any]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 67,
+      "line": 2101,
+      "message": "Argument 2 to \"_recent_external_fulfillment_summary\" has incompatible type \"list[dict[str, Any]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 33,
+      "line": 6035,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 34,
+      "line": 6042,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 21,
+      "line": 6045,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"get\"",
+      "path": "sentientos/orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 58,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "sentientos/orchestration_spine/facade_mechanical_assembly.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 78,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "sentientos/orchestration_spine/facade_mechanical_assembly.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 98,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "sentientos/orchestration_spine/facade_mechanical_assembly.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 50,
+      "line": 270,
+      "message": "Argument 1 to \"_goal_state_summary\" has incompatible type \"dict[str, GoalStateRecord]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 38,
+      "line": 314,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 318,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 70,
+      "line": 404,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 72,
+      "line": 405,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 48,
+      "line": 406,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"dict[str, object]\")",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "index",
+      "column": 37,
+      "line": 420,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 441,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str\")",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 442,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str | None\")",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 38,
+      "line": 443,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 589,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 590,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 16,
+      "line": 680,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 96,
+      "line": 681,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 859,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/orchestrator.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 171,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/perception/asr_listener.py"
+    },
+    {
+      "code": "index",
+      "column": 9,
+      "line": 461,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/perception/asr_listener.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 81,
+      "line": 20,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 117,
+      "line": 27,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 41,
+      "line": 31,
+      "message": "Argument 1 to \"_keyword_overlap\" of \"RealityFingerprinter\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 31,
+      "message": "Argument 2 to \"_keyword_overlap\" of \"RealityFingerprinter\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 79,
+      "line": 47,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 26,
+      "line": 71,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 25,
+      "line": 72,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/perception/reality_fingerprint.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 33,
+      "line": 167,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/persona/loop.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 188,
+      "message": "Incompatible types in assignment (expression has type \"str | None\", variable has type \"str\")",
+      "path": "sentientos/persona/loop.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 216,
+      "message": "Incompatible types in assignment (expression has type \"object\", variable has type \"str\")",
+      "path": "sentientos/persona/loop.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 58,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/persona/persona_boundary_enforcer.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 31,
+      "line": 75,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/persona/persona_boundary_enforcer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 304,
+      "message": "Argument \"affective_context\" to \"PressureSignal\" has incompatible type \"object\"; expected \"Mapping[str, float]\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 356,
+      "message": "Argument 1 to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 357,
+      "message": "Argument 2 to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"float\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 358,
+      "message": "Argument \"reason\" to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 360,
+      "message": "Argument \"blocked\" to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"bool\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 28,
+      "line": 361,
+      "message": "Argument \"provenance\" to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"Mapping[str, object] | SensorProvenance | None\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 54,
+      "line": 362,
+      "message": "Argument 1 to \"default_provenance_for_constraint\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 32,
+      "line": 363,
+      "message": "Argument \"classification\" to \"record_signal\" of \"ConstraintEngagementEngine\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 388,
+      "message": "Argument 1 to \"float\" has incompatible type \"float | None\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 76,
+      "line": 537,
+      "message": "Argument \"overlay\" to \"capture_affective_context\" has incompatible type \"Mapping[str, object]\"; expected \"Mapping[str, float] | None\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 13,
+      "line": 554,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 759,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 67,
+      "line": 762,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 49,
+      "line": 767,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/pressure_engagement.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 97,
+      "message": "Incompatible return value type (got \"dict[str, dict[str, int] | int | str | None]\", expected \"dict[str, object]\")",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 134,
+      "message": "Argument \"as_of_date\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 135,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 168,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 65,
+      "line": 169,
+      "message": "Argument \"severity\" to \"_next_persistence_count\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 172,
+      "message": "Argument \"signal_type\" to \"_compute_next_review_due_at\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 173,
+      "message": "Argument \"severity\" to \"_compute_next_review_due_at\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 178,
+      "message": "Argument \"signal_type\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 179,
+      "message": "Argument \"as_of_date\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 180,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 181,
+      "message": "Argument \"severity\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 16,
+      "line": 183,
+      "message": "Argument \"source\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 233,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 65,
+      "line": 234,
+      "message": "Argument \"severity\" to \"_next_persistence_count\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 238,
+      "message": "Argument 1 to \"_escalate_severity\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 243,
+      "message": "Argument \"signal_type\" to \"_compute_next_review_due_at\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 244,
+      "message": "Argument \"severity\" to \"_compute_next_review_due_at\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 249,
+      "message": "Argument \"signal_type\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 250,
+      "message": "Argument \"as_of_date\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 251,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 252,
+      "message": "Argument \"severity\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 16,
+      "line": 254,
+      "message": "Argument \"source\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 13,
+      "line": 376,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 379,
+      "message": "Returning Any from function declared to return \"int\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 413,
+      "message": "Argument \"signal_type\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 414,
+      "message": "Argument \"as_of_date\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 415,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 18,
+      "line": 416,
+      "message": "Argument \"severity\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 16,
+      "line": 418,
+      "message": "Argument \"source\" to \"PressureQueueEvent\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 32,
+      "line": 474,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 33,
+      "line": 484,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 38,
+      "line": 485,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 497,
+      "message": "Argument \"signal_type\" to \"_compute_next_review_due_at\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 502,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 42,
+      "line": 503,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pressure_queue.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 9,
+      "line": 113,
+      "message": "Need type annotation for \"tokens\" (hint: \"tokens: list[<type>] = ...\")",
+      "path": "sentientos/privacy.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 52,
+      "line": 92,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/protected_mutation_intent.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 113,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/protected_mutation_intent.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 44,
+      "line": 114,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/protected_mutation_intent.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 11,
+      "line": 18,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/pulse/pulse_observer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 114,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/pulse/pulse_observer.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 372,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pulse_query.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 17,
+      "line": 376,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/pulse_query.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 487,
+      "message": "Argument 1 to \"_apply_metrics_filters\" has incompatible type \"object\"; expected \"Mapping[str, object]\"",
+      "path": "sentientos/pulse_query.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 488,
+      "message": "Argument 1 to \"_filter_anomalies\" has incompatible type \"object\"; expected \"Sequence[Mapping[str, object]] | Mapping[str, object] | None\"",
+      "path": "sentientos/pulse_query.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 497,
+      "message": "Incompatible return value type (got \"dict[str, Collection[object]]\", expected \"dict[str, object]\")",
+      "path": "sentientos/pulse_query.py"
+    },
+    {
+      "code": "assignment",
+      "column": 25,
+      "line": 740,
+      "message": "Incompatible types in assignment (expression has type \"RealEffectCapabilityBlockReceipt\", variable has type \"RealEffectImplementationPlanScaffold\")",
+      "path": "sentientos/real_effect_admission.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 145,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/receipt_chain.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 39,
+      "line": 27,
+      "message": "Argument 2 to \"append_task_record\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 28,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 46,
+      "message": "Argument 2 to \"append_task_record\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 47,
+      "message": "Incompatible return value type (got \"dict[str, str | None]\", expected \"dict[str, object] | None\")",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 59,
+      "message": "Argument 2 to \"append_task_record\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 60,
+      "message": "Incompatible return value type (got \"dict[str, str]\", expected \"dict[str, object]\")",
+      "path": "sentientos/recovery_tasks.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 44,
+      "line": 68,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 72,
+      "message": "Returning Any from function declared to return \"dict[str, dict[Any, Any]]\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 50,
+      "line": 76,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 80,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 22,
+      "line": 83,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 88,
+      "line": 96,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 97,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 108,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 110,
+      "message": "Incompatible return value type (got \"Literal[''] | bool\", expected \"bool\")",
+      "path": "sentientos/reflex/reflex_petitioner.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 48,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/reflex/reflex_state_index.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 43,
+      "line": 168,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 17,
+      "line": 194,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 34,
+      "line": 264,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 301,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 74,
+      "line": 331,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 58,
+      "line": 333,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 48,
+      "line": 334,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 32,
+      "line": 335,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/remediation_pack.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 218,
+      "message": "Returning Any from function declared to return \"CompletedProcess[str]\"",
+      "path": "sentientos/research_timer.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 16,
+      "line": 218,
+      "message": "No overload variant of \"run\" matches argument types \"tuple[Any, ...]\", \"dict[str, Any]\", \"bool\", \"Path\", \"bool\"",
+      "path": "sentientos/research_timer.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 475,
+      "message": "Returning Any from function declared to return \"CompletedProcess[str]\"",
+      "path": "sentientos/research_timer.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 16,
+      "line": 475,
+      "message": "No overload variant of \"run\" matches argument types \"tuple[Any, ...]\", \"dict[str, Any]\", \"bool\", \"Path\", \"bool\"",
+      "path": "sentientos/research_timer.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 514,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/research_timer.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 62,
+      "line": 571,
+      "message": "Argument 1 to \"build_dry_run_audit_closure_wing\" has incompatible type \"DryRunExecutionReceipt | None\"; expected \"DryRunExecutionReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 66,
+      "line": 685,
+      "message": "Argument 1 to \"summarize_dry_run_execution_result\" has incompatible type \"DryRunExecutionResult | DryRunExecutionBlockReceipt\"; expected \"DryRunExecutionResult | Mapping[str, Any]\"",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 80,
+      "line": 686,
+      "message": "Argument 1 to \"summarize_dry_run_execution_block_receipt\" has incompatible type \"DryRunExecutionResult | DryRunExecutionBlockReceipt\"; expected \"DryRunExecutionBlockReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 89,
+      "line": 752,
+      "message": "Argument 1 to \"summarize_real_effect_implementation_plan_scaffold\" has incompatible type \"RealEffectImplementationPlanScaffold | RealEffectCapabilityBlockReceipt\"; expected \"RealEffectImplementationPlanScaffold | Mapping[str, Any]\"",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 85,
+      "line": 753,
+      "message": "Argument 1 to \"summarize_real_effect_capability_block_receipt\" has incompatible type \"RealEffectImplementationPlanScaffold | RealEffectCapabilityBlockReceipt\"; expected \"RealEffectCapabilityBlockReceipt | Mapping[str, Any]\"",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "comparison-overlap",
+      "column": 8,
+      "line": 1284,
+      "message": "Non-overlapping equality check (left operand type: \"Path\", right operand type: \"str\")",
+      "path": "sentientos/reviewer_proof_bundle.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 46,
+      "line": 192,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"Literal['normal', 'cautious', 'recovery', 'lockdown']\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"Literal['stability', 'balanced', 'velocity']\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"list[str] | None\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 194,
+      "message": "Argument 1 to \"RiskBudget\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/risk_budget.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 43,
+      "line": 361,
+      "message": "Item \"None\" of \"Any | list[Any] | None\" has no attribute \"__iter__\" (not iterable)",
+      "path": "sentientos/runtime_governor.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 78,
+      "message": "Module has no attribute \"CREATE_NEW_PROCESS_GROUP\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 84,
+      "message": "Module has no attribute \"windll\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 92,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 93,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 30,
+      "line": 95,
+      "message": "Module has no attribute \"ULONG_PTR\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 102,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 103,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 41,
+      "line": 104,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 105,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 106,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 107,
+      "message": "Module has no attribute \"ULONG64\"; maybe \"PULONG\"?",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 114,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 36,
+      "line": 115,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 43,
+      "line": 116,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 117,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 37,
+      "line": 123,
+      "message": "Module has no attribute \"SIZE_T\"",
+      "path": "sentientos/sandbox_runner.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 125,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/shell/cli.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 290,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], str]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 291,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], None]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 335,
+      "message": "Argument 1 to \"RollupSignature\" has incompatible type \"**dict[str, object]\"; expected \"int\"",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 335,
+      "message": "Argument 1 to \"RollupSignature\" has incompatible type \"**dict[str, object]\"; expected \"str | None\"",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 335,
+      "message": "Argument 1 to \"RollupSignature\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 27,
+      "line": 344,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/signed_rollups.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 26,
+      "line": 181,
+      "message": "Item \"None\" of \"StrategicSigner | None\" has no attribute \"public_key_id\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 22,
+      "line": 182,
+      "message": "Item \"None\" of \"StrategicSigner | None\" has no attribute \"algorithm\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 17,
+      "line": 185,
+      "message": "Item \"None\" of \"StrategicSigner | None\" has no attribute \"sign\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 23,
+      "line": 200,
+      "message": "Item \"None\" of \"StrategicSigner | None\" has no attribute \"public_key_id\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 19,
+      "line": 201,
+      "message": "Item \"None\" of \"StrategicSigner | None\" has no attribute \"algorithm\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 216,
+      "message": "Argument \"links\" to \"append_catalog_entry\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object] | None\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 91,
+      "line": 268,
+      "message": "Argument 2 to \"write_json\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "return-value",
+      "column": 16,
+      "line": 269,
+      "message": "Incompatible return value type (got \"tuple[dict[str, str | None], None]\", expected \"tuple[dict[str, object], str | None]\")",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 76,
+      "line": 274,
+      "message": "Argument 2 to \"write_json\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 275,
+      "message": "Argument 1 to \"_enforce_witness\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 72,
+      "line": 302,
+      "message": "Argument 2 to \"write_json\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 303,
+      "message": "Argument 1 to \"_enforce_witness\" has incompatible type \"dict[str, str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 313,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 27,
+      "line": 340,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/signed_strategic.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 145,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/start.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 34,
+      "line": 160,
+      "message": "Argument \"persona_state_getter\" to \"make_status_source\" has incompatible type \"Callable[[], object | None]\"; expected \"Callable[[], PersonaState | None] | None\"",
+      "path": "sentientos/start.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 31,
+      "line": 165,
+      "message": "Argument \"log_stream_source\" to \"ConsoleDashboard\" has incompatible type \"Callable[[], Iterable[str]]\"; expected \"Callable[[], Sequence[str]] | None\"",
+      "path": "sentientos/start.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 12,
+      "line": 249,
+      "message": "Argument \"ts\" to \"append_catalog_entry\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "index",
+      "column": 5,
+      "line": 345,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 346,
+      "message": "\"object\" has no attribute \"setdefault\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 417,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 17,
+      "line": 427,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "misc",
+      "column": 34,
+      "line": 473,
+      "message": "Generator has incompatible item type \"int\"; expected \"bool\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 53,
+      "line": 473,
+      "message": "\"object\" has no attribute \"items\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 30,
+      "line": 474,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 475,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 50,
+      "line": 477,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 18,
+      "line": 496,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 541,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 542,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 562,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 39,
+      "line": 564,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 632,
+      "message": "Argument \"posture\" to \"derive_risk_budget\" has incompatible type \"str\"; expected \"Literal['stability', 'balanced', 'velocity']\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 633,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 637,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "index",
+      "column": 35,
+      "line": 638,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 19,
+      "line": 639,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "index",
+      "column": 35,
+      "line": 640,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 34,
+      "line": 645,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 17,
+      "line": 701,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 19,
+      "line": 702,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 21,
+      "line": 703,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 825,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 24,
+      "line": 829,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 40,
+      "line": 833,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 24,
+      "line": 834,
+      "message": "Argument \"inputs_summary\" to \"GoalGraphAdjustmentProposal\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 842,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 845,
+      "message": "Argument \"allocator_inputs_snapshot\" to \"GoalGraphAdjustmentProposal\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 36,
+      "line": 846,
+      "message": "Argument \"current_allocation_summary\" to \"GoalGraphAdjustmentProposal\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 847,
+      "message": "Argument \"proposed_allocation_summary\" to \"GoalGraphAdjustmentProposal\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 25,
+      "line": 848,
+      "message": "Argument \"allocation_diff\" to \"GoalGraphAdjustmentProposal\" has incompatible type \"object\"; expected \"dict[str, object]\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 849,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 49,
+      "line": 851,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 35,
+      "line": 852,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 56,
+      "line": 853,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 24,
+      "line": 856,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 33,
+      "line": 857,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 32,
+      "line": 858,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/strategic_adaptation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 93,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/strategic_posture.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 119,
+      "message": "No overload variant of \"get\" of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/streams/drift_stream.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 20,
+      "line": 178,
+      "message": "No overload variant of \"get\" of \"dict\" matches argument type \"object\"",
+      "path": "sentientos/streams/drift_stream.py"
+    },
+    {
+      "code": "operator",
+      "column": 41,
+      "line": 77,
+      "message": "Unsupported left operand type for <= (\"object\")",
+      "path": "sentientos/streams/event_stream.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 90,
+      "message": "Argument \"digest\" to \"EventEnvelope\" has incompatible type \"object\"; expected \"str | None\"",
+      "path": "sentientos/streams/pressure_stream.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 65,
+      "line": 53,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/symbols/symbol_unifier.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 23,
+      "line": 116,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 288,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 30,
+      "line": 350,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 26,
+      "line": 351,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 27,
+      "line": 352,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 39,
+      "line": 353,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 30,
+      "line": 354,
+      "message": "No overload variant of \"list\" matches argument type \"object\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 21,
+      "line": 392,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_constitution.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 198,
+      "message": "Argument 1 to \"tuple\" has incompatible type \"object\"; expected \"Iterable[Never]\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 22,
+      "line": 221,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 28,
+      "line": 222,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 29,
+      "line": 223,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 240,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 35,
+      "line": 248,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 37,
+      "line": 249,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 42,
+      "line": 250,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 42,
+      "line": 251,
+      "message": "No overload variant of \"int\" matches argument type \"object\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 23,
+      "line": 334,
+      "message": "Argument 1 to \"asdict\" has incompatible type \"DataclassInstance | type[DataclassInstance]\"; expected \"DataclassInstance\"",
+      "path": "sentientos/system_identity.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 33,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/conftest.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 61,
+      "message": "Argument 2 to \"setdefault\" of \"MutableMapping\" has incompatible type \"SimpleNamespace\"; expected Module",
+      "path": "sentientos/tests/conftest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_digest_with_sanitizer.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 24,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_digest_with_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 27,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_digest_with_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 42,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_digest_with_sanitizer.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 66,
+      "line": 8,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 28,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 37,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 40,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 49,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 52,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "index",
+      "column": 43,
+      "line": 71,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 78,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 86,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "index",
+      "column": 52,
+      "line": 87,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 91,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_consensus.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 18,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 29,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 31,
+      "message": "Call to untyped function \"sample_identity_summary\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 32,
+      "message": "Call to untyped function \"sample_config\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 16,
+      "line": 39,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "index",
+      "column": 17,
+      "line": 40,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 43,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 45,
+      "message": "Call to untyped function \"sample_identity_summary\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 46,
+      "message": "Call to untyped function \"sample_config\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 23,
+      "line": 49,
+      "message": "Call to untyped function \"sample_config\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 57,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 59,
+      "message": "Call to untyped function \"sample_identity_summary\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 60,
+      "message": "Call to untyped function \"sample_config\" in typed context",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "index",
+      "column": 5,
+      "line": 70,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 73,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/federation/test_federation_digest.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_autobio_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 13,
+      "message": "Argument \"chapters\" to \"compress\" of \"AutobiographicalCompressor\" has incompatible type \"list[dict[str, str]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_autobio_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 49,
+      "line": 20,
+      "message": "Argument \"chapters\" to \"compress\" of \"AutobiographicalCompressor\" has incompatible type \"list[dict[str, str]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_autobio_compressor.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 30,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_autobio_compressor.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 42,
+      "line": 37,
+      "message": "Argument \"chapters\" to \"compress\" of \"AutobiographicalCompressor\" has incompatible type \"list[dict[str, str]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_autobio_compressor.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 14,
+      "line": 26,
+      "message": "Need type annotation for \"ethics\"",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 30,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 32,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 40,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 42,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 58,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 60,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 78,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 80,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 95,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 97,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 112,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 43,
+      "line": 114,
+      "message": "Call to untyped function \"base_inputs\" in typed context",
+      "path": "sentientos/tests/innerworld/test_cognitive_report.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 9,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/innerworld/test_cycle_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 17,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cycle_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 30,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cycle_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 41,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cycle_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 56,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_cycle_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 19,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 13,
+      "line": 24,
+      "message": "Call to untyped function \"evaluate_ethics\" in typed context",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 25,
+      "message": "Call to untyped function \"evaluate_ethics\" in typed context",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 30,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 9,
+      "line": 38,
+      "message": "Call to untyped function \"evaluate_ethics\" in typed context",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 45,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/innerworld/test_ethical_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 6,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 16,
+      "message": "Argument \"meta_notes\" to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"list[dict[str, str]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 26,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 14,
+      "line": 29,
+      "message": "Need type annotation for \"ethics\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 54,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 56,
+      "message": "Need type annotation for \"empty_qualia\" (hint: \"empty_qualia: dict[<type>, <type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 57,
+      "message": "Need type annotation for \"empty_meta\" (hint: \"empty_meta: list[<type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 58,
+      "message": "Need type annotation for \"empty_ethics\" (hint: \"empty_ethics: dict[<type>, <type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 59,
+      "message": "Need type annotation for \"reflection\" (hint: \"reflection: dict[<type>, <type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 60,
+      "message": "Need type annotation for \"identity\" (hint: \"identity: dict[<type>, <type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 88,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 98,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"Mapping[str, Any] | None\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 98,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 43,
+      "line": 98,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 99,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"Mapping[str, Any] | None\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 99,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 99,
+      "message": "Argument 1 to \"compute_spotlight\" of \"GlobalWorkspace\" has incompatible type \"**dict[str, Collection[Collection[str]]]\"; expected \"list[Mapping[str, Any]]\"",
+      "path": "sentientos/tests/innerworld/test_global_workspace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_inner_dialogue.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 23,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_inner_dialogue.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 5,
+      "line": 26,
+      "message": "Need type annotation for \"reflection\" (hint: \"reflection: dict[<type>, <type>] = ...\")",
+      "path": "sentientos/tests/innerworld/test_inner_dialogue.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 20,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/innerworld/test_orchestrator_runtime_consistency.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 35,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/innerworld/test_orchestrator_runtime_consistency.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 50,
+      "line": 10,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 21,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 31,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 45,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 60,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 90,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_reflection_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "index",
+      "column": 25,
+      "line": 37,
+      "message": "Value of type \"Collection[str]\" is not indexable",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 42,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 83,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 133,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 147,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_self_narrative.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 11,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_simulation_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 24,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_simulation_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 35,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_simulation_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 44,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_simulation_engine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_value_drift.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 38,
+      "line": 14,
+      "message": "Argument \"ethics\" to \"record_cycle\" of \"ValueDriftSentinel\" has incompatible type \"object\"; expected \"Mapping[str, Any]\"",
+      "path": "sentientos/tests/innerworld/test_value_drift.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 15,
+      "line": 16,
+      "message": "Call to untyped function \"get_history\" in typed context",
+      "path": "sentientos/tests/innerworld/test_value_drift.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 25,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/innerworld/test_value_drift.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "typeddict-item",
+      "column": 31,
+      "line": 16,
+      "message": "TypedDict \"CycleOutput\" has no key \"cognitive_report\"",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 23,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "typeddict-item",
+      "column": 62,
+      "line": 29,
+      "message": "TypedDict \"CycleOutput\" has no key \"cognitive_report\"",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "typeddict-item",
+      "column": 64,
+      "line": 30,
+      "message": "TypedDict \"CycleOutput\" has no key \"cognitive_report\"",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 35,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_cognitive_report_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 9,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 24,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 41,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 49,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 56,
+      "message": "\"Sequence[str]\" has no attribute \"append\"",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 62,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_config_sanitizer.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 11,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 28,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 41,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 27,
+      "line": 49,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 22,
+      "line": 55,
+      "message": "Argument 1 to \"normalize\" has incompatible type \"InnerWorldReport\"; expected \"dict[Any, Any]\"",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 58,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "index",
+      "column": 5,
+      "line": 63,
+      "message": "Unsupported target for indexed assignment (\"Mapping[str, float]\")",
+      "path": "sentientos/tests/runtime/test_core_loop_innerworld.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 9,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 22,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 31,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 12,
+      "line": 39,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 12,
+      "line": 40,
+      "message": "\"object\" has no attribute \"get\"",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 43,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_federation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 9,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_history_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 24,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_history_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 25,
+      "line": 29,
+      "message": "Call to untyped function \"get_history_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_history_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 24,
+      "line": 32,
+      "message": "Call to untyped function \"get_history_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_history_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_narrative_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 20,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_narrative_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 33,
+      "line": 23,
+      "message": "Call to untyped function \"get_narrative_chapters\" in typed context",
+      "path": "sentientos/tests/runtime/test_narrative_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 33,
+      "line": 26,
+      "message": "Call to untyped function \"get_narrative_chapters\" in typed context",
+      "path": "sentientos/tests/runtime/test_narrative_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 31,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_narrative_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 11,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 20,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 23,
+      "message": "Call to untyped function \"get_reflection_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 24,
+      "message": "Call to untyped function \"get_reflection_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 15,
+      "line": 29,
+      "message": "Call to untyped function \"get_reflection_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 33,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 44,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 46,
+      "message": "Call to untyped function \"get_reflection_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 24,
+      "line": 50,
+      "message": "Call to untyped function \"get_reflection_summary\" in typed context",
+      "path": "sentientos/tests/runtime/test_reflection_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_runtime_ethics.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 19,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/runtime/test_runtime_ethics.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 33,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/runtime/test_runtime_ethics.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 8,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_runtime_orchestrator_init.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 15,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_runtime_orchestrator_init.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_sanitized_config_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 20,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_sanitized_config_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 27,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_sanitized_config_integration.py"
+    },
+    {
+      "code": "typeddict-item",
+      "column": 42,
+      "line": 35,
+      "message": "TypedDict \"CycleOutput\" has no key \"config_snapshot\"",
+      "path": "sentientos/tests/runtime/test_sanitized_config_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 38,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_sanitized_config_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 9,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_simulation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 21,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_simulation_integration.py"
+    },
+    {
+      "code": "index",
+      "column": 5,
+      "line": 30,
+      "message": "Unsupported target for indexed assignment (\"Mapping[str, float]\")",
+      "path": "sentientos/tests/runtime/test_simulation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 37,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_simulation_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 6,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 10,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 37,
+      "line": 12,
+      "message": "Call to untyped function \"_base_input\" in typed context",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 25,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 41,
+      "line": 27,
+      "message": "Call to untyped function \"_base_input\" in typed context",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 35,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 40,
+      "line": 39,
+      "message": "Call to untyped function \"_base_input\" in typed context",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 41,
+      "line": 40,
+      "message": "Call to untyped function \"_base_input\" in typed context",
+      "path": "sentientos/tests/runtime/test_unified_cognition_integration.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 92,
+      "message": "Unsupported operand types for <= (\"int\" and \"object\")",
+      "path": "sentientos/tests/test_artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 58,
+      "line": 138,
+      "message": "Argument 2 to \"resolve_entry_path\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_artifact_catalog.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 47,
+      "line": 15,
+      "message": "Argument 1 to \"compute_envelope_hash\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_attestation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 48,
+      "line": 17,
+      "message": "Argument 1 to \"compute_envelope_hash\" has incompatible type \"dict[str, str]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_attestation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 30,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_attestation_snapshot.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 57,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_attestation_snapshot.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 8,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_autonomy_action_innervation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 23,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_autonomy_action_innervation.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 36,
+      "message": "Call to untyped function \"_read_last\" in typed context",
+      "path": "sentientos/tests/test_autonomy_action_innervation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 45,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_autonomy_action_innervation.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 14,
+      "line": 62,
+      "message": "Call to untyped function \"_read_last\" in typed context",
+      "path": "sentientos/tests/test_autonomy_action_innervation.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 48,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 49,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 50,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 68,
+      "line": 53,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 79,
+      "line": 54,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 65,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 66,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 24,
+      "line": 67,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 71,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 72,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 73,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 76,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_bootstrap_trust_restore.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 92,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_posture.py"
+    },
+    {
+      "code": "index",
+      "column": 41,
+      "line": 93,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_posture.py"
+    },
+    {
+      "code": "index",
+      "column": 44,
+      "line": 94,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_posture.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 96,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_posture.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 36,
+      "line": 15,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 69,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "index",
+      "column": 32,
+      "line": 70,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 71,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 72,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 103,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_cognitive_state_snapshot.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 69,
+      "line": 116,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_consciousness_pressure_context.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 40,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_consent_governance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 61,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_consent_governance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 89,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_consent_governance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 114,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_consent_governance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 135,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_consent_governance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 130,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_delegated_judgment_fabric.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 35,
+      "line": 9,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 21,
+      "line": 19,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 19,
+      "line": 20,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 20,
+      "line": 21,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 16,
+      "line": 22,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 6,
+      "line": 23,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "assignment",
+      "column": 37,
+      "line": 26,
+      "message": "Incompatible types in assignment (expression has type \"dict[Any, Any]\", target has type \"str\")",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "assignment",
+      "column": 35,
+      "line": 28,
+      "message": "Incompatible types in assignment (expression has type \"dict[Any, Any]\", target has type \"str\")",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "assignment",
+      "column": 36,
+      "line": 30,
+      "message": "Incompatible types in assignment (expression has type \"dict[Any, Any]\", target has type \"str\")",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "assignment",
+      "column": 32,
+      "line": 32,
+      "message": "Incompatible types in assignment (expression has type \"dict[Any, Any]\", target has type \"str\")",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 87,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 100,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_drift_detector.py"
+    },
+    {
+      "code": "index",
+      "column": 5,
+      "line": 41,
+      "message": "Unsupported target for indexed assignment (\"Sequence[ExplanationStatement]\")",
+      "path": "sentientos/tests/test_explanation_integrity.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 74,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_explanation_integrity.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 75,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_explanation_integrity.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 56,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 59,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 62,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 67,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 75,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 80,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 97,
+      "message": "Module \"sentientos.daemons.pulse_federation\" does not explicitly export attribute \"pulse_bus\"",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 137,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 153,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 177,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 310,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_bounded_lifecycle.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 25,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_execution.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 44,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_execution.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 64,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_execution.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 90,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_execution.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 113,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_execution.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 50,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 53,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 56,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 61,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 69,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 89,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 105,
+      "message": "Module \"sentientos.daemons.pulse_federation\" does not explicitly export attribute \"pulse_bus\"",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 111,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 51,
+      "line": 123,
+      "message": "Argument 1 to \"ingest_remote_event\" has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 137,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 46,
+      "line": 158,
+      "message": "Argument 1 to \"ingest_remote_event\" has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 165,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 46,
+      "line": 183,
+      "message": "Argument 1 to \"ingest_remote_event\" has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 193,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 46,
+      "line": 211,
+      "message": "Argument 1 to \"ingest_remote_event\" has incompatible type \"dict[str, Collection[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_federation_canonical_ingress.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 42,
+      "line": 136,
+      "message": "Call to untyped function \"_entry\" in typed context",
+      "path": "sentientos/tests/test_federation_integrity.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 53,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 79,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 92,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 109,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 118,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 127,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 154,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 175,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_seed_health_history.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 180,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_seed_health_history.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 185,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_seed_health_history.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 190,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_seed_health_history.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 195,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_federation_seed_health_history.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 93,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_slice_pattern.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 96,
+      "message": "Module \"sentientos.federation_slice_pattern\" does not explicitly export attribute \"FEDERATION_TYPED_ACTION_REGISTRY\"",
+      "path": "sentientos/tests/test_federation_slice_pattern.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 103,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_federation_slice_pattern.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 23,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_typed_actions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 103,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_federation_typed_actions.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 58,
+      "line": 104,
+      "message": "Argument \"runtime_governor\" to \"ControlPlaneKernel\" has incompatible type \"_AllowingGovernor\"; expected \"RuntimeGovernor | None\"",
+      "path": "sentientos/tests/test_federation_typed_actions.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 56,
+      "line": 105,
+      "message": "Argument \"runtime_governor\" to \"ControlPlaneKernel\" has incompatible type \"_AllowingGovernor\"; expected \"RuntimeGovernor | None\"",
+      "path": "sentientos/tests/test_federation_typed_actions.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 9,
+      "line": 20,
+      "message": "Need type annotation for \"regression_reasons\" (hint: \"regression_reasons: list[<type>] = ...\")",
+      "path": "sentientos/tests/test_forge_daemon_canary.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 48,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_forge_daemon_canary.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 57,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_daemon_canary.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 9,
+      "line": 58,
+      "message": "Need type annotation for \"called\" (hint: \"called: list[<type>] = ...\")",
+      "path": "sentientos/tests/test_forge_daemon_canary.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 45,
+      "line": 98,
+      "message": "Argument \"forge\" to \"ForgeDaemon\" has incompatible type \"_Forge\"; expected \"CathedralForge | None\"",
+      "path": "sentientos/tests/test_forge_daemon_canary.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 112,
+      "message": "Module has no attribute \"require_admin_banner\"",
+      "path": "sentientos/tests/test_forge_observatory.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 113,
+      "message": "Module has no attribute \"require_lumos_approval\"",
+      "path": "sentientos/tests/test_forge_observatory.py"
+    },
+    {
+      "code": "comparison-overlap",
+      "column": 12,
+      "line": 152,
+      "message": "Non-overlapping identity check (left operand type: \"Collection[Collection[str]] | None\", right operand type: \"Literal[True]\")",
+      "path": "sentientos/tests/test_forge_observatory.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 58,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 138,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 163,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 201,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 235,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 274,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 311,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 337,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 351,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 383,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_forge_status.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 32,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_generate_immutable_manifest_control_plane.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 35,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_generate_immutable_manifest_control_plane.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 69,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_generate_immutable_manifest_control_plane.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 72,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_generate_immutable_manifest_control_plane.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 8,
+      "message": "Module \"sentientos.github_checks\" does not explicitly export attribute \"shutil\"",
+      "path": "sentientos/tests/test_github_checks.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 21,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_github_checks.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 25,
+      "message": "Module \"sentientos.github_checks\" does not explicitly export attribute \"time\"",
+      "path": "sentientos/tests/test_github_checks.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 38,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_github_checks.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 25,
+      "line": 42,
+      "message": "Module \"sentientos.github_checks\" does not explicitly export attribute \"time\"",
+      "path": "sentientos/tests/test_github_checks.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"operating_mode\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"posture\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"pressure_level\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"quarantine_active\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"repo_root\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 15,
+      "line": 23,
+      "message": "Missing named argument \"risk_budget_summary\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"operating_mode\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"posture\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"pressure_level\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"quarantine_active\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"repo_root\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 13,
+      "line": 41,
+      "message": "Missing named argument \"risk_budget_summary\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"operating_mode\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"posture\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"pressure_level\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"quarantine_active\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"repo_root\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "call-arg",
+      "column": 14,
+      "line": 42,
+      "message": "Missing named argument \"risk_budget_summary\" for \"update_goal_state_from_run\"",
+      "path": "sentientos/tests/test_goal_state_update.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 1,
+      "line": 10,
+      "message": "Module \"sentientos.genesis_forge\" does not explicitly export attribute \"RecoveryLedger\"",
+      "path": "sentientos/tests/test_governance_trace.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 188,
+      "message": "Argument \"integrity_daemon\" to \"GenesisForge\" has incompatible type \"_IntegrityDaemon\"; expected \"IntegrityDaemon\"",
+      "path": "sentientos/tests/test_governance_trace.py"
+    },
+    {
+      "code": "operator",
+      "column": 38,
+      "line": 205,
+      "message": "Unsupported operand types for / (\"Path\" and \"object\")",
+      "path": "sentientos/tests/test_governance_trace.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 229,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_governance_trace.py"
+    },
+    {
+      "code": "untyped-decorator",
+      "column": 6,
+      "line": 16,
+      "message": "Untyped decorator makes function \"perform\" untyped",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 21,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 24,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 32,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 42,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 54,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 69,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 83,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_innervation_gate.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 28,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_integrity_quarantine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 32,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_integrity_quarantine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 61,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_introspection_spine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 95,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_introspection_spine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 145,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_introspection_spine.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 29,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_jurisprudence_consumption.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 41,
+      "message": "\"object\" has no attribute \"setattr\"; maybe \"__setattr__\"?",
+      "path": "sentientos/tests/test_jurisprudence_consumption.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 82,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 45,
+      "line": 82,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 164,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 165,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 175,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 45,
+      "line": 175,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 193,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 45,
+      "line": 193,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 211,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 212,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 213,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 45,
+      "line": 213,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 239,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 240,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 265,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 266,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 286,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 45,
+      "line": 286,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 296,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 297,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 298,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 299,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 300,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 301,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 302,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 311,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 312,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 313,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 314,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 315,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 316,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 317,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 326,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 327,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 328,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 329,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 330,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 331,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 347,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 348,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 349,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 350,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 351,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 359,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 360,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 361,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 377,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 378,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 379,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 380,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 381,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 382,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 418,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 419,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 442,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 443,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 459,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 460,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 469,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 470,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 502,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 503,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 517,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 526,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 565,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 566,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 601,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 602,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 618,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 619,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 636,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 637,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 650,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 651,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 687,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 707,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 709,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 710,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 719,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 720,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 736,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 737,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 753,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 754,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 755,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 756,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 757,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 758,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 769,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 770,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 773,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 774,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 790,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 802,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 802,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 807,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 807,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 826,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 829,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 846,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 52,
+      "line": 847,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "index",
+      "column": 18,
+      "line": 852,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_kernel_admission_provenance.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 35,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 49,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 50,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 51,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 52,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 53,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 56,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 69,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 70,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 71,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 74,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 92,
+      "message": "Unsupported operand types for > (\"float\" and \"object\")",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 16,
+      "line": 93,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 94,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 97,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 107,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 108,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 109,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_load_homeostasis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 25,
+      "message": "\"object\" has no attribute \"values\"",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 21,
+      "line": 40,
+      "message": "\"object\" has no attribute \"values\"",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 64,
+      "line": 61,
+      "message": "Argument \"policy\" to \"_summary_report\" has incompatible type \"dict[str, list[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 66,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 49,
+      "line": 110,
+      "message": "Argument 2 to \"_canonical_repo_targets\" has incompatible type \"dict[str, list[str]]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 114,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_mypy_ratchet.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 48,
+      "line": 67,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_narrative_synthesis.py"
+    },
+    {
+      "code": "index",
+      "column": 13,
+      "line": 91,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 44,
+      "line": 121,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 48,
+      "line": 160,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_narrative_synthesis.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 48,
+      "line": 161,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_narrative_synthesis.py"
+    },
+    {
+      "code": "operator",
+      "column": 37,
+      "line": 72,
+      "message": "Unsupported operand types for / (\"Path\" and \"object\")",
+      "path": "sentientos/tests/test_node_operations.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 74,
+      "message": "Unsupported operand types for <= (\"int\" and \"object\")",
+      "path": "sentientos/tests/test_node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 33,
+      "line": 76,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_node_operations.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 70,
+      "line": 91,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_node_operations.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 57,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 109,
+      "message": "Module \"audit_immutability\" does not explicitly export attribute \"append_entry\"",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 129,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 148,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 159,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 183,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 195,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 205,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 216,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 259,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 274,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 285,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_ops_cli.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 224,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 293,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 452,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 510,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 536,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 626,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 653,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 727,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 1266,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 80,
+      "line": 1883,
+      "message": "Argument 2 to \"_write_jsonl\" has incompatible type \"list[dict[str, dict[str, str]]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 86,
+      "line": 1916,
+      "message": "Argument 2 to \"_write_jsonl\" has incompatible type \"list[dict[str, Collection[str]]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 1999,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 2053,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 2118,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "index",
+      "column": 76,
+      "line": 2851,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 2883,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 2961,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3024,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3083,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3501,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3620,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3631,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3642,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3653,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3665,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 3676,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4066,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4109,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 4151,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 7500,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 8208,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "operator",
+      "column": 19,
+      "line": 8507,
+      "message": "\"object\" not callable",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "operator",
+      "column": 15,
+      "line": 8554,
+      "message": "\"object\" not callable",
+      "path": "sentientos/tests/test_orchestration_intent_fabric.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 18,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 34,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 56,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "misc",
+      "column": 9,
+      "line": 82,
+      "message": "Property \"claim_text\" defined in \"ProvisionalAssertion\" is read-only",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 85,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 103,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 131,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 135,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 138,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 157,
+      "message": "Unsupported operand types for < (\"int\" and \"object\")",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 161,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 185,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 200,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 53,
+      "line": 220,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_provisional_assertions.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 114,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/tests/test_quarantine_remediation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 114,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_quarantine_remediation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 117,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/tests/test_quarantine_remediation.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 14,
+      "line": 152,
+      "message": "\"object\" has no attribute \"provenance_intent\"",
+      "path": "sentientos/tests/test_quarantine_remediation.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 47,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_remote_probe.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 48,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_remote_probe.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 77,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_remote_probe.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 93,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_remote_probe.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 8,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_remote_smoke_inventory.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 70,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_scoped_slice_health.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 107,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_scoped_slice_health_history.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 23,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 24,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 29,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 32,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 40,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 55,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 63,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_simulation_federation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 30,
+      "line": 89,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/tests/test_strategic_adaptation.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 52,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_strategic_counterfactual.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 102,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 110,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 5,
+      "line": 110,
+      "message": "\"object\" has no attribute \"chdir\"",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 121,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 11,
+      "line": 121,
+      "message": "\"object\" has no attribute \"readouterr\"",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 65,
+      "line": 149,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 165,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_system_constitution.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 53,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_trust_ledger_recovery.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 71,
+      "line": 63,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_trust_ledger_recovery.py"
+    },
+    {
+      "code": "operator",
+      "column": 12,
+      "line": 75,
+      "message": "Unsupported right operand type for in (\"object\")",
+      "path": "sentientos/tests/test_trust_ledger_recovery.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 80,
+      "line": 103,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_trust_ledger_recovery.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 58,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_contradiction_policy.py"
+    },
+    {
+      "code": "index",
+      "column": 28,
+      "line": 90,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_contradiction_policy.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 16,
+      "line": 28,
+      "message": "Argument 1 to \"len\" has incompatible type \"object\"; expected \"Sized\"",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 29,
+      "line": 35,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 27,
+      "line": 52,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 67,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 92,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 111,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 129,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 20,
+      "line": 133,
+      "message": "Argument 1 to \"int\" has incompatible type \"str | int | None\"; expected \"str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc\"",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 171,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "index",
+      "column": 18,
+      "line": 172,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 206,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 280,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/tests/test_wan_federation_lab.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 87,
+      "message": "Argument \"hosts\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 15,
+      "line": 88,
+      "message": "Argument \"nodes\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "call-overload",
+      "column": 12,
+      "line": 91,
+      "message": "No overload variant of \"set\" matches argument type \"object\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 92,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 93,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 94,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 30,
+      "line": 95,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 17,
+      "line": 96,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 19,
+      "line": 121,
+      "message": "Argument \"node_rows\" to \"reconcile_provenance\" has incompatible type \"list[dict[str, dict[str, str] | dict[str, object] | str | None]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 19,
+      "line": 129,
+      "message": "Argument \"node_rows\" to \"reconcile_provenance\" has incompatible type \"list[dict[str, dict[str, str] | dict[str, object] | str | None]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 19,
+      "line": 136,
+      "message": "Argument \"node_rows\" to \"reconcile_provenance\" has incompatible type \"list[dict[str, dict[str, str] | dict[str, object] | str | None]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 128,
+      "line": 173,
+      "message": "Argument \"hosts\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 141,
+      "line": 173,
+      "message": "Argument \"nodes\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 174,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 175,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 137,
+      "line": 192,
+      "message": "Argument \"hosts\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 150,
+      "line": 192,
+      "message": "Argument \"nodes\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 67,
+      "line": 193,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 138,
+      "line": 194,
+      "message": "Argument \"hosts\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 151,
+      "line": 194,
+      "message": "Argument \"nodes\" to \"run_truth_oracle\" has incompatible type \"list[dict[str, str]]\"; expected \"list[dict[str, object]]\"",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 12,
+      "line": 195,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 17,
+      "line": 196,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "index",
+      "column": 17,
+      "line": 197,
+      "message": "Value of type \"object\" is not indexable",
+      "path": "sentientos/tests/test_wan_truth_oracle.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 6,
+      "message": "Name \"tomllib\" already defined (by an import)",
+      "path": "sentientos/toml_compat.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 61,
+      "line": 291,
+      "message": "\"object\" has no attribute \"__iter__\"; maybe \"__dir__\" or \"__str__\"? (not iterable)",
+      "path": "sentientos/trust_ledger.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 65,
+      "message": "Returning Any from function declared to return \"float\"",
+      "path": "sentientos/truth/epistemic_orientation.py"
+    },
+    {
+      "code": "operator",
+      "column": 21,
+      "line": 255,
+      "message": "Unsupported operand types for <= (\"float\" and \"object\")",
+      "path": "sentientos/truth/epistemic_orientation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 82,
+      "line": 261,
+      "message": "Argument \"claim_b\" to \"ContradictionLink\" has incompatible type \"object\"; expected \"str\"",
+      "path": "sentientos/truth/epistemic_orientation.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 44,
+      "line": 271,
+      "message": "Argument 1 to \"float\" has incompatible type \"object\"; expected \"str | Buffer | SupportsFloat | SupportsIndex\"",
+      "path": "sentientos/truth/epistemic_orientation.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 103,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 9,
+      "line": 252,
+      "message": "\"object\" has no attribute \"append\"",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "index",
+      "column": 9,
+      "line": 306,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "index",
+      "column": 9,
+      "line": 311,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "index",
+      "column": 9,
+      "line": 314,
+      "message": "Unsupported target for indexed assignment (\"object\")",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 27,
+      "line": 418,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, list[str] | str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 420,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, list[str] | str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 33,
+      "line": 422,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, list[str] | str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 37,
+      "line": 423,
+      "message": "Argument 1 to \"append\" of \"list\" has incompatible type \"dict[str, list[str] | str | None]\"; expected \"dict[str, object]\"",
+      "path": "sentientos/truth/provisional_assertion.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 68,
+      "line": 51,
+      "message": "Argument \"previous_claim\" to \"detect_no_new_evidence_reversal\" has incompatible type \"Mapping[str, Any]\"; expected \"dict[str, Any]\"",
+      "path": "sentientos/truth/stance_preflight.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 51,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/verify/adapters/arduino_serial.py"
+    },
+    {
+      "code": "assignment",
+      "column": 25,
+      "line": 116,
+      "message": "Incompatible types in assignment (expression has type \"dict[str, object]\", variable has type \"float\")",
+      "path": "sentientos/verify/adapters/arduino_serial.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 52,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 13,
+      "line": 84,
+      "message": "Call to untyped function \"_capture_frame\" in typed context",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 17,
+      "line": 107,
+      "message": "Call to untyped function \"_capture_frame\" in typed context",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 16,
+      "line": 124,
+      "message": "Call to untyped function \"_capture_frame\" in typed context",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 127,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 136,
+      "message": "Function is missing a type annotation for one or more parameters",
+      "path": "sentientos/verify/adapters/webcam_opencv.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 55,
+      "line": 93,
+      "message": "\"Adapter\" has no attribute \"simulation_mode\"",
+      "path": "sentientos/verify/sentient_verify_loop.py"
+    },
+    {
+      "code": "var-annotated",
+      "column": 18,
+      "line": 21,
+      "message": "Need type annotation for \"counts\"",
+      "path": "sentientos/vocabulary_residual_scanner.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 5,
+      "line": 40,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/voice/tts.py"
+    },
+    {
+      "code": "no-untyped-call",
+      "column": 18,
+      "line": 103,
+      "message": "Call to untyped function \"_ensure_engine\" in typed context",
+      "path": "sentientos/voice/tts.py"
+    },
+    {
+      "code": "assignment",
+      "column": 24,
+      "line": 17,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type Module)",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 18,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type Module)",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "assignment",
+      "column": 18,
+      "line": 19,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type Module)",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "name-defined",
+      "column": 29,
+      "line": 27,
+      "message": "Name \"win32serviceutil.ServiceFramework\" is not defined",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 31,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 31,
+      "message": "Function is missing a type annotation",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 35,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 35,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 39,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 9,
+      "line": 39,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 51,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-redef",
+      "column": 5,
+      "line": 51,
+      "message": "Name \"SentientOSService\" already defined on line 27",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 61,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 1,
+      "line": 71,
+      "message": "Function is missing a return type annotation",
+      "path": "sentientos/windows_service.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 54,
+      "line": 156,
+      "message": "Item \"None\" of \"Any | dict[Any, Any] | None\" has no attribute \"items\"",
+      "path": "sentientos/work_plan.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 529,
+      "message": "Argument 1 to \"WorkspaceFileEffectPolicy\" has incompatible type \"**dict[str, object]\"; expected \"bool\"",
+      "path": "sentientos/workspace_file_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 529,
+      "message": "Argument 1 to \"WorkspaceFileEffectPolicy\" has incompatible type \"**dict[str, object]\"; expected \"str\"",
+      "path": "sentientos/workspace_file_effect.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 40,
+      "line": 529,
+      "message": "Argument 1 to \"WorkspaceFileEffectPolicy\" has incompatible type \"**dict[str, object]\"; expected \"tuple[str, ...]\"",
+      "path": "sentientos/workspace_file_effect.py"
+    },
+    {
+      "code": "comparison-overlap",
+      "column": 8,
+      "line": 585,
+      "message": "Non-overlapping equality check (left operand type: \"Path\", right operand type: \"str\")",
+      "path": "sentientos/workspace_file_effect.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 13,
+      "line": 31,
+      "message": "Returning Any from function declared to return \"Mapping[str, Any] | Sequence[Mapping[str, Any]]\"",
+      "path": "speech_emitter.py"
+    },
+    {
+      "code": "union-attr",
+      "column": 28,
+      "line": 24,
+      "message": "Item \"None\" of \"str | None\" has no attribute \"lower\"",
+      "path": "speech_to_avatar_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 35,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "speech_to_avatar_bridge.py"
+    },
+    {
+      "code": "assignment",
+      "column": 24,
+      "line": 157,
+      "message": "Incompatible types in assignment (expression has type \"Any | None\", variable has type \"MutableMapping[str, Any]\")",
+      "path": "speech_to_avatar_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 192,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "speech_to_avatar_bridge.py"
+    },
+    {
+      "code": "arg-type",
+      "column": 35,
+      "line": 45,
+      "message": "Argument 1 to \"run\" has incompatible type \"list[str | None]\"; expected \"str | bytes | PathLike[str] | PathLike[bytes] | Sequence[str | bytes | PathLike[str] | PathLike[bytes]]\"",
+      "path": "talkback_bridge.py"
+    },
+    {
+      "code": "return-value",
+      "column": 12,
+      "line": 73,
+      "message": "Incompatible return value type (got \"Path | None\", expected \"Path\")",
+      "path": "task_admission.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 17,
+      "line": 71,
+      "message": "Returning Any from function declared to return \"dict[str, Any] | None\"",
+      "path": "trust_engine.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 98,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "trust_engine.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 134,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "trust_engine.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 28,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "tts_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 34,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "tts_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 36,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "tts_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 39,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "tts_bridge.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 195,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "tts_bridge.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 44,
+      "line": 25,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "version_consensus.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 53,
+      "line": 40,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "version_consensus.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 45,
+      "message": "Missing type arguments for generic type \"dict\"",
+      "path": "version_consensus.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 26,
+      "line": 11,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "wdm/policy.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 33,
+      "line": 23,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 50,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 87,
+      "line": 61,
+      "message": "\"object\" has no attribute \"name\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 71,
+      "message": "\"object\" has no attribute \"name\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 61,
+      "line": 71,
+      "message": "\"object\" has no attribute \"answer\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 31,
+      "line": 77,
+      "message": "\"object\" has no attribute \"name\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 39,
+      "line": 79,
+      "message": "\"object\" has no attribute \"name\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 69,
+      "line": 79,
+      "message": "\"object\" has no attribute \"critique\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "attr-defined",
+      "column": 20,
+      "line": 116,
+      "message": "\"object\" has no attribute \"name\"",
+      "path": "wdm/runner.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 49,
+      "line": 26,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "wdm/summarize.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 39,
+      "message": "Incompatible types in assignment (expression has type \"DeepSeekAdapter\", variable has type \"OpenAIAdapter | None\")",
+      "path": "wdm/summarize.py"
+    },
+    {
+      "code": "assignment",
+      "column": 27,
+      "line": 42,
+      "message": "Incompatible types in assignment (expression has type \"MistralAdapter\", variable has type \"OpenAIAdapter | None\")",
+      "path": "wdm/summarize.py"
+    },
+    {
+      "code": "assignment",
+      "column": 23,
+      "line": 19,
+      "message": "Incompatible types in assignment (expression has type \"float\", variable has type \"int\")",
+      "path": "wdm/utils.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 24,
+      "line": 34,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "wdm/utils.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 14,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "witness/witness_rules.py"
+    },
+    {
+      "code": "type-arg",
+      "column": 37,
+      "line": 52,
+      "message": "Missing type arguments for generic type \"Dict\"",
+      "path": "witness/witness_rules.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 16,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 29,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "misc",
+      "column": 5,
+      "line": 29,
+      "message": "Cannot assign to a type",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "assignment",
+      "column": 20,
+      "line": 29,
+      "message": "Incompatible types in assignment (expression has type \"None\", variable has type \"type[PolicyEngine]\")",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 38,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 9,
+      "line": 110,
+      "message": "Returning Any from function declared to return \"Callable[..., Any]\"",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 13,
+      "line": 145,
+      "message": "Function is missing a type annotation",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "no-untyped-def",
+      "column": 17,
+      "line": 280,
+      "message": "Function is missing a type annotation",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "truthy-function",
+      "column": 59,
+      "line": 416,
+      "message": "Function \"PolicyEngine\" could always be true in boolean context",
+      "path": "workflow_controller.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 32,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "workflow_dashboard.py"
+    },
+    {
+      "code": "unused-ignore",
+      "column": null,
+      "line": 33,
+      "message": "Unused \"type: ignore\" comment",
+      "path": "workflow_dashboard.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 5,
+      "line": 96,
+      "message": "Returning Any from function declared to return \"str\"",
+      "path": "workflow_dashboard.py"
+    },
+    {
+      "code": "no-any-return",
+      "column": 25,
+      "line": 87,
+      "message": "Returning Any from function declared to return \"dict[str, Any]\"",
+      "path": "workflow_library.py"
+    }
+  ],
+  "generated_at": "stable-baseline-refresh",
+  "generator": "scripts.build_mypy_baseline",
+  "mypy_command": [
+    "python",
+    "-m",
+    "mypy",
+    "--hide-error-context",
+    "--no-color-output",
+    "--show-column-numbers",
+    "--show-error-codes",
+    "scripts/",
+    "sentientos/"
+  ],
+  "mypy_version": "mypy 1.20.2 (compiled: yes)",
+  "per_file_counts": {
+    "admin_utils.py": 1,
+    "agents/forms/archive_util.py": 1,
+    "agents/forms/browser_plan.py": 2,
+    "agents/forms/oracle_session.py": 6,
+    "agents/forms/pdf_prep.py": 18,
+    "agents/forms/review_bundle.py": 8,
+    "agents/forms/screenshot_plan.py": 2,
+    "agents/forms/ssa_disability_agent.py": 1,
+    "avatar_state.py": 1,
+    "codex/amendments.py": 9,
+    "codex/autogenesis.py": 2,
+    "codex/gap_seeker.py": 3,
+    "codex/governance.py": 2,
+    "codex/implementations.py": 1,
+    "codex/integrity_daemon.py": 4,
+    "codex/narratives.py": 1,
+    "codex/orchestrator.py": 1,
+    "codex/proof_budget_governor.py": 1,
+    "codex/proof_verifier.py": 2,
+    "codex/scaffolds.py": 3,
+    "codex/specs.py": 3,
+    "codex/strategy.py": 3,
+    "control_plane/task_admission.py": 1,
+    "curiosity_executor.py": 6,
+    "curiosity_goal_helper.py": 14,
+    "daemon_autonomy_supervisor.py": 4,
+    "demo_recorder.py": 11,
+    "doctrine.py": 15,
+    "drift_report.py": 1,
+    "embodiment/silhouette.py": 4,
+    "emotion_fallback.py": 1,
+    "experiment_tracker.py": 1,
+    "final_approval.py": 2,
+    "godot_avatar_receiver.py": 2,
+    "gui/cathedral_gui.py": 25,
+    "gui/wdm_panel.py": 2,
+    "hf_intake/classifier.py": 1,
+    "hf_intake/discovery.py": 1,
+    "hf_intake/manifest.py": 2,
+    "integration_memory.py": 1,
+    "memory_manager.py": 54,
+    "notification.py": 1,
+    "plugin_framework.py": 21,
+    "policy_engine.py": 7,
+    "privilege_lint/reporting/format_engines.py": 2,
+    "privilege_lint/reporting/report_router.py": 2,
+    "reflex_manager.py": 7,
+    "relationship_log.py": 1,
+    "resident_kernel.py": 34,
+    "ritual.py": 5,
+    "scripts/apply_audit_repairs.py": 1,
+    "scripts/audit_immutability_verifier.py": 1,
+    "scripts/avatar_reflex.py": 3,
+    "scripts/benchmark_lint.py": 1,
+    "scripts/bootstrap_trust_restore.py": 1,
+    "scripts/build_host_embodiment_trace.py": 2,
+    "scripts/build_local_effect_transaction_ledger.py": 1,
+    "scripts/build_workspace_file_transaction_ledger.py": 1,
+    "scripts/capture_audit_baseline.py": 2,
+    "scripts/check_governance_drift.py": 1,
+    "scripts/converge_audits.py": 1,
+    "scripts/detect_audit_drift.py": 1,
+    "scripts/detect_federation_identity_drift.py": 1,
+    "scripts/detect_perception_schema_drift.py": 1,
+    "scripts/detect_pulse_schema_drift.py": 3,
+    "scripts/detect_self_model_drift.py": 1,
+    "scripts/editable_install.py": 1,
+    "scripts/emit_baseline_verification_status.py": 1,
+    "scripts/emit_contract_status.py": 15,
+    "scripts/emit_stability_doctrine.py": 1,
+    "scripts/expand_mode_sandbox.py": 3,
+    "scripts/export_manual_audit_issues.py": 1,
+    "scripts/federation_puller.py": 1,
+    "scripts/federation_stream_relay.py": 1,
+    "scripts/forge_replay.py": 6,
+    "scripts/forge_status.py": 15,
+    "scripts/formal_check.py": 1,
+    "scripts/generate_immutable_manifest.py": 1,
+    "scripts/generate_sbom.py": 3,
+    "scripts/goal_progress.py": 1,
+    "scripts/invariant_lint.py": 2,
+    "scripts/migrate_embeddings.py": 2,
+    "scripts/mypy_baseline_common.py": 1,
+    "scripts/perception/screen_adapter.py": 3,
+    "scripts/plan_audit_repairs.py": 2,
+    "scripts/prepare_secondary_build.py": 3,
+    "scripts/protected_corridor.py": 6,
+    "scripts/pytest_collection_reporter.py": 8,
+    "scripts/quarantine_clear.py": 3,
+    "scripts/reconcile_audits.py": 12,
+    "scripts/remote_probe.py": 10,
+    "scripts/rotate_pulse_keys.py": 1,
+    "scripts/run_builtin_runner_transaction.py": 2,
+    "scripts/run_local_diagnostic_effect.py": 26,
+    "scripts/run_local_diagnostic_rollback.py": 26,
+    "scripts/run_recovery_task.py": 1,
+    "scripts/run_tests.py": 3,
+    "scripts/sign_strategic.py": 1,
+    "scripts/strategic_propose.py": 3,
+    "scripts/test_cathedral_boot.py": 1,
+    "scripts/tooling_status.py": 4,
+    "scripts/verify_audits.py": 3,
+    "scripts/verify_context_hygiene_prompt_boundaries.py": 1,
+    "scripts/verify_pressure_state_chain.py": 2,
+    "semantic_embeddings.py": 4,
+    "sentientos/__main__.py": 2,
+    "sentientos/actuators/gui_control.py": 4,
+    "sentientos/adjudication/truth_tribunal.py": 9,
+    "sentientos/admin_utils.py": 1,
+    "sentientos/agents/browser_automator.py": 9,
+    "sentientos/alerts.py": 8,
+    "sentientos/analysis/pattern_volatility.py": 4,
+    "sentientos/anchor_witness.py": 7,
+    "sentientos/artifact_catalog.py": 9,
+    "sentientos/attestation_snapshot.py": 4,
+    "sentientos/audit_sink.py": 1,
+    "sentientos/authority_surface.py": 23,
+    "sentientos/auto_remediation.py": 5,
+    "sentientos/autonomy/audit.py": 3,
+    "sentientos/autonomy/conversation_triggers.py": 2,
+    "sentientos/autonomy/rehearsal.py": 1,
+    "sentientos/autonomy/state.py": 6,
+    "sentientos/boot_ceremony.py": 4,
+    "sentientos/boot_chronicler.py": 2,
+    "sentientos/builtin_local_effect_runner.py": 37,
+    "sentientos/builtin_runner_transaction_orchestrator.py": 1,
+    "sentientos/cathedral/amendment.py": 3,
+    "sentientos/cathedral/amendment_sentinel.py": 1,
+    "sentientos/cathedral/apply.py": 3,
+    "sentientos/cathedral/federation_guard.py": 1,
+    "sentientos/cathedral/rollback.py": 2,
+    "sentientos/cathedral/validator.py": 4,
+    "sentientos/cathedral_forge.py": 8,
+    "sentientos/change_narrator.py": 8,
+    "sentientos/chaos.py": 2,
+    "sentientos/chat_service.py": 1,
+    "sentientos/cli/ois_cli.py": 1,
+    "sentientos/cli/trace_cli.py": 1,
+    "sentientos/codex/codex_context_pruner.py": 1,
+    "sentientos/codex/retraining_prep.py": 5,
+    "sentientos/codex/scorekeeper.py": 5,
+    "sentientos/codex/self_training_daemon.py": 12,
+    "sentientos/codex_healer.py": 4,
+    "sentientos/codex_startup_guard.py": 1,
+    "sentientos/config.py": 2,
+    "sentientos/consciousness/attention_arbitrator.py": 3,
+    "sentientos/consciousness/cognitive_posture.py": 2,
+    "sentientos/consciousness/cognitive_state.py": 5,
+    "sentientos/consciousness/cycle_gate.py": 1,
+    "sentientos/consciousness/inner_narrator.py": 1,
+    "sentientos/consciousness/integration.py": 11,
+    "sentientos/consciousness/recursion_guard.py": 1,
+    "sentientos/consciousness/sentience_kernel.py": 16,
+    "sentientos/context_hygiene/pollution_guard.py": 1,
+    "sentientos/context_hygiene/prompt_external_audit_export.py": 13,
+    "sentientos/context_hygiene/prompt_external_security_review.py": 3,
+    "sentientos/context_hygiene/prompt_handoff_manifest.py": 1,
+    "sentientos/context_hygiene/prompt_internal_candidate.py": 2,
+    "sentientos/context_hygiene/prompt_materialization_policy.py": 1,
+    "sentientos/context_hygiene/prompt_model_call_preflight.py": 12,
+    "sentientos/context_hygiene/prompt_provider_invocation_denial_attestation.py": 20,
+    "sentientos/context_hygiene/prompt_provider_invocation_denial_closure.py": 15,
+    "sentientos/context_hygiene/prompt_provider_invocation_denial_review.py": 1,
+    "sentientos/context_hygiene/prompt_provider_null_transport.py": 2,
+    "sentientos/context_hygiene/prompt_provider_simulation.py": 4,
+    "sentientos/context_hygiene/prompt_provider_transport_registry.py": 7,
+    "sentientos/context_hygiene/prompt_synthetic_materializer.py": 4,
+    "sentientos/contract_sentinel.py": 2,
+    "sentientos/controlled_authorization.py": 3,
+    "sentientos/cor.py": 3,
+    "sentientos/council/governance_council.py": 2,
+    "sentientos/curiosity_scheduler.py": 6,
+    "sentientos/daemons/driver_manager.py": 3,
+    "sentientos/daemons/identity_continuity_daemon.py": 2,
+    "sentientos/daemons/integrity_daemon.py": 2,
+    "sentientos/daemons/memory_persona_linter.py": 2,
+    "sentientos/daemons/monitoring_daemon.py": 1,
+    "sentientos/daemons/narrative_reaper.py": 3,
+    "sentientos/daemons/reflex_anomaly_forecaster.py": 2,
+    "sentientos/daemons/reflex_guard.py": 14,
+    "sentientos/daemons/witness_daemon.py": 5,
+    "sentientos/delegated_judgment_fabric.py": 4,
+    "sentientos/determinism.py": 1,
+    "sentientos/diagnostics/error_frame.py": 5,
+    "sentientos/diagnostics/recovery.py": 2,
+    "sentientos/doctrine_identity.py": 2,
+    "sentientos/embodiment/consent.py": 2,
+    "sentientos/embodiment/contracts.py": 1,
+    "sentientos/embodiment/embodiment_digest.py": 5,
+    "sentientos/embodiment/simulation.py": 2,
+    "sentientos/embodiment_ingress.py": 2,
+    "sentientos/embodiment_proposal_diagnostic.py": 4,
+    "sentientos/embodiment_proposal_review.py": 1,
+    "sentientos/ethics/__init__.py": 1,
+    "sentientos/ethics/consent_memory_vault.py": 6,
+    "sentientos/ethics/covenant_digest_daemon.py": 8,
+    "sentientos/ethics/ethics_critic_daemon.py": 3,
+    "sentientos/ethics/semantic_scanner_daemon.py": 3,
+    "sentientos/ethics/symbolic_hygiene_monitor.py": 1,
+    "sentientos/ethics_core.py": 5,
+    "sentientos/experiments/chain.py": 3,
+    "sentientos/experiments/criteria_dsl.py": 1,
+    "sentientos/experiments/demo_gallery.py": 10,
+    "sentientos/external_adapters/__init__.py": 1,
+    "sentientos/external_adapters/filesystem_adapter.py": 2,
+    "sentientos/external_adapters/runtime.py": 3,
+    "sentientos/federation_mutation_control_preflight.py": 2,
+    "sentientos/feedback/feedback_attributor.py": 6,
+    "sentientos/first_boot.py": 16,
+    "sentientos/forge_daemon.py": 4,
+    "sentientos/forge_env.py": 2,
+    "sentientos/forge_env_cache.py": 3,
+    "sentientos/forge_failures.py": 7,
+    "sentientos/forge_index.py": 11,
+    "sentientos/forge_merge_train.py": 26,
+    "sentientos/forge_outcomes.py": 6,
+    "sentientos/forge_queue.py": 1,
+    "sentientos/forge_transaction.py": 1,
+    "sentientos/formal_verification.py": 8,
+    "sentientos/genesis_forge.py": 24,
+    "sentientos/goal_completion.py": 10,
+    "sentientos/goal_executor.py": 1,
+    "sentientos/governance/council_bias_analyzer.py": 14,
+    "sentientos/governance/governance_reducer.py": 1,
+    "sentientos/governance/intentional_forgetting.py": 38,
+    "sentientos/governance/routine_delegation.py": 17,
+    "sentientos/governance/sanction_engine.py": 3,
+    "sentientos/governance/vote_justifier.py": 4,
+    "sentientos/governance_trace.py": 6,
+    "sentientos/gradient_contract.py": 1,
+    "sentientos/helpers/__init__.py": 9,
+    "sentientos/host_collectors.py": 4,
+    "sentientos/host_embodiment_trace_export.py": 1,
+    "sentientos/host_inventory.py": 10,
+    "sentientos/host_resource_governor.py": 7,
+    "sentientos/host_steward_boundary.py": 9,
+    "sentientos/immutability.py": 2,
+    "sentientos/innervation.py": 13,
+    "sentientos/innerworld/autobio_compressor.py": 2,
+    "sentientos/innerworld/history.py": 4,
+    "sentientos/innerworld/orchestrator.py": 21,
+    "sentientos/innerworld/reflection.py": 8,
+    "sentientos/innerworld/self_narrative.py": 6,
+    "sentientos/innerworld/value_drift.py": 2,
+    "sentientos/integrity_controller.py": 3,
+    "sentientos/integrity_metrics.py": 1,
+    "sentientos/integrity_pressure.py": 3,
+    "sentientos/integrity_snapshot.py": 3,
+    "sentientos/intent_record.py": 1,
+    "sentientos/introspection/spine.py": 1,
+    "sentientos/jurisprudence_consumption.py": 2,
+    "sentientos/kernel_admission_provenance.py": 3,
+    "sentientos/lab/contradiction_policy.py": 1,
+    "sentientos/lab/federation_lab.py": 1,
+    "sentientos/lab/wan_federation.py": 27,
+    "sentientos/local_diagnostic_effect.py": 44,
+    "sentientos/local_model.py": 4,
+    "sentientos/logging/events.py": 12,
+    "sentientos/logging_middleware.py": 18,
+    "sentientos/memory/dream_loop.py": 1,
+    "sentientos/memory/pulse_view.py": 8,
+    "sentientos/memory_economics.py": 4,
+    "sentientos/meta/ambiguity_resolver.py": 4,
+    "sentientos/meta/narrative_genealogy.py": 4,
+    "sentientos/meta/reflection_loop.py": 10,
+    "sentientos/metrics.py": 1,
+    "sentientos/narrative/narrative_compressor.py": 3,
+    "sentientos/narrative/persona_decay_audit.py": 5,
+    "sentientos/narrative_synthesis.py": 52,
+    "sentientos/node_operations.py": 12,
+    "sentientos/ois.py": 16,
+    "sentientos/operator_report_attestation.py": 1,
+    "sentientos/oracle_cycle.py": 6,
+    "sentientos/oracle_relay.py": 4,
+    "sentientos/orchestration_intent_fabric.py": 6,
+    "sentientos/orchestration_spine/facade_mechanical_assembly.py": 3,
+    "sentientos/orchestrator.py": 15,
+    "sentientos/perception/asr_listener.py": 2,
+    "sentientos/perception/reality_fingerprint.py": 7,
+    "sentientos/persona/loop.py": 3,
+    "sentientos/persona/persona_boundary_enforcer.py": 2,
+    "sentientos/pressure_engagement.py": 14,
+    "sentientos/pressure_queue.py": 35,
+    "sentientos/privacy.py": 1,
+    "sentientos/protected_mutation_intent.py": 3,
+    "sentientos/pulse/pulse_observer.py": 2,
+    "sentientos/pulse_query.py": 5,
+    "sentientos/real_effect_admission.py": 1,
+    "sentientos/receipt_chain.py": 1,
+    "sentientos/recovery_tasks.py": 6,
+    "sentientos/reflex/reflex_petitioner.py": 9,
+    "sentientos/reflex/reflex_state_index.py": 1,
+    "sentientos/remediation_pack.py": 8,
+    "sentientos/research_timer.py": 5,
+    "sentientos/reviewer_proof_bundle.py": 6,
+    "sentientos/risk_budget.py": 7,
+    "sentientos/runtime_governor.py": 1,
+    "sentientos/sandbox_runner.py": 16,
+    "sentientos/shell/cli.py": 1,
+    "sentientos/signed_rollups.py": 6,
+    "sentientos/signed_strategic.py": 14,
+    "sentientos/start.py": 3,
+    "sentientos/strategic_adaptation.py": 41,
+    "sentientos/strategic_posture.py": 1,
+    "sentientos/streams/drift_stream.py": 2,
+    "sentientos/streams/event_stream.py": 1,
+    "sentientos/streams/pressure_stream.py": 1,
+    "sentientos/symbols/symbol_unifier.py": 1,
+    "sentientos/system_constitution.py": 8,
+    "sentientos/system_identity.py": 10,
+    "sentientos/tests/conftest.py": 2,
+    "sentientos/tests/federation/test_digest_with_sanitizer.py": 4,
+    "sentientos/tests/federation/test_federation_consensus.py": 11,
+    "sentientos/tests/federation/test_federation_digest.py": 16,
+    "sentientos/tests/innerworld/test_autobio_compressor.py": 5,
+    "sentientos/tests/innerworld/test_cognitive_report.py": 14,
+    "sentientos/tests/innerworld/test_cycle_history.py": 5,
+    "sentientos/tests/innerworld/test_ethical_integration.py": 7,
+    "sentientos/tests/innerworld/test_global_workspace.py": 17,
+    "sentientos/tests/innerworld/test_inner_dialogue.py": 3,
+    "sentientos/tests/innerworld/test_orchestrator_runtime_consistency.py": 2,
+    "sentientos/tests/innerworld/test_reflection_engine.py": 6,
+    "sentientos/tests/innerworld/test_self_narrative.py": 6,
+    "sentientos/tests/innerworld/test_simulation_engine.py": 4,
+    "sentientos/tests/innerworld/test_value_drift.py": 4,
+    "sentientos/tests/runtime/test_cognitive_report_integration.py": 6,
+    "sentientos/tests/runtime/test_config_sanitizer.py": 6,
+    "sentientos/tests/runtime/test_core_loop_innerworld.py": 7,
+    "sentientos/tests/runtime/test_federation_integration.py": 6,
+    "sentientos/tests/runtime/test_history_integration.py": 4,
+    "sentientos/tests/runtime/test_narrative_integration.py": 5,
+    "sentientos/tests/runtime/test_reflection_integration.py": 9,
+    "sentientos/tests/runtime/test_runtime_ethics.py": 3,
+    "sentientos/tests/runtime/test_runtime_orchestrator_init.py": 2,
+    "sentientos/tests/runtime/test_sanitized_config_integration.py": 5,
+    "sentientos/tests/runtime/test_simulation_integration.py": 4,
+    "sentientos/tests/runtime/test_unified_cognition_integration.py": 8,
+    "sentientos/tests/test_artifact_catalog.py": 2,
+    "sentientos/tests/test_attestation.py": 2,
+    "sentientos/tests/test_attestation_snapshot.py": 2,
+    "sentientos/tests/test_autonomy_action_innervation.py": 5,
+    "sentientos/tests/test_bootstrap_trust_restore.py": 12,
+    "sentientos/tests/test_cognitive_posture.py": 4,
+    "sentientos/tests/test_cognitive_state_snapshot.py": 6,
+    "sentientos/tests/test_consciousness_pressure_context.py": 1,
+    "sentientos/tests/test_consent_governance.py": 5,
+    "sentientos/tests/test_delegated_judgment_fabric.py": 1,
+    "sentientos/tests/test_drift_detector.py": 12,
+    "sentientos/tests/test_explanation_integrity.py": 3,
+    "sentientos/tests/test_federation_bounded_lifecycle.py": 11,
+    "sentientos/tests/test_federation_canonical_execution.py": 5,
+    "sentientos/tests/test_federation_canonical_ingress.py": 15,
+    "sentientos/tests/test_federation_integrity.py": 1,
+    "sentientos/tests/test_federation_lab.py": 7,
+    "sentientos/tests/test_federation_seed_health_history.py": 5,
+    "sentientos/tests/test_federation_slice_pattern.py": 3,
+    "sentientos/tests/test_federation_typed_actions.py": 4,
+    "sentientos/tests/test_forge_daemon_canary.py": 5,
+    "sentientos/tests/test_forge_observatory.py": 3,
+    "sentientos/tests/test_forge_status.py": 10,
+    "sentientos/tests/test_generate_immutable_manifest_control_plane.py": 4,
+    "sentientos/tests/test_github_checks.py": 5,
+    "sentientos/tests/test_goal_state_update.py": 18,
+    "sentientos/tests/test_governance_trace.py": 4,
+    "sentientos/tests/test_innervation_gate.py": 8,
+    "sentientos/tests/test_integrity_quarantine.py": 2,
+    "sentientos/tests/test_introspection_spine.py": 3,
+    "sentientos/tests/test_jurisprudence_consumption.py": 2,
+    "sentientos/tests/test_kernel_admission_provenance.py": 102,
+    "sentientos/tests/test_load_homeostasis.py": 18,
+    "sentientos/tests/test_mypy_ratchet.py": 6,
+    "sentientos/tests/test_narrative_synthesis.py": 5,
+    "sentientos/tests/test_node_operations.py": 4,
+    "sentientos/tests/test_ops_cli.py": 12,
+    "sentientos/tests/test_orchestration_intent_fabric.py": 33,
+    "sentientos/tests/test_provisional_assertions.py": 14,
+    "sentientos/tests/test_quarantine_remediation.py": 4,
+    "sentientos/tests/test_remote_probe.py": 4,
+    "sentientos/tests/test_remote_smoke_inventory.py": 1,
+    "sentientos/tests/test_scoped_slice_health.py": 1,
+    "sentientos/tests/test_scoped_slice_health_history.py": 1,
+    "sentientos/tests/test_simulation_federation.py": 7,
+    "sentientos/tests/test_strategic_adaptation.py": 1,
+    "sentientos/tests/test_strategic_counterfactual.py": 1,
+    "sentientos/tests/test_system_constitution.py": 7,
+    "sentientos/tests/test_trust_ledger_recovery.py": 4,
+    "sentientos/tests/test_wan_contradiction_policy.py": 2,
+    "sentientos/tests/test_wan_federation_lab.py": 12,
+    "sentientos/tests/test_wan_truth_oracle.py": 23,
+    "sentientos/toml_compat.py": 1,
+    "sentientos/trust_ledger.py": 1,
+    "sentientos/truth/epistemic_orientation.py": 4,
+    "sentientos/truth/provisional_assertion.py": 9,
+    "sentientos/truth/stance_preflight.py": 1,
+    "sentientos/verify/adapters/arduino_serial.py": 2,
+    "sentientos/verify/adapters/webcam_opencv.py": 6,
+    "sentientos/verify/sentient_verify_loop.py": 1,
+    "sentientos/vocabulary_residual_scanner.py": 1,
+    "sentientos/voice/tts.py": 2,
+    "sentientos/windows_service.py": 14,
+    "sentientos/work_plan.py": 1,
+    "sentientos/workspace_file_effect.py": 4,
+    "speech_emitter.py": 1,
+    "speech_to_avatar_bridge.py": 4,
+    "talkback_bridge.py": 1,
+    "task_admission.py": 1,
+    "trust_engine.py": 3,
+    "tts_bridge.py": 5,
+    "version_consensus.py": 3,
+    "wdm/policy.py": 1,
+    "wdm/runner.py": 9,
+    "wdm/summarize.py": 3,
+    "wdm/utils.py": 2,
+    "witness/witness_rules.py": 2,
+    "workflow_controller.py": 9,
+    "workflow_dashboard.py": 3,
+    "workflow_library.py": 1
+  },
+  "schema_version": 1,
+  "total_error_count": 2478
+}


### PR DESCRIPTION
### Motivation

- Capture the repository's existing mypy debt as a deterministic, reviewer-auditable baseline so new regressions can be detected without trying to fix historic typing debt. 
- Provide a deterministic, reviewable refresh flow and a ratchet that prevents new files/errors from silently entering the debt ledger.
- Provide a strict targeted typed-surface gate for newly added/workspace change-set modules so new work can remain strict while historical debt is preserved.

### Description

- Add deterministic baseline parsing and manifest generation in `scripts/mypy_baseline_common.py` and a normalized JSON manifest stored at `vow/mypy_baseline.json` (schema, stable `generated_at`, `mypy_command`, `mypy_version`, `total_error_count`, `affected_file_count`, `per_file_counts`, `digest`, and normalized `errors`).
- Add `scripts/build_mypy_baseline.py` to generate/refresh the baseline from live or captured mypy output and print a compact summary; refresh is explicit and gated by reviewer review of the manifest.
- Add `scripts/check_mypy_baseline.py` to validate the manifest digest and compare current mypy output to the baseline producing a compact reviewer summary (`matched_existing_errors`, `new_errors`, `retired_errors`, `affected_new_files`, `status`) and deterministic statuses (`mypy_baseline_clean`, `mypy_baseline_matches_existing_debt`, `mypy_baseline_regression_detected`, `mypy_baseline_improved`, `mypy_baseline_missing`, `mypy_baseline_invalid`).
- Document the ratchet and the focused typed-surface gate in `docs/architecture/mypy_baseline_ratchet.md` and wire guidance into `docs/REVIEWER_QUICKSTART.md` and `docs/index.md` including the documented targeted mypy command for workspace change-set modules/CLIs.
- Add focused unit tests in `tests/test_mypy_baseline.py` for parser, normalized manifest/digest determinism, compare behavior (match, new, retired), baseline missing/invalid handling, and explicit refresh semantics.
- Keep typed-surface strictness for the workspace change-set files by small, local typing-safe adjustments to summary/serialization helpers (safe casts / conversions) in the workspace change-set CLI and orchestration modules so the targeted mypy command for the new surface remains green; modified files include `scripts/preflight_workspace_change_set.py`, `scripts/run_workspace_change_set_transaction.py`, `sentientos/workspace_change_set_execution.py`, and `sentientos/workspace_change_set_lifecycle_orchestrator.py`.
- Files added/modified: `scripts/mypy_baseline_common.py`, `scripts/build_mypy_baseline.py`, `scripts/check_mypy_baseline.py`, `vow/mypy_baseline.json`, `tests/test_mypy_baseline.py`, `docs/architecture/mypy_baseline_ratchet.md`, `docs/REVIEWER_QUICKSTART.md`, `docs/index.md`, and small adjustments to `scripts/preflight_workspace_change_set.py`, `scripts/run_workspace_change_set_transaction.py`, `sentientos/workspace_change_set_execution.py`, `sentientos/workspace_change_set_lifecycle_orchestrator.py`.

### Testing

- Ran unit tests: `python -m scripts.run_tests -q tests/test_mypy_baseline.py` (tests passed: focused parser/manifest/compare tests succeeded).
- Exercised builder/checker CLIs: `python scripts/build_mypy_baseline.py --help`, `python scripts/check_mypy_baseline.py --help`, `python scripts/build_mypy_baseline.py` to write `vow/mypy_baseline.json`, and `python scripts/check_mypy_baseline.py` to compare current output; the checker reported deterministic summary and status (observed `mypy_baseline_matches_existing_debt` after refresh in the run).
- Verified targeted typed-surface: the documented command `python -m mypy --follow-imports=skip --hide-error-context --no-color-output --show-column-numbers --show-error-codes <workspace_change_set_files...>` was run and returned no issues for the selected workspace change-set surface after small, local typing-safe adjustments.
- Ran repository verification and doc tooling: `python scripts/verify_context_hygiene_prompt_boundaries.py` and `python verify_audits.py --strict` (both passed), and docs build flow `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` (initially flagged missing doc deps, `--bootstrap-docs` bootstrapped them and docs built successfully).

Remaining risks: the baseline reflects the mypy output of the environment used to capture it (stubs and dev extras can change results), and the baseline intentionally preserves historical debt rather than fixing it; reviewers must explicitly run a reviewed refresh to accept changes to the baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b370d87648320b2e83b4f2c0f6a61)