### PR TITLE
[codex:landing] add Codex landing evidence index

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -136,3 +136,11 @@ doctor's read-only perspective; operators must still require the actual finalize
 metadata guard decisions before commit or PR metadata. Diagnostic/non-proof matrix lanes
 remain visible in the doctor matrix summary but are reported as non-blocking unless a
 required proof lane failed.
+
+## Codex landing evidence index (metadata-only)
+
+`python scripts/build_codex_landing_evidence_index.py` writes `codex_landing_evidence_index.json`, a deterministic metadata-only manifest over already-produced landing evidence artifacts. It records each supplied artifact role, path, existence, JSON readability, raw-byte SHA-256 digest, byte size, schema hint, and status hint. Missing optional paths are represented as `path_not_provided`; supplied paths that do not exist are `path_missing`; existing invalid JSON remains indexed with its digest and an invalid-JSON error.
+
+The evidence index answers: “Which evidence artifacts exist, where are they, what are their digests, and what status hints do they expose?” It differs from the lifecycle summary, which summarizes lifecycle state from specific finalizer/guard evidence; the lifecycle doctor, which advises what an operator should inspect or rerun next; this finalizer, which decides whether a change can advance to commit or PR metadata; the PR metadata guard, which decides whether PR metadata creation is allowed; and the matrix, which reports whether required proof lanes passed.
+
+The index is intentionally non-authoritative. It does not rerun tests, matrix, finalizer, guard, lifecycle summary, doctor, docs, mypy, git, shell commands, provider calls, network calls, or runtime actions. It does not decide `ready_to_commit`, `ready_for_pr_metadata`, or `pr_metadata_guard_ready`, and it cannot authorize commit, `make_pr`, or PR metadata creation. Use it only to pass one portable manifest to inspection tooling while preserving the underlying artifact roles and authoritative checks.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -135,3 +135,11 @@ answers: “Did required proof lanes pass?”
 A doctor report is diagnostic-only recovery evidence. It does not replace same-workspace
 surgical recovery, does not bless stale finalizer artifacts, and does not create PR
 metadata permission.
+
+## Landing evidence index for portable inspection
+
+For late landing recovery, operators may create `codex_landing_evidence_index.json` with `scripts/build_codex_landing_evidence_index.py`. The index is a metadata-only manifest over existing evidence paths: matrix, pre-commit finalizer, post-commit/PR-metadata finalizer, PR metadata guard, lifecycle summary, lifecycle doctor report, and test-run provenance. It helps a recovery prompt or inspection tool receive one manifest instead of several separate path flags.
+
+The index preserves role distinctions. A matrix artifact remains matrix evidence, finalizer artifacts remain finalizer evidence, PR metadata guard artifacts remain guard evidence, lifecycle summary artifacts remain lifecycle-state summaries, doctor reports remain inspection reports, and test provenance remains run provenance. The index records existence, JSON readability, digests, byte sizes, schema hints, and status hints only; it does not convert diagnostic/non-proof lanes into proof and does not turn any hint into authority.
+
+Missing or invalid artifacts are explicit metadata rather than fatal recovery-loss events: omitted optional paths are `path_not_provided`, supplied nonexistent paths are `path_missing`, and invalid JSON records `readable_json: false` with an error while still retaining the raw-file digest. Operators must still inspect or rerun the underlying authoritative artifact according to the lifecycle doctor, finalizer, matrix, and PR metadata guard rules.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -76,3 +76,18 @@ non-proof failures and exit reasons, but they are not blocking when `required_fa
 is zero and no required proof lane has a non-passing `proof_status`. Required proof lane
 failures remain blocking and must be repaired or rerun through the authoritative matrix
 and landing flow.
+
+## Evidence index boundary
+
+The Codex landing evidence index is a deterministic manifest for developer-workflow evidence. It may be produced after evidence artifacts exist so operators can pass one JSON file to future inspection tooling. It records artifact roles, paths, presence, JSON readability, raw-byte digests, optional schema/status hints, aggregate hints, and explicit non-authority posture flags.
+
+The distinction is mandatory:
+
+- Evidence index: identifies which evidence artifacts exist, where they are, their digests, and their status hints.
+- Lifecycle doctor: given evidence artifacts, reports what an operator should inspect or rerun next.
+- Lifecycle summary: records lifecycle state from specific finalizer and guard evidence.
+- Finalizer: decides whether the change may advance to commit or PR metadata under landing rules.
+- PR metadata guard: decides whether PR metadata creation is allowed.
+- Matrix: reports whether required proof lanes passed.
+
+The evidence index must not replace or weaken bootstrap, validation, matrix, supervisor, finalizer, PR metadata guard, clean-tree requirements, commit requirements, or `make_pr` requirements. Missing optional artifacts and invalid JSON are represented in the index for visibility only; they do not become proof and must be handled by the authoritative tools that consume the underlying artifacts.

--- a/scripts/build_codex_landing_evidence_index.py
+++ b/scripts/build_codex_landing_evidence_index.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+
+from sentientos.codex_landing_evidence_index import CodexLandingEvidenceIndexRequest, build_landing_evidence_index, write_landing_evidence_index
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex landing evidence index without granting authority.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--intended-commit-title", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--matrix-json-path")
+    parser.add_argument("--pre-commit-finalizer-json")
+    parser.add_argument("--pr-metadata-finalizer-json")
+    parser.add_argument("--pr-metadata-guard-json")
+    parser.add_argument("--lifecycle-summary-json")
+    parser.add_argument("--doctor-report-json")
+    parser.add_argument("--test-provenance-json")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    index = build_landing_evidence_index(
+        CodexLandingEvidenceIndexRequest(
+            title=args.title,
+            intended_commit_title=args.intended_commit_title,
+            output=args.output,
+            matrix_json_path=args.matrix_json_path,
+            pre_commit_finalizer_json=args.pre_commit_finalizer_json,
+            pr_metadata_finalizer_json=args.pr_metadata_finalizer_json,
+            pr_metadata_guard_json=args.pr_metadata_guard_json,
+            lifecycle_summary_json=args.lifecycle_summary_json,
+            doctor_report_json=args.doctor_report_json,
+            test_provenance_json=args.test_provenance_json,
+        )
+    )
+    write_landing_evidence_index(index, args.output)
+    if args.summary:
+        print(json.dumps({"evidence_index_id": index["evidence_index_id"], "artifact_count": index["artifact_count"], "artifact_roles_missing": index["artifact_roles_missing"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_landing_evidence_index.py
+++ b/sentientos/codex_landing_evidence_index.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+DIGEST_ALGO = "sha256"
+CREATED_AT = "deterministic-input-digest"
+
+ARTIFACT_ROLES: tuple[str, ...] = (
+    "matrix",
+    "pre_commit_finalizer",
+    "pr_metadata_finalizer",
+    "pr_metadata_guard",
+    "lifecycle_summary",
+    "doctor_report",
+    "test_provenance",
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "index_is_read_only": True,
+    "index_does_not_rerun_commands": True,
+    "index_does_not_decide_readiness": True,
+    "index_does_not_bypass_finalizer": True,
+    "index_does_not_bypass_pr_metadata_guard": True,
+    "index_does_not_authorize_commit": True,
+    "index_does_not_authorize_pr_creation": True,
+    "index_does_not_authorize_runtime_action": True,
+}
+
+
+@dataclass(frozen=True)
+class CodexLandingEvidenceIndexRequest:
+    title: str
+    intended_commit_title: str
+    output: str | None = None
+    matrix_json_path: str | None = None
+    pre_commit_finalizer_json: str | None = None
+    pr_metadata_finalizer_json: str | None = None
+    pr_metadata_guard_json: str | None = None
+    lifecycle_summary_json: str | None = None
+    doctor_report_json: str | None = None
+    test_provenance_json: str | None = None
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _stable_id(prefix: str, payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"{prefix}_{_sha256(encoded)[:16]}"
+
+
+def _role_paths(request: CodexLandingEvidenceIndexRequest) -> dict[str, str | None]:
+    return {
+        "matrix": request.matrix_json_path,
+        "pre_commit_finalizer": request.pre_commit_finalizer_json,
+        "pr_metadata_finalizer": request.pr_metadata_finalizer_json,
+        "pr_metadata_guard": request.pr_metadata_guard_json,
+        "lifecycle_summary": request.lifecycle_summary_json,
+        "doctor_report": request.doctor_report_json,
+        "test_provenance": request.test_provenance_json,
+    }
+
+
+def _finalizer_status(payload: Mapping[str, Any]) -> str | None:
+    decision = payload.get("decision")
+    if isinstance(decision, Mapping) and isinstance(decision.get("status"), str):
+        return str(decision["status"])
+    status = payload.get("status")
+    return str(status) if isinstance(status, str) else None
+
+
+def _schema_hint(role: str, payload: Mapping[str, Any] | None) -> str | None:
+    if payload is None:
+        return None
+    if role == "matrix" and "results" in payload:
+        return "work_item_review_packet_matrix"
+    if role in {"pre_commit_finalizer", "pr_metadata_finalizer"} and ("decision" in payload or "evidence_freshness" in payload):
+        return "codex_finalize_landing"
+    if role == "pr_metadata_guard" and "status" in payload:
+        return "codex_pr_metadata_guard"
+    if role == "lifecycle_summary" and "overall_lifecycle_status" in payload:
+        return "codex_task_lifecycle_summary"
+    if role == "doctor_report" and "overall_doctor_status" in payload:
+        return "codex_lifecycle_doctor"
+    if role == "test_provenance" and ("exit_reason" in payload or "provenance_hash" in payload):
+        return "run_tests_provenance"
+    return None
+
+
+def _status_hint(role: str, payload: Mapping[str, Any] | None) -> str | None:
+    if payload is None:
+        return None
+    if role == "matrix" and isinstance(payload.get("status"), str):
+        return str(payload["status"])
+    if role in {"pre_commit_finalizer", "pr_metadata_finalizer"}:
+        return _finalizer_status(payload)
+    if role == "pr_metadata_guard" and isinstance(payload.get("status"), str):
+        return str(payload["status"])
+    if role == "lifecycle_summary" and isinstance(payload.get("overall_lifecycle_status"), str):
+        return str(payload["overall_lifecycle_status"])
+    if role == "doctor_report" and isinstance(payload.get("overall_doctor_status"), str):
+        return str(payload["overall_doctor_status"])
+    if role == "test_provenance" and isinstance(payload.get("exit_reason"), str):
+        return str(payload["exit_reason"])
+    return None
+
+
+def _artifact(role: str, path_text: str | None) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    artifact: dict[str, Any] = {
+        "role": role,
+        "path": path_text,
+        "exists": False,
+        "readable_json": False,
+        "digest": None,
+        "digest_algo": DIGEST_ALGO,
+        "byte_size": None,
+        "status_hint": None,
+        "schema_hint": None,
+    }
+    if not path_text:
+        artifact["error"] = "path_not_provided"
+        return artifact, None
+    path = Path(path_text)
+    if not path.exists():
+        artifact["error"] = "path_missing"
+        return artifact, None
+    raw = path.read_bytes()
+    artifact["exists"] = True
+    artifact["digest"] = _sha256(raw)
+    artifact["byte_size"] = len(raw)
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        artifact["error"] = f"invalid_json:{exc}"
+        return artifact, None
+    if not isinstance(loaded, dict):
+        artifact["error"] = "json_not_object"
+        return artifact, None
+    artifact["readable_json"] = True
+    artifact["status_hint"] = _status_hint(role, loaded)
+    artifact["schema_hint"] = _schema_hint(role, loaded)
+    return artifact, loaded
+
+
+def build_landing_evidence_index(request: CodexLandingEvidenceIndexRequest) -> dict[str, Any]:
+    artifacts: list[dict[str, Any]] = []
+    payloads: dict[str, Mapping[str, Any]] = {}
+    for role, path_text in _role_paths(request).items():
+        artifact, payload = _artifact(role, path_text)
+        artifacts.append(artifact)
+        if payload is not None:
+            payloads[role] = payload
+    present = [a["role"] for a in artifacts if a["exists"] and a["readable_json"]]
+    missing = [a["role"] for a in artifacts if not (a["exists"] and a["readable_json"])]
+    matrix = payloads.get("matrix", {})
+    aggregate_hints = {
+        "matrix_status": matrix.get("status") if isinstance(matrix.get("status"), str) else None,
+        "required_failure_count": matrix.get("required_failure_count") if isinstance(matrix.get("required_failure_count"), int) and not isinstance(matrix.get("required_failure_count"), bool) else None,
+        "doctor_status": payloads.get("doctor_report", {}).get("overall_doctor_status"),
+        "lifecycle_status": payloads.get("lifecycle_summary", {}).get("overall_lifecycle_status"),
+        "pre_commit_finalizer_status": _finalizer_status(payloads["pre_commit_finalizer"]) if "pre_commit_finalizer" in payloads else None,
+        "pr_metadata_finalizer_status": _finalizer_status(payloads["pr_metadata_finalizer"]) if "pr_metadata_finalizer" in payloads else None,
+        "pr_metadata_guard_status": payloads.get("pr_metadata_guard", {}).get("status"),
+        "test_provenance_exit_reason": payloads.get("test_provenance", {}).get("exit_reason"),
+    }
+    id_material = {"title": request.title, "intended_commit_title": request.intended_commit_title, "artifacts": [{"role": a["role"], "path": a["path"], "digest": a["digest"]} for a in artifacts]}
+    index = {
+        "evidence_index_id": _stable_id("codex_landing_evidence_index", id_material),
+        "title": request.title,
+        "intended_commit_title": request.intended_commit_title,
+        "created_at": CREATED_AT,
+        "metadata_only": True,
+        "developer_workflow_evidence_only": True,
+        "artifact_count": len(artifacts),
+        "artifact_roles_present": present,
+        "artifact_roles_missing": missing,
+        "artifacts": artifacts,
+        "aggregate_hints": aggregate_hints,
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+    return index
+
+
+def write_landing_evidence_index(index: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_build_codex_landing_evidence_index_script.py
+++ b/tests/test_build_codex_landing_evidence_index_script.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _write(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_cli_writes_deterministic_json_and_summary(tmp_path: Path) -> None:
+    title = "[codex:landing] add Codex landing evidence index"
+    matrix = _write(tmp_path / "matrix.json", {"status": "passed", "required_failure_count": 0, "results": []})
+    pre = _write(tmp_path / "pre.json", {"decision": {"status": "ready_to_commit"}})
+    output = tmp_path / "codex_landing_evidence_index.json"
+    cmd = [sys.executable, "scripts/build_codex_landing_evidence_index.py", "--title", title, "--intended-commit-title", title, "--matrix-json-path", str(matrix), "--pre-commit-finalizer-json", str(pre), "--output", str(output), "--summary"]
+    first = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert first.returncode == 0, first.stderr
+    first_payload = json.loads(output.read_text(encoding="utf-8"))
+    second = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert second.returncode == 0, second.stderr
+    second_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert first_payload == second_payload
+    summary = json.loads(first.stdout)
+    assert summary["evidence_index_id"] == first_payload["evidence_index_id"]
+    assert "pr_metadata_guard" in summary["artifact_roles_missing"]
+    assert first_payload["metadata_only"] is True

--- a/tests/test_codex_landing_evidence_index.py
+++ b/tests/test_codex_landing_evidence_index.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_landing_evidence_index import CodexLandingEvidenceIndexRequest, build_landing_evidence_index
+
+TITLE = "[codex:landing] add Codex landing evidence index"
+
+
+def _write(path: Path, payload: dict[str, object] | str) -> str:
+    path.write_text(payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return str(path)
+
+
+def _digest(path: str) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _request(tmp_path: Path, **overrides: str | None) -> CodexLandingEvidenceIndexRequest:
+    paths: dict[str, str | None] = {
+        "matrix_json_path": _write(tmp_path / "matrix.json", {"status": "passed", "required_failure_count": 0, "results": []}),
+        "pre_commit_finalizer_json": _write(tmp_path / "pre.json", {"decision": {"status": "ready_to_commit"}}),
+        "pr_metadata_finalizer_json": _write(tmp_path / "pr.json", {"decision": {"status": "ready_for_pr_metadata"}}),
+        "pr_metadata_guard_json": _write(tmp_path / "guard.json", {"status": "pr_metadata_guard_ready"}),
+        "lifecycle_summary_json": _write(tmp_path / "life.json", {"overall_lifecycle_status": "codex_lifecycle_ready"}),
+        "doctor_report_json": _write(tmp_path / "doctor.json", {"overall_doctor_status": "doctor_ready"}),
+        "test_provenance_json": _write(tmp_path / "prov.json", {"exit_reason": "tests-passed", "provenance_hash": "abc"}),
+    }
+    paths.update(overrides)
+    return CodexLandingEvidenceIndexRequest(title=TITLE, intended_commit_title=TITLE, **paths)
+
+
+def test_building_index_records_all_roles_and_digests(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    index = build_landing_evidence_index(request)
+    assert index["artifact_count"] == 7
+    assert index["artifact_roles_missing"] == []
+    assert set(index["artifact_roles_present"]) == {"matrix", "pre_commit_finalizer", "pr_metadata_finalizer", "pr_metadata_guard", "lifecycle_summary", "doctor_report", "test_provenance"}
+    by_role = {artifact["role"]: artifact for artifact in index["artifacts"]}
+    assert by_role["matrix"]["digest"] == _digest(request.matrix_json_path or "")
+    assert by_role["matrix"]["digest_algo"] == "sha256"
+    assert by_role["pr_metadata_guard"]["status_hint"] == "pr_metadata_guard_ready"
+
+
+def test_missing_optional_paths_are_recorded_without_crashing(tmp_path: Path) -> None:
+    index = build_landing_evidence_index(_request(tmp_path, doctor_report_json=None, test_provenance_json=str(tmp_path / "missing.json")))
+    by_role = {artifact["role"]: artifact for artifact in index["artifacts"]}
+    assert by_role["doctor_report"]["error"] == "path_not_provided"
+    assert by_role["test_provenance"]["error"] == "path_missing"
+    assert "doctor_report" in index["artifact_roles_missing"]
+    assert "test_provenance" in index["artifact_roles_missing"]
+
+
+def test_invalid_json_is_unreadable_but_digest_is_recorded(tmp_path: Path) -> None:
+    invalid = _write(tmp_path / "invalid.json", "{")
+    index = build_landing_evidence_index(_request(tmp_path, pr_metadata_guard_json=invalid))
+    guard = {artifact["role"]: artifact for artifact in index["artifacts"]}["pr_metadata_guard"]
+    assert guard["exists"] is True
+    assert guard["readable_json"] is False
+    assert guard["digest"] == _digest(invalid)
+    assert str(guard["error"]).startswith("invalid_json:")
+
+
+def test_aggregate_hints_are_extracted_without_deciding_readiness(tmp_path: Path) -> None:
+    index = build_landing_evidence_index(_request(tmp_path))
+    assert index["aggregate_hints"] == {
+        "matrix_status": "passed",
+        "required_failure_count": 0,
+        "doctor_status": "doctor_ready",
+        "lifecycle_status": "codex_lifecycle_ready",
+        "pre_commit_finalizer_status": "ready_to_commit",
+        "pr_metadata_finalizer_status": "ready_for_pr_metadata",
+        "pr_metadata_guard_status": "pr_metadata_guard_ready",
+        "test_provenance_exit_reason": "tests-passed",
+    }
+    assert "ready_to_commit" not in index
+    assert index["non_authority_posture"]["index_does_not_decide_readiness"] is True
+
+
+def test_non_authority_posture_fields_are_present_and_true(tmp_path: Path) -> None:
+    posture = build_landing_evidence_index(_request(tmp_path))["non_authority_posture"]
+    assert posture
+    assert all(value is True for value in posture.values())
+
+
+def test_index_output_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    assert build_landing_evidence_index(request) == build_landing_evidence_index(request)


### PR DESCRIPTION
### Motivation
- Provide a single, deterministic, metadata-only manifest that enumerates Codex landing evidence artifacts so inspection tools (like the lifecycle doctor) can consume one portable manifest instead of many separate path flags. 
- Keep the index strictly non-authoritative: it must not rerun tests/finalizers/guards, decide readiness, or grant commit/PR authority. 
- Preserve operator workflow and auditability by recording raw-byte digests, JSON readability, schema/status hints, and explicit non-authority posture.

### Description
- Add a new evidence-index module `sentientos/codex_landing_evidence_index.py` that records artifact roles (matrix, finalizers, guard, lifecycle summary, doctor report, test provenance), existence, JSON readability, raw-byte `sha256` digest, byte size, `status_hint`, `schema_hint`, `error` when applicable, and deterministic `evidence_index_id` and metadata fields. 
- Add a CLI `scripts/build_codex_landing_evidence_index.py` with `--title`, `--intended-commit-title`, `--output` and optional artifact path args plus `--summary`; the CLI only reads provided files and writes `codex_landing_evidence_index.json`. 
- Add focused tests `tests/test_codex_landing_evidence_index.py` and `tests/test_build_codex_landing_evidence_index_script.py` covering full-artifact indexing, missing/invalid paths, digest preservation, aggregate hints, deterministic output, and CLI summary behavior. 
- Update docs (`docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, `docs/development/codex_validation_and_landing_contract.md`) to describe the index, its non-authoritative role, and how it differs from lifecycle summary/doctor/finalizer/PR guard/matrix.

### Testing
- Bootstrap: ran `PYTHONPATH=. python scripts/bootstrap_codex_task.py ...` which returned `ready_with_warnings` (warnings about scaffold/preset verifier, no blockers). 
- Unit/CLI tests: `python -m scripts.run_tests -q tests/test_codex_landing_evidence_index.py tests/test_build_codex_landing_evidence_index_script.py` passed. 
- Adjacent tests: `tests/test_codex_lifecycle_doctor.py` and its CLI tests passed; matrix/validation lanes used by finalizer ran and reported `required_failure_count=0` where applicable. 
- Docs/mypy/build: resolved initial docs deps with `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py` passed; `mypy` on the new module and relevant doctor scripts passed. 
- Finalizer / guard verification: ran pre-commit and post-commit finalizer sequences and `python scripts/codex_pr_metadata_guard.py verify ...` which returned `pr_metadata_guard_ready`; `git diff --check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36e4b061b48320926c0564c6c39696)