### PR TITLE
[codex:work-item-authority] harden nested producer and artifact field coverage

### DIFF
--- a/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
+++ b/docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md
@@ -48,6 +48,8 @@ Work-item producer surfaces (intake packet, handoff plan, dry-run adapter result
   1. a shared alias in `AUTHORITY_CLAIM_ALIASES` mapped to a canonical authority family, or
   2. listed in `NON_AUTHORITY_FIELD_ALLOWLIST` with explicit non-authority rationale.
 - Unknown authority-looking fields fail deterministically so upstream producers cannot silently introduce unmapped authority semantics.
+- Coverage walks nested mapping/list/tuple structures and reports deterministic dotted paths (for example `dry_run_result.lifecycle_summary.execution_performed` or `closure_manifest.artifacts[0].artifact_created`) so deeply nested drift is visible.
+- Coverage includes representative serialized artifact payload shapes for intake packet, handoff plan, dry-run adapter artifact payload, and dry-run closure manifest payload.
 
 ### Safe update procedure for new producer fields
 

--- a/tests/test_work_item_authority_claims.py
+++ b/tests/test_work_item_authority_claims.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import Any
 
 from sentientos.work_item_authority_claims import (
     ALIASES_TO_FAMILY,
@@ -62,6 +63,32 @@ def _unknown_authority_fields(fields: set[str]) -> tuple[str, ...]:
     return tuple(unknown)
 
 
+def _iter_field_paths(node: Any, *, root: str = ""):
+    if isinstance(node, dict):
+        for key in sorted(node):
+            key_str = str(key)
+            path = f"{root}.{key_str}" if root else key_str
+            yield key_str, path
+            yield from _iter_field_paths(node[key], root=path)
+    elif isinstance(node, (list, tuple)):
+        for idx, item in enumerate(node):
+            path = f"{root}[{idx}]" if root else f"[{idx}]"
+            yield from _iter_field_paths(item, root=path)
+
+
+def _unknown_authority_field_paths(payloads: dict[str, Any]) -> tuple[str, ...]:
+    unknown_paths = []
+    for label in sorted(payloads):
+        for field, path in _iter_field_paths(payloads[label], root=label):
+            if (
+                any(token in field for token in AUTHORITY_HEURISTIC_TOKENS)
+                and field not in ALIASES_TO_FAMILY
+                and field not in NON_AUTHORITY_FIELD_ALLOWLIST_VALUES
+            ):
+                unknown_paths.append(path)
+    return tuple(sorted(unknown_paths))
+
+
 def test_all_families_have_aliases():
     for family in CANONICAL_AUTHORITY_CLAIM_FAMILIES:
         assert family in AUTHORITY_CLAIM_ALIASES
@@ -107,7 +134,7 @@ def test_nested_evidence_extraction_and_deterministic_outputs():
     )
 
 
-def test_producer_authority_like_fields_have_alias_or_non_authority_classification():
+def _build_representative_producer_outputs() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     packet, _ = normalize_work_item_intake(
         {
             "source_kind": "manual_operator_task",
@@ -134,8 +161,78 @@ def test_producer_authority_like_fields_have_alias_or_non_authority_classificati
     closure = build_work_item_dry_run_closure_manifest(
         WorkItemDryRunClosureRequest(packet=packet_dict, handoff_plan=asdict(handoff), dry_run_result=dry.to_dict())
     )
-    observed = set(packet_dict) | set(asdict(handoff)) | set(dry.to_dict()) | set(closure.manifest.to_dict())
+    return packet_dict, asdict(handoff), dry.to_dict(), closure.manifest.to_dict()
+
+
+def test_producer_authority_like_fields_have_alias_or_non_authority_classification():
+    packet_dict, handoff_dict, dry_dict, closure_manifest = _build_representative_producer_outputs()
+    observed = set(packet_dict) | set(handoff_dict) | set(dry_dict) | set(closure_manifest)
     assert _unknown_authority_fields(observed) == ()
+
+
+def test_nested_producer_authority_like_paths_have_alias_or_non_authority_classification():
+    packet_dict, handoff_dict, dry_dict, closure_manifest = _build_representative_producer_outputs()
+    unknown = _unknown_authority_field_paths(
+        {
+            "intake_packet": packet_dict,
+            "handoff_plan": handoff_dict,
+            "dry_run_result": dry_dict,
+            "closure_manifest": closure_manifest,
+        }
+    )
+    assert unknown == ()
+
+
+def test_serialized_artifact_payload_authority_like_paths_have_alias_or_non_authority_classification():
+    packet_dict, handoff_dict, dry_dict, closure_manifest = _build_representative_producer_outputs()
+    intake_artifact = {"packet": packet_dict}
+    handoff_artifact = {"plan": handoff_dict}
+    dry_run_artifact = {
+        "request": {
+            "work_item_id": packet_dict.get("work_item_id"),
+            "handoff_plan_id": dry_dict.get("handoff_plan_id"),
+            "workspace_root": None,
+            "request_dry_run": False,
+        },
+        "result": {
+            "adapter_status": dry_dict.get("adapter_status"),
+            "dry_run_eligibility_status": dry_dict.get("dry_run_eligibility_status"),
+            "lifecycle_orchestration_invoked": dry_dict.get("lifecycle_orchestration_invoked"),
+            "lifecycle_mode_used": dry_dict.get("lifecycle_mode_used"),
+            "lifecycle_dry_run_status": dry_dict.get("lifecycle_dry_run_status"),
+            "lifecycle_stop_reason": dry_dict.get("lifecycle_stop_reason"),
+            "admission_status": dry_dict.get("admission_status"),
+            "preflight_status": dry_dict.get("preflight_status"),
+            "transaction_plan_status": dry_dict.get("transaction_plan_status"),
+            "transaction_plan_ready": dry_dict.get("transaction_plan_ready"),
+        },
+    }
+    closure_artifact = {"manifest": closure_manifest, "artifact_records": []}
+    unknown = _unknown_authority_field_paths(
+        {
+            "intake_packet_artifact": intake_artifact,
+            "handoff_plan_artifact": handoff_artifact,
+            "dry_run_adapter_artifact": dry_run_artifact,
+            "dry_run_closure_manifest_artifact": closure_artifact,
+        }
+    )
+    assert unknown == ()
+
+
+def test_nested_unknown_authority_looking_field_fails_with_dotted_path():
+    unknown = _unknown_authority_field_paths(
+        {"dry_run_result": {"lifecycle_summary": {"execution_performed": False, "new_scheduler_enabled": False}}}
+    )
+    assert unknown == (
+        "dry_run_result.lifecycle_summary.new_scheduler_enabled",
+    )
+
+
+def test_nested_known_non_authority_field_passes_with_dotted_path_scan():
+    unknown = _unknown_authority_field_paths(
+        {"closure_manifest": {"artifacts": [{"artifact_created": True}], "closure_status": "dry_run_closed_clean"}}
+    )
+    assert unknown == ()
 
 
 def test_unknown_authority_looking_field_fails_coverage():


### PR DESCRIPTION
### Motivation
- Close a coverage gap where authority-looking fields could appear only in deeply nested producer substructures or serialized artifact payloads and escape test detection. 
- Keep this change strictly contract/test and documentation hardening without altering runtime semantics or adding execution surfaces.

### Description
- Added recursive nested-field coverage utilities and path enumeration in `tests/test_work_item_authority_claims.py` (`_iter_field_paths` and `_unknown_authority_field_paths`) to walk mapping/list/tuple primitives and emit deterministic dotted/indexed paths. 
- Added representative producer fixture assembly (`_build_representative_producer_outputs`) and new tests that assert nested producer outputs and serialized artifact payload shapes (intake packet, handoff plan, dry-run adapter artifact, dry-run closure manifest) have authority-like fields either mapped to `AUTHORITY_CLAIM_ALIASES` or allowlisted. 
- Added focused tests that assert unknown nested authority-looking fields fail with deterministic dotted paths (example: `dry_run_result.lifecycle_summary.new_scheduler_enabled`) and that known allowlisted non-authority nested fields pass (example: `artifact_created`, `closure_status`). 
- Updated docs to document nested/artifact producer contract coverage and dotted-path failure reporting in `docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md`.
- Files changed: `tests/test_work_item_authority_claims.py`, `docs/architecture/task_work_item_lifecycle_dry_run_closure_wing.md`; no runtime modules or authority alias/allowlist entries were modified.

### Testing
- Ran unit tests with `python -m scripts.run_tests -q tests/test_work_item_authority_claims.py tests/test_work_item_dry_run_closure.py tests/test_build_work_item_dry_run_closure_script.py` and the test suite passed. 
- Ran static checks with `python -m mypy sentientos/work_item_authority_claims.py sentintos/work_item_intake.py scripts/intake_work_item.py sentientos/work_item_lifecycle_handoff.py scripts/plan_work_item_handoff.py sentientos/work_item_lifecycle_dry_run_adapter.py scripts/run_work_item_dry_run.py sentientos/work_item_dry_run_closure.py scripts/build_work_item_dry_run_closure.py` which reported no issues. 
- Ran baseline and CI artifacts: `python scripts/check_mypy_baseline.py` (result: baseline improved, 0 new errors), `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py` (docs bootstrapped and built), `python scripts/verify_context_hygiene_prompt_boundaries.py` (clean), `python verify_audits.py --strict` (passed), and `python scripts/audit_immutability_verifier.py` (passed). 
- Summary: tests and tooling checks completed successfully; runtime behavior unchanged and no aliases or allowlist entries were added in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bffb5a91083209d10e80411ec5ba9)