### PR TITLE
[codex:developer] add Codex whole-system task scaffold generator

### DIFF
--- a/docs/development/codex_task_scaffold_generator.md
+++ b/docs/development/codex_task_scaffold_generator.md
@@ -1,0 +1,35 @@
+# Codex Whole-System Task Scaffold Generator
+
+`sentientos/codex_task_scaffold.py` and `scripts/build_codex_task_scaffold.py` provide deterministic developer-workflow scaffolding.
+
+## Purpose
+
+Generate a complete Codex task prompt scaffold from compact metadata so operators do not rewrite doctrine, validation, and boundary clauses for every subsystem task.
+
+## Non-authority boundary
+
+- Developer workflow scaffolding only.
+- No Codex invocation.
+- No provider/network/GitHub calls.
+- No branch/PR/issue mutation.
+- No shell/subprocess execution from library code.
+
+## Inputs
+
+Required: `task_name`, `task_goal`, `subsystem_kind`.
+
+Optional: mode, deliverables, expected module/CLI/test/doc paths, capability/proof references, validation commands, commit title, and explicit artifact output paths.
+
+## Outputs
+
+- Deterministic JSON scaffold payload.
+- Optional deterministic prompt text artifact.
+- Compact statuses (`codex_task_scaffold_*`).
+
+## CLI
+
+```bash
+python scripts/build_codex_task_scaffold.py --task-name ... --task-goal ... --subsystem-kind ... --summary
+```
+
+Use `--output` and `--prompt-output` for explicit artifact writes.

--- a/scripts/build_codex_task_scaffold.py
+++ b/scripts/build_codex_task_scaffold.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from sentientos.codex_task_scaffold import (
+    CodexTaskScaffoldRequest,
+    build_codex_task_scaffold,
+    write_prompt_artifact,
+    write_scaffold_artifact,
+)
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _list(base: dict[str, object], key: str, fallback: list[str]) -> tuple[str, ...]:
+    value = base.get(key, fallback)
+    if isinstance(value, list):
+        return tuple(str(v) for v in value)
+    if isinstance(value, tuple):
+        return tuple(str(v) for v in value)
+    return tuple(fallback)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", type=Path)
+    p.add_argument("--task-name")
+    p.add_argument("--task-goal")
+    p.add_argument("--subsystem-kind")
+    p.add_argument("--prompt-mode", choices=("whole_system", "narrow_repair"), default="whole_system")
+    p.add_argument("--current-chain-context", action="append", default=[])
+    p.add_argument("--deliverable", action="append", default=[])
+    p.add_argument("--new-module", action="append", default=[])
+    p.add_argument("--new-cli", action="append", default=[])
+    p.add_argument("--test-path", action="append", default=[])
+    p.add_argument("--doc-path", action="append", default=[])
+    p.add_argument("--capability-id")
+    p.add_argument("--proof-bundle-artifact-kind")
+    p.add_argument("--allowed-behavior", action="append", default=[])
+    p.add_argument("--forbidden-behavior", action="append", default=[])
+    p.add_argument("--validation-command", action="append", default=[])
+    p.add_argument("--commit-title")
+    p.add_argument("--output", type=Path)
+    p.add_argument("--prompt-output", type=Path)
+    p.add_argument("--summary", action="store_true")
+    p.add_argument("--emit-prompt", action="store_true")
+    a = p.parse_args(argv)
+
+    base: dict[str, object] = _load_json(a.input) if a.input else {}
+    req = CodexTaskScaffoldRequest(
+        task_name=str(base.get("task_name", a.task_name or "")),
+        task_goal=str(base.get("task_goal", a.task_goal or "")),
+        subsystem_kind=str(base.get("subsystem_kind", a.subsystem_kind or "")),
+        prompt_mode=str(base.get("prompt_mode", a.prompt_mode)),
+        current_chain_context=_list(base, "current_chain_context", a.current_chain_context),
+        deliverables=_list(base, "deliverables", a.deliverable),
+        new_module_path=_list(base, "new_module_path", a.new_module),
+        new_cli_path=_list(base, "new_cli_path", a.new_cli),
+        expected_test_paths=_list(base, "expected_test_paths", a.test_path),
+        expected_doc_paths=_list(base, "expected_doc_paths", a.doc_path),
+        capability_id=str(base.get("capability_id", a.capability_id or "")),
+        proof_bundle_artifact_kind=str(base.get("proof_bundle_artifact_kind", a.proof_bundle_artifact_kind or "")),
+        allowed_behaviors=_list(base, "allowed_behaviors", a.allowed_behavior),
+        forbidden_behaviors=_list(base, "forbidden_behaviors", a.forbidden_behavior),
+        validation_commands=_list(base, "validation_commands", a.validation_command),
+        commit_title=str(base.get("commit_title", a.commit_title or "")),
+    )
+    result = build_codex_task_scaffold(req)
+    if a.output:
+        write_scaffold_artifact(result, a.output)
+    if a.prompt_output:
+        write_prompt_artifact(result, a.prompt_output)
+    if a.summary:
+        print(json.dumps({"status": result.status, "scaffold_id": result.scaffold.scaffold_id}, sort_keys=True))
+    else:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    if a.emit_prompt:
+        print(result.scaffold.generated_prompt)
+    return 0 if result.status in {"codex_task_scaffold_ready", "codex_task_scaffold_ready_with_warnings", "codex_task_scaffold_manual_review_required"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_task_scaffold.py
+++ b/sentientos/codex_task_scaffold.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+STATUSES = frozenset({
+    "codex_task_scaffold_ready",
+    "codex_task_scaffold_ready_with_warnings",
+    "codex_task_scaffold_manual_review_required",
+    "codex_task_scaffold_insufficient_metadata",
+    "codex_task_scaffold_blocked",
+    "codex_task_scaffold_failed",
+})
+PROMPT_MODES = frozenset({"whole_system", "narrow_repair"})
+DEFAULT_VALIDATION_COMMANDS = (
+    "python -m scripts.run_tests -q tests/test_codex_task_scaffold.py tests/test_build_codex_task_scaffold_script.py",
+    "python -m mypy sentientos/codex_task_scaffold.py scripts/build_codex_task_scaffold.py",
+)
+
+@dataclass(frozen=True)
+class CodexTaskScaffoldPolicy:
+    default_prompt_mode: str = "whole_system"
+    require_full_matrix_default: bool = True
+    require_capability_registry_default: bool = True
+    require_proof_bundle_default: bool = True
+    require_docs_default: bool = True
+    require_matrix_runner_default: bool = True
+    require_safety_tests_default: bool = True
+
+
+@dataclass(frozen=True)
+class CodexTaskScaffoldRequest:
+    task_name: str = ""
+    task_goal: str = ""
+    subsystem_kind: str = ""
+    prompt_mode: str = "whole_system"
+    current_chain_context: tuple[str, ...] = ()
+    deliverables: tuple[str, ...] = ()
+    new_module_path: tuple[str, ...] = ()
+    new_cli_path: tuple[str, ...] = ()
+    expected_test_paths: tuple[str, ...] = ()
+    expected_doc_paths: tuple[str, ...] = ()
+    capability_id: str = ""
+    proof_bundle_artifact_kind: str = ""
+    allowed_behaviors: tuple[str, ...] = ()
+    forbidden_behaviors: tuple[str, ...] = ()
+    validation_commands: tuple[str, ...] = ()
+    commit_title: str = ""
+    require_full_matrix: bool = True
+    require_capability_registry: bool = True
+    require_proof_bundle: bool = True
+    require_docs: bool = True
+    require_matrix_runner: bool = True
+    require_safety_tests: bool = True
+
+
+@dataclass(frozen=True)
+class CodexTaskScaffoldSection:
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class CodexTaskScaffold:
+    scaffold_id: str
+    scaffold_digest: str
+    task_name: str
+    task_goal: str
+    subsystem_kind: str
+    prompt_mode: str
+    generated_prompt: str
+    validation_commands: tuple[str, ...]
+    expected_files: tuple[str, ...]
+    expected_tests: tuple[str, ...]
+    expected_docs: tuple[str, ...]
+    required_integrations: tuple[str, ...]
+    forbidden_surfaces: tuple[str, ...]
+    final_report_contract: tuple[str, ...]
+    commit_pr_title: str
+    doctrine_references: tuple[str, ...]
+    artifact_references: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    blocker_codes: tuple[str, ...]
+    explicit_non_authority_boundaries: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CodexTaskScaffoldResult:
+    status: str
+    scaffold: CodexTaskScaffold
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _norm(items: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({item.strip() for item in items if item and item.strip()}))
+
+
+TITLE_RE = re.compile(r"^\[codex:[a-z0-9-]+\]\s+.+$")
+
+
+def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTaskScaffoldPolicy | None = None) -> CodexTaskScaffoldResult:
+    _ = policy or CodexTaskScaffoldPolicy()
+    warnings: list[str] = []
+    blockers: list[str] = []
+    if not request.task_name.strip() or not request.task_goal.strip() or not request.subsystem_kind.strip():
+        blockers.append("insufficient_required_metadata")
+    if request.prompt_mode not in PROMPT_MODES:
+        blockers.append("invalid_prompt_mode")
+    if request.commit_title and not TITLE_RE.match(request.commit_title):
+        warnings.append("nonconforming_commit_title")
+    all_text = "\n".join(request.allowed_behaviors + request.forbidden_behaviors + request.deliverables + request.current_chain_context)
+    banned = ("invoke codex", "openai", "provider", "github api", "create branch", "create pr", "subprocess", "shell execution", "workspace execution", "lifecycle orchestration")
+    if any(term in all_text.lower() for term in banned):
+        blockers.append("forbidden_authority_surface_requested")
+    if request.prompt_mode == "whole_system" and not (request.new_module_path or request.new_cli_path or request.expected_test_paths or request.expected_doc_paths):
+        warnings.append("whole_system_paths_missing")
+
+    validation_commands = _norm(request.validation_commands or DEFAULT_VALIDATION_COMMANDS)
+    expected_files = _norm(request.new_module_path + request.new_cli_path)
+    expected_tests = _norm(request.expected_test_paths)
+    expected_docs = _norm(request.expected_doc_paths)
+    forbidden = _norm(request.forbidden_behaviors or (
+        "Do not invoke Codex.", "Do not call OpenAI/provider APIs.", "Do not call GitHub APIs.", "Do not invoke shell/subprocess from library code.",
+    ))
+    required_integrations = _norm(
+        tuple(x for x, enabled in (
+            ("capability_registry", request.require_capability_registry),
+            ("reviewer_proof_bundle", request.require_proof_bundle),
+            ("docs", request.require_docs),
+            ("matrix_runner", request.require_matrix_runner),
+            ("safety_tests", request.require_safety_tests),
+        ) if enabled)
+    )
+    if request.prompt_mode == "whole_system":
+        prompt = (
+            "Use AGENTS.md Whole-System Codex Operating Doctrine, whole-system task template, and validation/landing contract.\n"
+            "Critical landing rule: run the full relevant validation matrix after the final task-caused code/doc/test change and before final reporting or PR metadata.\n"
+            "Do not return 'feature exists but full matrix not run.' Do not offer to run matrix later.\n"
+            "Do not create PR metadata before green final validation.\n"
+            f"Goal: {request.task_goal}\nSubsystem: {request.task_name} ({request.subsystem_kind})."
+        )
+    else:
+        prompt = (
+            "Use AGENTS.md narrow repair doctrine and keep scope explicitly narrow.\n"
+            "No whole-system expansion unless task-caused fallout requires it.\n"
+            "Run minimal relevant validation and regression checks.\n"
+            "If no changes are required, do not fabricate commit/PR metadata.\n"
+            f"Goal: {request.task_goal}\nRepair target: {request.task_name} ({request.subsystem_kind})."
+        )
+    payload = {
+        "task_name": request.task_name,
+        "task_goal": request.task_goal,
+        "subsystem_kind": request.subsystem_kind,
+        "prompt_mode": request.prompt_mode,
+        "prompt": prompt,
+        "validation_commands": validation_commands,
+        "expected_files": expected_files,
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    scaffold = CodexTaskScaffold(
+        scaffold_id=f"codex-task-scaffold-{digest[:12]}",
+        scaffold_digest=digest,
+        task_name=request.task_name,
+        task_goal=request.task_goal,
+        subsystem_kind=request.subsystem_kind,
+        prompt_mode=request.prompt_mode,
+        generated_prompt=prompt,
+        validation_commands=validation_commands,
+        expected_files=expected_files,
+        expected_tests=expected_tests,
+        expected_docs=expected_docs,
+        required_integrations=required_integrations,
+        forbidden_surfaces=forbidden,
+        final_report_contract=("exact files changed", "full command matrix results", "unresolved risks"),
+        commit_pr_title=request.commit_title,
+        doctrine_references=("AGENTS.md", "docs/development/codex_whole_system_task_template.md", "docs/development/codex_validation_and_landing_contract.md"),
+        artifact_references=("json_scaffold", "prompt_text"),
+        warning_codes=tuple(sorted(warnings)),
+        blocker_codes=tuple(sorted(blockers)),
+        explicit_non_authority_boundaries=("developer workflow scaffolding only", "no runtime authority expansion"),
+    )
+    status = "codex_task_scaffold_ready"
+    if blockers:
+        status = "codex_task_scaffold_insufficient_metadata" if "insufficient_required_metadata" in blockers else "codex_task_scaffold_blocked"
+    elif warnings:
+        status = "codex_task_scaffold_ready_with_warnings"
+    return CodexTaskScaffoldResult(status=status, scaffold=scaffold)
+
+
+def write_scaffold_artifact(result: CodexTaskScaffoldResult, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_prompt_artifact(result: CodexTaskScaffoldResult, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(result.scaffold.generated_prompt + "\n", encoding="utf-8")

--- a/tests/test_build_codex_task_scaffold_script.py
+++ b/tests/test_build_codex_task_scaffold_script.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import build_codex_task_scaffold as cli
+
+
+def test_cli_summary(capsys) -> None:
+    rc = cli.main(["--task-name", "a", "--task-goal", "b", "--subsystem-kind", "c", "--summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "scaffold_id" in out
+
+
+def test_cli_emit_prompt(capsys) -> None:
+    rc = cli.main(["--task-name", "a", "--task-goal", "b", "--subsystem-kind", "c", "--emit-prompt"])
+    assert rc == 0
+    assert "Critical landing rule" in capsys.readouterr().out
+
+
+def test_cli_output_files(tmp_path: Path) -> None:
+    out = tmp_path / "s.json"
+    p = tmp_path / "p.txt"
+    rc = cli.main(["--task-name", "a", "--task-goal", "b", "--subsystem-kind", "c", "--output", str(out), "--prompt-output", str(p)])
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"].startswith("codex_task_scaffold")
+    assert p.read_text(encoding="utf-8")
+
+
+def test_cli_input_json(tmp_path: Path) -> None:
+    req = tmp_path / "in.json"
+    req.write_text(json.dumps({"task_name": "a", "task_goal": "b", "subsystem_kind": "c"}), encoding="utf-8")
+    assert cli.main(["--input", str(req), "--summary"]) == 0
+
+
+def test_cli_nonzero_for_missing() -> None:
+    assert cli.main(["--task-name", "a"]) == 1

--- a/tests/test_codex_task_scaffold.py
+++ b/tests/test_codex_task_scaffold.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from sentientos.codex_task_scaffold import CodexTaskScaffoldRequest, build_codex_task_scaffold
+
+
+def test_minimal_whole_system_ready_or_warn() -> None:
+    result = build_codex_task_scaffold(CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="z"))
+    assert result.status in {"codex_task_scaffold_ready", "codex_task_scaffold_ready_with_warnings"}
+    assert "full relevant validation matrix" in result.scaffold.generated_prompt
+
+
+def test_missing_metadata_insufficient() -> None:
+    result = build_codex_task_scaffold(CodexTaskScaffoldRequest())
+    assert result.status == "codex_task_scaffold_insufficient_metadata"
+
+
+def test_narrow_repair_mode_text() -> None:
+    result = build_codex_task_scaffold(CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="z", prompt_mode="narrow_repair"))
+    assert "narrow scope" in result.scaffold.generated_prompt.lower() or "narrow repair" in result.scaffold.generated_prompt.lower()
+
+
+def test_commit_title_warning() -> None:
+    result = build_codex_task_scaffold(CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="z", commit_title="bad title"))
+    assert "nonconforming_commit_title" in result.scaffold.warning_codes
+
+
+def test_deterministic_digest() -> None:
+    req = CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="z", new_module_path=("b", "a", "a"))
+    a = build_codex_task_scaffold(req)
+    b = build_codex_task_scaffold(req)
+    assert a.scaffold.scaffold_digest == b.scaffold.scaffold_digest
+    assert a.scaffold.expected_files == ("a", "b")


### PR DESCRIPTION
### Motivation
- Reduce operator turnaround by generating doctrine-compliant Codex task prompts from compact metadata and embed the repository "final-matrix" landing contract automatically. 
- Provide a deterministic, non-authority developer workflow scaffold that encodes scope, deliverables, forbidden surfaces, validation expectations, and final-report rules so humans need not hand-author repeatable boundary text. 
- Preserve repository safety and AGENTS.md doctrine by keeping the generator metadata-only and explicitly blocking provider/network/GitHub/subprocess/host-actuation behavior.

### Description
- Add a typed generator API in `sentientos/codex_task_scaffold.py` implementing `CodexTaskScaffoldPolicy`, `CodexTaskScaffoldRequest`, `CodexTaskScaffoldSection`, `CodexTaskScaffold`, `CodexTaskScaffoldResult`, deterministic digest/id creation, status taxonomy, prompt-mode (`whole_system`/`narrow_repair`) logic, policy checks, and artifact writers `write_scaffold_artifact` and `write_prompt_artifact`.
- Add a CLI `scripts/build_codex_task_scaffold.py` that accepts JSON or CLI flags, supports repeatable list flags, `--summary`/`--emit-prompt`, optional `--output` and `--prompt-output`, and returns exit codes per scaffold status.
- Add tests `tests/test_codex_task_scaffold.py` and `tests/test_build_codex_task_scaffold_script.py` covering minimal whole-system behavior, insufficient metadata blocking, narrow-repair text, deterministic digest/ordering, CLI summary, prompt emission, input JSON and artifact writes.
- Add developer docs `docs/development/codex_task_scaffold_generator.md` and wire deterministic defaults including validation command defaults, required non-authority boundaries, required integration points (capability registry, reviewer proof bundle, docs, matrix runner), and explicit forbidden surfaces.

### Testing
- Ran targeted API/CLI tests with `python -m scripts.run_tests -q tests/test_codex_task_scaffold.py tests/test_build_codex_task_scaffold_script.py` and they passed. 
- Ran broader repository validation including `python -m scripts.run_tests` for doctrine/proof/matrix tests, `python -m mypy sentientos/codex_task_scaffold.py scripts/build_codex_task_scaffold.py`, `python scripts/check_mypy_baseline.py`, `python scripts/run_work_item_review_packet_matrix.py --summary`, `python scripts/run_work_item_review_packet_matrix.py --output /tmp/work_item_review_packet_matrix.json`, `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`, `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`, and these runs completed successfully. 
- Produced deterministic JSON scaffold and optional prompt artifacts when `--output`/`--prompt-output` were supplied, and the matrix runner produced the JSON output at `/tmp/work_item_review_packet_matrix.json` as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a110dabb77c8320939a7bd2f434686f)