### PR TITLE
[codex:context-hygiene] consolidate denial-phase documentation

### DIFF
--- a/docs/architecture/context_hygiene_spine.md
+++ b/docs/architecture/context_hygiene_spine.md
@@ -451,6 +451,12 @@ The Phase 103 custody dimensions cover Phase 100 closure custody, Phase 101 enfo
 
 Phase 103 fails closed for missing Phase 100/101/102 metadata, Phase 100/101/102 digest mismatch, Phase 100/101/102 status contradiction, missing or failed strict audit verification, missing or failed immutable manifest verification, architecture-classification contradiction, prompt-boundary coverage gaps for Phase 100/101/102/103, allowlist broadening beyond metadata-only labels, unblock/approval/clearance markers, sensitive material markers, provider/network/export/runtime/prompt-text markers, prompt assembler modification markers, and artifact body read markers.
 
+## Phase 97-103 Denial-Phase Validation Coverage
+
+Phase 97-103 denial-phase coverage is validation coverage only. The spine records the architectural posture, `sentientos/capability_registry.py` registers the metadata-only capabilities and their proof commands, `scripts/run_work_item_review_packet_matrix.py` carries the default matrix lanes, `scripts/verify_context_hygiene_prompt_boundaries.py` carries the prompt/provider boundary scan targets, and `tests/test_capability_registry.py` plus `tests/test_work_item_review_packet_matrix.py` pin the registry and matrix expectations.
+
+Reviewers should verify this denial-phase posture with `python scripts/verify_context_hygiene_prompt_boundaries.py` and `python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_work_item_review_packet_matrix.py`; docs changes should also run `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`. These commands validate metadata coverage and documentation consistency only. They do not approve provider invocation, prompt assembly, prompt export, external disclosure, transport registration, credential use, endpoint use, client construction, network egress, release unblock, runtime authority, memory mutation, routing, admission, execution, or live `assemble_prompt(...)` behavior.
+
 ## Selective Memory Distillation Contract
 - The [selective memory distillation contract](selective_memory_distillation_contract.md) formalizes deferred Distiller/Pruner metadata decisions before any receipt/writer layer.
 - The [selective memory distillation receipt gate](selective_memory_distillation_receipt_gate.md) validates future receipt candidates over distillation packets without writing memory, completing tombs, assembling prompts, or granting authority.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -21,6 +21,8 @@ Situational validation selects the relevant lanes without weakening the landing 
 - lane/matrix/capability tests when those surfaces changed;
 - broader regression at threshold/risk points or when required by existing doctrine.
 
+For context-hygiene denial-phase documentation touching Phase 97-103 posture, treat the coverage as validation-only and non-runtime. The reviewer-facing consistency lane is `python scripts/verify_context_hygiene_prompt_boundaries.py` plus `python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_work_item_review_packet_matrix.py`; docs edits still require `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`. These checks confirm capability registry, matrix, verifier, spine, and validation-contract discoverability only; they do not grant provider invocation, prompt assembly, prompt export, external disclosure, release unblock, runtime authority, routing, admission, execution, or live `assemble_prompt(...)` behavior.
+
 Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intended-commit-title "..." --matrix-json-path /tmp/work_item_review_packet_matrix.json --summary` after matrix and PR gate when the landing rail requires supervisor evidence; do not finalize unless decision is `ready_to_commit` or `ready_for_pr_metadata`.
 
 ## Dirty tree rules

--- a/tests/test_codex_operating_doctrine_docs.py
+++ b/tests/test_codex_operating_doctrine_docs.py
@@ -168,3 +168,25 @@ def test_recovery_topology_and_local_node_notes_are_non_runtime() -> None:
     assert "does not implement routing, task execution, remote work dispatch, adoption, sync, merge, install, or execution behavior" in rail
     assert "Repository mainline state stays canonical" in rail
     assert "fresh local clone, clean baselines, dependency readiness, and local-node health checks" in rail
+
+def test_context_hygiene_denial_phase_docs_are_validation_only() -> None:
+    spine = _read("docs/architecture/context_hygiene_spine.md")
+    contract = _read("docs/development/codex_validation_and_landing_contract.md")
+    roadmap = _read("docs/development/codex_open_work_roadmap_index.md")
+
+    for doc in (spine, contract):
+        assert "Phase 97-103" in doc
+        assert "validation" in doc.lower()
+        assert "python scripts/verify_context_hygiene_prompt_boundaries.py" in doc
+        assert "python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_work_item_review_packet_matrix.py" in doc
+        assert "provider invocation" in doc
+        assert "prompt assembly" in doc
+        assert "runtime authority" in doc
+        assert "live `assemble_prompt(...)` behavior" in doc
+
+    assert "Phase 97-103 context-hygiene denial-phase coverage is wired" in roadmap
+    assert "tests/test_capability_registry.py" in spine
+    assert "tests/test_work_item_review_packet_matrix.py" in spine
+    assert "scripts/run_work_item_review_packet_matrix.py" in spine
+    assert "sentientos/capability_registry.py" in spine
+


### PR DESCRIPTION
### Motivation
- Consolidate and make discoverable the denial-phase (Phase 97–103) documentation so reviewers can verify the metadata-only, non-runtime posture consistently across spine, validation contract, capability registry, matrix, and verifier surfaces.
- Pin the reviewer-facing consistency lane (registry + matrix + prompt-boundary verifier + docs) to avoid discoverability drift without changing any runtime or authority behavior.

### Description
- Add a new section `Phase 97-103 Denial-Phase Validation Coverage` to `docs/architecture/context_hygiene_spine.md` that explicitly states the denial phases are validation-only and points to the registry, matrix, prompt-boundary verifier, and related tests.
- Insert a reviewer-note paragraph into `docs/development/codex_validation_and_landing_contract.md` clarifying that Phase 97–103 coverage is validation-only and listing the reviewer command set for docs/contract changes.
- Add assertions to `tests/test_codex_operating_doctrine_docs.py` that verify discoverability and the presence of the Phase 97–103 denial-phase references across the spine, contract, and roadmap.
- No runtime code, prompt-assembly behavior, provider invocation, export, or authority functionality was added or modified.

### Testing
- Ran prompt-boundary static guard `python scripts/verify_context_hygiene_prompt_boundaries.py` and it returned `boundary_clean` with `Findings: 0`.
- Ran focused tests `python -m scripts.run_tests -q tests/test_capability_registry.py tests/test_work_item_review_packet_matrix.py` and `python -m scripts.run_tests -q tests/test_codex_operating_doctrine_docs.py`, all passed.
- Executed the full work-item review packet matrix with `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/context_hygiene_denial_docs_matrix.json` and the matrix runner summary passed; matrix output path: `/tmp/context_hygiene_denial_docs_matrix.json`.
- Built docs with `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` and the docs build succeeded.
- Ran targeted mypy `python -m mypy tests/test_codex_operating_doctrine_docs.py` which passed with no issues.
- Verified strict audits with `python verify_audits.py --strict` (initial repair run performed where required) and `python scripts/audit_immutability_verifier.py` and both passed in the final run.
- Finalizer and landing checks completed: pre-commit finalizer returned `ready_to_commit`, post-commit/pr-metadata finalizer returned `ready_for_pr_metadata`, and `python scripts/codex_pr_metadata_guard.py verify ...` returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a339a91bcc4832fab29de1aef72b870)