### PR TITLE
[codex:reviewer-bundle] serialize work-item attestation reviewer artifacts

### DIFF
--- a/docs/architecture/reviewer_first_run_proof_bundle.md
+++ b/docs/architecture/reviewer_first_run_proof_bundle.md
@@ -40,6 +40,13 @@ The bundle writes:
 - `fulfillment_authorization.json` — authorization consumption posture; consuming authorization is not fulfillment.
 - `executor_contract.json` — executor contract/readiness posture; executor contract is not an executor.
 - `dry_run_execution.json` — simulation-only dry-run harness posture; dry-run execution is not real fulfillment or an effect receipt.
+- `work_item_lifecycle_attestation_index_capability.json` — work-item lifecycle attestation index reviewer evidence; metadata-only and proof checks are listed, not run.
+- `work_item_lifecycle_attestation_index_verifier_capability.json` — attestation index verifier reviewer evidence; verification commands are referenced, not executed by the bundle.
+- `work_item_lifecycle_attestation_review_digest_capability.json` — attestation review digest reviewer evidence; digest generation is described without lifecycle execution.
+- `work_item_lifecycle_attestation_review_digest_verifier_capability.json` — review digest verifier reviewer evidence; proof checks remain not run.
+- `work_item_lifecycle_attestation_review_digest_index_capability.json` — review digest index reviewer evidence; metadata-only digest-index posture.
+- `work_item_lifecycle_attestation_review_digest_index_verifier_capability.json` — review digest index verifier reviewer evidence; metadata-only verification posture.
+- `work_item_attestation_scenario.json` — deterministic scenario scaffold naming the work-item attestation artifacts and non-authority boundaries.
 - `proof_commands.json` — proof command manifest; commands are listed but not run by default.
 - `README.md` — local reviewer guide for the bundle directory.
 - `bundle_manifest.json` — manifest, artifact digests, command records, and safety flags.
@@ -58,7 +65,14 @@ Reviewers should inspect these files in order:
 8. `fulfillment_authorization.json`
 9. `executor_contract.json`
 10. `dry_run_execution.json`
-11. `proof_commands.json`
+11. `work_item_attestation_scenario.json`
+12. `work_item_lifecycle_attestation_index_capability.json`
+13. `work_item_lifecycle_attestation_index_verifier_capability.json`
+14. `work_item_lifecycle_attestation_review_digest_capability.json`
+15. `work_item_lifecycle_attestation_review_digest_verifier_capability.json`
+16. `work_item_lifecycle_attestation_review_digest_index_capability.json`
+17. `work_item_lifecycle_attestation_review_digest_index_verifier_capability.json`
+18. `proof_commands.json`
 
 ## What the bundle proves
 

--- a/docs/architecture/reviewer_release_readiness_index.md
+++ b/docs/architecture/reviewer_release_readiness_index.md
@@ -99,6 +99,8 @@ Work item lifecycle attestation index verification is documented in `docs/archit
 
 Work item lifecycle attestation review digest generation is documented in `docs/architecture/task_work_item_lifecycle_attestation_review_digest_wing.md` with metadata-only digest authority boundaries.
 
+The reviewer first-run proof bundle work-item attestation scenario now serializes deterministic reviewer artifacts for attestation index generation/verification, review digest generation/verification, and review digest index generation/verification. These artifacts name CLI, docs, matrix references, expected inputs/outputs, and explicit non-authority boundaries; they remain metadata-only reviewer proof and do not run proof checks, enable `--verify`, mutate work items, execute lifecycle steps, or promote releases.
+
 ### Docs build reliability
 
 `tests/test_build_docs_tooling.py`, `python scripts/build_docs.py --check-deps`,

--- a/sentientos/reviewer_proof_bundle.py
+++ b/sentientos/reviewer_proof_bundle.py
@@ -313,6 +313,35 @@ BUNDLE_FILE_NAMES = {
     "real_live_memory_commit_execution_gate_capability": "real_live_memory_commit_execution_gate_capability.json",
     "work_item_attestation_scenario": "work_item_attestation_scenario.json",
 }
+
+
+WORK_ITEM_ATTESTATION_ARTIFACT_POSTURE: Mapping[str, dict[str, Any]] = {
+    "work_item_lifecycle_attestation_index_capability": {
+        "expected_inputs": ["final lifecycle attestation JSON", "optional attestation index output path"],
+        "expected_outputs": ["metadata-only attestation index JSON", "stable attestation index digest", "summary output when requested"],
+    },
+    "work_item_lifecycle_attestation_index_verifier_capability": {
+        "expected_inputs": ["work-item lifecycle attestation index JSON"],
+        "expected_outputs": ["metadata-only verification result", "index consistency findings", "summary output when requested"],
+    },
+    "work_item_lifecycle_attestation_review_digest_capability": {
+        "expected_inputs": ["attestation index JSON", "optional review digest output path"],
+        "expected_outputs": ["metadata-only review digest JSON", "stable review digest digest", "summary output when requested"],
+    },
+    "work_item_lifecycle_attestation_review_digest_verifier_capability": {
+        "expected_inputs": ["work-item lifecycle attestation review digest JSON"],
+        "expected_outputs": ["metadata-only digest verification result", "review digest consistency findings", "summary output when requested"],
+    },
+    "work_item_lifecycle_attestation_review_digest_index_capability": {
+        "expected_inputs": ["attestation review digest JSON", "optional digest index output path"],
+        "expected_outputs": ["metadata-only review digest index JSON", "stable review digest index digest", "summary output when requested"],
+    },
+    "work_item_lifecycle_attestation_review_digest_index_verifier_capability": {
+        "expected_inputs": ["work-item lifecycle attestation review digest index JSON"],
+        "expected_outputs": ["metadata-only digest index verification result", "review digest index consistency findings", "summary output when requested"],
+    },
+}
+
 FORBIDDEN_MANIFEST_FLAGS = (
     "live_host_collection_performed",
     "live_authorization_granted",
@@ -630,6 +659,37 @@ def _work_item_attestation_scenario_metadata(created_at: str) -> dict[str, Any]:
         },
     }
 
+
+
+
+def _apply_work_item_attestation_artifact_posture(contents: dict[str, str], *, created_at: str) -> None:
+    for artifact_kind, posture in WORK_ITEM_ATTESTATION_ARTIFACT_POSTURE.items():
+        payload = json.loads(contents[artifact_kind])
+        payload.update(
+            {
+                "created_at": created_at,
+                "metadata_only": True,
+                "reviewer_proof_only": True,
+                "proof_command_not_run": True,
+                "proof_checks_posture": "listed_not_run",
+                "validation_posture": "deterministic reviewer evidence only; proof commands are listed for separate operator review and are not run by bundle generation",
+                "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES),
+                "non_authority_boundaries": {
+                    "does_not_authorize_live_work_item_mutation": True,
+                    "does_not_authorize_release_promotion": True,
+                    "does_not_mutate_memory": True,
+                    "does_not_perform_host_action": True,
+                    "does_not_execute_lifecycle": True,
+                    "does_not_run_proof_checks": True,
+                    "does_not_enable_verify_mode": True,
+                    "does_not_invoke_subprocess_shell_network_provider_github_remote_smoke_wan_ssh": True,
+                    "does_not_assemble_or_export_prompts": True,
+                    "does_not_disclose_externally": True,
+                },
+            }
+        )
+        payload.update(posture)
+        contents[artifact_kind] = _pretty_json(payload)
 
 def _readme_text(manifest_id: str, trace_digest: str) -> str:
     return "\n".join(
@@ -1525,6 +1585,8 @@ def build_reviewer_proof_bundle_payload(
         "household_presence_camera_operator_review_trend_ledger_capability": _pretty_json({"artifact_kind": "household_presence_camera_operator_review_trend_ledger_capability", "capability_id": "household_presence_camera_operator_review_trend_ledger", "category": "embodiment_governance", "status": "implemented", "authority_level": "metadata_verification_only", "metadata_only": True, "proof_command_not_run": True, "cli_reference": "scripts/build_household_presence_camera_operator_review_trend_ledger.py", "matrix_reference": "scripts/run_work_item_review_packet_matrix.py", "docs_reference": "docs/architecture/household_presence_camera_operator_review_trend_ledger.md", "blocked_or_deferred_surfaces": ["live camera execution", "media processing", "speaker runtime output", "external authority disclosure", "network/provider/subprocess/hardware authority"], "forbidden_next_steps": ["open_camera_now", "attempt_capture", "enable_live_capture", "enable_live_recording", "store_raw_media", "attach_media_payload", "bypass_authorization_envelope", "bypass_denial_ledger", "bypass_review_packet", "bypass_review_decision_ledger", "bypass_policy_chain", "bypass_zone_config", "bypass_disabled_capture_boundary", "bypass_dry_run", "infer_operator_consent_from_trends", "convert_trend_to_live_readiness", "enable_speaker_output", "enable_external_disclosure"], "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES)}),
         "household_presence_camera_capture_review_decision_ledger_capability": _pretty_json({"artifact_kind": "household_presence_camera_capture_review_decision_ledger_capability", "capability_id": "household_presence_camera_capture_review_decision_ledger", "category": "embodiment_governance", "status": "implemented", "authority_level": "metadata_verification_only", "metadata_only": True, "proof_command_not_run": True, "cli_reference": "scripts/build_household_presence_camera_capture_review_decision_ledger.py", "matrix_reference": "scripts/run_work_item_review_packet_matrix.py", "docs_reference": "docs/architecture/household_presence_camera_capture_review_decision_ledger.md", "blocked_or_deferred_surfaces": ["live camera execution", "media processing", "speaker runtime output", "external authority disclosure", "network/provider/subprocess/hardware authority"], "forbidden_next_steps": ["open_camera_now", "attempt_capture", "enable_live_capture", "enable_live_recording", "store_raw_media", "attach_media_payload", "bypass_authorization_envelope", "bypass_denial_ledger", "bypass_review_packet", "bypass_policy_chain", "bypass_zone_config", "bypass_disabled_capture_boundary", "bypass_dry_run", "enable_speaker_output", "enable_external_disclosure"], "explicit_non_authority_boundaries": list(EXPLICIT_NON_AUTHORITY_BOUNDARIES)}),
     }
+    _apply_work_item_attestation_artifact_posture(contents, created_at=created_at)
+
     future_gate_record = registry.by_id()["future_live_memory_commit_execution_gate"]
     contents["future_live_memory_commit_execution_gate_capability"] = _pretty_json({
         "artifact_kind": "future_live_memory_commit_execution_gate_capability",

--- a/tests/test_build_reviewer_proof_bundle_script.py
+++ b/tests/test_build_reviewer_proof_bundle_script.py
@@ -387,3 +387,27 @@ def test_cli_writes_work_item_attestation_scenario_without_running_proofs(tmp_pa
     assert manifest["scenario_id"] == "work_item_attestation"
     assert all(record["executed"] is False for record in manifest["proof_command_records"])
     assert all(record["status"] == "proof_command_not_run" for record in manifest["proof_command_records"])
+
+def test_cli_writes_work_item_attestation_capability_artifacts(tmp_path: Path) -> None:
+    output_dir = tmp_path / "bundle"
+    code, stdout, stderr = _run_main(["--output-dir", str(output_dir), "--scenario", "work_item_attestation"])
+    assert code == 0, (stdout, stderr)
+    expected_files = (
+        "work_item_lifecycle_attestation_index_capability.json",
+        "work_item_lifecycle_attestation_index_verifier_capability.json",
+        "work_item_lifecycle_attestation_review_digest_capability.json",
+        "work_item_lifecycle_attestation_review_digest_verifier_capability.json",
+        "work_item_lifecycle_attestation_review_digest_index_capability.json",
+        "work_item_lifecycle_attestation_review_digest_index_verifier_capability.json",
+    )
+    manifest = json.loads((output_dir / "bundle_manifest.json").read_text(encoding="utf-8"))
+    manifest_paths = {record["relative_path"] for record in manifest["artifact_records"]}
+    for file_name in expected_files:
+        artifact = json.loads((output_dir / file_name).read_text(encoding="utf-8"))
+        assert artifact["metadata_only"] is True
+        assert artifact["reviewer_proof_only"] is True
+        assert artifact["proof_command_not_run"] is True
+        assert artifact["expected_inputs"]
+        assert artifact["expected_outputs"]
+        assert artifact["non_authority_boundaries"]["does_not_authorize_release_promotion"] is True
+        assert file_name in manifest_paths

--- a/tests/test_reviewer_proof_bundle.py
+++ b/tests/test_reviewer_proof_bundle.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from sentientos.reviewer_proof_bundle import (
+    BUNDLE_FILE_NAMES,
     DEFERRED_ACTION_LABELS,
     ReviewerProofBundleArtifact,
     build_default_reviewer_proof_commands,
@@ -719,3 +720,33 @@ def test_work_item_attestation_scenario_is_metadata_only_and_deterministic() -> 
     assert scenario["non_authority_posture"]["does_not_execute_lifecycle"] is True
     validation = validate_reviewer_proof_bundle_manifest(first["manifest"])
     assert validation.ok, validation.findings
+
+def test_work_item_attestation_artifacts_are_serialized_reviewer_evidence() -> None:
+    payload = build_reviewer_proof_bundle_payload(scenario="work_item_attestation", created_at=FIXED_CREATED_AT)
+    artifact_kinds = (
+        "work_item_lifecycle_attestation_index_capability",
+        "work_item_lifecycle_attestation_index_verifier_capability",
+        "work_item_lifecycle_attestation_review_digest_capability",
+        "work_item_lifecycle_attestation_review_digest_verifier_capability",
+        "work_item_lifecycle_attestation_review_digest_index_capability",
+        "work_item_lifecycle_attestation_review_digest_index_verifier_capability",
+    )
+    manifest_paths = {record.relative_path: record.digest for record in payload["manifest"].artifact_records}
+    for artifact_kind in artifact_kinds:
+        artifact = json.loads(payload["artifacts"][artifact_kind])
+        assert artifact["created_at"] == FIXED_CREATED_AT
+        assert artifact["metadata_only"] is True
+        assert artifact["reviewer_proof_only"] is True
+        assert artifact["proof_command_not_run"] is True
+        assert artifact["proof_checks_posture"] == "listed_not_run"
+        assert artifact["cli_reference"].startswith("scripts/")
+        assert artifact["docs_reference"].startswith("docs/architecture/")
+        assert artifact["matrix_reference"] == "scripts/run_work_item_review_packet_matrix.py"
+        assert artifact["expected_inputs"]
+        assert artifact["expected_outputs"]
+        assert artifact["non_authority_boundaries"]["does_not_execute_lifecycle"] is True
+        assert artifact["non_authority_boundaries"]["does_not_authorize_live_work_item_mutation"] is True
+        assert BUNDLE_FILE_NAMES[artifact_kind] in manifest_paths
+    manifest = json.loads(payload["artifacts"]["bundle_manifest"])
+    manifest_records = {record["relative_path"]: record["digest"] for record in manifest["artifact_records"]}
+    assert {BUNDLE_FILE_NAMES[kind] for kind in artifact_kinds} <= set(manifest_records)


### PR DESCRIPTION
### Motivation
- Produce deterministic, metadata-only reviewer evidence payloads for the existing `work_item_attestation` scenario so reviewers can inspect attestation/index/review-digest surfaces without running proof checks or granting authority. 
- Keep proof commands listed-not-run, preserve the existing `work_item_attestation_scenario.json` scaffold, and enforce explicit non-authority boundaries in each serialized artifact.

### Description
- Add a `WORK_ITEM_ATTESTATION_ARTIFACT_POSTURE` mapping and helper `_apply_work_item_attestation_artifact_posture` which augment each of the six required artifact payloads with `created_at`, `metadata_only`, `reviewer_proof_only`, `proof_command_not_run`, listed-not-run posture, expected inputs/outputs, CLI/docs/matrix references, and explicit non-authority boundaries. 
- Apply the posture during `build_reviewer_proof_bundle_payload` so the six artifacts are emitted deterministically and included in `bundle_manifest.json` with stable digests. 
- Update `docs/architecture/reviewer_first_run_proof_bundle.md` and `docs/architecture/reviewer_release_readiness_index.md` to make the serialized work-item artifacts discoverable and to state the non-authority posture. 
- Add unit tests and CLI tests to verify artifact shapes, deterministic `created_at`, reviewer-only flags, listed-not-run proof posture, expected inputs/outputs, manifest inclusion, and that CLI `--scenario work_item_attestation` writes the capability files without running proofs. 
- Preserve `--verify` as unsupported in this pass and do not enable any new authority, execution, network, subprocess, or host-mutation behavior.

### Testing
- Ran focused reviewer-bundle tests with `python -m scripts.run_tests -q tests/test_reviewer_proof_bundle.py tests/test_build_reviewer_proof_bundle_script.py tests/test_reviewer_release_readiness_index.py` and they passed. 
- Bootstrapped and built docs with `python scripts/build_docs.py --bootstrap-docs`, `python scripts/build_docs.py --check-deps`, and `python scripts/build_docs.py`, and the docs build completed successfully. 
- Type-checked the changed modules with `python -m mypy sentientos/reviewer_proof_bundle.py scripts/build_reviewer_proof_bundle.py` with no errors. 
- Ran the review-packet matrix with `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json`, which produced `/tmp/work_item_review_packet_matrix.json` and returned a passed summary. 
- Finalizer checks completed: pre-commit finalizer returned `ready_to_commit` and post-commit/pr-metadata finalizer returned `ready_for_pr_metadata`. 
- PR metadata guard `python scripts/codex_pr_metadata_guard.py verify ...` returned `pr_metadata_guard_ready` and the canonical PR evidence body was produced. 

All automated checks listed above passed; no unresolved risks were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34d964f934832f99ad6f7ce6a12506)