### PR TITLE
[codex:doctrine] map Codex landing rails to beneficial trait rubrics

### DIFF
--- a/docs/development/codex_beneficial_trait_doctrine.md
+++ b/docs/development/codex_beneficial_trait_doctrine.md
@@ -1,0 +1,72 @@
+# Codex Beneficial Trait Doctrine Map
+
+The Codex beneficial trait doctrine map is a deterministic, metadata-only rubric that explains how existing SentientOS/Codex landing rails surface beneficial developer-workflow behaviors. It answers one reviewer question: **which beneficial behavioral traits are enforced or surfaced by each existing Codex landing rail?**
+
+This doctrine map is external governance doctrine. It is not model training, reinforcement learning, finetuning, provider behavior, runtime behavior, or an evaluation authority. It does not run commands, inspect runtime evidence artifacts, decide readiness, authorize commits, authorize PR metadata, or bypass the finalizer and PR metadata guard.
+
+## Purpose
+
+The map gives reviewers a compact vocabulary for the posture already present in the landing evidence stack:
+
+- truthfulness;
+- metacognitive transparency;
+- corrigibility;
+- downside-aware planning;
+- constraint-honest pragmatism;
+- bounded initiative;
+- controlled exploration;
+- human-protective helpfulness;
+- option-preserving patience;
+- deescalatory firmness;
+- dense usefulness;
+- universalizable fairness;
+- power-asymmetry awareness;
+- anti-hierarchy governance;
+- situational attunement.
+
+The implementation lives in `sentientos/codex_beneficial_trait_doctrine.py`, and the CLI renderer lives in `scripts/build_codex_beneficial_trait_doctrine.py`.
+
+## Outputs
+
+The builder writes deterministic static doctrine artifacts:
+
+```bash
+python scripts/build_codex_beneficial_trait_doctrine.py \
+  --output codex_beneficial_trait_doctrine_map.json \
+  --markdown-output codex_beneficial_trait_doctrine_map.md \
+  --summary
+```
+
+The JSON output includes the trait catalog, rail mappings, trait-to-rail and rail-to-trait indexes, and an explicit non-authority posture. The optional markdown output renders the same static doctrine for reviewer reading.
+
+## Relationship to existing rails
+
+The doctrine map describes existing rails only. It does not add a new gate and does not change the behavior of these systems:
+
+- `scripts/run_tests.py` remains the focused and targeted proof hardening rail.
+- `scripts/run_work_item_review_packet_matrix.py` remains the matrix proof and diagnostic classification rail.
+- `scripts/codex_finalize_landing.py` remains the finalizer readiness and stale-evidence refresh rail.
+- `scripts/codex_pr_metadata_guard.py` remains the PR metadata guard.
+- `sentientos/codex_task_lifecycle_summary.py` remains the lifecycle summary artifact builder.
+- `sentientos/codex_lifecycle_doctor.py` remains the lifecycle doctor.
+- `sentientos/codex_landing_evidence_index.py` remains the evidence index.
+- `sentientos/codex_landing_evidence_appendix.py` remains the evidence appendix renderer.
+- `docs/development/codex_validation_and_landing_contract.md` remains the validation and landing contract.
+- `docs/development/codex_landing_evidence_recovery_rail.md` remains the recovery rail doctrine.
+
+## What the map does not answer
+
+The beneficial trait doctrine map does **not** answer whether:
+
+- a change may commit;
+- PR metadata may be created;
+- matrix proof passed;
+- artifacts are fresh;
+- a model is aligned;
+- reinforcement learning training succeeded.
+
+Those answers remain with the existing landing rails and human review. The doctrine map only labels the behavioral posture those rails are designed to preserve.
+
+## Reviewer use
+
+Reviewers can use the map to understand what each rail is protecting. For example, a rail that refuses stale evidence may be mapped to truthfulness, corrigibility, downside-aware planning, and option-preserving patience. That mapping is explanatory, not authoritative: if the finalizer blocks, the map cannot override it; if the PR metadata guard blocks, the map cannot authorize PR metadata; if the matrix fails or times out, the map cannot convert that result into proof.

--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -174,3 +174,6 @@ python scripts/render_codex_landing_evidence_appendix.py \
 Evidence index answers: “Which artifacts exist, where are they, what are their digests, and what hints do they expose?” Lifecycle doctor answers: “Using the artifacts, what should an operator inspect or rerun next?” Evidence appendix answers: “How can the current evidence be rendered for reviewers in a compact deterministic markdown format?” Finalizer answers: “Can this change advance to commit/PR metadata under landing rules?” PR metadata guard answers: “Is PR metadata creation allowed?” Matrix answers: “Did required proof lanes pass?”
 
 The appendix can be pasted into PR bodies or operator logs without changing `make_pr`, finalizer, PR metadata guard, or matrix behavior. It never grants commit authority, PR creation authority, runtime authority, readiness, or proof status.
+## Beneficial trait doctrine map
+
+The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) explains which beneficial behavioral traits the existing finalizer, guard, matrix, lifecycle, and evidence rails surface. It is descriptive doctrine only: it does not decide readiness, authorize commits, authorize PR metadata, rerun evidence, or bypass this finalizer.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -166,3 +166,6 @@ The distinction is mandatory:
 - Matrix: records whether required proof lanes passed.
 
 The appendix is recovery evidence only. It does not rerun commands, decide readiness, convert diagnostic/non-proof lanes into proof, bypass finalizer or PR metadata guard, or authorize commit, PR creation, or runtime action.
+## Beneficial trait doctrine map
+
+The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) labels the recovery rail and adjacent landing evidence rails with reviewer-facing behavioral traits such as corrigibility and option-preserving patience. It is not a recovery authority and cannot replace recovery artifacts, finalizer readiness, matrix proof, or PR metadata guard readiness.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -113,3 +113,6 @@ Required distinction for reviews:
 - Matrix answers: “Did required proof lanes pass?”
 
 The appendix may be pasted into PR bodies or operator logs, but doing so does not change `make_pr`, finalizer, PR metadata guard, matrix, clean-tree, or proof requirements.
+## Beneficial trait doctrine map
+
+The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) provides a static rubric for how existing validation and landing rails support reviewer-facing behavioral traits. It does not change this contract, add a gate, decide matrix success, authorize commits, or authorize PR metadata.

--- a/scripts/build_codex_beneficial_trait_doctrine.py
+++ b/scripts/build_codex_beneficial_trait_doctrine.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+
+from sentientos.codex_beneficial_trait_doctrine import (
+    build_beneficial_trait_doctrine_map,
+    render_beneficial_trait_doctrine_markdown,
+    write_beneficial_trait_doctrine_json,
+    write_beneficial_trait_doctrine_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build the metadata-only Codex beneficial trait doctrine map.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    doctrine_map = build_beneficial_trait_doctrine_map()
+    write_beneficial_trait_doctrine_json(doctrine_map, args.output)
+    if args.markdown_output:
+        write_beneficial_trait_doctrine_markdown(render_beneficial_trait_doctrine_markdown(doctrine_map), args.markdown_output)
+    if args.summary:
+        print(
+            json.dumps(
+                {
+                    "doctrine_map_id": doctrine_map["doctrine_map_id"],
+                    "metadata_only": True,
+                    "output": args.output,
+                    "markdown_output": args.markdown_output,
+                    "rail_mapping_count": len(doctrine_map["rail_mappings"]),
+                    "trait_count": len(doctrine_map["trait_catalog"]),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_beneficial_trait_doctrine.py
+++ b/sentientos/codex_beneficial_trait_doctrine.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+DOCTRINE_MAP_ID = "codex_beneficial_trait_doctrine_map.v1"
+
+TRAIT_CATALOG: dict[str, str] = {
+    "anti_hierarchy_governance": "Keeps authority in reviewable procedure instead of unchecked rank, charisma, or model preference.",
+    "bounded_initiative": "Acts within the requested scope and does not invent new authority, gates, side effects, or runtime powers.",
+    "constraint_honest_pragmatism": "Names operational constraints and uses feasible evidence without pretending blocked or skipped work is proof.",
+    "controlled_exploration": "Permits diagnosis and metadata review while preventing exploratory action from becoming execution authority.",
+    "corrigibility": "Keeps failures, stale evidence, and reviewer objections visible so the work can be corrected before landing.",
+    "deescalatory_firmness": "Stops unsafe or under-proven landings without expanding conflict, bypassing procedure, or hiding blockers.",
+    "dense_usefulness": "Compresses scattered landing evidence into reviewer-usable summaries without replacing the underlying proof.",
+    "downside_aware_planning": "Plans around known failure modes, stale artifacts, timeout risk, and authority-boundary hazards.",
+    "human_protective_helpfulness": "Preserves operator and reviewer control by making evidence legible while refusing autonomous privilege escalation.",
+    "metacognitive_transparency": "Makes what is known, unknown, inferred, stale, or diagnostic explicit in machine-readable and reviewer-readable form.",
+    "option_preserving_patience": "Favors recoverable states, cleanup, reruns, and human review over irreversible or premature landing actions.",
+    "power_asymmetry_awareness": "Recognizes that automation can overclaim authority and therefore constrains outputs to evidence and doctrine.",
+    "situational_attunement": "Adapts explanations to the landing context, distinguishing focused tests, matrix proof, finalizer readiness, and metadata.",
+    "truthfulness": "Requires claims to match executed proof, artifact freshness, and explicit diagnostic status.",
+    "universalizable_fairness": "Uses stable, deterministic rubrics that reviewers can apply consistently across work items.",
+}
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "doctrine_map_is_read_only": True,
+    "doctrine_map_does_not_rerun_commands": True,
+    "doctrine_map_does_not_decide_readiness": True,
+    "doctrine_map_does_not_bypass_finalizer": True,
+    "doctrine_map_does_not_bypass_pr_metadata_guard": True,
+    "doctrine_map_does_not_authorize_commit": True,
+    "doctrine_map_does_not_authorize_pr_creation": True,
+    "doctrine_map_does_not_authorize_runtime_action": True,
+    "doctrine_map_does_not_train_or_modify_models": True,
+}
+
+
+def _rail(
+    rail_id: str,
+    rail_name: str,
+    file_paths: list[str],
+    enforced_traits: list[str],
+    evidence_artifacts: list[str],
+    prevented_failure_modes: list[str],
+    reviewer_summary: str,
+) -> dict[str, Any]:
+    return {
+        "rail_id": rail_id,
+        "rail_name": rail_name,
+        "file_paths": file_paths,
+        "enforced_traits": enforced_traits,
+        "evidence_artifacts": evidence_artifacts,
+        "prevented_failure_modes": prevented_failure_modes,
+        "non_authority_boundary": "This mapping is descriptive static doctrine only; it does not execute the rail, inspect live evidence, decide readiness, or grant landing authority.",
+        "why_this_is_not_authority": "The rail keeps its original authority semantics. This doctrine map only labels the behavioral posture reviewers can expect from that existing rail.",
+        "reviewer_summary": reviewer_summary,
+    }
+
+
+RAIL_MAPPINGS: list[dict[str, Any]] = [
+    _rail(
+        "run_tests_focused_proof_hardening",
+        "Focused and targeted proof hardening",
+        ["scripts/run_tests.py"],
+        ["truthfulness", "constraint_honest_pragmatism", "metacognitive_transparency", "corrigibility"],
+        ["focused test command output", "test provenance metadata"],
+        ["claiming selected tests passed when none executed", "treating skipped or unselected tests as proof"],
+        "Hardens focused proof so test claims stay tied to executed tests rather than optimistic summaries.",
+    ),
+    _rail(
+        "work_item_review_packet_matrix_classification",
+        "Work-item review packet matrix proof and diagnostic classification",
+        ["scripts/run_work_item_review_packet_matrix.py"],
+        ["truthfulness", "downside_aware_planning", "controlled_exploration", "universalizable_fairness"],
+        ["work item review packet matrix JSON", "lane classification summaries"],
+        ["counting diagnostic lanes as required proof", "hiding blocked or nonproof lanes", "weakening timed-out lanes into success"],
+        "Separates required proof from diagnostics so reviewers can compare lanes consistently.",
+    ),
+    _rail(
+        "codex_finalize_landing_readiness",
+        "Finalizer readiness and stale-evidence refresh handling",
+        ["scripts/codex_finalize_landing.py"],
+        ["corrigibility", "option_preserving_patience", "downside_aware_planning", "deescalatory_firmness"],
+        ["pre-commit finalizer JSON", "pr-metadata finalizer JSON", "stale-evidence refresh status"],
+        ["committing with stale evidence", "creating PR metadata before required finalizer readiness", "ignoring generated-artifact cleanup blockers"],
+        "Keeps landing decisions tied to explicit finalizer phases and refresh state.",
+    ),
+    _rail(
+        "codex_pr_metadata_guard",
+        "PR metadata guard",
+        ["scripts/codex_pr_metadata_guard.py"],
+        ["bounded_initiative", "truthfulness", "anti_hierarchy_governance", "power_asymmetry_awareness"],
+        ["PR metadata guard JSON", "finalizer and matrix cross-check references"],
+        ["calling PR metadata without guard readiness", "using a commit title outside the intended landing contract"],
+        "Prevents PR metadata from outrunning the finalizer, matrix, and title contract.",
+    ),
+    _rail(
+        "codex_task_lifecycle_summary",
+        "Codex task lifecycle summary",
+        ["sentientos/codex_task_lifecycle_summary.py"],
+        ["metacognitive_transparency", "dense_usefulness", "situational_attunement"],
+        ["task lifecycle summary JSON"],
+        ["scattered lifecycle evidence", "reviewers missing phase transitions or unresolved blockers"],
+        "Summarizes task lifecycle posture without replacing phase-specific proof.",
+    ),
+    _rail(
+        "codex_lifecycle_doctor",
+        "Codex lifecycle doctor",
+        ["sentientos/codex_lifecycle_doctor.py"],
+        ["corrigibility", "metacognitive_transparency", "human_protective_helpfulness", "option_preserving_patience"],
+        ["lifecycle doctor report JSON"],
+        ["unclear next safe action", "missing evidence hidden from reviewers", "premature irreversible action"],
+        "Diagnoses available landing evidence and names safe next actions while remaining non-authoritative.",
+    ),
+    _rail(
+        "codex_landing_evidence_index",
+        "Codex landing evidence index",
+        ["sentientos/codex_landing_evidence_index.py"],
+        ["dense_usefulness", "truthfulness", "metacognitive_transparency", "universalizable_fairness"],
+        ["landing evidence index JSON", "artifact digest and presence hints"],
+        ["losing artifact paths", "reviewing stale or missing evidence without visibility", "non-deterministic evidence inventory"],
+        "Indexes evidence artifacts so reviewers can see what exists, what is missing, and what each artifact claims.",
+    ),
+    _rail(
+        "codex_landing_evidence_appendix",
+        "Codex landing evidence appendix",
+        ["sentientos/codex_landing_evidence_appendix.py"],
+        ["dense_usefulness", "human_protective_helpfulness", "constraint_honest_pragmatism", "situational_attunement"],
+        ["landing evidence appendix markdown", "appendix metadata JSON"],
+        ["forcing reviewers to reconstruct evidence manually", "mistaking rendered summaries for readiness authority"],
+        "Renders evidence into compact reviewer-readable markdown while repeating non-authority boundaries.",
+    ),
+    _rail(
+        "codex_validation_and_landing_contract",
+        "Validation and landing contract",
+        ["docs/development/codex_validation_and_landing_contract.md"],
+        ["bounded_initiative", "downside_aware_planning", "constraint_honest_pragmatism", "deescalatory_firmness"],
+        ["documented validation contract", "required lane expectations"],
+        ["declaring done before required validation", "bypassing matrix or supervisor obligations", "treating partial proof as landing proof"],
+        "Documents the validation posture that keeps completion claims bounded by required evidence.",
+    ),
+    _rail(
+        "codex_landing_evidence_recovery_rail",
+        "Landing evidence recovery rail",
+        ["docs/development/codex_landing_evidence_recovery_rail.md"],
+        ["option_preserving_patience", "corrigibility", "controlled_exploration", "human_protective_helpfulness"],
+        ["recovery rail documentation", "recovery evidence references"],
+        ["losing recoverable task-owned files", "rerunning instead of surgical recovery", "closing failed work without recovery artifacts"],
+        "Explains how to preserve recovery options and avoid destructive recovery behavior.",
+    ),
+]
+
+
+def _validate_trait_references() -> None:
+    known = set(TRAIT_CATALOG)
+    for rail in RAIL_MAPPINGS:
+        unknown = sorted(set(rail["enforced_traits"]) - known)
+        if unknown:
+            raise ValueError(f"unknown_trait_reference:{rail['rail_id']}:{','.join(unknown)}")
+
+
+def _trait_to_rails_index() -> dict[str, list[str]]:
+    index: dict[str, list[str]] = {trait_id: [] for trait_id in sorted(TRAIT_CATALOG)}
+    for rail in RAIL_MAPPINGS:
+        for trait_id in rail["enforced_traits"]:
+            index[trait_id].append(rail["rail_id"])
+    return {trait_id: sorted(rail_ids) for trait_id, rail_ids in index.items()}
+
+
+def _rail_to_traits_index() -> dict[str, list[str]]:
+    return {rail["rail_id"]: list(rail["enforced_traits"]) for rail in RAIL_MAPPINGS}
+
+
+def build_beneficial_trait_doctrine_map() -> dict[str, Any]:
+    """Return the deterministic metadata-only Codex beneficial-trait doctrine map."""
+    _validate_trait_references()
+    return {
+        "doctrine_map_id": DOCTRINE_MAP_ID,
+        "metadata_only": True,
+        "developer_workflow_evidence_only": True,
+        "doctrine_only": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "trait_catalog": dict(sorted(TRAIT_CATALOG.items())),
+        "rail_mappings": sorted((dict(rail) for rail in RAIL_MAPPINGS), key=lambda rail: rail["rail_id"]),
+        "trait_to_rails_index": _trait_to_rails_index(),
+        "rail_to_traits_index": _rail_to_traits_index(),
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def render_beneficial_trait_doctrine_markdown(doctrine_map: Mapping[str, Any] | None = None) -> str:
+    doctrine = doctrine_map or build_beneficial_trait_doctrine_map()
+    lines = [
+        "# Codex Beneficial Trait Doctrine Map",
+        "",
+        "This is external governance doctrine for existing Codex/SentientOS landing rails. It is not model training, reinforcement learning, readiness authority, or a new gate.",
+        "",
+        "## Trait catalog",
+        "| trait_id | definition |",
+        "| --- | --- |",
+    ]
+    for trait_id, definition in doctrine["trait_catalog"].items():
+        lines.append(f"| {trait_id} | {definition} |")
+    lines.extend(["", "## Rail-to-trait mapping", "| rail_id | rail_name | enforced_traits |", "| --- | --- | --- |"])
+    for rail in doctrine["rail_mappings"]:
+        lines.append(f"| {rail['rail_id']} | {rail['rail_name']} | {', '.join(rail['enforced_traits'])} |")
+    lines.extend(["", "## Trait-to-rails index", "| trait_id | rails |", "| --- | --- |"])
+    for trait_id, rail_ids in doctrine["trait_to_rails_index"].items():
+        lines.append(f"| {trait_id} | {', '.join(rail_ids) if rail_ids else 'none'} |")
+    lines.extend(["", "## Non-authority posture"])
+    for key, value in doctrine["non_authority_posture"].items():
+        lines.append(f"- **{key}:** {'true' if value else 'false'}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_beneficial_trait_doctrine_json(doctrine_map: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(doctrine_map, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_beneficial_trait_doctrine_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_beneficial_trait_doctrine_script.py
+++ b/tests/test_build_codex_beneficial_trait_doctrine_script.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from scripts.build_codex_beneficial_trait_doctrine import main
+
+
+def test_cli_writes_json_and_prints_compact_summary(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output = tmp_path / "codex_beneficial_trait_doctrine_map.json"
+    assert main(["--output", str(output), "--summary"]) == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(capsys.readouterr().out)
+    assert payload["metadata_only"] is True
+    assert payload["doctrine_only"] is True
+    assert summary["output"] == str(output)
+    assert summary["metadata_only"] is True
+    assert summary["trait_count"] >= 15
+    assert summary["rail_mapping_count"] >= 10
+
+
+def test_cli_writes_markdown_when_requested(tmp_path: Path) -> None:
+    output = tmp_path / "codex_beneficial_trait_doctrine_map.json"
+    markdown_output = tmp_path / "codex_beneficial_trait_doctrine_map.md"
+    assert main(["--output", str(output), "--markdown-output", str(markdown_output)]) == 0
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert markdown.startswith("# Codex Beneficial Trait Doctrine Map")
+    assert "## Non-authority posture" in markdown
+    assert "not model training" in markdown

--- a/tests/test_codex_beneficial_trait_doctrine.py
+++ b/tests/test_codex_beneficial_trait_doctrine.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_beneficial_trait_doctrine import build_beneficial_trait_doctrine_map, render_beneficial_trait_doctrine_markdown
+
+REQUIRED_TRAITS = {
+    "truthfulness",
+    "metacognitive_transparency",
+    "corrigibility",
+    "downside_aware_planning",
+    "constraint_honest_pragmatism",
+    "bounded_initiative",
+    "controlled_exploration",
+    "human_protective_helpfulness",
+    "option_preserving_patience",
+    "deescalatory_firmness",
+    "dense_usefulness",
+    "universalizable_fairness",
+    "power_asymmetry_awareness",
+    "anti_hierarchy_governance",
+    "situational_attunement",
+}
+
+REQUIRED_RAILS = {
+    "run_tests_focused_proof_hardening",
+    "work_item_review_packet_matrix_classification",
+    "codex_finalize_landing_readiness",
+    "codex_pr_metadata_guard",
+    "codex_task_lifecycle_summary",
+    "codex_lifecycle_doctor",
+    "codex_landing_evidence_index",
+    "codex_landing_evidence_appendix",
+    "codex_validation_and_landing_contract",
+    "codex_landing_evidence_recovery_rail",
+}
+
+REQUIRED_NON_AUTHORITY = {
+    "doctrine_map_is_read_only",
+    "doctrine_map_does_not_rerun_commands",
+    "doctrine_map_does_not_decide_readiness",
+    "doctrine_map_does_not_bypass_finalizer",
+    "doctrine_map_does_not_bypass_pr_metadata_guard",
+    "doctrine_map_does_not_authorize_commit",
+    "doctrine_map_does_not_authorize_pr_creation",
+    "doctrine_map_does_not_authorize_runtime_action",
+    "doctrine_map_does_not_train_or_modify_models",
+}
+
+
+def test_trait_catalog_contains_required_stable_trait_ids() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    assert REQUIRED_TRAITS <= set(doctrine["trait_catalog"])
+
+
+def test_every_rail_mapping_references_only_known_traits() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    known = set(doctrine["trait_catalog"])
+    for rail in doctrine["rail_mappings"]:
+        assert set(rail["enforced_traits"]) <= known
+
+
+def test_required_rails_are_present() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    assert REQUIRED_RAILS <= {rail["rail_id"] for rail in doctrine["rail_mappings"]}
+
+
+def test_every_mapping_has_required_reviewer_fields() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    for rail in doctrine["rail_mappings"]:
+        assert rail["file_paths"]
+        assert rail["prevented_failure_modes"]
+        assert rail["non_authority_boundary"]
+        assert rail["why_this_is_not_authority"]
+        assert rail["reviewer_summary"]
+
+
+def test_indexes_are_internally_consistent() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    rail_to_traits = doctrine["rail_to_traits_index"]
+    trait_to_rails = doctrine["trait_to_rails_index"]
+    for rail_id, trait_ids in rail_to_traits.items():
+        for trait_id in trait_ids:
+            assert rail_id in trait_to_rails[trait_id]
+    for trait_id, rail_ids in trait_to_rails.items():
+        for rail_id in rail_ids:
+            assert trait_id in rail_to_traits[rail_id]
+
+
+def test_json_output_is_deterministic_for_same_inputs() -> None:
+    first = json.dumps(build_beneficial_trait_doctrine_map(), sort_keys=True)
+    second = json.dumps(build_beneficial_trait_doctrine_map(), sort_keys=True)
+    assert first == second
+
+
+def test_markdown_output_is_deterministic() -> None:
+    first = render_beneficial_trait_doctrine_markdown()
+    second = render_beneficial_trait_doctrine_markdown()
+    assert first == second
+    assert first.startswith("# Codex Beneficial Trait Doctrine Map")
+
+
+def test_non_authority_posture_fields_are_present_and_true() -> None:
+    doctrine = build_beneficial_trait_doctrine_map()
+    posture = doctrine["non_authority_posture"]
+    assert REQUIRED_NON_AUTHORITY <= set(posture)
+    assert all(posture[key] is True for key in REQUIRED_NON_AUTHORITY)
+
+
+def test_doctrine_map_does_not_include_readiness_authority_decisions() -> None:
+    serialized = json.dumps(build_beneficial_trait_doctrine_map(), sort_keys=True)
+    assert '"ready_to_commit"' not in serialized
+    assert '"pr_metadata_guard_ready"' not in serialized
+    assert '"ready_for_pr_metadata"' not in serialized


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only doctrine map that makes existing Codex/SentientOS landing rails legible to reviewers by mapping rails to a stable catalog of beneficial behavioral traits. 
- Keep clear authority boundaries: this is external governance doctrine only and must not run commands, decide readiness, or add new gates or model training.

### Description

- Add a deterministic doctrine module `sentientos/codex_beneficial_trait_doctrine.py` that exposes a stable `TRAIT_CATALOG`, explicit `NON_AUTHORITY_POSTURE`, `RAIL_MAPPINGS`, `trait_to_rails_index`, and `rail_to_traits_index`, plus deterministic JSON/markdown renderers. 
- Add a CLI `scripts/build_codex_beneficial_trait_doctrine.py` with `--output`, optional `--markdown-output`, and `--summary` to write the JSON map and optional markdown without executing any rails. 
- Add documentation `docs/development/codex_beneficial_trait_doctrine.md` and link the doctrine map from the finalizer, recovery-rail, and validation contract docs while preserving their original authority semantics. 
- Add focused tests `tests/test_codex_beneficial_trait_doctrine.py` and `tests/test_build_codex_beneficial_trait_doctrine_script.py` that assert required trait IDs and rails, index consistency, deterministic output, presence of reviewer-facing fields, non-authority posture, and CLI behavior; fix a mypy annotation to satisfy typing checks.

### Testing

- Bootstrap and focused tests: ran the bootstrap and `python -m scripts.run_tests -q tests/test_codex_beneficial_trait_doctrine.py tests/test_build_codex_beneficial_trait_doctrine_script.py`, both passed. 
- Integration/validation lanes: ran evidence appendix/index/doctor tests and the wider matrix lanes via `scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` (matrix passed; duration 496s). 
- Finalizer and guard: executed `scripts/codex_finalize_landing.py` (pre-commit and pr-metadata phases) which returned `ready_to_commit` and `ready_for_pr_metadata`, and `scripts/codex_pr_metadata_guard.py verify` returned `pr_metadata_guard_ready`. 
- Docs and typing: ran `python scripts/build_docs.py --bootstrap-docs` and `python scripts/build_docs.py` (bootstrapped missing docs deps and built successfully) and `python -m mypy sentientos/codex_beneficial_trait_doctrine.py scripts/build_codex_beneficial_trait_doctrine.py` (type checks passed after a small annotation fix). 

All automated tests and validation steps listed above completed successfully and confirm the doctrine map is deterministic, metadata-only, and non-authoritative.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a379142947083209fdae1b54b2b0f41)