### PR TITLE
[codex:embodiment] add household presence camera live adapter readiness

### DIFF
--- a/docs/architecture/household_presence_camera_live_adapter_readiness.md
+++ b/docs/architecture/household_presence_camera_live_adapter_readiness.md
@@ -1,0 +1,19 @@
+# Household Presence Camera Live Adapter Readiness
+
+Metadata-only readiness checker for future live adapter wrapping.
+
+- Inspects repository paths only; no hardware, media, or runtime execution.
+- Verifies prerequisite surfaces: sensor inventory, event bridge, redaction, zone config/resolver, policy chain, and matrix/gate/supervisor tooling.
+- Emits deterministic status/digest and conservative allowed/forbidden next steps.
+
+## Ready for stub only
+`ready_for_stub_only` / `ready_for_operator_review` means interface/design work may proceed, but live camera/speaker/external authority remains forbidden.
+
+## Future sequence
+1. Design metadata-only adapter interface.
+2. Add offline adapter fixtures.
+3. Add operator-confirmed dry-run.
+4. Add host inventory bridge.
+5. Add local policy-gated live adapter only after explicit operator confirmation.
+6. Keep speaker/talkback separate.
+7. Keep external authority blocked.

--- a/scripts/build_household_presence_camera_live_adapter_readiness.py
+++ b/scripts/build_household_presence_camera_live_adapter_readiness.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from typing import Any
+from sentientos.household_presence_camera_live_adapter_readiness import build_default_policy, validate_policy, evaluate_readiness
+
+def _load(p:str)->dict[str,Any]: return dict(json.loads(Path(p).read_text()))
+
+def main(argv:list[str]|None=None)->int:
+ a=argparse.ArgumentParser(); sub=a.add_subparsers(dest='cmd',required=True)
+ b=sub.add_parser('build-default'); b.add_argument('--output',required=True)
+ i=sub.add_parser('inspect-repo'); i.add_argument('--workspace-root',default='.')
+ e=sub.add_parser('evaluate'); e.add_argument('--workspace-root',default='.'); e.add_argument('--fixtures-dir',default='tests/fixtures/household_presence_camera_live_adapter_readiness'); e.add_argument('--input'); e.add_argument('--output'); e.add_argument('--summary',action='store_true')
+ v=sub.add_parser('validate'); v.add_argument('--input',required=True)
+ s=sub.add_parser('summarize'); s.add_argument('--input',required=True)
+ f=sub.add_parser('inspect-fixture'); f.add_argument('--fixtures-dir',default='tests/fixtures/household_presence_camera_live_adapter_readiness'); f.add_argument('--input',required=True)
+ ns=a.parse_args(argv)
+ if ns.cmd=='build-default': Path(ns.output).write_text(json.dumps(build_default_policy().__dict__,indent=2,sort_keys=True)); return 0
+ if ns.cmd=='validate': return 0 if validate_policy(build_default_policy())['ok'] else 1
+ if ns.cmd=='inspect-fixture': payload={"workspace_root":'.',"fixtures_dir":ns.fixtures_dir,"risk_flags":_load(str(Path(ns.fixtures_dir)/ns.input)).get('risk_flags',{})}
+ elif ns.cmd=='evaluate': payload=_load(ns.input) if ns.input else {"workspace_root":ns.workspace_root,"fixtures_dir":ns.fixtures_dir}
+ elif ns.cmd=='summarize': payload=_load(ns.input)
+ else: payload={"workspace_root":ns.workspace_root}
+ res=evaluate_readiness(payload).to_dict(); out=json.dumps(res,indent=2,sort_keys=True)
+ if getattr(ns,'output',None): Path(ns.output).write_text(out)
+ if ns.cmd in {'summarize'} or getattr(ns,'summary',False): print(json.dumps({"status":res['report']['status'],"digest":res['report']['deterministic_digest'],"missing":res['report']['missing_prerequisites']},sort_keys=True))
+ else: print(out)
+ return 1 if res['report']['status'].startswith('blocked') or res['report']['status']=='failed' else 0
+
+if __name__=='__main__': raise SystemExit(main())

--- a/sentientos/household_presence_camera_live_adapter_readiness.py
+++ b/sentientos/household_presence_camera_live_adapter_readiness.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping
+import hashlib, json
+
+ReadinessStatus = Literal["ready_for_design","ready_for_stub_only","ready_for_operator_review","blocked_missing_policy_chain","blocked_missing_zone_config","blocked_missing_deadzone_redaction","blocked_missing_event_bridge","blocked_missing_sensor_inventory","blocked_missing_tests","blocked_live_runtime_risk","blocked_speaker_boundary","blocked_external_authority_boundary","failed"]
+SurfaceClass = Literal["existing_live_camera_surface","existing_vision_surface","existing_perception_bus_surface","existing_affect_or_gaze_surface","existing_talkback_surface","existing_host_inventory_surface","policy_chain_surface","zone_config_surface","redaction_surface","fixture_surface","docs_surface","tests_surface","unknown_surface"]
+Severity = Literal["info","warning","error","blocked"]
+
+REQ = {
+ "sensor_inventory":"sentientos/household_presence_sensor_inventory.py", "event_bridge":"sentientos/household_presence_camera_event_bridge.py", "deadzone_redaction":"sentientos/household_presence_deadzone_redaction.py", "redaction_pipeline":"sentientos/household_presence_camera_redaction_pipeline.py", "zone_config":"sentientos/household_presence_camera_zone_config.py", "zone_resolver":"sentientos/household_presence_camera_zone_resolver.py", "policy_chain":"sentientos/household_presence_camera_policy_chain.py", "matrix_runner":"scripts/run_work_item_review_packet_matrix.py", "landing_gate":"scripts/codex_pr_landing_gate.py", "landing_supervisor":"scripts/codex_landing_supervisor.py",
+}
+ALLOWED=("design_live_adapter_stub","add_offline_adapter_fixtures","add_operator_confirmed_dry_run","add_policy_chain_contract_tests","add_host_inventory_bridge","manual_operator_review")
+FORBIDDEN=("open_camera_now","enable_live_recording","enable_speaker_output","enable_external_disclosure","bypass_policy_chain","bypass_zone_config","bypass_deadzone_redaction","store_raw_video_without_redaction","child_visible_sensitive_output")
+
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterReadinessPolicy: schema_version:str="household_camera_live_adapter_readiness_policy.v1"; require_fixtures:bool=True
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterSurface: surface_id:str; path:str; classification:SurfaceClass; exists:bool
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterPrerequisite: prerequisite_id:str; ok:bool; evidence_path:str=""
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterFinding: finding_id:str; severity:Severity; surface_id:str; message:str; recommendation:str; task_owned:bool; evidence_path:str=""
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterReadinessReport:
+    status:ReadinessStatus; surfaces:tuple[HouseholdCameraLiveAdapterSurface,...]; prerequisites:tuple[HouseholdCameraLiveAdapterPrerequisite,...]; findings:tuple[HouseholdCameraLiveAdapterFinding,...]; missing_prerequisites:tuple[str,...]; blocked_reasons:tuple[str,...]; allowed_next_steps:tuple[str,...]=ALLOWED; forbidden_next_steps:tuple[str,...]=FORBIDDEN; deterministic_digest:str=""
+@dataclass(frozen=True)
+class HouseholdCameraLiveAdapterReadinessResult:
+    report:HouseholdCameraLiveAdapterReadinessReport
+    def to_dict(self)->dict[str,Any]: return asdict(self)
+
+def build_default_policy()->HouseholdCameraLiveAdapterReadinessPolicy: return HouseholdCameraLiveAdapterReadinessPolicy()
+def validate_policy(policy:HouseholdCameraLiveAdapterReadinessPolicy)->dict[str,Any]: ok=policy.schema_version.endswith('.v1'); return {"ok":ok,"status":"household_camera_live_adapter_readiness_policy_valid" if ok else "household_camera_live_adapter_readiness_policy_invalid"}
+
+def _classify(path:str)->SurfaceClass:
+    if "camera_daemon" in path: return "existing_live_camera_surface"
+    if "vision_tracker" in path: return "existing_vision_surface"
+    if "PERCEPTION_BUS" in path or "perception_bus" in path: return "existing_perception_bus_surface"
+    if "face_emotion" in path or "gaze_adapter" in path: return "existing_affect_or_gaze_surface"
+    if "talkback" in path: return "existing_talkback_surface"
+    if "host_inventory" in path: return "existing_host_inventory_surface"
+    if "policy_chain" in path: return "policy_chain_surface"
+    if "zone_config" in path or "zone_resolver" in path: return "zone_config_surface"
+    if "redaction" in path: return "redaction_surface"
+    if "/fixtures/" in path: return "fixture_surface"
+    if path.startswith("docs/"): return "docs_surface"
+    if path.startswith("tests/"): return "tests_surface"
+    return "unknown_surface"
+
+def inspect_repo_surfaces(workspace_root:str)->tuple[HouseholdCameraLiveAdapterSurface,...]:
+    known=[*REQ.values(),"camera_daemon.py","vision_tracker.py","face_emotion.py","scripts/perception/gaze_adapter.py","docs/PERCEPTION_BUS.md","docs/schemas/perception_bus.schema.json","talkback_bridge.py","sentientos/host_inventory.py","tests/test_household_presence_camera_live_adapter_readiness.py","tests/test_build_household_presence_camera_live_adapter_readiness_script.py"]
+    root=Path(workspace_root); out=[]
+    for p in known:
+        out.append(HouseholdCameraLiveAdapterSurface(surface_id=p.replace('/','_'),path=p,classification=_classify(p),exists=(root/p).exists()))
+    return tuple(out)
+
+def evaluate_readiness(payload:Mapping[str,Any], policy:HouseholdCameraLiveAdapterReadinessPolicy|None=None)->HouseholdCameraLiveAdapterReadinessResult:
+    pol=policy or build_default_policy(); root=str(payload.get("workspace_root",".")); surfaces=inspect_repo_surfaces(root); exists={s.path:s.exists for s in surfaces}
+    prereq=[]; findings=[]; missing=[]; blocked=[]
+    simulated=set(payload.get("simulate_missing",())) if isinstance(payload.get("simulate_missing"),(list,tuple,set)) else set()
+    for k,v in REQ.items():
+        ok=exists.get(v,False) and k not in simulated; prereq.append(HouseholdCameraLiveAdapterPrerequisite(k,ok,v if ok else ""))
+        if not ok: missing.append(k)
+    fixtures_dir=Path(root)/str(payload.get("fixtures_dir","tests/fixtures/household_presence_camera_live_adapter_readiness"))
+    fixtures_ok=fixtures_dir.exists() and any(fixtures_dir.glob("*.json"))
+    prereq.append(HouseholdCameraLiveAdapterPrerequisite("offline_fixtures",fixtures_ok,str(fixtures_dir) if fixtures_ok else ""))
+    if pol.require_fixtures and not fixtures_ok: missing.append("offline_fixtures")
+    risk=dict(payload.get("risk_flags",{})) if isinstance(payload.get("risk_flags"),Mapping) else {}
+    if risk.get("live_runtime_risk_present"): blocked.append("blocked_live_runtime_risk")
+    if risk.get("talkback_boundary_risk"): blocked.append("blocked_speaker_boundary")
+    if risk.get("external_authority_risk"): blocked.append("blocked_external_authority_boundary")
+    for m in missing: findings.append(HouseholdCameraLiveAdapterFinding(f"missing_{m}","blocked",m,f"Missing prerequisite: {m}","add prerequisite surface",True))
+    for b in blocked: findings.append(HouseholdCameraLiveAdapterFinding(b,"blocked",b,"Boundary risk present","clear risk before stub",True))
+    status:ReadinessStatus="ready_for_stub_only"
+    mapping={"policy_chain":"blocked_missing_policy_chain","zone_config":"blocked_missing_zone_config","deadzone_redaction":"blocked_missing_deadzone_redaction","event_bridge":"blocked_missing_event_bridge","sensor_inventory":"blocked_missing_sensor_inventory","offline_fixtures":"blocked_missing_tests"}
+    for m in missing:
+        if m in mapping: status=mapping[m] # type: ignore[assignment]
+    if blocked: status=blocked[0] # type: ignore[assignment]
+    if status=="ready_for_stub_only" and risk.get("operator_review_required",True): status="ready_for_operator_review"
+    digest=hashlib.sha256(json.dumps({"status":status,"missing":sorted(missing),"blocked":sorted(blocked),"surfaces":[asdict(s) for s in surfaces]},sort_keys=True).encode()).hexdigest()
+    report=HouseholdCameraLiveAdapterReadinessReport(status,surfaces,tuple(prereq),tuple(findings),tuple(sorted(missing)),tuple(blocked),deterministic_digest=digest)
+    return HouseholdCameraLiveAdapterReadinessResult(report)
+
+def dumps_result(result:HouseholdCameraLiveAdapterReadinessResult)->str: return json.dumps(result.to_dict(),indent=2,sort_keys=True)

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/external_authority_risk.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/external_authority_risk.json
@@ -1,0 +1,1 @@
+{"risk_flags":{"external_authority_risk":true}}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/live_runtime_risk_present.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/live_runtime_risk_present.json
@@ -1,0 +1,1 @@
+{"risk_flags":{"live_runtime_risk_present":true}}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_offline_fixtures.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_offline_fixtures.json
@@ -1,0 +1,1 @@
+{"risk_flags":{},"fixtures_dir":"tests/fixtures/does_not_exist"}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_policy_chain.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_policy_chain.json
@@ -1,0 +1,1 @@
+{"risk_flags":{},"simulate_missing":["policy_chain"]}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_zone_config.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/missing_zone_config.json
@@ -1,0 +1,1 @@
+{"risk_flags":{},"simulate_missing":["zone_config"]}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/ready_for_stub_only.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/ready_for_stub_only.json
@@ -1,0 +1,1 @@
+{"risk_flags":{"operator_review_required":true}}

--- a/tests/fixtures/household_presence_camera_live_adapter_readiness/talkback_boundary_risk.json
+++ b/tests/fixtures/household_presence_camera_live_adapter_readiness/talkback_boundary_risk.json
@@ -1,0 +1,1 @@
+{"risk_flags":{"talkback_boundary_risk":true}}

--- a/tests/test_build_household_presence_camera_live_adapter_readiness_script.py
+++ b/tests/test_build_household_presence_camera_live_adapter_readiness_script.py
@@ -1,0 +1,11 @@
+import subprocess,sys,json
+from pathlib import Path
+
+def test_cli(tmp_path:Path):
+ p=tmp_path/'policy.json';o=tmp_path/'out.json'
+ assert subprocess.run([sys.executable,'scripts/build_household_presence_camera_live_adapter_readiness.py','build-default','--output',str(p)],check=False).returncode==0
+ assert subprocess.run([sys.executable,'scripts/build_household_presence_camera_live_adapter_readiness.py','validate','--input',str(p)],check=False).returncode==0
+ assert subprocess.run([sys.executable,'scripts/build_household_presence_camera_live_adapter_readiness.py','evaluate','--workspace-root','.','--fixtures-dir','tests/fixtures/household_presence_camera_live_adapter_readiness','--output',str(o)],check=False).returncode in {0,1}
+ data=json.loads(o.read_text()); assert 'report' in data
+ assert subprocess.run([sys.executable,'scripts/build_household_presence_camera_live_adapter_readiness.py','summarize','--input',str(o)],check=False).returncode in {0,1}
+ assert subprocess.run([sys.executable,'scripts/build_household_presence_camera_live_adapter_readiness.py','inspect-fixture','--input','live_runtime_risk_present.json'],check=False).returncode==1

--- a/tests/test_household_presence_camera_live_adapter_readiness.py
+++ b/tests/test_household_presence_camera_live_adapter_readiness.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from sentientos.household_presence_camera_live_adapter_readiness import build_default_policy,validate_policy,evaluate_readiness,dumps_result
+
+def test_default_policy_validates(): assert validate_policy(build_default_policy())["ok"]
+def test_ready_fixture_not_live_ready():
+ r=evaluate_readiness({"workspace_root":".","fixtures_dir":"tests/fixtures/household_presence_camera_live_adapter_readiness","risk_flags":{"operator_review_required":True}}).report
+ assert r.status in {"ready_for_stub_only","ready_for_operator_review"}
+ assert r.status!="ready_for_design"
+def test_missing_policy_chain_blocks(): assert evaluate_readiness({"workspace_root":".","simulate_missing":["policy_chain"]}).report.status=="blocked_missing_policy_chain"
+def test_missing_zone_config_blocks(): assert evaluate_readiness({"workspace_root":".","simulate_missing":["zone_config"]}).report.status=="blocked_missing_zone_config"
+def test_risks_block():
+ assert evaluate_readiness({"workspace_root":".","risk_flags":{"live_runtime_risk_present":True}}).report.status=="blocked_live_runtime_risk"
+ assert evaluate_readiness({"workspace_root":".","risk_flags":{"talkback_boundary_risk":True}}).report.status=="blocked_speaker_boundary"
+ assert evaluate_readiness({"workspace_root":".","risk_flags":{"external_authority_risk":True}}).report.status=="blocked_external_authority_boundary"
+def test_deterministic_digest():
+ a=evaluate_readiness({"workspace_root":"."}).report.deterministic_digest
+ b=evaluate_readiness({"workspace_root":"."}).report.deterministic_digest
+ assert a==b and len(a)==64
+ assert "open_camera_now" in dumps_result(evaluate_readiness({"workspace_root":"."}))


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only readiness checker that verifies repository-declared camera/perception surfaces and policy prerequisites without touching hardware or executing live modules.
- Prevent accidental escalation to live adapters by explicitly enumerating blocked conditions, forbidden next steps, and conservative allowed next steps.
- Produce a deterministic, auditable report (including a digest) to be used as a preflight for future policy-gated live adapter work.

### Description
- Added a new metadata-only module `sentientos/household_presence_camera_live_adapter_readiness.py` implementing typed records (`HouseholdCameraLiveAdapterReadinessPolicy`, `Surface`, `Prerequisite`, `Finding`, `ReadinessReport`, `ReadinessResult`), deterministic digesting, surface classification, prerequisite checks (sensor inventory, event bridge, redaction pipeline, zone config/resolver, policy chain, matrix/gate tooling), risk flags, and conservative allowed/forbidden next steps.
- Added a CLI script `scripts/build_household_presence_camera_live_adapter_readiness.py` with `build-default`, `inspect-repo`, `evaluate`, `validate`, `summarize`, and `inspect-fixture` commands that emit deterministic JSON and use exit codes to signal blocked/failed readiness.
- Added metadata-only fixtures under `tests/fixtures/household_presence_camera_live_adapter_readiness/` covering ready/missing-prerequisite and boundary-risk scenarios and a `simulate_missing` mechanism for deterministic test simulation.
- Added tests `tests/test_household_presence_camera_live_adapter_readiness.py` and `tests/test_build_household_presence_camera_live_adapter_readiness_script.py` and architecture docs `docs/architecture/household_presence_camera_live_adapter_readiness.md` explaining scope, non-live boundaries, and the recommended future sequence for a live adapter.

### Testing
- Ran targeted unit/CLI tests: `python -m scripts.run_tests -q tests/test_household_presence_camera_live_adapter_readiness.py tests/test_build_household_presence_camera_live_adapter_readiness_script.py`, and they passed (exit 0 with test suite success).
- Ran static typing checks: `python -m mypy sentientos/household_presence_camera_live_adapter_readiness.py scripts/build_household_presence_camera_live_adapter_readiness.py`, and mypy reported no issues.
- Note: full repository validation matrix (docs build, full matrix lanes, PR landing gate, Codex Landing Supervisor, and audit verifiers) required by the whole-system landing contract was not executed here and remains outstanding before final PR metadata/landing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14ccfa7b088320922267c6e84704a3)