### PR TITLE
[codex:embodiment] stabilize household presence camera zone resolver

### DIFF
--- a/scripts/build_household_presence_camera_zone_resolver.py
+++ b/scripts/build_household_presence_camera_zone_resolver.py
@@ -14,17 +14,18 @@ def main() -> int:
         s=sp.add_parser(c); s.add_argument('--config'); s.add_argument('--event'); s.add_argument('--input'); s.add_argument('--fixtures-dir',default='tests/fixtures/household_presence_camera_zone_resolver'); s.add_argument('--output'); s.add_argument('--summary',action='store_true')
     a=ap.parse_args()
     if a.cmd=='build-default':
-        out={'zones':build_default_config()}
-        text=json.dumps(out,indent=2,sort_keys=True)
+        default_payload={'zones':build_default_config()}
+        text=json.dumps(default_payload,indent=2,sort_keys=True)
         if a.output: Path(a.output).write_text(text+'\n')
         print(text); return 0
+    config: Mapping[str, Any]
     if a.cmd=='inspect-fixture':
-        event=_load(str(Path(a.fixtures_dir)/str(a.input))); config={'zones':build_default_config()}
+        event=_load(str(Path(a.fixtures_dir)/str(a.input))); config=cast(Mapping[str, Any], {'zones':build_default_config()})
     elif a.cmd in {'resolve','validate','summarize'}:
-        event=_load(a.event if a.event else a.input); config=_load(a.config) if a.config else {'zones':build_default_config()}
+        event=_load(a.event if a.event else a.input); config=_load(a.config) if a.config else cast(Mapping[str, Any], {'zones':build_default_config()})
     result=resolve_camera_event_zone(config,event,HouseholdCameraZoneResolverPolicy())
-    out={'status':result.report.status,'effective_zone':result.resolution.effective_zone,'warnings':list(result.report.warnings)} if (a.summary or a.cmd=='summarize') else json.loads(dumps_result(result))
-    text=json.dumps(out,indent=2,sort_keys=True)
+    output_payload: Mapping[str, Any] = ({'status':result.report.status,'effective_zone':result.resolution.effective_zone,'warnings':list(result.report.warnings)} if (a.summary or a.cmd=='summarize') else cast(Mapping[str, Any], json.loads(dumps_result(result))))
+    text=json.dumps(output_payload,indent=2,sort_keys=True)
     if a.output: Path(a.output).write_text(text+'\n')
     print(text)
     return 1 if result.report.status in {'blocked','review_required'} and a.cmd in {'resolve','validate','inspect-fixture'} else 0


### PR DESCRIPTION
### Motivation
- Stabilize the Household Presence Camera Zone Resolver landing by repairing task-caused mypy/type errors in the resolver CLI and completing the full required validation/landing contract. 

### Description
- Fix typing and shadowing in `scripts/build_household_presence_camera_zone_resolver.py` by renaming the build payload, declaring `config` and `output_payload` as `Mapping[str, Any]`, and adding `cast(...)` around JSON/dict branches so the CLI type-checks cleanly. 
- This is a stabilization-only change confined to the CLI script and does not widen runtime authority, add features, or touch camera/mic/Wi‑Fi/RF/adapters. 

### Testing
- Focused resolver tests were run with `python -m scripts.run_tests -q tests/test_household_presence_camera_zone_resolver.py tests/test_build_household_presence_camera_zone_resolver_script.py` and passed. 
- Adjacent embodiment regression suites were run with the camera config/redaction/deadzone tests and passed. 
- Integration/proof/readiness lanes and the matrix runner were executed and passed, with matrix output written to `/tmp/work_item_review_packet_matrix.json`. 
- Targeted `mypy` and the mypy baseline were run and passed with `new_errors: 0` (baseline improved). 
- PR landing gate and Codex Landing Supervisor evaluation passed (`pr_metadata_allowed` / `ready_for_pr_metadata`). 
- Docs build, prompt-boundary checks (`boundary_clean`), `verify_audits.py --strict`, and the audit immutability verifier were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14c175623c8320a87d1ffb8fb26b18)