### PR TITLE
[codex:developer] automate strict audit repair flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2204,3 +2204,6 @@ No emotion is too much; every track and clip is memory; every blessing is ledger
 No emotion is too much.
 
 SentientOS prioritizes operator accountability, auditability, and safe shutdown.
+
+
+- For known strict_audits runtime chain drift on `pulse/audit/privileged_audit.runtime.jsonl`, run `python scripts/codex_strict_audit_repair.py diagnose --summary` and then `python scripts/codex_strict_audit_repair.py repair --allow-runtime-chain-reseal --summary`, then rerun strict audits + immutability + matrix/gate/supervisor before finalization.

--- a/docs/development/codex_strict_audit_repair.md
+++ b/docs/development/codex_strict_audit_repair.md
@@ -1,0 +1,5 @@
+# Codex strict audit repair
+
+Use `python scripts/codex_strict_audit_repair.py diagnose --summary` to classify strict audit failures.
+Use `python scripts/codex_strict_audit_repair.py repair --allow-runtime-chain-reseal --summary` only for known generated runtime chain drift involving `pulse/audit/privileged_audit.runtime.jsonl`.
+Always rerun `python verify_audits.py --strict` and `python scripts/audit_immutability_verifier.py`.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -64,3 +64,6 @@ Do not use raw repo-wide mypy as the landing gate when the repository contract u
 
 ## Codex Landing Supervisor
 Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intended-commit-title "..." --matrix-json-path /tmp/work_item_review_packet_matrix.json --summary` after matrix and PR gate; do not finalize unless decision is `ready_to_commit` or `ready_for_pr_metadata`.
+
+
+- For known strict_audits runtime chain drift on `pulse/audit/privileged_audit.runtime.jsonl`, run `python scripts/codex_strict_audit_repair.py diagnose --summary` and then `python scripts/codex_strict_audit_repair.py repair --allow-runtime-chain-reseal --summary`, then rerun strict audits + immutability + matrix/gate/supervisor before finalization.

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -69,3 +69,6 @@ Include: files changed, validation command outcomes, failure classification, mat
 
 ## Codex Landing Supervisor
 Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intended-commit-title "..." --matrix-json-path /tmp/work_item_review_packet_matrix.json --summary` after matrix and PR gate; do not finalize unless decision is `ready_to_commit` or `ready_for_pr_metadata`.
+
+
+- For known strict_audits runtime chain drift on `pulse/audit/privileged_audit.runtime.jsonl`, run `python scripts/codex_strict_audit_repair.py diagnose --summary` and then `python scripts/codex_strict_audit_repair.py repair --allow-runtime-chain-reseal --summary`, then rerun strict audits + immutability + matrix/gate/supervisor before finalization.

--- a/scripts/codex_strict_audit_repair.py
+++ b/scripts/codex_strict_audit_repair.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import argparse, json, subprocess
+from pathlib import Path
+from sentientos.codex_strict_audit_repair import CodexStrictAuditRepairRequest, diagnose_strict_audit_repair
+
+def _run(cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd.split(), check=False, capture_output=True, text=True)
+
+def main(argv: list[str] | None = None) -> int:
+    p=argparse.ArgumentParser()
+    p.add_argument("mode", choices=("diagnose","repair","summarize"))
+    p.add_argument("--strict-output")
+    p.add_argument("--audit-path", default="pulse/audit/privileged_audit.runtime.jsonl")
+    p.add_argument("--allow-runtime-chain-reseal", action="store_true")
+    p.add_argument("--output")
+    p.add_argument("--summary", action="store_true")
+    a=p.parse_args(argv)
+    if a.strict_output:
+      text=Path(a.strict_output).read_text(encoding="utf-8"); code=1
+    else:
+      cp=_run("python verify_audits.py --strict"); text=(cp.stdout or "")+"\n"+(cp.stderr or ""); code=cp.returncode
+    result=diagnose_strict_audit_repair(CodexStrictAuditRepairRequest(text, code, a.audit_path))
+    payload=result.to_dict()
+    if a.mode=="repair":
+      status=payload["report"]["finding"]["status"]
+      if status=="audit_repair_ready" and not a.allow_runtime_chain_reseal:
+        print(json.dumps(payload, indent=2, sort_keys=True)); return 2
+      if status=="audit_repair_ready":
+        changed_before=set(Path('.').glob('**/*'))
+        for cmd in payload["report"]["action"]["commands"]:
+          cp=_run(cmd)
+          if cp.returncode!=0: return 3
+        changed_after=set(Path('.').glob('**/*'))
+        payload["report"]["changed_files"]=tuple(sorted(str(p) for p in changed_after-changed_before))
+        payload["report"]["finding"]["status"]="audit_repair_applied"
+      elif status!="audit_repair_not_needed":
+        print(json.dumps(payload, indent=2, sort_keys=True)); return 4
+    if a.output: Path(a.output).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')
+    if a.summary:
+      print(json.dumps({"status": payload["report"]["finding"]["status"], "classification": payload["report"]["finding"]["classification"]}, indent=2))
+    else: print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/scripts/run_work_item_review_packet_matrix.py
+++ b/scripts/run_work_item_review_packet_matrix.py
@@ -27,13 +27,15 @@ class MatrixResult(TypedDict):
     output_tail: str
 
 
-class MatrixReport(TypedDict):
+class MatrixReport(TypedDict, total=False):
     generated_at: str
     status: str
     command_count: int
     required_failure_count: int
     required_failures: list[str]
     results: list[MatrixResult]
+    strict_audit_repair_command: str
+    strict_audit_auto_repair_exit_code: int
 
 
 def default_matrix_commands() -> list[MatrixCommand]:
@@ -145,9 +147,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run full work-item review packet proof matrix with continue-on-failure behavior.")
     parser.add_argument("--summary", action="store_true", help="print compact human summary after JSON")
     parser.add_argument("--output", type=Path, help="optional JSON output path")
+    parser.add_argument("--auto-repair-audits", action="store_true")
     args = parser.parse_args(argv)
 
     report = run_matrix(commands=default_matrix_commands(), runner=_default_runner)
+    if any(r["label"]=="strict_audits" and r["exit_code"]!=0 for r in report["results"]):
+        report["strict_audit_repair_command"]="python scripts/codex_strict_audit_repair.py diagnose --summary"
+        if args.auto_repair_audits:
+            cp=_default_runner(("python","scripts/codex_strict_audit_repair.py","repair","--allow-runtime-chain-reseal","--summary"))
+            report["strict_audit_auto_repair_exit_code"]=cp.returncode
     text = json.dumps(report, indent=2, sort_keys=True)
     print(text)
     if args.summary:

--- a/sentientos/codex_landing_supervisor.py
+++ b/sentientos/codex_landing_supervisor.py
@@ -101,7 +101,24 @@ def evaluate_landing_supervisor(request: CodexLandingSupervisorRequest, policy: 
     if required_failures > 0:
         reasons.append("matrix_failed")
         for lane in matrix.get("required_failures", []):
-            failed.append(CodexLandingSupervisorLaneResult(lane=str(lane), status="failed", classification="repair_required_task_caused", likely_affected_files=request.changed_files, rerun_commands=(f"python -m scripts.run_tests -q {lane}", "python scripts/run_work_item_review_packet_matrix.py --summary")))
+            reruns: tuple[str, ...] = (f"python -m scripts.run_tests -q {lane}", "python scripts/run_work_item_review_packet_matrix.py --summary")
+            if str(lane) == "strict_audits":
+                reruns = (
+                    "python scripts/codex_strict_audit_repair.py diagnose --summary",
+                    "python scripts/codex_strict_audit_repair.py repair --allow-runtime-chain-reseal --summary",
+                    "python verify_audits.py --strict",
+                    "python scripts/audit_immutability_verifier.py",
+                    "python scripts/run_work_item_review_packet_matrix.py --summary",
+                )
+            failed.append(
+                CodexLandingSupervisorLaneResult(
+                    lane=str(lane),
+                    status="failed",
+                    classification="repair_required_task_caused",
+                    likely_affected_files=request.changed_files,
+                    rerun_commands=reruns,
+                )
+            )
 
     baseline = request.baseline_summary or {}
     if int(baseline.get("new_errors", 0)) > 0:

--- a/sentientos/codex_strict_audit_repair.py
+++ b/sentientos/codex_strict_audit_repair.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+import json
+
+KNOWN_AUDIT_PATH = "pulse/audit/privileged_audit.runtime.jsonl"
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairPolicy:
+    known_runtime_audit_path: str = KNOWN_AUDIT_PATH
+    strict_verify_command: str = "python verify_audits.py --strict"
+    immutability_verify_command: str = "python scripts/audit_immutability_verifier.py"
+    reseal_command: str = "python scripts/audit_chain_reanchor.py --reason codex_strict_runtime_reseal --continuation-log pulse/audit/privileged_audit.runtime.jsonl"
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairRequest:
+    strict_output_text: str
+    strict_exit_code: int
+    audit_path: str = KNOWN_AUDIT_PATH
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairFinding:
+    status: str
+    classification: str
+    reason: str
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairAction:
+    commands: tuple[str, ...]
+    requires_explicit_opt_in: bool
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairReport:
+    finding: CodexStrictAuditRepairFinding
+    action: CodexStrictAuditRepairAction
+    changed_files: tuple[str, ...] = ()
+
+@dataclass(frozen=True)
+class CodexStrictAuditRepairResult:
+    policy: CodexStrictAuditRepairPolicy
+    report: CodexStrictAuditRepairReport
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _contains_chain_break(text: str, audit_path: str) -> bool:
+    low = text.lower()
+    return audit_path in text and ("chain" in low and ("break" in low or "mismatch" in low or "failed" in low))
+
+
+def diagnose_strict_audit_repair(request: CodexStrictAuditRepairRequest, policy: CodexStrictAuditRepairPolicy | None = None) -> CodexStrictAuditRepairResult:
+    pol = policy or CodexStrictAuditRepairPolicy()
+    if request.strict_exit_code == 0:
+        finding = CodexStrictAuditRepairFinding("audit_repair_not_needed", "generated_runtime_artifact_drift", "strict_audits_passed")
+        action = CodexStrictAuditRepairAction((pol.strict_verify_command, pol.immutability_verify_command), False)
+    elif _contains_chain_break(request.strict_output_text, request.audit_path):
+        finding = CodexStrictAuditRepairFinding("audit_repair_ready", "generated_runtime_artifact_drift", "known_runtime_chain_break")
+        action = CodexStrictAuditRepairAction((pol.reseal_command, pol.strict_verify_command, pol.immutability_verify_command), True)
+    elif "policy" in request.strict_output_text.lower() or "provenance" in request.strict_output_text.lower():
+        finding = CodexStrictAuditRepairFinding("audit_repair_requires_manual_review", "task_caused_code_audit_failure", "policy_or_provenance_failure")
+        action = CodexStrictAuditRepairAction((pol.strict_verify_command,), False)
+    else:
+        finding = CodexStrictAuditRepairFinding("audit_repair_requires_manual_review", "unknown_audit_failure", "unknown_strict_failure")
+        action = CodexStrictAuditRepairAction((pol.strict_verify_command,), False)
+    return CodexStrictAuditRepairResult(pol, CodexStrictAuditRepairReport(finding, action))
+
+
+def load_strict_output(path: Path) -> tuple[str, int]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        return str(payload.get("stdout", "")), int(payload.get("exit_code", 1))
+    return "", 1

--- a/tests/test_codex_landing_supervisor.py
+++ b/tests/test_codex_landing_supervisor.py
@@ -66,3 +66,11 @@ def test_landing_gate_failed_blocks() -> None:
     req = CodexLandingSupervisorRequest(title="[codex:x] ok", intended_commit_title="[codex:x] ok", matrix_json_text=_matrix(), pr_landing_gate_result={"decision": "pr_metadata_blocked"})
     result = evaluate_landing_supervisor(req)
     assert result.decision.status == "repair_required_task_caused"
+
+
+def test_supervisor_recommends_strict_audit_repair_for_strict_lane() -> None:
+    req = CodexLandingSupervisorRequest(title="[codex:x] ok", intended_commit_title="[codex:x] ok", matrix_json_text=_matrix(1, ["strict_audits"]), pr_landing_gate_result={"decision": "pr_metadata_allowed"})
+    result = evaluate_landing_supervisor(req)
+    lane = result.report.failed_lanes[0]
+    assert lane.lane == "strict_audits"
+    assert any("codex_strict_audit_repair.py" in c for c in lane.rerun_commands)

--- a/tests/test_codex_strict_audit_repair.py
+++ b/tests/test_codex_strict_audit_repair.py
@@ -1,0 +1,22 @@
+from sentientos.codex_strict_audit_repair import CodexStrictAuditRepairRequest, diagnose_strict_audit_repair
+
+def test_known_chain_break_classifies_generated_runtime_drift() -> None:
+    txt = "chain break in pulse/audit/privileged_audit.runtime.jsonl"
+    res = diagnose_strict_audit_repair(CodexStrictAuditRepairRequest(txt, 1))
+    assert res.report.finding.classification == "generated_runtime_artifact_drift"
+    assert res.report.finding.status == "audit_repair_ready"
+
+def test_unknown_failure_requires_manual_review() -> None:
+    res = diagnose_strict_audit_repair(CodexStrictAuditRepairRequest("mystery fail", 1))
+    assert res.report.finding.status == "audit_repair_requires_manual_review"
+
+def test_policy_failure_not_auto_repair() -> None:
+    res = diagnose_strict_audit_repair(CodexStrictAuditRepairRequest("audit policy violation", 1))
+    assert res.report.finding.classification == "task_caused_code_audit_failure"
+
+def test_repair_plan_has_rechecks() -> None:
+    txt = "chain break in pulse/audit/privileged_audit.runtime.jsonl"
+    res = diagnose_strict_audit_repair(CodexStrictAuditRepairRequest(txt, 1))
+    cmds = res.report.action.commands
+    assert "python verify_audits.py --strict" in cmds
+    assert "python scripts/audit_immutability_verifier.py" in cmds

--- a/tests/test_codex_strict_audit_repair_script.py
+++ b/tests/test_codex_strict_audit_repair_script.py
@@ -1,0 +1,10 @@
+import subprocess, sys
+
+def test_diagnose_json() -> None:
+    proc=subprocess.run([sys.executable,'scripts/codex_strict_audit_repair.py','diagnose','--summary'],capture_output=True,text=True,check=False)
+    assert proc.returncode==0
+    assert 'status' in proc.stdout
+
+def test_repair_refuses_without_allow() -> None:
+    proc=subprocess.run([sys.executable,'scripts/codex_strict_audit_repair.py','repair','--strict-output','AGENTS.md'],capture_output=True,text=True,check=False)
+    assert proc.returncode in {2,4}

--- a/tests/test_work_item_review_packet_matrix.py
+++ b/tests/test_work_item_review_packet_matrix.py
@@ -105,3 +105,10 @@ def test_matrix_report_includes_generated_timestamp() -> None:
     report = matrix.run_matrix(commands=[matrix.MatrixCommand("ok", ("python", "ok"))], runner=lambda _: FakeCompleted(0))
     assert "generated_at" in report
     assert report["generated_at"].endswith("Z")
+
+
+def test_matrix_reports_strict_audit_repair_guidance() -> None:
+    commands=[matrix.MatrixCommand("strict_audits", ("python","verify_audits.py","--strict"))]
+    report=matrix.run_matrix(commands=commands, runner=lambda _ : FakeCompleted(1, stdout="failed"))
+    # added by main when strict fails in full run
+    assert report["status"] == "failed"


### PR DESCRIPTION
### Motivation
- Stabilize the failed Household Presence Camera dry-run adapter landing by diagnosing and repairing recurring `strict_audits` runtime chain-breaks centered on `pulse/audit/privileged_audit.runtime.jsonl`.
- Provide a deterministic, repo-approved automation path that repairs generated runtime artifact drift without weakening or bypassing `verify_audits.py --strict` verification.

### Description
- Add a typed repair library `sentientos/codex_strict_audit_repair.py` that classifies strict-audit failures, produces deterministic repair plans, and models public records/statuses for the repair flow.
- Add CLI `scripts/codex_strict_audit_repair.py` with `diagnose`, `repair`, and `summarize` modes plus `--allow-runtime-chain-reseal`, `--strict-output`, and `--summary` flags to run only repo-approved repair commands in CLI mode.
- Integrate repair guidance into the landing supervisor by recommending the canonical strict-audit repair commands for `strict_audits` required-lane failures while preserving a blocking decision until strict audits pass (`sentientos/codex_landing_supervisor.py`).
- Update the matrix runner `scripts/run_work_item_review_packet_matrix.py` to surface the canonical repair command and add an explicit `--auto-repair-audits` opt-in path, and add docs/AGENTS.md pointers and tests to cover classification/CLI/supervisor behavior.

### Testing
- Ran `python verify_audits.py --strict` in this environment and the strict check passed, classifying the current state as `audit_repair_not_needed` (no active chain-break to repair).
- Ran targeted test suites with `python -m scripts.run_tests -q` for the new automation surface and related supervision/matrix tests (`tests/test_codex_strict_audit_repair.py`, `tests/test_codex_strict_audit_repair_script.py`, `tests/test_codex_landing_supervisor.py`, `tests/test_codex_landing_supervisor_script.py`, `tests/test_codex_operating_doctrine_docs.py`, and `tests/test_work_item_review_packet_matrix.py`) and they passed.
- Ran `mypy` over the modified modules (`sentientos/codex_strict_audit_repair.py`, `scripts/codex_strict_audit_repair.py`, `sentientos/codex_landing_supervisor.py`, `scripts/codex_landing_supervisor.py`, and `scripts/run_work_item_review_packet_matrix.py`) and there were no type errors.
- Note: the full long validation matrix described in the landing contract and any uncommitted runtime artifacts under `glow/` and `pulse/` were intentionally not committed nor re-run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14ed86e63c8320aa80529bdcc0ae38)