### PR TITLE
Declare and propagate task-owned fixture roots for metadata_verification and scope untracked fixture allowances

### DIFF
--- a/scripts/build_codex_task_scaffold.py
+++ b/scripts/build_codex_task_scaffold.py
@@ -39,6 +39,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--new-cli", action="append", default=[])
     p.add_argument("--test-path", action="append", default=[])
     p.add_argument("--doc-path", action="append", default=[])
+    p.add_argument("--fixture-root", action="append", default=[])
     p.add_argument("--capability-id")
     p.add_argument("--proof-bundle-artifact-kind")
     p.add_argument("--allowed-behavior", action="append", default=[])
@@ -63,6 +64,7 @@ def main(argv: list[str] | None = None) -> int:
         new_cli_path=_list(base, "new_cli_path", a.new_cli),
         expected_test_paths=_list(base, "expected_test_paths", a.test_path),
         expected_doc_paths=_list(base, "expected_doc_paths", a.doc_path),
+        expected_fixture_roots=_list(base, "expected_fixture_roots", a.fixture_root),
         capability_id=str(base.get("capability_id", a.capability_id or "")),
         proof_bundle_artifact_kind=str(base.get("proof_bundle_artifact_kind", a.proof_bundle_artifact_kind or "")),
         allowed_behaviors=_list(base, "allowed_behaviors", a.allowed_behavior),

--- a/scripts/codex_finalize_landing.py
+++ b/scripts/codex_finalize_landing.py
@@ -140,13 +140,61 @@ def _git_tracked_changes() -> tuple[str, ...]:
     return tuple(sorted(set(names)))
 
 
-def _is_safe_untracked_task_file(path: str) -> bool:
+def _strip_fixture_path(path: str) -> str:
+    if path.startswith("tests/fixtures/"):
+        rest = path[len("tests/fixtures/"):].strip("/")
+        return rest.split("/", 1)[0] if rest else ""
+    return ""
+
+
+def _task_slug_from_path(path: str) -> str:
+    name = Path(path.rstrip("/")).name
+    if path.startswith("sentientos/") and name.endswith(".py"):
+        return name[:-3]
+    if path.startswith("tests/test_") and name.startswith("test_") and name.endswith(".py"):
+        stem = name[:-3]
+        if stem.endswith("_script"):
+            stem = stem[: -len("_script")]
+        return stem[len("test_"):]
+    if path.startswith("docs/") and name.endswith(".md"):
+        return name[:-3]
+    if path.startswith("scripts/") and name.endswith(".py"):
+        stem = name[:-3]
+        for prefix in ("build_", "plan_", "run_", "verify_", "evaluate_"):
+            if stem.startswith(prefix):
+                return stem[len(prefix):]
+        return stem
+    return ""
+
+
+def _infer_task_slugs(status_lines: list[str], changed_files: tuple[str, ...]) -> frozenset[str]:
+    slugs: set[str] = set()
+    for path in changed_files:
+        slug = _task_slug_from_path(path)
+        if slug:
+            slugs.add(slug)
+    for line in status_lines:
+        path = line[3:] if len(line) > 3 else line
+        if path.startswith("tests/fixtures/"):
+            continue
+        slug = _task_slug_from_path(path)
+        if slug:
+            slugs.add(slug)
+    return frozenset(slugs)
+
+
+def _is_task_scoped_fixture_path(path: str, task_slugs: frozenset[str]) -> bool:
+    fixture_slug = _strip_fixture_path(path)
+    return bool(fixture_slug and fixture_slug in task_slugs)
+
+
+def _is_safe_untracked_task_file(path: str, task_slugs: frozenset[str] = frozenset()) -> bool:
     if path == "AGENTS.md":
         return True
     if path.startswith(("sentientos/", "scripts/", "tests/", "docs/")) and path.endswith((".py", ".md")):
         return True
-    if path.startswith("tests/fixtures/") and path.endswith(".json"):
-        return True
+    if path.startswith("tests/fixtures/") and (path.endswith("/") or path.endswith(".json")):
+        return _is_task_scoped_fixture_path(path, task_slugs)
     if path.startswith("artifacts/proof_bundles/") and path.endswith(".json"):
         return True
     return False
@@ -304,12 +352,13 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps({"status": "error", "reason": "allow_current_task_files_requires_pre_commit"}, indent=2))
             return 2
         status_lines = _git_status()
+        task_slugs = _infer_task_slugs(status_lines, inferred_changed_files + tuple(a.changed_file))
         candidates = []
         for line in status_lines:
             if not line.startswith("??"):
                 continue
             path = line[3:] if len(line) > 3 else line
-            if _is_safe_untracked_task_file(path):
+            if _is_safe_untracked_task_file(path, task_slugs):
                 candidates.append(path)
         inferred_untracked_task_files = tuple(sorted(set(candidates)))
 

--- a/sentientos/codex_task_bootstrapper.py
+++ b/sentientos/codex_task_bootstrapper.py
@@ -91,6 +91,7 @@ def bootstrap_codex_task(request: CodexTaskBootstrapRequest, *, include_preset_v
         new_cli_path=tuple(scaffold_payload["new_cli_path"]),
         expected_test_paths=tuple(scaffold_payload["expected_test_paths"]),
         expected_doc_paths=tuple(scaffold_payload["expected_doc_paths"]),
+        expected_fixture_roots=tuple(scaffold_payload.get("expected_fixture_roots", ())),
         capability_id=str(scaffold_payload["capability_id"]),
         proof_bundle_artifact_kind=str(scaffold_payload["proof_bundle_artifact_kind"]),
         commit_title=str(scaffold_payload["commit_title"]),
@@ -130,6 +131,7 @@ def bootstrap_codex_task(request: CodexTaskBootstrapRequest, *, include_preset_v
             "cli_test_path": planned.cli_test_path,
             "dev_doc_path": planned.dev_doc_path,
             "proof_bundle_filename": planned.proof_bundle_filename,
+            "fixture_root": planned.fixture_root,
         },
         explicit_non_authority_boundaries=(
             "metadata-only bootstrap flow",

--- a/sentientos/codex_task_scaffold.py
+++ b/sentientos/codex_task_scaffold.py
@@ -45,6 +45,7 @@ class CodexTaskScaffoldRequest:
     new_cli_path: tuple[str, ...] = ()
     expected_test_paths: tuple[str, ...] = ()
     expected_doc_paths: tuple[str, ...] = ()
+    expected_fixture_roots: tuple[str, ...] = ()
     capability_id: str = ""
     proof_bundle_artifact_kind: str = ""
     allowed_behaviors: tuple[str, ...] = ()
@@ -78,6 +79,7 @@ class CodexTaskScaffold:
     expected_files: tuple[str, ...]
     expected_tests: tuple[str, ...]
     expected_docs: tuple[str, ...]
+    expected_fixture_roots: tuple[str, ...]
     required_integrations: tuple[str, ...]
     forbidden_surfaces: tuple[str, ...]
     final_report_contract: tuple[str, ...]
@@ -128,6 +130,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
     expected_files = _norm(request.new_module_path + request.new_cli_path)
     expected_tests = _norm(request.expected_test_paths)
     expected_docs = _norm(request.expected_doc_paths)
+    expected_fixture_roots = _norm(request.expected_fixture_roots or ((f"tests/fixtures/{request.capability_id}/",) if request.subsystem_kind == "metadata_verification" and request.capability_id else ()))
     forbidden = _norm(request.forbidden_behaviors or (preset.default_forbidden_surfaces if preset else (
         "Do not invoke Codex.", "Do not call OpenAI/provider APIs.", "Do not call GitHub APIs.", "Do not invoke shell/subprocess from library code.",
     )))
@@ -163,6 +166,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
             "Do not return 'feature exists but full matrix not run.' Do not offer to run matrix later.\n"
             "Do not create PR metadata before green final validation and a ready PR metadata guard; do not commit or make_pr if either finalizer phase or guard is blocked.\n"
             f"Goal: {request.task_goal}\nSubsystem: {request.task_name} ({request.subsystem_kind})."
+            + (f"\nExpected task-owned fixture roots: {', '.join(expected_fixture_roots)}." if expected_fixture_roots else "")
         )
     else:
         prompt = (
@@ -183,6 +187,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
         "prompt": prompt,
         "validation_commands": validation_commands,
         "expected_files": expected_files,
+        "expected_fixture_roots": expected_fixture_roots,
         "deliverables": deliverables,
     }
     digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
@@ -198,6 +203,7 @@ def build_codex_task_scaffold(request: CodexTaskScaffoldRequest, policy: CodexTa
         expected_files=expected_files,
         expected_tests=expected_tests,
         expected_docs=expected_docs,
+        expected_fixture_roots=expected_fixture_roots,
         required_integrations=required_integrations,
         forbidden_surfaces=forbidden,
         final_report_contract=final_report_contract,

--- a/sentientos/codex_task_scaffold_path_planner.py
+++ b/sentientos/codex_task_scaffold_path_planner.py
@@ -46,6 +46,7 @@ class PlannerOutput:
     capability_id: str
     proof_bundle_artifact_kind: str
     proof_bundle_filename: str
+    fixture_root: str
     commit_title: str
 
     def to_dict(self) -> dict[str, Any]:
@@ -83,6 +84,7 @@ def plan_codex_task_scaffold_paths(request: PlannerRequest) -> PlannerOutput:
     cap_default = _snake(request.capability_id or slug)
     proof_kind_default = _snake(request.proof_bundle_artifact_kind or f"{cap_default}_capability")
     proof_filename_default = f"artifacts/proof_bundles/{proof_kind_default}.json"
+    fixture_root_default = f"tests/fixtures/{cap_default}/" if (request.subsystem_kind or request.preset_id) == "metadata_verification" and cap_default else ""
     commit_default = f"[codex:{scope}] {action} {slug.replace('_', ' ')}"
 
     module_path = _choose(request.new_module, module_default)
@@ -98,7 +100,7 @@ def plan_codex_task_scaffold_paths(request: PlannerRequest) -> PlannerOutput:
             blockers.append("forbidden_authority_surface_requested")
             break
 
-    for path in (module_path, cli_path, api_test_path, cli_test_path, dev_doc_path, proof_filename_default):
+    for path in tuple(x for x in (module_path, cli_path, api_test_path, cli_test_path, dev_doc_path, proof_filename_default, fixture_root_default) if x):
         if _bad_path(path):
             blockers.append("path_traversal_or_metacharacters")
             break
@@ -114,7 +116,7 @@ def plan_codex_task_scaffold_paths(request: PlannerRequest) -> PlannerOutput:
         status = "blocked"
     elif warnings:
         status = "ready_with_warnings"
-    return PlannerOutput(status, tuple(sorted(set(warnings))), tuple(sorted(set(blockers))), slug, module_path, cli_path, api_test_path, cli_test_path, dev_doc_path, cap_default, proof_kind_default, proof_filename_default, commit_title)
+    return PlannerOutput(status, tuple(sorted(set(warnings))), tuple(sorted(set(blockers))), slug, module_path, cli_path, api_test_path, cli_test_path, dev_doc_path, cap_default, proof_kind_default, proof_filename_default, fixture_root_default, commit_title)
 
 
 def build_scaffold_request_payload(request: PlannerRequest, planned: PlannerOutput) -> dict[str, Any]:
@@ -126,6 +128,7 @@ def build_scaffold_request_payload(request: PlannerRequest, planned: PlannerOutp
         "new_cli_path": [planned.cli_path],
         "expected_test_paths": [planned.api_test_path, planned.cli_test_path],
         "expected_doc_paths": [planned.dev_doc_path],
+        "expected_fixture_roots": [planned.fixture_root] if planned.fixture_root else [],
         "capability_id": planned.capability_id,
         "proof_bundle_artifact_kind": planned.proof_bundle_artifact_kind,
         "commit_title": planned.commit_title,

--- a/tests/test_bootstrap_codex_task_script.py
+++ b/tests/test_bootstrap_codex_task_script.py
@@ -1,3 +1,4 @@
+import pytest
 import json
 from pathlib import Path
 
@@ -44,3 +45,20 @@ def test_script_blocked_prompt_output_is_hard_stop(tmp_path: Path) -> None:
     assert "BLOCKED_DO_NOT_IMPLEMENT" in text
     assert "Only then make_pr" not in text
     assert payload["artifact_classification"] == "diagnostic"
+
+
+@pytest.mark.no_legacy_skip
+def test_script_plan_output_includes_metadata_fixture_root(tmp_path: Path) -> None:
+    plan = tmp_path / "plan.json"
+    code = main([
+        "--task-name", "Memory Commit Execution Gate",
+        "--task-goal", "metadata-only execution gate",
+        "--preset-id", "metadata_verification",
+        "--subsystem-kind", "metadata_verification",
+        "--capability-id", "memory_commit_execution_gate",
+        "--commit-title", "[codex:memory] add memory commit execution gate",
+        "--plan-output", str(plan),
+    ])
+    assert code == 0
+    payload = json.loads(plan.read_text(encoding="utf-8"))
+    assert payload["fixture_root"] == "tests/fixtures/memory_commit_execution_gate/"

--- a/tests/test_build_codex_task_scaffold_script.py
+++ b/tests/test_build_codex_task_scaffold_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import json
 from pathlib import Path
 
@@ -37,3 +38,22 @@ def test_cli_input_json(tmp_path: Path) -> None:
 
 def test_cli_nonzero_for_missing() -> None:
     assert cli.main(["--task-name", "a"]) == 1
+
+
+@pytest.mark.no_legacy_skip
+def test_cli_accepts_fixture_root(capsys) -> None:
+    rc = cli.main([
+        "--task-name",
+        "a",
+        "--task-goal",
+        "b",
+        "--subsystem-kind",
+        "metadata_verification",
+        "--capability-id",
+        "a",
+        "--fixture-root",
+        "tests/fixtures/a/",
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scaffold"]["expected_fixture_roots"] == ["tests/fixtures/a/"]

--- a/tests/test_codex_finalize_landing_script.py
+++ b/tests/test_codex_finalize_landing_script.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import pytest
 import json
 from pathlib import Path
 
-from scripts.codex_finalize_landing import _classify, _collect_dirty_diagnostics, build_parser, main
+from scripts.codex_finalize_landing import (
+    _classify,
+    _collect_dirty_diagnostics,
+    _infer_task_slugs,
+    _is_safe_untracked_task_file,
+    build_parser,
+    main,
+)
 
 
 def test_parser_has_phase_and_changed_file() -> None:
@@ -110,3 +118,34 @@ def test_finalize_writes_output_and_decision_line(tmp_path: Path, capsys: object
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert "runtime" in payload
     assert "stages" in payload["runtime"]
+
+
+@pytest.mark.no_legacy_skip
+def test_fixture_root_inferred_only_for_matching_task_slug() -> None:
+    status = [
+        "?? sentientos/memory_commit_execution_gate.py",
+        "?? tests/test_memory_commit_execution_gate.py",
+        "?? tests/fixtures/memory_commit_execution_gate/",
+        "?? tests/fixtures/other_capability/",
+    ]
+    task_slugs = _infer_task_slugs(status, ())
+    assert _is_safe_untracked_task_file("tests/fixtures/memory_commit_execution_gate/", task_slugs) is True
+    assert _is_safe_untracked_task_file("tests/fixtures/memory_commit_execution_gate/nested/case.json", task_slugs) is True
+    assert _is_safe_untracked_task_file("tests/fixtures/other_capability/", task_slugs) is False
+
+
+@pytest.mark.no_legacy_skip
+def test_classify_allows_current_capability_fixture_root_but_blocks_other_root() -> None:
+    findings = _classify(
+        [
+            "?? tests/fixtures/memory_commit_execution_gate/",
+            "?? tests/fixtures/other_capability/",
+            "?? glow/test_runs/report.json",
+        ],
+        (),
+        ("tests/fixtures/memory_commit_execution_gate/",),
+    )
+    by_path = {item.path: item.classification for item in findings}
+    assert by_path["tests/fixtures/memory_commit_execution_gate/"] == "intended_task_change"
+    assert by_path["tests/fixtures/other_capability/"] == "unknown_dirty_file"
+    assert by_path["glow/test_runs/report.json"] == "generated_runtime_artifact"

--- a/tests/test_codex_task_bootstrapper.py
+++ b/tests/test_codex_task_bootstrapper.py
@@ -1,3 +1,4 @@
+import pytest
 from sentientos.codex_task_bootstrapper import CodexTaskBootstrapRequest, bootstrap_codex_task
 
 
@@ -93,3 +94,20 @@ def test_ready_with_warnings_still_emits_usable_implementation_prompt() -> None:
     assert result.artifact_classification == "implementation_contract"
     assert "pr_metadata_guard_ready" in result.generated_prompt_text
     assert "Only then make_pr" in result.generated_prompt_text
+
+
+@pytest.mark.no_legacy_skip
+def test_bootstrap_metadata_verification_declares_fixture_root() -> None:
+    result = bootstrap_codex_task(
+        CodexTaskBootstrapRequest(
+            task_name="Memory Commit Execution Gate",
+            task_goal="metadata-only execution gate",
+            preset_id="metadata_verification",
+            subsystem_kind="metadata_verification",
+            capability_id="memory_commit_execution_gate",
+            commit_title="[codex:memory] add memory commit execution gate",
+        )
+    )
+    assert result.planned_paths["fixture_root"] == "tests/fixtures/memory_commit_execution_gate/"
+    assert tuple(result.generated_scaffold_json["scaffold"]["expected_fixture_roots"]) == ("tests/fixtures/memory_commit_execution_gate/",)
+    assert "Expected task-owned fixture roots: tests/fixtures/memory_commit_execution_gate/" in result.generated_prompt_text

--- a/tests/test_codex_task_scaffold.py
+++ b/tests/test_codex_task_scaffold.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from sentientos.codex_task_scaffold import CodexTaskScaffoldRequest, build_codex_task_scaffold
 
 
@@ -62,3 +63,23 @@ def test_ready_scaffold_includes_pr_metadata_guard_sequence() -> None:
     assert "Run bootstrapper" in result.scaffold.generated_prompt
     assert "pr_metadata_guard_ready" in result.scaffold.generated_prompt
     assert "Only then make_pr" in result.scaffold.generated_prompt
+
+
+@pytest.mark.no_legacy_skip
+def test_metadata_verification_scaffold_declares_capability_fixture_root() -> None:
+    result = build_codex_task_scaffold(
+        CodexTaskScaffoldRequest(
+            task_name="Memory Commit Execution Gate",
+            task_goal="metadata gate",
+            subsystem_kind="metadata_verification",
+            capability_id="memory_commit_execution_gate",
+        )
+    )
+    assert result.scaffold.expected_fixture_roots == ("tests/fixtures/memory_commit_execution_gate/",)
+    assert "Expected task-owned fixture roots: tests/fixtures/memory_commit_execution_gate/" in result.scaffold.generated_prompt
+
+
+@pytest.mark.no_legacy_skip
+def test_non_metadata_scaffold_does_not_declare_fixture_root_by_default() -> None:
+    result = build_codex_task_scaffold(CodexTaskScaffoldRequest(task_name="x", task_goal="y", subsystem_kind="developer_workflow_metadata", capability_id="x"))
+    assert result.scaffold.expected_fixture_roots == ()


### PR DESCRIPTION
### Motivation
- Tasks that perform `metadata_verification` need an explicit declaration of their owned fixture roots (e.g. `tests/fixtures/<capability>/`) so scaffolds, planners, and bootstrappers can treat those fixtures as intended task-owned assets. 
- The finalizer must only allow untracked fixture directories when they clearly belong to the task being changed, to avoid silently permitting unrelated fixture additions.
- The CLI and planner should propagate fixture-root metadata through the scaffold and bootstrap flows so prompts and artifacts include the expectation and validators can use it.

### Description
- Add `--fixture-root` CLI option to `scripts/build_codex_task_scaffold.py` and map it into `CodexTaskScaffoldRequest.expected_fixture_roots`.
- Extend `PlannerOutput` and `plan_codex_task_scaffold_paths` to compute and return a `fixture_root` default for `metadata_verification` presets and include it in the scaffold request payload.
- Add `expected_fixture_roots` handling to `sentientos.codex_task_scaffold` (request/scaffold dataclasses, payload, prompt text, digest, and JSON output) and wire it through the bootstrapper in `sentientos.codex_task_bootstrapper` planned_paths and scaffold request.
- In `scripts/codex_finalize_landing.py` add `_strip_fixture_path`, `_task_slug_from_path`, and `_infer_task_slugs` helpers and change `_is_safe_untracked_task_file` to accept inferred task slugs so untracked `tests/fixtures/...` entries are allowed only when they match an inferred task slug.
- Add and update unit tests exercising planner/CLI/bootstrapping/scaffold behavior and finalizer fixture-scoping logic.

### Testing
- Ran the pytest suite with the updated and new unit tests targeting planner, scaffold, bootstrapper, CLI scripts, and finalizer classification, and all tests passed. 
- New tests include `test_bootstrap_metadata_verification_declares_fixture_root`, `test_script_plan_output_includes_metadata_fixture_root`, `test_cli_accepts_fixture_root`, `test_fixture_root_inferred_only_for_matching_task_slug`, and `test_classify_allows_current_capability_fixture_root_but_blocks_other_root`, and they succeeded. 
- Existing scaffold and finalizer tests were exercised and continued to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1afe3afc30832fa0b3d4352c2ad663)