### PR TITLE
[codex:landing] harden evidence and recovery rail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,14 @@ Reviewers are explicitly welcomed to question and strengthen this ledger.
 
 ## 🛠️ Codex Agent Operating Instructions
 
+### Codex recovery and evidence law
+- Do not close a failed Codex task that contains task-owned files until one of these is true: a PR is created; a commit, branch, or patch artifact is explicitly available for recovery; or the task reports `no-files-found` and recovery is impossible.
+- Recovery prompts only work in the same workspace when task-owned files or commits are still present; fresh workspaces cannot recover uncommitted task-owned files from closed Codex tasks.
+- For late PR metadata or finalizer failures, prefer same-task surgical recovery over a full rerun so task-owned files, matrix evidence, and finalizer artifacts remain available.
+- Future memory-chain tasks must generate PR body evidence with `scripts/build_codex_landing_evidence_body.py` instead of hand-written or ad hoc evidence bodies.
+- Do not call `make_pr` unless `scripts/codex_pr_metadata_guard.py verify` returns `pr_metadata_guard_ready`.
+- Do not use duplicated giant prompts for memory-chain rungs; use compact task deltas plus bootstrap/task-profile conventions whenever possible.
+
 ### Codex Quick Law / Agent Hot Path
 - Bootstrap first. If bootstrap returns `blocked`, stop immediately; blocked prompt/scaffold artifacts are diagnostic only and must not be used as implementation contracts.
 - `unknown_dirty_tree` and `manual_review_required` block commit until the exact reported paths are resolved.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -1,0 +1,84 @@
+# Codex landing evidence and recovery rail
+
+This rail hardening covers Codex process failures around late PR metadata and finalizer evidence. It is not a memory-chain advancement path and does not authorize Real Executor Invocation Gate implementation, executor invocation, prompt assembly, live-context retrieval, external disclosure, live-memory mutation, lock acquisition, or runtime flag changes.
+
+## Failure pattern: Real Executor Invocation Gate attempts
+
+The recurring failure pattern was procedural rather than an executor implementation success:
+
+1. A Real Executor Invocation Gate attempt appeared to create task-owned implementation files.
+2. The task failed late at PR metadata or finalizer evidence, including missing matrix output references or incomplete PR-body evidence.
+3. The task was closed without a PR, commit, branch, or patch artifact that preserved those task-owned files.
+4. A later recovery prompt ran in a fresh workspace where the uncommitted files were absent.
+5. Recovery was impossible, so a fresh rerun consumed substantial credits and repeated landing-risk conditions.
+
+The fix is to make landing evidence durable and repo-native before PR metadata is attempted. Future tasks should generate the PR body from canonical artifacts instead of reconstructing ad hoc text after a late guard failure.
+
+## No-files-found recovery limit
+
+`no-files-found` means recovery cannot find task-owned files, commits, branches, or patches in the current workspace. In a fresh workspace, uncommitted files from a closed Codex task are not present unless the previous task exported a patch, committed a branch, created a PR, or otherwise produced a durable artifact. A recovery prompt can inspect the current checkout, but it cannot reconstruct files that existed only in a previous ephemeral workspace.
+
+When `no-files-found` is reported, the correct conclusion is that recovery of uncommitted implementation is impossible in that workspace. Do not continue as if missing files are hidden implementation contracts. Either locate a durable artifact or perform a new implementation from the current repo state.
+
+## Canonical PR metadata evidence
+
+PR metadata evidence must be generated from canonical artifacts because the landing gate and PR metadata guard validate concrete evidence, not intent. The durable inputs are:
+
+- the matrix JSON written by `scripts/run_work_item_review_packet_matrix.py --output`;
+- the landing supervisor JSON, when already available;
+- explicit result text for targeted mypy, baseline, docs build, prompt-boundary checks, strict audit, immutability verifier, finalizer, PR metadata guard, landing gate, and unresolved risks.
+
+Use `scripts/build_codex_landing_evidence_body.py` to produce the PR body. The script writes the required sections, preserves guard-required marker text, and fails if the matrix JSON is missing, the matrix output path marker is absent, the unresolved risks section is absent, or the body is evidence-light.
+
+## Fresh matrix output path
+
+The matrix output path must remain explicit because `matrix_output_reference_missing` is a late PR metadata failure class. A body that claims validation passed but does not name the `--output` artifact is not recoverable enough for reviewers or guard tooling.
+
+The matrix path must also be fresh. The finalizer's `stale_evidence_matrix_output` behavior is correct: if cleanup or later validation changes can make earlier matrix evidence stale, the fix is to refresh matrix evidence and rerun landing gate/supervisor/finalizer in the same task. The finalizer does not need to delete `/tmp` matrix output to cause staleness; stale evidence can arise when the evidence no longer reflects the final source tree or post-cleanup state.
+
+## Same-task recovery for late landing failures
+
+For late PR metadata, landing gate, supervisor, or finalizer failures:
+
+1. Keep the task open in the same workspace.
+2. Preserve task-owned files and generated evidence paths.
+3. Repair only the missing evidence or stale-evidence blocker.
+4. Regenerate the PR body with `scripts/build_codex_landing_evidence_body.py`.
+5. Rerun the landing gate with the generated body.
+6. Rerun the landing supervisor with the fresh matrix JSON.
+7. Rerun the two-phase finalizer sequence as required.
+8. Run the PR metadata guard and call `make_pr` only after `pr_metadata_guard_ready`.
+
+Do not close the task until a PR exists, a commit/branch/patch artifact exists, or `no-files-found` has been reported and recovery is impossible.
+
+## Distinguishing failure classes
+
+- **Implementation failure**: source, docs, fixtures, or tests are missing or failing. Repair task-owned implementation and rerun focused validation before the landing sequence.
+- **PR metadata failure**: implementation exists, but PR title/body/evidence markers are incomplete. Regenerate the body from canonical artifacts and rerun landing gate/guard.
+- **Finalizer stale-evidence failure**: validation evidence no longer reflects the final tree, often after cleanup or audit repair. Refresh matrix output, landing gate, and supervisor evidence in the same task, then rerun the finalizer.
+- **Dependency setup noise**: Python or package setup warnings, such as environment bootstrap chatter, are not implementation evidence. Classify them as environment noise unless they cause a required command to fail.
+- **Workspace state loss**: a fresh workspace lacks uncommitted files from a closed task. If no commit, branch, PR, or patch artifact exists, report `no-files-found`; do not claim recovery is possible.
+
+## Using the generated PR body script
+
+Example:
+
+```bash
+python scripts/build_codex_landing_evidence_body.py \
+  --title "[codex:landing] harden evidence and recovery rail" \
+  --intended-commit-title "[codex:landing] harden evidence and recovery rail" \
+  --matrix-json-path /tmp/codex_landing_evidence_recovery_rail_matrix.json \
+  --landing-supervisor-json-path /tmp/codex_landing_evidence_recovery_rail_supervisor.json \
+  --output /tmp/codex_landing_evidence_recovery_rail_pr_body.txt \
+  --targeted-mypy "passed" \
+  --baseline "passed" \
+  --docs-build "passed" \
+  --prompt-boundary "passed" \
+  --strict-audit "passed" \
+  --immutability-verifier "passed" \
+  --finalizer "pre-commit ready_to_commit; post-commit pending" \
+  --pr-metadata-guard "pending" \
+  --unresolved-risks "None known."
+```
+
+The output body includes `Matrix output path: <path>` and `Unresolved risks: <text>`, plus the marker text required by the PR metadata contract. If the landing supervisor JSON is not yet written, the script records the requested path as pending so the body can be used for the landing gate before supervisor evaluation.

--- a/docs/development/codex_memory_chain_task_profile.md
+++ b/docs/development/codex_memory_chain_task_profile.md
@@ -99,6 +99,19 @@ Final reports for memory-chain profile tasks should include:
 - docs build, prompt-boundary, strict audit, immutability, focused test, matrix/landing gate/supervisor, finalizer, PR metadata guard, clean-tree, and PR metadata results;
 - unresolved risks or a statement that none are known.
 
+## Metadata-verification landing evidence and recovery
+
+Memory-chain metadata-verification rungs should treat bootstrap output as the canonical task contract and keep prompts compact. Provide only task deltas that differ from this profile: capability IDs, changed paths, fixtures, blockers, validation deltas, and final-report additions. Do not paste duplicated giant prompt bodies when bootstrap and this profile already define the stable contract.
+
+Generate PR-body evidence with `scripts/build_codex_landing_evidence_body.py` from canonical matrix and landing-supervisor artifacts. The generated body must preserve the matrix output path, unresolved risks, and PR metadata guard markers so late landing failures can be repaired surgically without reconstructing ad hoc PR text.
+
+Recovery handling must be explicit:
+
+- same-workspace recovery can continue when task-owned files, commits, branches, or patch artifacts are present;
+- `no-files-found` in a fresh workspace means uncommitted task-owned implementation is not recoverable from the closed task;
+- late PR metadata, finalizer, or stale-evidence failures should be repaired in the same task by refreshing canonical evidence and rerunning the finalizer/guard sequence, not by rerunning the whole rung;
+- landing-rail repair tasks must not advance the memory chain, invoke executors, assemble prompts, retrieve live context, mutate live memory roots, or enable runtime execution.
+
 ## Future prompt compression pattern
 
 Future memory-chain prompts should reference this profile and provide only task-specific deltas where possible:

--- a/scripts/build_codex_landing_evidence_body.py
+++ b/scripts/build_codex_landing_evidence_body.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REQUIRED_SECTIONS: tuple[str, ...] = (
+    "### Motivation",
+    "### Description",
+    "### Testing",
+    "### Full command matrix results",
+    "### Matrix runner summary",
+    "### Matrix runner output",
+    "### Targeted mypy",
+    "### Mypy baseline",
+    "### Docs build",
+    "### Prompt-boundary verification",
+    "### Strict audit",
+    "### Immutability verifier",
+    "### Landing gate",
+    "### Landing Supervisor",
+    "### Finalizer status",
+    "### PR metadata guard",
+    "### Unresolved risks",
+)
+
+GUARD_REQUIRED_MARKERS: tuple[str, ...] = (
+    "full command matrix results",
+    "matrix runner --summary result",
+    "matrix runner --output result/path",
+    "targeted mypy result",
+    "baseline result",
+    "docs build result",
+    "prompt-boundary result",
+    "strict audit result",
+    "immutability verifier result",
+    "unresolved risks",
+)
+
+MATRIX_OUTPUT_PATH_PREFIX = "Matrix output path: "
+
+
+def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return parsed
+
+
+def _load_optional_json_object(path_text: str) -> dict[str, Any] | None:
+    if not path_text:
+        return None
+    path = Path(path_text)
+    if not path.exists():
+        return None
+    return _load_json_object(path, label="landing supervisor JSON")
+
+
+def _row_exit_code(matrix: Mapping[str, Any], labels: tuple[str, ...]) -> int | None:
+    wanted = set(labels)
+    rows = matrix.get("results", [])
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        return None
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("label", "")) not in wanted:
+            continue
+        try:
+            return int(row.get("exit_code", 1))
+        except (TypeError, ValueError):
+            return 1
+    return None
+
+
+def _exit_summary(matrix: Mapping[str, Any], labels: tuple[str, ...], *, default: str = "not recorded in matrix") -> str:
+    exit_code = _row_exit_code(matrix, labels)
+    if exit_code is None:
+        return default
+    return "passed (exit_code=0)" if exit_code == 0 else f"failed (exit_code={exit_code})"
+
+
+def _matrix_command_lines(matrix: Mapping[str, Any]) -> list[str]:
+    rows = matrix.get("results", [])
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        return []
+    lines: list[str] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        label = str(row.get("label", "unknown"))
+        required = bool(row.get("required", True))
+        try:
+            exit_code = int(row.get("exit_code", 1))
+        except (TypeError, ValueError):
+            exit_code = 1
+        command_value = row.get("command", [])
+        if isinstance(command_value, Sequence) and not isinstance(command_value, (str, bytes)):
+            command = " ".join(str(part) for part in command_value)
+        else:
+            command = str(command_value or "not recorded")
+        lines.append(f"- {label}: exit_code={exit_code}; required={str(required).lower()}; command={command}")
+    return lines
+
+
+def _supervisor_summary(payload: Mapping[str, Any] | None, path_text: str) -> str:
+    if payload is None:
+        return f"Landing Supervisor result: pending or not yet written at {path_text}."
+    decision = payload.get("decision")
+    if isinstance(decision, Mapping):
+        status = str(decision.get("status", "unknown"))
+    else:
+        status = str(payload.get("status", "unknown"))
+    reasons_value = payload.get("report", {})
+    reasons: object = []
+    if isinstance(reasons_value, Mapping):
+        reasons = reasons_value.get("reasons", [])
+    return f"Landing Supervisor result: {status}; reasons={json.dumps(reasons, sort_keys=True)}."
+
+
+def _text(value: str, fallback: str) -> str:
+    stripped = value.strip()
+    return stripped if stripped else fallback
+
+
+def build_body(
+    *,
+    title: str,
+    intended_commit_title: str,
+    matrix_json_path: Path,
+    landing_supervisor_json_path: str,
+    targeted_mypy: str,
+    baseline: str,
+    docs_build: str,
+    prompt_boundary: str,
+    strict_audit: str,
+    immutability_verifier: str,
+    finalizer: str,
+    pr_metadata_guard: str,
+    unresolved_risks: str,
+    landing_gate: str,
+    motivation: str,
+    description: str,
+    testing: str,
+) -> str:
+    if not matrix_json_path.exists():
+        raise ValueError(f"matrix-json-path does not exist: {matrix_json_path}")
+    matrix = _load_json_object(matrix_json_path, label="matrix JSON")
+    supervisor = _load_optional_json_object(landing_supervisor_json_path)
+
+    status = str(matrix.get("status", "unknown"))
+    required_failure_count = str(matrix.get("required_failure_count", "unknown"))
+    command_count = str(matrix.get("command_count", len(_matrix_command_lines(matrix))))
+    required_failures = matrix.get("required_failures", [])
+    if not isinstance(required_failures, Sequence) or isinstance(required_failures, (str, bytes)):
+        required_failures = []
+
+    targeted_mypy_result = _text(targeted_mypy, _exit_summary(matrix, ("targeted_mypy",)))
+    baseline_result = _text(baseline, _exit_summary(matrix, ("mypy_baseline",)))
+    docs_build_result = _text(docs_build, _exit_summary(matrix, ("docs_build",)))
+    prompt_boundary_result = _text(prompt_boundary, _exit_summary(matrix, ("prompt_boundaries", "prompt_boundary")))
+    strict_audit_result = _text(strict_audit, _exit_summary(matrix, ("strict_audits", "strict_audit")))
+    immutability_result = _text(immutability_verifier, _exit_summary(matrix, ("audit_immutability", "immutability_verifier")))
+    unresolved = _text(unresolved_risks, "None known.")
+
+    matrix_lines = _matrix_command_lines(matrix)
+    matrix_lines_text = "\n".join(matrix_lines) if matrix_lines else "- Matrix contained no per-command rows."
+    path_text = str(matrix_json_path)
+
+    sections = [
+        ("### Motivation", _text(motivation, "Harden Codex landing evidence so late PR metadata/finalizer failures retain canonical, repo-native recovery information instead of relying on hand-written evidence bodies.")),
+        ("### Description", _text(description, f"Title: {title}\nIntended commit title: {intended_commit_title}\nGenerated from canonical matrix artifact and landing supervisor path.")),
+        ("### Testing", _text(testing, "See full matrix, targeted checks, landing gate, supervisor, finalizer, and PR metadata guard sections below.")),
+        (
+            "### Full command matrix results",
+            "\n".join(
+                [
+                    f"Full command matrix results: status={status}; required_failure_count={required_failure_count}; command_count={command_count}.",
+                    f"Required failures: {json.dumps(list(required_failures), sort_keys=True)}.",
+                    matrix_lines_text,
+                ]
+            ),
+        ),
+        ("### Matrix runner summary", f"Matrix runner --summary result: {status}; required_failure_count={required_failure_count}."),
+        ("### Matrix runner output", f"Matrix runner --output result/path: {path_text}\n{MATRIX_OUTPUT_PATH_PREFIX}{path_text}"),
+        ("### Targeted mypy", f"Targeted mypy result: {targeted_mypy_result}"),
+        ("### Mypy baseline", f"Baseline result: {baseline_result}"),
+        ("### Docs build", f"Docs build result: {docs_build_result}"),
+        ("### Prompt-boundary verification", f"Prompt-boundary result: {prompt_boundary_result}"),
+        ("### Strict audit", f"Strict audit result: {strict_audit_result}"),
+        ("### Immutability verifier", f"Immutability verifier result: {immutability_result}"),
+        ("### Landing gate", _text(landing_gate, "Landing gate result: pending until scripts/codex_pr_landing_gate.py verifies this generated body.")),
+        ("### Landing Supervisor", _supervisor_summary(supervisor, landing_supervisor_json_path)),
+        ("### Finalizer status", _text(finalizer, "Finalizer status: pending standard two-phase finalizer.")),
+        ("### PR metadata guard", _text(pr_metadata_guard, "PR metadata guard: pending post-commit finalizer evidence.")),
+        ("### Unresolved risks", f"Unresolved risks: {unresolved}"),
+    ]
+    body = "\n\n".join(f"{heading}\n{content.strip()}" for heading, content in sections).strip() + "\n"
+    validate_body(body, matrix_json_path=matrix_json_path)
+    return body
+
+
+def validate_body(body: str, *, matrix_json_path: Path) -> None:
+    normalized = " ".join(body.lower().replace("_", " ").split())
+    if len(body.strip()) < 600:
+        raise ValueError("generated body is evidence-light")
+    missing_sections = [section for section in REQUIRED_SECTIONS if section not in body]
+    if missing_sections:
+        raise ValueError("generated body omitted required sections: " + ", ".join(missing_sections))
+    if MATRIX_OUTPUT_PATH_PREFIX + str(matrix_json_path) not in body:
+        raise ValueError("generated body omitted Matrix output path marker")
+    if "### Unresolved risks" not in body or "unresolved risks:" not in normalized:
+        raise ValueError("generated body omitted unresolved risks section")
+    missing_markers = [marker for marker in GUARD_REQUIRED_MARKERS if marker not in normalized]
+    if missing_markers:
+        raise ValueError("generated body omitted PR metadata guard markers: " + ", ".join(missing_markers))
+    placeholder_tokens = ("todo", "tbd", "placeholder-only")
+    if any(token in normalized for token in placeholder_tokens):
+        raise ValueError("generated body contains placeholder-only evidence")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a deterministic Codex landing evidence PR body from canonical artifacts.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--intended-commit-title", required=True)
+    parser.add_argument("--matrix-json-path", required=True)
+    parser.add_argument("--landing-supervisor-json-path", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--targeted-mypy", default="")
+    parser.add_argument("--baseline", default="")
+    parser.add_argument("--docs-build", default="")
+    parser.add_argument("--prompt-boundary", default="")
+    parser.add_argument("--strict-audit", default="")
+    parser.add_argument("--immutability-verifier", default="")
+    parser.add_argument("--finalizer", default="")
+    parser.add_argument("--pr-metadata-guard", default="")
+    parser.add_argument("--unresolved-risks", default="None known.")
+    parser.add_argument("--landing-gate", default="")
+    parser.add_argument("--motivation", default="")
+    parser.add_argument("--description", default="")
+    parser.add_argument("--testing", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    matrix_json_path = Path(args.matrix_json_path)
+    if not args.matrix_json_path.strip():
+        print("matrix-json-path is required", file=sys.stderr)
+        return 2
+    try:
+        body = build_body(
+            title=args.title,
+            intended_commit_title=args.intended_commit_title,
+            matrix_json_path=matrix_json_path,
+            landing_supervisor_json_path=args.landing_supervisor_json_path,
+            targeted_mypy=args.targeted_mypy,
+            baseline=args.baseline,
+            docs_build=args.docs_build,
+            prompt_boundary=args.prompt_boundary,
+            strict_audit=args.strict_audit,
+            immutability_verifier=args.immutability_verifier,
+            finalizer=args.finalizer,
+            pr_metadata_guard=args.pr_metadata_guard,
+            unresolved_risks=args.unresolved_risks,
+            landing_gate=args.landing_gate,
+            motivation=args.motivation,
+            description=args.description,
+            testing=args.testing,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    Path(args.output).write_text(body, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_codex_landing_evidence_body_script.py
+++ b/tests/test_build_codex_landing_evidence_body_script.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sentientos.codex_pr_landing_gate import verify_pr_landing_gate
+from sentientos.codex_pr_metadata_contract import REQUIRED_BODY_MARKERS, verify_pr_metadata
+from scripts.build_codex_landing_evidence_body import main
+
+TITLE = "[codex:landing] harden evidence and recovery rail"
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _matrix(path: Path) -> Path:
+    payload = {
+        "status": "passed",
+        "required_failure_count": 0,
+        "command_count": 8,
+        "required_failures": [],
+        "results": [
+            {"label": "targeted_tests", "command": ["python", "-m", "scripts.run_tests", "-q", "tests/test_build_codex_landing_evidence_body_script.py"], "required": True, "exit_code": 0},
+            {"label": "targeted_mypy", "command": ["python", "-m", "mypy", "scripts/build_codex_landing_evidence_body.py"], "required": True, "exit_code": 0},
+            {"label": "mypy_baseline", "command": ["python", "scripts/check_mypy_baseline.py"], "required": True, "exit_code": 0},
+            {"label": "docs_check_deps", "command": ["python", "scripts/build_docs.py", "--check-deps"], "required": False, "exit_code": 0},
+            {"label": "docs_build", "command": ["python", "scripts/build_docs.py"], "required": True, "exit_code": 0},
+            {"label": "prompt_boundaries", "command": ["python", "scripts/verify_context_hygiene_prompt_boundaries.py"], "required": True, "exit_code": 0},
+            {"label": "strict_audits", "command": ["python", "verify_audits.py", "--strict"], "required": True, "exit_code": 0},
+            {"label": "audit_immutability", "command": ["python", "scripts/audit_immutability_verifier.py"], "required": True, "exit_code": 0},
+        ],
+    }
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _build(tmp_path: Path) -> Path:
+    matrix = _matrix(tmp_path / "matrix.json")
+    supervisor = tmp_path / "supervisor.json"
+    supervisor.write_text(json.dumps({"decision": {"status": "ready_for_pr_metadata"}, "report": {"reasons": []}}, sort_keys=True), encoding="utf-8")
+    output = tmp_path / "body.txt"
+    code = main(
+        [
+            "--title",
+            TITLE,
+            "--intended-commit-title",
+            TITLE,
+            "--matrix-json-path",
+            str(matrix),
+            "--landing-supervisor-json-path",
+            str(supervisor),
+            "--output",
+            str(output),
+            "--targeted-mypy",
+            "passed",
+            "--baseline",
+            "passed",
+            "--docs-build",
+            "passed",
+            "--prompt-boundary",
+            "passed",
+            "--strict-audit",
+            "passed",
+            "--immutability-verifier",
+            "passed",
+            "--landing-gate",
+            "passed",
+            "--finalizer",
+            "pre-commit ready_to_commit; post-commit ready_for_pr_metadata",
+            "--pr-metadata-guard",
+            "pr_metadata_guard_ready",
+            "--unresolved-risks",
+            "None known.",
+        ]
+    )
+    assert code == 0
+    return output
+
+
+def test_generated_body_includes_matrix_output_path(tmp_path: Path) -> None:
+    output = _build(tmp_path)
+    assert f"Matrix output path: {tmp_path / 'matrix.json'}" in output.read_text(encoding="utf-8")
+
+
+def test_generated_body_includes_unresolved_risks(tmp_path: Path) -> None:
+    body = _build(tmp_path).read_text(encoding="utf-8")
+    assert "### Unresolved risks" in body
+    assert "Unresolved risks: None known." in body
+
+
+def test_generated_body_includes_every_pr_metadata_guard_required_marker(tmp_path: Path) -> None:
+    body = _build(tmp_path).read_text(encoding="utf-8")
+    result = verify_pr_metadata(pr_title=TITLE, intended_commit_title=TITLE, pr_body=body)
+    assert result.status == "codex_pr_metadata_contract_ready"
+    for marker in REQUIRED_BODY_MARKERS:
+        assert marker in " ".join(body.lower().split())
+
+
+def test_missing_matrix_json_fails(tmp_path: Path) -> None:
+    output = tmp_path / "body.txt"
+    code = main(["--title", TITLE, "--intended-commit-title", TITLE, "--matrix-json-path", str(tmp_path / "missing.json"), "--landing-supervisor-json-path", str(tmp_path / "supervisor.json"), "--output", str(output)])
+    assert code == 1
+    assert not output.exists()
+
+
+def test_missing_matrix_path_marker_fails(tmp_path: Path) -> None:
+    from scripts.build_codex_landing_evidence_body import validate_body
+
+    matrix = _matrix(tmp_path / "matrix.json")
+    body = _build(tmp_path).read_text(encoding="utf-8").replace(f"Matrix output path: {matrix}", "Matrix output path omitted")
+    try:
+        validate_body(body, matrix_json_path=matrix)
+    except ValueError as exc:
+        assert "Matrix output path" in str(exc)
+    else:
+        raise AssertionError("validate_body accepted a body without the matrix path marker")
+
+
+def test_generated_body_passes_landing_gate_without_matrix_output_reference_missing(tmp_path: Path) -> None:
+    matrix = _matrix(tmp_path / "matrix.json")
+    body = _build(tmp_path).read_text(encoding="utf-8")
+    result = verify_pr_landing_gate(proposed_pr_title=TITLE, intended_commit_title=TITLE, proposed_pr_body=body, matrix_json_text=matrix.read_text(encoding="utf-8"))
+    assert result.decision == "pr_metadata_allowed"
+    assert "matrix_output_reference_missing" not in result.blocker_codes
+
+
+def test_script_is_deterministic(tmp_path: Path) -> None:
+    first = _build(tmp_path).read_text(encoding="utf-8")
+    second = _build(tmp_path).read_text(encoding="utf-8")
+    assert first == second

--- a/tests/test_codex_task_finalizer.py
+++ b/tests/test_codex_task_finalizer.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.codex_finalize_landing import build_parser
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def test_codex_task_finalizer_compatibility_parser_entrypoint() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["finalize", "--phase", "pre-commit", "--title", "x", "--intended-commit-title", "x"])
+    assert args.cmd == "finalize"
+    assert args.phase == "pre-commit"


### PR DESCRIPTION
### Motivation
- Prevent loss of task-owned implementation and late PR-metadata/finalizer failures by making landing evidence deterministic, repo-native, and recoverable. 
- Ensure future memory-chain tasks avoid embedding giant duplicated prompts and instead produce canonical PR bodies from stable artifacts. 
- Document explicit same-workspace recovery limits and recovery/repair procedures so surgical recovery is possible without re-running entire memory-chain rungs.

### Description
- Add `scripts/build_codex_landing_evidence_body.py`, a deterministic PR-body/evidence generator that requires `--matrix-json-path`, accepts a landing-supervisor JSON and per-check summaries, emits the exact required sections (Motivation, Description, Testing, Full command matrix results, Matrix runner summary, Matrix runner output, Targeted mypy, Mypy baseline, Docs build, Prompt-boundary verification, Strict audit, Immutability verifier, Landing gate, Landing Supervisor, Finalizer status, PR metadata guard, Unresolved risks), and fails when matrix JSON is missing, the matrix path marker is omitted, unresolved risks are omitted, or the body is evidence-light. 
- Add tests `tests/test_build_codex_landing_evidence_body_script.py` validating matrix output path inclusion, unresolved risks, required PR-metadata markers, failure modes for missing matrix JSON and missing matrix-path marker, landing-gate compatibility (no `matrix_output_reference_missing`), and determinism. 
- Update `AGENTS.md` with a concise “Codex recovery and evidence law” section that requires durable artifacts or `no-files-found` before closing tasks, mandates `scripts/build_codex_landing_evidence_body.py` for PR-body generation, and forbids `make_pr` until the PR metadata guard returns `pr_metadata_guard_ready`. 
- Extend `docs/development/codex_memory_chain_task_profile.md` with guidance to use compact prompt deltas, bootstrap output as canonical contract, repo-native PR-body generation, explicit `no-files-found` recovery handling, and same-task surgical recovery rules (no memory-chain advancement during repair). 
- Add `docs/development/codex_landing_evidence_recovery_rail.md` documenting the failure pattern, no-files-found limits, canonical evidence requirements, same-task recovery steps, and how to use the new script. 
- Add a small compatibility test `tests/test_codex_task_finalizer.py` for finalizer CLI parser surface.

### Testing
- Bootstrap: `python scripts/bootstrap_codex_task.py ...` returned `ready_with_warnings` (expected bootstrap posture). 
- Focused script tests: `python -m scripts.run_tests -q tests/test_build_codex_landing_evidence_body_script.py` passed (new script tests). 
- Dependent landing-rail suite: `python -m scripts.run_tests -q tests/test_codex_pr_metadata_guard.py tests/test_codex_pr_landing_gate.py tests/test_codex_landing_supervisor.py tests/test_codex_task_finalizer.py tests/test_codex_validation_matrix_lane_contract.py tests/test_codex_validation_matrix_lane_contract_script.py tests/test_work_item_review_packet_matrix.py` passed. 
- Type checks: `python -m mypy scripts/build_codex_landing_evidence_body.py` passed and targeted mypy/baseline checks passed. 
- Docs and hygiene: `python scripts/build_docs.py` (with bootstrap as needed) and `python scripts/verify_context_hygiene_prompt_boundaries.py` passed. 
- Audits: `python verify_audits.py --strict` and `python scripts/audit_immutability_verifier.py` passed. 
- Matrix and lane contract: `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/codex_landing_evidence_recovery_rail_matrix.json` produced a passing matrix and `python scripts/codex_validation_matrix_lane_contract.py verify --matrix-json-path /tmp/codex_landing_evidence_recovery_rail_matrix.json` returned `codex_validation_matrix_lane_contract_ready`. 
- Gate & supervisor: `scripts/codex_pr_landing_gate.py verify` accepted the generated body (`pr_metadata_allowed`) and `scripts/codex_landing_supervisor.py evaluate` returned `ready_for_pr_metadata`. 
- Finalizer & PR guard: pre-commit and post-commit finalizer runs returned `ready_to_commit` and `ready_for_pr_metadata` respectively, and `scripts/codex_pr_metadata_guard.py verify` returned `pr_metadata_guard_ready`. 
- All automated checks above completed successfully and the repo tree was left clean after commit and cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21bcdaac8c832091a97c4e0ac9100c)