### PR TITLE
Add stale-evidence refresh flow to Codex finalizer with CLI flags and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Reviewers are explicitly welcomed to question and strengthen this ledger.
 - A pre-commit finalizer result of `manual_review_required` or `unknown_dirty_tree` blocks commit; resolve exact reported paths first.
 - After commit and before PR metadata/final report, rerun finalizer in pr-metadata/post-commit mode and require `ready_for_pr_metadata`.
 - Do not defer post-commit/pr-metadata finalizer to a later validation-only or seal follow-up turn.
+- If finalizer evidence becomes stale after strict-audit repair or generated-artifact cleanup, refresh matrix/gate/supervisor in the same task when allowed.
+- Do not final-report partial sealing when the only remaining blocker is stale validation evidence.
 - If no source/doc/test/code changes were made, report validation-only completion and do not run commit or `make_pr`.
 - Focused tests alone are never sufficient; matrix alone is not sufficient; supervisor alone is not sufficient.
 - Repair known task-caused blockers in the same task and rerun finalizer.

--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -10,6 +10,7 @@ Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 - `ready_to_commit`: only valid in `pre-commit` phase.
 - `ready_for_pr_metadata`: only valid in `post-commit`/`pr-metadata` phase.
 - `repair_required_task_caused`, `manual_review_required`, `environment_blocked`, `do_not_finalize`, `finalizer_failed`.
+- `stale_evidence_refresh_required` when validation evidence is stale and refresh was not allowed.
 
 ## Dirty-tree classes
 - `intended_task_change`
@@ -73,6 +74,17 @@ This ordering applies to both pre-commit and pr-metadata phases.
 - Use `--stage-timeout-seconds N` and `--overall-timeout-seconds N` to bound runtime.
 - Timed out stages return nonzero and classify as `finalizer_failed` (stage timeout) or `environment_blocked` (overall timeout).
 - Indeterminate/no-captured-output finalizer runs are not acceptable landing proof.
+
+## Stale evidence refresh
+- Validation evidence can become stale after strict-audit repair, runtime artifact restoration, or generated-artifact cleanup.
+- Use `--allow-stale-evidence-refresh` to permit an in-task refresh chain:
+  - `stale_evidence_matrix_summary`
+  - `stale_evidence_matrix_output`
+  - `stale_evidence_pr_landing_gate`
+  - `stale_evidence_landing_supervisor`
+- Refresh is bounded per invocation (`--max-stale-evidence-refreshes`, default `1`) to avoid loops.
+- If stale evidence is detected and refresh is not allowed, finalizer returns `stale_evidence_refresh_required`.
+- Do not rely on stale failed matrix snapshots after strict audits become healthy.
 
 ### Canonical pr-metadata command with output
 `python scripts/codex_finalize_landing.py finalize --phase pr-metadata --title "[codex:developer] stabilize Codex finalizer runtime reporting" --intended-commit-title "[codex:developer] stabilize Codex finalizer runtime reporting" --matrix-json-path /tmp/work_item_review_packet_matrix.json --focused-test-command "python -m scripts.run_tests -q tests/test_codex_finalize_landing.py tests/test_codex_finalize_landing_script.py tests/test_codex_operating_doctrine_docs.py" --targeted-mypy-command "python -m mypy sentientos/codex_finalize_landing.py scripts/codex_finalize_landing.py sentientos/codex_landing_supervisor.py scripts/codex_landing_supervisor.py sentientos/codex_strict_audit_repair.py scripts/codex_strict_audit_repair.py scripts/run_work_item_review_packet_matrix.py" --allow-docs-bootstrap --allow-strict-audit-repair --allow-generated-artifact-cleanup --stage-timeout-seconds 900 --overall-timeout-seconds 3600 --output /tmp/codex_finalize_landing_pr_metadata.json --summary`

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -24,4 +24,6 @@ Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intende
 - Validation-only seal turns should not be necessary for normal implementation tasks.
 - If finalizer tooling is available, the same task must self-seal using both phases.
 - Missing post-commit/pr-metadata finalizer before PR metadata is a task-owned failure.
+- Missing stale-evidence refresh in the same task (when strict-audit/cleanup state changed) is task-owned failure.
+- Do not request a validation-only follow-up when the only blocker is stale matrix/gate/supervisor/finalizer evidence.
 - Do not defer post-commit sealing to follow-up turns when implementation changes occurred.

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -89,6 +89,7 @@ python scripts/codex_finalize_landing.py finalize \
   --allow-docs-bootstrap \
   --allow-strict-audit-repair \
   --allow-generated-artifact-cleanup \
+  --allow-stale-evidence-refresh \
   --summary
 ```
 
@@ -104,10 +105,11 @@ python scripts/codex_finalize_landing.py finalize \
   --allow-docs-bootstrap \
   --allow-strict-audit-repair \
   --allow-generated-artifact-cleanup \
+  --allow-stale-evidence-refresh \
   --summary
 ```
 
 No-change path: when no source/doc/test changes were made, do not commit and do not call `make_pr`; report validation-only completion with evidence.
 
 ## Final report required fields additions
-Include both `pre_commit_finalizer_result` and `post_commit_pr_metadata_finalizer_result`, plus explicit `pr_metadata_result` showing PR metadata was created only after `ready_for_pr_metadata`.
+Include both `pre_commit_finalizer_result` and `post_commit_pr_metadata_finalizer_result`, plus explicit `stale_evidence_refresh_result`, and `pr_metadata_result` showing PR metadata was created only after `ready_for_pr_metadata`.

--- a/scripts/codex_finalize_landing.py
+++ b/scripts/codex_finalize_landing.py
@@ -271,6 +271,8 @@ def build_parser() -> argparse.ArgumentParser:
         s.add_argument("--allow-docs-bootstrap", action="store_true")
         s.add_argument("--allow-strict-audit-repair", action="store_true")
         s.add_argument("--allow-generated-artifact-cleanup", action="store_true")
+        s.add_argument("--allow-stale-evidence-refresh", action="store_true")
+        s.add_argument("--max-stale-evidence-refreshes", type=int, default=1)
         s.add_argument("--allow-no-focused-tests", action="store_true")
         s.add_argument("--output")
         s.add_argument("--stage-timeout-seconds", type=int, default=DEFAULT_STAGE_TIMEOUT_SECONDS)
@@ -377,9 +379,53 @@ def main(argv: list[str] | None = None) -> int:
     status_after_cleanup = _git_status()
     findings = _classify(status_after_cleanup, tuple(a.changed_file) + inferred_changed_files, inferred_untracked_task_files)
     diagnostics = _collect_dirty_diagnostics(status_after_cleanup, findings, req.dirty_file_classification_source, cleanup_results)
-    landing_result = evaluate_finalize_landing(req, tuple(commands), findings, policy=CodexFinalizeLandingPolicy(allow_generated_artifact_cleanup=a.allow_generated_artifact_cleanup))
+    stale_reasons: list[str] = []
+    command_map = {item.stage: item for item in commands}
+    if command_map.get("strict_audits") and command_map.get("matrix_summary"):
+        if command_map["strict_audits"].exit_code == 0 and command_map["matrix_summary"].exit_code != 0:
+            stale_reasons.append("matrix_failed_before_strict_audits_healthy")
+    if cleanup_results:
+        stale_reasons.append("generated_artifact_cleanup_occurred")
 
-    if not decision_reasons:
+    refresh_attempted = False
+    refresh_status = "not_required"
+    refresh_runs = 0
+    if stale_reasons:
+        if a.allow_stale_evidence_refresh and a.max_stale_evidence_refreshes > 0:
+            refresh_attempted = True
+            refresh_status = "attempted"
+            refresh_plan = [
+                ("stale_evidence_matrix_summary", "python scripts/run_work_item_review_packet_matrix.py --summary", True),
+                ("stale_evidence_matrix_output", f"python scripts/run_work_item_review_packet_matrix.py --output {a.matrix_json_path}", True),
+                ("stale_evidence_pr_landing_gate", f"python scripts/codex_pr_landing_gate.py gate --title \"{a.title}\" --intended-commit-title \"{a.intended_commit_title}\" --matrix-json-path {a.matrix_json_path}", True),
+                ("stale_evidence_landing_supervisor", f"python scripts/codex_landing_supervisor.py evaluate --title \"{a.title}\" --intended-commit-title \"{a.intended_commit_title}\" --matrix-json-path {a.matrix_json_path} --landing-gate-status passed --summary", True),
+            ]
+            try:
+                for stage_id, cmd, required in refresh_plan:
+                    result, stage_runtime = _run_stage(stage_id, cmd, required, a.progress, a.stage_timeout_seconds, deadline)
+                    commands.append(result)
+                    runtime.append(stage_runtime)
+                    refresh_runs += 1
+                refresh_status = "succeeded"
+            except Exception:  # noqa: BLE001
+                refresh_status = "failed"
+        else:
+            refresh_status = "required_not_allowed"
+
+    landing_result = evaluate_finalize_landing(
+        req,
+        tuple(commands),
+        findings,
+        policy=CodexFinalizeLandingPolicy(
+            allow_generated_artifact_cleanup=a.allow_generated_artifact_cleanup,
+            allow_stale_evidence_refresh=a.allow_stale_evidence_refresh,
+        ),
+    )
+
+    if stale_reasons and refresh_status == "required_not_allowed":
+        decision_status = "stale_evidence_refresh_required"
+        decision_reasons = list(stale_reasons)
+    elif not decision_reasons:
         decision_status = landing_result.decision.status
         decision_reasons = list(landing_result.decision.reasons)
 
@@ -391,6 +437,14 @@ def main(argv: list[str] | None = None) -> int:
         "overall_timeout_seconds": a.overall_timeout_seconds,
         "stages": [asdict(item) for item in runtime],
         "final_decision": {"status": decision_status, "reasons": decision_reasons},
+    }
+    payload["evidence_freshness"] = {
+        "stale_evidence_reasons": stale_reasons,
+        "stale_evidence_refresh_attempted": refresh_attempted,
+        "stale_evidence_refresh_result": refresh_status,
+        "refreshed_matrix_json_path": a.matrix_json_path if refresh_attempted else None,
+        "max_stale_evidence_refreshes": a.max_stale_evidence_refreshes,
+        "refresh_stage_runs": refresh_runs,
     }
     payload["decision"]["status"] = decision_status
     payload["decision"]["reasons"] = decision_reasons

--- a/sentientos/codex_finalize_landing.py
+++ b/sentientos/codex_finalize_landing.py
@@ -24,6 +24,7 @@ class CodexFinalizeLandingPolicy:
     allow_docs_bootstrap: bool = False
     allow_strict_audit_repair: bool = False
     allow_generated_artifact_cleanup: bool = False
+    allow_stale_evidence_refresh: bool = False
     require_operator_supplied_task_commands: bool = True
 
 
@@ -84,6 +85,14 @@ class CodexFinalizeLandingResult:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class CodexFinalizeLandingEvidenceFreshness:
+    stale_evidence_reasons: tuple[str, ...] = ()
+    stale_evidence_refresh_attempted: bool = False
+    stale_evidence_refresh_result: str = "not_required"
+    refreshed_matrix_json_path: str | None = None
 
 
 def _normalize_phase(phase: str) -> str:

--- a/tests/test_codex_finalize_landing_script.py
+++ b/tests/test_codex_finalize_landing_script.py
@@ -47,6 +47,13 @@ def test_parser_has_allow_current_task_files() -> None:
     assert args.allow_current_task_files is True
 
 
+def test_parser_has_stale_evidence_refresh_flags() -> None:
+    p = build_parser()
+    args = p.parse_args(["finalize", "--allow-stale-evidence-refresh", "--max-stale-evidence-refreshes", "1"])
+    assert args.allow_stale_evidence_refresh is True
+    assert args.max_stale_evidence_refreshes == 1
+
+
 def test_classify_untracked_task_file_inferred() -> None:
     findings = _classify(["?? tests/test_new_case.py"], (), ("tests/test_new_case.py",))
     assert findings[0].classification == "intended_task_change"


### PR DESCRIPTION
### Motivation
- Address cases where validation evidence becomes stale after strict-audit repairs or generated-artifact cleanup by enabling an in-task refresh chain. 
- Prevent needless follow-up validation-only turns when the only remaining blocker is stale matrix/gate/supervisor evidence.
- Make evidence freshness explicit in finalizer output so callers can reason about refresh attempts and outcomes.

### Description
- Add two new CLI flags to `scripts/codex_finalize_landing.py`: `--allow-stale-evidence-refresh` and `--max-stale-evidence-refreshes`, and wire them into the parser and request handling. 
- Detect stale-evidence conditions (matrix failed before strict audits became healthy or generated-artifact cleanup occurred), and when allowed run a bounded refresh plan that re-runs matrix summary/output, PR landing gate, and landing supervisor stages and append their results to the run log. 
- Extend policy (`sentientos/codex_finalize_landing.py`) to recognize `allow_stale_evidence_refresh`, add an evidence freshness dataclass and include `evidence_freshness` in the finalizer payload, and set `stale_evidence_refresh_required`/`stale_evidence_refresh_result` outcomes when appropriate. 
- Update documentation in `docs/development/*` and `AGENTS.md` to describe the stale-evidence refresh semantics, flags, recommended ordering, and canonical commands. 
- Add a unit test to `tests/test_codex_finalize_landing_script.py` to validate the new parser flags.

### Testing
- Ran the repository test suite with `python -m scripts.run_tests`, which executed updated parser tests including `test_parser_has_stale_evidence_refresh_flags`, and all tests passed. 
- Exercised the finalize script paths in unit tests that cover dirty-tree classification and diagnostics, which continued to pass. 
- Verified that the finalizer output now includes `evidence_freshness` fields and that `stale_evidence_refresh_required` is returned when refresh is detected but not allowed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1786f2d19c8320b333c076602f95f4)