### PR TITLE
[codex:developer] stabilize Codex validation matrix lane contract

### DIFF
--- a/sentientos/capability_registry.py
+++ b/sentientos/capability_registry.py
@@ -84,6 +84,7 @@ CAPABILITY_CATEGORIES = frozenset(
         "task_work_item_lifecycle_attestation_review_digest_verifier",
         "task_work_item_lifecycle_attestation_review_digest_index",
         "task_work_item_lifecycle_attestation_review_digest_index_verifier",
+        "developer_workflow_metadata",
     }
 )
 CAPABILITY_STATUSES = frozenset({"implemented", "partial", "scaffolded", "deferred", "blocked", "unknown"})


### PR DESCRIPTION
### Motivation
- Fix validation fallout where the new `codex_validation_matrix_lane_contract` capability record used a category not present in the capability allowlist, causing registry validation failures.

### Description
- Add `developer_workflow_metadata` to `CAPABILITY_CATEGORIES` in `sentientos/capability_registry.py` so the lane-contract capability validates cleanly, and commit with `[codex:developer] stabilize Codex validation matrix lane contract`.

### Testing
- Ran the focused lane-contract and PR-evidence tests, targeted mypy checks and baseline ratchet, the work-item review packet matrix (`--summary` and `--output /tmp/work_item_review_packet_matrix.json`), docs dependency/check/build, prompt-boundary scan, `python verify_audits.py --strict`, and `scripts/audit_immutability_verifier.py`, and all required checks for this landing passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1337d200d0832098127d5a1e3bcf4d)