### PR TITLE
[codex:doctrine] render beneficial trait doctrine in evidence appendix

### DIFF
--- a/docs/development/codex_beneficial_trait_doctrine.md
+++ b/docs/development/codex_beneficial_trait_doctrine.md
@@ -70,3 +70,9 @@ Those answers remain with the existing landing rails and human review. The doctr
 ## Reviewer use
 
 Reviewers can use the map to understand what each rail is protecting. For example, a rail that refuses stale evidence may be mapped to truthfulness, corrigibility, downside-aware planning, and option-preserving patience. That mapping is explanatory, not authoritative: if the finalizer blocks, the map cannot override it; if the PR metadata guard blocks, the map cannot authorize PR metadata; if the matrix fails or times out, the map cannot convert that result into proof.
+
+## Evidence appendix rendering
+
+`scripts/render_codex_landing_evidence_appendix.py` can optionally accept the doctrine JSON with `--doctrine-map-json` and render a compact **Beneficial Trait Doctrine** section for reviewers. The doctrine map answers: “Which beneficial traits are connected to each existing landing/evidence rail?” The evidence appendix with doctrine answers: “How can existing evidence and doctrine context be rendered for reviewers in a compact deterministic markdown document?”
+
+This rendering is review context only. The appendix does not make the doctrine map authoritative, does not decide readiness, does not authorize commit or PR creation, does not train or modify models, and does not rerun the doctrine builder or any validation command. Finalizer readiness and PR metadata guard readiness remain the only landing authorities for their respective phases.

--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -177,3 +177,9 @@ The appendix can be pasted into PR bodies or operator logs without changing `mak
 ## Beneficial trait doctrine map
 
 The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) explains which beneficial behavioral traits the existing finalizer, guard, matrix, lifecycle, and evidence rails surface. It is descriptive doctrine only: it does not decide readiness, authorize commits, authorize PR metadata, rerun evidence, or bypass this finalizer.
+
+### Appendix doctrine-map intake
+
+The evidence appendix renderer may include static beneficial-trait context with `--doctrine-map-json PATH`, where `PATH` is JSON emitted by `scripts/build_codex_beneficial_trait_doctrine.py`. The renderer only reads that supplied JSON and renders the **Beneficial Trait Doctrine** section; it does not execute the doctrine builder, run validation, decide readiness, or create PR metadata.
+
+Doctrine rendering is reviewer context only. It explains which beneficial traits are connected to existing landing/evidence rails and how that context can be displayed beside evidence metadata. It does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed, whether artifacts are fresh, whether a model is aligned, or whether reinforcement learning succeeded. The finalizer and PR metadata guard remain the landing authorities.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -169,3 +169,9 @@ The appendix is recovery evidence only. It does not rerun commands, decide readi
 ## Beneficial trait doctrine map
 
 The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) labels the recovery rail and adjacent landing evidence rails with reviewer-facing behavioral traits such as corrigibility and option-preserving patience. It is not a recovery authority and cannot replace recovery artifacts, finalizer readiness, matrix proof, or PR metadata guard readiness.
+
+### Doctrine context in the appendix
+
+For recovery review, `scripts/render_codex_landing_evidence_appendix.py --doctrine-map-json PATH` may render the static beneficial-trait doctrine map beside existing evidence appendix metadata. This is a compact reviewer aid for connecting recovered evidence rails to stable trait rubrics. It is not recovery authority, readiness proof, matrix proof, freshness proof, model-alignment evidence, or reinforcement-learning evidence.
+
+The appendix does not make doctrine authoritative and does not authorize commit or PR creation. Finalizer readiness and PR metadata guard readiness remain required before landing actions.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -116,3 +116,9 @@ The appendix may be pasted into PR bodies or operator logs, but doing so does no
 ## Beneficial trait doctrine map
 
 The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_doctrine.md) provides a static rubric for how existing validation and landing rails support reviewer-facing behavioral traits. It does not change this contract, add a gate, decide matrix success, authorize commits, or authorize PR metadata.
+
+### Doctrine context in evidence appendix
+
+The evidence appendix can optionally render beneficial-trait doctrine context by passing `--doctrine-map-json PATH` to `scripts/render_codex_landing_evidence_appendix.py`. This reads an already-built doctrine map JSON and adds deterministic reviewer tables for doctrine posture, trait catalog, rail-to-trait mappings, and trait-to-rails index.
+
+This appendix mode is review context only. It does not make doctrine authoritative, add a validation gate, decide matrix success, authorize commits, authorize PR creation, establish artifact freshness, infer model alignment, or claim reinforcement-learning outcomes. The finalizer and PR metadata guard remain the only landing authority for commit and PR metadata phases.

--- a/scripts/render_codex_landing_evidence_appendix.py
+++ b/scripts/render_codex_landing_evidence_appendix.py
@@ -21,6 +21,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", required=True)
     parser.add_argument("--evidence-index-json")
     parser.add_argument("--doctor-report-json")
+    parser.add_argument("--doctrine-map-json")
     parser.add_argument("--json-output")
     parser.add_argument("--summary", action="store_true")
     return parser
@@ -35,6 +36,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_index_json=args.evidence_index_json,
         doctor_report_json=args.doctor_report_json,
         json_output=args.json_output,
+        doctrine_map_json=args.doctrine_map_json,
     )
     try:
         markdown, metadata = build_landing_evidence_appendix(request)
@@ -45,7 +47,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json_output:
         write_landing_evidence_appendix_metadata(metadata, args.json_output)
     if args.summary:
-        print(json.dumps({"appendix_is_non_authoritative": True, "doctor_report_provided": metadata["doctor_report_provided"], "evidence_index_provided": metadata["evidence_index_provided"], "output": args.output}, sort_keys=True))
+        print(json.dumps({"appendix_is_non_authoritative": True, "doctor_report_provided": metadata["doctor_report_provided"], "evidence_index_provided": metadata["evidence_index_provided"], "doctrine_map_provided": metadata["doctrine_map_json_path"] is not None, "doctrine_trait_count": metadata["doctrine_trait_count"], "doctrine_rail_mapping_count": metadata["doctrine_rail_mapping_count"], "output": args.output}, sort_keys=True))
     return 0
 
 

--- a/sentientos/codex_landing_evidence_appendix.py
+++ b/sentientos/codex_landing_evidence_appendix.py
@@ -29,6 +29,7 @@ class CodexLandingEvidenceAppendixRequest:
     evidence_index_json: str | None = None
     doctor_report_json: str | None = None
     json_output: str | None = None
+    doctrine_map_json: str | None = None
 
 
 def _load_json_object(path_text: str, label: str) -> dict[str, Any]:
@@ -157,6 +158,93 @@ def _render_finalizer(lines: list[str], index: Mapping[str, Any] | None, doctor:
     lines.append("")
 
 
+def _doctrine_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _truthy_mapping_flags(mapping: Mapping[str, Any], keys: tuple[str, ...]) -> bool:
+    return all(mapping.get(key) is True for key in keys)
+
+
+def _render_doctrine(lines: list[str], doctrine: Mapping[str, Any] | None) -> None:
+    lines.append("## Beneficial Trait Doctrine")
+    if doctrine is None:
+        lines.append("Beneficial trait doctrine map JSON was not provided; no doctrine tables were rendered.")
+        lines.append("The appendix remains review context only and does not use doctrine as readiness authority.")
+        lines.append("")
+        return
+
+    posture = _as_mapping(doctrine.get("non_authority_posture"))
+    lines.append("### Doctrine posture")
+    for key in ("metadata_only", "doctrine_only", "not_model_training", "not_reinforcement_learning"):
+        _kv(lines, key, doctrine.get(key))
+    for key in sorted(posture):
+        _kv(lines, key, posture[key])
+    lines.append("")
+
+    lines.append("### Trait catalog summary")
+    lines.append("| trait_id | short definition |")
+    lines.append("| --- | --- |")
+    trait_catalog = _as_mapping(doctrine.get("trait_catalog"))
+    for trait_id in sorted(str(key) for key in trait_catalog):
+        lines.append(f"| {_cell(trait_id)} | {_cell(trait_catalog.get(trait_id))} |")
+    lines.append("")
+
+    lines.append("### Rail-to-trait summary")
+    lines.append("| rail_id | rail_name | enforced_traits | reviewer_summary |")
+    lines.append("| --- | --- | --- | --- |")
+    rails = [_as_mapping(item) for item in _doctrine_list(doctrine.get("rail_mappings"))]
+    for rail in sorted(rails, key=lambda item: _display(item.get("rail_id"))):
+        row = [rail.get("rail_id"), rail.get("rail_name"), rail.get("enforced_traits"), rail.get("reviewer_summary")]
+        lines.append("| " + " | ".join(_cell(value) for value in row) + " |")
+    lines.append("")
+
+    lines.append("### Trait-to-rails index")
+    lines.append("| trait_id | rails |")
+    lines.append("| --- | --- |")
+    trait_to_rails = _as_mapping(doctrine.get("trait_to_rails_index"))
+    for trait_id in sorted(str(key) for key in trait_to_rails):
+        lines.append(f"| {_cell(trait_id)} | {_cell(trait_to_rails.get(trait_id))} |")
+    lines.append("")
+
+    lines.append("### Doctrine boundary")
+    lines.append("- doctrine map explains existing rails")
+    lines.append("- doctrine map does not decide readiness")
+    lines.append("- doctrine map does not authorize commit")
+    lines.append("- doctrine map does not authorize PR creation")
+    lines.append("- doctrine map does not train or modify models")
+    lines.append("")
+
+
+def _doctrine_metadata(request: CodexLandingEvidenceAppendixRequest, doctrine: Mapping[str, Any] | None) -> dict[str, Any]:
+    trait_catalog = _as_mapping(doctrine.get("trait_catalog")) if doctrine is not None else {}
+    rails = [_as_mapping(item) for item in _doctrine_list(doctrine.get("rail_mappings"))] if doctrine is not None else []
+    posture = _as_mapping(doctrine.get("non_authority_posture")) if doctrine is not None else {}
+    return {
+        "appendix_does_not_use_doctrine_as_authority": True,
+        "appendix_renders_doctrine_as_review_context_only": True,
+        "doctrine_map_id": doctrine.get("doctrine_map_id") if doctrine is not None else None,
+        "doctrine_map_json_path": request.doctrine_map_json,
+        "doctrine_non_authority_posture_seen": _truthy_mapping_flags(
+            posture,
+            (
+                "doctrine_map_does_not_decide_readiness",
+                "doctrine_map_does_not_authorize_commit",
+                "doctrine_map_does_not_authorize_pr_creation",
+                "doctrine_map_does_not_train_or_modify_models",
+            ),
+        ),
+        "doctrine_rail_mapping_count": len(rails),
+        "doctrine_rails_rendered": [_display(rail.get("rail_id")) for rail in sorted(rails, key=lambda item: _display(item.get("rail_id")))],
+        "doctrine_trait_count": len(trait_catalog),
+        "doctrine_traits_rendered": sorted(str(key) for key in trait_catalog),
+    }
+
+
 def _render_test_provenance(lines: list[str], index: Mapping[str, Any] | None, doctor: Mapping[str, Any] | None) -> None:
     hints = _as_mapping(index.get("aggregate_hints")) if index is not None else {}
     provenance = _as_mapping(_doctor_summary(doctor, "test_provenance_summary"))
@@ -170,6 +258,7 @@ def _render_test_provenance(lines: list[str], index: Mapping[str, Any] | None, d
 def build_landing_evidence_appendix(request: CodexLandingEvidenceAppendixRequest) -> tuple[str, dict[str, Any]]:
     index = _load_json_object(request.evidence_index_json, "evidence_index_json") if request.evidence_index_json else None
     doctor = _load_json_object(request.doctor_report_json, "doctor_report_json") if request.doctor_report_json else None
+    doctrine = _load_json_object(request.doctrine_map_json, "doctrine_map_json") if request.doctrine_map_json else None
     lines = [
         "# Codex Landing Evidence Appendix",
         "",
@@ -189,6 +278,7 @@ def build_landing_evidence_appendix(request: CodexLandingEvidenceAppendixRequest
     _render_matrix(lines, index, doctor)
     _render_finalizer(lines, index, doctor)
     _render_test_provenance(lines, index, doctor)
+    _render_doctrine(lines, doctrine)
     lines.append("## Non-authority posture")
     for key in sorted(NON_AUTHORITY_POSTURE):
         _kv(lines, key, NON_AUTHORITY_POSTURE[key])
@@ -203,6 +293,7 @@ def build_landing_evidence_appendix(request: CodexLandingEvidenceAppendixRequest
         "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
         "output": request.output,
         "title": request.title,
+        **_doctrine_metadata(request, doctrine),
     }
     return "\n".join(lines), metadata
 

--- a/tests/test_codex_landing_evidence_appendix.py
+++ b/tests/test_codex_landing_evidence_appendix.py
@@ -133,3 +133,89 @@ def test_json_sidecar_output_is_deterministic_for_same_inputs(tmp_path: Path) ->
     _, first = _render(tmp_path, index=_index(), doctor=_doctor())
     _, second = _render(tmp_path, index=_index(), doctor=_doctor())
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def _doctrine() -> dict[str, object]:
+    return {
+        "doctrine_map_id": "doctrine.vtest",
+        "metadata_only": True,
+        "doctrine_only": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "trait_catalog": {
+            "a_trait": "Alpha | line\nbreak.",
+            "b_trait": "Beta definition.",
+        },
+        "rail_mappings": [
+            {"rail_id": "z_rail", "rail_name": "Z rail | name", "enforced_traits": ["b_trait"], "reviewer_summary": "Z summary\nline."},
+            {"rail_id": "a_rail", "rail_name": "A rail", "enforced_traits": ["a_trait", "b_trait"], "reviewer_summary": "A summary."},
+        ],
+        "trait_to_rails_index": {"b_trait": ["a_rail", "z_rail"], "a_trait": ["a_rail"]},
+        "non_authority_posture": {
+            "doctrine_map_does_not_decide_readiness": True,
+            "doctrine_map_does_not_authorize_commit": True,
+            "doctrine_map_does_not_authorize_pr_creation": True,
+            "doctrine_map_does_not_train_or_modify_models": True,
+        },
+    }
+
+
+def _render_with_doctrine(tmp_path: Path, doctrine: dict[str, object]) -> tuple[str, dict[str, object]]:
+    doctrine_path = _write(tmp_path / "doctrine.json", doctrine)
+    return build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, output=str(tmp_path / "out.md"), doctrine_map_json=doctrine_path))
+
+
+def test_appendix_renders_successfully_without_doctrine_map(tmp_path: Path) -> None:
+    markdown, metadata = _render(tmp_path)
+    assert "## Beneficial Trait Doctrine" in markdown
+    assert "Beneficial trait doctrine map JSON was not provided" in markdown
+    assert metadata["doctrine_map_json_path"] is None
+    assert metadata["appendix_does_not_use_doctrine_as_authority"] is True
+
+
+def test_appendix_renders_doctrine_section_when_map_is_supplied(tmp_path: Path) -> None:
+    markdown, metadata = _render_with_doctrine(tmp_path, _doctrine())
+    assert "### Doctrine posture" in markdown
+    assert "### Trait catalog summary" in markdown
+    assert "### Rail-to-trait summary" in markdown
+    assert "### Trait-to-rails index" in markdown
+    assert "doctrine map does not decide readiness" in markdown
+    assert metadata["doctrine_map_id"] == "doctrine.vtest"
+
+
+def test_invalid_doctrine_json_fails_cleanly(tmp_path: Path) -> None:
+    bad = _write(tmp_path / "bad_doctrine.json", "{")
+    with pytest.raises(CodexLandingEvidenceAppendixError, match="doctrine_map_json_invalid_json"):
+        build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, doctrine_map_json=bad))
+
+
+def test_missing_provided_doctrine_json_path_fails_cleanly(tmp_path: Path) -> None:
+    with pytest.raises(CodexLandingEvidenceAppendixError, match="doctrine_map_json_missing"):
+        build_landing_evidence_appendix(CodexLandingEvidenceAppendixRequest(TITLE, TITLE, doctrine_map_json=str(tmp_path / "missing_doctrine.json")))
+
+
+def test_doctrine_tables_are_deterministic_and_safely_escaped(tmp_path: Path) -> None:
+    markdown, _metadata = _render_with_doctrine(tmp_path, _doctrine())
+    assert "| a_trait | Alpha \\| line<br>break. |" in markdown
+    assert markdown.index("| a_rail | A rail") < markdown.index("| z_rail | Z rail \\| name")
+    assert "Z summary<br>line." in markdown
+    assert markdown.index("| a_trait | a_rail |") < markdown.index("| b_trait | a_rail, z_rail |")
+
+
+def test_doctrine_json_sidecar_fields_are_deterministic(tmp_path: Path) -> None:
+    _markdown, first = _render_with_doctrine(tmp_path, _doctrine())
+    _markdown, second = _render_with_doctrine(tmp_path, _doctrine())
+    assert first["doctrine_trait_count"] == 2
+    assert first["doctrine_rail_mapping_count"] == 2
+    assert first["doctrine_traits_rendered"] == ["a_trait", "b_trait"]
+    assert first["doctrine_rails_rendered"] == ["a_rail", "z_rail"]
+    assert first["doctrine_non_authority_posture_seen"] is True
+    assert first["appendix_renders_doctrine_as_review_context_only"] is True
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_appendix_output_does_not_include_doctrine_as_readiness_authority(tmp_path: Path) -> None:
+    markdown, metadata = _render_with_doctrine(tmp_path, _doctrine())
+    assert "does not use doctrine as readiness authority" not in markdown  # only absent from provided-map section
+    assert "doctrine map does not decide readiness" in markdown
+    assert metadata["appendix_does_not_use_doctrine_as_authority"] is True

--- a/tests/test_render_codex_landing_evidence_appendix_script.py
+++ b/tests/test_render_codex_landing_evidence_appendix_script.py
@@ -26,7 +26,7 @@ def test_cli_writes_markdown_json_sidecar_and_prints_compact_summary(tmp_path: P
     assert result.returncode == 0, result.stderr
     assert "# Codex Landing Evidence Appendix" in output.read_text(encoding="utf-8")
     assert json.loads(sidecar.read_text(encoding="utf-8"))["appendix_is_non_authoritative"] is True
-    assert json.loads(result.stdout) == {"appendix_is_non_authoritative": True, "doctor_report_provided": False, "evidence_index_provided": True, "output": str(output)}
+    assert json.loads(result.stdout) == {"appendix_is_non_authoritative": True, "doctor_report_provided": False, "evidence_index_provided": True, "doctrine_map_provided": False, "doctrine_trait_count": 0, "doctrine_rail_mapping_count": 0, "output": str(output)}
 
 
 def test_cli_failure_returns_exit_code_2_with_useful_message(tmp_path: Path) -> None:
@@ -39,4 +39,24 @@ def test_cli_failure_returns_exit_code_2_with_useful_message(tmp_path: Path) -> 
     )
     assert result.returncode == 2
     assert "codex_landing_evidence_appendix_error: evidence_index_json_missing" in result.stderr
+    assert not output.exists()
+
+
+def test_cli_accepts_doctrine_map_json_and_summary_mentions_intake(tmp_path: Path) -> None:
+    doctrine = tmp_path / "doctrine.json"
+    doctrine.write_text(json.dumps({"doctrine_map_id": "d", "metadata_only": True, "doctrine_only": True, "not_model_training": True, "not_reinforcement_learning": True, "trait_catalog": {"t": "definition"}, "rail_mappings": [{"rail_id": "r", "rail_name": "Rail", "enforced_traits": ["t"], "reviewer_summary": "summary"}], "trait_to_rails_index": {"t": ["r"]}, "non_authority_posture": {"doctrine_map_does_not_decide_readiness": True, "doctrine_map_does_not_authorize_commit": True, "doctrine_map_does_not_authorize_pr_creation": True, "doctrine_map_does_not_train_or_modify_models": True}}), encoding="utf-8")
+    output = tmp_path / "appendix.md"
+    sidecar = tmp_path / "appendix.json"
+    result = subprocess.run([sys.executable, "scripts/render_codex_landing_evidence_appendix.py", "--title", TITLE, "--intended-commit-title", TITLE, "--doctrine-map-json", str(doctrine), "--output", str(output), "--json-output", str(sidecar), "--summary"], check=False, text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    assert "## Beneficial Trait Doctrine" in output.read_text(encoding="utf-8")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["doctrine_map_json_path"] == str(doctrine)
+    assert json.loads(result.stdout)["doctrine_map_provided"] is True
+
+
+def test_cli_doctrine_json_failure_returns_exit_code_2_with_useful_message(tmp_path: Path) -> None:
+    output = tmp_path / "appendix.md"
+    result = subprocess.run([sys.executable, "scripts/render_codex_landing_evidence_appendix.py", "--title", TITLE, "--intended-commit-title", TITLE, "--doctrine-map-json", str(tmp_path / "missing_doctrine.json"), "--output", str(output)], check=False, text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "codex_landing_evidence_appendix_error: doctrine_map_json_missing" in result.stderr
     assert not output.exists()


### PR DESCRIPTION
### Motivation
- Provide reviewers a deterministic, metadata-only view that connects existing Codex landing/evidence rails to the beneficial-trait doctrine map without changing any landing authority semantics. 
- Keep the appendix read-only and non-authoritative so doctrine context can be shown for inspection but never used to decide readiness, run commands, or authorize commits/PR metadata.

### Description
- Add optional doctrine intake to the appendix request by extending `CodexLandingEvidenceAppendixRequest` with `doctrine_map_json` and loading it via the existing `_load_json_object` path so missing/invalid doctrine JSON fails cleanly with the same error handling. 
- Implement deterministic doctrine rendering via `_render_doctrine` (doctrine posture, trait catalog, rail-to-trait summary, trait-to-rails index, doctrine boundary) and supporting helpers, and include those sections in the markdown appendix when doctrine is supplied. 
- Extend JSON sidecar metadata with doctrine fields such as `doctrine_map_json_path`, `doctrine_map_id`, `doctrine_trait_count`, `doctrine_rail_mapping_count`, `doctrine_traits_rendered`, `doctrine_rails_rendered`, `doctrine_non_authority_posture_seen`, `appendix_renders_doctrine_as_review_context_only`, and `appendix_does_not_use_doctrine_as_authority`. 
- Add CLI flag `--doctrine-map-json` to `scripts/render_codex_landing_evidence_appendix.py` and extend `--summary` output to report doctrine intake/counts; update docs (`docs/development/codex_beneficial_trait_doctrine.md`, `docs/development/codex_finalize_landing.md`, `docs/development/codex_landing_evidence_recovery_rail.md`, `docs/development/codex_validation_and_landing_contract.md`) to explain the review-context-only posture. 
- Add and update focused tests to exercise omission, valid doctrine rendering, missing/invalid doctrine JSON failure, deterministic and escaped tables, and deterministic JSON sidecar fields.

### Testing
- Ran focused unit tests `python -m scripts.run_tests -q tests/test_codex_landing_evidence_appendix.py tests/test_render_codex_landing_evidence_appendix_script.py` and doctrine builder tests `tests/test_codex_beneficial_trait_doctrine.py tests/test_build_codex_beneficial_trait_doctrine_script.py`, all passing. 
- Built docs (bootstrapped dependencies when necessary) with `python scripts/build_docs.py` and ran `mypy` on the modified files, both succeeding. 
- Executed the full review matrix with `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json`, and ran the finalizer and PR metadata guard flows; matrix status was `passed`, the pre-commit finalizer returned `ready_to_commit`, the post-commit finalizer returned `ready_for_pr_metadata`, and the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38a35c6ac083208273b361923e5253)