### PR TITLE
[codex:work-item] stabilize operator execution review landing

### DIFF
--- a/sentientos/work_item_execution_review.py
+++ b/sentientos/work_item_execution_review.py
@@ -160,7 +160,7 @@ def evaluate_operator_execution_review(request: OperatorExecutionReviewRequest, 
         operation_types=operation_types, proposed_paths_summary=path_summary, preflight_blockers=_tuple(pr.get("preflight_blocker_codes")), preflight_warnings=tuple(sorted(warnings)),
         execution_attempt_preconditions=("human_operator_review_required", "preflight_packet_accepted"), execution_attempt_blockers=tuple(sorted(blockers)), execution_attempt_warnings=tuple(sorted(warnings)),
         rollback_review_requirements=("review_rollback_policy_before_execution",), operator_acknowledgements=_tuple(pr.get("operator_acknowledgements")), operator_checklist=tuple(checklist),
-        evidence_references=tuple(sorted(set(_tuple(pr.get("evidence_references")) | {"preflight_run_packet", "proposal"}))), artifact_references=_tuple(pr.get("artifact_references")),
+        evidence_references=tuple(sorted(set(_tuple(pr.get("evidence_references"))) | {"preflight_run_packet", "proposal"})), artifact_references=_tuple(pr.get("artifact_references")),
         candidate_manual_execution_command=cmd, explicit_non_authority_boundaries=tuple(pr.get("explicit_non_authority_boundaries") or EXPLICIT_NON_AUTHORITY_BOUNDARIES)
     )
     return OperatorExecutionReviewResult(status=status, packet=packet)


### PR DESCRIPTION
### Motivation
- Complete the Operator Execution Review Packet System landing by finishing the full validation/landing matrix required by the AGENTS.md whole-system doctrine because the previous handoff did not demonstrate an end-to-end green matrix.

### Description
- Apply a one-line stabilization fix in `sentientos/work_item_execution_review.py` to correct the evidence-reference set-union expression (use `set(_tuple(...)) | {...}` form) so targeted `mypy` no longer errors and the execution-review packet assembly types are valid.

### Testing
- Re-ran the full required matrix locally including targeted `mypy`, `python scripts/check_mypy_baseline.py`, `python scripts/run_work_item_review_packet_matrix.py --summary` and `--output /tmp/work_item_review_packet_matrix.json`, `python scripts/build_docs.py` (and `--check-deps`), `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, `python scripts/audit_immutability_verifier.py`, and the execution-review test lanes; all required lanes passed and the matrix runner produced `/tmp/work_item_review_packet_matrix.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0dedbdb2608320b4176d784bc26f07)