### PR TITLE
Add Codex landing evidence appendix renderer and CLI, document usage, and add tests

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -153,3 +153,24 @@ readiness authority.
 The evidence index answers: “Which evidence artifacts exist, where are they, what are their digests, and what status hints do they expose?” It differs from the lifecycle summary, which summarizes lifecycle state from specific finalizer/guard evidence; the lifecycle doctor, which advises what an operator should inspect or rerun next; this finalizer, which decides whether a change can advance to commit or PR metadata; the PR metadata guard, which decides whether PR metadata creation is allowed; and the matrix, which reports whether required proof lanes passed.
 
 The index is intentionally non-authoritative. It does not rerun tests, matrix, finalizer, guard, lifecycle summary, doctor, docs, mypy, git, shell commands, provider calls, network calls, or runtime actions. It does not decide `ready_to_commit`, `ready_for_pr_metadata`, or `pr_metadata_guard_ready`, and it cannot authorize commit, `make_pr`, or PR metadata creation. Use it only to pass one portable manifest to inspection tooling while preserving the underlying artifact roles and authoritative checks.
+
+## Codex landing evidence appendix
+
+`python scripts/render_codex_landing_evidence_appendix.py` renders an existing Codex landing evidence index and/or lifecycle doctor report into deterministic markdown for PR bodies, reviewer notes, or operator logs. It is metadata-only, read-only, and non-authoritative. It reads only the JSON paths supplied on the command line and writes markdown plus an optional JSON sidecar; it does not run tests, matrix, docs, mypy, finalizer, PR metadata guard, lifecycle doctor, evidence-index builder, git, network, provider, shell, or runtime actions.
+
+Example:
+
+```bash
+python scripts/render_codex_landing_evidence_appendix.py \
+  --title "<task title>" \
+  --intended-commit-title "<intended commit title>" \
+  --evidence-index-json /tmp/codex_landing_evidence_index.json \
+  --doctor-report-json /tmp/codex_lifecycle_doctor.json \
+  --output /tmp/codex_landing_evidence_appendix.md \
+  --json-output /tmp/codex_landing_evidence_appendix.summary.json \
+  --summary
+```
+
+Evidence index answers: “Which artifacts exist, where are they, what are their digests, and what hints do they expose?” Lifecycle doctor answers: “Using the artifacts, what should an operator inspect or rerun next?” Evidence appendix answers: “How can the current evidence be rendered for reviewers in a compact deterministic markdown format?” Finalizer answers: “Can this change advance to commit/PR metadata under landing rules?” PR metadata guard answers: “Is PR metadata creation allowed?” Matrix answers: “Did required proof lanes pass?”
+
+The appendix can be pasted into PR bodies or operator logs without changing `make_pr`, finalizer, PR metadata guard, or matrix behavior. It never grants commit authority, PR creation authority, runtime authority, readiness, or proof status.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -150,3 +150,19 @@ For late landing recovery, operators may create `codex_landing_evidence_index.js
 The index preserves role distinctions. A matrix artifact remains matrix evidence, finalizer artifacts remain finalizer evidence, PR metadata guard artifacts remain guard evidence, lifecycle summary artifacts remain lifecycle-state summaries, doctor reports remain inspection reports, and test provenance remains run provenance. The index records existence, JSON readability, digests, byte sizes, schema hints, and status hints only; it does not convert diagnostic/non-proof lanes into proof and does not turn any hint into authority.
 
 Missing or invalid artifacts are explicit metadata rather than fatal recovery-loss events: omitted optional paths are `path_not_provided`, supplied nonexistent paths are `path_missing`, and invalid JSON records `readable_json: false` with an error while still retaining the raw-file digest. Operators must still inspect or rerun the underlying authoritative artifact according to the lifecycle doctor, finalizer, matrix, and PR metadata guard rules. The index answers: “Which artifacts exist, where are they, what are their digests, and what hints do they expose?” Lifecycle doctor with index answers: “Using the index as a map, what do the underlying artifacts say should be inspected or rerun?”
+
+## Evidence appendix for recovery review
+
+When a recovery task already has an evidence index and/or lifecycle doctor report, `scripts/render_codex_landing_evidence_appendix.py` may render those existing JSON files into a compact markdown appendix. The appendix is a portable review surface for artifact roles, paths, digest short forms, doctor status, matrix proof counts, finalizer/guard hints, test provenance, and non-authority posture.
+
+The distinction is mandatory:
+
+- Evidence index: identifies artifact paths, existence, readable JSON state, digests, and aggregate hints.
+- Lifecycle doctor: reads underlying artifacts and reports inspection/rerun guidance without granting authority.
+- Lifecycle summary: records lifecycle state from specific finalizer and guard artifacts.
+- Evidence appendix: formats already-existing index/doctor evidence as markdown for reviewers.
+- Finalizer: decides whether landing may advance to commit or PR metadata under landing rules.
+- PR metadata guard: decides whether PR metadata creation is allowed.
+- Matrix: records whether required proof lanes passed.
+
+The appendix is recovery evidence only. It does not rerun commands, decide readiness, convert diagnostic/non-proof lanes into proof, bypass finalizer or PR metadata guard, or authorize commit, PR creation, or runtime action.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -96,3 +96,20 @@ The distinction is mandatory:
 - Matrix: reports whether required proof lanes passed.
 
 The evidence index must not replace or weaken bootstrap, validation, matrix, supervisor, finalizer, PR metadata guard, clean-tree requirements, commit requirements, or `make_pr` requirements. Missing optional artifacts and invalid JSON are represented in the index for visibility only; they do not become proof and must be handled by the authoritative tools that consume the underlying artifacts.
+
+## Evidence appendix review surface
+
+A Codex landing evidence appendix can be generated from existing evidence index and/or lifecycle doctor JSON with `scripts/render_codex_landing_evidence_appendix.py`. It creates deterministic markdown for PR bodies, reviewer notes, or operator logs and can optionally write a deterministic metadata sidecar with `--json-output`.
+
+The appendix is not a validation lane and not a landing authority. Missing optional inputs render as “not provided”; supplied missing or invalid JSON paths fail cleanly. The renderer does not run `scripts.run_tests`, the matrix, docs, mypy, finalizer, PR metadata guard, lifecycle doctor, evidence index builder, git, network, provider, shell, or runtime commands.
+
+Required distinction for reviews:
+
+- Evidence index answers: “Which artifacts exist, where are they, what are their digests, and what hints do they expose?”
+- Lifecycle doctor answers: “Using the artifacts, what should an operator inspect or rerun next?”
+- Evidence appendix answers: “How can the current evidence be rendered for reviewers in a compact deterministic markdown format?”
+- Finalizer answers: “Can this change advance to commit/PR metadata under landing rules?”
+- PR metadata guard answers: “Is PR metadata creation allowed?”
+- Matrix answers: “Did required proof lanes pass?”
+
+The appendix may be pasted into PR bodies or operator logs, but doing so does not change `make_pr`, finalizer, PR metadata guard, matrix, clean-tree, or proof requirements.

--- a/scripts/render_codex_landing_evidence_appendix.py
+++ b/scripts/render_codex_landing_evidence_appendix.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_landing_evidence_appendix import (
+    CodexLandingEvidenceAppendixError,
+    CodexLandingEvidenceAppendixRequest,
+    build_landing_evidence_appendix,
+    write_landing_evidence_appendix,
+    write_landing_evidence_appendix_metadata,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render existing Codex landing evidence as a non-authoritative markdown appendix.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--intended-commit-title", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--evidence-index-json")
+    parser.add_argument("--doctor-report-json")
+    parser.add_argument("--json-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    request = CodexLandingEvidenceAppendixRequest(
+        title=args.title,
+        intended_commit_title=args.intended_commit_title,
+        output=args.output,
+        evidence_index_json=args.evidence_index_json,
+        doctor_report_json=args.doctor_report_json,
+        json_output=args.json_output,
+    )
+    try:
+        markdown, metadata = build_landing_evidence_appendix(request)
+    except CodexLandingEvidenceAppendixError as exc:
+        print(f"codex_landing_evidence_appendix_error: {exc}", file=sys.stderr)
+        return 2
+    write_landing_evidence_appendix(markdown, args.output)
+    if args.json_output:
+        write_landing_evidence_appendix_metadata(metadata, args.json_output)
+    if args.summary:
+        print(json.dumps({"appendix_is_non_authoritative": True, "doctor_report_provided": metadata["doctor_report_provided"], "evidence_index_provided": metadata["evidence_index_provided"], "output": args.output}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_landing_evidence_appendix.py
+++ b/sentientos/codex_landing_evidence_appendix.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "appendix_is_read_only": True,
+    "appendix_does_not_rerun_commands": True,
+    "appendix_does_not_decide_readiness": True,
+    "appendix_does_not_bypass_finalizer": True,
+    "appendix_does_not_bypass_pr_metadata_guard": True,
+    "appendix_does_not_authorize_commit": True,
+    "appendix_does_not_authorize_pr_creation": True,
+    "appendix_does_not_authorize_runtime_action": True,
+}
+
+
+class CodexLandingEvidenceAppendixError(ValueError):
+    """Raised when appendix input evidence cannot be read as a JSON object."""
+
+
+@dataclass(frozen=True)
+class CodexLandingEvidenceAppendixRequest:
+    title: str
+    intended_commit_title: str
+    output: str | None = None
+    evidence_index_json: str | None = None
+    doctor_report_json: str | None = None
+    json_output: str | None = None
+
+
+def _load_json_object(path_text: str, label: str) -> dict[str, Any]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexLandingEvidenceAppendixError(f"{label}_missing:{path_text}")
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CodexLandingEvidenceAppendixError(f"{label}_invalid_json:{path_text}:{exc.msg}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexLandingEvidenceAppendixError(f"{label}_json_not_object:{path_text}")
+    return loaded
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _display(value: Any) -> str:
+    if value is None:
+        return "unavailable"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return value if value else "unavailable"
+    if isinstance(value, list):
+        return "none" if not value else ", ".join(_display(item) for item in value)
+    if isinstance(value, Mapping):
+        return "none" if not value else ", ".join(f"{key}={_display(value[key])}" for key in sorted(value))
+    return str(value)
+
+
+def _cell(value: Any) -> str:
+    return _display(value).replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
+def _short_digest(value: Any) -> str:
+    digest = _display(value)
+    if digest == "unavailable":
+        return digest
+    if digest.startswith("sha256:"):
+        return "sha256:" + digest.removeprefix("sha256:")[:12]
+    return digest[:12]
+
+
+def _kv(lines: list[str], key: str, value: Any) -> None:
+    lines.append(f"- **{key}:** {_cell(value)}")
+
+
+def _doctor_summary(doctor: Mapping[str, Any] | None, key: str) -> Any:
+    return _as_mapping(doctor).get(key) if doctor is not None else None
+
+
+def _render_index(lines: list[str], index: Mapping[str, Any] | None) -> None:
+    lines.append("## Evidence index summary")
+    if index is None:
+        lines.append("Evidence index JSON was not provided.")
+        lines.append("")
+        lines.append("## Artifact table")
+        lines.append("Evidence index JSON was not provided.")
+        lines.append("")
+        return
+    _kv(lines, "evidence_index_id", index.get("evidence_index_id"))
+    _kv(lines, "artifact_count", index.get("artifact_count"))
+    _kv(lines, "artifact_roles_present", index.get("artifact_roles_present"))
+    _kv(lines, "artifact_roles_missing", index.get("artifact_roles_missing"))
+    _kv(lines, "aggregate_hints", index.get("aggregate_hints"))
+    lines.append("")
+    lines.append("## Artifact table")
+    lines.append("| role | path | exists | readable_json | digest | status_hint | schema_hint | error |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    artifacts = [_as_mapping(item) for item in _as_list(index.get("artifacts"))]
+    for artifact in sorted(artifacts, key=lambda item: _display(item.get("role"))):
+        row = [
+            artifact.get("role"),
+            artifact.get("path"),
+            artifact.get("exists"),
+            artifact.get("readable_json"),
+            _short_digest(artifact.get("digest")),
+            artifact.get("status_hint"),
+            artifact.get("schema_hint"),
+            artifact.get("error"),
+        ]
+        lines.append("| " + " | ".join(_cell(value) for value in row) + " |")
+    lines.append("")
+
+
+def _render_doctor(lines: list[str], doctor: Mapping[str, Any] | None) -> None:
+    lines.append("## Lifecycle doctor summary")
+    if doctor is None:
+        lines.append("Lifecycle doctor report JSON was not provided.")
+        lines.append("")
+        return
+    for key in ("doctor_report_id", "overall_doctor_status", "readiness_summary", "next_safe_action", "next_safe_action_reason", "missing_evidence"):
+        _kv(lines, key, doctor.get(key))
+    lines.append("")
+
+
+def _render_matrix(lines: list[str], index: Mapping[str, Any] | None, doctor: Mapping[str, Any] | None) -> None:
+    hints = _as_mapping(index.get("aggregate_hints")) if index is not None else {}
+    matrix = _as_mapping(_doctor_summary(doctor, "matrix_summary"))
+    source = matrix or hints
+    lines.append("## Matrix proof summary")
+    for key in ("required_failure_count", "nonproof_count", "diagnostic_failure_count", "blocked_lane_count"):
+        _kv(lines, key, source.get(key))
+    lines.append("")
+
+
+def _render_finalizer(lines: list[str], index: Mapping[str, Any] | None, doctor: Mapping[str, Any] | None) -> None:
+    hints = _as_mapping(index.get("aggregate_hints")) if index is not None else {}
+    finalizer = _as_mapping(_doctor_summary(doctor, "finalizer_summary"))
+    guard = _as_mapping(_doctor_summary(doctor, "pr_metadata_guard_summary"))
+    lines.append("## Finalizer / guard summary")
+    _kv(lines, "pre_commit_finalizer_status", finalizer.get("pre_commit_status", hints.get("pre_commit_finalizer_status")))
+    _kv(lines, "pr_metadata_finalizer_status", finalizer.get("pr_metadata_status", hints.get("pr_metadata_finalizer_status")))
+    _kv(lines, "pr_metadata_guard_status", guard.get("status", hints.get("pr_metadata_guard_status")))
+    _kv(lines, "rerun_required", finalizer.get("rerun_required"))
+    _kv(lines, "terminal_refresh_status", finalizer.get("terminal_refresh_status"))
+    lines.append("")
+
+
+def _render_test_provenance(lines: list[str], index: Mapping[str, Any] | None, doctor: Mapping[str, Any] | None) -> None:
+    hints = _as_mapping(index.get("aggregate_hints")) if index is not None else {}
+    provenance = _as_mapping(_doctor_summary(doctor, "test_provenance_summary"))
+    lines.append("## Test provenance summary")
+    for key in ("run_intent", "execution_mode", "tests_selected", "tests_executed", "tests_passed", "tests_skipped"):
+        _kv(lines, key, provenance.get(key))
+    _kv(lines, "exit_reason", provenance.get("exit_reason", hints.get("test_provenance_exit_reason")))
+    lines.append("")
+
+
+def build_landing_evidence_appendix(request: CodexLandingEvidenceAppendixRequest) -> tuple[str, dict[str, Any]]:
+    index = _load_json_object(request.evidence_index_json, "evidence_index_json") if request.evidence_index_json else None
+    doctor = _load_json_object(request.doctor_report_json, "doctor_report_json") if request.doctor_report_json else None
+    lines = [
+        "# Codex Landing Evidence Appendix",
+        "",
+        f"- **Task title:** {_cell(request.title)}",
+        f"- **Intended commit title:** {_cell(request.intended_commit_title)}",
+        "",
+        "## Evidence posture",
+        "- metadata-only",
+        "- read-only",
+        "- non-authoritative",
+        "- does not grant commit authority",
+        "- does not grant PR creation authority",
+        "",
+    ]
+    _render_index(lines, index)
+    _render_doctor(lines, doctor)
+    _render_matrix(lines, index, doctor)
+    _render_finalizer(lines, index, doctor)
+    _render_test_provenance(lines, index, doctor)
+    lines.append("## Non-authority posture")
+    for key in sorted(NON_AUTHORITY_POSTURE):
+        _kv(lines, key, NON_AUTHORITY_POSTURE[key])
+    lines.append("")
+    metadata = {
+        "appendix_is_non_authoritative": True,
+        "doctor_report_id": doctor.get("doctor_report_id") if doctor is not None else None,
+        "doctor_report_provided": doctor is not None,
+        "evidence_index_id": index.get("evidence_index_id") if index is not None else None,
+        "evidence_index_provided": index is not None,
+        "intended_commit_title": request.intended_commit_title,
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+        "output": request.output,
+        "title": request.title,
+    }
+    return "\n".join(lines), metadata
+
+
+def write_landing_evidence_appendix(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")
+
+
+def write_landing_evidence_appendix_metadata(metadata: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_codex_landing_evidence_appendix.py
+++ b/tests/test_codex_landing_evidence_appendix.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_landing_evidence_appendix import CodexLandingEvidenceAppendixError, CodexLandingEvidenceAppendixRequest, build_landing_evidence_appendix
+
+TITLE = "[codex:landing] render Codex landing evidence appendix"
+
+
+def _write(path: Path, payload: dict[str, object] | str) -> str:
+    path.write_text(payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return str(path)
+
+
+def _index() -> dict[str, object]:
+    return {
+        "evidence_index_id": "idx",
+        "artifact_count": 2,
+        "artifact_roles_present": ["matrix"],
+        "artifact_roles_missing": ["doctor_report"],
+        "aggregate_hints": {"required_failure_count": 0, "pre_commit_finalizer_status": "ready_to_commit", "pr_metadata_guard_status": "pr_metadata_guard_ready"},
+        "artifacts": [
+            {"role": "matrix", "path": "/tmp/matrix.json", "exists": True, "readable_json": True, "digest": "sha256:abcdef1234567890", "status_hint": "passed", "schema_hint": "work_item_review_packet_matrix"},
+            {"role": "doctor|report", "path": "line1\nline2", "exists": False, "readable_json": False, "digest": None, "error": "path|missing"},
+        ],
+    }
+
+
+def _doctor(status: str = "doctor_ready") -> dict[str, object]:
+    return {
+        "doctor_report_id": "doctor",
+        "overall_doctor_status": status,
+        "readiness_summary": "rendered evidence only",
+        "next_safe_action": "no_action_ready",
+        "next_safe_action_reason": "doctor field only",
+        "missing_evidence": [],
+        "matrix_summary": {"required_failure_count": 0, "nonproof_count": 1, "diagnostic_failure_count": 2, "blocked_lane_count": 3},
+        "finalizer_summary": {"pre_commit_status": "ready_to_commit", "pr_metadata_status": "ready_for_pr_metadata", "rerun_required": {"pre_commit": False, "pr_metadata": False}, "terminal_refresh_status": {"pre_commit": None, "pr_metadata": "succeeded"}},
+        "pr_metadata_guard_summary": {"status": "pr_metadata_guard_ready"},
+        "test_provenance_summary": {"run_intent": "targeted", "execution_mode": "pytest", "tests_selected": 2, "tests_executed": 2, "tests_passed": 2, "tests_skipped": 0, "exit_reason": None},
+    }
+
+
+def _render(tmp_path: Path, *, index: dict[str, object] | None = None, doctor: dict[str, object] | None = None) -> tuple[str, dict[str, object]]:
+    index_path = _write(tmp_path / "index.json", index) if index is not None else None
+    doctor_path = _write(tmp_path / "doctor.json", doctor) if doctor is not None else None
+    return build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, output=str(tmp_path / "out.md"), evidence_index_json=index_path, doctor_report_json=doctor_path))
+
+
+def test_rendering_appendix_from_evidence_index_only(tmp_path: Path) -> None:
+    markdown, metadata = _render(tmp_path, index=_index())
+    assert "# Codex Landing Evidence Appendix" in markdown
+    assert "**evidence_index_id:** idx" in markdown
+    assert "| matrix | /tmp/matrix.json | true | true | sha256:abcdef123456" in markdown
+    assert "Lifecycle doctor report JSON was not provided." in markdown
+    assert metadata["evidence_index_provided"] is True
+
+
+def test_rendering_appendix_from_doctor_report_only(tmp_path: Path) -> None:
+    markdown, metadata = _render(tmp_path, doctor=_doctor())
+    assert "Evidence index JSON was not provided." in markdown
+    assert "**overall_doctor_status:** doctor_ready" in markdown
+    assert "**blocked_lane_count:** 3" in markdown
+    assert metadata["doctor_report_provided"] is True
+
+
+def test_rendering_appendix_from_both_index_and_doctor_report(tmp_path: Path) -> None:
+    markdown, _metadata = _render(tmp_path, index=_index(), doctor=_doctor("doctor_blocked"))
+    assert "**evidence_index_id:** idx" in markdown
+    assert "**overall_doctor_status:** doctor_blocked" in markdown
+    assert "**pr_metadata_guard_status:** pr_metadata_guard_ready" in markdown
+
+
+def test_missing_optional_inputs_render_as_not_provided(tmp_path: Path) -> None:
+    markdown, metadata = _render(tmp_path)
+    assert "Evidence index JSON was not provided." in markdown
+    assert "Lifecycle doctor report JSON was not provided." in markdown
+    assert metadata["appendix_is_non_authoritative"] is True
+
+
+def test_invalid_index_json_fails_cleanly(tmp_path: Path) -> None:
+    bad = _write(tmp_path / "bad_index.json", "{")
+    with pytest.raises(CodexLandingEvidenceAppendixError, match="evidence_index_json_invalid_json"):
+        build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, evidence_index_json=bad))
+
+
+def test_invalid_doctor_json_fails_cleanly(tmp_path: Path) -> None:
+    bad = _write(tmp_path / "bad_doctor.json", "{")
+    with pytest.raises(CodexLandingEvidenceAppendixError, match="doctor_report_json_invalid_json"):
+        build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, doctor_report_json=bad))
+
+
+def test_missing_provided_json_path_fails_cleanly(tmp_path: Path) -> None:
+    with pytest.raises(CodexLandingEvidenceAppendixError, match="evidence_index_json_missing"):
+        build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, evidence_index_json=str(tmp_path / "missing.json")))
+
+
+def test_artifact_table_escapes_markdown_pipes_and_newlines_safely(tmp_path: Path) -> None:
+    markdown, _metadata = _render(tmp_path, index=_index())
+    assert "doctor\\|report" in markdown
+    assert "line1<br>line2" in markdown
+    assert "path\\|missing" in markdown
+
+
+def test_non_authority_posture_section_is_present(tmp_path: Path) -> None:
+    markdown, metadata = _render(tmp_path, doctor=_doctor())
+    assert "## Non-authority posture" in markdown
+    assert "**appendix_does_not_decide_readiness:** true" in markdown
+    assert "**appendix_does_not_authorize_pr_creation:** true" in markdown
+    assert metadata["non_authority_posture"]["appendix_does_not_rerun_commands"] is True  # type: ignore[index]
+
+
+def test_renderer_does_not_decide_readiness_only_renders_evidence_status(tmp_path: Path) -> None:
+    markdown, _metadata = _render(tmp_path, doctor=_doctor("doctor_ready"))
+    assert "does not grant commit authority" in markdown
+    assert "**overall_doctor_status:** doctor_ready" in markdown
+    assert "ready_to_commit" in markdown
+    assert "appendix_does_not_authorize_commit" in markdown
+
+
+def test_markdown_output_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    first, _ = _render(tmp_path, index=_index(), doctor=_doctor())
+    second, _ = _render(tmp_path, index=_index(), doctor=_doctor())
+    assert first == second
+
+
+def test_json_sidecar_output_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    _, first = _render(tmp_path, index=_index(), doctor=_doctor())
+    _, second = _render(tmp_path, index=_index(), doctor=_doctor())
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)

--- a/tests/test_render_codex_landing_evidence_appendix_script.py
+++ b/tests/test_render_codex_landing_evidence_appendix_script.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+TITLE = "[codex:landing] render Codex landing evidence appendix"
+
+
+def test_cli_writes_markdown_json_sidecar_and_prints_compact_summary(tmp_path: Path) -> None:
+    index = tmp_path / "index.json"
+    index.write_text(json.dumps({"evidence_index_id": "idx", "artifact_count": 0, "artifact_roles_present": [], "artifact_roles_missing": [], "aggregate_hints": {}, "artifacts": []}), encoding="utf-8")
+    output = tmp_path / "appendix.md"
+    sidecar = tmp_path / "appendix.json"
+    result = subprocess.run(
+        [sys.executable, "scripts/render_codex_landing_evidence_appendix.py", "--title", TITLE, "--intended-commit-title", TITLE, "--evidence-index-json", str(index), "--output", str(output), "--json-output", str(sidecar), "--summary"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "# Codex Landing Evidence Appendix" in output.read_text(encoding="utf-8")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["appendix_is_non_authoritative"] is True
+    assert json.loads(result.stdout) == {"appendix_is_non_authoritative": True, "doctor_report_provided": False, "evidence_index_provided": True, "output": str(output)}
+
+
+def test_cli_failure_returns_exit_code_2_with_useful_message(tmp_path: Path) -> None:
+    output = tmp_path / "appendix.md"
+    result = subprocess.run(
+        [sys.executable, "scripts/render_codex_landing_evidence_appendix.py", "--title", TITLE, "--intended-commit-title", TITLE, "--evidence-index-json", str(tmp_path / "missing.json"), "--output", str(output)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert "codex_landing_evidence_appendix_error: evidence_index_json_missing" in result.stderr
+    assert not output.exists()


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only way to render existing Codex landing evidence (evidence index and/or lifecycle doctor report) into markdown for PR bodies, reviewer notes, and recovery logs. 
- Make the appendix explicitly read-only and non-authoritative so it can be used for review without altering finalizer, guard, matrix, or commit authority.

### Description
- Add a renderer module `sentientos.codex_landing_evidence_appendix` that loads index/doctor JSON, formats a deterministic markdown appendix, and returns a metadata sidecar. 
- Add a CLI wrapper script `scripts/render_codex_landing_evidence_appendix.py` that builds the appendix, writes the markdown and optional JSON sidecar, and exposes a compact `--summary` output and clean failure exit code. 
- Update documentation in `docs/development/codex_finalize_landing.md`, `codex_landing_evidence_recovery_rail.md`, and `codex_validation_and_landing_contract.md` to describe the appendix, its non-authoritative posture, and an example usage. 
- Ensure deterministic output, safe escaping of markdown pipes/newlines, and explicit non-authority posture metadata keys in the produced sidecar.

### Testing
- Ran unit tests `tests/test_codex_landing_evidence_appendix.py` which exercise index-only, doctor-only, combined inputs, invalid/missing JSON handling, markdown escaping, determinism, and metadata content; all assertions passed. 
- Ran CLI tests `tests/test_render_codex_landing_evidence_appendix_script.py` which validate CLI output, sidecar JSON, `--summary` behavior, and failure exit code `2` on missing input; the CLI tests passed. 
- All added tests completed successfully (both module and CLI tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a37200954c88320ad691f21854fb390)