### PR TITLE
[codex:developer] stabilize finalizer task-file inference

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -3,7 +3,7 @@
 Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 
 ## Phases
-- `--phase pre-commit`: permits intended task files (via `--allow-current-tracked-changes` (or explicit `--changed-file` for tightly controlled tasks)) to be dirty, but still requires validation evidence and blocks unknown/generated drift unless cleanup is allowed and succeeds.
+- `--phase pre-commit`: permits intended task files (via `--allow-current-tracked-changes` and `--allow-current-task-files` (or explicit `--changed-file` for tightly controlled tasks)) to be dirty, but still requires validation evidence and blocks unknown/generated drift unless cleanup is allowed and succeeds.
 - `--phase post-commit` / `--phase pr-metadata`: requires a clean source tree and only returns PR-metadata readiness when all required validation lanes pass.
 
 ## Decisions
@@ -19,7 +19,7 @@ Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 - `unknown_dirty_file`
 - `clean`
 
-Pre-commit allows `intended_task_change` when declared by `--changed-file` or inferred from tracked git changes with `--allow-current-tracked-changes`. Post-commit/pr-metadata blocks all source dirty files.
+Pre-commit allows `intended_task_change` when declared by `--changed-file`, inferred from tracked git changes with `--allow-current-tracked-changes`, and inferred from safe untracked task files with `--allow-current-task-files`. Post-commit/pr-metadata blocks all source dirty files.
 
 ## Why PR metadata is forbidden early
 Focused tests, matrix, gate, or supervisor alone are insufficient. PR metadata is forbidden until the post-commit/pr-metadata finalizer returns `ready_for_pr_metadata`.
@@ -31,7 +31,7 @@ Focused tests, matrix, gate, or supervisor alone are insufficient. PR metadata i
 
 
 ## Canonical two-phase command examples
-Pre-commit: run finalize with `--phase pre-commit`, `--allow-current-tracked-changes` (or explicit `--changed-file` entries), and require `ready_to_commit` before commit.
+Pre-commit: run finalize with `--phase pre-commit`, `--allow-current-tracked-changes`, `--allow-current-task-files` (or explicit `--changed-file` entries), and require `ready_to_commit` before commit.
 Post-commit/pr-metadata: rerun finalize with `--phase pr-metadata` and require `ready_for_pr_metadata` before `make_pr` and final reporting.
 
 ## No-change validation-only example

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -3,7 +3,7 @@
 ## Two-phase finalizer contract
 1. Before commit, run `python scripts/codex_finalize_landing.py finalize --phase pre-commit ...`.
    - Commit only if status is `ready_to_commit`.
-   - Intended source/doc/test changes may be present when declared via `--changed-file` or inferred from tracked changes with `--allow-current-tracked-changes` (pre-commit only).
+   - Intended source/doc/test changes may be present when declared via `--changed-file`, inferred from tracked changes with `--allow-current-tracked-changes`, and inferred from safe untracked task files with `--allow-current-task-files` (pre-commit only).
 2. After commit and before PR metadata/final report, run `python scripts/codex_finalize_landing.py finalize --phase pr-metadata ...` (or `post-commit`).
    - Create/update PR metadata only if status is `ready_for_pr_metadata`.
    - Tree must be clean except allowed generated artifacts that are cleaned successfully.

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -85,6 +85,7 @@ python scripts/codex_finalize_landing.py finalize \
   --focused-test-command "<TASK_FOCUSED_TEST_COMMAND>" \
   --targeted-mypy-command "<TASK_TARGETED_MYPY_COMMAND>" \
   --allow-current-tracked-changes \
+  --allow-current-task-files \
   --allow-docs-bootstrap \
   --allow-strict-audit-repair \
   --allow-generated-artifact-cleanup \

--- a/scripts/codex_finalize_landing.py
+++ b/scripts/codex_finalize_landing.py
@@ -16,6 +16,8 @@ from sentientos.codex_finalize_landing import (
 )
 
 GENERATED_PREFIXES = ("glow/", "pulse/", "artifacts/codex/")
+BLOCKED_PATH_PARTS = ("__pycache__", ".pytest_cache")
+MEDIA_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".mp4", ".mov", ".wav", ".mp3")
 DEFAULT_STAGE_TIMEOUT_SECONDS = 900
 DEFAULT_OVERALL_TIMEOUT_SECONDS = 3600
 MAX_OUTPUT_LINES = 40
@@ -125,18 +127,36 @@ def _git_tracked_changes() -> tuple[str, ...]:
     return tuple(sorted(set(names)))
 
 
-def _classify(status_lines: list[str], changed_files: tuple[str, ...]) -> tuple[CodexFinalizeLandingArtifactFinding, ...]:
+def _is_safe_untracked_task_file(path: str) -> bool:
+    if path == "AGENTS.md":
+        return True
+    if path.startswith(("sentientos/", "scripts/", "tests/", "docs/")) and path.endswith((".py", ".md")):
+        return True
+    if path.startswith("tests/fixtures/") and path.endswith(".json"):
+        return True
+    if path.startswith("artifacts/proof_bundles/") and path.endswith(".json"):
+        return True
+    return False
+
+
+def _classify(status_lines: list[str], changed_files: tuple[str, ...], inferred_untracked_task_files: tuple[str, ...]) -> tuple[CodexFinalizeLandingArtifactFinding, ...]:
     out: list[CodexFinalizeLandingArtifactFinding] = []
     changed_file_set = set(changed_files)
     for line in status_lines:
         is_untracked = line.startswith("??")
         path = line[3:] if len(line) > 3 else line
-        if path.startswith(GENERATED_PREFIXES):
+        if path.startswith(GENERATED_PREFIXES) or any(part in path for part in BLOCKED_PATH_PARTS):
             cls = "generated_runtime_artifact"
             action = "cleanup"
+        elif path.lower().endswith(MEDIA_SUFFIXES):
+            cls = "unknown_dirty_file"
+            action = "block"
         elif path.startswith("pulse/audit/"):
             cls = "versioned_audit_artifact"
             action = "review"
+        elif is_untracked and path in set(inferred_untracked_task_files):
+            cls = "intended_task_change"
+            action = "allow_pre_commit"
         elif (not is_untracked) and path in changed_file_set:
             cls = "intended_task_change"
             action = "allow_pre_commit"
@@ -184,6 +204,7 @@ def build_parser() -> argparse.ArgumentParser:
         s.add_argument("--extra-required-command", action="append", default=[])
         s.add_argument("--changed-file", action="append", default=[])
         s.add_argument("--allow-current-tracked-changes", action="store_true")
+        s.add_argument("--allow-current-task-files", action="store_true")
         s.add_argument("--allow-docs-bootstrap", action="store_true")
         s.add_argument("--allow-strict-audit-repair", action="store_true")
         s.add_argument("--allow-generated-artifact-cleanup", action="store_true")
@@ -212,6 +233,20 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps({"status": "error", "reason": "allow_current_tracked_changes_requires_pre_commit"}, indent=2))
             return 2
         inferred_changed_files = _git_tracked_changes()
+    inferred_untracked_task_files: tuple[str, ...] = ()
+    if a.allow_current_task_files:
+        if a.phase.replace("_", "-") != "pre-commit":
+            print(json.dumps({"status": "error", "reason": "allow_current_task_files_requires_pre_commit"}, indent=2))
+            return 2
+        status_lines = _git_status()
+        candidates = []
+        for line in status_lines:
+            if not line.startswith("??"):
+                continue
+            path = line[3:] if len(line) > 3 else line
+            if _is_safe_untracked_task_file(path):
+                candidates.append(path)
+        inferred_untracked_task_files = tuple(sorted(set(candidates)))
 
     req = CodexFinalizeLandingRequest(
         title=a.title or "",
@@ -223,8 +258,11 @@ def main(argv: list[str] | None = None) -> int:
         extra_required_commands=tuple(a.extra_required_command),
         changed_files=tuple(a.changed_file),
         inferred_changed_files=inferred_changed_files,
+        inferred_tracked_changed_files=inferred_changed_files,
+        inferred_untracked_task_files=inferred_untracked_task_files,
         allow_current_tracked_changes=a.allow_current_tracked_changes,
-        dirty_file_classification_source="inferred" if a.allow_current_tracked_changes else "declared",
+        allow_current_task_files=a.allow_current_task_files,
+        dirty_file_classification_source="tracked+untracked_inferred" if (a.allow_current_tracked_changes or a.allow_current_task_files) else "declared",
         allow_no_focused_tests=a.allow_no_focused_tests,
         workspace_root=a.workspace_root,
         summary=a.summary,
@@ -271,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
         _cleanup_generated()
         _progress(a.progress, "[finalizer] stage end: generated_artifact_cleanup status=passed exit_code=0")
 
-    findings = _classify(_git_status(), tuple(a.changed_file) + inferred_changed_files)
+    findings = _classify(_git_status(), tuple(a.changed_file) + inferred_changed_files, inferred_untracked_task_files)
     landing_result = evaluate_finalize_landing(req, tuple(commands), findings, policy=CodexFinalizeLandingPolicy(allow_generated_artifact_cleanup=a.allow_generated_artifact_cleanup))
 
     if not decision_reasons:

--- a/sentientos/codex_finalize_landing.py
+++ b/sentientos/codex_finalize_landing.py
@@ -38,7 +38,10 @@ class CodexFinalizeLandingRequest:
     extra_required_commands: tuple[str, ...] = ()
     changed_files: tuple[str, ...] = ()
     inferred_changed_files: tuple[str, ...] = ()
+    inferred_tracked_changed_files: tuple[str, ...] = ()
+    inferred_untracked_task_files: tuple[str, ...] = ()
     allow_current_tracked_changes: bool = False
+    allow_current_task_files: bool = False
     dirty_file_classification_source: str = "declared"
     allow_no_focused_tests: bool = False
     workspace_root: str = "."
@@ -112,7 +115,7 @@ def evaluate_finalize_landing(
         if result.required and result.exit_code != 0:
             reasons.append(f"stage_failed:{result.stage}")
 
-    changed_file_set = set(request.changed_files) | set(request.inferred_changed_files)
+    changed_file_set = set(request.changed_files) | set(request.inferred_changed_files) | set(request.inferred_tracked_changed_files) | set(request.inferred_untracked_task_files)
     found_source_not_declared = False
     found_unknown = False
     found_generated = False

--- a/sentientos/codex_task_scaffold.py
+++ b/sentientos/codex_task_scaffold.py
@@ -144,6 +144,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
         prompt = (
             "Use AGENTS.md Whole-System Codex Operating Doctrine, whole-system task template, and validation/landing contract.\n"
             "Critical landing rule: run the full relevant validation matrix after the final task-caused code/doc/test change and before final reporting or PR metadata.\n"
+            "Pre-commit finalizer commands for normal implementation tasks should include --allow-current-tracked-changes and --allow-current-task-files.\n"
             "Do not return 'feature exists but full matrix not run.' Do not offer to run matrix later.\n"
             "Do not create PR metadata before green final validation.\n"
             f"Goal: {request.task_goal}\nSubsystem: {request.task_name} ({request.subsystem_kind})."

--- a/tests/test_codex_finalize_landing.py
+++ b/tests/test_codex_finalize_landing.py
@@ -59,3 +59,19 @@ def test_pre_commit_ready_with_inferred_source_changes() -> None:
     artifacts = (CodexFinalizeLandingArtifactFinding("docs/development/codex_finalize_landing.md", "intended_task_change", "allow_pre_commit"),)
     res = evaluate_finalize_landing(req, _ok_cmds(), artifacts)
     assert res.decision.status == "ready_to_commit"
+
+
+def test_pre_commit_ready_with_inferred_untracked_task_files() -> None:
+    req = CodexFinalizeLandingRequest(
+        title="x",
+        intended_commit_title="x",
+        matrix_json_path="/tmp/m.json",
+        phase="pre-commit",
+        focused_test_commands=("t",),
+        inferred_untracked_task_files=("tests/test_new_case.py",),
+        allow_current_task_files=True,
+        dirty_file_classification_source="tracked+untracked_inferred",
+    )
+    artifacts = (CodexFinalizeLandingArtifactFinding("tests/test_new_case.py", "intended_task_change", "allow_pre_commit"),)
+    res = evaluate_finalize_landing(req, _ok_cmds(), artifacts)
+    assert res.decision.status == "ready_to_commit"

--- a/tests/test_codex_finalize_landing_script.py
+++ b/tests/test_codex_finalize_landing_script.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scripts.codex_finalize_landing import build_parser, main
+from scripts.codex_finalize_landing import _classify, build_parser, main
 
 
 def test_parser_has_phase_and_changed_file() -> None:
@@ -39,6 +39,23 @@ def test_parser_has_allow_current_tracked_changes() -> None:
         ]
     )
     assert args.allow_current_tracked_changes is True
+
+
+def test_parser_has_allow_current_task_files() -> None:
+    p = build_parser()
+    args = p.parse_args(["finalize", "--phase", "pre-commit", "--allow-current-task-files"])
+    assert args.allow_current_task_files is True
+
+
+def test_classify_untracked_task_file_inferred() -> None:
+    findings = _classify(["?? tests/test_new_case.py"], (), ("tests/test_new_case.py",))
+    assert findings[0].classification == "intended_task_change"
+
+
+def test_classify_untracked_unknown_root_and_media_blocked() -> None:
+    findings = _classify(["?? random.bin", "?? docs/image.png"], (), ())
+    assert findings[0].classification == "unknown_dirty_file"
+    assert findings[1].classification == "unknown_dirty_file"
 
 
 def test_parser_has_output_timeouts_and_progress_flags() -> None:


### PR DESCRIPTION
### Motivation

- The pre-commit finalizer could not safely infer newly created untracked source/doc/test/fixture files and therefore required manual `--changed-file` lists, causing normal feature landings to be blocked.  
- The goal is to allow safe task-file inference in the pre-commit phase so normal implementation tasks that add new source/docs/tests can return `ready_to_commit` without enumerating every new file.  
- This must be scoped to pre-commit only, preserve existing validation/audit requirements, and continue to block generated artifacts, media payloads, unknown-root files, and unrelated dirty-tree state.

### Description

- Add a pre-commit-only CLI flag `--allow-current-task-files` and safe-untracked allowlist logic to `scripts/codex_finalize_landing.py`, including `_is_safe_untracked_task_file` and classification changes to treat allowed untracked files as `intended_task_change` while blocking generated and media files.  
- Extend the request metadata in `sentientos/codex_finalize_landing.py` with `inferred_tracked_changed_files`, `inferred_untracked_task_files`, and `allow_current_task_files`, and include inferred files in the decision `changed_file_set` so pre-commit evaluation accepts them as declared.  
- Tighten classification rules to continue treating `glow/`, `pulse/`, `artifacts/codex/`, `__pycache__`, `.pytest_cache` and common media suffixes as blocking/generated, and surface deterministic outputs listing inferred tracked and untracked files.  
- Update user-facing guidance and scaffolding prompts in `docs/development/*` and `sentientos/codex_task_scaffold.py` to document the new pre-commit flow and add tests in `tests/` to cover parser flags, classifier behavior, and library-level decision logic.

### Testing

- Unit and script tests including `tests/test_codex_finalize_landing.py` and `tests/test_codex_finalize_landing_script.py` (and related scaffold/doctrine tests) were run via `python -m scripts.run_tests -q` and passed.  
- Static type checks were run with `python -m mypy ...` for the changed modules and `python scripts/check_mypy_baseline.py`, and the runs completed with no new errors reported.  
- Matrix, gate and supervisor validation were exercised with `python scripts/run_work_item_review_packet_matrix.py --output /tmp/work_item_review_packet_matrix.json`, `python scripts/codex_pr_landing_gate.py gate ...`, and `python scripts/codex_landing_supervisor.py evaluate ...` and returned pass/ready results.  
- Two-phase finalizer validation was executed end-to-end: `python scripts/codex_finalize_landing.py finalize --phase pre-commit ... --allow-current-tracked-changes --allow-current-task-files --output /tmp/codex_finalize_landing_task_file_inference_pre_commit.json` produced `ready_to_commit`, and the post-commit/pr-metadata run produced `ready_for_pr_metadata` at `/tmp/codex_finalize_landing_task_file_inference_pr_metadata.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a167eb57eec832097c491530edbfc11)