### PR TITLE
[codex:work-item-closure] harden dry-run contradiction detection with structured claims

### DIFF
--- a/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
+++ b/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
@@ -12,7 +12,7 @@ This wing seals completed work-item lifecycle dry-run adapter outputs into a det
 
 ## Output
 
-A single metadata-only closure manifest containing compact IDs/digests/statuses/counts and contradiction/missing-metadata findings. Optional explicit caller-supplied artifact write is supported.
+A single metadata-only closure manifest containing compact IDs/digests/statuses/counts and contradiction/missing-metadata findings. Contradiction detection is primarily structured via explicit authority-claim flags, with legacy blocker/warning token scans retained as compatibility fallback signals. Optional explicit caller-supplied artifact write is supported.
 
 ## Boundaries
 

--- a/sentientos/work_item_dry_run_closure.py
+++ b/sentientos/work_item_dry_run_closure.py
@@ -53,6 +53,11 @@ class WorkItemDryRunClosureManifest:
     blocker_codes: tuple[str, ...]
     warning_codes: tuple[str, ...]
     contradiction_codes: tuple[str, ...]
+    structured_authority_claims: Mapping[str, bool]
+    structured_contradiction_codes: tuple[str, ...]
+    fallback_token_scan_used: bool
+    fallback_token_contradiction_codes: tuple[str, ...]
+    contradiction_source: str
     missing_metadata_fields: tuple[str, ...]
     authority_request_summary: tuple[str, ...]
     proposal_candidate_id: str | None
@@ -98,6 +103,30 @@ def _write_artifact(path: str | None, payload: Mapping[str, Any]) -> tuple[Mappi
     return ({"stage": "work_item_dry_run_closure", "path": str(p), "digest": digest},)
 
 
+_STRUCTURED_AUTHORITY_CLAIMS: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("execution_authority_claimed", ("execution_permitted", "execution_performed", "rollback_performed", "target_write_performed"), "dry_run_claims_real_execution_authority"),
+    ("verification_replay_claimed", ("verification_replay_performed",), "dry_run_claims_verification_replay_authority"),
+    ("lifecycle_real_closure_claimed", ("real_lifecycle_closure_performed",), "dry_run_claims_real_lifecycle_closure_authority"),
+    ("agent_execution_claimed", ("agent_execution_permitted", "agent_execution_performed"), "dry_run_claims_agent_execution_authority"),
+    ("scheduler_claimed", ("scheduler_authority_claimed", "scheduler_invoked", "scheduler_permitted"), "dry_run_claims_scheduler_authority"),
+    ("live_tracker_claimed", ("live_tracker_authority_claimed", "live_tracker_mutation_claimed", "live_tracker_invoked"), "dry_run_claims_live_tracker_authority"),
+    ("network_claimed", ("network_authority_claimed", "network_permitted", "network_invoked"), "dry_run_claims_network_authority"),
+    ("provider_claimed", ("provider_authority_claimed", "provider_invocation_claimed", "provider_invoked"), "dry_run_claims_provider_authority"),
+    ("prompt_export_claimed", ("prompt_export_authority_claimed", "prompt_export_performed", "prompt_assembly_performed"), "dry_run_claims_prompt_export_authority"),
+    ("subprocess_or_shell_claimed", ("subprocess_authority_claimed", "subprocess_invoked", "shell_authority_claimed", "shell_invoked"), "dry_run_claims_subprocess_or_shell_authority"),
+    ("pr_branch_issue_mutation_claimed", ("pr_mutation_claimed", "pr_creation_claimed", "branch_mutation_claimed", "branch_creation_claimed", "issue_mutation_claimed", "issue_comment_mutation_claimed"), "dry_run_claims_pr_branch_issue_mutation_authority"),
+    ("workspace_execution_claimed", ("workspace_execution_performed",), "dry_run_claims_workspace_execution_authority"),
+)
+
+
+def _bool_claim_from_evidence(field_names: tuple[str, ...], packet: Mapping[str, Any], handoff: Mapping[str, Any], dry: Mapping[str, Any]) -> bool:
+    for evidence in (packet, handoff, dry):
+        for field in field_names:
+            if isinstance(evidence.get(field), bool) and bool(evidence.get(field)):
+                return True
+    return False
+
+
 def build_work_item_dry_run_closure_manifest(request: WorkItemDryRunClosureRequest, *, policy: WorkItemDryRunClosurePolicy | None = None) -> WorkItemDryRunClosureResult:
     _ = policy or WorkItemDryRunClosurePolicy()
     if request.packet is None or request.handoff_plan is None or request.dry_run_result is None:
@@ -105,8 +134,9 @@ def build_work_item_dry_run_closure_manifest(request: WorkItemDryRunClosureReque
             closure_status="dry_run_closure_insufficient_evidence", work_item_id="", source_kind="", source_ref="", intake_status="", risk_class="",
             handoff_recommended_surface="", dry_run_adapter_status="", lifecycle_dry_run_invoked=False, lifecycle_mode_used=None, lifecycle_stop_reason=None,
             admission_status=None, preflight_status=None, transaction_plan_status=None, transaction_plan_ready=None, blocker_codes=(), warning_codes=(),
-            contradiction_codes=(), missing_metadata_fields=("packet", "handoff_plan", "dry_run_result"), authority_request_summary=(), proposal_candidate_id=None,
-            proposal_candidate_digest=None, handoff_plan_id=None, dry_run_artifact_records=(),
+            contradiction_codes=(), structured_authority_claims={}, structured_contradiction_codes=(), fallback_token_scan_used=False,
+            fallback_token_contradiction_codes=(), contradiction_source="none", missing_metadata_fields=("packet", "handoff_plan", "dry_run_result"),
+            authority_request_summary=(), proposal_candidate_id=None, proposal_candidate_digest=None, handoff_plan_id=None, dry_run_artifact_records=(),
         )
         return WorkItemDryRunClosureResult(manifest=manifest, artifact_records=())
 
@@ -118,6 +148,8 @@ def build_work_item_dry_run_closure_manifest(request: WorkItemDryRunClosureReque
     warnings = set(_tuple(packet.get("warning_codes")) + _tuple(handoff.get("warning_codes")) + _tuple(dry.get("warning_codes")))
     missing = set(_tuple(handoff.get("missing_metadata_fields")) + _tuple(dry.get("missing_metadata_fields")))
     contradictions: set[str] = set()
+    structured_contradictions: set[str] = set()
+    fallback_contradictions: set[str] = set()
 
     work_item_id = str(packet.get("work_item_id", "")).strip()
     handoff_work_item_id = str(handoff.get("work_item_id", "")).strip()
@@ -134,9 +166,28 @@ def build_work_item_dry_run_closure_manifest(request: WorkItemDryRunClosureReque
     if bool(packet.get("agent_execution_is_requested", False) or packet.get("agent_execution_is_permitted_by_this_packet", False)):
         contradictions.add("agent_execution_not_denied")
 
+    structured_claims = {
+        claim_name: _bool_claim_from_evidence(field_names, packet, handoff, dry)
+        for claim_name, field_names, _ in _STRUCTURED_AUTHORITY_CLAIMS
+    }
+    for claim_name, _, contradiction_code in _STRUCTURED_AUTHORITY_CLAIMS:
+        if structured_claims[claim_name]:
+            structured_contradictions.add(contradiction_code)
+
     forbidden = {"execution", "verification", "closure"}
     if any(tok in " ".join(_tuple(dry.get("blocker_codes")) + _tuple(dry.get("warning_codes"))).lower() for tok in forbidden):
-        contradictions.add("dry_run_claims_real_effect_authority")
+        fallback_contradictions.add("dry_run_claims_real_effect_authority")
+    contradictions.update(structured_contradictions)
+    contradictions.update(fallback_contradictions)
+
+    fallback_used = bool(fallback_contradictions)
+    contradiction_source = "none"
+    if structured_contradictions and fallback_contradictions:
+        contradiction_source = "structured_and_fallback"
+    elif structured_contradictions:
+        contradiction_source = "structured_flag"
+    elif fallback_contradictions:
+        contradiction_source = "fallback_token_scan"
 
     adapter_status = str(dry.get("adapter_status", "")).strip()
     closure_status = "dry_run_closed_clean"
@@ -170,6 +221,11 @@ def build_work_item_dry_run_closure_manifest(request: WorkItemDryRunClosureReque
         blocker_codes=tuple(sorted(blockers)),
         warning_codes=tuple(sorted(warnings)),
         contradiction_codes=tuple(sorted(contradictions)),
+        structured_authority_claims=structured_claims,
+        structured_contradiction_codes=tuple(sorted(structured_contradictions)),
+        fallback_token_scan_used=fallback_used,
+        fallback_token_contradiction_codes=tuple(sorted(fallback_contradictions)),
+        contradiction_source=contradiction_source,
         missing_metadata_fields=tuple(sorted(missing)),
         authority_request_summary=_tuple(packet.get("declared_authority_requests")),
         proposal_candidate_id=str(handoff.get("workspace_change_set_proposal_candidate_id", "")).strip() or None,

--- a/tests/test_build_work_item_dry_run_closure_script.py
+++ b/tests/test_build_work_item_dry_run_closure_script.py
@@ -17,3 +17,4 @@ def test_script(tmp_path):
     assert rc == 0
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["manifest"]["closure_status"] == "dry_run_closed_clean"
+    assert payload["manifest"]["contradiction_source"] == "none"

--- a/tests/test_work_item_dry_run_closure.py
+++ b/tests/test_work_item_dry_run_closure.py
@@ -59,3 +59,53 @@ def test_metadata_only_and_output(tmp_path):
     assert result.manifest.metadata_only
     assert out.exists()
     assert "description" not in out.read_text(encoding="utf-8")
+
+
+def test_structured_claims_contradict():
+    claim_fields = [
+        "execution_performed",
+        "verification_replay_performed",
+        "real_lifecycle_closure_performed",
+        "agent_execution_performed",
+        "scheduler_authority_claimed",
+        "live_tracker_authority_claimed",
+        "network_authority_claimed",
+        "provider_authority_claimed",
+        "prompt_export_authority_claimed",
+        "subprocess_authority_claimed",
+        "pr_creation_claimed",
+        "workspace_execution_performed",
+    ]
+    for field in claim_fields:
+        dry = _dry()
+        dry[field] = True
+        manifest = build_work_item_dry_run_closure_manifest(WorkItemDryRunClosureRequest(_packet(), _handoff(), dry)).manifest
+        assert manifest.closure_status == "dry_run_closed_contradicted"
+        assert manifest.structured_authority_claims
+        assert manifest.contradiction_source == "structured_flag"
+        assert manifest.structured_contradiction_codes
+
+
+def test_fallback_token_scan_source():
+    dry = _dry()
+    dry["warning_codes"] = ["verification_token_legacy"]
+    manifest = build_work_item_dry_run_closure_manifest(WorkItemDryRunClosureRequest(_packet(), _handoff(), dry)).manifest
+    assert manifest.closure_status == "dry_run_closed_contradicted"
+    assert manifest.fallback_token_scan_used is True
+    assert manifest.contradiction_source == "fallback_token_scan"
+    assert "dry_run_claims_real_effect_authority" in manifest.fallback_token_contradiction_codes
+
+
+def test_structured_and_fallback_source():
+    dry = _dry()
+    dry["execution_performed"] = True
+    dry["blocker_codes"] = ["closure_token_legacy"]
+    manifest = build_work_item_dry_run_closure_manifest(WorkItemDryRunClosureRequest(_packet(), _handoff(), dry)).manifest
+    assert manifest.closure_status == "dry_run_closed_contradicted"
+    assert manifest.contradiction_source == "structured_and_fallback"
+
+
+def test_clean_has_no_fallback():
+    manifest = build_work_item_dry_run_closure_manifest(WorkItemDryRunClosureRequest(_packet(), _handoff(), _dry())).manifest
+    assert manifest.fallback_token_scan_used is False
+    assert manifest.contradiction_source == "none"


### PR DESCRIPTION
### Motivation
- Replace the heuristic text-token detection of real-effect authority claims in the work-item dry-run closure manifest with deterministic, structured evidence extraction so contradiction decisions are reviewer-auditable and repeatable.
- Preserve metadata-only boundaries and avoid any widening of authority or runtime invocation while removing ambiguity from token-only heuristics.

### Description
- Add explicit structured authority claim families and deterministic mapping to contradiction codes via `_STRUCTURED_AUTHORITY_CLAIMS` and `_bool_claim_from_evidence`, and surface the boolean claim map as `structured_authority_claims` in the manifest. (changed `sentientos/work_item_dry_run_closure.py`)
- Record structured contradictions and legacy token fallback separately as `structured_contradiction_codes`, `fallback_token_contradiction_codes`, `fallback_token_scan_used`, and set a `contradiction_source` (`none`, `structured_flag`, `fallback_token_scan`, `structured_and_fallback`). (changed `sentientos/work_item_dry_run_closure.py`)
- Keep legacy blocker/warning token scanning as a compatibility fallback only and no longer rely on it as the primary proof; contradictions now derive from structured flags first. (changed `sentientos/work_item_dry_run_closure.py`)
- Add unit tests covering each structured forbidden claim, fallback-only detection, mixed structured+fallback, and clean-path behavior; also assert CLI output includes `contradiction_source`. (changed `tests/test_work_item_dry_run_closure.py`, `tests/test_build_work_item_dry_run_closure_script.py`)
- Update reviewer docs to state contradiction detection is structured-first with token-scan fallback compatibility. (changed `docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md`)

### Testing
- Ran unit tests: `python -m scripts.run_tests -q tests/test_work_item_dry_run_closure.py tests/test_build_work_item_dry_run_closure_script.py` — tests passed (closure and added structured-claim tests succeeded).
- Ran static typing: `python -m mypy sentientos/work_item_intake.py scripts/intake_work_item.py sentientos/work_item_lifecycle_handoff.py scripts/plan_work_item_handoff.py sentientos/work_item_lifecycle_dry_run_adapter.py scripts/run_work_item_dry_run.py sentientos/work_item_dry_run_closure.py scripts/build_work_item_dry_run_closure.py` — no issues reported.
- Ran baseline check: `python scripts/check_mypy_baseline.py` — baseline improved (no new errors).
- Built docs: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py` — docs bootstrapped and build completed successfully.
- Context hygiene and audits: `python scripts/verify_context_hygiene_prompt_boundaries.py` and `python verify_audits.py --strict` and `python scripts/audit_immutability_verifier.py` — all checks passed.

Notes/risks: structured detection relies on upstream evidence field-name contracts; if producers rename boolean flags without compatibility aliases, structured detection could miss claims (legacy token fallback remains available but is less precise). This change is metadata-only and does not alter runtime authority or introduce execution paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bf9851a948320ba47b1043d8dd2d5)