### PR TITLE
[codex:architecture] add Codex workcell health snapshot

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -188,3 +188,7 @@ Doctrine rendering is reviewer context only. It explains which beneficial traits
 ## Codex workcell architecture
 
 The [Codex Workcell Architecture](codex_workcell_architecture.md) places this finalizer inside the bounded SentientOS developer-workflow workcell. The architecture map is descriptive only: it preserves this finalizer as the only commit-readiness authority and does not add runtime authority, scheduling, execution, or new gates.
+
+## Health snapshot boundary
+
+The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) may render supplied finalizer statuses as observed evidence, but it does not create `ready_to_commit`, `ready_for_pr_metadata`, or any other readiness decision. Finalizer authority remains here.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -180,3 +180,7 @@ The appendix does not make doctrine authoritative and does not authorize commit 
 ## Codex workcell architecture
 
 The [Codex Workcell Architecture](codex_workcell_architecture.md) describes the recovery rail as part of a bounded evidence/review workcell. It does not make recovery evidence a landing authority; finalizer and PR metadata guard authority remain unchanged.
+
+## Health snapshot observation surface
+
+The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) can summarize supplied recovery/evidence metadata for reviewers. It is an observation surface only and cannot recover files, refresh stale evidence, trigger repair, or authorize landing.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -127,3 +127,7 @@ This appendix mode is review context only. It does not make doctrine authoritati
 ## Codex workcell architecture
 
 The [Codex Workcell Architecture](codex_workcell_architecture.md) summarizes how validation, proof, review, doctrine, finalizer authority, PR metadata guard authority, and future ledger/glow/pulse/daemon/federation surfaces fit together. It is metadata-only doctrine and does not change this validation and landing contract.
+
+## Health snapshot is not a landing gate
+
+The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) is a cockpit/vitals rendering of supplied metadata artifacts. It is not a validation lane, readiness gate, finalizer replacement, PR metadata guard replacement, or authority source.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -91,3 +91,7 @@ It does not answer whether a change may commit, whether PR metadata may be creat
 ## Non-authority posture
 
 This architecture map is metadata-only, architecture-only, developer-workflow evidence-only, not runtime authority, not a scheduler, not an executor, not model training, and not reinforcement learning. It adds no provider calls, network calls, host actions, daemon actions, runtime packets, readiness decisions, or new gates.
+
+## Health snapshot relationship
+
+The Codex Workcell Architecture answers “How do the workcell organs and flows fit together?” The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) answers “What is currently observable about the workcell from supplied metadata artifacts?” The health snapshot may consume architecture JSON, but it remains cockpit/vitals observation only and does not add authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -1,0 +1,39 @@
+# Codex Workcell Health Snapshot
+
+The Codex Workcell Health Snapshot is a deterministic, metadata-only cockpit/vitals layer for the Codex developer-workflow workcell. It answers: **What is currently observable about the workcell from supplied metadata artifacts?** It reads optional JSON artifacts and renders a compact JSON snapshot plus optional Markdown for reviewers.
+
+It is not authority. It does not run commands, create gates, schedule tasks, trigger daemons, authorize commits, authorize PR metadata, call providers, use the network, or train/modify models.
+
+## Inputs and outputs
+
+`scripts/build_codex_workcell_health_snapshot.py` accepts `--output` and optional `--markdown-output`, plus optional JSON inputs for architecture, matrix, pre-commit finalizer, PR-metadata finalizer, PR metadata guard, lifecycle summary, lifecycle doctor, evidence index, evidence appendix sidecar, and beneficial trait doctrine map.
+
+The builder only reads paths supplied to those input flags. Missing optional inputs are recorded as not provided. A supplied path that is missing or invalid JSON fails cleanly before a successful snapshot is written.
+
+## Difference from adjacent artifacts
+
+- The Codex Workcell Architecture answers: **How do the workcell organs and flows fit together?**
+- The health snapshot answers: **What is currently observable about the workcell from supplied metadata artifacts?**
+- The review packet matrix remains proof-signal evidence; the snapshot only summarizes observed matrix fields.
+- `codex_finalize_landing.py` remains commit/pr-metadata phase authority; the snapshot only displays provided finalizer statuses as observed evidence.
+- `codex_pr_metadata_guard.py` remains PR metadata authority; the snapshot only displays the supplied guard status.
+- The lifecycle doctor interprets lifecycle evidence; the snapshot summarizes the supplied doctor report without replacing it.
+- The evidence index catalogs artifacts; the snapshot summarizes supplied catalog fields.
+- The evidence appendix renders reviewer context; the snapshot can reference appendix sidecar provenance without verifying authority.
+- The beneficial trait doctrine map explains doctrine posture; the snapshot summarizes that map as doctrine-only and not model training.
+
+## SentientOS mount relationship
+
+The snapshot renders a mount view for `/vow`, `/glow`, `/pulse`, `/daemon`, and `/ledger`. When architecture JSON is supplied, mount summaries are observed from the architecture map. Without architecture JSON, the snapshot uses static conceptual mount categories and marks them as not provided.
+
+- `/vow`: doctrine and constraint observations.
+- `/glow`: evidence memory and rendered review-surface observations.
+- `/pulse`: stale-evidence, diagnostic, and pressure observations.
+- `/daemon`: repair-recommendation context only, never daemon action.
+- `/ledger`: receipt/provenance context only, never landing authority.
+
+## Non-authority posture
+
+The snapshot does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed as a new decision, whether artifacts are fresh as a new decision, whether a daemon should act, whether federation consensus has been reached, whether a model is aligned, or whether reinforcement-learning training succeeded.
+
+Its recommendations are phrased as observation recommendations only, such as supplying architecture JSON for fuller component/flow context or supplying appendix sidecar JSON for rendered-surface provenance.

--- a/scripts/build_codex_workcell_health_snapshot.py
+++ b/scripts/build_codex_workcell_health_snapshot.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_health_snapshot import (
+    CodexWorkcellHealthSnapshotError,
+    CodexWorkcellHealthSnapshotRequest,
+    build_codex_workcell_health_snapshot,
+    render_codex_workcell_health_snapshot_markdown,
+    write_codex_workcell_health_snapshot_json,
+    write_codex_workcell_health_snapshot_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell health snapshot from supplied JSON artifacts.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    for arg in ("architecture-json", "matrix-json", "pre-commit-finalizer-json", "pr-metadata-finalizer-json", "pr-metadata-guard-json", "lifecycle-summary-json", "lifecycle-doctor-json", "evidence-index-json", "evidence-appendix-sidecar-json", "beneficial-trait-doctrine-json"):
+        parser.add_argument(f"--{arg}")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        snapshot = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(
+            architecture_json=args.architecture_json,
+            matrix_json=args.matrix_json,
+            pre_commit_finalizer_json=args.pre_commit_finalizer_json,
+            pr_metadata_finalizer_json=args.pr_metadata_finalizer_json,
+            pr_metadata_guard_json=args.pr_metadata_guard_json,
+            lifecycle_summary_json=args.lifecycle_summary_json,
+            lifecycle_doctor_json=args.lifecycle_doctor_json,
+            evidence_index_json=args.evidence_index_json,
+            evidence_appendix_sidecar_json=args.evidence_appendix_sidecar_json,
+            beneficial_trait_doctrine_json=args.beneficial_trait_doctrine_json,
+        ))
+    except CodexWorkcellHealthSnapshotError as exc:
+        print(f"codex_workcell_health_snapshot_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_health_snapshot_json(snapshot, args.output)
+    if args.markdown_output:
+        write_codex_workcell_health_snapshot_markdown(render_codex_workcell_health_snapshot_markdown(snapshot), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"workcell_health_snapshot_id": snapshot["workcell_health_snapshot_id"], "metadata_only": True, "cockpit_snapshot_only": True, "output": args.output, "markdown_output": args.markdown_output, "supplied_input_count": snapshot["provenance_summary"]["input_digest_count"], "missing_input_count": len(snapshot["missing_inputs"]), "pressure_signal_count": len(snapshot["observed_pressure_signals"])}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_health_snapshot.py
+++ b/sentientos/codex_workcell_health_snapshot.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_HEALTH_SNAPSHOT_ID = "codex_workcell_health_snapshot.v1"
+DIGEST_ALGO = "sha256"
+INPUT_IDS: tuple[str, ...] = (
+    "architecture_json",
+    "matrix_json",
+    "pre_commit_finalizer_json",
+    "pr_metadata_finalizer_json",
+    "pr_metadata_guard_json",
+    "lifecycle_summary_json",
+    "lifecycle_doctor_json",
+    "evidence_index_json",
+    "evidence_appendix_sidecar_json",
+    "beneficial_trait_doctrine_json",
+)
+MOUNTS = ("/vow", "/glow", "/pulse", "/daemon", "/ledger")
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "health_snapshot_is_read_only": True,
+    "health_snapshot_is_metadata_only": True,
+    "health_snapshot_does_not_rerun_commands": True,
+    "health_snapshot_does_not_decide_readiness": True,
+    "health_snapshot_does_not_bypass_finalizer": True,
+    "health_snapshot_does_not_bypass_pr_metadata_guard": True,
+    "health_snapshot_does_not_authorize_commit": True,
+    "health_snapshot_does_not_authorize_pr_creation": True,
+    "health_snapshot_does_not_trigger_daemon": True,
+    "health_snapshot_does_not_schedule_tasks": True,
+    "health_snapshot_does_not_train_or_modify_models": True,
+    "health_snapshot_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellHealthSnapshotError(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class CodexWorkcellHealthSnapshotRequest:
+    architecture_json: str | None = None
+    matrix_json: str | None = None
+    pre_commit_finalizer_json: str | None = None
+    pr_metadata_finalizer_json: str | None = None
+    pr_metadata_guard_json: str | None = None
+    lifecycle_summary_json: str | None = None
+    lifecycle_doctor_json: str | None = None
+    evidence_index_json: str | None = None
+    evidence_appendix_sidecar_json: str | None = None
+    beneficial_trait_doctrine_json: str | None = None
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _read_input(input_id: str, path_text: str | None) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    record = {"input_id": input_id, "provided": bool(path_text), "path": path_text, "readable_json": False, "digest_algo": DIGEST_ALGO, "digest": None, "byte_size": None, "error": None}
+    if not path_text:
+        return record, None
+    path = Path(path_text)
+    if not path.exists():
+        record["error"] = f"missing_json:{input_id}:{path_text}"
+        raise CodexWorkcellHealthSnapshotError(str(record["error"]))
+    raw = path.read_bytes()
+    record["digest"] = _sha256(raw)
+    record["byte_size"] = len(raw)
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        record["error"] = f"invalid_json:{input_id}:{path_text}:{exc}"
+        raise CodexWorkcellHealthSnapshotError(str(record["error"])) from exc
+    if not isinstance(loaded, dict):
+        record["error"] = f"json_not_object:{input_id}:{path_text}"
+        raise CodexWorkcellHealthSnapshotError(str(record["error"]))
+    record["readable_json"] = True
+    return record, loaded
+
+
+def _status(payload: Mapping[str, Any] | None, *keys: str) -> str | None:
+    if payload is None:
+        return None
+    for key in keys:
+        val = payload.get(key)
+        if isinstance(val, str):
+            return val
+    dec = payload.get("decision")
+    if isinstance(dec, Mapping) and isinstance(dec.get("status"), str):
+        return str(dec["status"])
+    return None
+
+
+def _int(payload: Mapping[str, Any], key: str) -> int | None:
+    val = payload.get(key)
+    return val if isinstance(val, int) and not isinstance(val, bool) else None
+
+
+def _count_matrix(payload: Mapping[str, Any], classification: str) -> int:
+    direct = _int(payload, f"{classification}_count")
+    if direct is not None:
+        return direct
+    results = payload.get("results") or payload.get("lanes")
+    if not isinstance(results, list):
+        return 0
+    count = 0
+    for item in results:
+        if not isinstance(item, Mapping):
+            continue
+        cls = item.get("classification") or item.get("proof_class") or item.get("lane_class")
+        status = item.get("status")
+        if cls == classification and status not in {"passed", "pass", "success"}:
+            count += 1
+    return count
+
+
+def _architecture_summary(arch: Mapping[str, Any] | None) -> dict[str, Any]:
+    if arch is None:
+        return {"provided": False}
+    comps_raw = arch.get("components")
+    flows_raw = arch.get("flows")
+    future_raw = arch.get("future_integration_points")
+    mounts_raw = arch.get("sentientos_mount_alignment")
+    comps: list[Any] = comps_raw if isinstance(comps_raw, list) else []
+    flows: list[Any] = flows_raw if isinstance(flows_raw, list) else []
+    future: list[Any] = future_raw if isinstance(future_raw, list) else []
+    mounts: Mapping[str, Any] = mounts_raw if isinstance(mounts_raw, Mapping) else {}
+    return {"provided": True, "workcell_architecture_id": arch.get("workcell_architecture_id"), "component_count": len(comps), "flow_count": len(flows), "transition_authority_components": sorted(c.get("component_id") for c in comps if isinstance(c, Mapping) and c.get("authority_level") == "transition_authority"), "review_only_components": sorted(c.get("component_id") for c in comps if isinstance(c, Mapping) and c.get("authority_level") == "review_only"), "future_integration_count": len(future), "mount_alignment_keys": sorted(str(k) for k in mounts.keys())}
+
+
+def _proof_summary(matrix: Mapping[str, Any] | None) -> dict[str, Any]:
+    if matrix is None:
+        return {"provided": False, "proof_signal_only": True}
+    out = {"provided": True, "matrix_status": _status(matrix, "status", "overall_status"), "required_failure_count": _count_matrix(matrix, "required"), "nonproof_count": _count_matrix(matrix, "nonproof"), "diagnostic_failure_count": _count_matrix(matrix, "diagnostic"), "proof_signal_only": True}
+    blocked = _int(matrix, "blocked_lane_count")
+    if blocked is not None:
+        out["blocked_lane_count"] = blocked
+    return out
+
+
+def _rerun(payload: Mapping[str, Any] | None) -> Any:
+    if payload is None: return None
+    if "rerun_required" in payload: return payload.get("rerun_required")
+    fresh = payload.get("evidence_freshness")
+    if isinstance(fresh, Mapping): return fresh.get("rerun_required")
+    return None
+
+
+def _terminal(payload: Mapping[str, Any] | None) -> Any:
+    if payload is None: return None
+    if "terminal_refresh_status" in payload: return payload.get("terminal_refresh_status")
+    fresh = payload.get("evidence_freshness")
+    if isinstance(fresh, Mapping): return fresh.get("terminal_refresh_status")
+    return None
+
+
+def _authority_summary(pre: Mapping[str, Any] | None, pr: Mapping[str, Any] | None, guard: Mapping[str, Any] | None) -> dict[str, Any]:
+    return {"pre_commit_finalizer_status": _status(pre, "status"), "pr_metadata_finalizer_status": _status(pr, "status"), "pr_metadata_guard_status": _status(guard, "status"), "pre_commit_rerun_required": _rerun(pre), "pr_metadata_rerun_required": _rerun(pr), "pre_commit_terminal_refresh_status": _terminal(pre), "pr_metadata_terminal_refresh_status": _terminal(pr), "authority_observed_from_inputs_only": True}
+
+
+def _evidence_summary(lifecycle: Mapping[str, Any] | None, doctor: Mapping[str, Any] | None, index: Mapping[str, Any] | None, sidecar: Mapping[str, Any] | None) -> dict[str, Any]:
+    artifacts_raw = index.get("artifacts") if isinstance(index, Mapping) else None
+    artifacts: list[Any] = artifacts_raw if isinstance(artifacts_raw, list) else []
+    present_raw = index.get("artifact_roles_present") if isinstance(index, Mapping) else None
+    missing_raw = index.get("artifact_roles_missing") if isinstance(index, Mapping) else None
+    present = sorted(str(item) for item in present_raw) if isinstance(present_raw, list) else []
+    missing = sorted(str(item) for item in missing_raw) if isinstance(missing_raw, list) else []
+    return {"lifecycle_status": _status(lifecycle, "overall_lifecycle_status", "status"), "doctor_status": _status(doctor, "overall_doctor_status", "status"), "next_safe_action": doctor.get("next_safe_action") if isinstance(doctor, Mapping) else None, "evidence_index_id": index.get("evidence_index_id") if isinstance(index, Mapping) else None, "artifact_count": len(artifacts), "artifact_roles_present": present, "artifact_roles_missing": missing, "appendix_provenance_version": sidecar.get("provenance_version") if isinstance(sidecar, Mapping) else None, "appendix_rendered_markdown_digest": sidecar.get("rendered_markdown_digest") if isinstance(sidecar, Mapping) else None, "evidence_review_only": True}
+
+
+def _doctrine_summary(doctrine: Mapping[str, Any] | None) -> dict[str, Any]:
+    if doctrine is None:
+        return {"provided": False, "doctrine_review_only": True}
+    traits = doctrine.get("traits") or doctrine.get("trait_catalog")
+    rails = doctrine.get("rail_mappings")
+    return {"provided": True, "doctrine_map_id": doctrine.get("doctrine_map_id"), "trait_count": len(traits) if isinstance(traits, (list, dict)) else 0, "rail_mapping_count": len(rails) if isinstance(rails, list) else 0, "doctrine_only": doctrine.get("doctrine_only", True), "not_model_training": doctrine.get("not_model_training", True), "not_reinforcement_learning": doctrine.get("not_reinforcement_learning", True), "doctrine_review_only": True}
+
+
+def _future() -> list[dict[str, Any]]:
+    names = ["ledger receipt archival", "glow evidence memory", "pulse stale-evidence watch", "daemon repair recommendation", "federation drift consensus", "canonical vow digest checks", "workcell health snapshot", "operator cockpit rendering"]
+    return [{"integration": n, "current_status": "future_integration" if n != "workcell health snapshot" else "observed_metadata_surface", "active_authority": False} for n in names]
+
+
+def _mounts(arch: Mapping[str, Any] | None, supplied: list[str]) -> list[dict[str, Any]]:
+    align = arch.get("sentientos_mount_alignment") if isinstance(arch, Mapping) and isinstance(arch.get("sentientos_mount_alignment"), Mapping) else {}
+    out=[]
+    for mount in MOUNTS:
+        details = align.get(mount) if isinstance(align, Mapping) else None
+        out.append({"mount": mount, "observed_inputs": supplied, "current_status": "observed" if details else "not_provided", "review_summary": details.get("purpose") if isinstance(details, Mapping) else f"Conceptual {mount} observation category; architecture map not provided.", "authority_boundary": "Mount snapshot is observational only and does not authorize action."})
+    return out
+
+
+def _pressure(missing: list[str], proof: Mapping[str, Any], authority: Mapping[str, Any]) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    for item in missing:
+        signals.append({"signal": "missing_input", "input_id": item, "observation_only": True})
+    if proof.get("required_failure_count"):
+        signals.append({"signal": "matrix_required_failures", "count": proof["required_failure_count"], "observation_only": True})
+    if proof.get("diagnostic_failure_count"):
+        signals.append({"signal": "diagnostic_failures_nonproof", "count": proof["diagnostic_failure_count"], "observation_only": True})
+    for key in ("pre_commit_rerun_required", "pr_metadata_rerun_required"):
+        if authority.get(key):
+            signals.append({"signal": "finalizer_rerun_required", "source": key, "value": authority[key], "observation_only": True})
+    for key in ("pre_commit_terminal_refresh_status", "pr_metadata_terminal_refresh_status"):
+        if authority.get(key):
+            signals.append({"signal": "stale_evidence_refresh_status", "source": key, "value": authority[key], "observation_only": True})
+    if "architecture_json" in missing: signals.append({"signal": "absent_architecture_map", "observation_only": True})
+    if "evidence_appendix_sidecar_json" in missing: signals.append({"signal": "absent_provenance_sidecar", "observation_only": True})
+    if "beneficial_trait_doctrine_json" in missing: signals.append({"signal": "absent_doctrine_map", "observation_only": True})
+    return signals
+
+
+def build_codex_workcell_health_snapshot(request: CodexWorkcellHealthSnapshotRequest | None = None) -> dict[str, Any]:
+    request = request or CodexWorkcellHealthSnapshotRequest()
+    records=[]; payloads={}
+    for input_id in INPUT_IDS:
+        rec, payload = _read_input(input_id, getattr(request, input_id))
+        records.append(rec); payloads[input_id] = payload
+    supplied = [r["input_id"] for r in records if r["provided"]]
+    missing = [r["input_id"] for r in records if not r["provided"]]
+    arch = payloads["architecture_json"]
+    proof = _proof_summary(payloads["matrix_json"])
+    authority = _authority_summary(payloads["pre_commit_finalizer_json"], payloads["pr_metadata_finalizer_json"], payloads["pr_metadata_guard_json"])
+    sidecar = payloads["evidence_appendix_sidecar_json"]
+    provenance = {"input_digest_count": sum(1 for r in records if r["digest"]), "supplied_input_ids": supplied, "missing_input_ids": missing, "appendix_provenance_digest_version": sidecar.get("provenance_version") if isinstance(sidecar, Mapping) else None, "rendered_markdown_digest": sidecar.get("rendered_markdown_digest") if isinstance(sidecar, Mapping) else None, "provenance_does_not_verify_authority": True}
+    return {"workcell_health_snapshot_id": WORKCELL_HEALTH_SNAPSHOT_ID, "metadata_only": True, "architecture_review_only": True, "cockpit_snapshot_only": True, "not_runtime_authority": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_model_training": True, "not_reinforcement_learning": True, "generated_from_inputs": records, "architecture_summary": _architecture_summary(arch), "proof_summary": proof, "authority_summary": authority, "evidence_summary": _evidence_summary(payloads["lifecycle_summary_json"], payloads["lifecycle_doctor_json"], payloads["evidence_index_json"], sidecar), "doctrine_summary": _doctrine_summary(payloads["beneficial_trait_doctrine_json"]), "provenance_summary": provenance, "sentientos_mount_snapshot": _mounts(arch, supplied), "future_integration_snapshot": _future(), "observed_pressure_signals": _pressure(missing, proof, authority), "missing_inputs": missing, "next_observation_recommendations": ["Observation only: provide architecture JSON for fuller component/flow summary.", "Observation only: provide matrix JSON for proof signal summary.", "Observation only: provide finalizer/guard JSON for observed authority status.", "Observation only: provide evidence index and doctor JSON for evidence interpretation.", "Observation only: provide appendix sidecar for rendered-surface provenance.", "Observation only: provide doctrine map for trait context."], "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items()))}
+
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def render_codex_workcell_health_snapshot_markdown(snapshot: Mapping[str, Any]) -> str:
+    lines=["# Codex Workcell Health Snapshot", "", "This is a read-only cockpit snapshot of supplied metadata artifacts. It observes evidence only; it does not run commands, decide readiness, authorize commits or PR metadata, schedule work, trigger daemons, or train models.", "", "## Input provenance", "| input_id | provided | readable_json | digest | byte_size | error |", "| --- | --- | --- | --- | --- | --- |"]
+    for r in snapshot["generated_from_inputs"]:
+        lines.append(f"| {_cell(r['input_id'])} | {_cell(r['provided'])} | {_cell(r['readable_json'])} | {_cell(r['digest'])} | {_cell(r['byte_size'])} | {_cell(r['error'])} |")
+    sections=[("Architecture summary","architecture_summary"),("Proof summary","proof_summary"),("Authority observation summary","authority_summary"),("Evidence summary","evidence_summary"),("Doctrine summary","doctrine_summary"),("Provenance summary","provenance_summary")]
+    for title,key in sections:
+        lines += ["", f"## {title}", "| key | value |", "| --- | --- |"]
+        for k,v in sorted(snapshot[key].items()): lines.append(f"| {_cell(k)} | {_cell(v)} |")
+    lines += ["", "## SentientOS mount snapshot", "| mount | current_status | observed_inputs | review_summary | authority_boundary |", "| --- | --- | --- | --- | --- |"]
+    for m in snapshot["sentientos_mount_snapshot"]: lines.append(f"| {_cell(m['mount'])} | {_cell(m['current_status'])} | {_cell(m['observed_inputs'])} | {_cell(m['review_summary'])} | {_cell(m['authority_boundary'])} |")
+    lines += ["", "## Future integration snapshot", "| integration | current_status | active_authority |", "| --- | --- | --- |"]
+    for f in snapshot["future_integration_snapshot"]: lines.append(f"| {_cell(f['integration'])} | {_cell(f['current_status'])} | {_cell(f['active_authority'])} |")
+    lines += ["", "## Observed pressure signals"] + [f"- {_cell(s)}" for s in snapshot["observed_pressure_signals"]]
+    lines += ["", "## Next observation recommendations"] + [f"- {_cell(s)}" for s in snapshot["next_observation_recommendations"]]
+    lines += ["", "## Non-authority posture"] + [f"- **{k}:** {str(v).lower()}" for k,v in sorted(snapshot["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_health_snapshot_json(snapshot: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_health_snapshot_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_health_snapshot_script.py
+++ b/tests/test_build_codex_workcell_health_snapshot_script.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/build_codex_workcell_health_snapshot.py"
+
+
+def test_cli_writes_json_and_summary(tmp_path: Path) -> None:
+    matrix = tmp_path / "matrix.json"; matrix.write_text('{"status":"ok"}', encoding="utf-8")
+    output = tmp_path / "snapshot.json"
+    result = subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--matrix-json", str(matrix), "--summary"], text=True, capture_output=True, check=True)
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert payload["proof_summary"]["matrix_status"] == "ok"
+    assert summary["workcell_health_snapshot_id"] == "codex_workcell_health_snapshot.v1"
+    assert summary["supplied_input_count"] == 1
+
+
+def test_cli_writes_markdown(tmp_path: Path) -> None:
+    output = tmp_path / "snapshot.json"
+    markdown = tmp_path / "snapshot.md"
+    subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--markdown-output", str(markdown)], check=True)
+    assert output.exists()
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Health Snapshot")
+
+
+def test_cli_failure_returns_exit_code_2_with_useful_message(tmp_path: Path) -> None:
+    output = tmp_path / "snapshot.json"
+    result = subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--matrix-json", str(tmp_path / "missing.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "missing_json:matrix_json" in result.stderr
+    assert not output.exists()

--- a/tests/test_codex_workcell_health_snapshot.py
+++ b/tests/test_codex_workcell_health_snapshot.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_health_snapshot import (
+    CodexWorkcellHealthSnapshotError,
+    CodexWorkcellHealthSnapshotRequest,
+    build_codex_workcell_health_snapshot,
+    render_codex_workcell_health_snapshot_markdown,
+)
+
+
+def _write(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_snapshot_without_inputs_marks_all_not_provided() -> None:
+    snap = build_codex_workcell_health_snapshot()
+    assert snap["metadata_only"] is True
+    assert len(snap["generated_from_inputs"]) == 10
+    assert all(not item["provided"] for item in snap["generated_from_inputs"])
+    assert snap["architecture_summary"] == {"provided": False}
+
+
+def test_architecture_json_is_summarized(tmp_path: Path) -> None:
+    arch = _write(tmp_path / "arch.json", {"workcell_architecture_id": "a", "components": [{"component_id": "f", "authority_level": "transition_authority"}, {"component_id": "r", "authority_level": "review_only"}], "flows": [{"flow_id": "x"}], "future_integration_points": [{"integration_id": "i"}], "sentientos_mount_alignment": {"/vow": {"purpose": "v", "components": []}}})
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(architecture_json=str(arch)))
+    assert snap["architecture_summary"]["component_count"] == 2
+    assert snap["architecture_summary"]["transition_authority_components"] == ["f"]
+    assert snap["architecture_summary"]["mount_alignment_keys"] == ["/vow"]
+
+
+def test_matrix_json_is_proof_signal_only(tmp_path: Path) -> None:
+    matrix = _write(tmp_path / "matrix.json", {"status": "failed", "required_count": 3, "diagnostic_count": 2, "nonproof_count": 1, "blocked_lane_count": 4})
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(matrix_json=str(matrix)))
+    assert snap["proof_summary"]["matrix_status"] == "failed"
+    assert snap["proof_summary"]["required_failure_count"] == 3
+    assert snap["proof_summary"]["proof_signal_only"] is True
+
+
+def test_finalizer_and_guard_statuses_are_observed_not_decisions(tmp_path: Path) -> None:
+    pre = _write(tmp_path / "pre.json", {"decision": {"status": "ready_to_commit"}, "evidence_freshness": {"rerun_required": True, "terminal_refresh_status": "stale"}})
+    pr = _write(tmp_path / "pr.json", {"status": "ready_for_pr_metadata"})
+    guard = _write(tmp_path / "guard.json", {"status": "pr_metadata_guard_ready"})
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(pre_commit_finalizer_json=str(pre), pr_metadata_finalizer_json=str(pr), pr_metadata_guard_json=str(guard)))
+    assert snap["authority_summary"]["pre_commit_finalizer_status"] == "ready_to_commit"
+    assert snap["authority_summary"]["authority_observed_from_inputs_only"] is True
+    assert "ready_to_commit" not in snap
+    assert snap["non_authority_posture"]["health_snapshot_does_not_decide_readiness"] is True
+
+
+def test_evidence_index_doctor_and_sidecar_are_summarized(tmp_path: Path) -> None:
+    life = _write(tmp_path / "life.json", {"overall_lifecycle_status": "lifecycle_ready"})
+    doctor = _write(tmp_path / "doctor.json", {"overall_doctor_status": "doctor_ready", "next_safe_action": "review"})
+    index = _write(tmp_path / "index.json", {"evidence_index_id": "idx", "artifacts": [{"role": "matrix"}], "artifact_roles_present": ["matrix"], "artifact_roles_missing": ["doctor_report"]})
+    sidecar = _write(tmp_path / "sidecar.json", {"provenance_version": "v1", "rendered_markdown_digest": "abc"})
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(lifecycle_summary_json=str(life), lifecycle_doctor_json=str(doctor), evidence_index_json=str(index), evidence_appendix_sidecar_json=str(sidecar)))
+    assert snap["evidence_summary"]["doctor_status"] == "doctor_ready"
+    assert snap["evidence_summary"]["artifact_count"] == 1
+    assert snap["provenance_summary"]["rendered_markdown_digest"] == "abc"
+
+
+def test_doctrine_map_is_doctrine_only(tmp_path: Path) -> None:
+    doctrine = _write(tmp_path / "doctrine.json", {"doctrine_map_id": "d", "traits": {"a": "b"}, "rail_mappings": [{"rail_id": "r"}]})
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(beneficial_trait_doctrine_json=str(doctrine)))
+    assert snap["doctrine_summary"]["trait_count"] == 1
+    assert snap["doctrine_summary"]["doctrine_only"] is True
+    assert snap["doctrine_summary"]["not_model_training"] is True
+
+
+def test_raw_byte_digests_and_sizes_are_recorded(tmp_path: Path) -> None:
+    path = tmp_path / "matrix.json"
+    raw = b'{"status":"ok"}\n'
+    path.write_bytes(raw)
+    snap = build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(matrix_json=str(path)))
+    rec = next(r for r in snap["generated_from_inputs"] if r["input_id"] == "matrix_json")
+    assert rec["digest"] == hashlib.sha256(raw).hexdigest()
+    assert rec["byte_size"] == len(raw)
+
+
+def test_invalid_json_and_missing_path_fail_cleanly(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"; bad.write_text("{", encoding="utf-8")
+    with pytest.raises(CodexWorkcellHealthSnapshotError, match="invalid_json"):
+        build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(matrix_json=str(bad)))
+    with pytest.raises(CodexWorkcellHealthSnapshotError, match="missing_json"):
+        build_codex_workcell_health_snapshot(CodexWorkcellHealthSnapshotRequest(matrix_json=str(tmp_path / "missing.json")))
+
+
+def test_pressure_future_mount_determinism_and_markdown(tmp_path: Path) -> None:
+    matrix = _write(tmp_path / "matrix.json", {"status": "failed", "required_count": 1, "diagnostic_count": 1})
+    req = CodexWorkcellHealthSnapshotRequest(matrix_json=str(matrix))
+    first = build_codex_workcell_health_snapshot(req)
+    second = build_codex_workcell_health_snapshot(req)
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert {m["mount"] for m in first["sentientos_mount_snapshot"]} == {"/vow", "/glow", "/pulse", "/daemon", "/ledger"}
+    assert all(item["active_authority"] is False for item in first["future_integration_snapshot"])
+    assert first["observed_pressure_signals"] == second["observed_pressure_signals"]
+    md1 = render_codex_workcell_health_snapshot_markdown(first)
+    md2 = render_codex_workcell_health_snapshot_markdown(first)
+    assert md1 == md2
+    assert md1.startswith("# Codex Workcell Health Snapshot")
+
+
+def test_non_authority_posture_fields_true() -> None:
+    posture = build_codex_workcell_health_snapshot()["non_authority_posture"]
+    assert posture
+    assert all(value is True for value in posture.values())


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only cockpit/vitals snapshot for the Codex workcell that renders observable state from existing architecture, evidence, finalizer, guard, lifecycle, and doctrine artifacts without adding authority, execution, scheduling, or runtime behavior.

### Description

- Add a new module `sentientos/codex_workcell_health_snapshot.py` that consumes ten optional JSON artifacts, records raw-byte `sha256` digests/byte sizes, validates JSON as objects, and fails cleanly for missing/invalid provided inputs. 
- Add a CLI `scripts/build_codex_workcell_health_snapshot.py` which writes `codex_workcell_health_snapshot.json` and optional markdown, supports `--summary`, accepts the required optional input flags, and returns exit code `2` on input failures. 
- Produce the requested JSON fields and deterministic summaries for architecture, proof/matrix signals, finalizer/guard authority observations, evidence/index/appendix summaries, doctrine summary, provenance, SentientOS mount snapshot (`/vow`, `/glow`, `/pulse`, `/daemon`, `/ledger`), future integration snapshot, observed pressure signals, next-observation recommendations, and explicit non-authority posture flags. 
- Add deterministic Markdown rendering with safe table-cell escaping, writers, focused unit tests for module and CLI, and documentation `docs/development/codex_workcell_health_snapshot.md` plus brief links/notes in adjacent docs to preserve the non-authority boundary.

### Testing

- Focused unit tests `tests/test_codex_workcell_health_snapshot.py` and CLI tests `tests/test_build_codex_workcell_health_snapshot_script.py` were executed and passed. 
- Related regression/adjacent test suites were run (architecture, evidence appendix, doctrine, evidence index, lifecycle doctor, matrix lanes) and passed. 
- Docs build was bootstrapped and completed successfully, targeted `mypy` type-checking for the new files passed, and the full review-packet matrix run completed with status `passed` (no required failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f7b31fd4832fbb15400775bad9ff)