### PR TITLE
[codex:work-item] audit work-item attestation matrix proof consistency

### DIFF
--- a/docs/development/codex_capability_landing_checklist.md
+++ b/docs/development/codex_capability_landing_checklist.md
@@ -11,6 +11,8 @@ When adding or changing a capability ID, verify all adjacent integration surface
 - proof bundle payload exists (if applicable)
 - reviewer readiness/index link tests pass (if applicable)
 - matrix runner required lane exists (if applicable)
+  - Work-item lifecycle attestation review surfaces must keep their proof chain aligned: attestation index builder/verifier lanes, review digest builder/verifier lanes, and review digest index builder/verifier lanes stay registered in `scripts/run_work_item_review_packet_matrix.py` as required matrix lanes whenever their docs or tests are changed.
+  - The focused proof for the current review digest consistency surface is `python -m scripts.run_tests -q tests/test_work_item_lifecycle_attestation_review_digest.py tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py`; use the full work-item matrix when lane membership or matrix behavior changes.
 - targeted mypy scope includes new module/CLI (if applicable)
 - docs link/index coverage exists (if applicable)
 - no runtime authority is widened accidentally

--- a/tests/test_work_item_lifecycle_attestation_review_digest.py
+++ b/tests/test_work_item_lifecycle_attestation_review_digest.py
@@ -39,3 +39,19 @@ def test_digest_mismatch_contradicted() -> None:
 def test_matrix_required_failed_blocks() -> None:
     r = evaluate_work_item_lifecycle_attestation_review_digest(WorkItemLifecycleAttestationReviewDigestRequest(attestation_index=_index(), index_verification_report=_report(), matrix_report={"status": "failed"}), policy=WorkItemLifecycleAttestationReviewDigestPolicy(matrix_required=True))
     assert r.status == "lifecycle_attestation_review_digest_blocked"
+
+
+def test_review_digest_matrix_lane_is_registered() -> None:
+    from scripts.run_work_item_review_packet_matrix import default_matrix_commands
+
+    commands = {command.label: command for command in default_matrix_commands()}
+    lane = commands["work_item_lifecycle_attestation_review_digest_tests"]
+    assert lane.required is True
+    assert lane.command == (
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest.py",
+        "tests/test_build_work_item_lifecycle_attestation_review_digest_script.py",
+    )

--- a/tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py
+++ b/tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py
@@ -63,3 +63,19 @@ def test_contradiction_for_indexed_count_mismatch() -> None:
     bad["index"]["indexed_count"] = 9  # type: ignore[index]
     r = evaluate_work_item_lifecycle_attestation_review_digest_index_verification(WorkItemLifecycleAttestationReviewDigestIndexVerificationRequest(review_digest_index=bad))
     assert r.status == "lifecycle_attestation_review_digest_index_verification_contradicted"
+
+
+def test_review_digest_index_verifier_matrix_lane_is_registered() -> None:
+    from scripts.run_work_item_review_packet_matrix import default_matrix_commands
+
+    commands = {command.label: command for command in default_matrix_commands()}
+    lane = commands["work_item_lifecycle_attestation_review_digest_index_verifier_tests"]
+    assert lane.required is True
+    assert lane.command == (
+        "python",
+        "-m",
+        "scripts.run_tests",
+        "-q",
+        "tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py",
+        "tests/test_verify_work_item_lifecycle_attestation_review_digest_index_script.py",
+    )


### PR DESCRIPTION
### Motivation
- Audit the work-item lifecycle attestation proof chain for consistency drift across attestation index, review digest, review-digest-index verifier, matrix lanes, docs, and tests.
- Ensure matrix runner lanes for these attestation surfaces remain registered as required when related docs or tests change so proof-chain regressions are detected early.

### Description
- Add regression assertions to `tests/test_work_item_lifecycle_attestation_review_digest.py` asserting the `work_item_lifecycle_attestation_review_digest_tests` lane is registered, required, and uses the expected `scripts.run_tests` command.
- Add regression assertions to `tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py` asserting the `work_item_lifecycle_attestation_review_digest_index_verifier_tests` lane is registered, required, and uses the expected verifier test command.
- Update `docs/development/codex_capability_landing_checklist.md` to require that attestation index/review digest/review digest index proof-chain lanes remain registered in `scripts/run_work_item_review_packet_matrix.py` and to document the focused proof command for this surface.

### Testing
- Ran focused tests `python -m scripts.run_tests -q tests/test_work_item_lifecycle_attestation_review_digest.py tests/test_work_item_lifecycle_attestation_review_digest_index_verifier.py`, and they passed.
- Bootstrapped and ran docs build (`python scripts/build_docs.py --bootstrap-docs`, `--check-deps`, `python scripts/build_docs.py`) and the docs build passed after bootstrapping dependencies.
- Ran full work-item review packet matrix (`python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_attestation_consistency_matrix.json`) which returned `status=passed` with `command_count=110` and `required_failure_count=0`.
- Finalizer/guard results: pre-commit finalizer returned `ready_to_commit`, post-commit finalizer returned `ready_for_pr_metadata`, PR metadata guard returned `pr_metadata_guard_ready`, and the change was committed at `eb5ba434fbb3f4a786b37fa60a5ffb9aa47fc40e`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3359824e60832fa1e5942d177aae2b)