### PR TITLE
[codex:landing] let lifecycle doctor consume evidence index

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -137,6 +137,15 @@ metadata guard decisions before commit or PR metadata. Diagnostic/non-proof matr
 remain visible in the doctor matrix summary but are reported as non-blocking unless a
 required proof lane failed.
 
+The doctor may also accept `--evidence-index-json <codex_landing_evidence_index.json>`
+as a portable manifest. When supplied, the doctor may populate omitted artifact path
+arguments from indexed roles such as matrix, pre-commit finalizer, post-commit/PR-metadata
+finalizer, PR metadata guard, lifecycle summary, and test provenance. Explicit CLI path
+arguments always override index paths. The doctor still opens and reads the underlying
+artifact JSON files at the resolved paths, reports missing or invalid referenced artifacts
+through its normal incomplete/error rules, and never trusts index aggregate hints as
+readiness authority.
+
 ## Codex landing evidence index (metadata-only)
 
 `python scripts/build_codex_landing_evidence_index.py` writes `codex_landing_evidence_index.json`, a deterministic metadata-only manifest over already-produced landing evidence artifacts. It records each supplied artifact role, path, existence, JSON readability, raw-byte SHA-256 digest, byte size, schema hint, and status hint. Missing optional paths are represented as `path_not_provided`; supplied paths that do not exist are `path_missing`; existing invalid JSON remains indexed with its digest and an invalid-JSON error.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -136,10 +136,17 @@ A doctor report is diagnostic-only recovery evidence. It does not replace same-w
 surgical recovery, does not bless stale finalizer artifacts, and does not create PR
 metadata permission.
 
+If a landing evidence index is available, the lifecycle doctor may be invoked with
+`--evidence-index-json` so one portable manifest supplies omitted evidence paths. This
+index intake is map-only: explicit doctor CLI artifact paths override indexed paths, and
+the doctor still reads each resolved matrix/finalizer/guard/lifecycle/test-provenance JSON
+artifact before diagnosing incomplete, blocked, stale, rerun-required, or ready states.
+Index aggregate hints remain non-authoritative and do not decide readiness.
+
 ## Landing evidence index for portable inspection
 
 For late landing recovery, operators may create `codex_landing_evidence_index.json` with `scripts/build_codex_landing_evidence_index.py`. The index is a metadata-only manifest over existing evidence paths: matrix, pre-commit finalizer, post-commit/PR-metadata finalizer, PR metadata guard, lifecycle summary, lifecycle doctor report, and test-run provenance. It helps a recovery prompt or inspection tool receive one manifest instead of several separate path flags.
 
 The index preserves role distinctions. A matrix artifact remains matrix evidence, finalizer artifacts remain finalizer evidence, PR metadata guard artifacts remain guard evidence, lifecycle summary artifacts remain lifecycle-state summaries, doctor reports remain inspection reports, and test provenance remains run provenance. The index records existence, JSON readability, digests, byte sizes, schema hints, and status hints only; it does not convert diagnostic/non-proof lanes into proof and does not turn any hint into authority.
 
-Missing or invalid artifacts are explicit metadata rather than fatal recovery-loss events: omitted optional paths are `path_not_provided`, supplied nonexistent paths are `path_missing`, and invalid JSON records `readable_json: false` with an error while still retaining the raw-file digest. Operators must still inspect or rerun the underlying authoritative artifact according to the lifecycle doctor, finalizer, matrix, and PR metadata guard rules.
+Missing or invalid artifacts are explicit metadata rather than fatal recovery-loss events: omitted optional paths are `path_not_provided`, supplied nonexistent paths are `path_missing`, and invalid JSON records `readable_json: false` with an error while still retaining the raw-file digest. Operators must still inspect or rerun the underlying authoritative artifact according to the lifecycle doctor, finalizer, matrix, and PR metadata guard rules. The index answers: “Which artifacts exist, where are they, what are their digests, and what hints do they expose?” Lifecycle doctor with index answers: “Using the index as a map, what do the underlying artifacts say should be inspected or rerun?”

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -70,6 +70,10 @@ The doctor must not run validation, tests, matrix lanes, finalizer commands, gua
 commands, docs commands, mypy, git, network calls, provider calls, shell commands, or
 runtime actions. It marks missing requested evidence as incomplete and invalid JSON as a
 clean CLI error. It must not infer readiness from title or intended commit title alone.
+It may accept `--evidence-index-json` to populate omitted artifact path arguments from a
+portable evidence-index manifest, but explicit CLI paths override index paths and the
+doctor must still read the resolved underlying artifact JSON files. Index aggregate hints
+are inspectability metadata only and cannot decide readiness.
 
 Diagnostic/non-proof matrix lanes appear in doctor output for visibility, including
 non-proof failures and exit reasons, but they are not blocking when `required_failure_count`
@@ -84,7 +88,8 @@ The Codex landing evidence index is a deterministic manifest for developer-workf
 The distinction is mandatory:
 
 - Evidence index: identifies which evidence artifacts exist, where they are, their digests, and their status hints.
-- Lifecycle doctor: given evidence artifacts, reports what an operator should inspect or rerun next.
+- Lifecycle doctor with index: uses the index as a map, then reads the underlying artifacts to report what an operator should inspect or rerun next.
+- Lifecycle doctor without index: given explicit evidence artifact paths, reports what an operator should inspect or rerun next.
 - Lifecycle summary: records lifecycle state from specific finalizer and guard evidence.
 - Finalizer: decides whether the change may advance to commit or PR metadata under landing rules.
 - PR metadata guard: decides whether PR metadata creation is allowed.

--- a/scripts/codex_lifecycle_doctor.py
+++ b/scripts/codex_lifecycle_doctor.py
@@ -17,7 +17,8 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Inspect existing Codex landing artifacts without granting authority.")
     parser.add_argument("--title", required=True)
     parser.add_argument("--intended-commit-title", required=True)
-    parser.add_argument("--matrix-json-path", required=True)
+    parser.add_argument("--matrix-json-path")
+    parser.add_argument("--evidence-index-json")
     parser.add_argument("--pre-commit-finalizer-json")
     parser.add_argument("--pr-metadata-finalizer-json")
     parser.add_argument("--pr-metadata-guard-json")
@@ -41,6 +42,7 @@ def main(argv: list[str] | None = None) -> int:
                 pr_metadata_guard_json=args.pr_metadata_guard_json,
                 lifecycle_summary_json=args.lifecycle_summary_json,
                 test_provenance_json=args.test_provenance_json,
+                evidence_index_json=args.evidence_index_json,
                 output=args.output,
             )
         )
@@ -50,7 +52,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.output:
         write_lifecycle_doctor_report(report, args.output)
     if args.summary:
-        print(json.dumps({"doctor_report_id": report["doctor_report_id"], "overall_doctor_status": report["overall_doctor_status"], "next_safe_action": report["next_safe_action"]}, sort_keys=True))
+        summary = {"doctor_report_id": report["doctor_report_id"], "overall_doctor_status": report["overall_doctor_status"], "next_safe_action": report["next_safe_action"]}
+        if args.evidence_index_json:
+            summary["evidence_index_intake"] = "supplied"
+            summary["evidence_index_used_roles"] = report.get("evidence_index_used_roles", [])
+        print(json.dumps(summary, sort_keys=True))
     elif not args.output:
         print(json.dumps(report, indent=2, sort_keys=True))
     return 0

--- a/sentientos/codex_lifecycle_doctor.py
+++ b/sentientos/codex_lifecycle_doctor.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+from sentientos.codex_landing_evidence_index import ARTIFACT_ROLES
+
 READY = "doctor_ready"
 BLOCKED = "doctor_blocked"
 INCOMPLETE = "doctor_incomplete"
@@ -20,6 +22,31 @@ NON_AUTHORITY_POSTURE: dict[str, bool] = {
     "doctor_does_not_authorize_commit": True,
     "doctor_does_not_authorize_pr_creation": True,
     "doctor_does_not_authorize_runtime_action": True,
+    "doctor_uses_index_only_as_manifest": True,
+    "doctor_reads_underlying_artifacts": True,
+    "doctor_does_not_trust_index_hints_as_authority": True,
+}
+
+INDEX_CONSUMED_ROLES: tuple[str, ...] = tuple(
+    role
+    for role in ARTIFACT_ROLES
+    if role in {
+        "matrix",
+        "pre_commit_finalizer",
+        "pr_metadata_finalizer",
+        "pr_metadata_guard",
+        "lifecycle_summary",
+        "test_provenance",
+    }
+)
+
+ROLE_TO_REQUEST_FIELD: dict[str, str] = {
+    "matrix": "matrix_json_path",
+    "pre_commit_finalizer": "pre_commit_finalizer_json",
+    "pr_metadata_finalizer": "pr_metadata_finalizer_json",
+    "pr_metadata_guard": "pr_metadata_guard_json",
+    "lifecycle_summary": "lifecycle_summary_json",
+    "test_provenance": "test_provenance_json",
 }
 
 
@@ -31,12 +58,13 @@ class CodexLifecycleDoctorError(ValueError):
 class CodexLifecycleDoctorRequest:
     title: str
     intended_commit_title: str
-    matrix_json_path: str
+    matrix_json_path: str | None = None
     pre_commit_finalizer_json: str | None = None
     pr_metadata_finalizer_json: str | None = None
     pr_metadata_guard_json: str | None = None
     lifecycle_summary_json: str | None = None
     test_provenance_json: str | None = None
+    evidence_index_json: str | None = None
     output: str | None = None
 
 
@@ -58,6 +86,72 @@ def _load_json_object(path_text: str, label: str, missing: list[str]) -> dict[st
         raise CodexLifecycleDoctorError(f"{label}_json_not_object:{path_text}")
     return loaded
 
+
+
+def _load_evidence_index(path_text: str, missing: list[str]) -> dict[str, Any] | None:
+    return _load_json_object(path_text, "evidence_index_json", missing)
+
+
+def _index_artifact_paths(index: Mapping[str, Any] | None) -> dict[str, str]:
+    if index is None:
+        return {}
+    artifacts = index.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {}
+    paths: dict[str, str] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, Mapping):
+            continue
+        role = artifact.get("role")
+        path = artifact.get("path")
+        if isinstance(role, str) and role in INDEX_CONSUMED_ROLES and isinstance(path, str) and path:
+            paths[role] = path
+    return paths
+
+
+def _resolve_request_paths(request: CodexLifecycleDoctorRequest, index: Mapping[str, Any] | None) -> tuple[dict[str, str | None], dict[str, Any] | None]:
+    index_paths = _index_artifact_paths(index)
+    resolved = {field: getattr(request, field) for field in ROLE_TO_REQUEST_FIELD.values()}
+    used: list[str] = []
+    overridden: list[str] = []
+    unusable: list[dict[str, str]] = []
+    for role in INDEX_CONSUMED_ROLES:
+        field = ROLE_TO_REQUEST_FIELD[role]
+        explicit = getattr(request, field)
+        index_path = index_paths.get(role)
+        if explicit:
+            if index_path:
+                overridden.append(role)
+            continue
+        if not index_path:
+            continue
+        if Path(index_path).exists():
+            resolved[field] = index_path
+            used.append(role)
+        else:
+            unusable.append({"role": role, "path": index_path, "reason": "path_missing"})
+            if role == "matrix":
+                resolved[field] = index_path
+                used.append(role)
+    if index is None:
+        return resolved, None
+    present_raw = index.get("artifact_roles_present")
+    missing_raw = index.get("artifact_roles_missing")
+    present = [str(role) for role in present_raw] if isinstance(present_raw, list) else sorted(index_paths)
+    missing = [str(role) for role in missing_raw] if isinstance(missing_raw, list) else [role for role in INDEX_CONSUMED_ROLES if role not in present]
+    nonauth = index.get("non_authority_posture")
+    summary = {
+        "path": request.evidence_index_json,
+        "readable_json": True,
+        "evidence_index_id": index.get("evidence_index_id") if isinstance(index.get("evidence_index_id"), str) else None,
+        "roles_present": sorted(present),
+        "roles_missing": sorted(missing),
+        "used_roles": sorted(used),
+        "overridden_roles": sorted(overridden),
+        "unusable_roles": sorted(unusable, key=lambda item: (item["role"], item["path"])),
+        "non_authority_posture_seen": bool(nonauth) if isinstance(nonauth, Mapping) else False,
+    }
+    return resolved, summary
 
 def _as_int(value: Any) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
@@ -177,12 +271,24 @@ def _test_provenance_summary(payload: Mapping[str, Any] | None) -> dict[str, Any
 
 def build_lifecycle_doctor_report(request: CodexLifecycleDoctorRequest) -> dict[str, Any]:
     missing: list[str] = []
-    matrix = _load_json_object(request.matrix_json_path, "matrix_json_path", missing) or {}
-    pre = _load_json_object(request.pre_commit_finalizer_json, "pre_commit_finalizer_json", missing) if request.pre_commit_finalizer_json else None
-    pr = _load_json_object(request.pr_metadata_finalizer_json, "pr_metadata_finalizer_json", missing) if request.pr_metadata_finalizer_json else None
-    guard = _load_json_object(request.pr_metadata_guard_json, "pr_metadata_guard_json", missing) if request.pr_metadata_guard_json else None
-    lifecycle = _load_json_object(request.lifecycle_summary_json, "lifecycle_summary_json", missing) if request.lifecycle_summary_json else None
-    provenance = _load_json_object(request.test_provenance_json, "test_provenance_json", missing) if request.test_provenance_json else None
+    evidence_index = _load_evidence_index(request.evidence_index_json, missing) if request.evidence_index_json else None
+    resolved_paths, evidence_index_summary = _resolve_request_paths(request, evidence_index)
+    matrix_path = resolved_paths["matrix_json_path"]
+    if matrix_path:
+        matrix = _load_json_object(matrix_path, "matrix_json_path", missing) or {}
+    else:
+        missing.append("matrix_json_path")
+        matrix = {}
+    pre_path = resolved_paths["pre_commit_finalizer_json"]
+    pr_path = resolved_paths["pr_metadata_finalizer_json"]
+    guard_path = resolved_paths["pr_metadata_guard_json"]
+    lifecycle_path = resolved_paths["lifecycle_summary_json"]
+    provenance_path = resolved_paths["test_provenance_json"]
+    pre = _load_json_object(pre_path, "pre_commit_finalizer_json", missing) if pre_path else None
+    pr = _load_json_object(pr_path, "pr_metadata_finalizer_json", missing) if pr_path else None
+    guard = _load_json_object(guard_path, "pr_metadata_guard_json", missing) if guard_path else None
+    lifecycle = _load_json_object(lifecycle_path, "lifecycle_summary_json", missing) if lifecycle_path else None
+    provenance = _load_json_object(provenance_path, "test_provenance_json", missing) if provenance_path else None
 
     matrix_s = _matrix_summary(matrix)
     finalizer_s = _finalizer_summary(pre, pr)
@@ -225,19 +331,20 @@ def build_lifecycle_doctor_report(request: CodexLifecycleDoctorRequest) -> dict[
         reasons.append("stale_or_refresh_required_finalizer_evidence")
 
     report = {
-        "doctor_report_id": _stable_id("codex_lifecycle_doctor", request.title, request.intended_commit_title, request.matrix_json_path),
+        "doctor_report_id": _stable_id("codex_lifecycle_doctor", request.title, request.intended_commit_title, str(matrix_path or "")),
         "title": request.title,
         "intended_commit_title": request.intended_commit_title,
         "overall_doctor_status": status,
         "readiness_summary": ";".join(reasons) if reasons else "available evidence is mutually ready; inspection-only, not authority",
         "missing_evidence": sorted(missing),
         "evidence_inputs": {
-            "matrix_json_path": request.matrix_json_path,
-            "pre_commit_finalizer_json_path": request.pre_commit_finalizer_json,
-            "pr_metadata_finalizer_json_path": request.pr_metadata_finalizer_json,
-            "pr_metadata_guard_json_path": request.pr_metadata_guard_json,
-            "lifecycle_summary_json_path": request.lifecycle_summary_json,
-            "test_provenance_json_path": request.test_provenance_json,
+            "matrix_json_path": matrix_path,
+            "pre_commit_finalizer_json_path": pre_path,
+            "pr_metadata_finalizer_json_path": pr_path,
+            "pr_metadata_guard_json_path": guard_path,
+            "lifecycle_summary_json_path": lifecycle_path,
+            "test_provenance_json_path": provenance_path,
+            "evidence_index_json_path": request.evidence_index_json,
         },
         "matrix_summary": matrix_s,
         "finalizer_summary": finalizer_s,
@@ -248,6 +355,15 @@ def build_lifecycle_doctor_report(request: CodexLifecycleDoctorRequest) -> dict[
         "next_safe_action_reason": ";".join(reasons) if reasons else "no blocking, stale, rerun-required, or missing evidence was visible to the doctor",
         "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
     }
+    if evidence_index_summary is not None:
+        report["evidence_index_summary"] = evidence_index_summary
+        report["evidence_index_json_path"] = evidence_index_summary["path"]
+        report["evidence_index_id"] = evidence_index_summary["evidence_index_id"]
+        report["evidence_index_artifact_roles_present"] = evidence_index_summary["roles_present"]
+        report["evidence_index_artifact_roles_missing"] = evidence_index_summary["roles_missing"]
+        report["evidence_index_used_roles"] = evidence_index_summary["used_roles"]
+        report["evidence_index_overridden_roles"] = evidence_index_summary["overridden_roles"]
+        report["evidence_index_unusable_roles"] = evidence_index_summary["unusable_roles"]
     return report
 
 

--- a/tests/test_codex_lifecycle_doctor.py
+++ b/tests/test_codex_lifecycle_doctor.py
@@ -17,6 +17,7 @@ TITLE = "[codex:landing] add Codex lifecycle doctor CLI"
 
 
 def _write(path: Path, payload: dict[str, object] | str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True), encoding="utf-8")
     return str(path)
 
@@ -111,3 +112,77 @@ def test_non_authority_posture_fields_are_true(tmp_path: Path) -> None:
     report = build_lifecycle_doctor_report(_ready_request(tmp_path))
     assert report["non_authority_posture"]
     assert all(value is True for value in report["non_authority_posture"].values())
+
+
+def _index(path: Path, **role_paths: str) -> str:
+    artifacts = []
+    for role in ("matrix", "pre_commit_finalizer", "pr_metadata_finalizer", "pr_metadata_guard", "lifecycle_summary", "doctor_report", "test_provenance"):
+        role_path = role_paths.get(role)
+        artifacts.append({"role": role, "path": role_path, "exists": bool(role_path and Path(role_path).exists()), "readable_json": bool(role_path and Path(role_path).exists())})
+    payload = {
+        "evidence_index_id": "codex_landing_evidence_index_test",
+        "artifact_roles_present": [a["role"] for a in artifacts if a["readable_json"]],
+        "artifact_roles_missing": [a["role"] for a in artifacts if not a["readable_json"]],
+        "artifacts": artifacts,
+        "aggregate_hints": {"matrix_status": "passed", "required_failure_count": 0},
+        "non_authority_posture": {"index_does_not_decide_readiness": True},
+    }
+    return _write(path, payload)
+
+
+def test_doctor_uses_evidence_index_for_omitted_paths(tmp_path: Path) -> None:
+    request = _ready_request(tmp_path)
+    index = _index(
+        tmp_path / "index.json",
+        matrix=request.matrix_json_path or "",
+        pre_commit_finalizer=request.pre_commit_finalizer_json or "",
+        pr_metadata_finalizer=request.pr_metadata_finalizer_json or "",
+        pr_metadata_guard=request.pr_metadata_guard_json or "",
+        lifecycle_summary=request.lifecycle_summary_json or "",
+        test_provenance=request.test_provenance_json or "",
+    )
+    report = build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, evidence_index_json=index))
+    assert report["overall_doctor_status"] == "doctor_ready"
+    assert report["evidence_inputs"]["matrix_json_path"] == request.matrix_json_path
+    assert "matrix" in report["evidence_index_summary"]["used_roles"]
+    assert report["non_authority_posture"]["doctor_uses_index_only_as_manifest"] is True
+    assert report["non_authority_posture"]["doctor_reads_underlying_artifacts"] is True
+    assert report["non_authority_posture"]["doctor_does_not_trust_index_hints_as_authority"] is True
+
+
+def test_explicit_paths_override_evidence_index_paths(tmp_path: Path) -> None:
+    index_request = _ready_request(tmp_path / "indexed")
+    explicit_matrix = _write(tmp_path / "explicit_matrix.json", _matrix(required_failure_count=1, results=[{"label": "explicit", "required": True, "proof_required": True, "proof_status": "proof-failed"}]))
+    index = _index(tmp_path / "index.json", matrix=index_request.matrix_json_path or "")
+    report = build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, matrix_json_path=explicit_matrix, evidence_index_json=index))
+    assert report["overall_doctor_status"] == "doctor_blocked"
+    assert report["evidence_inputs"]["matrix_json_path"] == explicit_matrix
+    assert report["evidence_index_summary"]["overridden_roles"] == ["matrix"]
+
+
+def test_index_hints_do_not_override_underlying_artifact_content(tmp_path: Path) -> None:
+    blocked_matrix = _write(tmp_path / "blocked_matrix.json", _matrix(required_failure_count=1, results=[{"label": "underlying", "required": True, "proof_required": True, "proof_status": "proof-failed"}]))
+    index = _index(tmp_path / "index.json", matrix=blocked_matrix)
+    report = build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, evidence_index_json=index))
+    assert report["overall_doctor_status"] == "doctor_blocked"
+    assert report["matrix_summary"]["required_failure_count"] == 1
+
+
+def test_index_missing_matrix_is_incomplete(tmp_path: Path) -> None:
+    index = _index(tmp_path / "index.json", matrix=str(tmp_path / "missing_matrix.json"))
+    report = build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, evidence_index_json=index))
+    assert report["overall_doctor_status"] == "doctor_incomplete"
+    assert "matrix_json_path" in report["missing_evidence"]
+    assert report["evidence_index_summary"]["unusable_roles"][0]["role"] == "matrix"
+
+
+def test_invalid_evidence_index_json_fails_cleanly(tmp_path: Path) -> None:
+    bad = _write(tmp_path / "bad_index.json", "{")
+    with pytest.raises(CodexLifecycleDoctorError, match="evidence_index_json_invalid_json"):
+        build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE, evidence_index_json=bad))
+
+
+def test_matrix_path_required_without_evidence_index(tmp_path: Path) -> None:
+    report = build_lifecycle_doctor_report(CodexLifecycleDoctorRequest(title=TITLE, intended_commit_title=TITLE))
+    assert report["overall_doctor_status"] == "doctor_incomplete"
+    assert report["missing_evidence"] == ["matrix_json_path"]

--- a/tests/test_codex_lifecycle_doctor_script.py
+++ b/tests/test_codex_lifecycle_doctor_script.py
@@ -38,3 +38,18 @@ def test_cli_invalid_json_exits_cleanly(tmp_path: Path) -> None:
     result = subprocess.run([sys.executable, "scripts/codex_lifecycle_doctor.py", "--title", "t", "--intended-commit-title", "t", "--matrix-json-path", str(bad)], check=False, capture_output=True, text=True)
     assert result.returncode == 2
     assert "codex_lifecycle_doctor_error" in result.stderr
+
+
+def test_cli_summary_mentions_evidence_index_intake(tmp_path: Path) -> None:
+    title = "[codex:landing] add Codex lifecycle doctor CLI"
+    matrix = _write(tmp_path / "matrix.json", {"status": "passed", "required_failure_count": 0, "nonproof_count": 0, "diagnostic_failure_count": 0, "results": []})
+    index = _write(tmp_path / "index.json", {"evidence_index_id": "idx", "artifact_roles_present": ["matrix"], "artifact_roles_missing": [], "artifacts": [{"role": "matrix", "path": str(matrix), "exists": True, "readable_json": True}], "non_authority_posture": {"index_does_not_decide_readiness": True}})
+    cmd = [sys.executable, "scripts/codex_lifecycle_doctor.py", "--title", title, "--intended-commit-title", title, "--evidence-index-json", str(index), "--summary"]
+    first = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    second = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert json.loads(first.stdout) == json.loads(second.stdout)
+    summary = json.loads(first.stdout)
+    assert summary["evidence_index_intake"] == "supplied"
+    assert summary["evidence_index_used_roles"] == ["matrix"]


### PR DESCRIPTION
### Motivation

- Allow operators to run the read-only Codex lifecycle doctor with a single portable evidence-index manifest instead of passing many artifact paths individually while preserving non-authoritative, inspection-only behavior.

### Description

- Add optional `--evidence-index-json` CLI intake and make `--matrix-json-path` optional when an index provides a matrix role, while preserving explicit CLI-path precedence over index-provided paths.
- Implement index parsing and resolution in `sentientos/codex_lifecycle_doctor.py` via `_load_evidence_index`, `_index_artifact_paths`, and `_resolve_request_paths`, reusing `ARTIFACT_ROLES` from `sentientos/codex_landing_evidence_index.py` for role names.
- Ensure the doctor always opens and reads the resolved underlying artifact JSON files, does not trust aggregate index hints as authority, and emits an `evidence_index_summary` plus `evidence_index_*` report fields (used/overridden/unusable roles, id, path, present/missing roles).
- Add explicit non-authority posture flags (`doctor_uses_index_only_as_manifest`, `doctor_reads_underlying_artifacts`, `doctor_does_not_trust_index_hints_as_authority`) and include index-intake markers in CLI `--summary` output, plus documentation updates describing usage and semantics.

### Testing

- Ran unit and CLI-focused tests: `python -m scripts.run_tests -q tests/test_codex_lifecycle_doctor.py tests/test_codex_lifecycle_doctor_script.py` and `python -m scripts.run_tests -q tests/test_codex_landing_evidence_index.py tests/test_build_codex_landing_evidence_index_script.py`, all passing.
- Ran broader validation lanes: `python -m scripts.run_tests -q tests/test_work_item_review_packet_matrix.py tests/test_codex_validation_matrix_lane_contract.py`, `python scripts/verify_context_hygiene_prompt_boundaries.py`, `python scripts/build_docs.py --bootstrap-docs && python scripts/build_docs.py`, and `python -m mypy sentientos/codex_lifecycle_doctor.py scripts/codex_lifecycle_doctor.py sentientos/codex_landing_evidence_index.py scripts/build_codex_landing_evidence_index.py`, all of which completed successfully after bootstrapping docs.
- Performed finalize flows used for validation: pre-commit finalizer produced `ready_to_commit`, post-commit/pr-metadata finalizer produced `ready_for_pr_metadata`, and `python scripts/codex_pr_metadata_guard.py verify ...` returned `pr_metadata_guard_ready`.
- Tests and validation runs were deterministic and completed without unexpected failures; docs and non-authority semantics were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36ff705ffc83208b20075ee236a175)