### PR TITLE
[codex:landing] add Codex lifecycle doctor CLI

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -113,3 +113,26 @@ The summary emits reviewer/developer workflow fields such as `summary_id`, `task
 The summary differs from the finalizer: the finalizer remains the executable landing authority that evaluates the tree and validation evidence. The lifecycle summary only records what the finalizer and optional guard artifacts already said. It must not be used as permission to commit, create PR metadata, call `make_pr`, ignore dirty source files, or bypass the two-phase finalizer and PR metadata guard sequence.
 
 Status interpretation is intentionally narrow: `codex_lifecycle_ready` requires `ready_to_commit`, `ready_for_pr_metadata`, and either no guard artifact or `pr_metadata_guard_ready`; any not-ready finalizer, rerun-required finalizer evidence, or non-ready provided guard artifact is `codex_lifecycle_blocked`. Missing or invalid required JSON evidence fails cleanly instead of inventing readiness.
+
+## Codex lifecycle doctor (inspection only)
+
+The Codex lifecycle doctor is a read-only operator inspection CLI:
+`python scripts/codex_lifecycle_doctor.py`. It consumes existing JSON artifacts such
+as the work-item matrix report, pre-commit finalizer JSON, post-commit/PR-metadata
+finalizer JSON, PR metadata guard JSON, lifecycle summary JSON, and run-tests
+provenance JSON. It writes an optional deterministic `codex_lifecycle_doctor_report.json`
+that explains the currently visible landing state and a next safe inspection action.
+
+The doctor is not a replacement for this finalizer. The finalizer answers whether a
+change may advance to commit or PR metadata under landing rules. The lifecycle doctor
+answers which available evidence artifact an operator should inspect or rerun next.
+Doctor reports are inspection-only evidence: they do not authorize commits, do not
+authorize PR creation, do not bypass the finalizer, and do not bypass the PR metadata
+guard.
+
+Doctor output exposes ready, blocked, stale, incomplete, and rerun-required states. A
+`doctor_ready` result only means the supplied artifacts are mutually consistent from the
+doctor's read-only perspective; operators must still require the actual finalizer and PR
+metadata guard decisions before commit or PR metadata. Diagnostic/non-proof matrix lanes
+remain visible in the doctor matrix summary but are reported as non-blocking unless a
+required proof lane failed.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -116,3 +116,22 @@ Codex Windows local-node readiness remains planning-only. Repository mainline st
 For late landing recovery inspection, a task may create `codex_task_lifecycle_summary.json` with `scripts/build_codex_task_lifecycle_summary.py` after the required finalizer and PR metadata guard evidence has already been produced. The artifact consumes existing pre-commit finalizer JSON, post-commit/pr-metadata finalizer JSON, matrix JSON path, and optional PR metadata guard JSON, then emits one compact deterministic summary of lifecycle state.
 
 This helps reviewers see whether the existing evidence says the task is ready, blocked, or requires rerun without rerunning the landing ritual. It is not a recovery rail, authority grant, readiness gate, packet, envelope, or repeated ladder. It cannot repair stale evidence, cannot satisfy missing finalizer or guard proof, and cannot authorize PR metadata when the guard is absent or blocked.
+
+## Lifecycle doctor recovery inspection
+
+When evidence artifacts already exist, the lifecycle doctor may be used to inspect them
+without rerunning commands or creating authority. It reads only JSON evidence and can
+summarize missing optional evidence as `doctor_incomplete`, required matrix proof
+failures as `doctor_blocked`, finalizer freshness problems as `doctor_stale`, and explicit
+rerun signals as `doctor_rerun_required`.
+
+Use the doctor to decide what to inspect next, not to recover authority. Lifecycle summary
+answers: “What was the lifecycle state from specific finalizer/guard evidence?” Lifecycle
+doctor answers: “Given all available evidence artifacts, what should an operator inspect
+or rerun next?” Finalizer answers: “Can this change advance to commit/PR metadata under
+landing rules?” PR metadata guard answers: “Is PR metadata creation allowed?” Matrix
+answers: “Did required proof lanes pass?”
+
+A doctor report is diagnostic-only recovery evidence. It does not replace same-workspace
+surgical recovery, does not bless stale finalizer artifacts, and does not create PR
+metadata permission.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -55,3 +55,24 @@ Strict landing sequence: run bootstrapper; stop if blocked; implement only if re
 A Codex task lifecycle summary may be produced as a developer workflow artifact after validation/finalizer/guard evidence exists. The summary consumes already-produced finalizer JSON artifacts, the matrix JSON path, and optional PR metadata guard JSON. It emits deterministic metadata including finalizer decisions, optional PR #1878 terminal freshness fields, cleanup fields, guard status, lifecycle status, rerun reason, and explicit non-authority posture flags.
 
 The summary is evidence only. It does not replace bootstrap, validation, matrix, supervisor, pre-commit finalizer, post-commit/pr-metadata finalizer, PR metadata guard, clean-tree checks, commit requirements, or `make_pr` requirements. If the summary reports `codex_lifecycle_ready`, that means only that the supplied artifacts contain ready statuses; the executable landing sequence still controls.
+
+## Lifecycle doctor and validation evidence boundaries
+
+The Codex lifecycle doctor is a deterministic inspection surface over existing landing
+artifacts. Inputs may include matrix JSON, finalizer JSON from both phases, PR metadata
+guard JSON, lifecycle summary JSON, and `scripts.run_tests` provenance JSON. Outputs
+include `doctor_report_id`, evidence path summaries, matrix proof counts, blocked lane
+summaries with `proof_status` and `exit_reason`, finalizer freshness fields, test
+provenance proof-quality classification, a next safe action, and an explicit
+non-authority posture.
+
+The doctor must not run validation, tests, matrix lanes, finalizer commands, guard
+commands, docs commands, mypy, git, network calls, provider calls, shell commands, or
+runtime actions. It marks missing requested evidence as incomplete and invalid JSON as a
+clean CLI error. It must not infer readiness from title or intended commit title alone.
+
+Diagnostic/non-proof matrix lanes appear in doctor output for visibility, including
+non-proof failures and exit reasons, but they are not blocking when `required_failure_count`
+is zero and no required proof lane has a non-passing `proof_status`. Required proof lane
+failures remain blocking and must be repaired or rerun through the authoritative matrix
+and landing flow.

--- a/scripts/codex_lifecycle_doctor.py
+++ b/scripts/codex_lifecycle_doctor.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_lifecycle_doctor import (
+    CodexLifecycleDoctorError,
+    CodexLifecycleDoctorRequest,
+    build_lifecycle_doctor_report,
+    write_lifecycle_doctor_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect existing Codex landing artifacts without granting authority.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--intended-commit-title", required=True)
+    parser.add_argument("--matrix-json-path", required=True)
+    parser.add_argument("--pre-commit-finalizer-json")
+    parser.add_argument("--pr-metadata-finalizer-json")
+    parser.add_argument("--pr-metadata-guard-json")
+    parser.add_argument("--lifecycle-summary-json")
+    parser.add_argument("--test-provenance-json")
+    parser.add_argument("--output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = build_lifecycle_doctor_report(
+            CodexLifecycleDoctorRequest(
+                title=args.title,
+                intended_commit_title=args.intended_commit_title,
+                matrix_json_path=args.matrix_json_path,
+                pre_commit_finalizer_json=args.pre_commit_finalizer_json,
+                pr_metadata_finalizer_json=args.pr_metadata_finalizer_json,
+                pr_metadata_guard_json=args.pr_metadata_guard_json,
+                lifecycle_summary_json=args.lifecycle_summary_json,
+                test_provenance_json=args.test_provenance_json,
+                output=args.output,
+            )
+        )
+    except CodexLifecycleDoctorError as exc:
+        print(f"codex_lifecycle_doctor_error: {exc}", file=sys.stderr)
+        return 2
+    if args.output:
+        write_lifecycle_doctor_report(report, args.output)
+    if args.summary:
+        print(json.dumps({"doctor_report_id": report["doctor_report_id"], "overall_doctor_status": report["overall_doctor_status"], "next_safe_action": report["next_safe_action"]}, sort_keys=True))
+    elif not args.output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_lifecycle_doctor.py
+++ b/sentientos/codex_lifecycle_doctor.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+READY = "doctor_ready"
+BLOCKED = "doctor_blocked"
+INCOMPLETE = "doctor_incomplete"
+STALE = "doctor_stale"
+RERUN_REQUIRED = "doctor_rerun_required"
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "doctor_is_read_only": True,
+    "doctor_does_not_rerun_commands": True,
+    "doctor_does_not_bypass_finalizer": True,
+    "doctor_does_not_bypass_pr_metadata_guard": True,
+    "doctor_does_not_authorize_commit": True,
+    "doctor_does_not_authorize_pr_creation": True,
+    "doctor_does_not_authorize_runtime_action": True,
+}
+
+
+class CodexLifecycleDoctorError(ValueError):
+    """Raised when doctor evidence cannot be read as deterministic JSON."""
+
+
+@dataclass(frozen=True)
+class CodexLifecycleDoctorRequest:
+    title: str
+    intended_commit_title: str
+    matrix_json_path: str
+    pre_commit_finalizer_json: str | None = None
+    pr_metadata_finalizer_json: str | None = None
+    pr_metadata_guard_json: str | None = None
+    lifecycle_summary_json: str | None = None
+    test_provenance_json: str | None = None
+    output: str | None = None
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("\u241f".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def _load_json_object(path_text: str, label: str, missing: list[str]) -> dict[str, Any] | None:
+    path = Path(path_text)
+    if not path.exists():
+        missing.append(label)
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CodexLifecycleDoctorError(f"{label}_invalid_json:{path_text}:{exc.msg}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexLifecycleDoctorError(f"{label}_json_not_object:{path_text}")
+    return loaded
+
+
+def _as_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _finalizer_status(payload: Mapping[str, Any] | None) -> str | None:
+    if payload is None:
+        return None
+    decision = payload.get("decision")
+    if isinstance(decision, Mapping) and isinstance(decision.get("status"), str):
+        return str(decision["status"])
+    if isinstance(payload.get("status"), str):
+        return str(payload["status"])
+    return None
+
+
+def _freshness(payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if payload is None:
+        return {}
+    freshness = payload.get("evidence_freshness")
+    return freshness if isinstance(freshness, Mapping) else {}
+
+
+def _is_stale_refresh(value: Any) -> bool:
+    return isinstance(value, str) and value not in {"", "not_required", "succeeded", "ready", "passed", "not_applicable"}
+
+
+def _matrix_summary(matrix: Mapping[str, Any]) -> dict[str, Any]:
+    results = matrix.get("results")
+    rows = results if isinstance(results, list) else []
+    blocked: list[dict[str, Any]] = []
+    proof_required_count = 0
+    proof_passed_count = 0
+    diagnostic_failure_count = _as_int(matrix.get("diagnostic_failure_count")) or 0
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        proof_required = bool(row.get("proof_required", row.get("required", False)))
+        required = bool(row.get("required", False))
+        proof_status = str(row.get("proof_status", ""))
+        diagnostic_only = bool(row.get("diagnostic_only", False))
+        if proof_required:
+            proof_required_count += 1
+        if proof_status == "proof-passed":
+            proof_passed_count += 1
+        if diagnostic_only and proof_status.startswith("nonproof-diagnostic-failed"):
+            diagnostic_failure_count += 1
+        if required and proof_status != "proof-passed":
+            blocked.append(
+                {
+                    "lane": str(row.get("label") or row.get("id") or "unknown"),
+                    "proof_status": proof_status or None,
+                    "exit_reason": row.get("exit_reason"),
+                    "classification": row.get("classification_reason") or ("required_proof_failure" if proof_required else "required_nonproof_failure"),
+                }
+            )
+    return {
+        "status": matrix.get("status"),
+        "required_failure_count": _as_int(matrix.get("required_failure_count")),
+        "nonproof_count": _as_int(matrix.get("nonproof_count")),
+        "diagnostic_failure_count": diagnostic_failure_count,
+        "proof_required_count": _as_int(matrix.get("proof_required_count")) if matrix.get("proof_required_count") is not None else proof_required_count,
+        "proof_passed_count": _as_int(matrix.get("proof_passed_count")) if matrix.get("proof_passed_count") is not None else proof_passed_count,
+        "blocked_lane_count": len(blocked),
+        "blocked_lanes": blocked,
+    }
+
+
+def _finalizer_summary(pre: Mapping[str, Any] | None, pr: Mapping[str, Any] | None) -> dict[str, Any]:
+    pre_fresh = _freshness(pre)
+    pr_fresh = _freshness(pr)
+    return {
+        "pre_commit_status": _finalizer_status(pre),
+        "pr_metadata_status": _finalizer_status(pr),
+        "terminal_refresh_status": {"pre_commit": pre_fresh.get("terminal_refresh_status"), "pr_metadata": pr_fresh.get("terminal_refresh_status")},
+        "rerun_required": {"pre_commit": pre_fresh.get("rerun_required"), "pr_metadata": pr_fresh.get("rerun_required")},
+        "stale_evidence_refresh_result": {"pre_commit": pre_fresh.get("stale_evidence_refresh_result"), "pr_metadata": pr_fresh.get("stale_evidence_refresh_result")},
+        "cleaned_paths_count": len(pre_fresh.get("cleaned_paths") or []) + len(pr_fresh.get("cleaned_paths") or []),
+        "terminal_cleaned_paths_count": len(pre_fresh.get("terminal_cleaned_paths") or []) + len(pr_fresh.get("terminal_cleaned_paths") or []),
+    }
+
+
+def _guard_summary(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {"status": None, "ready": None}
+    status = payload.get("status")
+    return {"status": status, "ready": status == "pr_metadata_guard_ready" or payload.get("ready") is True}
+
+
+def _lifecycle_summary(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {"overall_lifecycle_status": None, "rerun_required": None, "rerun_reason": None}
+    return {"overall_lifecycle_status": payload.get("overall_lifecycle_status"), "rerun_required": payload.get("rerun_required"), "rerun_reason": payload.get("rerun_reason")}
+
+
+def _test_provenance_summary(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {"run_intent": None, "execution_mode": None, "tests_selected": None, "tests_executed": None, "tests_passed": None, "tests_skipped": None, "exit_reason": None, "proof_quality": None}
+    selected = _as_int(payload.get("tests_selected"))
+    executed = _as_int(payload.get("tests_executed"))
+    passed = _as_int(payload.get("tests_passed"))
+    run_intent = payload.get("run_intent")
+    proof_quality = True
+    if run_intent in {"targeted", "focused"}:
+        proof_quality = bool(selected and selected > 0 and executed and executed > 0 and passed and passed > 0)
+    return {
+        "run_intent": run_intent,
+        "execution_mode": payload.get("execution_mode"),
+        "tests_selected": selected,
+        "tests_executed": executed,
+        "tests_passed": passed,
+        "tests_skipped": _as_int(payload.get("tests_skipped")),
+        "exit_reason": payload.get("exit_reason"),
+        "proof_quality": proof_quality,
+    }
+
+
+def build_lifecycle_doctor_report(request: CodexLifecycleDoctorRequest) -> dict[str, Any]:
+    missing: list[str] = []
+    matrix = _load_json_object(request.matrix_json_path, "matrix_json_path", missing) or {}
+    pre = _load_json_object(request.pre_commit_finalizer_json, "pre_commit_finalizer_json", missing) if request.pre_commit_finalizer_json else None
+    pr = _load_json_object(request.pr_metadata_finalizer_json, "pr_metadata_finalizer_json", missing) if request.pr_metadata_finalizer_json else None
+    guard = _load_json_object(request.pr_metadata_guard_json, "pr_metadata_guard_json", missing) if request.pr_metadata_guard_json else None
+    lifecycle = _load_json_object(request.lifecycle_summary_json, "lifecycle_summary_json", missing) if request.lifecycle_summary_json else None
+    provenance = _load_json_object(request.test_provenance_json, "test_provenance_json", missing) if request.test_provenance_json else None
+
+    matrix_s = _matrix_summary(matrix)
+    finalizer_s = _finalizer_summary(pre, pr)
+    guard_s = _guard_summary(guard)
+    lifecycle_s = _lifecycle_summary(lifecycle)
+    provenance_s = _test_provenance_summary(provenance)
+
+    reasons: list[str] = []
+    status = READY
+    action = "no_action_ready"
+    if missing:
+        status, action = INCOMPLETE, "provide_missing_evidence"
+        reasons.append("missing_evidence:" + ",".join(sorted(missing)))
+    elif (matrix_s["required_failure_count"] or 0) > 0 or matrix_s["blocked_lane_count"] > 0:
+        status, action = BLOCKED, "inspect_blocked_lanes"
+        reasons.append("matrix_required_proof_blocked")
+    elif pre is not None and finalizer_s["pre_commit_status"] != "ready_to_commit":
+        status, action = BLOCKED, "rerun_finalizer_with_refresh"
+        reasons.append(f"pre_commit_finalizer_not_ready:{finalizer_s['pre_commit_status']}")
+    elif pr is not None and finalizer_s["pr_metadata_status"] != "ready_for_pr_metadata":
+        status, action = BLOCKED, "rerun_finalizer_with_refresh"
+        reasons.append(f"pr_metadata_finalizer_not_ready:{finalizer_s['pr_metadata_status']}")
+    elif guard is not None and guard_s["status"] != "pr_metadata_guard_ready":
+        status, action = BLOCKED, "provide_missing_evidence"
+        reasons.append(f"pr_metadata_guard_not_ready:{guard_s['status']}")
+    elif lifecycle is not None and lifecycle_s["overall_lifecycle_status"] != "codex_lifecycle_ready":
+        status, action = RERUN_REQUIRED if lifecycle_s["rerun_required"] is True else BLOCKED, "rerun_matrix"
+        reasons.append(f"lifecycle_not_ready:{lifecycle_s['overall_lifecycle_status']}")
+    elif provenance is not None and provenance_s["proof_quality"] is False:
+        status, action = BLOCKED, "inspect_test_airlock_provenance"
+        reasons.append("targeted_test_provenance_not_proof_quality")
+
+    stale_values = [*finalizer_s["terminal_refresh_status"].values(), *finalizer_s["stale_evidence_refresh_result"].values()]
+    rerun_values = [*finalizer_s["rerun_required"].values(), lifecycle_s["rerun_required"]]
+    if status == READY and any(value is True for value in rerun_values):
+        status, action = RERUN_REQUIRED, "rerun_finalizer_with_refresh"
+        reasons.append("evidence_rerun_required")
+    if status in {READY, RERUN_REQUIRED} and any(_is_stale_refresh(value) for value in stale_values):
+        status, action = STALE, "rerun_finalizer_with_refresh"
+        reasons.append("stale_or_refresh_required_finalizer_evidence")
+
+    report = {
+        "doctor_report_id": _stable_id("codex_lifecycle_doctor", request.title, request.intended_commit_title, request.matrix_json_path),
+        "title": request.title,
+        "intended_commit_title": request.intended_commit_title,
+        "overall_doctor_status": status,
+        "readiness_summary": ";".join(reasons) if reasons else "available evidence is mutually ready; inspection-only, not authority",
+        "missing_evidence": sorted(missing),
+        "evidence_inputs": {
+            "matrix_json_path": request.matrix_json_path,
+            "pre_commit_finalizer_json_path": request.pre_commit_finalizer_json,
+            "pr_metadata_finalizer_json_path": request.pr_metadata_finalizer_json,
+            "pr_metadata_guard_json_path": request.pr_metadata_guard_json,
+            "lifecycle_summary_json_path": request.lifecycle_summary_json,
+            "test_provenance_json_path": request.test_provenance_json,
+        },
+        "matrix_summary": matrix_s,
+        "finalizer_summary": finalizer_s,
+        "pr_metadata_guard_summary": guard_s,
+        "lifecycle_summary": lifecycle_s,
+        "test_provenance_summary": provenance_s,
+        "next_safe_action": action,
+        "next_safe_action_reason": ";".join(reasons) if reasons else "no blocking, stale, rerun-required, or missing evidence was visible to the doctor",
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+    return report
+
+
+def write_lifecycle_doctor_report(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_codex_lifecycle_doctor.py
+++ b/tests/test_codex_lifecycle_doctor.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_lifecycle_doctor import (
+    CodexLifecycleDoctorError,
+    CodexLifecycleDoctorRequest,
+    build_lifecycle_doctor_report,
+)
+
+TITLE = "[codex:landing] add Codex lifecycle doctor CLI"
+
+
+def _write(path: Path, payload: dict[str, object] | str) -> str:
+    path.write_text(payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return str(path)
+
+
+def _matrix(*, required_failure_count: int = 0, results: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {"status": "passed" if required_failure_count == 0 else "failed", "required_failure_count": required_failure_count, "nonproof_count": 0, "diagnostic_failure_count": 0, "results": results or [{"label": "targeted_tests", "required": True, "proof_required": True, "proof_status": "proof-passed", "exit_reason": None}]}
+
+
+def _finalizer(status: str, **freshness: object) -> dict[str, object]:
+    return {"decision": {"status": status}, "evidence_freshness": freshness or {"rerun_required": False, "stale_evidence_refresh_result": "not_required"}}
+
+
+def _ready_request(tmp_path: Path, **overrides: str) -> CodexLifecycleDoctorRequest:
+    paths = {
+        "matrix_json_path": _write(tmp_path / "ready_matrix.json", _matrix()),
+        "pre_commit_finalizer_json": _write(tmp_path / "pre.json", _finalizer("ready_to_commit")),
+        "pr_metadata_finalizer_json": _write(tmp_path / "pr.json", _finalizer("ready_for_pr_metadata", terminal_refresh_status="succeeded")),
+        "pr_metadata_guard_json": _write(tmp_path / "guard.json", {"status": "pr_metadata_guard_ready"}),
+        "lifecycle_summary_json": _write(tmp_path / "life.json", {"overall_lifecycle_status": "codex_lifecycle_ready", "rerun_required": False, "rerun_reason": None}),
+        "test_provenance_json": _write(tmp_path / "prov.json", {"run_intent": "targeted", "execution_mode": "pytest", "tests_selected": 2, "tests_executed": 2, "tests_passed": 2, "tests_skipped": 0, "exit_reason": None}),
+    }
+    paths.update(overrides)
+    return CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, **paths)
+
+
+def test_doctor_ready_with_mutually_ready_evidence(tmp_path: Path) -> None:
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path))
+    assert report["overall_doctor_status"] == "doctor_ready"
+    assert report["next_safe_action"] == "no_action_ready"
+    assert report["test_provenance_summary"]["proof_quality"] is True
+
+
+def test_incomplete_when_requested_optional_evidence_missing(tmp_path: Path) -> None:
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, pr_metadata_guard_json=str(tmp_path / "missing.json")))
+    assert report["overall_doctor_status"] == "doctor_incomplete"
+    assert report["next_safe_action"] == "provide_missing_evidence"
+    assert "pr_metadata_guard_json" in report["missing_evidence"]
+
+
+def test_blocked_when_matrix_required_failures(tmp_path: Path) -> None:
+    matrix = _write(tmp_path / "blocked_matrix.json", _matrix(required_failure_count=1, results=[{"label": "targeted_tests", "required": True, "proof_required": True, "proof_status": "proof-failed", "exit_reason": "pytest-failed"}]))
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, matrix_json_path=matrix))
+    assert report["overall_doctor_status"] == "doctor_blocked"
+    assert report["matrix_summary"]["blocked_lanes"][0]["exit_reason"] == "pytest-failed"
+
+
+def test_blocked_when_required_lane_proof_not_passed_even_with_zero_declared_count(tmp_path: Path) -> None:
+    matrix = _write(tmp_path / "matrix.json", _matrix(results=[{"label": "targeted_tests", "required": True, "proof_required": True, "proof_status": "proof-not-executed", "exit_reason": "no-tests-collected"}]))
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, matrix_json_path=matrix))
+    assert report["overall_doctor_status"] == "doctor_blocked"
+    assert report["matrix_summary"]["blocked_lane_count"] == 1
+
+
+def test_diagnostic_nonproof_lane_visible_but_nonblocking(tmp_path: Path) -> None:
+    matrix = _write(tmp_path / "diag_matrix.json", _matrix(results=[{"label": "diag", "required": False, "proof_required": False, "diagnostic_only": True, "proof_status": "nonproof-diagnostic-failed", "exit_reason": "no-tests-collected"}]))
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, matrix_json_path=matrix))
+    assert report["overall_doctor_status"] == "doctor_ready"
+    assert report["matrix_summary"]["diagnostic_failure_count"] == 1
+    assert report["matrix_summary"]["blocked_lane_count"] == 0
+
+
+def test_rerun_required_from_finalizer_or_lifecycle(tmp_path: Path) -> None:
+    pre = _write(tmp_path / "rerun_pre.json", _finalizer("ready_to_commit", rerun_required=True))
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, pre_commit_finalizer_json=pre))
+    assert report["overall_doctor_status"] == "doctor_rerun_required"
+    life = _write(tmp_path / "rerun_life.json", {"overall_lifecycle_status": "codex_lifecycle_ready", "rerun_required": True, "rerun_reason": "refresh"})
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, lifecycle_summary_json=life))
+    assert report["overall_doctor_status"] == "doctor_rerun_required"
+
+
+def test_stale_when_finalizer_freshness_requires_refresh(tmp_path: Path) -> None:
+    pr = _write(tmp_path / "stale_pr.json", _finalizer("ready_for_pr_metadata", stale_evidence_refresh_result="required_not_allowed"))
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, pr_metadata_finalizer_json=pr))
+    assert report["overall_doctor_status"] == "doctor_stale"
+    assert report["next_safe_action"] == "rerun_finalizer_with_refresh"
+
+
+def test_blocked_when_targeted_provenance_not_executed_or_none_passed(tmp_path: Path) -> None:
+    prov = _write(tmp_path / "bad_prov.json", {"run_intent": "targeted", "execution_mode": "pytest", "tests_selected": 2, "tests_executed": 0, "tests_passed": 0, "tests_skipped": 2, "exit_reason": "no-tests-collected"})
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path, test_provenance_json=prov))
+    assert report["overall_doctor_status"] == "doctor_blocked"
+    assert report["test_provenance_summary"]["proof_quality"] is False
+
+
+def test_invalid_json_fails_cleanly(tmp_path: Path) -> None:
+    bad = _write(tmp_path / "bad.json", "{")
+    with pytest.raises(CodexLifecycleDoctorError, match="matrix_json_path_invalid_json"):
+        build_lifecycle_doctor_report(_ready_request(tmp_path, matrix_json_path=bad))
+
+
+def test_non_authority_posture_fields_are_true(tmp_path: Path) -> None:
+    report = build_lifecycle_doctor_report(_ready_request(tmp_path))
+    assert report["non_authority_posture"]
+    assert all(value is True for value in report["non_authority_posture"].values())

--- a/tests/test_codex_lifecycle_doctor_script.py
+++ b/tests/test_codex_lifecycle_doctor_script.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _write(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_cli_writes_deterministic_json_and_summary(tmp_path: Path) -> None:
+    title = "[codex:landing] add Codex lifecycle doctor CLI"
+    matrix = _write(tmp_path / "matrix.json", {"status": "passed", "required_failure_count": 0, "nonproof_count": 0, "diagnostic_failure_count": 0, "results": []})
+    output = tmp_path / "codex_lifecycle_doctor_report.json"
+    cmd = [sys.executable, "scripts/codex_lifecycle_doctor.py", "--title", title, "--intended-commit-title", title, "--matrix-json-path", str(matrix), "--output", str(output), "--summary"]
+    first = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert first.returncode == 0, first.stderr
+    first_payload = json.loads(output.read_text(encoding="utf-8"))
+    second = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert second.returncode == 0, second.stderr
+    second_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert first_payload == second_payload
+    summary = json.loads(first.stdout)
+    assert summary["overall_doctor_status"] == "doctor_ready"
+    assert first_payload["non_authority_posture"]["doctor_does_not_rerun_commands"] is True
+
+
+def test_cli_invalid_json_exits_cleanly(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    result = subprocess.run([sys.executable, "scripts/codex_lifecycle_doctor.py", "--title", "t", "--intended-commit-title", "t", "--matrix-json-path", str(bad)], check=False, capture_output=True, text=True)
+    assert result.returncode == 2
+    assert "codex_lifecycle_doctor_error" in result.stderr


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic read-only inspector that consumes existing Codex landing artifacts (matrix, finalizer JSONs, PR-metadata guard, lifecycle summary, and test-run provenance) and surfaces whether evidence is ready, blocked, stale, incomplete, or rerun-required without rerunning commands or granting authority. 
- Operators and reviewers need a developer-facing inspection surface after PR #1880 hardened proof semantics so they can decide what to inspect or rerun next without relying on finalizer authority.

### Description
- Add `sentientos/codex_lifecycle_doctor.py`, a pure JSON-reading engine that summarizes matrix, pre-/post-finalizer freshness, PR-metadata guard, lifecycle summary, and test provenance and computes an overall doctor status (`doctor_ready`, `doctor_blocked`, `doctor_incomplete`, `doctor_stale`, `doctor_rerun_required`). 
- Add CLI `scripts/codex_lifecycle_doctor.py` with required arguments (`--title`, `--intended-commit-title`, `--matrix-json-path`) and optional evidence inputs, deterministic `--output` JSON, and compact `--summary` output. 
- Ensure matrix/proof semantics: diagnostic/non-proof lanes are visible but non-blocking, required proof failures are blocking, targeted/focused test provenance must show executed and at least one selected test passed for proof-quality, and `exit_reason` values are preserved. 
- Add focused unit and CLI tests (`tests/test_codex_lifecycle_doctor.py`, `tests/test_codex_lifecycle_doctor_script.py`) and update docs (`docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, `docs/development/codex_validation_and_landing_contract.md`) to describe the doctor as inspection-only and to document inputs, outputs, and non-authority posture.

### Testing
- Ran the new focused tests: `python -m scripts.run_tests -q tests/test_codex_lifecycle_doctor.py tests/test_codex_lifecycle_doctor_script.py` and they passed. 
- Ran repository validation lanes used by the landing flow and docs build: `python -m scripts.run_tests -q tests/test_work_item_review_packet_matrix.py tests/test_codex_validation_matrix_lane_contract.py`, `python scripts/verify_context_hygiene_prompt_boundaries.py`, and `python scripts/build_docs.py` (with docs bootstrap as needed); these completed successfully in this environment. 
- Static checks and artifacts: `python -m mypy sentientos/codex_lifecycle_doctor.py scripts/codex_lifecycle_doctor.py` passed; `python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` produced the matrix summary; pre-commit and pr-metadata finalizer runs produced `ready_to_commit` and `ready_for_pr_metadata` artifacts and the PR metadata guard evaluation returned `pr_metadata_guard_ready`. 
- Bootstrap note: initial bootstrap returned `ready_with_warnings` (docs bootstrap handled during validation); no unresolved automated-test failures remain for the new doctor changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a364f2948648320be450180dcdb2ec6)