### PR TITLE
[codex:landing] add Codex task lifecycle summary artifact

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -103,3 +103,13 @@ This ordering applies to both pre-commit and pr-metadata phases.
 The pr-metadata/post-commit finalizer is necessary but not sufficient for `make_pr`. After it returns `ready_for_pr_metadata`, run `python scripts/codex_pr_metadata_guard.py verify` with the pre-commit finalizer artifact, pr-metadata finalizer artifact, and matrix artifact. PR metadata is forbidden unless the guard returns `pr_metadata_guard_ready`.
 
 Blocked guard decisions are hard stops. Do not reinterpret a ready finalizer artifact as permission to create PR metadata when `codex_pr_metadata_guard.py verify` reports missing proof, title mismatch, stale evidence, dirty tree evidence, matrix failure, or validation-only mismatch.
+
+## Codex task lifecycle summary artifact
+
+`python scripts/build_codex_task_lifecycle_summary.py` builds a deterministic, metadata-only `codex_task_lifecycle_summary.json` artifact from evidence that already exists. It consumes the pre-commit finalizer JSON, the post-commit/pr-metadata finalizer JSON, the matrix JSON path used for those checks, and optionally the PR metadata guard JSON. It does not rerun tests, matrix lanes, finalizer stages, PR metadata guard checks, shell commands, or cleanup.
+
+The summary emits reviewer/developer workflow fields such as `summary_id`, `task_id`, finalizer statuses, PR metadata guard status, terminal stale-evidence refresh fields, cleanup fields, refreshed matrix path fields, `overall_lifecycle_status`, `rerun_required`, and a non-authority posture block. Missing optional terminal evidence fields are represented as null/unavailable rather than treated as parser failures.
+
+The summary differs from the finalizer: the finalizer remains the executable landing authority that evaluates the tree and validation evidence. The lifecycle summary only records what the finalizer and optional guard artifacts already said. It must not be used as permission to commit, create PR metadata, call `make_pr`, ignore dirty source files, or bypass the two-phase finalizer and PR metadata guard sequence.
+
+Status interpretation is intentionally narrow: `codex_lifecycle_ready` requires `ready_to_commit`, `ready_for_pr_metadata`, and either no guard artifact or `pr_metadata_guard_ready`; any not-ready finalizer, rerun-required finalizer evidence, or non-ready provided guard artifact is `codex_lifecycle_blocked`. Missing or invalid required JSON evidence fails cleanly instead of inventing readiness.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -110,3 +110,9 @@ This compression does not weaken bootstrap, finalizer, PR metadata guard, matrix
 Federation/Genesis Forge distributed coding labor is future proof-sharing and non-duplicative work-claim topology only until claim semantics, proof exchange, artifact schema, and authority boundaries are defined. This rail does not implement routing, task execution, remote work dispatch, adoption, sync, merge, install, or execution behavior.
 
 Codex Windows local-node readiness remains planning-only. Repository mainline state stays canonical until a fresh local clone, clean baselines, dependency readiness, and local-node health checks exist; do not add setup automation from this rail.
+
+## Lifecycle summary artifact for inspection only
+
+For late landing recovery inspection, a task may create `codex_task_lifecycle_summary.json` with `scripts/build_codex_task_lifecycle_summary.py` after the required finalizer and PR metadata guard evidence has already been produced. The artifact consumes existing pre-commit finalizer JSON, post-commit/pr-metadata finalizer JSON, matrix JSON path, and optional PR metadata guard JSON, then emits one compact deterministic summary of lifecycle state.
+
+This helps reviewers see whether the existing evidence says the task is ready, blocked, or requires rerun without rerunning the landing ritual. It is not a recovery rail, authority grant, readiness gate, packet, envelope, or repeated ladder. It cannot repair stale evidence, cannot satisfy missing finalizer or guard proof, and cannot authorize PR metadata when the guard is absent or blocked.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -49,3 +49,9 @@ Run `python scripts/codex_landing_supervisor.py evaluate --title "..." --intende
 - Focused tests passing without a ready PR metadata guard is not a complete landing.
 
 Strict landing sequence: run bootstrapper; stop if blocked; implement only if ready/ready_with_warnings; run required validation; run pre-commit finalizer and require `ready_to_commit`; commit; run post-commit/pr-metadata finalizer and require `ready_for_pr_metadata`; run PR metadata guard and require `pr_metadata_guard_ready`; only then `make_pr`.
+
+## Metadata-only lifecycle summaries
+
+A Codex task lifecycle summary may be produced as a developer workflow artifact after validation/finalizer/guard evidence exists. The summary consumes already-produced finalizer JSON artifacts, the matrix JSON path, and optional PR metadata guard JSON. It emits deterministic metadata including finalizer decisions, optional PR #1878 terminal freshness fields, cleanup fields, guard status, lifecycle status, rerun reason, and explicit non-authority posture flags.
+
+The summary is evidence only. It does not replace bootstrap, validation, matrix, supervisor, pre-commit finalizer, post-commit/pr-metadata finalizer, PR metadata guard, clean-tree checks, commit requirements, or `make_pr` requirements. If the summary reports `codex_lifecycle_ready`, that means only that the supplied artifacts contain ready statuses; the executable landing sequence still controls.

--- a/scripts/build_codex_task_lifecycle_summary.py
+++ b/scripts/build_codex_task_lifecycle_summary.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_task_lifecycle_summary import (
+    CodexTaskLifecycleSummaryError,
+    CodexTaskLifecycleSummaryRequest,
+    build_task_lifecycle_summary,
+    write_task_lifecycle_summary,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a deterministic Codex task lifecycle summary artifact from existing landing evidence.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--intended-commit-title", required=True)
+    parser.add_argument("--pre-commit-finalizer-json", required=True)
+    parser.add_argument("--pr-metadata-finalizer-json", required=True)
+    parser.add_argument("--matrix-json-path", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--pr-metadata-guard-json")
+    parser.add_argument("--task-id")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        summary = build_task_lifecycle_summary(
+            CodexTaskLifecycleSummaryRequest(
+                title=args.title,
+                intended_commit_title=args.intended_commit_title,
+                pre_commit_finalizer_json=args.pre_commit_finalizer_json,
+                pr_metadata_finalizer_json=args.pr_metadata_finalizer_json,
+                matrix_json_path=args.matrix_json_path,
+                output=args.output,
+                pr_metadata_guard_json=args.pr_metadata_guard_json,
+                task_id=args.task_id,
+            )
+        )
+        write_task_lifecycle_summary(summary, args.output)
+    except CodexTaskLifecycleSummaryError as exc:
+        print(f"codex_task_lifecycle_summary_error: {exc}", file=sys.stderr)
+        return 1
+    if args.summary:
+        print(json.dumps({"summary_id": summary["summary_id"], "overall_lifecycle_status": summary["overall_lifecycle_status"], "rerun_required": summary["rerun_required"], "rerun_reason": summary["rerun_reason"]}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_task_lifecycle_summary.py
+++ b/sentientos/codex_task_lifecycle_summary.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+READY = "codex_lifecycle_ready"
+INCOMPLETE = "codex_lifecycle_incomplete"
+BLOCKED = "codex_lifecycle_blocked"
+GUARD_READY = "pr_metadata_guard_ready"
+GUARD_NOT_PROVIDED = "not_provided"
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "summary_does_not_bypass_finalizer": True,
+    "summary_does_not_bypass_pr_metadata_guard": True,
+    "summary_does_not_authorize_pr_creation": True,
+    "summary_does_not_authorize_dirty_source_files": True,
+    "summary_does_not_grant_runtime_authority": True,
+}
+
+OPTIONAL_FRESHNESS_FIELDS = (
+    "terminal_refresh_status",
+    "rerun_required",
+    "stale_evidence_refresh_result",
+    "cleanup_occurred",
+    "terminal_cleanup_occurred",
+    "cleaned_paths",
+    "terminal_cleaned_paths",
+    "refresh_stage_runs",
+    "refresh_stages_ran",
+    "refreshed_matrix_json_path",
+)
+
+
+class CodexTaskLifecycleSummaryError(ValueError):
+    """Raised when required lifecycle evidence cannot be summarized safely."""
+
+
+@dataclass(frozen=True)
+class CodexTaskLifecycleSummaryRequest:
+    title: str
+    intended_commit_title: str
+    pre_commit_finalizer_json: str
+    pr_metadata_finalizer_json: str
+    matrix_json_path: str
+    output: str = ""
+    pr_metadata_guard_json: str | None = None
+    task_id: str | None = None
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("\u241f".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def _load_json_object(path_text: str, label: str) -> dict[str, Any]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexTaskLifecycleSummaryError(f"{label}_missing:{path_text}")
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CodexTaskLifecycleSummaryError(f"{label}_invalid_json:{path_text}:{exc.msg}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexTaskLifecycleSummaryError(f"{label}_json_not_object:{path_text}")
+    return loaded
+
+
+def _decision_status(payload: Mapping[str, Any], label: str) -> str:
+    decision = payload.get("decision")
+    if not isinstance(decision, Mapping):
+        raise CodexTaskLifecycleSummaryError(f"{label}_missing_finalizer_decision")
+    status = decision.get("status")
+    if not isinstance(status, str) or not status:
+        raise CodexTaskLifecycleSummaryError(f"{label}_missing_finalizer_status")
+    return status
+
+
+def _guard_status(payload: Mapping[str, Any]) -> str:
+    status = payload.get("status")
+    if isinstance(status, str) and status:
+        return status
+    raise CodexTaskLifecycleSummaryError("pr_metadata_guard_missing_status")
+
+
+def _freshness_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    freshness = payload.get("evidence_freshness")
+    if not isinstance(freshness, Mapping):
+        freshness = {}
+    return {field: freshness.get(field) for field in OPTIONAL_FRESHNESS_FIELDS}
+
+
+def _finalizer_section(path: str, payload: Mapping[str, Any], label: str) -> dict[str, Any]:
+    section = {"path": path, "status": _decision_status(payload, label)}
+    section.update(_freshness_summary(payload))
+    return section
+
+
+def build_task_lifecycle_summary(request: CodexTaskLifecycleSummaryRequest) -> dict[str, Any]:
+    task_id = request.task_id or _stable_id("task", request.title, request.intended_commit_title)
+    pre_payload = _load_json_object(request.pre_commit_finalizer_json, "pre_commit_finalizer_json")
+    pr_payload = _load_json_object(request.pr_metadata_finalizer_json, "pr_metadata_finalizer_json")
+    pre = _finalizer_section(request.pre_commit_finalizer_json, pre_payload, "pre_commit_finalizer")
+    pr = _finalizer_section(request.pr_metadata_finalizer_json, pr_payload, "pr_metadata_finalizer")
+
+    guard_status = GUARD_NOT_PROVIDED
+    guard_path: str | None = None
+    if request.pr_metadata_guard_json:
+        guard_path = request.pr_metadata_guard_json
+        guard_status = _guard_status(_load_json_object(request.pr_metadata_guard_json, "pr_metadata_guard_json"))
+
+    reasons: list[str] = []
+    missing_required = False
+    if pre["status"] != "ready_to_commit":
+        reasons.append(f"pre_commit_finalizer_not_ready:{pre['status']}")
+    if pr["status"] != "ready_for_pr_metadata":
+        reasons.append(f"pr_metadata_finalizer_not_ready:{pr['status']}")
+    for label, section in (("pre_commit", pre), ("pr_metadata", pr)):
+        if section.get("rerun_required") is True:
+            reasons.append(f"{label}_finalizer_rerun_required")
+    if guard_status not in {GUARD_NOT_PROVIDED, GUARD_READY}:
+        reasons.append(f"pr_metadata_guard_not_ready:{guard_status}")
+
+    overall = INCOMPLETE if missing_required else (BLOCKED if reasons else READY)
+    rerun_required = bool(reasons or missing_required)
+
+    summary: dict[str, Any] = {
+        "summary_id": _stable_id("codex_task_lifecycle_summary", task_id, request.title, request.intended_commit_title, request.matrix_json_path),
+        "task_id": task_id,
+        "title": request.title,
+        "intended_commit_title": request.intended_commit_title,
+        "matrix_json_path": request.matrix_json_path,
+        "pre_commit_finalizer_status": pre["status"],
+        "pr_metadata_finalizer_status": pr["status"],
+        "pr_metadata_guard_status": guard_status,
+        "pr_metadata_guard_json_path": guard_path,
+        "finalizers": {"pre_commit": pre, "pr_metadata": pr},
+        "overall_lifecycle_status": overall,
+        "rerun_required": rerun_required,
+        "rerun_reason": ";".join(reasons) if rerun_required else None,
+        "metadata_only": True,
+        "developer_workflow_evidence_only": True,
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+    return summary
+
+
+def write_task_lifecycle_summary(summary: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_build_codex_task_lifecycle_summary_script.py
+++ b/tests/test_build_codex_task_lifecycle_summary_script.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write(path: Path, payload: dict[str, object]) -> str:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return str(path)
+
+
+def test_cli_writes_deterministic_json_and_prints_summary(tmp_path: Path) -> None:
+    pre = _write(tmp_path / "pre.json", {"decision": {"status": "ready_to_commit"}, "evidence_freshness": {"rerun_required": False, "stale_evidence_refresh_result": "not_required"}})
+    pr = _write(tmp_path / "pr.json", {"decision": {"status": "ready_for_pr_metadata"}, "evidence_freshness": {"rerun_required": False, "terminal_refresh_status": "succeeded"}})
+    guard = _write(tmp_path / "guard.json", {"status": "pr_metadata_guard_ready"})
+    out = tmp_path / "codex_task_lifecycle_summary.json"
+    cmd = [
+        sys.executable,
+        "scripts/build_codex_task_lifecycle_summary.py",
+        "--title",
+        "[codex:landing] add Codex task lifecycle summary artifact",
+        "--intended-commit-title",
+        "[codex:landing] add Codex task lifecycle summary artifact",
+        "--pre-commit-finalizer-json",
+        pre,
+        "--pr-metadata-finalizer-json",
+        pr,
+        "--matrix-json-path",
+        "/tmp/work_item_review_packet_matrix.json",
+        "--pr-metadata-guard-json",
+        guard,
+        "--output",
+        str(out),
+        "--summary",
+    ]
+    first = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    first_payload = out.read_text(encoding="utf-8")
+    second = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    assert out.read_text(encoding="utf-8") == first_payload
+    summary = json.loads(first_payload)
+    assert summary["overall_lifecycle_status"] == "codex_lifecycle_ready"
+    assert "codex_lifecycle_ready" in first.stdout
+    assert second.returncode == 0
+
+
+def test_cli_invalid_json_returns_clean_error(tmp_path: Path) -> None:
+    pre = tmp_path / "pre.json"
+    pre.write_text("not-json", encoding="utf-8")
+    pr = _write(tmp_path / "pr.json", {"decision": {"status": "ready_for_pr_metadata"}})
+    out = tmp_path / "summary.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/build_codex_task_lifecycle_summary.py",
+            "--title",
+            "title",
+            "--intended-commit-title",
+            "title",
+            "--pre-commit-finalizer-json",
+            str(pre),
+            "--pr-metadata-finalizer-json",
+            pr,
+            "--matrix-json-path",
+            "/tmp/matrix.json",
+            "--output",
+            str(out),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "codex_task_lifecycle_summary_error" in result.stderr
+    assert not out.exists()

--- a/tests/test_codex_task_lifecycle_summary.py
+++ b/tests/test_codex_task_lifecycle_summary.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sentientos.codex_task_lifecycle_summary import (
+    BLOCKED,
+    GUARD_NOT_PROVIDED,
+    READY,
+    CodexTaskLifecycleSummaryError,
+    CodexTaskLifecycleSummaryRequest,
+    build_task_lifecycle_summary,
+)
+
+
+def _write(path: Path, payload: dict[str, object]) -> str:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return str(path)
+
+
+def _finalizer(status: str, **freshness: object) -> dict[str, object]:
+    payload: dict[str, object] = {"decision": {"status": status, "reasons": []}}
+    if freshness:
+        payload["evidence_freshness"] = freshness
+    return payload
+
+
+def _request(tmp_path: Path, pre: dict[str, object], pr: dict[str, object], guard: dict[str, object] | None = None) -> CodexTaskLifecycleSummaryRequest:
+    guard_path = _write(tmp_path / "guard.json", guard) if guard is not None else None
+    return CodexTaskLifecycleSummaryRequest(
+        title="[codex:landing] add Codex task lifecycle summary artifact",
+        intended_commit_title="[codex:landing] add Codex task lifecycle summary artifact",
+        pre_commit_finalizer_json=_write(tmp_path / "pre.json", pre),
+        pr_metadata_finalizer_json=_write(tmp_path / "pr.json", pr),
+        matrix_json_path="/tmp/work_item_review_packet_matrix.json",
+        pr_metadata_guard_json=guard_path,
+    )
+
+
+def test_ready_lifecycle_summary_with_ready_guard(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("ready_for_pr_metadata"), {"status": "pr_metadata_guard_ready"}))
+    assert summary["overall_lifecycle_status"] == READY
+    assert summary["pr_metadata_guard_status"] == "pr_metadata_guard_ready"
+    assert summary["rerun_required"] is False
+
+
+def test_ready_lifecycle_summary_without_guard(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("ready_for_pr_metadata")))
+    assert summary["overall_lifecycle_status"] == READY
+    assert summary["pr_metadata_guard_status"] == GUARD_NOT_PROVIDED
+
+
+def test_blocked_when_pre_commit_not_ready(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("manual_review_required"), _finalizer("ready_for_pr_metadata")))
+    assert summary["overall_lifecycle_status"] == BLOCKED
+    assert "pre_commit_finalizer_not_ready" in str(summary["rerun_reason"])
+
+
+def test_blocked_when_pr_metadata_not_ready(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("repair_required_task_caused")))
+    assert summary["overall_lifecycle_status"] == BLOCKED
+    assert "pr_metadata_finalizer_not_ready" in str(summary["rerun_reason"])
+
+
+def test_blocked_when_any_finalizer_rerun_required(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit", rerun_required=True), _finalizer("ready_for_pr_metadata")))
+    assert summary["overall_lifecycle_status"] == BLOCKED
+    assert summary["rerun_required"] is True
+    assert "pre_commit_finalizer_rerun_required" in str(summary["rerun_reason"])
+
+
+def test_blocked_when_guard_not_ready(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("ready_for_pr_metadata"), {"status": "pr_metadata_guard_blocked_matrix_failed"}))
+    assert summary["overall_lifecycle_status"] == BLOCKED
+    assert "pr_metadata_guard_not_ready" in str(summary["rerun_reason"])
+
+
+def test_missing_optional_refresh_fields_are_tolerated(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("ready_for_pr_metadata")))
+    assert summary["finalizers"]["pre_commit"]["terminal_refresh_status"] is None
+    assert summary["finalizers"]["pr_metadata"]["stale_evidence_refresh_result"] is None
+
+
+def test_invalid_json_fails_cleanly(tmp_path: Path) -> None:
+    pre = tmp_path / "pre.json"
+    pre.write_text("{not-json", encoding="utf-8")
+    pr = _write(tmp_path / "pr.json", _finalizer("ready_for_pr_metadata"))
+    request = CodexTaskLifecycleSummaryRequest("title", "title", str(pre), pr, "/tmp/matrix.json")
+    with pytest.raises(CodexTaskLifecycleSummaryError, match="invalid_json"):
+        build_task_lifecycle_summary(request)
+
+
+def test_non_authority_posture_fields_are_true(tmp_path: Path) -> None:
+    summary = build_task_lifecycle_summary(_request(tmp_path, _finalizer("ready_to_commit"), _finalizer("ready_for_pr_metadata")))
+    assert summary["metadata_only"] is True
+    assert summary["developer_workflow_evidence_only"] is True
+    assert all(summary["non_authority_posture"].values())


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only inspector for Codex landing state that consumes existing finalizer and PR metadata guard JSON and lets reviewers/developers see lifecycle status without rerunning the landing ritual. 
- Support the hardened finalizer evidence shape introduced by PR #1878 (terminal freshness fields) while avoiding any change to finalizer refresh behavior or landing authority. 
- Reduce reviewer friction for late/evidence-only recovery scenarios by emitting a compact summary object that is explicitly non-authoritative.

### Description
- Added `sentientos/codex_task_lifecycle_summary.py`, a pure-evidence module that loads pre-commit and post-commit/pr-metadata finalizer JSON (and optional PR metadata guard JSON), produces stable `task_id`/`summary_id`, preserves optional terminal freshness fields as nullable values, and produces the lifecycle summary dict. 
- Added CLI `scripts/build_codex_task_lifecycle_summary.py` with required args `--title`, `--intended-commit-title`, `--pre-commit-finalizer-json`, `--pr-metadata-finalizer-json`, `--matrix-json-path`, and `--output`, plus optional `--pr-metadata-guard-json`, `--task-id`, and `--summary` flags. 
- Summary content includes finalizer/guard statuses, per-finalizer freshness/cleanup fields (nullable), `overall_lifecycle_status` (`codex_lifecycle_ready|codex_lifecycle_blocked|codex_lifecycle_incomplete`), `rerun_required` and `rerun_reason`, `metadata_only` / `developer_workflow_evidence_only`, and a `non_authority_posture` block that explicitly disclaims authority. 
- Updated docs (`docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, `docs/development/codex_validation_and_landing_contract.md`) and added focused tests and CLI tests under `tests/` to validate ready/blocked/rerun/invalid-JSON behaviors and deterministic output.

### Testing
- Ran focused unit + CLI tests `tests/test_codex_task_lifecycle_summary.py` and `tests/test_build_codex_task_lifecycle_summary_script.py` (exercised ready/omitted-guard/blocked/rerun/invalid-JSON behavior); test run exited successfully though some test-airlock collection reported skips. 
- Executed pre-commit and post-commit finalizer runs for this change via `scripts/codex_finalize_landing.py` which produced `/tmp/codex_task_lifecycle_summary_pre_commit.json` (`ready_to_commit`, terminal refresh `succeeded`) and `/tmp/codex_task_lifecycle_summary_pr_metadata.json` (`ready_for_pr_metadata`, terminal refresh `succeeded`). 
- Ran `scripts/codex_pr_metadata_guard.py verify` which returned `pr_metadata_guard_ready`, `python -m mypy` on the new files (passed), `python scripts/run_work_item_review_packet_matrix.py --summary` (matrix passed), and `python scripts/build_docs.py` after `--bootstrap-docs` (docs build passed). 
- `git diff --check` and local commit succeeded; commit hash is `aecd85b0f3ff18d9187da5f11e5549112e089fa1` and PR metadata creation step completed via the repo toolchain (guard returned ready); no unresolved automated-test failures were left.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a35ce2563348320a7fea679beb5a81d)