### PR TITLE
[codex:docs] harden Codex final-matrix landing doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ unless explicitly marked **sealed** or **deprecated**.
 - Do not defer docs/proof bundle/capability registry/matrix integration to follow-up unless explicitly instructed.
 - If adjacent integration fallout is required to land the subsystem, fix it in the same task.
 - Run relevant matrix/checks before final reporting; if validation fails, continue feasible checks, classify failures, and fix failures caused by the task.
+- No post-landing stabilization churn: after the final task-caused code/doc/test change, run the full relevant validation matrix before any done-reporting or PR metadata creation.
+- Do not create PR metadata, say "feature exists but full matrix not run," or say "If you want, I can run the full matrix now" for a system task before that post-final-change matrix run completes.
+- Follow-up stabilization PRs for task-caused fallout are a failure mode; fix that fallout in the same task. Tiny stabilization diffs are acceptable only for pre-existing, external, environment/bootstrap issues, or explicitly requested narrow repairs.
 - Preserve runtime authority boundaries; workflow/documentation/governance prompts may explicitly authorize `AGENTS.md`, `docs/`, `tests/`, and matrix-script edits.
 
 #### System-task completion contract (when relevant)

--- a/docs/development/codex_narrow_repair_task_template.md
+++ b/docs/development/codex_narrow_repair_task_template.md
@@ -18,13 +18,13 @@ List only files touched by the repair.
 Run targeted tests that prove the localized fix.
 
 ## Baseline/matrix/docs impact statement
-State whether mypy baseline, matrix lanes, and docs are impacted.
+State whether mypy baseline, matrix lanes, and docs are impacted. This template must not be used to defer task-caused subsystem fallout that belongs in a whole-system landing.
 
 ## Safety constraints
 No authority widening, no runtime boundary expansion.
 
 ## Done when
-The localized failure is reproduced, fixed, and proven by focused tests with no unintended scope expansion.
+The localized failure is reproduced, fixed, and proven by focused tests with no unintended scope expansion. It does not supersede whole-system requirements unless the repair is explicitly scoped as narrow by the user or justified as pre-existing/external/environmental fallout.
 
 ## Commit/report rule
 Do not fabricate a commit if no code or docs changes are required.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -1,7 +1,7 @@
 # Codex Validation and Landing Contract
 
 ## Required validation posture for system tasks
-Run the relevant validation matrix/check chain before final reporting. A subsystem landing is incomplete without matrix evidence.
+Run the relevant validation matrix/check chain before final reporting. A subsystem landing is incomplete without matrix evidence. The full relevant matrix must run after the final task-caused code/doc/test change.
 
 ## Continue-after-failure behavior
 If a command fails, continue running remaining feasible commands to produce full diagnostics.
@@ -25,7 +25,23 @@ Report baseline result and any ratchet impact; do not weaken/suppress the baseli
 Report matrix summary status, required-failure set, and output artifact path when generated.
 
 ## Final report expectations
-Include command-by-command results, classifications, fixes, and unresolved risks.
+Include command-by-command results, classifications, fixes, and unresolved risks. Do not create PR metadata or final done-reporting before the post-final-change full matrix run completes.
 
 ## Completion rule
 "Feature exists but full matrix not run" is not a completed landing for a system task.
+
+## Finalization order (system tasks)
+Required order is strict:
+1. Make the final task-caused code/doc/test change.
+2. Run the full relevant validation matrix and address task-caused fallout in the same task.
+3. Only then produce final report and PR metadata.
+
+Follow-up stabilization PRs for task-caused fallout are a failure mode, not expected workflow.
+
+## Non-compliant statements and outcomes
+The following are non-compliant for system tasks:
+- "Feature exists but full matrix not run."
+- "If you want, I can run the full matrix now" after creating PR metadata or done-reporting.
+- Deferring task-caused matrix fallout to a follow-up stabilization PR.
+
+Tiny stabilization diffs are acceptable only for pre-existing, external dependency, or environment/bootstrap issues, or when the user explicitly requested a narrow repair.

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -5,6 +5,9 @@
 - Land the complete subsystem.
 - Fix validation fallout caused by the work.
 - Do not stop at local green.
+- After the last task-caused code/doc/test change, run the full relevant validation matrix again before finalization.
+- Do not create PR metadata or final "done" reporting before that post-final-change full matrix run passes.
+- Returning "If you want, I can run the full matrix now" is non-compliant for system tasks once finalization has started.
 - Do not return piddly diffs for subsystem tasks.
 - Do not leave proof bundle, capability registry, docs, or matrix integration for follow-up unless explicitly instructed.
 
@@ -54,10 +57,10 @@ Re-state no authority widening and no forbidden runtime semantics.
 List full relevant command matrix, not only local targeted tests.
 
 ## Failure handling
-Continue remaining feasible checks after failures, classify failures, and fix failures caused by this task.
+Continue remaining feasible checks after failures, classify failures, and fix failures caused by this task. Task-caused fallout discovered by the matrix must be fixed in this same task, not deferred to stabilization follow-ups.
 
 ## Done when
-Subsystem landing is complete only when implementation, integration, docs, tests, typing, proof/capability/matrix wiring, and relevant matrix validation are complete.
+Subsystem landing is complete only when implementation, integration, docs, tests, typing, proof/capability/matrix wiring, and relevant matrix validation are complete. Non-compliant outcomes include: "feature exists but full matrix not run," creating PR metadata before the post-final-change full matrix run, or proposing follow-up stabilization PRs for task-caused fallout.
 
 ## Final report format
-Include: files changed, validation command outcomes, failure classification, matrix summary/output paths, and unresolved risks.
+Include: files changed, validation command outcomes, failure classification, matrix summary/output paths, and unresolved risks. Final report/PR metadata order is strict: final task-caused change -> full matrix run -> final report and PR metadata.

--- a/tests/test_codex_operating_doctrine_docs.py
+++ b/tests/test_codex_operating_doctrine_docs.py
@@ -15,6 +15,9 @@ def test_agents_mentions_whole_system_doctrine_and_links() -> None:
     assert "complete bounded subsystem" in agents
     assert "Tiny diffs are exceptional" in agents
     assert "full matrix not run" in agents
+    assert "after the final task-caused code/doc/test change" in agents
+    assert "No post-landing stabilization churn" in agents
+    assert "If you want, I can run the full matrix now" in agents
     assert "proof-bundle" in agents
     assert "capability registry" in agents
     for path in [
@@ -50,9 +53,12 @@ def test_templates_exist_and_have_required_sections() -> None:
         assert section in whole
     assert "Think in systems." in whole
     assert "Do not return piddly diffs" in whole
+    assert "After the last task-caused code/doc/test change" in whole
+    assert "Do not create PR metadata" in whole
 
     narrow = _read("docs/development/codex_narrow_repair_task_template.md")
     assert "Narrow repairs are exceptional" in narrow
+    assert "must not be used to defer task-caused subsystem fallout" in narrow
     assert "exact command" in narrow.lower() or "exact failure" in narrow.lower()
 
 
@@ -61,6 +67,11 @@ def test_validation_contract_and_reviewer_docs_discoverability() -> None:
     assert "continue running remaining feasible commands" in contract
     assert "failure as one of" in contract
     assert "Feature exists but full matrix not run" in contract
+    assert "Required order is strict" in contract
+    assert "1. Make the final task-caused code/doc/test change." in contract
+    assert "2. Run the full relevant validation matrix" in contract
+    assert "3. Only then produce final report and PR metadata." in contract
+    assert "If you want, I can run the full matrix now" in contract
 
     quick = _read("docs/REVIEWER_QUICKSTART.md")
     index = _read("docs/architecture/reviewer_release_readiness_index.md")


### PR DESCRIPTION
### Motivation
- Recent subsystem landings repeatedly required follow-up stabilization PRs to fix task-caused integration fallout, wasting human turnaround bandwidth. 
- The Codex whole-system doctrine and templates must explicitly require a final full validation run after the last task-caused change so that fallout is fixed in the same task and not deferred.

### Description
- Add a concise “No post-landing stabilization churn” clause to `AGENTS.md` requiring the full relevant validation matrix be run after the final task-caused code/doc/test change and before any done-reporting or PR metadata. 
- Update the whole-system task template `docs/development/codex_whole_system_task_template.md` to forbid finalization after local green and require re-running the full matrix after the last change before producing PR metadata. 
- Update the validation/landing contract `docs/development/codex_validation_and_landing_contract.md` to codify a strict finalization order: final change → full matrix (fix fallout) → final report/PR metadata, and enumerate non-compliant statements/outcomes. 
- Strengthen the narrow-repair template to document that it must not be used to defer task-caused subsystem fallout and update `tests/test_codex_operating_doctrine_docs.py` to assert the new doctrine language and template rules. 

### Testing
- Ran `python -m scripts.run_tests -q tests/test_codex_operating_doctrine_docs.py` and the updated doctrine tests passed. 
- Ran `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` and `python -m scripts.run_tests -q tests/test_work_item_review_packet_matrix.py` and both passed. 
- Executed the matrix runner `python scripts/run_work_item_review_packet_matrix.py --summary` which reported `status: passed` and then `python scripts/run_work_item_review_packet_matrix.py --output /tmp/work_item_review_packet_matrix.json` which produced the JSON output file. 
- Ran docs validation flow (`python scripts/build_docs.py --check-deps`, `--bootstrap-docs`, recheck, then `python scripts/build_docs.py`) where an initial `--check-deps` triggered bootstrap but the bootstrap + recheck + final build completed successfully. 
- Ran `python scripts/check_mypy_baseline.py`, `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py` and all required lanes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ea148e2d88320a150c3b7e5cd9da4)