### PR TITLE
[codex:workspace] repair workspace_file_effect mypy seam

### DIFF
--- a/sentientos/workspace_file_effect.py
+++ b/sentientos/workspace_file_effect.py
@@ -516,17 +516,16 @@ class WorkspaceFileRollbackWingResult(NamedTuple):
 
 
 def build_default_workspace_file_effect_policy() -> WorkspaceFileEffectPolicy:
-    payload = {
-        "policy_id": "workspace-file-effect-default-policy",
-        "required_scope_labels": ("explicit_workspace_root", "relative_single_file_target", "exact_rollback_available"),
-        "blocked_actions": BLOCKED_ACTION_LABELS,
-        "create_allowed": True,
-        "parent_directory_creation_allowed": False,
-        "default_payload_media_type": "text/plain; charset=utf-8",
-        "warning_codes": (),
-        "risk_codes": ("workspace_scoped_single_file_write_is_real_host_mutation",),
-    }
-    return WorkspaceFileEffectPolicy(**payload)
+    return WorkspaceFileEffectPolicy(
+        policy_id="workspace-file-effect-default-policy",
+        required_scope_labels=("explicit_workspace_root", "relative_single_file_target", "exact_rollback_available"),
+        blocked_actions=BLOCKED_ACTION_LABELS,
+        create_allowed=True,
+        parent_directory_creation_allowed=False,
+        default_payload_media_type="text/plain; charset=utf-8",
+        warning_codes=(),
+        risk_codes=("workspace_scoped_single_file_write_is_real_host_mutation",),
+    )
 
 
 def build_workspace_file_effect_request(
@@ -582,7 +581,7 @@ def _resolve_target(workspace_root: str | Path, relative_target_path: str) -> tu
     except OSError:
         findings.append("workspace_root_unresolvable")
         return None, None, tuple(findings)
-    if root_resolved == root_resolved.anchor or str(root_resolved) == root_resolved.anchor:
+    if str(root_resolved) == root_resolved.anchor:
         findings.append("root_workspace_rejected")
     if PurePath(target_text).is_absolute():
         findings.append("absolute_target_path")


### PR DESCRIPTION
### Motivation
- Make the targeted typed-surface mypy gate green again by removing a local typing seam in `sentientos/workspace_file_effect.py` without changing runtime behavior or widening authority.
- Isolate type debt so the `work_item_lifecycle_dry_run_adapter` set can be type-checked cleanly by addressing only the `workspace_file_effect` surface.

### Description
- Replaced an untyped intermediate `payload` dict + `**payload` dataclass expansion with an explicit, typed `WorkspaceFileEffectPolicy(...)` constructor call to eliminate `arg-type` errors while preserving identical runtime values. 
- Removed a non-overlapping `Path == str` comparison and kept the anchor check as `str(root_resolved) == root_resolved.anchor` to resolve the `comparison-overlap` mypy warning without altering rejection semantics. 
- Changes limited to a single file: `sentientos/workspace_file_effect.py`, and do not alter workspace authority, rollback, atomic write, or other runtime semantics.

### Testing
- Ran `mypy` on the file with `python -m mypy --follow-imports=skip --hide-error-context --no-color-output --show-column-numbers --show-error-codes sentientos/workspace_file_effect.py` and it reported no issues. 
- Ran the targeted typed-surface mypy set with `python -m mypy --follow-imports=skip ... sentientos/work_item_intake.py scripts/intake_work_item.py sentientos/work_item_lifecycle_handoff.py scripts/plan_work_item_handoff.py sentientos/work_item_lifecycle_dry_run_adapter.py scripts/run_work_item_dry_run.py` and it reported no issues. 
- Ran unit tests `python -m scripts.run_tests -q tests/test_workspace_file_effect.py tests/test_run_workspace_file_effect_script.py` and `python -m scripts.run_tests -q tests/test_work_item_dry_run_adapter.py tests/test_run_work_item_dry_run_script.py` and they passed. 
- Ran `python scripts/check_mypy_baseline.py` which showed the baseline improved with retired records and no new errors, and `vow/mypy_baseline.json` was not modified. 
- Built docs (required one-time `--bootstrap-docs` to install missing doc deps) and ran `python scripts/build_docs.py` which completed successfully, and ran `python verify_audits.py --strict` and `python scripts/audit_immutability_verifier.py` which passed. 
- Runtime behavior unchanged, no authority expansion, no baseline file edits, and no unresolved risks introduced by this repair.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bf5d019548320aa2c71e6488d8760)