### PR TITLE
[codex:workspace-change-set] audit preflight proof coverage

### DIFF
--- a/docs/architecture/host_workspace_change_set_preflight_wing.md
+++ b/docs/architecture/host_workspace_change_set_preflight_wing.md
@@ -38,7 +38,9 @@ The optional CLI can write one explicit local preflight/plan JSON artifact to a 
 
 ## Reviewer proof posture
 
-The reviewer proof bundle documents `workspace_change_set_preflight_capability.json` but does not run change-set preflight by default. The proof command is listed as `proof_command_not_run` for reviewers who explicitly want to inspect the preflight/planning CLI.
+The reviewer proof bundle documents `workspace_change_set_preflight_capability.json` but does not run change-set preflight by default. The proof command is listed as `proof_command_not_run` for reviewers who explicitly want to inspect the preflight/planning CLI. This optional command can prove that the preflight/planning wing builds bounded manifest, preflight report, rollback-plan, and transaction-plan records for the declared targets; it cannot prove that a workspace change was applied, that rollback executed, or that any runner/orchestrator was invoked.
+
+Focused regression coverage for the preceding admission handoff lives in `tests/test_workspace_change_set_admission.py`. Those tests prove admission remains metadata-only, omits payload bodies, does not read target files, does not check target existence, does not compute filesystem digests, and does not invoke preflight helpers before declaring that preflight may be attempted next.
 
 ## Future work remains deferred
 

--- a/tests/test_reviewer_release_readiness_index.py
+++ b/tests/test_reviewer_release_readiness_index.py
@@ -673,6 +673,10 @@ def test_workspace_change_set_preflight_doc_is_linked_and_preserves_boundaries()
     assert "no built-in runner or transaction orchestrator is invoked" in doc
     assert "bounded successor" in doc
     assert "passed preflight and ready transaction plans" in doc
+    assert "cannot prove that a workspace change was applied" in doc
+    assert "Focused regression coverage for the preceding admission handoff" in doc
+    assert "tests/test_workspace_change_set_admission.py" in doc
+    assert "does not invoke preflight helpers" in doc
 
 
 HOST_WORKSPACE_CHANGE_SET_EXECUTION = "docs/architecture/host_workspace_change_set_execution_wing.md"


### PR DESCRIPTION
### Motivation
- Clarify reviewer-facing proof posture for the workspace change-set preflight so reviewers can distinguish metadata-only planning evidence from any evidence of apply/rollback/runner execution.
- Surface where focused regression coverage for the admission→preflight handoff lives so proof discoverability is explicit and consistent with tests.

### Description
- Add explanatory guidance to `docs/architecture/host_workspace_change_set_preflight_wing.md` stating that the optional preflight CLI proves bounded planning records but does not prove workspace mutation, rollback execution, or runner/orchestrator invocation.
- Add discoverability text in the same doc pointing reviewers to the admission handoff tests in `tests/test_workspace_change_set_admission.py` that assert metadata-only behavior and no preflight helper invocation.
- Update `tests/test_reviewer_release_readiness_index.py` to assert the new doc text is present so release-readiness coverage remains pinned and discoverable.
- No Python runtime behavior was changed; this PR is limited to documentation and test discoverability fixes.

### Testing
- Ran `python -m scripts.run_tests -q tests/test_workspace_change_set_admission.py` and the tests passed.
- Ran `python -m scripts.run_tests -q tests/test_reviewer_release_readiness_index.py` and the tests passed.
- Verified prompt-boundary and docs: `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python scripts/build_docs.py --check-deps`, and `python scripts/build_docs.py` succeeded after bootstrapping docs dependencies.
- Ran the Codex finalizer and PR metadata guard flows (`python scripts/codex_finalize_landing.py finalize` pre-commit/pr-metadata phases and `python scripts/codex_pr_metadata_guard.py verify`) and observed `ready_to_commit`, `ready_for_pr_metadata`, and `pr_metadata_guard_ready` decisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a337f9ec66c832fbb29f51608beabbb)