### PR TITLE
[codex:host-boundary] audit deferred blocked host labels

### DIFF
--- a/docs/REMOTE_HOST_SMOKE_LAB.md
+++ b/docs/REMOTE_HOST_SMOKE_LAB.md
@@ -6,7 +6,7 @@ This runbook defines the bounded true remote-host smoke lane for WAN federation 
 
 This lane verifies that the existing WAN federation + truth oracle + contradiction policy + WAN release gate stack can be exercised over declared remote hosts using the existing transport abstraction.
 
-It is optional and non-default.
+It is optional and non-default. Its outputs are review evidence only: they do not grant host-actuation authority, executor authority, admission grants, rollback authority, panic-path authority, or permission to perform fan/PWM/thermal writes.
 
 ## What it runs
 
@@ -61,7 +61,7 @@ For SSH hosts, bounded remote collection captures per-node dispatch artifacts in
 - `remote_dispatch_log.jsonl`
 - merged `artifact_hash_manifest.json`
 
-All files remain in the existing WAN run folder and flow through existing truth/gate outputs.
+All files remain in the existing WAN run folder and flow through existing truth/gate outputs. Reviewers should treat those outputs as transport/truth/gate evidence, not as authorization to mutate a host or actuate hardware.
 
 ## Failure interpretation
 
@@ -71,9 +71,14 @@ All files remain in the existing WAN run folder and flow through existing truth/
 
 ## Out of scope
 
+This smoke lane proves only that bounded remote SSH dispatch, preflight classification, artifact collection, and existing WAN truth/gate evaluation can run across declared hosts.
+
 This smoke lane does **not** prove:
 
 - long-haul WAN soak resilience
 - internet-scale federation behavior
 - high-cardinality remote host scheduling
 - full production rollout readiness by itself
+- host actuation, fan/PWM/thermal control, power mutation, service control, rollback, panic-path, executor, or admission authority
+
+Deferred or blocked host labels found in these artifacts remain labels for reviewer triage only. They are not permission to actuate, mutate, or execute on a host. The no-actuation posture is pinned in `AGENTS.md` and `tests/test_codex_operating_doctrine_docs.py`.

--- a/docs/REMOTE_PROBES.md
+++ b/docs/REMOTE_PROBES.md
@@ -1,6 +1,6 @@
 # Remote Probes
 
-Remote probes are read-only trust checks over exported artifacts from another node.
+Remote probes are read-only trust checks over exported artifacts from another node. Probe outputs are local review evidence only; they do not grant host-actuation authority, executor authority, admission grants, rollback authority, panic-path authority, remote mutation behavior, or permission to perform fan/PWM/thermal writes.
 
 ## Export a bundle
 
@@ -38,4 +38,4 @@ Signing is off by default.
 
 ## Forensics
 
-Remote probe flow never writes to or mutates remote nodes. It only reads exported artifacts and emits local report artifacts.
+Remote probe flow never writes to or mutates remote nodes. It only reads exported artifacts and emits local report artifacts. Deferred or blocked host labels in probe reports remain non-authority review labels: they describe evidence needing triage and never authorize actuation, mutation, execution, or host control. Reviewers can cross-check this posture in `AGENTS.md`, `docs/REMOTE_HOST_SMOKE_LAB.md`, `docs/REMOTE_SMOKE_CI_LANE.md`, and `tests/test_codex_operating_doctrine_docs.py`.

--- a/docs/REMOTE_SMOKE_CI_LANE.md
+++ b/docs/REMOTE_SMOKE_CI_LANE.md
@@ -35,5 +35,5 @@ python -m sentientos.ops lab federation --wan-gate --remote-smoke --hosts .githu
 
 ## What this lane proves / does not prove
 
-It proves the bounded remote SSH dispatch + preflight + collection path is still operational.
-It does **not** replace full operator-driven WAN campaigns or exhaustive remote topology coverage.
+It proves the bounded remote SSH dispatch + preflight + collection path is still operational, and produces review evidence only.
+It does **not** replace full operator-driven WAN campaigns or exhaustive remote topology coverage. It also does **not** grant host-actuation authority, executor authority, admission grants, rollback authority, panic-path authority, remote mutation behavior, or permission to perform fan/PWM/thermal writes. Deferred or blocked host labels emitted by the lane remain non-authority review labels for triage.

--- a/tests/test_codex_operating_doctrine_docs.py
+++ b/tests/test_codex_operating_doctrine_docs.py
@@ -190,3 +190,32 @@ def test_context_hygiene_denial_phase_docs_are_validation_only() -> None:
     assert "scripts/run_work_item_review_packet_matrix.py" in spine
     assert "sentientos/capability_registry.py" in spine
 
+
+
+def test_remote_host_boundary_docs_keep_labels_non_authority() -> None:
+    smoke_lab = _read("docs/REMOTE_HOST_SMOKE_LAB.md")
+    ci_lane = _read("docs/REMOTE_SMOKE_CI_LANE.md")
+    probes = _read("docs/REMOTE_PROBES.md")
+    agents = _read("AGENTS.md")
+    roadmap = _read("docs/development/codex_open_work_roadmap_index.md")
+
+    for doc in (smoke_lab, ci_lane):
+        assert "optional and non-default" in doc
+        assert "review evidence only" in doc
+        assert "host-actuation authority" in doc
+        assert "fan/PWM/thermal writes" in doc
+        assert "Deferred or blocked host labels" in doc
+        assert "non-authority review" in doc
+
+    assert "read-only trust checks" in probes
+    assert "never writes to or mutates remote nodes" in probes
+    assert "local review evidence only" in probes
+    assert "Deferred or blocked host labels" in probes
+    assert "never authorize actuation" in probes
+
+    assert "Do not add direct host actuation" in agents
+    assert "Do not implement direct fan/PWM/thermal writes" in agents
+    assert "Host-boundary deferred/blocked host-actuation label audit" in roadmap
+    assert "Audit-only or docs-only" in roadmap
+    assert "Must not add direct host actuation" in roadmap
+    assert "fan/PWM/thermal writes" in roadmap


### PR DESCRIPTION
### Motivation
- Ensure remote-host smoke lanes, CI smoke lane, and remote probes explicitly state that their outputs (including deferred/blocked host labels) are review evidence only and do not grant any host-actuation or hardware/control authority.
- Repair discoverability drift so documentation, roadmap, and doctrine tests agree about the non-authority posture for deferred/blocked host labels.
- Provide minimal, audit-only changes (docs + test) to pin reviewer expectations without adding any runtime or actuation behavior.

### Description
- Clarified non-authority posture in remote docs by updating `docs/REMOTE_HOST_SMOKE_LAB.md` to mark smoke outputs as review evidence only and to note deferred/blocked host labels are reviewer-triage labels, not authorization to actuate.
- Clarified the CI smoke lane and probe docs by updating `docs/REMOTE_SMOKE_CI_LANE.md` and `docs/REMOTE_PROBES.md` to state these lanes/probes produce local review evidence only and do not grant host-actuation, executor, admission, rollback, panic-path, or fan/PWM/thermal authority.
- Added a focused doctrine regression test in `tests/test_codex_operating_doctrine_docs.py` (`test_remote_host_boundary_docs_keep_labels_non_authority`) to pin discoverability and agreement between `AGENTS.md`, the roadmap, and the remote docs.
- No Python runtime behavior, executor, or host-actuation code was added or modified; change scope is docs + test only.

### Testing
- `python -m scripts.run_tests -q tests/test_codex_operating_doctrine_docs.py` ran and passed.
- `python scripts/verify_context_hygiene_prompt_boundaries.py` ran and reported `boundary_clean` (passed).
- `python scripts/build_docs.py --bootstrap-docs` and `python scripts/build_docs.py` ran successfully and produced the docs build without errors.
- `python -m mypy tests/test_codex_operating_doctrine_docs.py` (targeted mypy) ran and passed.
- `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` ran and produced a passing matrix summary (matrix output: `/tmp/work_item_review_packet_matrix.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a343ffd1d50832fbfd5e9a3a3eb220d)