### PR TITLE
[codex:landing] harden stale-evidence refresh loop handling

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -11,6 +11,8 @@ Use `python scripts/codex_finalize_landing.py finalize` as landing authority.
 - `ready_for_pr_metadata`: only valid in `post-commit`/`pr-metadata` phase.
 - `repair_required_task_caused`, `manual_review_required`, `environment_blocked`, `do_not_finalize`, `finalizer_failed`.
 - `stale_evidence_refresh_required` when validation evidence is stale and refresh was not allowed.
+- `stale_evidence_refresh_failed` when an allowed bounded refresh fails or times out.
+- `generated_artifact_cleanup_incomplete` when cleanup was allowed but generated artifacts remain after the cleanup/refresh decision point.
 
 ## Dirty-tree classes
 - `intended_task_change`
@@ -28,7 +30,7 @@ Focused tests, matrix, gate, or supervisor alone are insufficient. PR metadata i
 ## Example flows
 1. Normal feature landing: run pre-commit finalizer (`ready_to_commit`) -> commit -> run post-commit finalizer (`ready_for_pr_metadata`) -> create/update PR metadata.
 2. Validation-only sealing with no changes: run post-commit/pr-metadata finalizer directly; expect `ready_for_pr_metadata` with clean tree.
-3. Stabilization with generated artifact cleanup only: allow cleanup flags, clean artifacts, then rerun finalizer for phase-appropriate readiness.
+3. Stabilization with generated artifact cleanup only: allow cleanup flags and stale-evidence refresh flags; one finalizer invocation cleans artifacts, refreshes matrix/gate/supervisor evidence once, and returns the phase-appropriate terminal status when the tree is clean.
 
 
 ## Canonical two-phase command examples
@@ -82,8 +84,10 @@ This ordering applies to both pre-commit and pr-metadata phases.
   - `stale_evidence_matrix_output`
   - `stale_evidence_pr_landing_gate`
   - `stale_evidence_landing_supervisor`
-- Refresh is bounded per invocation (`--max-stale-evidence-refreshes`, default `1`) to avoid loops.
-- If stale evidence is detected and refresh is not allowed, finalizer returns `stale_evidence_refresh_required`.
+- Refresh is bounded per invocation (`--max-stale-evidence-refreshes`, default `1`) to avoid loops; the finalizer never recursively invokes itself and does not increase retries to escape stale evidence.
+- With `--allow-stale-evidence-refresh --max-stale-evidence-refreshes 1`, cleanup-caused staleness has exactly one terminal outcome in that invocation: phase-ready status when refresh succeeds and no blocking dirty paths remain, `stale_evidence_refresh_failed` when a refresh stage fails or times out, or `generated_artifact_cleanup_incomplete` when generated artifacts remain dirty after cleanup.
+- `stale_evidence_refresh_required` is reserved for stale evidence when refresh was needed but not allowed. It is not used after a successful bounded refresh.
+- The output JSON `evidence_freshness` records `cleanup_occurred`, `cleaned_paths`, `terminal_cleanup_occurred`, `terminal_cleaned_paths`, `stale_evidence_refresh_attempted`, `stale_evidence_refresh_result`, `refresh_stage_runs`, `refresh_stages_ran`, `refreshed_matrix_json_path`, `refresh_failure_reason`, and `rerun_required`; successful bounded refreshes set `rerun_required` to `false` so summaries do not instruct repeated cleanup/refresh reruns.
 - Do not rely on stale failed matrix snapshots after strict audits become healthy.
 
 ### Canonical pr-metadata command with output

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -34,7 +34,7 @@ Use `scripts/build_codex_landing_evidence_body.py` to produce the PR body. The s
 
 The matrix output path must remain explicit because `matrix_output_reference_missing` is a late PR metadata failure class. A body that claims validation passed but does not name the `--output` artifact is not recoverable enough for reviewers or guard tooling.
 
-The matrix path must also be fresh. The finalizer's `stale_evidence_matrix_output` behavior is correct: if cleanup or later validation changes can make earlier matrix evidence stale, the fix is to refresh matrix evidence and rerun landing gate/supervisor/finalizer in the same task. The finalizer does not need to delete `/tmp` matrix output to cause staleness; stale evidence can arise when the evidence no longer reflects the final source tree or post-cleanup state.
+The matrix path must also be fresh. If cleanup or later validation changes can make earlier matrix evidence stale, the finalizer may perform one bounded in-invocation refresh of matrix evidence plus landing gate and supervisor evidence when `--allow-stale-evidence-refresh` is supplied. A successful bounded refresh is terminal and may return `ready_to_commit` or `ready_for_pr_metadata`; it must not leave callers with a repeated `stale_evidence_refresh_required` loop. The finalizer does not need to delete `/tmp` matrix output to cause staleness; stale evidence can arise when the evidence no longer reflects the final source tree or post-cleanup state.
 
 ## Same-task recovery for late landing failures
 
@@ -57,7 +57,7 @@ Use stable snake-case labels in task reports and recovery prompts so failures ar
 
 - `implementation_failure`: source, docs, fixtures, or tests are missing or failing. Repair task-owned implementation and rerun focused validation before the landing sequence.
 - `pr_metadata_failure`: implementation exists, but PR title/body/evidence markers are incomplete. Regenerate the body from canonical artifacts and rerun landing gate/guard.
-- `finalizer_stale_evidence_failure`: validation evidence no longer reflects the final tree, often after cleanup or audit repair. Refresh matrix output, landing gate, and supervisor evidence in the same task, then rerun the finalizer.
+- `finalizer_stale_evidence_failure`: validation evidence no longer reflects the final tree, often after cleanup or audit repair. Prefer the finalizer's bounded stale-evidence refresh when allowed; if refresh is not allowed, rerun with explicit refresh authority. Treat `stale_evidence_refresh_failed` and `generated_artifact_cleanup_incomplete` as terminal repair statuses, not prompts for unbounded repeated reruns.
 - `workspace_state_loss`: a fresh workspace lacks uncommitted files from a closed task. If no commit, branch, PR, or patch artifact exists, report `no-files-found`; do not claim recovery is possible.
 - `workspace_contamination_or_absence_gate_failure`: unknown dirty files, missing expected task-owned files, or absence gates block commit until exact paths are resolved or classified.
 - `environment_or_dependency_noise`: Python/package setup warnings, dependency chatter, or platform limitations are not implementation evidence unless a required command fails.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -30,13 +30,14 @@ Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intende
 - Post-commit/pr-metadata: source dirty files block.
 - Unknown dirty files always block.
 - Generated runtime artifacts must be cleaned or block.
+- Generated-artifact cleanup can make prior matrix/gate/supervisor evidence stale. When stale-evidence refresh is allowed, the finalizer performs one bounded refresh and must return a terminal status from that invocation. Successful refresh can permit `ready_to_commit`/`ready_for_pr_metadata`; failed refresh or leftover generated artifacts block with explicit terminal statuses.
 
 
 ## Self-sealing requirement
 - Validation-only seal turns should not be necessary for normal implementation tasks.
 - If finalizer tooling is available, the same task must self-seal using both phases.
 - Missing post-commit/pr-metadata finalizer before PR metadata is a task-owned failure.
-- Missing stale-evidence refresh in the same task (when strict-audit/cleanup state changed) is task-owned failure.
+- Missing stale-evidence refresh in the same task (when strict-audit/cleanup state changed) is task-owned failure. Allowed stale-evidence refresh must be bounded to one terminal finalizer outcome rather than repeated cleanup/refresh cycles.
 - Do not request a validation-only follow-up when the only blocker is stale matrix/gate/supervisor/finalizer evidence.
 - Do not defer post-commit sealing to follow-up turns when implementation changes occurred.
 

--- a/scripts/codex_finalize_landing.py
+++ b/scripts/codex_finalize_landing.py
@@ -294,7 +294,13 @@ def _emit_and_optionally_write(payload: dict[str, object], output: str | None, s
     if summary:
         decision_payload = payload.get("decision")
         reasons = decision_payload.get("reasons", []) if isinstance(decision_payload, dict) else []
-        print(json.dumps({"status": decision_status, "reasons": reasons}, indent=2))
+        freshness = payload.get("evidence_freshness")
+        terminal_refresh_status = "not_required"
+        rerun_required = False
+        if isinstance(freshness, dict):
+            terminal_refresh_status = str(freshness.get("stale_evidence_refresh_result", "not_required"))
+            rerun_required = bool(freshness.get("rerun_required", False))
+        print(json.dumps({"status": decision_status, "reasons": reasons, "terminal_refresh_status": terminal_refresh_status, "rerun_required": rerun_required}, indent=2))
         print(f"Codex Finalize Landing decision: {decision_status}", flush=True)
     else:
         print(json.dumps(payload, indent=2))
@@ -439,6 +445,9 @@ def main(argv: list[str] | None = None) -> int:
     refresh_attempted = False
     refresh_status = "not_required"
     refresh_runs = 0
+    refresh_failure_reason = ""
+    refresh_stage_names: list[str] = []
+    rerun_required = False
     if stale_reasons:
         if a.allow_stale_evidence_refresh and a.max_stale_evidence_refreshes > 0:
             refresh_attempted = True
@@ -449,31 +458,60 @@ def main(argv: list[str] | None = None) -> int:
                 ("stale_evidence_pr_landing_gate", f"python scripts/codex_pr_landing_gate.py gate --title \"{a.title}\" --intended-commit-title \"{a.intended_commit_title}\" --matrix-json-path {a.matrix_json_path}", True),
                 ("stale_evidence_landing_supervisor", f"python scripts/codex_landing_supervisor.py evaluate --title \"{a.title}\" --intended-commit-title \"{a.intended_commit_title}\" --matrix-json-path {a.matrix_json_path} --landing-gate-status passed --summary", True),
             ]
+            # The refresh is intentionally bounded to one pass per finalizer
+            # invocation; max_stale_evidence_refreshes controls permission, not
+            # recursive retries.
             try:
-                for stage_id, cmd, required in refresh_plan:
+                for stage_id, cmd, required in refresh_plan[:1 if a.max_stale_evidence_refreshes < 1 else len(refresh_plan)]:
                     result, stage_runtime = _run_stage(stage_id, cmd, required, a.progress, a.stage_timeout_seconds, deadline)
                     commands.append(result)
                     runtime.append(stage_runtime)
                     refresh_runs += 1
-                refresh_status = "succeeded"
-            except Exception:  # noqa: BLE001
+                    refresh_stage_names.append(stage_id)
+                    if required and result.exit_code != 0:
+                        refresh_failure_reason = f"stage_failed:{stage_id}"
+                        break
+                refresh_status = "failed" if refresh_failure_reason else "succeeded"
+            except FinalizerTimeoutError as exc:
+                refresh_failure_reason = f"{exc.kind}_timeout:{exc.stage_id}"
+                refresh_status = "failed"
+            except Exception as exc:  # noqa: BLE001
+                refresh_failure_reason = f"runtime_exception:{type(exc).__name__}"
                 refresh_status = "failed"
         else:
             refresh_status = "required_not_allowed"
+            rerun_required = True
+
+    terminal_cleanup_results: dict[str, tuple[bool, str, str]] = {}
+    if refresh_status == "succeeded" and a.allow_generated_artifact_cleanup:
+        status_after_refresh_before_cleanup = _git_status()
+        terminal_cleanup_results = _cleanup_generated(status_after_refresh_before_cleanup)
+        cleanup_results.update(terminal_cleanup_results)
+
+    status_after_refresh = _git_status()
+    findings_after_refresh = _classify(status_after_refresh, tuple(a.changed_file) + inferred_changed_files, inferred_untracked_task_files)
+    diagnostics_after_refresh = _collect_dirty_diagnostics(status_after_refresh, findings_after_refresh, req.dirty_file_classification_source, cleanup_results)
+    generated_dirty_after_refresh = [item.path for item in findings_after_refresh if item.classification == "generated_runtime_artifact"]
 
     landing_result = evaluate_finalize_landing(
         req,
         tuple(commands),
-        findings,
+        findings_after_refresh,
         policy=CodexFinalizeLandingPolicy(
             allow_generated_artifact_cleanup=a.allow_generated_artifact_cleanup,
             allow_stale_evidence_refresh=a.allow_stale_evidence_refresh,
         ),
     )
 
-    if stale_reasons and refresh_status == "required_not_allowed":
+    if generated_dirty_after_refresh and a.allow_generated_artifact_cleanup:
+        decision_status = "generated_artifact_cleanup_incomplete"
+        decision_reasons = ["generated_artifacts_remain_after_cleanup", *generated_dirty_after_refresh]
+    elif stale_reasons and refresh_status == "required_not_allowed":
         decision_status = "stale_evidence_refresh_required"
         decision_reasons = list(stale_reasons)
+    elif refresh_status == "failed":
+        decision_status = "stale_evidence_refresh_failed"
+        decision_reasons = [refresh_failure_reason or "stale_evidence_refresh_failed"]
     elif not decision_reasons:
         decision_status = landing_result.decision.status
         decision_reasons = list(landing_result.decision.reasons)
@@ -485,7 +523,8 @@ def main(argv: list[str] | None = None) -> int:
         "phase": req.phase,
         "matrix_json_path": req.matrix_json_path,
     }
-    payload["dirty_paths"] = [asdict(item) for item in diagnostics]
+    payload["dirty_paths"] = [asdict(item) for item in diagnostics_after_refresh]
+    payload["dirty_paths_after_cleanup"] = [asdict(item) for item in diagnostics]
     payload["cleanup_actions"] = {k: {"attempted": v[0], "result": v[1], "reason": v[2]} for k, v in cleanup_results.items()}
     payload["runtime"] = {
         "stage_timeout_seconds": a.stage_timeout_seconds,
@@ -497,14 +536,21 @@ def main(argv: list[str] | None = None) -> int:
         "stale_evidence_reasons": stale_reasons,
         "stale_evidence_refresh_attempted": refresh_attempted,
         "stale_evidence_refresh_result": refresh_status,
-        "refreshed_matrix_json_path": a.matrix_json_path if refresh_attempted else None,
+        "refresh_failure_reason": refresh_failure_reason or None,
+        "refreshed_matrix_json_path": a.matrix_json_path if refresh_attempted and refresh_status == "succeeded" else None,
         "max_stale_evidence_refreshes": a.max_stale_evidence_refreshes,
         "refresh_stage_runs": refresh_runs,
+        "refresh_stages_ran": refresh_stage_names,
+        "cleanup_occurred": bool(cleanup_results),
+        "cleaned_paths": [path for path, result in cleanup_results.items() if result[1] in {"removed", "restored"}],
+        "terminal_cleanup_occurred": bool(terminal_cleanup_results),
+        "terminal_cleaned_paths": [path for path, result in terminal_cleanup_results.items() if result[1] in {"removed", "restored"}],
+        "rerun_required": rerun_required,
     }
     payload["decision"]["status"] = decision_status
     payload["decision"]["reasons"] = decision_reasons
     if a.summary:
-        for item in diagnostics[:20]:
+        for item in diagnostics_after_refresh[:20]:
             print(
                 f"[finalizer] dirty path: {item.git_status} {item.path} "
                 f"classification={item.classification} cleanup={item.cleanup_result}"

--- a/tests/test_codex_finalize_landing_script.py
+++ b/tests/test_codex_finalize_landing_script.py
@@ -149,3 +149,187 @@ def test_classify_allows_current_capability_fixture_root_but_blocks_other_root()
     assert by_path["tests/fixtures/memory_commit_execution_gate/"] == "intended_task_change"
     assert by_path["tests/fixtures/other_capability/"] == "unknown_dirty_file"
     assert by_path["glow/test_runs/report.json"] == "generated_runtime_artifact"
+
+
+def _successful_runtime(stage_id: str, command: str, required: bool):
+    from scripts.codex_finalize_landing import StageRuntime
+
+    return StageRuntime(
+        stage_id=stage_id,
+        command=command,
+        started_at=0.0,
+        completed=True,
+        exit_code=0,
+        duration_seconds=0.0,
+        stdout_tail="",
+        stderr_tail="",
+        decision_impact="required" if required else "optional",
+        status="passed",
+        timed_out=False,
+    )
+
+
+@pytest.mark.no_legacy_skip
+def test_generated_cleanup_allowed_refresh_terminal_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    out = tmp_path / "finalizer.json"
+    statuses = iter([["?? glow/test_runs/run.json"], [], []])
+    monkeypatch.setattr("scripts.codex_finalize_landing._git_status", lambda: next(statuses, []))
+    monkeypatch.setattr(
+        "scripts.codex_finalize_landing._cleanup_generated",
+        lambda status_lines: {"glow/test_runs/run.json": (True, "removed", "generated_artifact_cleanup")},
+    )
+
+    def fake_run_stage(stage_id: str, command: str, required: bool, progress: bool, stage_timeout_seconds: int, overall_deadline: float):
+        from sentientos.codex_finalize_landing import CodexFinalizeLandingCommandResult
+
+        return CodexFinalizeLandingCommandResult(stage_id, command, 0, required=required), _successful_runtime(stage_id, command, required)
+
+    monkeypatch.setattr("scripts.codex_finalize_landing._run_stage", fake_run_stage)
+    code = main([
+        "finalize",
+        "--title",
+        "x",
+        "--intended-commit-title",
+        "x",
+        "--phase",
+        "pre-commit",
+        "--focused-test-command",
+        "python -c 'pass'",
+        "--allow-generated-artifact-cleanup",
+        "--allow-stale-evidence-refresh",
+        "--max-stale-evidence-refreshes",
+        "1",
+        "--allow-current-tracked-changes",
+        "--output",
+        str(out),
+        "--summary",
+    ])
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["decision"]["status"] == "ready_to_commit"
+    freshness = payload["evidence_freshness"]
+    assert freshness["cleanup_occurred"] is True
+    assert freshness["cleaned_paths"] == ["glow/test_runs/run.json"]
+    assert freshness["stale_evidence_refresh_attempted"] is True
+    assert freshness["stale_evidence_refresh_result"] == "succeeded"
+    assert freshness["refreshed_matrix_json_path"]
+    assert freshness["refresh_stage_runs"] == 4
+    assert freshness["rerun_required"] is False
+
+
+@pytest.mark.no_legacy_skip
+def test_stale_refresh_required_only_when_not_allowed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    out = tmp_path / "finalizer.json"
+    statuses = iter([["?? glow/test_runs/run.json"], [], []])
+    monkeypatch.setattr("scripts.codex_finalize_landing._git_status", lambda: next(statuses, []))
+    monkeypatch.setattr(
+        "scripts.codex_finalize_landing._cleanup_generated",
+        lambda status_lines: {"glow/test_runs/run.json": (True, "removed", "generated_artifact_cleanup")},
+    )
+
+    def fake_run_stage(stage_id: str, command: str, required: bool, progress: bool, stage_timeout_seconds: int, overall_deadline: float):
+        from sentientos.codex_finalize_landing import CodexFinalizeLandingCommandResult
+
+        return CodexFinalizeLandingCommandResult(stage_id, command, 0, required=required), _successful_runtime(stage_id, command, required)
+
+    monkeypatch.setattr("scripts.codex_finalize_landing._run_stage", fake_run_stage)
+    code = main([
+        "finalize",
+        "--title",
+        "x",
+        "--intended-commit-title",
+        "x",
+        "--phase",
+        "pre-commit",
+        "--focused-test-command",
+        "python -c 'pass'",
+        "--allow-generated-artifact-cleanup",
+        "--output",
+        str(out),
+    ])
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["decision"]["status"] == "stale_evidence_refresh_required"
+    assert payload["evidence_freshness"]["stale_evidence_refresh_result"] == "required_not_allowed"
+    assert payload["evidence_freshness"]["rerun_required"] is True
+
+
+@pytest.mark.no_legacy_skip
+def test_refresh_failure_is_terminal_without_rerun_suggestion(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    out = tmp_path / "finalizer.json"
+    statuses = iter([["?? glow/test_runs/run.json"], [], []])
+    monkeypatch.setattr("scripts.codex_finalize_landing._git_status", lambda: next(statuses, []))
+    monkeypatch.setattr(
+        "scripts.codex_finalize_landing._cleanup_generated",
+        lambda status_lines: {"glow/test_runs/run.json": (True, "removed", "generated_artifact_cleanup")},
+    )
+
+    def fake_run_stage(stage_id: str, command: str, required: bool, progress: bool, stage_timeout_seconds: int, overall_deadline: float):
+        from sentientos.codex_finalize_landing import CodexFinalizeLandingCommandResult
+
+        exit_code = 1 if stage_id == "stale_evidence_matrix_output" else 0
+        return CodexFinalizeLandingCommandResult(stage_id, command, exit_code, required=required), _successful_runtime(stage_id, command, required)
+
+    monkeypatch.setattr("scripts.codex_finalize_landing._run_stage", fake_run_stage)
+    code = main([
+        "finalize",
+        "--title",
+        "x",
+        "--intended-commit-title",
+        "x",
+        "--phase",
+        "pre-commit",
+        "--focused-test-command",
+        "python -c 'pass'",
+        "--allow-generated-artifact-cleanup",
+        "--allow-stale-evidence-refresh",
+        "--max-stale-evidence-refreshes",
+        "1",
+        "--allow-current-tracked-changes",
+        "--output",
+        str(out),
+    ])
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["decision"]["status"] == "stale_evidence_refresh_failed"
+    assert payload["evidence_freshness"]["stale_evidence_refresh_result"] == "failed"
+    assert payload["evidence_freshness"]["refresh_stage_runs"] == 2
+    assert payload["evidence_freshness"]["rerun_required"] is False
+
+
+@pytest.mark.no_legacy_skip
+def test_dirty_source_blocks_after_cleanup_and_refresh(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    out = tmp_path / "finalizer.json"
+    statuses = iter([["?? glow/test_runs/run.json", " M sentientos/codex_finalize_landing.py"], [" M sentientos/codex_finalize_landing.py"], [" M sentientos/codex_finalize_landing.py"]])
+    monkeypatch.setattr("scripts.codex_finalize_landing._git_status", lambda: next(statuses, [" M sentientos/codex_finalize_landing.py"]))
+    monkeypatch.setattr(
+        "scripts.codex_finalize_landing._cleanup_generated",
+        lambda status_lines: {"glow/test_runs/run.json": (True, "removed", "generated_artifact_cleanup")},
+    )
+
+    def fake_run_stage(stage_id: str, command: str, required: bool, progress: bool, stage_timeout_seconds: int, overall_deadline: float):
+        from sentientos.codex_finalize_landing import CodexFinalizeLandingCommandResult
+
+        return CodexFinalizeLandingCommandResult(stage_id, command, 0, required=required), _successful_runtime(stage_id, command, required)
+
+    monkeypatch.setattr("scripts.codex_finalize_landing._run_stage", fake_run_stage)
+    code = main([
+        "finalize",
+        "--title",
+        "x",
+        "--intended-commit-title",
+        "x",
+        "--phase",
+        "pre-commit",
+        "--focused-test-command",
+        "python -c 'pass'",
+        "--allow-generated-artifact-cleanup",
+        "--allow-stale-evidence-refresh",
+        "--output",
+        str(out),
+    ])
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["decision"]["status"] == "repair_required_task_caused"
+    assert "source_change_not_declared" in payload["decision"]["reasons"]
+    assert payload["evidence_freshness"]["refresh_stage_runs"] == 4


### PR DESCRIPTION
### Motivation

- Finalizer runs could enter repeated generated-artifact cleanup → stale-evidence refresh cycles after PR #1877 added reviewer-bundle receipts, leaving callers without a single bounded terminal outcome. The change aims to ensure one bounded refresh pass per invocation with explicit terminal evidence and statuses. 

### Description

- Implement a single bounded stale-evidence refresh pass in `scripts/codex_finalize_landing.py` and make the refresh permission controlled by `--allow-stale-evidence-refresh` and `--max-stale-evidence-refreshes`, with refresh stages run once per invocation. 
- Add explicit terminal outcomes and decision labels: `stale_evidence_refresh_required` (needed but not allowed), `stale_evidence_refresh_failed` (allowed refresh failed/timed out), and `generated_artifact_cleanup_incomplete` (cleanup left generated artifacts), while allowing phase-ready status when refresh succeeds and the tree is clean. 
- Perform a terminal cleanup step after a successful refresh (when allowed) so any refresh-generated artifacts are cleaned once within the same finalizer invocation rather than forcing another cleanup/refresh loop. 
- Record inspectable evidence in the finalizer JSON under `evidence_freshness` (fields include `cleanup_occurred`, `cleaned_paths`, `terminal_cleanup_occurred`, `terminal_cleaned_paths`, `stale_evidence_refresh_attempted`, `stale_evidence_refresh_result`, `refresh_failure_reason`, `refresh_stage_runs`, `refresh_stages_ran`, `refreshed_matrix_json_path`, and `rerun_required`) and expose `terminal_refresh_status` and `rerun_required` in summary output. 
- Add regression tests in `tests/test_codex_finalize_landing_script.py` to cover: successful cleanup+refresh → terminal ready, refresh-not-allowed → `stale_evidence_refresh_required`, allowed refresh failure → terminal `stale_evidence_refresh_failed` (no rerun suggestion), and dirty source still blocking after cleanup/refresh. 
- Update documentation in `docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, and `docs/development/codex_validation_and_landing_contract.md` to describe bounded refresh semantics, terminal statuses, and the new evidence fields. 

### Testing

- Ran the bootstrap command used for the task scaffold and it returned `ready_with_warnings`. 
- Unit/regression tests: `python -m scripts.run_tests -q tests/test_codex_finalize_landing.py tests/test_codex_finalize_landing_script.py` passed. 
- Finalizer integration runs: pre-commit finalizer run with `--allow-generated-artifact-cleanup --allow-stale-evidence-refresh --max-stale-evidence-refreshes 1` produced a `ready_to_commit` terminal result and evidence showing `stale_evidence_refresh_result: succeeded` and `rerun_required: false`; post-commit/pr-metadata finalizer run produced `ready_for_pr_metadata` with matching terminal refresh evidence. 
- PR guard: `python scripts/codex_pr_metadata_guard.py verify ... --summary` returned `pr_metadata_guard_ready`. 
- Docs: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` completed (initial `--check-deps` reported missing doc deps until `--bootstrap-docs` was run). 
- Static checks: `python -m mypy sentientos/codex_finalize_landing.py scripts/codex_finalize_landing.py` passed. 

Files changed: `scripts/codex_finalize_landing.py`, `tests/test_codex_finalize_landing_script.py`, `docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, and `docs/development/codex_validation_and_landing_contract.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a359e2d93308320963826f8d4978f01)