### PR TITLE
[codex:work-item] harden authority vocabulary producer coverage contracts

### DIFF
--- a/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
+++ b/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
@@ -38,3 +38,27 @@ A single metadata-only closure manifest containing compact IDs/digests/statuses/
 - Tests: `tests/test_work_item_dry_run_closure.py`, `tests/test_build_work_item_dry_run_closure_script.py`
 
 The reviewer proof bundle documents this capability and does not run the closure builder by default.
+
+## Shared authority vocabulary producer contract
+
+Work-item producer surfaces (intake packet, handoff plan, dry-run adapter result, and dry-run closure manifest) are contract-tested for authority-like field drift.
+
+- Authority-looking field names are detected in tests using reviewer-only heuristics (for example `*_requested`, `*_invoked`, `*_performed`, plus tokens such as `authority`, `workspace`, `provider`, `network`, `scheduler`, `verification`, and `closure`).
+- Every detected field must be either:
+  1. a shared alias in `AUTHORITY_CLAIM_ALIASES` mapped to a canonical authority family, or
+  2. listed in `NON_AUTHORITY_FIELD_ALLOWLIST` with explicit non-authority rationale.
+- Unknown authority-looking fields fail deterministically so upstream producers cannot silently introduce unmapped authority semantics.
+
+### Safe update procedure for new producer fields
+
+When adding a new authority-related producer field:
+
+1. Add the exact field name to the correct canonical family in `AUTHORITY_CLAIM_ALIASES` (no fuzzy matching in runtime logic).
+2. Ensure the field appears in representative producer output fixtures/tests.
+3. Run the work-item authority tests to confirm deterministic coverage.
+
+When adding a new non-authority field that happens to match heuristic tokens:
+
+1. Add it to `NON_AUTHORITY_FIELD_ALLOWLIST` under the most specific category.
+2. Include a compact rationale in code review/PR notes.
+3. Keep runtime claim normalization unchanged unless the field actually conveys authority.

--- a/sentientos/work_item_authority_claims.py
+++ b/sentientos/work_item_authority_claims.py
@@ -92,6 +92,40 @@ AUTHORITY_CLAIM_ALIASES: dict[str, tuple[str, ...]] = {
     ),
 }
 
+NON_AUTHORITY_FIELD_ALLOWLIST: dict[str, tuple[str, ...]] = {
+    "lifecycle_gate_metadata": (
+        "workspace_change_set_admission_may_be_attempted",
+        "workspace_change_set_proposal_candidate_id",
+        "workspace_change_set_proposal_candidate_digest",
+        "dry_run_lifecycle_may_be_attempted",
+        "full_lifecycle_may_be_reviewed",
+        "dry_run_eligibility_status",
+        "lifecycle_orchestration_invoked",
+        "lifecycle_mode_used",
+        "lifecycle_dry_run_status",
+        "handoff_recommended_surface",
+    ),
+    "review_and_artifact_metadata": (
+        "closure_status",
+        "dry_run_adapter_status",
+        "dry_run_artifact_records",
+        "fallback_token_scan_used",
+        "fallback_token_contradiction_codes",
+        "contradiction_source",
+    ),
+    "declarative_request_metadata": (
+        "declared_authority_requests",
+        "authority_request_summary",
+        "agent_execution_is_requested",
+        "agent_execution_is_permitted_by_this_packet",
+        "explicit_non_authority_boundaries",
+    ),
+}
+
+NON_AUTHORITY_FIELD_ALLOWLIST_VALUES: frozenset[str] = frozenset(
+    field for fields in NON_AUTHORITY_FIELD_ALLOWLIST.values() for field in fields
+)
+
 ALIASES_TO_FAMILY: dict[str, str] = {
     alias: family for family in CANONICAL_AUTHORITY_CLAIM_FAMILIES for alias in AUTHORITY_CLAIM_ALIASES[family]
 }
@@ -179,6 +213,8 @@ __all__ = [
     "AUTHORITY_CLAIM_ALIASES",
     "AUTHORITY_CONTRADICTION_CODES",
     "CANONICAL_AUTHORITY_CLAIM_FAMILIES",
+    "NON_AUTHORITY_FIELD_ALLOWLIST",
+    "NON_AUTHORITY_FIELD_ALLOWLIST_VALUES",
     "authority_claim_summary",
     "authority_claims_from_nested_evidence",
     "authority_contradiction_codes",

--- a/tests/test_work_item_authority_claims.py
+++ b/tests/test_work_item_authority_claims.py
@@ -1,14 +1,65 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+
 from sentientos.work_item_authority_claims import (
     ALIASES_TO_FAMILY,
     AUTHORITY_CLAIM_ALIASES,
     CANONICAL_AUTHORITY_CLAIM_FAMILIES,
+    NON_AUTHORITY_FIELD_ALLOWLIST_VALUES,
     authority_claim_summary,
     authority_claims_from_nested_evidence,
     authority_contradiction_codes,
     normalize_authority_claims,
 )
+from sentientos.work_item_dry_run_closure import WorkItemDryRunClosureRequest, build_work_item_dry_run_closure_manifest
+from sentientos.work_item_intake import normalize_work_item_intake
+from sentientos.work_item_lifecycle_dry_run_adapter import WorkItemLifecycleDryRunAdapterRequest, run_work_item_lifecycle_dry_run_adapter
+from sentientos.work_item_lifecycle_handoff import WorkItemLifecycleHandoffRequest, plan_work_item_lifecycle_handoff
+
+AUTHORITY_HEURISTIC_TOKENS: tuple[str, ...] = (
+    "_requested",
+    "_permitted",
+    "_performed",
+    "_invoked",
+    "_used",
+    "_claimed",
+    "_enabled",
+    "_allowed",
+    "_created",
+    "_mutated",
+    "_executed",
+    "authority",
+    "execution",
+    "scheduler",
+    "tracker",
+    "network",
+    "provider",
+    "prompt",
+    "subprocess",
+    "shell",
+    "branch",
+    "pr_",
+    "issue",
+    "workspace",
+    "target_write",
+    "rollback",
+    "verification",
+    "closure",
+)
+
+
+def _authority_looking_fields(fields: set[str]) -> set[str]:
+    return {f for f in fields if any(token in f for token in AUTHORITY_HEURISTIC_TOKENS)}
+
+
+def _unknown_authority_fields(fields: set[str]) -> tuple[str, ...]:
+    unknown = sorted(
+        field
+        for field in _authority_looking_fields(fields)
+        if field not in ALIASES_TO_FAMILY and field not in NON_AUTHORITY_FIELD_ALLOWLIST_VALUES
+    )
+    return tuple(unknown)
 
 
 def test_all_families_have_aliases():
@@ -54,3 +105,44 @@ def test_nested_evidence_extraction_and_deterministic_outputs():
         "dry_run_claims_network_authority",
         "dry_run_claims_workspace_execution_authority",
     )
+
+
+def test_producer_authority_like_fields_have_alias_or_non_authority_classification():
+    packet, _ = normalize_work_item_intake(
+        {
+            "source_kind": "manual_operator_task",
+            "source_ref": "WI-123",
+            "title": "Add authority vocabulary coverage",
+            "description": "metadata only",
+            "requested_outcome": "deterministic coverage",
+            "declared_targets": ["sentientos/work_item_authority_claims.py"],
+            "declared_authority_requests": ["filesystem_write"],
+            "agent_execution_requested": False,
+        },
+        derive_workspace_proposal=True,
+    )
+    packet_dict = asdict(packet)
+    handoff = plan_work_item_lifecycle_handoff(WorkItemLifecycleHandoffRequest(packet=packet_dict, emit_lifecycle_candidate=True))
+    dry = run_work_item_lifecycle_dry_run_adapter(
+        WorkItemLifecycleDryRunAdapterRequest(
+            packet=packet_dict,
+            handoff_plan=asdict(handoff),
+            workspace_root=None,
+            request_dry_run=False,
+        )
+    )
+    closure = build_work_item_dry_run_closure_manifest(
+        WorkItemDryRunClosureRequest(packet=packet_dict, handoff_plan=asdict(handoff), dry_run_result=dry.to_dict())
+    )
+    observed = set(packet_dict) | set(asdict(handoff)) | set(dry.to_dict()) | set(closure.manifest.to_dict())
+    assert _unknown_authority_fields(observed) == ()
+
+
+def test_unknown_authority_looking_field_fails_coverage():
+    unknown = _unknown_authority_fields({"network_permitted", "new_scheduler_enabled"})
+    assert unknown == ("new_scheduler_enabled",)
+
+
+def test_known_non_authority_field_passes_coverage_allowlist():
+    unknown = _unknown_authority_fields({"workspace_change_set_admission_may_be_attempted"})
+    assert unknown == ()


### PR DESCRIPTION
### Motivation

- Prevent upstream producers from silently introducing new authority-like fields that escape the shared vocabulary by adding reviewer-visible producer coverage tests and an explicit non-authority allowlist. 
- Provide a deterministic guard so every authority-looking producer field is either mapped to a canonical family or explicitly classified as non-authority metadata.

### Description

- Add `NON_AUTHORITY_FIELD_ALLOWLIST` and `NON_AUTHORITY_FIELD_ALLOWLIST_VALUES` to `sentientos/work_item_authority_claims.py` to document and export compact categories of intentionally non-authority metadata (e.g. `lifecycle_gate_metadata`, `review_and_artifact_metadata`, `declarative_request_metadata`).
- Add producer-contract coverage tests to `tests/test_work_item_authority_claims.py` that instantiate representative producer outputs via `normalize_work_item_intake`, `plan_work_item_lifecycle_handoff`, `run_work_item_lifecycle_dry_run_adapter`, and `build_work_item_dry_run_closure_manifest`, heuristic-scan field names, and assert each authority-looking field is either an alias or allowlisted. 
- Add deterministic positive/negative tests proving unknown authority-looking fields fail coverage and known allowlisted non-authority fields pass. 
- Update docs `docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md` with a reviewer-facing “Shared authority vocabulary producer contract” and a safe update procedure for adding new producer fields. 
- No runtime authority semantics were changed and no new canonical aliases were added; normalization continues to rely only on `AUTHORITY_CLAIM_ALIASES`.

### Testing

- Ran unit tests: `python -m scripts.run_tests -q tests/test_work_item_authority_claims.py tests/test_work_item_dry_run_closure.py tests/test_build_work_item_dry_run_closure_script.py`, and the test suite completed successfully. 
- Ran static typing: `python -m mypy sentientos/work_item_authority_claims.py sentientos/work_item_intake.py scripts/intake_work_item.py sentientos/work_item_lifecycle_handoff.py scripts/plan_work_item_handoff.py sentientos/work_item_lifecycle_dry_run_adapter.py scripts/run_work_item_dry_run.py sentientos/work_item_dry_run_closure.py scripts/build_work_item_dry_run_closure.py`, which returned no issues for the targeted sources. 
- Ran baseline and tooling checks: `python scripts/check_mypy_baseline.py` (baseline improved/no new errors), `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py` (docs build succeeded after bootstrapping), `python scripts/verify_context_hygiene_prompt_boundaries.py` (clean), `python verify_audits.py --strict` (passed), and `python scripts/audit_immutability_verifier.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bfdb670b88320ad51c734c6c31621)