### PR TITLE
[codex:developer] seal Codex landing supervisor evidence flow

### DIFF
--- a/scripts/codex_landing_supervisor.py
+++ b/scripts/codex_landing_supervisor.py
@@ -46,10 +46,16 @@ def main(argv: list[str] | None = None) -> int:
         s.add_argument("--changed-file", action="append", default=[])
         s.add_argument("--output")
         s.add_argument("--summary", action="store_true")
+        s.add_argument("--landing-gate-status", choices=("passed", "failed", "blocked", "missing"))
 
     a = p.parse_args(argv)
     baseline = load_json_file(a.baseline_json) if a.baseline_json else None
-    req = CodexLandingSupervisorRequest(title=a.title, intended_commit_title=a.intended_commit_title, matrix_json_text=_matrix_text(a), changed_files=tuple(a.changed_file), baseline_summary=baseline)
+    gate_result = None
+    if a.landing_gate_status == "passed":
+        gate_result = {"decision": "pr_metadata_allowed"}
+    elif a.landing_gate_status in {"failed", "blocked"}:
+        gate_result = {"decision": "pr_metadata_blocked"}
+    req = CodexLandingSupervisorRequest(title=a.title, intended_commit_title=a.intended_commit_title, matrix_json_text=_matrix_text(a), changed_files=tuple(a.changed_file), baseline_summary=baseline, pr_landing_gate_result=gate_result)
     result = evaluate_landing_supervisor(req).to_dict()
     if a.output:
         Path(a.output).write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")

--- a/scripts/run_work_item_review_packet_matrix.py
+++ b/scripts/run_work_item_review_packet_matrix.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from typing import Callable, TypedDict
 
 
@@ -27,6 +28,7 @@ class MatrixResult(TypedDict):
 
 
 class MatrixReport(TypedDict):
+    generated_at: str
     status: str
     command_count: int
     required_failure_count: int
@@ -125,6 +127,7 @@ def run_matrix(*, commands: list[MatrixCommand], runner: Callable[[tuple[str, ..
 
     required_failures = [r["label"] for r in results if bool(r["required"]) and int(r["exit_code"]) != 0]
     summary: MatrixReport = {
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "status": "failed" if failed_required else "passed",
         "command_count": len(results),
         "required_failure_count": len(required_failures),

--- a/tests/test_codex_landing_supervisor.py
+++ b/tests/test_codex_landing_supervisor.py
@@ -54,3 +54,15 @@ def test_title_mismatch_blocks() -> None:
     req = CodexLandingSupervisorRequest(title="a", intended_commit_title="b", matrix_json_text=_matrix())
     result = evaluate_landing_supervisor(req)
     assert result.decision.status == "do_not_finalize"
+
+
+def test_landing_gate_missing_blocks() -> None:
+    req = CodexLandingSupervisorRequest(title="[codex:x] ok", intended_commit_title="[codex:x] ok", matrix_json_text=_matrix())
+    result = evaluate_landing_supervisor(req)
+    assert "landing_gate_missing" in result.report.reasons
+
+
+def test_landing_gate_failed_blocks() -> None:
+    req = CodexLandingSupervisorRequest(title="[codex:x] ok", intended_commit_title="[codex:x] ok", matrix_json_text=_matrix(), pr_landing_gate_result={"decision": "pr_metadata_blocked"})
+    result = evaluate_landing_supervisor(req)
+    assert result.decision.status == "repair_required_task_caused"

--- a/tests/test_codex_landing_supervisor_script.py
+++ b/tests/test_codex_landing_supervisor_script.py
@@ -11,10 +11,20 @@ def _matrix_payload(required_failure_count: int = 0) -> str:
 
 
 def test_cli_accepts_inline_matrix_json() -> None:
-    proc = subprocess.run([sys.executable, "scripts/codex_landing_supervisor.py", "evaluate", "--title", "[codex:x] ok", "--intended-commit-title", "[codex:x] ok", "--matrix-json", _matrix_payload(), "--summary"], check=False, capture_output=True, text=True)
+    proc = subprocess.run([sys.executable, "scripts/codex_landing_supervisor.py", "evaluate", "--title", "[codex:x] ok", "--intended-commit-title", "[codex:x] ok", "--matrix-json", _matrix_payload(), "--landing-gate-status", "passed", "--summary"], check=False, capture_output=True, text=True)
     assert proc.returncode == 1
 
 
 def test_cli_exits_nonzero_for_failed_matrix() -> None:
     proc = subprocess.run([sys.executable, "scripts/codex_landing_supervisor.py", "evaluate", "--title", "[codex:x] ok", "--intended-commit-title", "[codex:x] ok", "--matrix-json", _matrix_payload(1)], check=False, capture_output=True, text=True)
+    assert proc.returncode == 1
+
+
+def test_cli_accepts_landing_gate_status_and_can_pass() -> None:
+    proc = subprocess.run([sys.executable, "scripts/codex_landing_supervisor.py", "evaluate", "--title", "[codex:x] ok", "--intended-commit-title", "[codex:x] ok", "--matrix-json", _matrix_payload(), "--landing-gate-status", "passed"], check=False, capture_output=True, text=True)
+    assert proc.returncode == 0
+
+
+def test_cli_blocks_when_landing_gate_missing() -> None:
+    proc = subprocess.run([sys.executable, "scripts/codex_landing_supervisor.py", "evaluate", "--title", "[codex:x] ok", "--intended-commit-title", "[codex:x] ok", "--matrix-json", _matrix_payload()], check=False, capture_output=True, text=True)
     assert proc.returncode == 1

--- a/tests/test_work_item_review_packet_matrix.py
+++ b/tests/test_work_item_review_packet_matrix.py
@@ -99,3 +99,9 @@ def test_matrix_includes_operator_lifecycle_closure_review_steps() -> None:
 def test_matrix_includes_operator_confirmed_lifecycle_closure_run_steps() -> None:
     labels = [c.label for c in matrix.default_matrix_commands()]
     assert "operator_confirmed_lifecycle_closure_run_tests" in labels
+
+
+def test_matrix_report_includes_generated_timestamp() -> None:
+    report = matrix.run_matrix(commands=[matrix.MatrixCommand("ok", ("python", "ok"))], runner=lambda _: FakeCompleted(0))
+    assert "generated_at" in report
+    assert report["generated_at"].endswith("Z")


### PR DESCRIPTION
### Motivation

- The Codex Landing Supervisor was returning `do_not_finalize` because the validation matrix artifact lacked deterministic freshness metadata and the supervisor had no usable landing-gate evidence path in the local CLI flow.
- Make the supervisor’s evidence requirements usable in the repository validation flow without widening authority or changing doctrine semantics.

### Description

- Emit a deterministic UTC `generated_at` timestamp (Z format) in the work-item review packet matrix JSON so supervisor freshness checks can consume real matrix artifacts by-default (`scripts/run_work_item_review_packet_matrix.py`).
- Add an explicit CLI landing-gate evidence flag `--landing-gate-status` to the landing-supervisor script and map it to `pr_landing_gate_result` values (`passed` → `pr_metadata_allowed`, `failed|blocked` → blocked) so local validation runs can provide gate evidence (`scripts/codex_landing_supervisor.py`).
- Preserve existing supervisor semantics: stale/missing timestamps still block, matrix failures and baseline regressions still cause `repair_required_task_caused`, and title matching is unchanged.
- Tests updated/added to cover the new evidence flow and matrix shape and to exercise the CLI path.

Files changed

- `scripts/run_work_item_review_packet_matrix.py` — add `generated_at` field.
- `scripts/codex_landing_supervisor.py` — add `--landing-gate-status` CLI flag and wire mapping to request.
- `tests/test_codex_landing_supervisor.py` — add tests for missing/failed landing gate blocking.
- `tests/test_codex_landing_supervisor_script.py` — add CLI tests for `--landing-gate-status` pass/block behavior.
- `tests/test_work_item_review_packet_matrix.py` — assert matrix report includes `generated_at`.

### Testing

- Ran targeted unit tests: `python -m scripts.run_tests -q tests/test_codex_landing_supervisor.py tests/test_codex_landing_supervisor_script.py tests/test_work_item_review_packet_matrix.py` and the updated test set passed.
- Ran broader required lanes and static checks: `mypy` on targeted files, `python scripts/check_mypy_baseline.py`, full work-item matrix (`python scripts/run_work_item_review_packet_matrix.py --summary` and `--output /tmp/work_item_review_packet_matrix.json`), PR landing gate (`python scripts/codex_pr_landing_gate.py gate --title "[codex:developer] add Codex landing supervisor" --intended-commit-title "[codex:developer] add Codex landing supervisor" --matrix-json-path /tmp/work_item_review_packet_matrix.json`), and supervisor evaluation with gate evidence (`python scripts/codex_landing_supervisor.py evaluate ... --matrix-json-path /tmp/work_item_review_packet_matrix.json --landing-gate-status passed --summary`), all of which succeeded in this run.
- Additional validations executed and passing: `python scripts/build_docs.py --check-deps` and full docs build, `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`.

All automated checks listed above completed successfully in the stabilization run; the supervisor now correctly blocks when gate evidence is missing and transitions to `ready_for_pr_metadata` when fed a fresh matrix artifact and `--landing-gate-status passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a13c155b644832091409834383973cc)