### PR TITLE
[codex:developer] stabilize two-phase finalizer enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Reviewers are explicitly welcomed to question and strengthen this ledger.
 
 ## Codex Landing Authority (Streamlined)
 - After any task-caused repository change, run `python scripts/codex_finalize_landing.py finalize ...` in two phases during the same implementation task.
-- Before committing task-caused changes, run finalizer in pre-commit mode and commit only if it returns `ready_to_commit`.
+- Before committing task-caused changes, run finalizer in pre-commit mode (normally with `--allow-current-tracked-changes`) and commit only if it returns `ready_to_commit`.
 - After commit and before PR metadata/final report, rerun finalizer in pr-metadata/post-commit mode and require `ready_for_pr_metadata`.
 - Do not defer post-commit/pr-metadata finalizer to a later validation-only or seal follow-up turn.
 - If no source/doc/test/code changes were made, report validation-only completion and do not run commit or `make_pr`.

--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -3,7 +3,7 @@
 Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 
 ## Phases
-- `--phase pre-commit`: permits intended task files (via `--changed-file`) to be dirty, but still requires validation evidence and blocks unknown/generated drift unless cleanup is allowed and succeeds.
+- `--phase pre-commit`: permits intended task files (via `--allow-current-tracked-changes` (or explicit `--changed-file` for tightly controlled tasks)) to be dirty, but still requires validation evidence and blocks unknown/generated drift unless cleanup is allowed and succeeds.
 - `--phase post-commit` / `--phase pr-metadata`: requires a clean source tree and only returns PR-metadata readiness when all required validation lanes pass.
 
 ## Decisions
@@ -19,7 +19,7 @@ Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 - `unknown_dirty_file`
 - `clean`
 
-Pre-commit allows `intended_task_change` only when declared by `--changed-file`. Post-commit/pr-metadata blocks all source dirty files.
+Pre-commit allows `intended_task_change` when declared by `--changed-file` or inferred from tracked git changes with `--allow-current-tracked-changes`. Post-commit/pr-metadata blocks all source dirty files.
 
 ## Why PR metadata is forbidden early
 Focused tests, matrix, gate, or supervisor alone are insufficient. PR metadata is forbidden until the post-commit/pr-metadata finalizer returns `ready_for_pr_metadata`.
@@ -31,7 +31,7 @@ Focused tests, matrix, gate, or supervisor alone are insufficient. PR metadata i
 
 
 ## Canonical two-phase command examples
-Pre-commit: run finalize with `--phase pre-commit`, declared `--changed-file` entries, and require `ready_to_commit` before commit.
+Pre-commit: run finalize with `--phase pre-commit`, `--allow-current-tracked-changes` (or explicit `--changed-file` entries), and require `ready_to_commit` before commit.
 Post-commit/pr-metadata: rerun finalize with `--phase pr-metadata` and require `ready_for_pr_metadata` before `make_pr` and final reporting.
 
 ## No-change validation-only example

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -3,7 +3,7 @@
 ## Two-phase finalizer contract
 1. Before commit, run `python scripts/codex_finalize_landing.py finalize --phase pre-commit ...`.
    - Commit only if status is `ready_to_commit`.
-   - Intended source/doc/test changes may be present when declared via `--changed-file`.
+   - Intended source/doc/test changes may be present when declared via `--changed-file` or inferred from tracked changes with `--allow-current-tracked-changes` (pre-commit only).
 2. After commit and before PR metadata/final report, run `python scripts/codex_finalize_landing.py finalize --phase pr-metadata ...` (or `post-commit`).
    - Create/update PR metadata only if status is `ready_for_pr_metadata`.
    - Tree must be clean except allowed generated artifacts that are cleaned successfully.

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -84,7 +84,7 @@ python scripts/codex_finalize_landing.py finalize \
   --matrix-json-path /tmp/work_item_review_packet_matrix.json \
   --focused-test-command "<TASK_FOCUSED_TEST_COMMAND>" \
   --targeted-mypy-command "<TASK_TARGETED_MYPY_COMMAND>" \
-  --changed-file "<EACH_INTENDED_CHANGED_FILE>" \
+  --allow-current-tracked-changes \
   --allow-docs-bootstrap \
   --allow-strict-audit-repair \
   --allow-generated-artifact-cleanup \

--- a/scripts/codex_finalize_landing.py
+++ b/scripts/codex_finalize_landing.py
@@ -24,13 +24,20 @@ def _run(stage: str, cmd: str, required: bool = True) -> CodexFinalizeLandingCom
 
 def _git_status() -> list[str]:
     p = subprocess.run("git status --short", shell=True, text=True, capture_output=True)
-    return [l.strip() for l in p.stdout.splitlines() if l.strip()]
+    return [l.rstrip() for l in p.stdout.splitlines() if l.strip()]
+
+
+def _git_tracked_changes() -> tuple[str, ...]:
+    p = subprocess.run("git diff --name-only --cached && git diff --name-only", shell=True, text=True, capture_output=True)
+    names = [line.strip() for line in p.stdout.splitlines() if line.strip()]
+    return tuple(sorted(set(names)))
 
 
 def _classify(status_lines: list[str], changed_files: tuple[str, ...]) -> tuple[CodexFinalizeLandingArtifactFinding, ...]:
     out: list[CodexFinalizeLandingArtifactFinding] = []
     changed_file_set = set(changed_files)
     for line in status_lines:
+        is_untracked = line.startswith("??")
         path = line[3:] if len(line) > 3 else line
         if path.startswith(GENERATED_PREFIXES):
             cls = "generated_runtime_artifact"
@@ -38,7 +45,7 @@ def _classify(status_lines: list[str], changed_files: tuple[str, ...]) -> tuple[
         elif path.startswith("pulse/audit/"):
             cls = "versioned_audit_artifact"
             action = "review"
-        elif path in changed_file_set:
+        elif (not is_untracked) and path in changed_file_set:
             cls = "intended_task_change"
             action = "allow_pre_commit"
         elif path.endswith((".py", ".md", ".json", ".yaml", ".yml", ".toml", ".txt", ".bat")):
@@ -72,6 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
         s.add_argument("--targeted-mypy-command", action="append", default=[])
         s.add_argument("--extra-required-command", action="append", default=[])
         s.add_argument("--changed-file", action="append", default=[])
+        s.add_argument("--allow-current-tracked-changes", action="store_true")
         s.add_argument("--allow-docs-bootstrap", action="store_true")
         s.add_argument("--allow-strict-audit-repair", action="store_true")
         s.add_argument("--allow-generated-artifact-cleanup", action="store_true")
@@ -90,6 +98,13 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"status": "ok", "git_status": _git_status()}, indent=2))
         return 0
 
+    inferred_changed_files: tuple[str, ...] = ()
+    if a.allow_current_tracked_changes:
+        if a.phase.replace("_", "-") != "pre-commit":
+            print(json.dumps({"status": "error", "reason": "allow_current_tracked_changes_requires_pre_commit"}, indent=2))
+            return 2
+        inferred_changed_files = _git_tracked_changes()
+
     req = CodexFinalizeLandingRequest(
         title=a.title or "",
         intended_commit_title=a.intended_commit_title or "",
@@ -99,6 +114,9 @@ def main(argv: list[str] | None = None) -> int:
         targeted_mypy_commands=tuple(a.targeted_mypy_command),
         extra_required_commands=tuple(a.extra_required_command),
         changed_files=tuple(a.changed_file),
+        inferred_changed_files=inferred_changed_files,
+        allow_current_tracked_changes=a.allow_current_tracked_changes,
+        dirty_file_classification_source="inferred" if a.allow_current_tracked_changes else "declared",
         allow_no_focused_tests=a.allow_no_focused_tests,
         workspace_root=a.workspace_root,
         summary=a.summary,
@@ -122,7 +140,7 @@ def main(argv: list[str] | None = None) -> int:
     ]
     if a.allow_generated_artifact_cleanup:
         _cleanup_generated()
-    findings = _classify(_git_status(), tuple(a.changed_file))
+    findings = _classify(_git_status(), tuple(a.changed_file) + inferred_changed_files)
     result = evaluate_finalize_landing(
         req,
         tuple(cmds),
@@ -132,7 +150,18 @@ def main(argv: list[str] | None = None) -> int:
     payload = result.to_dict()
     if a.output:
         Path(a.output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    print(json.dumps(payload if not a.summary else {"status": result.decision.status, "reasons": result.decision.reasons}, indent=2))
+    print(
+        json.dumps(
+            payload
+            if not a.summary
+            else {
+                "status": result.decision.status,
+                "reasons": result.decision.reasons,
+                "inferred_changed_files": inferred_changed_files,
+            },
+            indent=2,
+        )
+    )
     return 0 if result.decision.status in {"ready_to_commit", "ready_for_pr_metadata"} else 1
 
 

--- a/sentientos/codex_finalize_landing.py
+++ b/sentientos/codex_finalize_landing.py
@@ -37,6 +37,9 @@ class CodexFinalizeLandingRequest:
     targeted_mypy_commands: tuple[str, ...] = ()
     extra_required_commands: tuple[str, ...] = ()
     changed_files: tuple[str, ...] = ()
+    inferred_changed_files: tuple[str, ...] = ()
+    allow_current_tracked_changes: bool = False
+    dirty_file_classification_source: str = "declared"
     allow_no_focused_tests: bool = False
     workspace_root: str = "."
     summary: bool = False
@@ -109,7 +112,7 @@ def evaluate_finalize_landing(
         if result.required and result.exit_code != 0:
             reasons.append(f"stage_failed:{result.stage}")
 
-    changed_file_set = set(request.changed_files)
+    changed_file_set = set(request.changed_files) | set(request.inferred_changed_files)
     found_source_not_declared = False
     found_unknown = False
     found_generated = False

--- a/tests/test_codex_finalize_landing.py
+++ b/tests/test_codex_finalize_landing.py
@@ -43,3 +43,19 @@ def test_pr_metadata_clean_ready() -> None:
     artifacts = (CodexFinalizeLandingArtifactFinding("", "clean", "none"),)
     res = evaluate_finalize_landing(req, _ok_cmds(), artifacts)
     assert res.decision.status == "ready_for_pr_metadata"
+
+
+def test_pre_commit_ready_with_inferred_source_changes() -> None:
+    req = CodexFinalizeLandingRequest(
+        title="x",
+        intended_commit_title="x",
+        matrix_json_path="/tmp/m.json",
+        phase="pre-commit",
+        focused_test_commands=("t",),
+        inferred_changed_files=("docs/development/codex_finalize_landing.md",),
+        allow_current_tracked_changes=True,
+        dirty_file_classification_source="inferred",
+    )
+    artifacts = (CodexFinalizeLandingArtifactFinding("docs/development/codex_finalize_landing.md", "intended_task_change", "allow_pre_commit"),)
+    res = evaluate_finalize_landing(req, _ok_cmds(), artifacts)
+    assert res.decision.status == "ready_to_commit"

--- a/tests/test_codex_finalize_landing_script.py
+++ b/tests/test_codex_finalize_landing_script.py
@@ -17,3 +17,20 @@ def test_parser_has_phase_and_changed_file() -> None:
     assert args.cmd == "finalize"
     assert args.phase == "pre-commit"
     assert args.changed_file == ["sentientos/codex_finalize_landing.py"]
+
+
+def test_parser_has_allow_current_tracked_changes() -> None:
+    p = build_parser()
+    args = p.parse_args(
+        [
+            "finalize",
+            "--title",
+            "t",
+            "--intended-commit-title",
+            "t",
+            "--phase",
+            "pre-commit",
+            "--allow-current-tracked-changes",
+        ]
+    )
+    assert args.allow_current_tracked_changes is True


### PR DESCRIPTION
### Motivation
- Make the pre-commit finalizer usable and hard-to-bypass by allowing it to safely infer intended tracked changes from git instead of requiring brittle manual `--changed-file` lists. 
- Preserve strict validation and audit behavior so unknown/untracked generated artifacts still block and post-commit/pr-metadata phases still require a clean tree. 
- Fix the root cause of spurious `source_change_not_declared` failures caused by incorrect parsing of `git status --short` output. 

### Description
- Add request fields to the finalizer model: `inferred_changed_files`, `allow_current_tracked_changes`, and `dirty_file_classification_source` and incorporate `inferred_changed_files` into evaluator comparisons. 
- Add CLI flag `--allow-current-tracked-changes` to `scripts/codex_finalize_landing.py` (pre-commit only) which runs a safe `git diff --name-only --cached && git diff --name-only` subprocess and passes inferred tracked file names into the library request. 
- Harden dirty-file classification: preserve leading status spacing from `git status --short` (`rstrip()`), detect untracked lines (`??`) so only tracked files can be inferred as `intended_task_change`, and continue to classify generated/untracked/unknown files as before. 
- Keep generated-artifact cleanup explicit and phase-gated: inference is allowed only in `--phase pre-commit`, and the inference path does not bypass validation or allow post-commit dirty trees. 
- Update docs/templates (`AGENTS.md`, `docs/development/codex_finalize_landing.md`, `docs/development/codex_validation_and_landing_contract.md`, `docs/development/codex_whole_system_task_template.md`) to recommend the new inference flag for normal implementation tasks while preserving `--changed-file` for tightly controlled flows. 
- Add tests: parser flag coverage and a unit test exercising the evaluator with `inferred_changed_files` to prove `ready_to_commit` when tracked changes are inferred. 

### Testing
- Ran the focused and integration test matrix via `python -m scripts.run_tests -q` covering `tests/test_codex_finalize_landing.py`, `tests/test_codex_finalize_landing_script.py`, doctrine/docs, scaffold/bootstrapper/presets, strict audit repair, landing supervisor, matrix, and proof bundle lanes, and all required test suites completed successfully. 
- Ran type checks and baselines with `mypy` and `python scripts/check_mypy_baseline.py`, and the targeted mypy/baseline checks succeeded. 
- Ran matrix summary and output via `python scripts/run_work_item_review_packet_matrix.py --summary` and `--output` and verified required matrix evidence. 
- Ran PR landing gate and landing supervisor evaluation via `python scripts/codex_pr_landing_gate.py gate` and `python scripts/codex_landing_supervisor.py evaluate` and observed passing results for the validation packet. 
- Exercised the new CLI inference path with `python scripts/codex_finalize_landing.py finalize --phase pre-commit ... --allow-current-tracked-changes --summary` which returned `ready_to_commit`, then ran the `--phase pr-metadata` finalizer which returned `ready_for_pr_metadata`. 
- Built docs (`python scripts/build_docs.py`), ran prompt-boundary checks (`python scripts/verify_context_hygiene_prompt_boundaries.py`), `verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`, and all verification steps passed after explicit generated-artifact cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15e31eba1c83209d05a90dbfa4b1e4)