### PR TITLE
[codex:reviewer-bundle] add work-item attestation scenario scaffold

### DIFF
--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -164,3 +164,15 @@ The proof bundle includes `live_commit_execution_packet_capability.json` for the
 The proof bundle includes `real_executor_runtime_gate_capability.json` for the [Real Executor Runtime Gate](real_executor_runtime_gate.md). The artifact is metadata-only and records that the gate does not enable executors, flip runtime flags, invoke or activate executors, execute live commits, acquire locks, create lockfiles, touch real memory roots, write, delete, purge, index, assemble prompts, retrieve live context, execute actions, disclose externally, or grant authority.
 
 The proof bundle includes `guarded_executor_path_packet_capability.json` for the [Guarded Executor Path Packet](guarded_executor_path_packet.md). The artifact is metadata-only and records that the packet does not enable executors, flip runtime flags, invoke or activate executors, execute live commits, acquire locks, create lockfiles, touch real memory roots, write, delete, purge, index, assemble prompts, retrieve live context, execute actions, disclose externally, or grant authority.
+
+## Work-item attestation scenario scaffold
+
+Reviewers may also build the metadata-only work-item attestation scenario:
+
+```bash
+python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof-work-item --scenario work_item_attestation --summary
+```
+
+This scenario adds `work_item_attestation_scenario.json` alongside the existing reviewer proof bundle artifacts. It inventories the expected work-item lifecycle attestation index, attestation review digest, review digest index, verifier artifacts, and proof checks in deterministic order. The proof checks are listed only and remain `proof_command_not_run`; the bundle generator does not execute them and `--verify` remains unsupported.
+
+The work-item attestation scenario is review evidence only. It does not authorize live work-item mutation, release promotion, memory mutation, host action, lifecycle execution, subprocess or shell execution, network/GitHub/provider/remote-smoke/WAN/SSH behavior, prompt assembly or export, external disclosure, readiness gates, packets, envelopes, or authority conversion from receipts/readiness/proposals.

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -510,3 +510,7 @@ Guarded executor path reviewers should also inspect `docs/architecture/guarded_e
 - Real live memory commit execution packet: `docs/architecture/real_live_memory_commit_execution_packet.md`
 - Real live memory commit adapter admission gate: `docs/architecture/real_live_memory_commit_adapter_admission_gate.md`
 - Real live memory commit adapter admission packet: `docs/architecture/real_live_memory_commit_adapter_admission_packet.md`
+
+### Reviewer proof bundle work-item attestation scenario
+
+`python scripts/build_reviewer_proof_bundle.py --output-dir /tmp/sentientos-reviewer-proof-work-item --scenario work_item_attestation --summary` builds the deterministic metadata-only work-item attestation reviewer scenario. It adds `work_item_attestation_scenario.json` to the reviewer bundle so reviewers can inspect expected attestation index, review digest, digest index, verifier artifact names, README ordering, and listed proof checks without running them. The scenario is review evidence only and does not authorize live work-item mutation, release promotion, memory mutation, host action, lifecycle execution, prompt assembly/export, network/provider/GitHub/remote-smoke/WAN/SSH behavior, external disclosure, or any conversion of receipts/readiness/proposals into authority.

--- a/scripts/build_reviewer_proof_bundle.py
+++ b/scripts/build_reviewer_proof_bundle.py
@@ -43,7 +43,7 @@ def _summary_text(summary: dict[str, object], output_dir: str) -> str:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build a metadata-only SentientOS reviewer proof bundle")
     parser.add_argument("--output-dir", required=True, help="explicit local output directory for bundle files")
-    parser.add_argument("--scenario", choices=("thermal_pwm_demo",), default="thermal_pwm_demo", help="deterministic reviewer scenario")
+    parser.add_argument("--scenario", choices=("thermal_pwm_demo", "work_item_attestation"), default="thermal_pwm_demo", help="deterministic reviewer scenario")
     parser.add_argument("--created-at", default="1970-01-01T00:00:00+00:00", help="deterministic creation timestamp")
     parser.add_argument("--verify", action="store_true", help="unsupported in this pass; proof commands are listed but not run")
     parser.add_argument("--no-verify", action="store_true", help="list proof commands without running them (default)")

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -202,6 +202,7 @@ REVIEWER_PROOF_ARTIFACT_KINDS = frozenset(
         "real_executor_execution_commit_plan_gate_capability",
         "real_executor_execution_commit_window_packet_capability",
         "real_live_memory_commit_execution_gate_capability",
+        "work_item_attestation_scenario",
     }
 )
 REVIEWER_PROOF_COMMAND_STATUSES = frozenset(
@@ -310,6 +311,7 @@ BUNDLE_FILE_NAMES = {
     "real_executor_execution_commit_plan_gate_capability": "real_executor_execution_commit_plan_gate_capability.json",
     "real_executor_execution_commit_window_packet_capability": "real_executor_execution_commit_window_packet_capability.json",
     "real_live_memory_commit_execution_gate_capability": "real_live_memory_commit_execution_gate_capability.json",
+    "work_item_attestation_scenario": "work_item_attestation_scenario.json",
 }
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
@@ -576,6 +578,59 @@ def _deferred_action_inventory() -> dict[str, Any]:
     }
 
 
+def _work_item_attestation_scenario_metadata(created_at: str) -> dict[str, Any]:
+    return {
+        "scenario_id": "work_item_attestation",
+        "scenario_label": "Work-item lifecycle attestation and review digest evidence scaffold",
+        "created_at": created_at,
+        "metadata_only": True,
+        "reviewer_proof_only": True,
+        "proof_checks_posture": "listed_not_run",
+        "manifest_status_posture": "reviewer_proof_bundle_ready",
+        "expected_artifact_names": [
+            "work_item_lifecycle_attestation_index_capability.json",
+            "work_item_lifecycle_attestation_index_verifier_capability.json",
+            "work_item_lifecycle_attestation_review_digest_capability.json",
+            "work_item_lifecycle_attestation_review_digest_verifier_capability.json",
+            "work_item_lifecycle_attestation_review_digest_index_capability.json",
+            "work_item_lifecycle_attestation_review_digest_index_verifier_capability.json",
+            "work_item_attestation_scenario.json",
+            "proof_commands.json",
+            "bundle_manifest.json",
+            "README.md",
+        ],
+        "proof_check_inventory": [
+            "python scripts/build_work_item_lifecycle_attestation_index.py --attestation <final_attestation.json> --summary",
+            "python scripts/verify_work_item_lifecycle_attestation_index.py --index <attestation_index.json> --summary",
+            "python scripts/build_work_item_lifecycle_attestation_review_digest.py --attestation-index <attestation_index.json> --summary",
+            "python scripts/verify_work_item_lifecycle_attestation_review_digest.py --digest <review_digest.json> --summary",
+            "python scripts/build_work_item_lifecycle_attestation_review_digest_index.py --digest <review_digest.json> --summary",
+            "python scripts/verify_work_item_lifecycle_attestation_review_digest_index.py --index <review_digest_index.json> --summary",
+            "python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json",
+        ],
+        "readme_inspection_order": [
+            "README.md",
+            "work_item_attestation_scenario.json",
+            "work_item_lifecycle_attestation_index_capability.json",
+            "work_item_lifecycle_attestation_review_digest_capability.json",
+            "work_item_lifecycle_attestation_review_digest_index_capability.json",
+            "proof_commands.json",
+            "bundle_manifest.json",
+        ],
+        "non_authority_posture": {
+            "does_not_authorize_live_work_item_mutation": True,
+            "does_not_authorize_release_promotion": True,
+            "does_not_mutate_memory": True,
+            "does_not_perform_host_action": True,
+            "does_not_execute_lifecycle": True,
+            "does_not_run_proof_checks": True,
+            "does_not_invoke_subprocess_shell_network_provider_github_remote_smoke_wan_ssh": True,
+            "does_not_assemble_or_export_prompts": True,
+            "does_not_disclose_externally": True,
+        },
+    }
+
+
 def _readme_text(manifest_id: str, trace_digest: str) -> str:
     return "\n".join(
         [
@@ -642,7 +697,7 @@ def build_reviewer_proof_bundle_payload(
     created_at: str = "1970-01-01T00:00:00+00:00",
     proof_command_records: Sequence[ReviewerProofCommandRecord] | None = None,
 ) -> dict[str, Any]:
-    if scenario != "thermal_pwm_demo":
+    if scenario not in {"thermal_pwm_demo", "work_item_attestation"}:
         raise ValueError(f"unsupported scenario: {scenario}")
     trace = build_host_embodiment_demo_trace(created_at=created_at)
     trace_validation = validate_trace_export_payload(trace)
@@ -650,7 +705,7 @@ def build_reviewer_proof_bundle_payload(
         raise ValueError("invalid trace export payload: " + ", ".join(trace_validation.findings))
 
     registry = build_default_capability_registry()
-    manifest_id = "reviewer-proof-bundle-thermal-pwm-demo"
+    manifest_id = f"reviewer-proof-bundle-{scenario.replace('_', '-')}"
     safety_gates = build_safety_gates_for_domain("cooling_control_future", created_at=created_at)
     controlled_ledger = {
         "ledger_id": "sample-controlled-authorization-ledger-for-reviewer-proof",
@@ -714,6 +769,7 @@ def build_reviewer_proof_bundle_payload(
         "trace_markdown": serialize_host_embodiment_trace_markdown(trace),
         "trace_summary": _trace_summary_text(trace),
         "capability_registry_summary": _pretty_json({"summary": summarize_capability_registry(registry), "records": [record.to_dict() for record in registry.records], "metadata_only": True, "reviewer_proof_only": True}),
+        "work_item_attestation_scenario": _pretty_json(_work_item_attestation_scenario_metadata(created_at)),
         "selective_memory_distillation_contract_capability": _pretty_json({"artifact_kind": "selective_memory_distillation_contract_capability", "capability_id": "selective_memory_distillation_contract", "category": "memory_distillation", "status": "implemented", "authority_level": "metadata_verification_only", "metadata_only": True, "proof_command_not_run": True, "cli_reference": "scripts/build_selective_memory_distillation_contract.py", "matrix_reference": "scripts/run_work_item_review_packet_matrix.py", "docs_reference": "docs/architecture/selective_memory_distillation_contract.md", "blocked_or_deferred_surfaces": ["runtime memory write", "runtime memory deletion", "vector index mutation", "prompt assembly", "provider/network/GitHub calls", "external disclosure", "action execution", "authority escalation"], "forbidden_next_steps": ["delete_memory_now", "purge_memory_now", "write_memory_now", "mutate_vector_index", "call_append_memory", "call_purge_memory", "call_curate_memory", "assemble_prompt_now", "retrieve_live_context", "call_llm_provider", "call_network_api", "call_github_api", "execute_action_ingress", "infer_truth_from_retention", "infer_authority_from_memory", "convert_capsule_to_policy", "convert_distillation_to_action", "enable_external_disclosure"], "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES)}),
         "selective_memory_distillation_receipt_gate_capability": _pretty_json({"artifact_kind": "selective_memory_distillation_receipt_gate_capability", "capability_id": "selective_memory_distillation_receipt_gate", "category": "memory_distillation", "status": "implemented", "authority_level": "metadata_verification_only", "metadata_only": True, "proof_command_not_run": True, "cli_reference": "scripts/build_selective_memory_distillation_receipt_gate.py", "matrix_reference": "scripts/run_work_item_review_packet_matrix.py", "docs_reference": "docs/architecture/selective_memory_distillation_receipt_gate.md", "blocked_or_deferred_surfaces": ["runtime memory write", "runtime memory deletion", "tomb completion", "capsule persistence", "vector index mutation", "prompt assembly", "provider/network/GitHub calls", "external disclosure", "action execution", "authority escalation", "policy creation"], "forbidden_next_steps": ["write_memory_now", "delete_memory_now", "purge_memory_now", "claim_tomb_completed", "claim_capsule_written", "mutate_vector_index", "assemble_prompt_now", "retrieve_live_context", "execute_action_ingress", "infer_truth_from_receipt", "infer_authority_from_receipt", "infer_consent_from_receipt", "convert_receipt_to_policy", "convert_receipt_gate_to_action", "enable_external_disclosure"], "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES)}),
         "selective_memory_tomb_receipt_verifier_capability": _pretty_json({"artifact_kind": "selective_memory_tomb_receipt_verifier_capability", "capability_id": "selective_memory_tomb_receipt_verifier", "category": "memory_distillation", "status": "implemented", "authority_level": "metadata_verification_only", "metadata_only": True, "proof_command_not_run": True, "cli_reference": "scripts/build_selective_memory_tomb_receipt_verifier.py", "matrix_reference": "scripts/run_work_item_review_packet_matrix.py", "docs_reference": "docs/architecture/selective_memory_tomb_receipt_verifier.md", "blocked_or_deferred_surfaces": ["runtime memory write", "runtime memory deletion", "tomb completion", "capsule persistence", "vector index mutation", "prompt assembly", "provider/network/GitHub calls", "external disclosure", "action execution", "authority escalation", "policy creation"], "forbidden_next_steps": ["write_memory_now", "delete_memory_now", "purge_memory_now", "claim_deletion_performed_by_verifier", "claim_tomb_completed_by_verifier", "mutate_vector_index", "assemble_prompt_now", "retrieve_live_context", "execute_action_ingress", "infer_truth_from_tomb_receipt", "infer_authority_from_tomb_receipt", "convert_tomb_receipt_to_policy", "convert_tomb_verification_to_action", "enable_external_disclosure"], "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES)}),
@@ -1733,8 +1789,8 @@ def build_reviewer_proof_bundle_payload(
     )
     manifest = ReviewerProofBundleManifest(
         manifest_id=manifest_id,
-        scenario_id=trace.scenario_id,
-        scenario_label=trace.scenario_label,
+        scenario_id=scenario,
+        scenario_label=("Thermal/PWM non-mutating host embodiment demo" if scenario == "thermal_pwm_demo" else "Work-item lifecycle attestation and review digest evidence scaffold"),
         bundle_status="reviewer_proof_bundle_ready",
         created_at=created_at,
         trace_id=trace.trace_id,

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -368,3 +368,22 @@ def test_reviewer_proof_bundle_cli_writes_workspace_change_set_lifecycle_orchest
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["lifecycle_orchestration_exists"] is True
     assert payload["proof_command_status"] == "proof_command_not_run"
+
+
+
+def test_cli_writes_work_item_attestation_scenario_without_running_proofs(tmp_path: Path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir), "--scenario", "work_item_attestation"])
+    assert code == 0, (stdout, stderr)
+    assert "scenario: work_item_attestation" in stdout
+    scenario_path = output_dir / "work_item_attestation_scenario.json"
+    assert scenario_path.exists()
+    scenario = json.loads(scenario_path.read_text(encoding="utf-8"))
+    assert scenario["metadata_only"] is True
+    assert scenario["reviewer_proof_only"] is True
+    assert scenario["proof_checks_posture"] == "listed_not_run"
+    assert scenario["non_authority_posture"]["does_not_execute_lifecycle"] is True
+    manifest = json.loads((output_dir / "bundle_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["scenario_id"] == "work_item_attestation"
+    assert all(record["executed"] is False for record in manifest["proof_command_records"])
+    assert all(record["status"] == "proof_command_not_run" for record in manifest["proof_command_records"])

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -698,3 +698,24 @@ def test_reviewer_bundle_includes_sandboxed_live_memory_commit_adapter_gate_capa
     assert '"capability_id": "sandboxed_live_memory_commit_adapter_gate"' in text
     assert "scripts/build_sandboxed_live_memory_commit_adapter_gate.py" in text
     assert "docs/architecture/sandboxed_live_memory_commit_adapter_gate.md" in text
+
+
+
+def test_work_item_attestation_scenario_is_metadata_only_and_deterministic() -> None:
+    first = build_reviewer_proof_bundle_payload(scenario="work_item_attestation", created_at=FIXED_CREATED_AT)
+    second = build_reviewer_proof_bundle_payload(scenario="work_item_attestation", created_at=FIXED_CREATED_AT)
+    assert first["manifest"].to_dict() == second["manifest"].to_dict()
+    assert first["manifest"].scenario_id == "work_item_attestation"
+    assert first["manifest"].manifest_id == "reviewer-proof-bundle-work-item-attestation"
+    assert first["manifest"].bundle_status == "reviewer_proof_bundle_ready"
+    assert all(record.status == "proof_command_not_run" and record.executed is False for record in first["manifest"].proof_command_records)
+    scenario = json.loads(first["artifacts"]["work_item_attestation_scenario"])
+    assert scenario["proof_checks_posture"] == "listed_not_run"
+    assert "work_item_lifecycle_attestation_review_digest_capability.json" in scenario["expected_artifact_names"]
+    assert scenario["non_authority_posture"]["does_not_authorize_live_work_item_mutation"] is True
+    assert scenario["non_authority_posture"]["does_not_authorize_release_promotion"] is True
+    assert scenario["non_authority_posture"]["does_not_mutate_memory"] is True
+    assert scenario["non_authority_posture"]["does_not_perform_host_action"] is True
+    assert scenario["non_authority_posture"]["does_not_execute_lifecycle"] is True
+    validation = validate_reviewer_proof_bundle_manifest(first["manifest"])
+    assert validation.ok, validation.findings


### PR DESCRIPTION
### Motivation

- Add a metadata-only reviewer proof-bundle scenario named `work_item_attestation` so reviewers can inspect deterministic work-item attestation/artifact inventories and a listed proof-check inventory without executing proof checks or granting any authority.
- Preserve existing thermal/demo `thermal_pwm_demo` behavior and maintain clear non-authority posture and forbidden surfaces (no live host mutation, no release promotion, no network/provider/prompt execution).

### Description

- Add scenario metadata and artifact wiring via `_work_item_attestation_scenario_metadata` and include `work_item_attestation_scenario` in the bundle `contents`, with `work_item_attestation_scenario.json` added to `BUNDLE_FILE_NAMES` and `REVIEWER_PROOF_ARTIFACT_KINDS`.
- Extend `build_reviewer_proof_bundle_payload` to accept `scenario` values `"thermal_pwm_demo"` and `"work_item_attestation"`, generate deterministic `manifest_id` from the scenario, and include the new scenario artifact in the generated `artifacts` map without running any proof commands.
- Update the CLI in `scripts/build_reviewer_proof_bundle.py` to accept `--scenario work_item_attestation` and keep `--verify` explicitly unsupported in this pass so proof commands remain listed as `proof_command_not_run`.
- Update docs (`docs/architecture/reviewer_first_run_proof_bundle.md`, `docs/architecture/reviewer_release_readiness_index.md`) to document how to build and inspect the new scenario and to emphasize the review-evidence-only, non-authority posture.
- Add tests asserting deterministic manifest/artifact behavior and that proof checks remain listed but not run (`tests/test_reviewer_proof_bundle.py`, `tests/test_build_reviewer_proof_bundle_script.py`), and add a CLI test that writes `work_item_attestation_scenario.json` without executing proofs.

### Testing

- Ran focused reviewer bundle tests: `python -m scripts.run_tests -q tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_reviewer_release_readiness_index.py` and they passed.
- Built docs and bootstrapped docs deps then ran `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` (docs bootstrap was required), and the docs build passed.
- Ran targeted typing: `python -m mypy sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py` and it reported no issues.
- Ran the work-item review packet matrix: `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` and the matrix passed; output written to `/tmp/work_item_review_packet_matrix.json`.
- Finalizer/supervisor/PR metadata guard checks completed with `ready_to_commit`, `ready_for_pr_metadata`, and `pr_metadata_guard_ready` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34a091d370832f858429c34dfa4b7b)