### PR TITLE
[codex:architecture] define Codex workcell architecture

### DIFF
--- a/docs/development/codex_beneficial_trait_doctrine.md
+++ b/docs/development/codex_beneficial_trait_doctrine.md
@@ -78,3 +78,6 @@ Reviewers can use the map to understand what each rail is protecting. For exampl
 This rendering is review context only. The appendix does not make the doctrine map authoritative, does not decide readiness, does not authorize commit or PR creation, does not train or modify models, and does not rerun the doctrine builder or any validation command. Finalizer readiness and PR metadata guard readiness remain the only landing authorities for their respective phases.
 
 If `--json-output` is supplied, the appendix sidecar records raw-byte SHA-256 provenance for the doctrine map input alongside the evidence index and lifecycle doctor inputs, plus the rendered markdown digest and byte size. These digests are tamper-evidence for reviewer surfaces only and do not replace the doctrine map, evidence index, lifecycle doctor, finalizer, matrix, or PR metadata guard. The sidecar intentionally avoids a naive digest of its own final file so provenance does not depend on an impossible embedded self-reference.
+## Codex workcell architecture
+
+The [Codex Workcell Architecture](codex_workcell_architecture.md) positions this beneficial-trait doctrine map as a non-authoritative review surface inside the bounded Codex workcell. The doctrine map explains traits; it does not train models, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -185,3 +185,6 @@ The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_d
 The evidence appendix renderer may include static beneficial-trait context with `--doctrine-map-json PATH`, where `PATH` is JSON emitted by `scripts/build_codex_beneficial_trait_doctrine.py`. The renderer only reads that supplied JSON and renders the **Beneficial Trait Doctrine** section; it does not execute the doctrine builder, run validation, decide readiness, or create PR metadata.
 
 Doctrine rendering is reviewer context only. It explains which beneficial traits are connected to existing landing/evidence rails and how that context can be displayed beside evidence metadata. It does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed, whether artifacts are fresh, whether a model is aligned, or whether reinforcement learning succeeded. The finalizer and PR metadata guard remain the landing authorities.
+## Codex workcell architecture
+
+The [Codex Workcell Architecture](codex_workcell_architecture.md) places this finalizer inside the bounded SentientOS developer-workflow workcell. The architecture map is descriptive only: it preserves this finalizer as the only commit-readiness authority and does not add runtime authority, scheduling, execution, or new gates.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -177,3 +177,6 @@ The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_d
 For recovery review, `scripts/render_codex_landing_evidence_appendix.py --doctrine-map-json PATH` may render the static beneficial-trait doctrine map beside existing evidence appendix metadata. This is a compact reviewer aid for connecting recovered evidence rails to stable trait rubrics. It is not recovery authority, readiness proof, matrix proof, freshness proof, model-alignment evidence, or reinforcement-learning evidence.
 
 The appendix does not make doctrine authoritative and does not authorize commit or PR creation. Finalizer readiness and PR metadata guard readiness remain required before landing actions.
+## Codex workcell architecture
+
+The [Codex Workcell Architecture](codex_workcell_architecture.md) describes the recovery rail as part of a bounded evidence/review workcell. It does not make recovery evidence a landing authority; finalizer and PR metadata guard authority remain unchanged.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -124,3 +124,6 @@ The metadata-only [Codex beneficial trait doctrine map](codex_beneficial_trait_d
 The evidence appendix can optionally render beneficial-trait doctrine context by passing `--doctrine-map-json PATH` to `scripts/render_codex_landing_evidence_appendix.py`. This reads an already-built doctrine map JSON and adds deterministic reviewer tables for doctrine posture, trait catalog, rail-to-trait mappings, and trait-to-rails index.
 
 This appendix mode is review context only. It does not make doctrine authoritative, add a validation gate, decide matrix success, authorize commits, authorize PR creation, establish artifact freshness, infer model alignment, or claim reinforcement-learning outcomes. The finalizer and PR metadata guard remain the only landing authority for commit and PR metadata phases.
+## Codex workcell architecture
+
+The [Codex Workcell Architecture](codex_workcell_architecture.md) summarizes how validation, proof, review, doctrine, finalizer authority, PR metadata guard authority, and future ledger/glow/pulse/daemon/federation surfaces fit together. It is metadata-only doctrine and does not change this validation and landing contract.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -1,0 +1,93 @@
+# Codex Workcell Architecture
+
+The Codex Workcell Architecture defines Codex as a bounded SentientOS developer-workflow organ. It explains how user intent, task workspace, bootstrap scaffolding, focused proof, matrix proof, lifecycle interpretation, evidence indexing, appendix rendering, doctrine, provenance, finalizer authority, PR metadata authority, ledger, glow, pulse, daemon, vow, and federation surfaces fit together without creating runtime authority.
+
+This architecture is deterministic metadata and doctrine only. It does not execute commands, schedule work, invoke providers, train models, create new packets, create new readiness gates, authorize commits, authorize PR metadata, or decide whether evidence is fresh.
+
+## Component roles
+
+| Component | Role | Authority posture |
+| --- | --- | --- |
+| `user_intent_ingress` | Receives bounded human task intent and non-goals. | No landing authority. |
+| `codex_task_workspace` | Holds task-owned files, diagnostics, and local evidence. | Workspace context only. |
+| `bootstrap_scaffold` | Checks initial task shape and blocker posture. | Review scaffold; blocked bootstrap still stops implementation under existing doctrine. |
+| `focused_tests` | Produces targeted executable proof. | Proof signal only. |
+| `targeted_mypy` | Produces targeted typing proof. | Proof signal only. |
+| `review_packet_matrix` | Aggregates required and diagnostic proof lanes. | Proof signal only; never PR metadata authority. |
+| `codex_task_lifecycle_summary` | Summarizes lifecycle phase evidence. | Review surface only. |
+| `codex_lifecycle_doctor` | Interprets lifecycle and evidence-index posture. | Diagnostic review only. |
+| `codex_landing_evidence_index` | Catalogs evidence artifacts and artifact hints. | Catalog only. |
+| `codex_landing_evidence_appendix` | Renders evidence context for reviewers. | Review surface only. |
+| `codex_beneficial_trait_doctrine` | Explains beneficial-trait posture of landing rails. | Doctrine only; not model training. |
+| `appendix_provenance_sidecar` | Identifies appendix input bytes and digests. | Provenance only. |
+| `codex_finalize_landing` | Evaluates commit/pr-metadata phase readiness. | The only commit-readiness authority. |
+| `codex_pr_metadata_guard` | Authorizes PR metadata after finalizer and matrix evidence. | The only PR metadata authorization authority. |
+| `git_commit_boundary` | Represents the commit transition boundary. | It does not authorize itself. |
+| `pr_metadata_boundary` | Represents the PR metadata transition boundary. | It does not authorize itself. |
+| `sentientos_ledger` | Future receipt-chain history surface. | Future/archival only unless separately implemented. |
+| `glow_archive` | Future evidence memory and review archive. | Archival surface only. |
+| `pulse_monitor` | Future freshness, drift, timeout, and pressure signal surface. | Future signal only. |
+| `daemon_repair_substrate` | Future bounded repair-planning surface. | Recommendation only; no action authority. |
+| `vow_digest` | Future canonical constraint digest surface. | Future review only. |
+| `federation_consensus_boundary` | Future federated drift consensus boundary. | Future review only. |
+
+## Evidence, proof, review, and authority separation
+
+The workcell separates proof from interpretation and authority:
+
+1. User intent enters bootstrap and the task workspace.
+2. Focused tests and targeted mypy produce proof signals for changed surfaces.
+3. The review packet matrix classifies proof lanes and diagnostics.
+4. Lifecycle summary, lifecycle doctor, evidence index, appendix, doctrine, and provenance surfaces make evidence easier to review.
+5. Only `scripts/codex_finalize_landing.py` can return commit-readiness authority.
+6. Only `scripts/codex_pr_metadata_guard.py` can authorize PR metadata.
+
+Review surfaces are intentionally non-authoritative. They can summarize, catalog, explain, render, and identify evidence, but they cannot turn missing, stale, skipped, failed, diagnostic, or timed-out evidence into landing proof.
+
+## Finalizer and PR metadata guard remain the landing authorities
+
+The architecture map preserves existing landing doctrine:
+
+- The finalizer is the only commit-readiness authority.
+- The PR metadata guard is the only PR metadata authorization authority.
+- Matrix output is required proof context but not a PR metadata creator.
+- The lifecycle doctor interprets evidence but never decides readiness.
+- The evidence index catalogs artifacts but never verifies landing authority.
+- The evidence appendix renders review context but never authorizes state transition.
+- Beneficial-trait doctrine explains governance posture but never trains models or decides readiness.
+- Appendix provenance identifies bytes but never verifies authority.
+
+## SentientOS mount alignment
+
+| Mount | Alignment | Components |
+| --- | --- | --- |
+| `/vow` | Canonical constraints, vow digest, doctrine invariants. | `vow_digest`, `codex_beneficial_trait_doctrine` |
+| `/glow` | Archived evidence, landed receipts, review surfaces. | `glow_archive`, `codex_landing_evidence_appendix` |
+| `/pulse` | Freshness, drift, timeout, pressure, and rerun signals. | `pulse_monitor`, `codex_lifecycle_doctor` |
+| `/daemon` | Repair planning, bounded next-task generation, self-healing substrate. | `daemon_repair_substrate` |
+| `/ledger` | Tamper-evident landing history and receipt chain. | `sentientos_ledger` |
+
+These mounts are conceptual alignment points for whole-system review. They are not activated as runtime features by this architecture map.
+
+## Future integration points
+
+Future integration points are deliberately marked as future integration or review-only unless separately implemented:
+
+- Ledger receipt archival records authorized landing receipts after the fact.
+- Glow evidence memory archives review surfaces without deciding readiness.
+- Pulse stale-evidence watch surfaces freshness, drift, timeout, and pressure signals.
+- Daemon repair recommendation proposes bounded follow-up work without acting or scheduling.
+- Federation drift consensus surfaces cross-node drift context without overriding local authority.
+- Canonical vow digest checks compare doctrine constraints without replacing the finalizer or guard.
+- Workcell health snapshots summarize review posture without creating gates.
+- Operator cockpit rendering displays evidence and posture without adding runtime authority.
+
+## What this architecture answers
+
+Codex Workcell Architecture answers: how do the Codex proof, evidence, review, doctrine, authority, memory, pulse, daemon, and federation surfaces fit together as a bounded SentientOS workcell?
+
+It does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed, whether artifacts are fresh, whether a doctrine map is authority, whether a daemon should act, whether federation consensus has been reached, whether a model is aligned, or whether reinforcement-learning training succeeded.
+
+## Non-authority posture
+
+This architecture map is metadata-only, architecture-only, developer-workflow evidence-only, not runtime authority, not a scheduler, not an executor, not model training, and not reinforcement learning. It adds no provider calls, network calls, host actions, daemon actions, runtime packets, readiness decisions, or new gates.

--- a/scripts/build_codex_workcell_architecture.py
+++ b/scripts/build_codex_workcell_architecture.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+
+from sentientos.codex_workcell_architecture import (
+    build_codex_workcell_architecture,
+    render_codex_workcell_architecture_markdown,
+    write_codex_workcell_architecture_json,
+    write_codex_workcell_architecture_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build the metadata-only Codex workcell architecture map.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    architecture = build_codex_workcell_architecture()
+    write_codex_workcell_architecture_json(architecture, args.output)
+    if args.markdown_output:
+        write_codex_workcell_architecture_markdown(render_codex_workcell_architecture_markdown(architecture), args.markdown_output)
+    if args.summary:
+        print(
+            json.dumps(
+                {
+                    "workcell_architecture_id": architecture["workcell_architecture_id"],
+                    "metadata_only": True,
+                    "architecture_only": True,
+                    "output": args.output,
+                    "markdown_output": args.markdown_output,
+                    "component_count": len(architecture["components"]),
+                    "flow_count": len(architecture["flows"]),
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_architecture.py
+++ b/sentientos/codex_workcell_architecture.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_ARCHITECTURE_ID = "codex_workcell_architecture.v1"
+AUTHORITY_LEVELS = {"none", "review_only", "proof_signal", "transition_authority", "archival_surface", "future_integration"}
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "architecture_map_is_metadata_only": True,
+    "architecture_map_is_descriptive_only": True,
+    "architecture_map_does_not_decide_readiness": True,
+    "architecture_map_does_not_authorize_commit": True,
+    "architecture_map_does_not_authorize_pr_metadata": True,
+    "architecture_map_does_not_run_commands": True,
+    "architecture_map_does_not_schedule_work": True,
+    "architecture_map_does_not_execute_runtime_actions": True,
+    "architecture_map_does_not_train_or_modify_models": True,
+    "architecture_map_does_not_create_new_gates": True,
+}
+
+
+def _component(
+    component_id: str,
+    component_name: str,
+    role: str,
+    file_paths: list[str],
+    inputs: list[str],
+    outputs: list[str],
+    authority_level: str,
+    state_transition_power: bool,
+    non_authority_boundary: str,
+    failure_modes_prevented: list[str],
+    reviewer_summary: str,
+) -> dict[str, Any]:
+    if authority_level not in AUTHORITY_LEVELS:
+        raise ValueError(f"unknown_authority_level:{authority_level}")
+    return {
+        "component_id": component_id,
+        "component_name": component_name,
+        "role": role,
+        "file_paths": file_paths,
+        "inputs": inputs,
+        "outputs": outputs,
+        "authority_level": authority_level,
+        "state_transition_power": state_transition_power,
+        "non_authority_boundary": non_authority_boundary,
+        "failure_modes_prevented": failure_modes_prevented,
+        "reviewer_summary": reviewer_summary,
+    }
+
+
+_COMPONENTS: list[dict[str, Any]] = [
+    _component("user_intent_ingress", "User intent ingress", "Receives bounded human task intent and constraints.", [], ["operator prompt", "task title"], ["task scope", "declared non-goals"], "none", False, "Intent describes requested work but does not authorize landing or runtime action.", ["scope drift", "implicit authority expansion"], "Starting surface for bounded developer-workflow work."),
+    _component("codex_task_workspace", "Codex task workspace", "Holds task-owned files, diagnostics, and implementation context.", [], ["bootstrap scaffold", "repository state"], ["task-caused changes", "local evidence"], "none", False, "Workspace state is evidence context, not readiness authority.", ["lost task-owned files", "untracked evidence confusion"], "Recoverable local work area for the task."),
+    _component("bootstrap_scaffold", "Bootstrap scaffold", "Checks task shape and records initial readiness or blockers.", ["scripts/bootstrap_codex_task.py"], ["task name", "task goal", "declared paths"], ["bootstrap summary"], "review_only", False, "Bootstrap can block starting work, but this architecture map does not add new bootstrap gates.", ["unknown dirty tree", "unsupported task shape"], "Initial procedural scaffold for bounded work."),
+    _component("focused_tests", "Focused tests", "Provides targeted proof for changed behavior.", ["scripts/run_tests.py"], ["selected pytest files"], ["focused test result"], "proof_signal", False, "Focused tests provide proof signals only and cannot authorize commit or PR metadata.", ["claiming unexecuted tests as proof", "skipped test inflation"], "Targeted executable proof lane."),
+    _component("targeted_mypy", "Targeted mypy", "Checks typed surface for changed modules and CLIs.", [], ["selected Python paths"], ["targeted mypy result"], "proof_signal", False, "Type results are proof signals, not landing decisions.", ["typing regressions", "unreviewed CLI import drift"], "Targeted static typing proof lane."),
+    _component("review_packet_matrix", "Review packet matrix", "Aggregates required and diagnostic proof lanes for reviewer evidence.", ["scripts/run_work_item_review_packet_matrix.py"], ["repository state", "test lanes", "audit lanes"], ["matrix JSON"], "proof_signal", False, "Matrix supplies proof signals but does not create commits or PR metadata.", ["partial proof treated as full proof", "timed-out lanes hidden"], "Whole-work-item proof classifier."),
+    _component("codex_task_lifecycle_summary", "Codex task lifecycle summary", "Summarizes phase evidence across task lifecycle.", ["sentientos/codex_task_lifecycle_summary.py"], ["matrix JSON", "finalizer JSON"], ["lifecycle summary JSON"], "review_only", False, "Lifecycle summary is interpretive context and does not decide readiness.", ["phase evidence scattered", "reviewer misses blockers"], "Compact lifecycle review surface."),
+    _component("codex_lifecycle_doctor", "Codex lifecycle doctor", "Interprets landing evidence and names diagnostic posture.", ["sentientos/codex_lifecycle_doctor.py"], ["lifecycle summary", "evidence index"], ["doctor report"], "review_only", False, "Doctor interpretation is non-authoritative and cannot decide readiness.", ["unsafe next action ambiguity", "hidden missing evidence"], "Diagnostic interpreter for reviewers."),
+    _component("codex_landing_evidence_index", "Codex landing evidence index", "Catalogs landing artifacts and artifact hints.", ["sentientos/codex_landing_evidence_index.py"], ["artifact paths"], ["evidence index JSON"], "review_only", False, "Evidence index catalogs artifacts but does not verify landing authority.", ["lost artifact inventory", "unlabeled missing artifacts"], "Artifact catalog for review."),
+    _component("codex_landing_evidence_appendix", "Codex landing evidence appendix", "Renders reviewer-readable landing evidence context.", ["sentientos/codex_landing_evidence_appendix.py"], ["evidence index", "doctor report", "doctrine map"], ["evidence appendix markdown"], "review_only", False, "Appendix renders context but does not authorize state transition.", ["reviewer reconstructs context manually", "summary mistaken for authority"], "Human-readable evidence surface."),
+    _component("codex_beneficial_trait_doctrine", "Codex beneficial trait doctrine", "Explains beneficial-trait posture of landing rails.", ["sentientos/codex_beneficial_trait_doctrine.py"], ["existing rail catalog"], ["doctrine map"], "review_only", False, "Doctrine explains traits but does not train models or decide readiness.", ["doctrine overclaim", "model-training confusion"], "Static doctrine map for review."),
+    _component("appendix_provenance_sidecar", "Appendix provenance sidecar", "Identifies bytes and digests behind appendix inputs.", [], ["appendix input bytes"], ["provenance digests"], "review_only", False, "Provenance identifies bytes but does not verify authority.", ["opaque appendix inputs", "digest omission"], "Byte provenance surface."),
+    _component("codex_finalize_landing", "Codex finalize landing", "Evaluates commit/pr-metadata phase readiness under landing doctrine.", ["scripts/codex_finalize_landing.py"], ["matrix JSON", "focused tests", "targeted mypy", "changed files"], ["finalizer JSON"], "transition_authority", True, "Only this finalizer is commit-readiness authority; this architecture merely describes it.", ["commit before readiness", "stale evidence landing"], "Commit readiness authority for finalizer phases."),
+    _component("codex_pr_metadata_guard", "Codex PR metadata guard", "Authorizes PR metadata only after finalizer and matrix checks.", ["scripts/codex_pr_metadata_guard.py"], ["pre-commit finalizer", "pr-metadata finalizer", "matrix JSON"], ["guard summary"], "transition_authority", True, "Only this guard is PR metadata authorization authority; this architecture merely describes it.", ["PR metadata before readiness", "title contract drift"], "PR metadata boundary authority."),
+    _component("git_commit_boundary", "Git commit boundary", "Represents irreversible local commit transition after readiness.", [], ["ready_to_commit finalizer"], ["git commit"], "none", False, "The boundary is acted on by git/operator procedure, not by this map.", ["unreviewed commit transition"], "Commit transition boundary."),
+    _component("pr_metadata_boundary", "PR metadata boundary", "Represents PR metadata creation after guard readiness.", [], ["pr_metadata_guard_ready"], ["PR metadata"], "none", False, "The boundary does not authorize itself and this map cannot create PR metadata.", ["unguarded PR metadata"], "PR metadata transition boundary."),
+    _component("sentientos_ledger", "SentientOS ledger", "Future tamper-evident landing history and receipt chain surface.", [], ["landed receipts"], ["ledger records"], "future_integration", False, "Future integration surface unless separately implemented; not current authority.", ["receipt loss", "history opacity"], "Future ledger alignment."),
+    _component("glow_archive", "Glow archive", "Future/review archival memory for evidence and landed receipts.", [], ["evidence appendix", "receipts"], ["glow memory"], "archival_surface", False, "Archival surface does not decide readiness or execute work.", ["review surface loss", "evidence memory drift"], "Evidence memory alignment."),
+    _component("pulse_monitor", "Pulse monitor", "Future stale-evidence, drift, timeout, and pressure signal surface.", [], ["stale evidence hints", "timeouts"], ["pulse signals"], "future_integration", False, "Pulse signals may recommend review but do not authorize action.", ["stale evidence unnoticed", "timeout pressure hidden"], "Freshness and pressure alignment."),
+    _component("daemon_repair_substrate", "Daemon repair substrate", "Future bounded repair-planning and next-task recommendation surface.", [], ["pulse signals", "doctor diagnostics"], ["repair recommendations"], "future_integration", False, "Daemon substrate may recommend future tasks but must not act or schedule here.", ["unbounded self-healing", "autonomous action confusion"], "Future repair planning surface."),
+    _component("vow_digest", "Vow digest", "Future canonical constraint and doctrine invariant digest surface.", [], ["AGENTS.md", "development doctrine"], ["vow digest"], "future_integration", False, "Vow digest can describe constraints but does not replace finalizer or guard.", ["constraint drift", "doctrine mismatch"], "Canonical constraint alignment."),
+    _component("federation_consensus_boundary", "Federation consensus boundary", "Future drift consensus surface across federated review contexts.", [], ["federated drift reports"], ["consensus signals"], "future_integration", False, "Federation consensus is not reached or acted on by this map.", ["single-node drift overclaim", "unreviewed federation adoption"], "Future federation drift boundary."),
+]
+
+
+def _flow(flow_id: str, source: str, target: str, artifact: str, forbidden: str, authority: str, summary: str) -> dict[str, str]:
+    return {"flow_id": flow_id, "source_component": source, "target_component": target, "artifact_or_signal": artifact, "allowed_direction": f"{source} -> {target}", "forbidden_reverse_inference": forbidden, "authority_boundary": authority, "reviewer_summary": summary}
+
+
+_FLOWS: list[dict[str, str]] = [
+    _flow("intent_to_bootstrap", "user_intent_ingress", "bootstrap_scaffold", "task constraints", "Bootstrap output must not invent broader user intent.", "No landing authority.", "Intent enters procedural scaffold."),
+    _flow("bootstrap_to_task_workspace", "bootstrap_scaffold", "codex_task_workspace", "bootstrap summary", "Workspace edits cannot retroactively make blocked bootstrap ready.", "Blocked bootstrap stops work.", "Ready scaffold opens bounded workspace."),
+    _flow("task_workspace_to_focused_proof", "codex_task_workspace", "focused_tests", "changed files and selected tests", "Passing focused tests cannot prove untested workspace behavior.", "Proof signal only.", "Task changes receive focused proof."),
+    _flow("focused_proof_to_matrix", "focused_tests", "review_packet_matrix", "focused test result", "Matrix cannot convert skipped focused tests into executed proof.", "Proof signal only.", "Focused proof feeds matrix classification."),
+    _flow("matrix_to_finalizer", "review_packet_matrix", "codex_finalize_landing", "matrix JSON", "Finalizer readiness cannot be inferred from matrix alone.", "Finalizer remains commit-readiness authority.", "Matrix evidence is consumed by finalizer."),
+    _flow("matrix_to_lifecycle_summary", "review_packet_matrix", "codex_task_lifecycle_summary", "matrix status", "Lifecycle summary cannot upgrade matrix failures.", "Review only.", "Matrix posture is summarized."),
+    _flow("lifecycle_summary_to_doctor", "codex_task_lifecycle_summary", "codex_lifecycle_doctor", "lifecycle summary", "Doctor advice cannot rewrite source evidence.", "Review only.", "Doctor interprets lifecycle evidence."),
+    _flow("artifacts_to_evidence_index", "codex_task_workspace", "codex_landing_evidence_index", "artifact paths", "Index presence cannot imply artifact freshness or readiness.", "Review only.", "Artifacts are cataloged."),
+    _flow("index_doctor_doctrine_to_appendix", "codex_landing_evidence_index", "codex_landing_evidence_appendix", "index, doctor, doctrine context", "Appendix rendering cannot authorize state transition.", "Review only.", "Evidence context is rendered for reviewers."),
+    _flow("appendix_to_reviewer_surface", "codex_landing_evidence_appendix", "glow_archive", "review appendix", "Archive presence cannot imply readiness.", "Archival/review only.", "Appendix can be archived as review surface."),
+    _flow("finalizer_to_commit_boundary", "codex_finalize_landing", "git_commit_boundary", "ready_to_commit", "A commit cannot prove finalizer readiness after the fact.", "Finalizer is only commit-readiness authority.", "Commit boundary follows finalizer readiness."),
+    _flow("pr_metadata_finalizer_to_guard", "codex_finalize_landing", "codex_pr_metadata_guard", "ready_for_pr_metadata", "Guard readiness cannot be inferred without pr-metadata finalizer evidence.", "Guard remains PR metadata authority.", "Finalizer evidence feeds guard."),
+    _flow("guard_to_pr_metadata_boundary", "codex_pr_metadata_guard", "pr_metadata_boundary", "pr_metadata_guard_ready", "PR metadata cannot retroactively authorize itself.", "Guard is only PR metadata authorization authority.", "PR metadata boundary follows guard readiness."),
+    _flow("landed_receipts_to_ledger", "pr_metadata_boundary", "sentientos_ledger", "landed receipts", "Ledger entries cannot authorize the prior landing.", "Future archival surface.", "Receipts may be ledgered in future integration."),
+    _flow("evidence_to_glow_archive", "codex_landing_evidence_appendix", "glow_archive", "evidence review surface", "Glow memory cannot decide readiness.", "Archival surface.", "Evidence can align with glow memory."),
+    _flow("stale_or_pressure_signal_to_pulse", "codex_lifecycle_doctor", "pulse_monitor", "stale or pressure signal", "Pulse cannot make stale evidence fresh.", "Future signal surface.", "Diagnostics may inform pulse."),
+    _flow("pulse_to_daemon_repair_recommendation", "pulse_monitor", "daemon_repair_substrate", "repair pressure signal", "Daemon recommendation cannot execute itself.", "Future recommendation only.", "Pulse may inform bounded repair planning."),
+    _flow("daemon_to_future_codex_task", "daemon_repair_substrate", "user_intent_ingress", "future task recommendation", "Recommendation cannot become user consent or scheduling authority.", "Future/review only.", "Repair recommendations return through human intent ingress."),
+    _flow("federation_consensus_to_drift_control", "federation_consensus_boundary", "vow_digest", "drift consensus signal", "Consensus signal cannot override canonical local authority.", "Future integration only.", "Federation signals may inform drift review."),
+]
+
+AUTHORITY_BOUNDARIES: list[str] = [
+    "codex_finalize_landing is the only commit-readiness authority.",
+    "codex_pr_metadata_guard is the only PR metadata authorization authority.",
+    "review_packet_matrix supplies proof signals but does not create PR metadata.",
+    "codex_lifecycle_doctor interprets evidence but does not decide readiness.",
+    "codex_landing_evidence_index catalogs artifacts but does not verify landing authority.",
+    "codex_landing_evidence_appendix renders review context but does not authorize state transition.",
+    "codex_beneficial_trait_doctrine explains traits but does not train models or decide readiness.",
+    "appendix_provenance_sidecar identifies bytes but does not verify authority.",
+    "ledger/glow/pulse/daemon/federation integration points are future surfaces unless separately implemented.",
+]
+
+SENTIENTOS_MOUNT_ALIGNMENT: dict[str, dict[str, Any]] = {
+    "/daemon": {"purpose": "repair planning, bounded next-task generation, self-healing substrate", "components": ["daemon_repair_substrate"]},
+    "/glow": {"purpose": "archived evidence, landed receipts, review surfaces", "components": ["glow_archive", "codex_landing_evidence_appendix"]},
+    "/ledger": {"purpose": "tamper-evident landing history and receipt chain", "components": ["sentientos_ledger"]},
+    "/pulse": {"purpose": "freshness, drift, timeout, pressure, and rerun signals", "components": ["pulse_monitor", "codex_lifecycle_doctor"]},
+    "/vow": {"purpose": "canonical constraints, vow digest, doctrine invariants", "components": ["vow_digest", "codex_beneficial_trait_doctrine"]},
+}
+
+FUTURE_INTEGRATION_POINTS: list[dict[str, str]] = [
+    {"integration_id": "canonical_vow_digest_checks", "status": "future_integration", "authority_posture": "review_only", "description": "Compare current doctrine constraints against canonical vow digests without replacing finalizer or guard authority."},
+    {"integration_id": "daemon_repair_recommendation", "status": "future_integration", "authority_posture": "review_only", "description": "Recommend bounded follow-up repair tasks without scheduling or executing them."},
+    {"integration_id": "federation_drift_consensus", "status": "future_integration", "authority_posture": "review_only", "description": "Surface federated drift signals for review without adopting external authority."},
+    {"integration_id": "glow_evidence_memory", "status": "future_integration", "authority_posture": "archival_surface", "description": "Archive evidence and review surfaces as memory without deciding readiness."},
+    {"integration_id": "ledger_receipt_archival", "status": "future_integration", "authority_posture": "archival_surface", "description": "Record landed receipts after authorized transitions without authorizing them."},
+    {"integration_id": "operator_cockpit_rendering", "status": "future_integration", "authority_posture": "review_only", "description": "Render workcell health and evidence to operators without introducing new gates."},
+    {"integration_id": "pulse_stale_evidence_watch", "status": "future_integration", "authority_posture": "review_only", "description": "Watch for stale evidence and timeout pressure as signals, not readiness decisions."},
+    {"integration_id": "workcell_health_snapshot", "status": "future_integration", "authority_posture": "review_only", "description": "Summarize workcell health for reviewers without runtime execution or scheduling."},
+]
+
+
+def build_codex_workcell_architecture() -> dict[str, Any]:
+    components = sorted((dict(component) for component in _COMPONENTS), key=lambda item: item["component_id"])
+    flows = sorted((dict(flow) for flow in _FLOWS), key=lambda item: item["flow_id"])
+    known = {component["component_id"] for component in components}
+    for flow in flows:
+        if flow["source_component"] not in known or flow["target_component"] not in known:
+            raise ValueError(f"unknown_flow_component:{flow['flow_id']}")
+    return {
+        "workcell_architecture_id": WORKCELL_ARCHITECTURE_ID,
+        "metadata_only": True,
+        "architecture_only": True,
+        "developer_workflow_evidence_only": True,
+        "not_runtime_authority": True,
+        "not_scheduler": True,
+        "not_executor": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "components": components,
+        "flows": flows,
+        "authority_boundaries": list(AUTHORITY_BOUNDARIES),
+        "sentientos_mount_alignment": dict(sorted(SENTIENTOS_MOUNT_ALIGNMENT.items())),
+        "future_integration_points": sorted((dict(item) for item in FUTURE_INTEGRATION_POINTS), key=lambda item: item["integration_id"]),
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def render_codex_workcell_architecture_markdown(architecture: Mapping[str, Any] | None = None) -> str:
+    payload = architecture or build_codex_workcell_architecture()
+    lines = [
+        "# Codex Workcell Architecture",
+        "",
+        "Codex is described here as a bounded SentientOS developer-workflow workcell: ingress, workspace, proof, interpretation, review, authority, memory, pulse, daemon, and federation surfaces remain separated. This map is metadata-only architecture doctrine, not runtime authority.",
+        "",
+        "## Components",
+        "| component_id | authority_level | state_transition_power | reviewer_summary |",
+        "| --- | --- | --- | --- |",
+    ]
+    for component in payload["components"]:
+        lines.append(f"| {component['component_id']} | {component['authority_level']} | {'true' if component['state_transition_power'] else 'false'} | {component['reviewer_summary']} |")
+    lines.extend(["", "## Flows", "| flow_id | source | target | authority_boundary |", "| --- | --- | --- | --- |"])
+    for flow in payload["flows"]:
+        lines.append(f"| {flow['flow_id']} | {flow['source_component']} | {flow['target_component']} | {flow['authority_boundary']} |")
+    lines.extend(["", "## Authority boundaries"])
+    for boundary in payload["authority_boundaries"]:
+        lines.append(f"- {boundary}")
+    lines.extend(["", "## SentientOS mount alignment"])
+    for mount, details in payload["sentientos_mount_alignment"].items():
+        lines.append(f"- **{mount}:** {details['purpose']} ({', '.join(details['components'])})")
+    lines.extend(["", "## Future integration"])
+    for item in payload["future_integration_points"]:
+        lines.append(f"- **{item['integration_id']}** ({item['status']}, {item['authority_posture']}): {item['description']}")
+    lines.extend(["", "## Non-authority posture"])
+    for key, value in payload["non_authority_posture"].items():
+        lines.append(f"- **{key}:** {'true' if value else 'false'}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_architecture_json(architecture: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(architecture, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_architecture_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_architecture_script.py
+++ b/tests/test_build_codex_workcell_architecture_script.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from scripts.build_codex_workcell_architecture import main
+
+
+def test_cli_writes_json_and_prints_compact_summary(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output = tmp_path / "codex_workcell_architecture.json"
+    assert main(["--output", str(output), "--summary"]) == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(capsys.readouterr().out)
+    assert payload["metadata_only"] is True
+    assert payload["architecture_only"] is True
+    assert summary["output"] == str(output)
+    assert summary["metadata_only"] is True
+    assert summary["component_count"] >= 22
+    assert summary["flow_count"] >= 19
+
+
+def test_cli_writes_markdown_when_requested(tmp_path: Path) -> None:
+    output = tmp_path / "codex_workcell_architecture.json"
+    markdown_output = tmp_path / "codex_workcell_architecture.md"
+    assert main(["--output", str(output), "--markdown-output", str(markdown_output)]) == 0
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert markdown.startswith("# Codex Workcell Architecture")
+    assert "## Components" in markdown
+    assert "## Non-authority posture" in markdown

--- a/tests/test_codex_workcell_architecture.py
+++ b/tests/test_codex_workcell_architecture.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_architecture import build_codex_workcell_architecture, render_codex_workcell_architecture_markdown
+
+REQUIRED_COMPONENTS = {
+    "user_intent_ingress", "codex_task_workspace", "bootstrap_scaffold", "focused_tests", "targeted_mypy",
+    "review_packet_matrix", "codex_task_lifecycle_summary", "codex_lifecycle_doctor", "codex_landing_evidence_index",
+    "codex_landing_evidence_appendix", "codex_beneficial_trait_doctrine", "appendix_provenance_sidecar",
+    "codex_finalize_landing", "codex_pr_metadata_guard", "git_commit_boundary", "pr_metadata_boundary",
+    "sentientos_ledger", "glow_archive", "pulse_monitor", "daemon_repair_substrate", "vow_digest",
+    "federation_consensus_boundary",
+}
+
+REQUIRED_FLOWS = {
+    "intent_to_bootstrap", "bootstrap_to_task_workspace", "task_workspace_to_focused_proof", "focused_proof_to_matrix",
+    "matrix_to_finalizer", "matrix_to_lifecycle_summary", "lifecycle_summary_to_doctor", "artifacts_to_evidence_index",
+    "index_doctor_doctrine_to_appendix", "appendix_to_reviewer_surface", "finalizer_to_commit_boundary",
+    "pr_metadata_finalizer_to_guard", "guard_to_pr_metadata_boundary", "landed_receipts_to_ledger",
+    "evidence_to_glow_archive", "stale_or_pressure_signal_to_pulse", "pulse_to_daemon_repair_recommendation",
+    "daemon_to_future_codex_task", "federation_consensus_to_drift_control",
+}
+
+REQUIRED_NON_AUTHORITY = {
+    "architecture_map_is_metadata_only", "architecture_map_is_descriptive_only", "architecture_map_does_not_decide_readiness",
+    "architecture_map_does_not_authorize_commit", "architecture_map_does_not_authorize_pr_metadata",
+    "architecture_map_does_not_run_commands", "architecture_map_does_not_schedule_work",
+    "architecture_map_does_not_execute_runtime_actions", "architecture_map_does_not_train_or_modify_models",
+    "architecture_map_does_not_create_new_gates",
+}
+
+
+def _components_by_id() -> dict[str, dict[str, object]]:
+    return {component["component_id"]: component for component in build_codex_workcell_architecture()["components"]}
+
+
+def test_all_required_component_ids_are_present() -> None:
+    assert REQUIRED_COMPONENTS <= set(_components_by_id())
+
+
+def test_all_required_flow_ids_are_present() -> None:
+    architecture = build_codex_workcell_architecture()
+    assert REQUIRED_FLOWS <= {flow["flow_id"] for flow in architecture["flows"]}
+
+
+def test_every_flow_references_known_components() -> None:
+    architecture = build_codex_workcell_architecture()
+    known = {component["component_id"] for component in architecture["components"]}
+    for flow in architecture["flows"]:
+        assert flow["source_component"] in known
+        assert flow["target_component"] in known
+
+
+def test_finalizer_and_guard_are_only_transition_authority_components() -> None:
+    transition_components = {component["component_id"] for component in build_codex_workcell_architecture()["components"] if component["authority_level"] == "transition_authority"}
+    assert transition_components == {"codex_finalize_landing", "codex_pr_metadata_guard"}
+
+
+def test_review_surfaces_do_not_have_state_transition_power() -> None:
+    for component in build_codex_workcell_architecture()["components"]:
+        if component["authority_level"] in {"review_only", "archival_surface", "proof_signal", "future_integration"}:
+            assert component["state_transition_power"] is False
+
+
+def test_interpretive_and_catalog_surfaces_are_non_authoritative() -> None:
+    components = _components_by_id()
+    for component_id in {"codex_beneficial_trait_doctrine", "codex_landing_evidence_appendix", "appendix_provenance_sidecar", "codex_lifecycle_doctor", "codex_landing_evidence_index"}:
+        assert components[component_id]["state_transition_power"] is False
+        assert components[component_id]["authority_level"] == "review_only"
+
+
+def test_sentientos_mount_alignment_contains_required_mounts() -> None:
+    alignment = build_codex_workcell_architecture()["sentientos_mount_alignment"]
+    assert {"/vow", "/glow", "/pulse", "/daemon", "/ledger"} <= set(alignment)
+
+
+def test_future_integration_points_are_not_active_authority() -> None:
+    architecture = build_codex_workcell_architecture()
+    for point in architecture["future_integration_points"]:
+        assert point["status"] == "future_integration"
+        assert point["authority_posture"] in {"review_only", "archival_surface"}
+        assert point["authority_posture"] != "transition_authority"
+
+
+def test_output_json_is_deterministic_for_same_inputs() -> None:
+    first = json.dumps(build_codex_workcell_architecture(), sort_keys=True)
+    second = json.dumps(build_codex_workcell_architecture(), sort_keys=True)
+    assert first == second
+
+
+def test_markdown_output_is_deterministic() -> None:
+    first = render_codex_workcell_architecture_markdown()
+    second = render_codex_workcell_architecture_markdown()
+    assert first == second
+    assert first.startswith("# Codex Workcell Architecture")
+
+
+def test_non_authority_posture_fields_are_present_and_true() -> None:
+    posture = build_codex_workcell_architecture()["non_authority_posture"]
+    assert REQUIRED_NON_AUTHORITY <= set(posture)
+    assert all(posture[key] is True for key in REQUIRED_NON_AUTHORITY)
+
+
+def test_top_level_non_authority_flags_are_true() -> None:
+    architecture = build_codex_workcell_architecture()
+    for key in ["metadata_only", "architecture_only", "developer_workflow_evidence_only", "not_runtime_authority", "not_scheduler", "not_executor", "not_model_training", "not_reinforcement_learning"]:
+        assert architecture[key] is True


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only architecture map that defines Codex as a bounded SentientOS developer-workflow workcell and clarifies ingress, proof, interpretation, review, authority, ledger, memory, pulse, daemon, and federation surfaces. 
- Preserve existing landing doctrine: do not add runtime authority, scheduling, execution, model training, new gates, or readiness decisions, and make explicit the finalizer and PR-metadata guard as the only landing authorities.

### Description

- Add a deterministic architecture module `sentientos/codex_workcell_architecture.py` that emits JSON/markdown describing components, flows, authority boundaries, SentientOS mount alignment, future integration points, and non-authority posture flags. 
- Add a CLI `scripts/build_codex_workcell_architecture.py` with `--output`, optional `--markdown-output`, and `--summary` to write deterministic JSON and optional markdown. 
- Add documentation `docs/development/codex_workcell_architecture.md` and link the architecture map into the finalizer, recovery rail, validation-and-landing-contract, and beneficial-trait doctrine docs to position the map as non-authoritative review context. 
- Add focused tests (`tests/test_codex_workcell_architecture.py`, `tests/test_build_codex_workcell_architecture_script.py`) that validate presence of required component and flow IDs, reference consistency, exclusive transition authorities, non-authority posture, deterministic output, CLI behavior, and SentientOS mount alignment.

### Testing

- Bootstrap run returned `ready_with_warnings` and the task bootstrap summary was produced. 
- Focused tests for the new module and CLI passed: `python -m scripts.run_tests -q tests/test_codex_workcell_architecture.py tests/test_build_codex_workcell_architecture_script.py`. 
- Adjacent Codex lanes and validation checks ran and passed, including evidence appendix, beneficial-trait doctrine, evidence index, lifecycle doctor tests, prompt-boundary scan, and docs build (docs bootstrap performed when needed). 
- Full review packet matrix ran to completion (`/tmp/work_item_review_packet_matrix.json`) and passed; finalizer/guard validation completed with the finalizer reporting readiness for commit phases and the PR metadata guard reporting readiness for PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39d7dbe880832fa45976dc8d894d63)