### PR TITLE
[codex] harden Codex prompt and AGENTS efficiency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,25 @@ Reviewers are explicitly welcomed to question and strengthen this ledger.
 
 ## 🛠️ Codex Agent Operating Instructions
 
+### Codex Quick Law / Agent Hot Path
+- Bootstrap first. If bootstrap returns `blocked`, stop immediately; blocked prompt/scaffold artifacts are diagnostic only and must not be used as implementation contracts.
+- `unknown_dirty_tree` and `manual_review_required` block commit until the exact reported paths are resolved.
+- Focused tests alone are insufficient when the landing contract requires matrix, governance, audit, supervisor, or proof validation.
+- Pre-commit finalizer must return `ready_to_commit` before commit.
+- Post-commit/pr-metadata finalizer must return `ready_for_pr_metadata` before PR metadata.
+- PR metadata guard must return `pr_metadata_guard_ready` before `make_pr`.
+- Memory-chain tasks should use the canonical memory-chain task profile or recovery profile unless a prompt explicitly justifies deviation.
+- Metadata-only, dry-run, sandbox, and review-only work grants no authority, truth, consent, policy, prompt assembly, action execution, external disclosure, or real live-memory mutation.
+
+### Canonical Profile and Template Index
+- Whole-system task template: `docs/development/codex_whole_system_task_template.md`
+- Narrow-repair task template: `docs/development/codex_narrow_repair_task_template.md`
+- Memory-chain task profile: `docs/development/codex_memory_chain_task_profile.md`
+- Memory-chain recovery profile: `docs/development/codex_memory_chain_recovery_profile.md`
+- Validation and landing contract: `docs/development/codex_validation_and_landing_contract.md`
+- Finalizer landing authority: `docs/development/codex_finalize_landing.md`
+- Capability landing checklist: `docs/development/codex_capability_landing_checklist.md`
+
 ## Codex Landing Authority (Streamlined)
 - After any task-caused repository change, run `python scripts/codex_finalize_landing.py finalize ...` in two phases during the same implementation task.
 - Before committing task-caused changes, run finalizer in pre-commit mode (normally with `--allow-current-tracked-changes`) and commit only if it returns `ready_to_commit`.
@@ -143,7 +162,11 @@ A system task is not complete until the following are satisfied as applicable:
 Use the linked guidance for task shaping and landing posture:
 - `docs/development/codex_whole_system_task_template.md`
 - `docs/development/codex_narrow_repair_task_template.md`
+- `docs/development/codex_memory_chain_task_profile.md`
+- `docs/development/codex_memory_chain_recovery_profile.md`
 - `docs/development/codex_validation_and_landing_contract.md`
+- `docs/development/codex_finalize_landing.md`
+- `docs/development/codex_capability_landing_checklist.md`
 
 ### Procedure-Required Actions
 - Any invocation of `bless`, `animate`, or `reflect` must write a corresponding

--- a/docs/development/codex_memory_chain_recovery_profile.md
+++ b/docs/development/codex_memory_chain_recovery_profile.md
@@ -1,0 +1,71 @@
+# Codex Memory-Chain Recovery Profile
+
+This profile defines compact recovery behavior for partial failures in recurring memory-chain metadata-verification tasks. It is for repairing incomplete or failed landings without repeating the full subsystem prompt, while preserving the same safety, authority, audit, finalizer, PR metadata guard, fixture-root, and clean-tree requirements.
+
+## When to use this recovery profile
+
+Use this profile when a memory-chain metadata-verification task partially failed, left task-owned docs/tests/fixtures/artifacts inconsistent, failed a validation lane, produced stale evidence, or needs deterministic cleanup before landing. It applies to recovery of review-only, dry-run, sandbox, fixture-backed, or metadata-only memory-chain work.
+
+Do not use this profile to broaden scope into a new subsystem landing unless the prompt explicitly authorizes that expansion. If the task is explicitly scoped as an even narrower surgical repair, follow [`codex_narrow_repair_task_template.md`](codex_narrow_repair_task_template.md) and cite why this recovery profile is not the controlling shape.
+
+## First action
+
+Inspect the tree first:
+
+```bash
+git status --short
+```
+
+Use that status as the recovery baseline before editing, testing, finalizing, committing, or creating PR metadata.
+
+## Classify current changes
+
+Classify every dirty path before repair:
+
+- `task-owned`: files explicitly in the current task, profile, capability, or task slug scope;
+- `generated-expected`: deterministic outputs expected from allowed docs, matrix, audit, finalizer, or fixture generation;
+- `unrelated`: pre-existing or operator-owned changes outside the current task scope;
+- `unknown`: changes whose source or ownership is unclear.
+
+Unknown dirty files block commit. Unrelated files must not be hidden, reverted, or absorbed into the task without explicit ownership.
+
+## Repair task-owned files in place
+
+Repair task-owned files directly and minimally while preserving the whole-system contract for the original task. Do not mask failures by deleting required evidence, loosening tests, weakening docs, bypassing audits, or shrinking required matrix/proof/capability/doc obligations.
+
+## Respect fixture-root ownership
+
+For metadata-verification tasks, fixture roots must match the declared capability ID or task slug unless the prompt declares a different root. Update only task-owned fixture roots. Do not edit unrelated fixture roots to satisfy tests. If generated expected data changes, ensure it is deterministic and tied to the current capability/task slug.
+
+## Re-run failing lanes and refresh evidence
+
+After repair, re-run the failing validation lanes and any dependent evidence refresh required by the landing contract. If strict-audit repair, generated-artifact cleanup, fixture regeneration, or docs bootstrap makes matrix, landing-gate, supervisor, or finalizer evidence stale, refresh that evidence in the same recovery task when allowed.
+
+## Do not bypass finalizer
+
+Recovery does not bypass the two-phase finalizer. The finalizer remains the landing authority described in [`codex_finalize_landing.md`](codex_finalize_landing.md) and [`codex_validation_and_landing_contract.md`](codex_validation_and_landing_contract.md).
+
+## Commit and PR metadata hard stops
+
+Do not commit unless the pre-commit finalizer returns `ready_to_commit`. Do not create PR metadata or call `make_pr` unless the post-commit/pr-metadata finalizer returns `ready_for_pr_metadata` and the PR metadata guard returns `pr_metadata_guard_ready`.
+
+`manual_review_required`, `unknown_dirty_tree`, failed required lanes, stale evidence without an allowed refresh, or blocked PR metadata guard are hard stops.
+
+## Preserve runtime and authority boundaries
+
+Preserve all no-runtime, no-authority, no-prompt-assembly, no-action-execution, no-external-disclosure, and no-real-memory-mutation boundaries. Recovery may repair metadata, docs, tests, fixtures, and deterministic review artifacts; it does not grant live memory writes, memory-chain advancement, provider calls, prompt export, policy truth, consent, external disclosure, or runtime authority.
+
+## Recovery report addendum fields
+
+Add these fields to the normal final report when using this recovery profile:
+
+- recovery baseline from `git status --short`;
+- dirty-path classification summary;
+- task-owned files repaired;
+- generated-expected artifacts refreshed or cleaned;
+- unrelated or unknown changes found, with disposition;
+- fixture-root ownership confirmation;
+- failing lanes reproduced and rerun;
+- stale evidence refresh result, if applicable;
+- finalizer and PR metadata guard decisions;
+- remaining risks or blockers.

--- a/docs/development/codex_memory_chain_task_profile.md
+++ b/docs/development/codex_memory_chain_task_profile.md
@@ -1,0 +1,115 @@
+# Codex Memory-Chain Task Profile
+
+This profile is the reusable contract for recurring memory-chain metadata-verification work. It reduces prompt bulk by moving stable requirements into one canonical profile while preserving every executable landing control in `AGENTS.md`, the validation contract, finalizer, PR metadata guard, matrix runner, supervisor, audit tooling, and clean-tree rules.
+
+## When to use this profile
+
+Use this profile for recurring memory-chain work that is metadata-verification, review-packet, fixture-backed, dry-run, sandboxed, or governance-only in nature. Typical tasks add or update candidate/status/decision metadata, deterministic fixtures, review proof surfaces, docs, tests, CLI/module shells, or matrix wiring around the memory-chain subsystem without mutating real live memory.
+
+Do not use this profile to authorize live memory writes, provider invocation, prompt export, external disclosure, host action, action execution, runtime authority expansion, or policy/consent truth. If a prompt needs any of those behaviors, it must say so explicitly and satisfy the separate authority, audit, rollback, panic, and operator-admission requirements in `AGENTS.md`.
+
+## Relationship to AGENTS.md hot-path law
+
+`AGENTS.md` remains the root operating law. This profile only summarizes recurring memory-chain expectations so future prompts can reference a stable profile instead of repeating the same paragraphs. If this profile and `AGENTS.md` conflict, `AGENTS.md` wins.
+
+The hot path is mandatory: bootstrap first; stop on blocked bootstrap artifacts; do not commit on `unknown_dirty_tree` or `manual_review_required`; do not treat focused tests as sufficient when matrix/governance validation is required; require `ready_to_commit` before commit; require `ready_for_pr_metadata` before PR metadata; require `pr_metadata_guard_ready` before `make_pr`.
+
+## Relationship to codex_whole_system_task_template.md
+
+Use this profile together with [`codex_whole_system_task_template.md`](codex_whole_system_task_template.md) for complete subsystem landings. The whole-system template defines the general landing shape; this profile supplies the memory-chain defaults for non-authority boundaries, fixture roots, proof surfaces, and prompt compression.
+
+For explicit surgical repairs, use [`codex_narrow_repair_task_template.md`](codex_narrow_repair_task_template.md) and, when the repair is a recurring memory-chain partial-failure recovery, [`codex_memory_chain_recovery_profile.md`](codex_memory_chain_recovery_profile.md).
+
+## Required bootstrap posture
+
+Run the Codex task bootstrapper before implementation. Implement only from `ready` or `ready_with_warnings` bootstrap output. If bootstrap returns `blocked`, stop and report the blocker; blocked prompt/scaffold artifacts are diagnostic only and must not be used as implementation contracts.
+
+If bootstrap tooling cannot express a root-law documentation touch such as `AGENTS.md`, keep the bootstrap artifact limited to allowed task docs and still obey the prompt's explicit authority to edit `AGENTS.md`; do not reinterpret that limitation as permission to ignore blocked bootstrap output or dirty-tree rules.
+
+## Standard non-authority boundaries
+
+Memory-chain metadata-verification work is not authority. It does not grant or imply:
+
+- consent, policy truth, operator approval, or live memory truth;
+- prompt assembly, prompt export, provider invocation, provider SDK use, or network egress;
+- action execution, host actuation, external disclosure, federation adoption, transport, sync, merge, install, or runtime apply behavior;
+- real live-memory mutation, memory-chain advancement, or privileged runtime mutation.
+
+Receipts, readiness records, proposals, review packets, fixtures, and sandbox outputs are evidence artifacts only unless a separate authorized runtime gate consumes them under its own audited contract.
+
+## Standard no-runtime boundaries
+
+Do not run live memory adapters, advance the memory chain, mutate live memory stores, invoke providers, execute actions, disclose data externally, widen runtime authority, or modify `prompt_assembler.py` unless the task explicitly requests that behavior and provides the required admission, audit, rollback, panic, and operator-authority contract.
+
+Metadata-only, dry-run, sandbox, and review-only code must remain deterministic and local. Test fixtures may model candidates/statuses/decisions, but they must not become runtime writes.
+
+## Standard memory-chain integration expectations
+
+When applicable, memory-chain tasks should make the chain's metadata legible through stable IDs, deterministic candidate/status/decision naming, fixture-backed examples, review-packet evidence, and docs that distinguish metadata evidence from live mutation.
+
+Integration should preserve upstream/downstream dependency order, make blockers explicit, and keep review artifacts reproducible. Any readiness or receipt language must state that it is not adoption, execution, prompt assembly, policy truth, consent, external disclosure, or real memory mutation.
+
+## Required docs/tests/fixtures/CLI/module surfaces
+
+For whole-system memory-chain work, provide the surfaces required by the task prompt and whole-system template:
+
+- module/API surface when behavior is implemented;
+- operator-facing CLI when the subsystem has a command surface;
+- deterministic tests covering module and CLI behavior;
+- public docs and discoverability links when behavior or reviewer workflow changes;
+- fixture roots for metadata-verification inputs and expected outputs;
+- deterministic artifacts, receipts, manifests, or review packets when the task defines them.
+
+If the task is documentation/governance-only and no Python behavior changes, state that targeted mypy is not applicable because no Python surfaces changed.
+
+## Capability, proof bundle, matrix, and readiness expectations
+
+When a capability landing or changed capability ID is involved, follow [`codex_capability_landing_checklist.md`](codex_capability_landing_checklist.md). Verify capability registry entries, reviewer proof-bundle integration, readiness/index links, matrix lanes, targeted mypy scope, and docs link/index coverage before finalization.
+
+When those surfaces are not applicable, say why. Do not use this profile to reduce proof, capability, matrix, or docs obligations for capability landings.
+
+## Fixture-root ownership expectations
+
+Metadata-verification tasks own only their declared fixture roots. Fixture roots should normally match the capability ID or task slug. Do not edit unrelated fixture roots to make tests pass. Unknown fixture drift must be classified and resolved before commit; generated-expected fixture updates must be deterministic and tied to the task-owned capability or slug.
+
+## Standard validation categories
+
+Run the validation categories required by `AGENTS.md`, the whole-system template, the validation/landing contract, and the task prompt. For memory-chain metadata-verification work, that usually includes:
+
+- focused module/CLI/governance tests;
+- docs dependency check and docs build;
+- prompt-boundary checks when docs or context-hygiene surfaces are touched;
+- strict audit verification and audit immutability verification;
+- matrix/landing-gate/supervisor sequence when required by the landing contract;
+- targeted mypy for changed Python surfaces, or an explicit not-applicable statement for docs/governance-only work.
+
+## Finalizer and PR metadata guard references
+
+Do not duplicate or weaken the executable landing sequence here. Use [`codex_validation_and_landing_contract.md`](codex_validation_and_landing_contract.md) and [`codex_finalize_landing.md`](codex_finalize_landing.md) for the required two-phase finalizer process, and require the PR metadata guard described there before `make_pr`.
+
+## Standard final report evidence list
+
+Final reports for memory-chain profile tasks should include:
+
+- why the task ran before any live-memory adapter or memory-chain advancement when sequencing matters;
+- exact files changed;
+- whether Python/tooling changed and targeted mypy applicability;
+- profile/template changes and future prompt-compression impact;
+- non-negotiable authority, runtime, audit, fixture-root, finalizer, PR metadata guard, clean-tree, and matrix rules that remain intact;
+- docs build, prompt-boundary, strict audit, immutability, focused test, matrix/landing gate/supervisor, finalizer, PR metadata guard, clean-tree, and PR metadata results;
+- unresolved risks or a statement that none are known.
+
+## Future prompt compression pattern
+
+Future memory-chain prompts should reference this profile and provide only task-specific deltas where possible:
+
+- task name;
+- capability id;
+- module/CLI/test/doc/fixture paths;
+- upstream dependencies;
+- unique candidate/status/decision names;
+- unique blockers;
+- unique validation deltas;
+- unique final report deltas.
+
+Prompts may still expand any section when the task deviates from the standard profile. Deviations must be explicit and cannot override `AGENTS.md`, finalizer, PR metadata guard, matrix, supervisor, audit, clean-tree, fixture-root, or authority-boundary requirements.

--- a/docs/development/codex_narrow_repair_task_template.md
+++ b/docs/development/codex_narrow_repair_task_template.md
@@ -20,6 +20,9 @@ Run targeted tests that prove the localized fix.
 ## Baseline/matrix/docs impact statement
 State whether mypy baseline, matrix lanes, and docs are impacted. This template must not be used to defer task-caused subsystem fallout that belongs in a whole-system landing.
 
+## Recurring memory-chain recovery note
+Recurring memory-chain metadata-verification failures should use [`codex_memory_chain_recovery_profile.md`](codex_memory_chain_recovery_profile.md) when applicable, unless the task is explicitly scoped as a narrower repair and explains why this narrower template controls.
+
 ## Safety constraints
 No authority widening, no runtime boundary expansion.
 

--- a/docs/development/codex_whole_system_task_template.md
+++ b/docs/development/codex_whole_system_task_template.md
@@ -53,6 +53,9 @@ List unit/integration/docs tests and expected assertions.
 ## Safety constraints
 Re-state no authority widening and no forbidden runtime semantics.
 
+## Compact subsystem profiles
+Recurring subsystem families may define compact task profiles so future prompts can reference stable requirements and provide only task-specific deltas. A profile can reduce prompt bulk, but it cannot override `AGENTS.md`, finalizer, PR metadata guard, matrix, supervisor, audit, clean-tree, fixture-root, proof, capability, docs, or authority-boundary requirements. For recurring memory-chain metadata-verification work, use [`codex_memory_chain_task_profile.md`](codex_memory_chain_task_profile.md) unless the prompt explicitly justifies a different profile.
+
 ## Validation commands
 List full relevant command matrix, not only local targeted tests.
 


### PR DESCRIPTION
### Motivation
- Reduce repeated prompt bulk and Codex credit waste for recurring memory-chain metadata-verification work while preserving every safety, validation, finalizer, PR-metadata, audit, and fixture-root requirement. 
- Provide a concise execution hot path so prompts can stop/start deterministically on bootstrap, dirty-tree, finalizer, and PR-guard hard stops. 
- Enable delta-only future prompts via canonical memory-chain profiles so recurring tasks can reference stable law instead of repeating large blocks of governance text.

### Description
- Add a compact "Codex Quick Law / Agent Hot Path" and a "Canonical Profile and Template Index" to `AGENTS.md` that summarize bootstrap hard stops, dirty-tree/manual-review blockers, finalizer/PR-guard requirements, memory-chain profile guidance, and non-authority boundaries. 
- Create `docs/development/codex_memory_chain_task_profile.md` as the reusable memory-chain task profile covering when to use it, relation to `AGENTS.md`, bootstrap posture, non-authority/no-runtime boundaries, fixture-root expectations, validation categories, final-report evidence, and a prompt-compression delta pattern. 
- Create `docs/development/codex_memory_chain_recovery_profile.md` defining compact recovery behavior for partial memory-chain failures including first-action `git status --short`, dirty-path classification, repair rules, evidence refresh, and hard stops for finalizer/PR-guard decisions. 
- Update templates to reference the new profiles by link: `docs/development/codex_whole_system_task_template.md` gains a short note about compact subsystem profiles and `docs/development/codex_narrow_repair_task_template.md` adds a recovery-note pointing to the recovery profile.

### Testing
- Bootstrapped and built docs using `python scripts/build_docs.py --bootstrap-docs`, `python scripts/build_docs.py --check-deps`, and `python scripts/build_docs.py`, and the docs build completed successfully. 
- Ran prompt-boundary and audit checks with `python scripts/verify_context_hygiene_prompt_boundaries.py`, `verify_audits.py --strict`, and `python scripts/audit_immutability_verifier.py`, and all returned passing results. 
- Executed the governance/matrix validation including `python scripts/run_work_item_review_packet_matrix.py --summary` and the focused test set (`python -m scripts.run_tests -q` for the codex finalizer, PR-guard, landing supervisor, validation-matrix-lane, and operating doctrine docs tests), and the matrix and test runs passed. 
- Exercised the two-phase finalizer checks and PR metadata guard (`python scripts/codex_finalize_landing.py finalize` in pre-commit and pr-metadata modes and `python scripts/codex_pr_metadata_guard.py verify`) which returned `ready_to_commit`, `ready_for_pr_metadata`, and `pr_metadata_guard_ready` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c648b4d888320806fa076f6e53764)