### PR TITLE
[codex:validation] stabilize review packet matrix typing

### DIFF
--- a/scripts/mypy_baseline_common.py
+++ b/scripts/mypy_baseline_common.py
@@ -85,7 +85,7 @@ def _optional_int(value: Any) -> int | None:
         return None
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError("optional integer field must be an integer or null")
-    return value
+    return int(value)
 
 
 def _optional_str(value: Any) -> str | None:

--- a/scripts/run_work_item_review_packet_matrix.py
+++ b/scripts/run_work_item_review_packet_matrix.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 import time
-from typing import Callable
+from typing import Callable, TypedDict
 
 
 @dataclass(frozen=True)
@@ -15,6 +15,23 @@ class MatrixCommand:
     label: str
     command: tuple[str, ...]
     required: bool = True
+
+
+class MatrixResult(TypedDict):
+    label: str
+    command: list[str]
+    required: bool
+    exit_code: int
+    duration_seconds: float
+    output_tail: str
+
+
+class MatrixReport(TypedDict):
+    status: str
+    command_count: int
+    required_failure_count: int
+    required_failures: list[str]
+    results: list[MatrixResult]
 
 
 def default_matrix_commands() -> list[MatrixCommand]:
@@ -40,7 +57,7 @@ def _tail(text: str, lines: int = 30) -> str:
     return "\n".join(parts[-lines:])
 
 
-def run_one(command: MatrixCommand, runner: Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]) -> dict[str, object]:
+def run_one(command: MatrixCommand, runner: Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]) -> MatrixResult:
     started = time.perf_counter()
     completed = runner(command.command)
     duration = round(time.perf_counter() - started, 3)
@@ -57,8 +74,8 @@ def run_one(command: MatrixCommand, runner: Callable[[tuple[str, ...]], subproce
     }
 
 
-def run_matrix(*, commands: list[MatrixCommand], runner: Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]) -> dict[str, object]:
-    results: list[dict[str, object]] = []
+def run_matrix(*, commands: list[MatrixCommand], runner: Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]) -> MatrixReport:
+    results: list[MatrixResult] = []
     failed_required = False
     docs_check_passed = False
 
@@ -84,7 +101,7 @@ def run_matrix(*, commands: list[MatrixCommand], runner: Callable[[tuple[str, ..
             failed_required = True
 
     required_failures = [r["label"] for r in results if bool(r["required"]) and int(r["exit_code"]) != 0]
-    summary = {
+    summary: MatrixReport = {
         "status": "failed" if failed_required else "passed",
         "command_count": len(results),
         "required_failure_count": len(required_failures),


### PR DESCRIPTION
### Motivation

- The new work-item review packet matrix runner introduced mypy regressions (call-overload / return-value / iterable issues) that prevented the validation matrix from reporting green, so the runner needs stronger typing and a small baseline utility fix to restore the matrix.

### Description

- Added explicit typed report contracts `MatrixResult` and `MatrixReport` (as `TypedDict`) to `scripts/run_work_item_review_packet_matrix.py` and tightened `run_one` / `run_matrix` return types to eliminate object-typed access patterns and preserve the runner behavior. 
- Fixed `scripts/mypy_baseline_common._optional_int` to return a concrete `int` instead of returning an untyped value to remove a `no-any-return` mypy regression. 
- Files changed: `scripts/run_work_item_review_packet_matrix.py` and `scripts/mypy_baseline_common.py`, with no changes to `vow/mypy_baseline.json` or docs sources.

### Testing

- Ran `python -m scripts.run_tests -q tests/test_mypy_baseline.py` and `python -m scripts.run_tests -q tests/test_work_item_review_packet_matrix.py` which completed successfully. 
- Verified typing with `python -m mypy scripts/run_work_item_review_packet_matrix.py scripts/mypy_baseline_common.py scripts/check_mypy_baseline.py` and `python scripts/check_mypy_baseline.py` which reported no new errors (baseline improved). 
- Exercised the matrix end-to-end with `python scripts/run_work_item_review_packet_matrix.py --summary` and `python scripts/run_work_item_review_packet_matrix.py --output /tmp/work_item_review_packet_matrix.json` and confirmed the runner exited 0, handled docs bootstrap/recheck, and wrote deterministic JSON output to `/tmp/work_item_review_packet_matrix.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cce3c16d483208e2bac38a8c01ef0)