### PR TITLE
[codex:work-item] stabilize lifecycle completion verifier landing

### DIFF
--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -76,6 +76,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "task_work_item_operator_confirmed_verification_run",
         "task_work_item_operator_lifecycle_closure_review",
         "task_work_item_lifecycle_completion_dossier",
+        "task_work_item_lifecycle_completion_verifier",
     }
 )
 CAPABILITY_STATUSES = frozenset({"implemented", "partial", "scaffolded", "deferred", "blocked", "unknown"})
@@ -107,6 +108,7 @@ AUTHORITY_LEVELS = frozenset(
         "revocation_record_only",
         "expiry_evaluation_only",
         "verification_only",
+        "metadata_verification_only",
         "request_only",
         "assessment_only",
         "consumption_receipt_only",


### PR DESCRIPTION
### Motivation
- The lifecycle completion verifier landed with capability metadata values that the capability registry validator did not recognize, causing required proof-bundle/capability tests to fail and blocking subsystem completion; the change restores validator coverage for the new verifier metadata.

### Description
- Add the verifier metadata to the canonical allowlists by inserting `"task_work_item_lifecycle_completion_verifier"` into `CAPABILITY_CATEGORIES` and `"metadata_verification_only"` into `AUTHORITY_LEVELS` in `sentientos/capability_registry.py`, with no runtime authority or behavior changes to capabilities.

### Testing
- Reproduced the failure (`capability:work_item_lifecycle_completion_verifier:unknown_category` and `...:unknown_authority_level`) in `tests/test_capability_registry.py`, applied the metadata fix, and then re-ran the full validation matrix (required proof-bundle tests, matrix runner summary/output, targeted `mypy`, `scripts/build_docs.py`, prompt-boundary checks, `verify_audits --strict`, and `scripts/audit_immutability_verifier.py`); all required checks passed and `run_work_item_review_packet_matrix --summary` reported `required_failure_count=0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0fd08778c08320ba0d9dee515af9e7)