### PR TITLE
[codex:memory-chain] define post-envelope topology pause

### DIFF
--- a/docs/architecture/sandboxed_live_memory_commit_adapter_envelope.md
+++ b/docs/architecture/sandboxed_live_memory_commit_adapter_envelope.md
@@ -28,6 +28,27 @@ Failed or partial sandboxed adapter readiness-gate workspaces must not be recove
 
 Later repo-native topology review may reference the sandboxed envelope's carried metadata, but the envelope does not authorize a `sandboxed_live_memory_commit_adapter_readiness_gate`, `sandboxed_live_memory_commit_adapter_readiness_packet`, `sandboxed_live_memory_commit_adapter_readiness_envelope`, or repeated sandboxed ladder. Any future live-adjacent progression must either use an already-defined repo-native chain or land a separate topology decision proving the exact non-recursive handoff. Historical decision strings, future-flag names, safe-next-action labels, or registry deferred-surface labels that mention a sandboxed readiness gate are terminal review markers only, not implementation authority and not proof that a sandboxed readiness gate should be created.
 
+
+## Post-envelope topology decision
+
+The sandboxed adapter branch terminates at `sandboxed_live_memory_commit_adapter_envelope`. The envelope has no currently implemented repo-native consumer, and historical sandboxed-readiness wording is a terminal review marker only, not an implementation contract. Codex must not proceed to implementation after the envelope by mechanical rename, sequence inference, or reuse of readiness-gate wording.
+
+The default state after `sandboxed_live_memory_commit_adapter_envelope` is implementation pause. Until repo-native docs define a concrete continuation, no post-envelope implementation task is authorized and no sandboxed readiness gate, packet, envelope, runtime adapter, executor, lock, live-memory root, admission path, or authority component may be created from the envelope.
+
+A future continuation requires a separate architecture decision that defines all of the following fields before implementation:
+
+- exact next rung name;
+- upstream evidence key;
+- candidate key;
+- ready decision;
+- capability id;
+- validation lane;
+- terminal handoff target;
+- non-recursive proof;
+- why the existing real-root, final-review, and real-readiness topology is insufficient.
+
+Until those fields exist in repo-native docs, `sandboxed_live_memory_commit_adapter_envelope` remains a terminal evidence artifact and no post-envelope implementation is authorized.
+
 ## CLI
 
 Use `scripts/build_sandboxed_live_memory_commit_adapter_envelope.py` with `build-default`, `evaluate`, `validate`, `summarize`, or `inspect-fixture`. Evaluation emits deterministic JSON and writes nothing.


### PR DESCRIPTION
### Motivation

- The repo-native memory-chain topology audit found no implemented consumer after `sandboxed_live_memory_commit_adapter_envelope`, so the change clarifies the intended pause point to avoid accidental implementation. 
- Prevent mechanical continuation or reuse of historical sandboxed-readiness wording as an implementation contract. 
- Ensure future continuation is gated by an explicit architecture decision rather than inferred from review markers.

### Description

- Added a `Post-envelope topology decision` section to `docs/architecture/sandboxed_live_memory_commit_adapter_envelope.md` that states the sandboxed adapter branch terminates at `sandboxed_live_memory_commit_adapter_envelope` and that the envelope has no currently implemented repo-native consumer. 
- Declares the default state after the envelope as an implementation pause and forbids creating any sandboxed readiness gate/packet/envelope, runtime adapter, executor, lock, live-memory root, admission path, or authority component from the envelope. 
- Documents the required fields any future continuation architecture decision must define before implementation: exact next rung name, upstream evidence key, candidate key, ready decision, capability id, validation lane, terminal handoff target, non-recursive proof, and explanation of why existing real-root/final-review/real-readiness topology is insufficient.

### Testing

- Ran focused tests and matrix lanes: `python -m scripts.run_tests -q tests/test_sandboxed_live_memory_commit_adapter_envelope.py tests/test_build_sandboxed_live_memory_commit_adapter_envelope_script.py` and `python -m scripts.run_tests -q tests/test_codex_validation_matrix_lane_contract.py tests/test_work_item_review_packet_matrix.py tests/test_capability_registry.py` and `python -m scripts.run_tests -q tests/test_codex_operating_doctrine_docs.py`, all of which passed. 
- Performed prompt-boundary and docs build checks: `python scripts/verify_context_hygiene_prompt_boundaries.py` passed, `python scripts/build_docs.py --bootstrap-docs` was used to repair docs deps, and `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` completed successfully. 
- Finalizer and metadata guard checks completed: `codex_finalize_landing.py` returned `ready_to_commit` (pre-commit) and `ready_for_pr_metadata` (pr-metadata), and `codex_pr_metadata_guard.py verify` returned `pr_metadata_guard_ready`; a commit was created (`b20c5aca74260a340dd191fe41ee0ed565b04cce`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31a1ccc46c832f8e7ef6bae353c3a4)