### PR TITLE
[codex:work-item] harden dry-run adapter negative-path proofs

### DIFF
--- a/tests/test_run_work_item_dry_run_script.py
+++ b/tests/test_run_work_item_dry_run_script.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.run_work_item_dry_run import main
 from sentientos.work_item_intake import normalize_work_item_intake
 from sentientos.work_item_lifecycle_handoff import WorkItemLifecycleHandoffRequest, plan_work_item_lifecycle_handoff
 
 
-def test_script_summary(tmp_path: Path, capsys) -> None:
+
+def _write_packet_handoff(tmp_path: Path, *, packet_overrides: dict[str, object] | None = None, handoff_overrides: dict[str, object] | None = None) -> tuple[Path, Path]:
     payload = {
         "source_kind": "generic_issue",
         "title": "x",
@@ -18,12 +21,40 @@ def test_script_summary(tmp_path: Path, capsys) -> None:
         "change_intent": "metadata",
     }
     packet, _ = normalize_work_item_intake(payload, derive_workspace_proposal=True)
-    handoff = plan_work_item_lifecycle_handoff(WorkItemLifecycleHandoffRequest(packet=packet.__dict__))
+    packet_data = packet.__dict__.copy()
+    if packet_overrides:
+        packet_data.update(packet_overrides)
+    handoff = plan_work_item_lifecycle_handoff(WorkItemLifecycleHandoffRequest(packet=packet_data))
+    handoff_data = handoff.__dict__.copy()
+    if handoff_overrides:
+        handoff_data.update(handoff_overrides)
     packet_path = tmp_path / "packet.json"
     handoff_path = tmp_path / "handoff.json"
-    packet_path.write_text(json.dumps(packet.__dict__), encoding="utf-8")
-    handoff_path.write_text(json.dumps(handoff.__dict__), encoding="utf-8")
+    packet_path.write_text(json.dumps(packet_data), encoding="utf-8")
+    handoff_path.write_text(json.dumps(handoff_data), encoding="utf-8")
+    return packet_path, handoff_path
+
+
+def test_script_summary_completed(tmp_path: Path, capsys) -> None:
+    packet_path, handoff_path = _write_packet_handoff(tmp_path)
     rc = main(["--packet", str(packet_path), "--handoff", str(handoff_path), "--workspace-root", str(tmp_path), "--summary"])
     out = capsys.readouterr().out
     assert rc == 0
     assert "dry_run_adapter_completed" in out
+
+
+@pytest.mark.parametrize(
+    "packet_overrides,handoff_overrides,expected_status",
+    [
+        ({"declared_authority_requests": ["network"]}, {}, "dry_run_adapter_blocked"),
+        ({"intake_status": "intake_insufficient_metadata"}, {}, "dry_run_adapter_blocked"),
+        ({}, {"recommended_next_governed_surface": "needs_manual_review"}, "dry_run_adapter_manual_review_required"),
+        ({"workspace_change_set_proposal_metadata": None}, {}, "dry_run_adapter_insufficient_metadata"),
+    ],
+)
+def test_script_summary_negative_paths(tmp_path: Path, capsys, packet_overrides: dict[str, object], handoff_overrides: dict[str, object], expected_status: str) -> None:
+    packet_path, handoff_path = _write_packet_handoff(tmp_path, packet_overrides=packet_overrides, handoff_overrides=handoff_overrides)
+    rc = main(["--packet", str(packet_path), "--handoff", str(handoff_path), "--workspace-root", str(tmp_path), "--summary"])
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert expected_status in out

--- a/tests/test_work_item_dry_run_adapter.py
+++ b/tests/test_work_item_dry_run_adapter.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sentientos.work_item_lifecycle_dry_run_adapter import WorkItemLifecycleDryRunAdapterRequest, run_work_item_lifecycle_dry_run_adapter
+import pytest
+
 from sentientos.work_item_intake import normalize_work_item_intake
+from sentientos.work_item_lifecycle_dry_run_adapter import WorkItemLifecycleDryRunAdapterRequest, run_work_item_lifecycle_dry_run_adapter
 from sentientos.work_item_lifecycle_handoff import WorkItemLifecycleHandoffRequest, plan_work_item_lifecycle_handoff
+
 
 
 def _packet(**overrides: object) -> dict[str, object]:
@@ -13,12 +16,13 @@ def _packet(**overrides: object) -> dict[str, object]:
         "title": "dry run adapter",
         "description": "desc",
         "requested_outcome": "outcome",
-        "declared_targets": ["sentientos/work_item_intake.py"],
+        "declared_targets": ["sentientos/work_item_intake.py", "tests/*.py"],
         "change_intent": "metadata",
     }
     payload.update(overrides)
     packet, _ = normalize_work_item_intake(payload, derive_workspace_proposal=True)
     return packet.__dict__
+
 
 
 def _handoff(packet: dict[str, object], **overrides: object) -> dict[str, object]:
@@ -28,63 +32,169 @@ def _handoff(packet: dict[str, object], **overrides: object) -> dict[str, object
     return out
 
 
-def test_eligible_invokes_dry_run_mode(monkeypatch, tmp_path: Path) -> None:
+class _Result:
+    stop_reason = "lifecycle_completed_for_requested_mode"
+    admission_status = "workspace_change_set_admission_accepted"
+    preflight_status = "workspace_change_set_preflight_passed"
+    transaction_plan_status = "workspace_change_set_transaction_plan_ready"
+    transaction_plan_ready = True
+
+
+class _Wing:
+    result = _Result()
+
+
+@pytest.mark.parametrize(
+    "candidate_overrides",
+    [
+        {},
+        {"orchestration_not_invoked": False},
+        {"lifecycle_mode": "admit_preflight_execute_verify_close"},
+        {"execution_permitted": True},
+        {"agent_execution_permitted": True},
+        {"evidence_source": "real_execution"},
+        {"declared_authority_requests": ["network", "provider", "shell", "prompt_export", "subprocess"]},
+        {"declared_authority_requests": ["pr_creation", "branch_creation", "issue_mutation"]},
+        {"declared_authority_requests": ["scheduler", "live_tracker"]},
+    ],
+)
+def test_unsafe_lifecycle_candidates_never_invoke(monkeypatch, tmp_path: Path, candidate_overrides: dict[str, object]) -> None:
     packet = _packet()
     handoff = _handoff(packet)
-    called: dict[str, object] = {}
+    candidate = dict(handoff.get("lifecycle_orchestration_request_candidate_metadata") or {})
+    for key, value in candidate_overrides.items():
+        if key == "declared_authority_requests":
+            packet["declared_authority_requests"] = value
+        else:
+            candidate[key] = value
+    if "orchestration_not_invoked" not in candidate and candidate_overrides == {}:
+        candidate.pop("orchestration_not_invoked", None)
+    handoff["lifecycle_orchestration_request_candidate_metadata"] = candidate
 
-    class _Result:
-        stop_reason = "lifecycle_completed_for_requested_mode"
-        admission_status = "workspace_change_set_admission_accepted"
-        preflight_status = "workspace_change_set_preflight_passed"
-        transaction_plan_status = "workspace_change_set_transaction_plan_ready"
-        transaction_plan_ready = True
-
-    class _Wing:
-        result = _Result()
-
-    def _fake(proposal, *, mode, workspace_root, **kwargs):
-        called["mode"] = mode
-        called["workspace_root"] = workspace_root
-        return _Wing()
-
-    monkeypatch.setattr("sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration", _fake)
-    res = run_work_item_lifecycle_dry_run_adapter(WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True))
-    assert res.adapter_status == "dry_run_adapter_completed"
-    assert res.lifecycle_orchestration_invoked is True
-    assert called["mode"] == "dry_run_full_lifecycle"
-    assert res.transaction_plan_ready is True
-
-
-def test_blocked_authority_does_not_invoke(monkeypatch, tmp_path: Path) -> None:
-    packet = _packet(declared_authority_requests=["network"])
-    handoff = _handoff(packet)
-    monkeypatch.setattr("sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not invoke")))
-    res = run_work_item_lifecycle_dry_run_adapter(WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True))
+    monkeypatch.setattr(
+        "sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("orchestrator should not be called")),
+    )
+    res = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True)
+    )
     assert res.lifecycle_orchestration_invoked is False
-    assert res.adapter_status == "dry_run_adapter_blocked"
+    assert res.adapter_status in {"dry_run_adapter_blocked", "dry_run_adapter_contradicted"}
 
 
-def test_manual_review_surface_does_not_invoke(tmp_path: Path) -> None:
-    packet = _packet()
-    handoff = _handoff(packet, recommended_next_governed_surface="needs_manual_review")
-    res = run_work_item_lifecycle_dry_run_adapter(WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True))
-    assert res.adapter_status == "dry_run_adapter_manual_review_required"
+@pytest.mark.parametrize(
+    "packet_overrides,handoff_overrides,expected_status",
+    [
+        ({"intake_status": "intake_blocked"}, {}, "dry_run_adapter_blocked"),
+        ({"intake_status": "intake_contradicted"}, {}, "dry_run_adapter_blocked"),
+        ({"intake_status": "intake_insufficient_metadata"}, {}, "dry_run_adapter_blocked"),
+        ({}, {"recommended_next_governed_surface": "needs_manual_review"}, "dry_run_adapter_manual_review_required"),
+        ({}, {"recommended_next_governed_surface": "needs_operator_clarification"}, "dry_run_adapter_manual_review_required"),
+        ({}, {"recommended_next_governed_surface": "blocked_authority_request"}, "dry_run_adapter_manual_review_required"),
+        ({}, {"recommended_next_governed_surface": "blocked_external_integration_request"}, "dry_run_adapter_manual_review_required"),
+        ({}, {"recommended_next_governed_surface": "blocked_agent_execution_request"}, "dry_run_adapter_manual_review_required"),
+        ({"agent_execution_is_requested": True}, {}, "dry_run_adapter_blocked"),
+        ({"agent_execution_is_permitted_by_this_packet": True}, {}, "dry_run_adapter_blocked"),
+    ],
+)
+def test_blocked_no_invoke_variants(monkeypatch, tmp_path: Path, packet_overrides: dict[str, object], handoff_overrides: dict[str, object], expected_status: str) -> None:
+    packet = _packet(**packet_overrides)
+    handoff = _handoff(packet, **handoff_overrides)
+    monkeypatch.setattr(
+        "sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("orchestrator should not be called")),
+    )
+    res = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True)
+    )
+    assert res.adapter_status == expected_status
     assert res.lifecycle_orchestration_invoked is False
 
 
-def test_missing_proposal_metadata_insufficient(tmp_path: Path) -> None:
+def test_missing_metadata_and_dry_run_not_explicit_do_not_invoke(monkeypatch, tmp_path: Path) -> None:
     packet = _packet()
     packet.pop("workspace_change_set_proposal_metadata", None)
     handoff = _handoff(packet)
-    res = run_work_item_lifecycle_dry_run_adapter(WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True))
-    assert res.adapter_status == "dry_run_adapter_insufficient_metadata"
+    monkeypatch.setattr(
+        "sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("orchestrator should not be called")),
+    )
+    res_missing = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True)
+    )
+    assert res_missing.adapter_status == "dry_run_adapter_insufficient_metadata"
+    packet2 = _packet()
+    handoff2 = _handoff(packet2)
+    res_not_explicit = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet2, handoff_plan=handoff2, workspace_root=str(tmp_path), request_dry_run=False)
+    )
+    assert res_not_explicit.adapter_status == "dry_run_adapter_manual_review_required"
+    assert res_not_explicit.lifecycle_orchestration_invoked is False
 
 
-def test_cli_artifact_only_write(tmp_path: Path) -> None:
+def test_orchestrator_called_once_in_dry_run_mode_only(monkeypatch, tmp_path: Path) -> None:
     packet = _packet()
     handoff = _handoff(packet)
-    out = tmp_path / "out.json"
-    res = run_work_item_lifecycle_dry_run_adapter(WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=False, artifact_output_path=str(out)))
-    assert out.exists()
-    assert res.adapter_status != "dry_run_adapter_completed"
+    calls: list[tuple[str, str | None]] = []
+
+    def _fake(proposal, *, mode, workspace_root, **kwargs):
+        calls.append((mode, workspace_root))
+        return _Wing()
+
+    monkeypatch.setattr("sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration", _fake)
+    res = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True)
+    )
+    assert res.adapter_status == "dry_run_adapter_completed"
+    assert calls == [("dry_run_full_lifecycle", str(tmp_path))]
+
+
+def test_adapter_never_calls_stage_helpers_or_workspace_effect_helpers(monkeypatch, tmp_path: Path) -> None:
+    packet = _packet()
+    handoff = _handoff(packet, recommended_next_governed_surface="needs_manual_review")
+
+    forbidden_paths = [
+        "sentientos.workspace_change_set_execution.apply_workspace_change_target_effect",
+        "sentientos.workspace_change_set_execution.rollback_workspace_change_target_effect",
+        "sentientos.workspace_change_set_admission.run_workspace_change_set_admission_wing",
+        "sentientos.workspace_change_set_preflight.run_workspace_change_set_preflight_wing",
+        "sentientos.workspace_change_set_execution.run_workspace_change_set_execution_wing",
+        "sentientos.workspace_change_set_execution_verification.verify_workspace_change_set_execution",
+        "sentientos.workspace_change_set_lifecycle_closure.build_workspace_change_set_lifecycle_closure_manifest",
+    ]
+    for dotted in forbidden_paths:
+        monkeypatch.setattr(dotted, lambda *a, **k: (_ for _ in ()).throw(AssertionError(f"forbidden helper called: {dotted}")))
+    monkeypatch.setattr(
+        "sentientos.work_item_lifecycle_dry_run_adapter.run_workspace_change_set_lifecycle_orchestration",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("orchestrator should not be called in blocked flow")),
+    )
+
+    res = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(packet=packet, handoff_plan=handoff, workspace_root=str(tmp_path), request_dry_run=True)
+    )
+    assert res.adapter_status == "dry_run_adapter_manual_review_required"
+
+
+def test_adapter_does_not_read_targets_and_writes_only_artifact(tmp_path: Path) -> None:
+    packet = _packet(declared_targets=["forbidden/secret.txt", "**/*.py"])
+    handoff = _handoff(packet, recommended_next_governed_surface="needs_manual_review")
+    target = tmp_path / "forbidden" / "secret.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("do-not-read", encoding="utf-8")
+    output = tmp_path / "adapter.json"
+
+    res = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(
+            packet=packet,
+            handoff_plan=handoff,
+            workspace_root=str(tmp_path),
+            request_dry_run=True,
+            artifact_output_path=str(output),
+        )
+    )
+
+    assert res.lifecycle_orchestration_invoked is False
+    assert output.exists()
+    assert output.read_text(encoding="utf-8")
+    assert target.read_text(encoding="utf-8") == "do-not-read"
+    assert sorted(p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*") if p.is_file()) == ["adapter.json", "forbidden/secret.txt"]


### PR DESCRIPTION
### Motivation

- Ensure the Work Item Lifecycle dry-run adapter has explicit, exhaustive negative-path coverage proving it will not escalate authority or perform workspace/target effects. 
- Make safety boundaries (never-call guarantees, no target reads, no execution-mode escalation) explicitly testable without changing adapter semantics.

### Description

- Added comprehensive unit tests in `tests/test_work_item_dry_run_adapter.py` covering unsafe lifecycle-candidate variants, blocked/no-invoke variants, never-call proofs for forbidden helpers, single-invocation/dry-run-mode assertions, and filesystem/write-boundary proofs. 
- Expanded CLI tests in `tests/test_run_work_item_dry_run_script.py` to assert negative outcomes for blocked authority, insufficient metadata, and manual-review surfaces. 
- Tests use `monkeypatch` to assert forbidden helpers (admission/preflight/execution/verification/closure and workspace effect helpers) are never called and that the orchestrator is invoked exactly once only for eligible dry-run input with `mode="dry_run_full_lifecycle"`. 
- No production code or runtime authority was altered; changes are test/proof hardening only and include small test scaffolding refactors to make assertions easier.

### Testing

- Ran the targeted tests with `python -m scripts.run_tests -q tests/test_work_item_dry_run_adapter.py tests/test_run_work_item_dry_run_script.py` and the new tests passed. 
- Ran targeted `mypy` on modified surfaces with `mypy sentientos/work_item_intake.py scripts/intake_work_item.py sentientos/work_item_lifecycle_handoff.py scripts/plan_work_item_handoff.py sentientos/work_item_lifecycle_dry_run_adapter.py scripts/run_work_item_dry_run.py` which reported pre-existing unrelated type errors in `sentientos/workspace_file_effect.py` (no new mypy errors introduced by this change). 
- `python scripts/check_mypy_baseline.py` returned that the baseline improved with no new errors. 
- Documentation build was bootstrapped and completed successfully using `python scripts/build_docs.py --bootstrap-docs` followed by `python scripts/build_docs.py`. 
- Context hygiene and audits succeeded with `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`. 

Files changed: `tests/test_work_item_dry_run_adapter.py`, `tests/test_run_work_item_dry_run_script.py`.

Unresolved risks: existing mypy debt in `sentientos/workspace_file_effect.py` remains unrelated to this PR and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bea2cdf64832094ecdccaa153ab96)