### PR TITLE
[codex:developer] add Codex task scaffold preset catalog

### DIFF
--- a/artifacts/codex_task_scaffold_preset_catalog.json
+++ b/artifacts/codex_task_scaffold_preset_catalog.json
@@ -1,0 +1,61 @@
+{
+  "scaffold": {
+    "artifact_references": [
+      "json_scaffold",
+      "prompt_text"
+    ],
+    "blocker_codes": [],
+    "commit_pr_title": "[codex:developer] add Codex task scaffold preset catalog",
+    "doctrine_references": [
+      "AGENTS.md",
+      "docs/development/codex_whole_system_task_template.md",
+      "docs/development/codex_validation_and_landing_contract.md"
+    ],
+    "expected_docs": [
+      "docs/development/codex_task_scaffold_presets.md"
+    ],
+    "expected_files": [
+      "scripts/list_codex_task_scaffold_presets.py",
+      "sentientos/codex_task_scaffold_presets.py"
+    ],
+    "expected_tests": [
+      "tests/test_codex_task_scaffold_presets.py",
+      "tests/test_list_codex_task_scaffold_presets_script.py"
+    ],
+    "explicit_non_authority_boundaries": [
+      "developer workflow scaffolding only",
+      "no runtime authority expansion"
+    ],
+    "final_report_contract": [
+      "exact files changed",
+      "full command matrix results",
+      "unresolved risks"
+    ],
+    "forbidden_surfaces": [
+      "Do not call GitHub APIs.",
+      "Do not call OpenAI/provider APIs.",
+      "Do not invoke Codex.",
+      "Do not invoke shell/subprocess from library code."
+    ],
+    "generated_prompt": "Use AGENTS.md Whole-System Codex Operating Doctrine, whole-system task template, and validation/landing contract.\nCritical landing rule: run the full relevant validation matrix after the final task-caused code/doc/test change and before final reporting or PR metadata.\nDo not return 'feature exists but full matrix not run.' Do not offer to run matrix later.\nDo not create PR metadata before green final validation.\nGoal: Add deterministic preset profiles for common SentientOS Codex subsystem types so the scaffold generator can expand compact task metadata into doctrine-compliant default deliverables, validation expectations, forbidden surfaces, and report contracts.\nSubsystem: Codex Task Scaffold Preset Catalog (developer_workflow_metadata).",
+    "prompt_mode": "whole_system",
+    "required_integrations": [
+      "capability_registry",
+      "docs",
+      "matrix_runner",
+      "reviewer_proof_bundle",
+      "safety_tests"
+    ],
+    "scaffold_digest": "aa10fdfc4e49701eda48863a25feab849de84b08746167302c3e7deccf428008",
+    "scaffold_id": "codex-task-scaffold-aa10fdfc4e49",
+    "subsystem_kind": "developer_workflow_metadata",
+    "task_goal": "Add deterministic preset profiles for common SentientOS Codex subsystem types so the scaffold generator can expand compact task metadata into doctrine-compliant default deliverables, validation expectations, forbidden surfaces, and report contracts.",
+    "task_name": "Codex Task Scaffold Preset Catalog",
+    "validation_commands": [
+      "python -m mypy sentientos/codex_task_scaffold.py scripts/build_codex_task_scaffold.py",
+      "python -m scripts.run_tests -q tests/test_codex_task_scaffold.py tests/test_build_codex_task_scaffold_script.py"
+    ],
+    "warning_codes": []
+  },
+  "status": "codex_task_scaffold_ready"
+}

--- a/artifacts/codex_task_scaffold_preset_catalog.prompt.txt
+++ b/artifacts/codex_task_scaffold_preset_catalog.prompt.txt
@@ -1,0 +1,6 @@
+Use AGENTS.md Whole-System Codex Operating Doctrine, whole-system task template, and validation/landing contract.
+Critical landing rule: run the full relevant validation matrix after the final task-caused code/doc/test change and before final reporting or PR metadata.
+Do not return 'feature exists but full matrix not run.' Do not offer to run matrix later.
+Do not create PR metadata before green final validation.
+Goal: Add deterministic preset profiles for common SentientOS Codex subsystem types so the scaffold generator can expand compact task metadata into doctrine-compliant default deliverables, validation expectations, forbidden surfaces, and report contracts.
+Subsystem: Codex Task Scaffold Preset Catalog (developer_workflow_metadata).

--- a/artifacts/work_item_review_packet_matrix.json
+++ b/artifacts/work_item_review_packet_matrix.json
@@ -1,0 +1,540 @@
+{
+  "command_count": 34,
+  "required_failure_count": 0,
+  "required_failures": [],
+  "results": [
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_review_packet.py",
+        "tests/test_build_work_item_review_packet_script.py"
+      ],
+      "duration_seconds": 3.511,
+      "exit_code": 0,
+      "label": "review_packet_tests",
+      "output_tail": "ssssss                                                                   [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_b67fddf481424844926da56421fb407b.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_review_packet.py tests/test_build_work_item_review_packet_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_authority_claims.py",
+        "tests/test_work_item_dry_run_closure.py",
+        "tests/test_build_work_item_dry_run_closure_script.py"
+      ],
+      "duration_seconds": 3.48,
+      "exit_code": 0,
+      "label": "authority_closure_tests",
+      "output_tail": "ssssssssssssssssssss                                                     [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_9dccf26c7aeb4225b626c4c73435f26d.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_authority_claims.py tests/test_work_item_dry_run_closure.py tests/test_build_work_item_dry_run_closure_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_dry_run_adapter.py",
+        "tests/test_run_work_item_dry_run_script.py"
+      ],
+      "duration_seconds": 3.435,
+      "exit_code": 0,
+      "label": "dry_run_adapter_tests",
+      "output_tail": "ssssssssssssssssssssssssssss                                             [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_042776bcda9b41cea1338bc1cfe9b7c7.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_dry_run_adapter.py tests/test_run_work_item_dry_run_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_handoff.py",
+        "tests/test_plan_work_item_handoff_script.py"
+      ],
+      "duration_seconds": 3.127,
+      "exit_code": 0,
+      "label": "handoff_tests",
+      "output_tail": "sssssss                                                                  [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_b0ad5496290d48be90a528f62c4adfc0.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_handoff.py tests/test_plan_work_item_handoff_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_intake.py",
+        "tests/test_intake_work_item_script.py"
+      ],
+      "duration_seconds": 3.033,
+      "exit_code": 0,
+      "label": "intake_tests",
+      "output_tail": "ssssssssss                                                               [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_b840bafebe97493ea2241daa31e419ff.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_intake.py tests/test_intake_work_item_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_promotion_gate.py",
+        "tests/test_evaluate_work_item_promotion_script.py"
+      ],
+      "duration_seconds": 3.229,
+      "exit_code": 0,
+      "label": "promotion_gate_tests",
+      "output_tail": "sssssss                                                                  [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_c524de9f162943a4be273824f4e40414.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_promotion_gate.py tests/test_evaluate_work_item_promotion_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_operator_admission_review.py",
+        "tests/test_build_operator_admission_review_script.py"
+      ],
+      "duration_seconds": 3.242,
+      "exit_code": 0,
+      "label": "operator_admission_review_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_393277b0e01d4954a6476487e56cebbf.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_operator_admission_review.py tests/test_build_operator_admission_review_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_admission_run.py",
+        "tests/test_run_operator_confirmed_admission_script.py"
+      ],
+      "duration_seconds": 3.232,
+      "exit_code": 0,
+      "label": "operator_confirmed_admission_run_tests",
+      "output_tail": "sssssssss                                                                [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_17faf6968b1d44a28536f15622287c4a.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_admission_run.py tests/test_run_operator_confirmed_admission_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_preflight_run.py",
+        "tests/test_run_operator_confirmed_preflight_script.py"
+      ],
+      "duration_seconds": 3.384,
+      "exit_code": 0,
+      "label": "operator_confirmed_preflight_run_tests",
+      "output_tail": "ssssssss                                                                 [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_7b0c7b13350040a29a85cfb1de8d11fd.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_preflight_run.py tests/test_run_operator_confirmed_preflight_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_execution_review.py",
+        "tests/test_build_operator_execution_review_script.py"
+      ],
+      "duration_seconds": 3.356,
+      "exit_code": 0,
+      "label": "operator_execution_review_tests",
+      "output_tail": "ssssss                                                                   [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_f83d27bb2ff5415d9f58e4f9f731bfa1.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_execution_review.py tests/test_build_operator_execution_review_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_execution_run.py",
+        "tests/test_run_operator_confirmed_execution_script.py"
+      ],
+      "duration_seconds": 3.322,
+      "exit_code": 0,
+      "label": "operator_confirmed_execution_run_tests",
+      "output_tail": "sss                                                                      [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_e0f863b03fc64524a47acc655c518c5d.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_execution_run.py tests/test_run_operator_confirmed_execution_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_verification_run.py",
+        "tests/test_run_operator_confirmed_verification_script.py"
+      ],
+      "duration_seconds": 3.334,
+      "exit_code": 0,
+      "label": "operator_confirmed_verification_run_tests",
+      "output_tail": "sssssss                                                                  [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_37fb3513cbbe4a24950c912824d0edfb.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_verification_run.py tests/test_run_operator_confirmed_verification_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_closure_review.py",
+        "tests/test_build_operator_lifecycle_closure_review_script.py"
+      ],
+      "duration_seconds": 3.342,
+      "exit_code": 0,
+      "label": "operator_lifecycle_closure_review_tests",
+      "output_tail": "ssssss                                                                   [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_942fadb93060499d8b8069eb6796aeb6.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_closure_review.py tests/test_build_operator_lifecycle_closure_review_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_completion_dossier.py",
+        "tests/test_build_work_item_lifecycle_completion_dossier_script.py"
+      ],
+      "duration_seconds": 3.255,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_completion_dossier_tests",
+      "output_tail": "ssss                                                                     [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_9a787d349eb548a38a408492a52e6d2c.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_completion_dossier.py tests/test_build_work_item_lifecycle_completion_dossier_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_codex_task_scaffold_verifier.py",
+        "tests/test_verify_codex_task_scaffold_script.py"
+      ],
+      "duration_seconds": 3.253,
+      "exit_code": 0,
+      "label": "codex_task_scaffold_verifier_tests",
+      "output_tail": "sss                                                                      [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_751c29bf2c1345d78657247bf9079904.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_codex_task_scaffold_verifier.py tests/test_verify_codex_task_scaffold_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_completion_verifier.py",
+        "tests/test_verify_work_item_lifecycle_completion_dossier_script.py"
+      ],
+      "duration_seconds": 3.245,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_completion_verifier_tests",
+      "output_tail": "ssssss                                                                   [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_e573e363299a41b09c1a6ee46751cb51.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_completion_verifier.py tests/test_verify_work_item_lifecycle_completion_dossier_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_final_attestation.py",
+        "tests/test_build_work_item_lifecycle_final_attestation_script.py"
+      ],
+      "duration_seconds": 3.152,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_final_attestation_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_8b541c6947ab475ca37433073ce73e57.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_final_attestation.py tests/test_build_work_item_lifecycle_final_attestation_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_index.py",
+        "tests/test_build_work_item_lifecycle_attestation_index_script.py"
+      ],
+      "duration_seconds": 3.214,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_index_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_1a552b289c614ece8a4b165717e961b7.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_index.py tests/test_build_work_item_lifecycle_attestation_index_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_index_verifier.py",
+        "tests/test_verify_work_item_lifecycle_attestation_index_script.py"
+      ],
+      "duration_seconds": 3.167,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_index_verifier_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_922bd0a78a054a80a58decd077123e86.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_index_verifier.py tests/test_verify_work_item_lifecycle_attestation_index_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest.py",
+        "tests/test_build_work_item_lifecycle_attestation_review_digest_script.py"
+      ],
+      "duration_seconds": 3.196,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_review_digest_tests",
+      "output_tail": "ssssssss                                                                 [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_d8ac13fc3a8f4bf8901dabbe491ff039.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_review_digest.py tests/test_build_work_item_lifecycle_attestation_review_digest_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest_verifier.py",
+        "tests/test_verify_work_item_lifecycle_attestation_review_digest_script.py"
+      ],
+      "duration_seconds": 3.322,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_review_digest_verifier_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_44e586e6015a48e09daca65dfd6b17fb.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_review_digest_verifier.py tests/test_verify_work_item_lifecycle_attestation_review_digest_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest_index.py",
+        "tests/test_build_work_item_lifecycle_attestation_review_digest_index_script.py"
+      ],
+      "duration_seconds": 3.296,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_review_digest_index_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_0c62185fbbde411b95460a20b502d48d.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_review_digest_index.py tests/test_build_work_item_lifecycle_attestation_review_digest_index_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py",
+        "tests/test_verify_work_item_lifecycle_attestation_review_digest_index_script.py"
+      ],
+      "duration_seconds": 3.19,
+      "exit_code": 0,
+      "label": "work_item_lifecycle_attestation_review_digest_index_verifier_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_620df2c5d9474e7783cd420d2151263e.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py tests/test_verify_work_item_lifecycle_attestation_review_digest_index_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_closure_run.py",
+        "tests/test_run_operator_confirmed_lifecycle_closure_script.py"
+      ],
+      "duration_seconds": 3.326,
+      "exit_code": 0,
+      "label": "operator_confirmed_lifecycle_closure_run_tests",
+      "output_tail": "sssss                                                                    [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_3aeeb2a6c0674c76adfe25647fc11b0d.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_work_item_lifecycle_closure_run.py tests/test_run_operator_confirmed_lifecycle_closure_script.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_capability_registry.py",
+        "tests/test_reviewer_proof_bundle.py",
+        "tests/test_build_reviewer_proof_bundle_script.py",
+        "tests/test_reviewer_release_readiness_index.py",
+        "tests/test_codex_operating_doctrine_docs.py"
+      ],
+      "duration_seconds": 10.43,
+      "exit_code": 0,
+      "label": "proof_bundle_tests",
+      "output_tail": "........................................................................ [ 36%]\n........................................................................ [ 73%]\n................................................sss                      [100%]\n- generated xml file: /workspace/SentientOS/glow/test_runs/pytest_junitxml_eb6042beea9544dda28324954bad19d8.xml -\nrun_tests: python=/root/.pyenv/versions/3.14.4/bin/python install_performed=False editable_ok=true install_mode=none repo_root=/workspace/SentientOS pytest_args=tests/test_capability_registry.py tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_reviewer_release_readiness_index.py tests/test_codex_operating_doctrine_docs.py -q",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "-m",
+        "mypy",
+        "sentientos/work_item_authority_claims.py",
+        "sentientos/work_item_intake.py",
+        "scripts/intake_work_item.py",
+        "sentientos/work_item_lifecycle_handoff.py",
+        "scripts/plan_work_item_handoff.py",
+        "sentientos/work_item_lifecycle_dry_run_adapter.py",
+        "scripts/run_work_item_dry_run.py",
+        "sentientos/work_item_dry_run_closure.py",
+        "scripts/build_work_item_dry_run_closure.py",
+        "sentientos/work_item_review_packet.py",
+        "scripts/build_work_item_review_packet.py",
+        "sentientos/work_item_promotion_gate.py",
+        "scripts/evaluate_work_item_promotion.py",
+        "sentientos/work_item_operator_admission_review.py",
+        "scripts/build_operator_admission_review.py",
+        "sentientos/work_item_admission_run.py",
+        "scripts/run_operator_confirmed_admission.py",
+        "sentientos/work_item_preflight_run.py",
+        "scripts/run_operator_confirmed_preflight.py",
+        "sentientos/work_item_execution_review.py",
+        "scripts/build_operator_execution_review.py",
+        "sentientos/work_item_execution_run.py",
+        "scripts/run_operator_confirmed_execution.py",
+        "sentientos/work_item_verification_run.py",
+        "scripts/run_operator_confirmed_verification.py",
+        "sentientos/work_item_lifecycle_closure_review.py",
+        "scripts/build_operator_lifecycle_closure_review.py",
+        "sentientos/work_item_lifecycle_closure_run.py",
+        "scripts/run_operator_confirmed_lifecycle_closure.py",
+        "sentientos/work_item_lifecycle_completion_dossier.py",
+        "scripts/build_work_item_lifecycle_completion_dossier.py",
+        "sentientos/work_item_lifecycle_completion_verifier.py",
+        "scripts/verify_work_item_lifecycle_completion_dossier.py",
+        "sentientos/codex_task_scaffold_verifier.py",
+        "scripts/verify_codex_task_scaffold.py",
+        "sentientos/work_item_lifecycle_final_attestation.py",
+        "scripts/build_work_item_lifecycle_final_attestation.py",
+        "sentientos/work_item_lifecycle_attestation_index.py",
+        "scripts/build_work_item_lifecycle_attestation_index.py",
+        "sentientos/work_item_lifecycle_attestation_index_verifier.py",
+        "scripts/verify_work_item_lifecycle_attestation_index.py",
+        "sentientos/work_item_lifecycle_attestation_review_digest.py",
+        "scripts/build_work_item_lifecycle_attestation_review_digest.py",
+        "sentientos/work_item_lifecycle_attestation_review_digest_verifier.py",
+        "scripts/verify_work_item_lifecycle_attestation_review_digest.py",
+        "sentientos/work_item_lifecycle_attestation_review_digest_index.py",
+        "scripts/build_work_item_lifecycle_attestation_review_digest_index.py",
+        "sentientos/work_item_lifecycle_attestation_review_digest_index_verifier.py",
+        "scripts/verify_work_item_lifecycle_attestation_review_digest_index.py"
+      ],
+      "duration_seconds": 2.038,
+      "exit_code": 0,
+      "label": "targeted_mypy",
+      "output_tail": "Success: no issues found in 49 source files",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "scripts/check_mypy_baseline.py"
+      ],
+      "duration_seconds": 36.019,
+      "exit_code": 0,
+      "label": "mypy_baseline",
+      "output_tail": "      \"column\": 34,\n      \"line\": 1004,\n      \"message\": \"Incompatible types in assignment (expression has type \\\"dict[str, Any]\\\", target has type \\\"str\\\")\",\n      \"path\": \"codex/amendments.py\"\n    },\n    {\n      \"code\": \"attr-defined\",\n      \"column\": 9,\n      \"line\": 1093,\n      \"message\": \"\\\"SpecAmender\\\" has no attribute \\\"_update_preferences\\\"\",\n      \"path\": \"codex/amendments.py\"\n    },\n    {\n      \"code\": \"attr-defined\",\n      \"column\": 9,\n      \"line\": 1113,\n      \"message\": \"\\\"SpecAmender\\\" has no attribute \\\"_update_preferences\\\"\",\n      \"path\": \"codex/amendments.py\"\n    },\n    {\n      \"code\": \"unused-ignore\",\n      \"column\": null,\n      \"line\": 293,\n      \"message\": \"Unused \\\"type: ignore\\\" comment, use narrower [method-assign] instead of [assignment] code\",\n      \"path\": \"codex/autogenesis.py\"\n    }\n  ],\n  \"retired_errors\": 361,\n  \"status\": \"mypy_baseline_improved\"\n}",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "scripts/build_docs.py",
+        "--check-deps"
+      ],
+      "duration_seconds": 0.259,
+      "exit_code": 2,
+      "label": "docs_check_deps",
+      "output_tail": "/workspace/SentientOS/scripts/build_docs.py:15: DeprecationWarning: require_lumos_approval() is deprecated; use require_covenant_alignment()\n  require_lumos_approval()\nENVIRONMENT/BOOTSTRAP ERROR: Docs build dependencies missing. Run: python scripts/build_docs.py --bootstrap-docs (minimal), or pip install -e .[docs]\nMissing Python import(s): mkdocs, watchdog.observers\nMissing docs package requirement(s): mkdocs>=1.6,<2, watchdog>=2,<3",
+      "required": false
+    },
+    {
+      "command": [
+        "python",
+        "scripts/build_docs.py",
+        "--bootstrap-docs"
+      ],
+      "duration_seconds": 4.003,
+      "exit_code": 0,
+      "label": "docs_bootstrap",
+      "output_tail": "Docs build dependencies bootstrapped and available.\n\n/workspace/SentientOS/scripts/build_docs.py:15: DeprecationWarning: require_lumos_approval() is deprecated; use require_covenant_alignment()\n  require_lumos_approval()\nERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\nsentientos 1.2.0b0 requires brainflow<6,>=5, which is not installed.\nsentientos 1.2.0b0 requires colorama<1,>=0.4, which is not installed.\nsentientos 1.2.0b0 requires Flask<3,>=2.2, which is not installed.\nsentientos 1.2.0b0 requires Flask-SocketIO<6,>=5, which is not installed.\nsentientos 1.2.0b0 requires librosa<1,>=0.10, which is not installed.\nsentientos 1.2.0b0 requires mne<2,>=1, which is not installed.\nsentientos 1.2.0b0 requires pandas<2,>=1.5, which is not installed.\nsentientos 1.2.0b0 requires pdfrw<1,>=0.4, which is not installed.\nsentientos 1.2.0b0 requires psutil<6,>=5, which is not installed.\nsentientos 1.2.0b0 requires pydub<1,>=0.25, which is not installed.\nsentientos 1.2.0b0 requires pyserial<4,>=3, which is not installed.\nsentientos 1.2.0b0 requires python-dotenv<1,>=0.21, which is not installed.\nsentientos 1.2.0b0 requires python-socketio<6,>=5, which is not installed.\nsentientos 1.2.0b0 requires pyttsx3<3,>=2, which is not installed.\nsentientos 1.2.0b0 requires requests<3,>=2.31, which is not installed.\nsentientos 1.2.0b0 requires sounddevice<1,>=0.4, which is not installed.\nsentientos 1.2.0b0 requires SpeechRecognition<4,>=3, which is not installed.\nsentientos 1.2.0b0 requires streamlit<2,>=1, which is not installed.\nsentientos 1.2.0b0 requires transformers<5,>=4, which is not installed.\nsentientos 1.2.0b0 requires uvicorn<1,>=0.23, which is not installed.\nsentientos 1.2.0b0 requires vosk<1,>=0.3, which is not installed.\nWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\n\n[notice] A new release of pip is available: 26.1 -> 26.1.1\n[notice] To update, run: pip install --upgrade pip",
+      "required": false
+    },
+    {
+      "command": [
+        "python",
+        "scripts/build_docs.py",
+        "--check-deps"
+      ],
+      "duration_seconds": 0.297,
+      "exit_code": 0,
+      "label": "docs_check_deps_recheck",
+      "output_tail": "Docs build dependencies available.\n\n/workspace/SentientOS/scripts/build_docs.py:15: DeprecationWarning: require_lumos_approval() is deprecated; use require_covenant_alignment()\n  require_lumos_approval()",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "scripts/build_docs.py"
+      ],
+      "duration_seconds": 3.384,
+      "exit_code": 0,
+      "label": "docs_build",
+      "output_tail": "- enter_cathedral/index.html\n- experiments/index.html\n- global_validation_note/index.html\n- governance_claims_checklist/index.html\n- governance_tools/index.html\n- healing_guide/index.html\n- index.html\n- lived_liturgy/index.html\n- living_ledger/index.html\n- master_file_doctrine/index.html\n- music_rituals/index.html\n- orchestration_next_move_proposal_note/index.html\n- proof_validity/index.html\n- protected_corridor/index.html\n- protected_mutation_proof/index.html\n- pulse_trust_epoch_model/index.html\n- release_notes/index.html\n- release_notes_v1.0.0/index.html\n- runtime_posture_model/index.html\n- sanctuary_invocation/index.html\n- scoped_canonical_trace_coherence/index.html\n- search.html\n- treasury_federation/index.html\n- treasury_of_love/index.html\n- verifier_consensus/index.html\n- video_ritual_guide/index.html\n- vow_consensus_primitives/index.html\n\n/workspace/SentientOS/scripts/build_docs.py:15: DeprecationWarning: require_lumos_approval() is deprecated; use require_covenant_alignment()\n  require_lumos_approval()",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "scripts/verify_context_hygiene_prompt_boundaries.py"
+      ],
+      "duration_seconds": 2.384,
+      "exit_code": 0,
+      "label": "prompt_boundaries",
+      "output_tail": "Context hygiene prompt boundary scan: boundary_clean\nScanned files: 39\nFindings: 0\nNo prompt materialization, forbidden runtime import/call, or context-hygiene bypass findings detected.",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "verify_audits.py",
+        "--strict"
+      ],
+      "duration_seconds": 0.63,
+      "exit_code": 0,
+      "label": "strict_audits",
+      "output_tail": "/workspace/SentientOS/logs/federation_log.jsonl: valid\n/workspace/SentientOS/logs/migration_ledger.jsonl: valid\n/workspace/SentientOS/logs/privileged_audit.jsonl: valid\n/workspace/SentientOS/logs/support_log.jsonl: valid\n100.0% of logs valid\n\u2705 No mismatches.\n{\"audit_chain_report\": \"glow/forge/audit_reports/audit_chain_report_20260523T074845Z.json\", \"audit_chain_status\": \"ok\"}\n{\"baseline_path\": \"/workspace/SentientOS/logs/privileged_audit.jsonl\", \"baseline_status\": \"ok\", \"environment_issues\": [], \"runtime_error_examples\": [], \"runtime_error_kind\": \"unknown\", \"runtime_path\": \"/workspace/SentientOS/pulse/audit/privileged_audit.runtime.jsonl\", \"runtime_status\": \"ok\", \"strict_artifact_paths\": {\"final_strict_audit_digest\": \"glow/contracts/final_strict_audit_digest.json\", \"strict_audit_breakdown\": \"glow/contracts/strict_audit_breakdown.json\", \"strict_audit_manifest\": \"glow/contracts/strict_audit_manifest.json\", \"strict_audit_recovery_links\": \"glow/contracts/strict_audit_recovery_links.json\", \"strict_audit_status\": \"glow/contracts/strict_audit_status.json\"}, \"strict_bucket\": \"healthy_strict\", \"strict_readiness_class\": \"acceptable\", \"suggested_fix\": \"run: make audit-repair\"}\n{\"classification\": \"optional\", \"dependency\": null, \"non_blocking\": true, \"reason\": null, \"status\": \"passed\", \"tool\": \"verify_audits\"}",
+      "required": true
+    },
+    {
+      "command": [
+        "python",
+        "scripts/audit_immutability_verifier.py"
+      ],
+      "duration_seconds": 0.714,
+      "exit_code": 0,
+      "label": "audit_immutability",
+      "output_tail": "{\"classification\": \"artifact-dependent\", \"dependency\": \"/vow/immutable_manifest.json\", \"exit_code\": 0, \"non_blocking\": true, \"reason\": null, \"status\": \"passed\", \"tool\": \"audit_immutability_verifier\"}\n\n/workspace/SentientOS/scripts/audit_immutability_verifier.py:32: DeprecationWarning: require_lumos_approval() is deprecated; use require_covenant_alignment()\n  require_lumos_approval()",
+      "required": true
+    }
+  ],
+  "status": "passed"
+}

--- a/docs/development/codex_task_scaffold_presets.md
+++ b/docs/development/codex_task_scaffold_presets.md
@@ -1,0 +1,35 @@
+# Codex Task Scaffold Preset Catalog
+
+This metadata-only subsystem defines deterministic preset profiles used by Codex task scaffolding.
+
+## Preset IDs
+
+- metadata_verification
+- metadata_index
+- metadata_digest
+- metadata_attestation
+- operator_review_packet
+- operator_confirmed_run
+- stabilization
+- narrow_repair
+- developer_workflow_metadata
+
+## API
+
+Module: `sentientos/codex_task_scaffold_presets.py`
+
+- `list_preset_ids()` returns deterministic sorted IDs.
+- `get_preset(preset_id)` returns a typed preset.
+- `validate_preset_shape(preset)` validates required groups.
+
+## CLI
+
+`python scripts/list_codex_task_scaffold_presets.py`
+
+- Lists preset IDs.
+- `--json` emits machine-readable ID payload.
+- `--preset-id <id>` emits full preset JSON.
+
+## Integration behavior
+
+`sentientos/codex_task_scaffold.py` applies preset defaults when `subsystem_kind` matches a known preset ID, while allowing explicit request fields to override defaults.

--- a/scripts/list_codex_task_scaffold_presets.py
+++ b/scripts/list_codex_task_scaffold_presets.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from sentientos.codex_task_scaffold_presets import get_preset, list_preset_ids
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preset-id")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.preset_id:
+        preset = get_preset(args.preset_id)
+        payload = {
+            "preset_id": preset.preset_id,
+            "default_deliverables": preset.default_deliverables,
+            "default_forbidden_surfaces": preset.default_forbidden_surfaces,
+            "default_integration_expectations": preset.default_integration_expectations,
+            "default_validation_command_families": preset.default_validation_command_families,
+            "default_final_report_items": preset.default_final_report_items,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.json:
+        print(json.dumps({"preset_ids": list_preset_ids()}, indent=2, sort_keys=True))
+    else:
+        for preset_id in list_preset_ids():
+            print(preset_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_task_scaffold.py
+++ b/sentientos/codex_task_scaffold.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Sequence
+from sentientos.codex_task_scaffold_presets import get_preset, list_preset_ids
 
 STATUSES = frozenset({
     "codex_task_scaffold_ready",
@@ -121,13 +122,15 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
     if request.prompt_mode == "whole_system" and not (request.new_module_path or request.new_cli_path or request.expected_test_paths or request.expected_doc_paths):
         warnings.append("whole_system_paths_missing")
 
+    preset = get_preset(request.subsystem_kind) if request.subsystem_kind in list_preset_ids() else None
     validation_commands = _norm(request.validation_commands or DEFAULT_VALIDATION_COMMANDS)
+    deliverables = _norm(request.deliverables or (preset.default_deliverables if preset else ()))
     expected_files = _norm(request.new_module_path + request.new_cli_path)
     expected_tests = _norm(request.expected_test_paths)
     expected_docs = _norm(request.expected_doc_paths)
-    forbidden = _norm(request.forbidden_behaviors or (
+    forbidden = _norm(request.forbidden_behaviors or (preset.default_forbidden_surfaces if preset else (
         "Do not invoke Codex.", "Do not call OpenAI/provider APIs.", "Do not call GitHub APIs.", "Do not invoke shell/subprocess from library code.",
-    ))
+    )))
     required_integrations = _norm(
         tuple(x for x, enabled in (
             ("capability_registry", request.require_capability_registry),
@@ -153,6 +156,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
             "If no changes are required, do not fabricate commit/PR metadata.\n"
             f"Goal: {request.task_goal}\nRepair target: {request.task_name} ({request.subsystem_kind})."
         )
+    final_report_contract = _norm(preset.default_final_report_items) if preset else ("exact files changed", "full command matrix results", "unresolved risks")
     payload = {
         "task_name": request.task_name,
         "task_goal": request.task_goal,
@@ -161,6 +165,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
         "prompt": prompt,
         "validation_commands": validation_commands,
         "expected_files": expected_files,
+        "deliverables": deliverables,
     }
     digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
     scaffold = CodexTaskScaffold(
@@ -177,7 +182,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
         expected_docs=expected_docs,
         required_integrations=required_integrations,
         forbidden_surfaces=forbidden,
-        final_report_contract=("exact files changed", "full command matrix results", "unresolved risks"),
+        final_report_contract=final_report_contract,
         commit_pr_title=request.commit_title,
         doctrine_references=("AGENTS.md", "docs/development/codex_whole_system_task_template.md", "docs/development/codex_validation_and_landing_contract.md"),
         artifact_references=("json_scaffold", "prompt_text"),

--- a/sentientos/codex_task_scaffold_presets.py
+++ b/sentientos/codex_task_scaffold_presets.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class CodexTaskScaffoldPreset:
+    preset_id: str
+    default_deliverables: tuple[str, ...]
+    default_forbidden_surfaces: tuple[str, ...]
+    default_integration_expectations: tuple[str, ...]
+    default_validation_command_families: tuple[str, ...]
+    default_final_report_items: tuple[str, ...]
+
+
+_PRESETS: dict[str, CodexTaskScaffoldPreset] = {
+    "developer_workflow_metadata": CodexTaskScaffoldPreset(
+        preset_id="developer_workflow_metadata",
+        default_deliverables=("typed_metadata_api", "deterministic_cli", "docs", "tests"),
+        default_forbidden_surfaces=("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"),
+        default_integration_expectations=("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"),
+        default_validation_command_families=("targeted_tests", "targeted_mypy", "docs_build", "prompt_boundary", "matrix_runner_summary", "matrix_runner_output", "audit"),
+        default_final_report_items=("module_api_summary", "cli_summary", "preset_ids_and_behavior", "generator_integration_behavior", "capability_proof_doc_integration", "matrix_runner_integration", "full_command_matrix_results", "unresolved_risks"),
+    ),
+    "metadata_attestation": CodexTaskScaffoldPreset("metadata_attestation", ("attestation_schema", "attestation_validation", "docs", "tests"), ("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"), ("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("module_api_summary", "validation_results", "attestation_scope", "unresolved_risks")),
+    "metadata_digest": CodexTaskScaffoldPreset("metadata_digest", ("digest_spec", "digest_validation", "docs", "tests"), ("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"), ("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("module_api_summary", "validation_results", "digest_behavior", "unresolved_risks")),
+    "metadata_index": CodexTaskScaffoldPreset("metadata_index", ("index_schema", "index_validation", "docs", "tests"), ("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"), ("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("module_api_summary", "validation_results", "index_behavior", "unresolved_risks")),
+    "metadata_verification": CodexTaskScaffoldPreset("metadata_verification", ("verification_schema", "verification_rules", "docs", "tests"), ("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"), ("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("module_api_summary", "validation_results", "verification_behavior", "unresolved_risks")),
+    "narrow_repair": CodexTaskScaffoldPreset("narrow_repair", ("surgical_fix", "regression_test", "docs_if_behavior_changes"), ("whole_system_scope_expansion", "runtime_authority_expansion", "provider_calls", "github_mutation"), ("docs_if_behavior_changes", "matrix_runner_if_required"), ("targeted_tests", "targeted_mypy", "audit"), ("repair_scope", "regression_result", "unresolved_risks")),
+    "operator_confirmed_run": CodexTaskScaffoldPreset("operator_confirmed_run", ("operator_ack_contract", "execution_receipt", "docs", "tests"), ("autonomous_execution", "provider_calls", "github_mutation", "shell_from_library"), ("capability_registry", "reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("operator_confirmation_summary", "validation_results", "unresolved_risks")),
+    "operator_review_packet": CodexTaskScaffoldPreset("operator_review_packet", ("review_packet_schema", "deterministic_packet_builder", "docs", "tests"), ("runtime_authority_expansion", "provider_calls", "github_mutation", "shell_from_library"), ("reviewer_proof_bundle", "matrix_runner", "docs"), ("targeted_tests", "targeted_mypy", "docs_build", "audit"), ("review_packet_contents", "validation_results", "unresolved_risks")),
+    "stabilization": CodexTaskScaffoldPreset("stabilization", ("fallout_fixes", "regression_coverage", "docs_if_behavior_changes"), ("new_feature_expansion", "runtime_authority_expansion", "provider_calls", "github_mutation"), ("matrix_runner", "docs_if_behavior_changes"), ("targeted_tests", "targeted_mypy", "audit", "matrix_runner_summary"), ("stabilization_scope", "validation_results", "unresolved_risks")),
+}
+
+
+def list_preset_ids() -> tuple[str, ...]:
+    return tuple(sorted(_PRESETS))
+
+
+def get_preset(preset_id: str) -> CodexTaskScaffoldPreset:
+    return _PRESETS[preset_id]
+
+
+def validate_preset_shape(preset: CodexTaskScaffoldPreset) -> tuple[str, ...]:
+    errors: list[str] = []
+    if not preset.preset_id:
+        errors.append("preset_id_required")
+    fields = (
+        preset.default_deliverables,
+        preset.default_forbidden_surfaces,
+        preset.default_integration_expectations,
+        preset.default_validation_command_families,
+        preset.default_final_report_items,
+    )
+    if any(not field for field in fields):
+        errors.append("all_default_groups_required")
+    return tuple(errors)
+
+
+def preset_catalog() -> Mapping[str, CodexTaskScaffoldPreset]:
+    return dict(_PRESETS)

--- a/tests/test_codex_task_scaffold_presets.py
+++ b/tests/test_codex_task_scaffold_presets.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sentientos.codex_task_scaffold import CodexTaskScaffoldRequest, build_codex_task_scaffold
+from sentientos.codex_task_scaffold_presets import get_preset, list_preset_ids, validate_preset_shape
+
+
+def test_preset_ids_deterministic() -> None:
+    ids = list_preset_ids()
+    assert ids == tuple(sorted(ids))
+    assert "developer_workflow_metadata" in ids
+
+
+def test_get_preset_and_shape() -> None:
+    preset = get_preset("developer_workflow_metadata")
+    assert preset.preset_id == "developer_workflow_metadata"
+    assert validate_preset_shape(preset) == ()
+
+
+def test_scaffold_uses_preset_defaults() -> None:
+    result = build_codex_task_scaffold(
+        CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="developer_workflow_metadata")
+    )
+    assert "typed_metadata_api" in result.scaffold.final_report_contract or "module_api_summary" in result.scaffold.final_report_contract
+    assert "runtime_authority_expansion" in result.scaffold.forbidden_surfaces

--- a/tests/test_list_codex_task_scaffold_presets_script.py
+++ b/tests/test_list_codex_task_scaffold_presets_script.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from scripts import list_codex_task_scaffold_presets as cli
+
+
+def test_list_ids(capsys) -> None:
+    assert cli.main([]) == 0
+    assert "developer_workflow_metadata" in capsys.readouterr().out
+
+
+def test_list_json(capsys) -> None:
+    assert cli.main(["--json"]) == 0
+    assert "preset_ids" in capsys.readouterr().out
+
+
+def test_emit_preset_json(capsys) -> None:
+    assert cli.main(["--preset-id", "developer_workflow_metadata"]) == 0
+    out = capsys.readouterr().out
+    assert "default_deliverables" in out


### PR DESCRIPTION
### Motivation

- Provide deterministic, typed preset profiles for common Codex subsystem kinds so the scaffold generator can expand compact task metadata into doctrine-compliant default deliverables, validation expectations, forbidden surfaces, and report contracts.
- Make scaffold generation consistent and auditable by exposing preset IDs, lookups, and shape validation while preserving explicit request overrides and preserving the non-authority, metadata-only boundary.
- Ship minimal operator-facing tooling (CLI + docs) so operators and reviewers can list and inspect presets deterministically.

### Description

- Added a new metadata-only module `sentientos/codex_task_scaffold_presets.py` implementing a frozen `CodexTaskScaffoldPreset` dataclass, a deterministic `list_preset_ids()` API, `get_preset(preset_id)`, `validate_preset_shape()`, and a `preset_catalog()` view, and populated the requested preset IDs.
- Added a small CLI `scripts/list_codex_task_scaffold_presets.py` that prints preset IDs, emits JSON IDs with `--json`, and prints a single preset as JSON with `--preset-id`.
- Integrated preset defaults into the scaffold builder so `sentientos/codex_task_scaffold.py` will apply preset defaults (forbidden surfaces, final report contract, deliverables, etc.) when `subsystem_kind` matches a known preset while allowing explicit request fields to override them.
- Added unit tests (`tests/test_codex_task_scaffold_presets.py`, `tests/test_list_codex_task_scaffold_presets_script.py`), documentation (`docs/development/codex_task_scaffold_presets.md`), and generated scaffold/prompt artifacts under `artifacts/`.

### Testing

- Ran unit tests for the scaffold and preset pieces with `PYTHONPATH=. python -m scripts.run_tests -q tests/test_codex_task_scaffold.py tests/test_build_codex_task_scaffold_script.py tests/test_codex_task_scaffold_presets.py tests/test_list_codex_task_scaffold_presets_script.py`, and they passed (exit 0).
- Ran `PYTHONPATH=. python -m mypy sentientos/codex_task_scaffold.py sentientos/codex_task_scaffold_presets.py scripts/build_codex_task_scaffold.py scripts/list_codex_task_scaffold_presets.py` and mypy reported no issues.
- Executed the full relevant matrix command `PYTHONPATH=. python scripts/run_work_item_review_packet_matrix.py --summary --output artifacts/work_item_review_packet_matrix.json` and the matrix completed with status `passed` and `required_failure_count: 0` (artifact: `artifacts/work_item_review_packet_matrix.json`).
- Docs build & hygiene checks were run as part of the matrix; an initial docs dependency bootstrap step was required and was remedied in-run, and the final `scripts/build_docs.py` and `scripts/verify_context_hygiene_prompt_boundaries.py` checks passed.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a115ab83b1c8320b376afb9af75d862)