### PR TITLE
[codex:embodiment] add household presence camera capture authorization envelope

### DIFF
--- a/docs/architecture/household_presence_camera_capture_authorization.md
+++ b/docs/architecture/household_presence_camera_capture_authorization.md
@@ -1,0 +1,20 @@
+# Household Presence Camera Capture Authorization Envelope
+
+Metadata-only authorization envelope for **future review** of household camera capture attempts. It never opens hardware, captures media, or executes live adapters.
+
+## Purpose
+Provides deterministic records for operator grant, scope/expiry/revocation checks, and proof bindings (disabled-capture adapter, local shell, live-adapter stub, host candidate, zone config, dry-run, policy chain).
+
+## Boundaries
+- No camera/microphone/hardware access.
+- No media payload handling.
+- No subprocess or provider/network authority.
+- Always returns `capture_enabled=false` and related disabled flags.
+
+## Flow
+1. authorization envelope
+2. operator review
+3. dry-run proof renewal
+4. disabled-capture boundary verification
+5. future live-candidate review only
+6. policy-gated live adapter only after explicit future separate task

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -435,6 +435,7 @@ Work item lifecycle attestation review digest index verification is documented i
 - Household presence camera local adapter shell: `docs/architecture/household_presence_camera_local_adapter_shell.md`
 - Household presence camera live adapter stub: `docs/architecture/household_presence_camera_live_adapter_stub.md`
 - Household presence camera disabled-capture adapter: `docs/architecture/household_presence_camera_disabled_capture_adapter.md`
+- Household presence camera capture-authorization envelope: `docs/architecture/household_presence_camera_capture_authorization.md`
 
 - docs/development/codex_landing_supervisor.md
 

--- a/scripts/build_household_presence_camera_capture_authorization.py
+++ b/scripts/build_household_presence_camera_capture_authorization.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from sentientos.household_presence_camera_capture_authorization import build_default_policy, evaluate_capture_authorization, validate_policy
+
+def _read(p:str)->dict:
+    return json.loads(Path(p).read_text())
+
+def main()->int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('command',choices=['build-default','evaluate','validate','summarize','inspect-fixture'])
+    ap.add_argument('--input');ap.add_argument('--fixtures-dir',default='tests/fixtures/household_presence_camera_capture_authorization');ap.add_argument('--output');ap.add_argument('--summary',action='store_true');ap.add_argument('--fixture-name')
+    a=ap.parse_args()
+    out={}
+    if a.command=='build-default': out={'policy':build_default_policy().__dict__}
+    elif a.command=='validate': out=validate_policy(build_default_policy())
+    elif a.command=='inspect-fixture': out=_read(str(Path(a.fixtures_dir)/str(a.fixture_name)))
+    else:
+        payload=_read(a.input) if a.input else {}
+        r=evaluate_capture_authorization(payload)
+        out=r.to_dict()
+    text=json.dumps(out,indent=2,sort_keys=True)
+    if a.output: Path(a.output).write_text(text+'\n')
+    print(text)
+    return 1 if out.get('status','').startswith('capture_authorization_blocked') or out.get('status')=='capture_authorization_failed' else 0
+if __name__=='__main__': raise SystemExit(main())

--- a/sentientos/household_presence_camera_capture_authorization.py
+++ b/sentientos/household_presence_camera_capture_authorization.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from dataclasses import dataclass, asdict
+import hashlib, json
+from typing import Any, Literal, Mapping
+
+Status = Literal["capture_authorization_valid_for_future_review","capture_authorization_ready_for_dry_run_only","capture_authorization_operator_review_required","capture_authorization_blocked_missing_operator_grant","capture_authorization_blocked_expired_grant","capture_authorization_blocked_revoked_grant","capture_authorization_blocked_scope_mismatch","capture_authorization_blocked_missing_disabled_capture_proof","capture_authorization_blocked_missing_shell_proof","capture_authorization_blocked_missing_stub_proof","capture_authorization_blocked_missing_host_candidate","capture_authorization_blocked_missing_zone_config","capture_authorization_blocked_missing_dry_run_proof","capture_authorization_blocked_missing_policy_chain","capture_authorization_blocked_raw_media","capture_authorization_blocked_speaker_boundary","capture_authorization_blocked_external_authority","capture_authorization_failed"]
+Mode = Literal["design_only","dry_run_only","future_live_review","capture_attempt"]
+
+FORBIDDEN_NEXT_STEPS=("open_camera_now","attempt_capture","enable_live_capture","enable_live_recording","store_raw_media","attach_media_payload","bypass_policy_chain","bypass_zone_config","bypass_disabled_capture_boundary","bypass_dry_run","enable_speaker_output","enable_external_disclosure")
+
+@dataclass(frozen=True)
+class HouseholdCameraCaptureAuthorizationPolicy:
+    schema_version:str="household_presence_camera_capture_authorization_policy.v1"
+    allow_design_only_without_dry_run_proof:bool=True
+
+@dataclass(frozen=True)
+class HouseholdCameraCaptureAuthorizationResult:
+    status:Status
+    findings:tuple[str,...]
+    authorization_enables_live_capture:bool=False
+    capture_enabled:bool=False
+    capture_available:bool=False
+    live_hardware_enabled:bool=False
+    raw_media_storage_enabled:bool=False
+    no_live_capture_performed:bool=True
+    speaker_output_enabled:bool=False
+    external_disclosure_enabled:bool=False
+    forbidden_next_steps:tuple[str,...]=FORBIDDEN_NEXT_STEPS
+    deterministic_digest:str=""
+    def to_dict(self)->dict[str,Any]: return asdict(self)
+
+def build_default_policy()->HouseholdCameraCaptureAuthorizationPolicy: return HouseholdCameraCaptureAuthorizationPolicy()
+def validate_policy(policy:HouseholdCameraCaptureAuthorizationPolicy)->dict[str,Any]:
+    ok=policy.schema_version.endswith('.v1')
+    return {"ok":ok,"status":"household_presence_camera_capture_authorization_policy_valid" if ok else "household_presence_camera_capture_authorization_policy_invalid"}
+
+def _has(v:Mapping[str,Any],k:str)->bool: return bool(str(v.get(k,"")).strip())
+def _digest(payload:dict[str,Any])->str: return hashlib.sha256(json.dumps(payload,sort_keys=True).encode()).hexdigest()
+
+def evaluate_capture_authorization(payload:Mapping[str,Any], policy:HouseholdCameraCaptureAuthorizationPolicy|None=None)->HouseholdCameraCaptureAuthorizationResult:
+    p=policy or build_default_policy(); f:list[str]=[]
+    grant=dict(payload.get('operator_grant',{})) if isinstance(payload.get('operator_grant'),Mapping) else {}
+    req=dict(payload.get('request',{})) if isinstance(payload.get('request'),Mapping) else {}
+    mode=str(req.get('requested_mode','design_only'))
+    if not grant: return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_missing_operator_grant",("missing_operator_grant",),deterministic_digest=_digest({"f":["missing_operator_grant"]}))
+    if not _has(grant,'expires_at'): f.append('missing_grant_expiry')
+    if str(grant.get('expires_at','')) <= str(req.get('requested_at','')): return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_expired_grant",("expired_grant",),deterministic_digest=_digest({"f":["expired_grant"]}))
+    if _has(grant,'revoked_at'): return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_revoked_grant",("revoked_grant",),deterministic_digest=_digest({"f":["revoked_grant"]}))
+    for key,tag,status in (("live_capture_allowed","grant_allows_live_capture","capture_authorization_blocked_scope_mismatch"),("raw_media_allowed","grant_allows_raw_media","capture_authorization_blocked_raw_media"),("speaker_output_allowed","grant_allows_speaker_output","capture_authorization_blocked_speaker_boundary"),("external_disclosure_allowed","grant_allows_external_disclosure","capture_authorization_blocked_external_authority")):
+        if grant.get(key) is True: return HouseholdCameraCaptureAuthorizationResult(status,(tag,),deterministic_digest=_digest({"f":[tag]}))
+    for rk,status,tag in (("disabled_capture_proof_digest","capture_authorization_blocked_missing_disabled_capture_proof","missing_disabled_capture_proof"),("local_shell_proof_digest","capture_authorization_blocked_missing_shell_proof","missing_shell_proof"),("live_adapter_stub_proof_digest","capture_authorization_blocked_missing_stub_proof","missing_stub_proof"),("host_inventory_candidate_digest","capture_authorization_blocked_missing_host_candidate","missing_host_candidate"),("zone_config_id","capture_authorization_blocked_missing_zone_config","missing_zone_config"),("policy_chain_id","capture_authorization_blocked_missing_policy_chain","missing_policy_chain")):
+        if not _has(req,rk): return HouseholdCameraCaptureAuthorizationResult(status,(tag,),deterministic_digest=_digest({"f":[tag]}))
+    if mode != 'design_only' or not p.allow_design_only_without_dry_run_proof:
+        if not _has(req,'dry_run_proof_digest'): return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_missing_dry_run_proof",("missing_dry_run_proof",),deterministic_digest=_digest({"f":["missing_dry_run_proof"]}))
+    if any(bool(req.get(k,False)) for k in ('capture_requested','live_hardware_requested','raw_media_requested','raw_media_payload_present','base64_media_present')):
+        return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_raw_media",("raw_or_capture_requested",),deterministic_digest=_digest({"f":["raw_or_capture_requested"]}))
+    if bool(req.get('speaker_output_requested',False)): return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_speaker_boundary",("speaker_output_requested",),deterministic_digest=_digest({"f":["speaker_output_requested"]}))
+    if bool(req.get('external_disclosure_requested',False)): return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_external_authority",("external_disclosure_requested",),deterministic_digest=_digest({"f":["external_disclosure_requested"]}))
+    if mode=='capture_attempt': return HouseholdCameraCaptureAuthorizationResult("capture_authorization_blocked_scope_mismatch",("capture_attempt_blocked",),deterministic_digest=_digest({"f":["capture_attempt_blocked"]}))
+    status:Status = "capture_authorization_ready_for_dry_run_only" if mode in {"design_only","dry_run_only"} else "capture_authorization_operator_review_required"
+    return HouseholdCameraCaptureAuthorizationResult(status,tuple(f),deterministic_digest=_digest({"status":status,"f":f,"mode":mode}))

--- a/tests/fixtures/household_presence_camera_capture_authorization/base64_media_present_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/base64_media_present_blocked.json
@@ -1,0 +1,27 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "base64_media_present": true,
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/capture_attempt_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/capture_attempt_blocked.json
@@ -1,0 +1,27 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "capture_requested": true,
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/expired_grant_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/expired_grant_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2026-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/future_live_review_requires_operator_review.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/future_live_review_requires_operator_review.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "future_live_review",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_external_disclosure_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_external_disclosure_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": true,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_live_capture_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_live_capture_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": true,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_raw_media_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_raw_media_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": true,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_speaker_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/grant_allows_speaker_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": true
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_disabled_capture_proof_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_disabled_capture_proof_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_dry_run_proof_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_dry_run_proof_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "dry_run_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_host_candidate_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_host_candidate_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_operator_grant_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_operator_grant_blocked.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_policy_chain_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_policy_chain_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_shell_proof_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_shell_proof_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_stub_proof_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_stub_proof_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/missing_zone_config_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/missing_zone_config_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": ""
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/raw_media_payload_present_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/raw_media_payload_present_blocked.json
@@ -1,0 +1,27 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "raw_media_payload_present": true,
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/revoked_grant_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/revoked_grant_blocked.json
@@ -1,0 +1,27 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "revoked_at": "2026-01-15T00:00:00Z",
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/scope_mismatch_blocked.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/scope_mismatch_blocked.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "capture_attempt",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/valid_design_only_authorization.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/valid_design_only_authorization.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "design_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/fixtures/household_presence_camera_capture_authorization/valid_dry_run_only_authorization.json
+++ b/tests/fixtures/household_presence_camera_capture_authorization/valid_dry_run_only_authorization.json
@@ -1,0 +1,26 @@
+{
+  "operator_grant": {
+    "expires_at": "2027-01-01T00:00:00Z",
+    "external_disclosure_allowed": false,
+    "grant_id": "g1",
+    "grant_scope": "household_presence",
+    "granted_at": "2026-01-01T00:00:00Z",
+    "live_capture_allowed": false,
+    "operator_id": "op",
+    "raw_media_allowed": false,
+    "speaker_output_allowed": false
+  },
+  "request": {
+    "disabled_capture_proof_digest": "d1",
+    "dry_run_proof_digest": "dr1",
+    "host_inventory_candidate_digest": "h1",
+    "live_adapter_stub_proof_digest": "l1",
+    "local_shell_proof_digest": "s1",
+    "policy_chain_id": "pc1",
+    "request_id": "r1",
+    "requested_at": "2026-02-01T00:00:00Z",
+    "requested_mode": "dry_run_only",
+    "source_candidate_id": "cam1",
+    "zone_config_id": "zone1"
+  }
+}

--- a/tests/test_build_household_presence_camera_capture_authorization_script.py
+++ b/tests/test_build_household_presence_camera_capture_authorization_script.py
@@ -1,0 +1,13 @@
+import json,subprocess,sys
+from pathlib import Path
+
+SCRIPT='scripts/build_household_presence_camera_capture_authorization.py'
+FIX='tests/fixtures/household_presence_camera_capture_authorization/valid_design_only_authorization.json'
+
+def test_cli_build_default_and_evaluate(tmp_path: Path):
+    r=subprocess.run([sys.executable,SCRIPT,'build-default'],check=True,capture_output=True,text=True)
+    assert 'schema_version' in r.stdout
+    out=tmp_path/'o.json'
+    ok=subprocess.run([sys.executable,SCRIPT,'evaluate','--input',FIX,'--output',str(out)],check=True,capture_output=True,text=True)
+    payload=json.loads(out.read_text())
+    assert payload['capture_enabled'] is False

--- a/tests/test_household_presence_camera_capture_authorization.py
+++ b/tests/test_household_presence_camera_capture_authorization.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import json
+from sentientos.household_presence_camera_capture_authorization import build_default_policy,validate_policy,evaluate_capture_authorization
+
+FIX=Path('tests/fixtures/household_presence_camera_capture_authorization')
+
+def _f(n): return json.loads((FIX/n).read_text())
+
+def test_default_policy_validates(): assert validate_policy(build_default_policy())["ok"]
+
+def test_valid_design_and_dry_run_do_not_enable_capture():
+    for n in ('valid_design_only_authorization.json','valid_dry_run_only_authorization.json'):
+        r=evaluate_capture_authorization(_f(n)).to_dict(); assert r['capture_enabled'] is False and r['authorization_enables_live_capture'] is False and r['no_live_capture_performed'] is True
+
+def test_blocked_fixtures_block():
+    for n in FIX.glob('*blocked.json'):
+        assert evaluate_capture_authorization(_f(n)).status.startswith('capture_authorization_blocked')
+
+def test_forbidden_next_steps_present():
+    r=evaluate_capture_authorization(_f('valid_design_only_authorization.json')).to_dict()
+    for key in ('attempt_capture','enable_live_capture','bypass_disabled_capture_boundary'): assert key in r['forbidden_next_steps']


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only authorization envelope modeling what future Household Presence camera live capture attempts must present before any live capture is permitted, while ensuring no capture, media, speaker, or external-disclosure behavior is enabled by this change.
- Encode operator-grant semantics, expiry/revocation/scope checks, and required proof bindings (disabled-capture proof, local shell proof, live-adapter stub proof, host candidate, zone config, dry-run proof, policy-chain) so future live-capture workflows can be policy-gated and auditable.

### Description
- Added `sentientos/household_presence_camera_capture_authorization.py` which defines typed records, statuses, `evaluate_capture_authorization`, deterministic digesting, explicit no-live-capture flags, and `forbidden_next_steps` that enumerate blocked actions.
- Added CLI `scripts/build_household_presence_camera_capture_authorization.py` with `build-default`, `evaluate`, `validate`, `summarize`, and `inspect-fixture` commands that emit deterministic JSON and exit nonzero for blocked/failed results.
- Added metadata-only fixtures under `tests/fixtures/household_presence_camera_capture_authorization/`, tests `tests/test_household_presence_camera_capture_authorization.py` and `tests/test_build_household_presence_camera_capture_authorization_script.py`, architecture doc `docs/architecture/household_presence_camera_capture_authorization.md`, and linked the doc from the reviewer readiness index.

### Testing
- Ran unit/CLI focused tests with `python -m scripts.run_tests -q tests/test_household_presence_camera_capture_authorization.py tests/test_build_household_presence_camera_capture_authorization_script.py`, and they passed.
- Ran the work-item review packet matrix with `python scripts/run_work_item_review_packet_matrix.py --summary`, which failed a required `mypy_baseline` regression that is pre-existing and outside the touched files.
- Ran the pre-commit finalizer `python scripts/codex_finalize_landing.py finalize --phase pre-commit ...`, which completed validation stages but returned `manual_review_required` because targeted mypy / baseline / matrix stages failed; docs build, prompt-boundary, strict audits, and audit immutability checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17265e5a108320816ce7e0c779c580)