### PR TITLE
[sentientos:pulse] define Codex workcell pressure signal contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -192,3 +192,7 @@ The [Codex Workcell Architecture](codex_workcell_architecture.md) places this fi
 ## Health snapshot boundary
 
 The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) may render supplied finalizer statuses as observed evidence, but it does not create `ready_to_commit`, `ready_for_pr_metadata`, or any other readiness decision. Finalizer authority remains here.
+
+## Pulse contract non-bypass note
+
+The Codex Workcell Pulse Contract may label finalizer pressure from supplied health snapshot metadata, including rerun or stale-evidence observations. It is not landing authority and cannot replace, bypass, or weaken pre-commit finalizer readiness, post-commit/pr-metadata finalizer readiness, or PR metadata guard readiness.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -184,3 +184,7 @@ The [Codex Workcell Architecture](codex_workcell_architecture.md) describes the 
 ## Health snapshot observation surface
 
 The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) can summarize supplied recovery/evidence metadata for reviewers. It is an observation surface only and cannot recover files, refresh stale evidence, trigger repair, or authorize landing.
+
+## Pulse contract evidence note
+
+The Codex Workcell Pulse Contract may classify evidence recovery pressure observed in a supplied health snapshot, such as missing evidence index, lifecycle doctor, appendix sidecar, or stale refresh signals. These labels are observation-only and do not trigger recovery, daemon repair, alerts, scheduling, or federation action.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -131,3 +131,7 @@ The [Codex Workcell Architecture](codex_workcell_architecture.md) summarizes how
 ## Health snapshot is not a landing gate
 
 The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) is a cockpit/vitals rendering of supplied metadata artifacts. It is not a validation lane, readiness gate, finalizer replacement, PR metadata guard replacement, or authority source.
+
+## Pulse contract validation boundary
+
+The Codex Workcell Pulse Contract is a deterministic metadata catalog for pressure signal names and categories. It does not add a landing gate, does not decide matrix success, does not authorize commits or PR metadata, and does not make skipped, nonexecuted, timed-out, stale, or missing proof count as validation.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -95,3 +95,7 @@ This architecture map is metadata-only, architecture-only, developer-workflow ev
 ## Health snapshot relationship
 
 The Codex Workcell Architecture answers “How do the workcell organs and flows fit together?” The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) answers “What is currently observable about the workcell from supplied metadata artifacts?” The health snapshot may consume architecture JSON, but it remains cockpit/vitals observation only and does not add authority.
+
+## Pulse contract relationship
+
+The Codex Workcell Pulse Contract is a metadata-only catalog layered after the architecture map and health snapshot. It can classify architecture-related pressure such as a missing architecture map, but it does not change workcell architecture, mount behavior, scheduler behavior, daemon behavior, or authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -37,3 +37,7 @@ The snapshot renders a mount view for `/vow`, `/glow`, `/pulse`, `/daemon`, and 
 The snapshot does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed as a new decision, whether artifacts are fresh as a new decision, whether a daemon should act, whether federation consensus has been reached, whether a model is aligned, or whether reinforcement-learning training succeeded.
 
 Its recommendations are phrased as observation recommendations only, such as supplying architecture JSON for fuller component/flow context or supplying appendix sidecar JSON for rendered-surface provenance.
+
+## Pulse contract relationship
+
+The Codex Workcell Health Snapshot answers what is currently observable from supplied metadata artifacts. The Codex Workcell Pulse Contract consumes an optional snapshot JSON only as input evidence and answers how observed pressure signals are named, classified, bounded, and prepared for future `/pulse` observation. It does not run this snapshot builder or decide readiness.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -1,0 +1,42 @@
+# Codex Workcell Pulse Contract
+
+The Codex Workcell Pulse Contract is a deterministic, read-only catalog for naming, classifying, and bounding pressure signals that are already observable in a supplied Codex Workcell Health Snapshot. It answers: **“How are observed pressure signals named, classified, bounded, and prepared for future `/pulse` observation?”**
+
+It does not answer whether a change may commit, whether PR metadata may be created, whether matrix proof passed as a new decision, whether artifacts are fresh as a new decision, whether a daemon should act, whether a watcher should run, whether federation consensus has been reached, whether a model is aligned, or whether reinforcement-learning training succeeded.
+
+## Contract boundaries
+
+The pulse contract is metadata-only and contract-only. It may define a static signal catalog and may optionally read one provided health snapshot JSON to summarize which catalog signals are observed. It must not run the health snapshot builder, tests, matrix, mypy, finalizer, PR metadata guard, lifecycle doctor, evidence index builder, appendix renderer, doctrine builder, docs, git, network, provider calls, shell commands, watchers, schedulers, daemon actions, model training, or reinforcement learning.
+
+Missing optional health snapshot input is represented as `provided: false`. A provided but missing or invalid health snapshot fails cleanly before writing output.
+
+## Difference from adjacent surfaces
+
+- The architecture map defines component boundaries, flows, mounts, and future integration surfaces; the pulse contract only names pressure signals observed through metadata.
+- The health snapshot answers **“What is currently observable about the workcell from supplied metadata artifacts?”** The pulse contract answers how those observed pressure signals are named, classified, bounded, and prepared for future `/pulse` observation.
+- The matrix remains the proof runner and proof classifier. The pulse contract can label observed matrix pressure, but it does not rerun or reinterpret proof.
+- The finalizer and PR metadata guard remain landing authorities. The pulse contract can label absent or rerun pressure from supplied metadata, but it does not authorize commits or PR creation.
+- The lifecycle doctor, evidence index, evidence appendix, and doctrine map remain their own review surfaces. The pulse contract only records whether corresponding pressure categories are visible.
+- Daemon repair remains future-only. The pulse contract is not a daemon trigger, alerting system, scheduler, or watcher.
+
+## Signal naming and classification
+
+Pulse signal IDs are stable snake-case identifiers such as `missing_matrix_evidence`, `matrix_required_failure_observed`, `stale_evidence_refresh_observed`, and `pulse_watch_not_active`. Each signal has a stable category and severity hint. Categories are `missing_input`, `proof_pressure`, `authority_pressure`, `freshness_pressure`, `provenance_pressure`, `doctrine_pressure`, `future_integration_pressure`, `daemon_boundary`, and `federation_boundary`. Severity hints are `info`, `watch`, `caution`, and `blocked_observation`.
+
+Each catalog entry includes source health snapshot fields, an interpretation, a forbidden inference, a next observation recommendation, a non-authority boundary, and a reviewer summary. Observed signals are evidence labels only; they never trigger action.
+
+## SentientOS mount alignment
+
+- `/pulse`: pressure signal naming plus freshness, drift, timeout, and rerun observation.
+- `/glow`: archived evidence and review surfaces that may provide observation context.
+- `/ledger`: landed receipts that may provide history context.
+- `/daemon`: a future repair recommendation consumer, not active in this contract.
+- `/vow`: canonical constraints that bound interpretation and forbidden inference.
+
+## Future activation requirements
+
+Before this contract could become an active watcher, a separate future implementation would need an explicit scheduler or watch loop, explicit operator consent, explicit daemon boundary, explicit ledger/glow storage policy, explicit federation drift consensus rule, explicit finalizer/guard non-bypass invariant, tests proving no readiness authority, and docs marking active behavior. For this contract, every activation requirement is unmet and future-only.
+
+## Non-authority posture
+
+The contract is read-only, metadata-only, does not watch files, does not poll state, does not rerun commands, does not decide readiness, does not bypass the finalizer or PR metadata guard, does not authorize commit or PR creation, does not trigger daemons, does not schedule tasks, does not send alerts, does not train or modify models, and does not establish federation consensus.

--- a/scripts/build_codex_workcell_pulse_contract.py
+++ b/scripts/build_codex_workcell_pulse_contract.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_pulse_contract import (
+    CodexWorkcellPulseContractError,
+    CodexWorkcellPulseContractRequest,
+    build_codex_workcell_pulse_contract,
+    render_codex_workcell_pulse_contract_markdown,
+    write_codex_workcell_pulse_contract_json,
+    write_codex_workcell_pulse_contract_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell pulse contract.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--health-snapshot-json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        contract = build_codex_workcell_pulse_contract(CodexWorkcellPulseContractRequest(health_snapshot_json=args.health_snapshot_json))
+    except CodexWorkcellPulseContractError as exc:
+        print(f"codex_workcell_pulse_contract_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_pulse_contract_json(contract, args.output)
+    if args.markdown_output:
+        write_codex_workcell_pulse_contract_markdown(render_codex_workcell_pulse_contract_markdown(contract), args.markdown_output)
+    if args.summary:
+        print(json.dumps({
+            "pulse_contract_id": contract["pulse_contract_id"],
+            "metadata_only": True,
+            "pulse_contract_only": True,
+            "output": args.output,
+            "markdown_output": args.markdown_output,
+            "health_snapshot_provided": contract["health_snapshot_input_summary"].get("provided"),
+            "signal_count": len(contract["signal_catalog"]),
+            "observed_signal_count": len(contract["observed_signal_summary"].get("observed_signal_ids", [])),
+        }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_pulse_contract.py
+++ b/sentientos/codex_workcell_pulse_contract.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+PULSE_CONTRACT_ID = "codex_workcell_pulse_contract.v1"
+DIGEST_ALGO = "sha256"
+CATEGORIES: tuple[str, ...] = (
+    "missing_input",
+    "proof_pressure",
+    "authority_pressure",
+    "freshness_pressure",
+    "provenance_pressure",
+    "doctrine_pressure",
+    "future_integration_pressure",
+    "daemon_boundary",
+    "federation_boundary",
+)
+SEVERITY_HINTS: tuple[str, ...] = ("info", "watch", "caution", "blocked_observation")
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "pulse_contract_is_read_only": True,
+    "pulse_contract_is_metadata_only": True,
+    "pulse_contract_does_not_watch_files": True,
+    "pulse_contract_does_not_poll_state": True,
+    "pulse_contract_does_not_rerun_commands": True,
+    "pulse_contract_does_not_decide_readiness": True,
+    "pulse_contract_does_not_bypass_finalizer": True,
+    "pulse_contract_does_not_bypass_pr_metadata_guard": True,
+    "pulse_contract_does_not_authorize_commit": True,
+    "pulse_contract_does_not_authorize_pr_creation": True,
+    "pulse_contract_does_not_trigger_daemon": True,
+    "pulse_contract_does_not_schedule_tasks": True,
+    "pulse_contract_does_not_send_alerts": True,
+    "pulse_contract_does_not_train_or_modify_models": True,
+    "pulse_contract_does_not_establish_federation_consensus": True,
+}
+
+FUTURE_ACTIVATION_REQUIREMENTS: tuple[str, ...] = (
+    "explicit separate implementation",
+    "explicit scheduler/watch loop",
+    "explicit operator consent",
+    "explicit daemon boundary",
+    "explicit ledger/glow storage policy",
+    "explicit federation drift consensus rule",
+    "explicit finalizer/guard non-bypass invariant",
+    "tests proving no readiness authority",
+    "docs marking active behavior",
+)
+
+_SIGNAL_SPECS: tuple[tuple[str, str, str, str, tuple[str, ...], str], ...] = (
+    ("missing_architecture_map", "Missing architecture map", "missing_input", "watch", ("missing_inputs", "observed_pressure_signals"), "Architecture map metadata was not supplied."),
+    ("missing_matrix_evidence", "Missing matrix evidence", "missing_input", "caution", ("missing_inputs",), "Matrix evidence metadata was not supplied."),
+    ("missing_finalizer_evidence", "Missing finalizer evidence", "missing_input", "caution", ("missing_inputs", "authority_summary"), "Finalizer evidence metadata was not supplied."),
+    ("missing_pr_metadata_guard_evidence", "Missing PR metadata guard evidence", "missing_input", "caution", ("missing_inputs", "authority_summary"), "PR metadata guard evidence metadata was not supplied."),
+    ("missing_evidence_index", "Missing evidence index", "missing_input", "watch", ("missing_inputs", "evidence_summary"), "Evidence index metadata was not supplied."),
+    ("missing_lifecycle_doctor", "Missing lifecycle doctor", "missing_input", "watch", ("missing_inputs", "evidence_summary"), "Lifecycle doctor metadata was not supplied."),
+    ("missing_appendix_sidecar", "Missing appendix sidecar", "provenance_pressure", "watch", ("missing_inputs", "provenance_summary"), "Evidence appendix sidecar provenance was not supplied."),
+    ("missing_doctrine_map", "Missing doctrine map", "doctrine_pressure", "watch", ("missing_inputs", "doctrine_summary"), "Doctrine map metadata was not supplied."),
+    ("matrix_required_failure_observed", "Matrix required failure observed", "proof_pressure", "blocked_observation", ("proof_summary.required_failure_count", "observed_pressure_signals"), "Required matrix failure was observed in supplied metadata."),
+    ("matrix_diagnostic_failure_observed", "Matrix diagnostic failure observed", "proof_pressure", "watch", ("proof_summary.diagnostic_failure_count", "observed_pressure_signals"), "Diagnostic matrix failure was observed as non-authority evidence."),
+    ("finalizer_rerun_required_observed", "Finalizer rerun required observed", "authority_pressure", "caution", ("authority_summary", "observed_pressure_signals"), "Finalizer metadata reported rerun pressure."),
+    ("stale_evidence_refresh_observed", "Stale evidence refresh observed", "freshness_pressure", "caution", ("authority_summary", "observed_pressure_signals"), "Finalizer metadata reported terminal refresh or stale evidence pressure."),
+    ("generated_artifact_cleanup_incomplete_observed", "Generated artifact cleanup incomplete observed", "freshness_pressure", "caution", ("authority_summary", "observed_pressure_signals"), "Generated artifact cleanup pressure was observed in supplied metadata."),
+    ("authority_status_absent", "Authority status absent", "authority_pressure", "watch", ("authority_summary",), "Authority status fields were absent from supplied metadata."),
+    ("provenance_absent", "Provenance absent", "provenance_pressure", "watch", ("provenance_summary", "missing_inputs"), "Provenance context was absent or incomplete."),
+    ("doctrine_context_absent", "Doctrine context absent", "doctrine_pressure", "watch", ("doctrine_summary", "missing_inputs"), "Doctrine context was absent or incomplete."),
+    ("future_integration_unwired", "Future integration unwired", "future_integration_pressure", "info", ("future_integration_snapshot",), "Future integration surface remains metadata-only and unwired."),
+    ("federation_consensus_absent", "Federation consensus absent", "federation_boundary", "info", ("future_integration_snapshot",), "No federation consensus is established by this contract."),
+    ("daemon_repair_not_active", "Daemon repair not active", "daemon_boundary", "info", ("future_integration_snapshot",), "Daemon repair is not active in this contract."),
+    ("pulse_watch_not_active", "Pulse watch not active", "future_integration_pressure", "info", ("future_integration_snapshot",), "Pulse watch behavior is not active in this contract."),
+)
+
+MISSING_INPUT_MAP = {
+    "architecture_json": "missing_architecture_map",
+    "matrix_json": "missing_matrix_evidence",
+    "pre_commit_finalizer_json": "missing_finalizer_evidence",
+    "pr_metadata_finalizer_json": "missing_finalizer_evidence",
+    "pr_metadata_guard_json": "missing_pr_metadata_guard_evidence",
+    "evidence_index_json": "missing_evidence_index",
+    "lifecycle_doctor_json": "missing_lifecycle_doctor",
+    "evidence_appendix_sidecar_json": "missing_appendix_sidecar",
+    "beneficial_trait_doctrine_json": "missing_doctrine_map",
+}
+PRESSURE_SIGNAL_MAP = {
+    "absent_architecture_map": "missing_architecture_map",
+    "matrix_required_failures": "matrix_required_failure_observed",
+    "diagnostic_failures_nonproof": "matrix_diagnostic_failure_observed",
+    "finalizer_rerun_required": "finalizer_rerun_required_observed",
+    "stale_evidence_refresh_status": "stale_evidence_refresh_observed",
+    "absent_provenance_sidecar": "provenance_absent",
+    "absent_doctrine_map": "doctrine_context_absent",
+}
+
+class CodexWorkcellPulseContractError(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class CodexWorkcellPulseContractRequest:
+    health_snapshot_json: str | None = None
+
+
+def _signal_catalog() -> list[dict[str, Any]]:
+    catalog = []
+    for signal_id, signal_name, category, severity, fields, interpretation in _SIGNAL_SPECS:
+        catalog.append({
+            "signal_id": signal_id,
+            "signal_name": signal_name,
+            "category": category,
+            "severity_hint": severity,
+            "source_health_snapshot_fields": list(fields),
+            "interpretation": interpretation,
+            "forbidden_inference": "Does not decide readiness, authorize commit or PR metadata, trigger daemon action, schedule tasks, send alerts, or establish federation consensus.",
+            "next_observation_recommendation": "Review supplied metadata evidence only; any active behavior requires a separate future implementation and operator authority.",
+            "non_authority_boundary": "Observation-only catalog entry; no runtime authority is granted.",
+            "reviewer_summary": f"{signal_name} is classified as {category} with {severity} severity hint.",
+        })
+    return catalog
+
+
+def _index(catalog: list[dict[str, Any]], key: str, values: tuple[str, ...]) -> dict[str, list[str]]:
+    return {value: sorted(str(item["signal_id"]) for item in catalog if item[key] == value) for value in values}
+
+
+def _load_health_snapshot(path_text: str | None) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return {"provided": False, "path": None, "digest": None, "byte_size": None}, None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellPulseContractError(f"missing_health_snapshot_json:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellPulseContractError(f"invalid_health_snapshot_json:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellPulseContractError(f"health_snapshot_json_not_object:{path_text}")
+    summary: dict[str, Any] = {"provided": True, "path": path_text, "readable_json": True, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw)}
+    if "workcell_health_snapshot_id" in loaded:
+        summary["workcell_health_snapshot_id"] = loaded["workcell_health_snapshot_id"]
+    pressure = loaded.get("observed_pressure_signals")
+    if isinstance(pressure, list):
+        summary["observed_pressure_signal_count"] = len(pressure)
+    missing = loaded.get("missing_inputs")
+    if isinstance(missing, list):
+        summary["missing_inputs_count"] = len(missing)
+    return summary, loaded
+
+
+def _observed_summary(snapshot: Mapping[str, Any] | None, catalog: list[dict[str, Any]]) -> dict[str, Any]:
+    if snapshot is None:
+        return {"provided": False, "observation_only": True}
+    known_ids = {str(item["signal_id"]) for item in catalog}
+    observed: set[str] = set()
+    unmatched: list[Any] = []
+    missing = snapshot.get("missing_inputs")
+    if isinstance(missing, list):
+        for item in missing:
+            mapped = MISSING_INPUT_MAP.get(str(item))
+            if mapped:
+                observed.add(mapped)
+    pressure = snapshot.get("observed_pressure_signals")
+    if isinstance(pressure, list):
+        for item in pressure:
+            signal = item.get("signal") if isinstance(item, Mapping) else item
+            mapped = PRESSURE_SIGNAL_MAP.get(str(signal))
+            if mapped:
+                observed.add(mapped)
+            else:
+                unmatched.append(item)
+    proof = snapshot.get("proof_summary")
+    if isinstance(proof, Mapping):
+        if proof.get("required_failure_count"):
+            observed.add("matrix_required_failure_observed")
+        if proof.get("diagnostic_failure_count"):
+            observed.add("matrix_diagnostic_failure_observed")
+    authority = snapshot.get("authority_summary")
+    if isinstance(authority, Mapping):
+        statuses = [authority.get("pre_commit_finalizer_status"), authority.get("pr_metadata_finalizer_status"), authority.get("pr_metadata_guard_status")]
+        if not any(isinstance(status, str) and status for status in statuses):
+            observed.add("authority_status_absent")
+        if authority.get("pre_commit_rerun_required") or authority.get("pr_metadata_rerun_required"):
+            observed.add("finalizer_rerun_required_observed")
+        if authority.get("pre_commit_terminal_refresh_status") or authority.get("pr_metadata_terminal_refresh_status"):
+            observed.add("stale_evidence_refresh_observed")
+    doctrine = snapshot.get("doctrine_summary")
+    if isinstance(doctrine, Mapping) and doctrine.get("provided") is False:
+        observed.add("doctrine_context_absent")
+    provenance = snapshot.get("provenance_summary")
+    if isinstance(provenance, Mapping) and not provenance.get("appendix_provenance_digest_version"):
+        observed.add("provenance_absent")
+    for item in snapshot.get("future_integration_snapshot", []) if isinstance(snapshot.get("future_integration_snapshot"), list) else []:
+        if isinstance(item, Mapping) and item.get("active_authority") is False:
+            observed.add("future_integration_unwired")
+            if "daemon" in str(item.get("integration", "")):
+                observed.add("daemon_repair_not_active")
+            if "federation" in str(item.get("integration", "")):
+                observed.add("federation_consensus_absent")
+            if "pulse" in str(item.get("integration", "")):
+                observed.add("pulse_watch_not_active")
+    catalog_by_id = {str(item["signal_id"]): item for item in catalog}
+    observed_ids = sorted(observed & known_ids)
+    return {
+        "observed_signal_ids": observed_ids,
+        "unmatched_health_snapshot_pressure_signals": unmatched,
+        "missing_contract_signal_ids": sorted(observed - known_ids),
+        "observed_categories": sorted({str(catalog_by_id[s]["category"]) for s in observed_ids}),
+        "observed_severity_hints": sorted({str(catalog_by_id[s]["severity_hint"]) for s in observed_ids}),
+        "observation_only": True,
+    }
+
+
+def build_codex_workcell_pulse_contract(request: CodexWorkcellPulseContractRequest | None = None) -> dict[str, Any]:
+    request = request or CodexWorkcellPulseContractRequest()
+    catalog = _signal_catalog()
+    health_summary, snapshot = _load_health_snapshot(request.health_snapshot_json)
+    return {
+        "pulse_contract_id": PULSE_CONTRACT_ID,
+        "metadata_only": True,
+        "pulse_contract_only": True,
+        "not_runtime_authority": True,
+        "not_watcher": True,
+        "not_scheduler": True,
+        "not_executor": True,
+        "not_daemon_action": True,
+        "not_alerting_system": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "signal_catalog": catalog,
+        "category_index": _index(catalog, "category", CATEGORIES),
+        "severity_index": _index(catalog, "severity_hint", SEVERITY_HINTS),
+        "health_snapshot_input_summary": health_summary,
+        "observed_signal_summary": _observed_summary(snapshot, catalog),
+        "sentientos_mount_alignment": {
+            "/pulse": "Pressure signal naming and freshness/drift/timeout/rerun observation only.",
+            "/glow": "Archived evidence and review surfaces may provide observation context only.",
+            "/ledger": "Landed receipts may provide history context only.",
+            "/daemon": "Future repair recommendation consumer; not active here.",
+            "/vow": "Canonical constraints bound interpretation and forbidden inference.",
+        },
+        "future_activation_requirements": [{"requirement": item, "status": "future_only", "met": False, "active": False} for item in FUTURE_ACTIVATION_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\\r\\n", "<br>").replace("\\n", "<br>").replace("\\r", "<br>").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
+def render_codex_workcell_pulse_contract_markdown(contract: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Pulse Contract", "", "This is a read-only pulse signal catalog. It names and bounds observed pressure signals from supplied metadata only; it does not watch files, schedule tasks, trigger daemons, send alerts, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.", "", "## Health snapshot input summary", "| key | value |", "| --- | --- |"]
+    for key, value in sorted(contract["health_snapshot_input_summary"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Signal catalog", "| signal_id | signal_name | category | severity_hint | source_health_snapshot_fields | reviewer_summary |", "| --- | --- | --- | --- | --- | --- |"]
+    for signal in contract["signal_catalog"]:
+        lines.append(f"| {_cell(signal['signal_id'])} | {_cell(signal['signal_name'])} | {_cell(signal['category'])} | {_cell(signal['severity_hint'])} | {_cell(signal['source_health_snapshot_fields'])} | {_cell(signal['reviewer_summary'])} |")
+    if contract["health_snapshot_input_summary"].get("provided"):
+        lines += ["", "## Observed signal summary", "| key | value |", "| --- | --- |"]
+        for key, value in sorted(contract["observed_signal_summary"].items()):
+            lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    for title, key in (("Category index", "category_index"), ("Severity index", "severity_index"), ("SentientOS mount alignment", "sentientos_mount_alignment")):
+        lines += ["", f"## {title}", "| key | value |", "| --- | --- |"]
+        for item_key, value in sorted(contract[key].items()):
+            lines.append(f"| {_cell(item_key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in contract["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(contract["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_pulse_contract_json(contract: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_pulse_contract_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_pulse_contract_script.py
+++ b/tests/test_build_codex_workcell_pulse_contract_script.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/build_codex_workcell_pulse_contract.py"
+
+
+def test_cli_writes_json_and_summary(tmp_path: Path) -> None:
+    output = tmp_path / "contract.json"
+    result = subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--summary"], text=True, capture_output=True, check=True)
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert payload["pulse_contract_id"] == "codex_workcell_pulse_contract.v1"
+    assert payload["health_snapshot_input_summary"]["provided"] is False
+    assert summary["pulse_contract_only"] is True
+    assert summary["signal_count"] >= 20
+
+
+def test_cli_writes_markdown_when_requested(tmp_path: Path) -> None:
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--markdown-output", str(markdown)], check=True)
+    assert output.exists()
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Pulse Contract")
+
+
+def test_cli_maps_health_snapshot_and_returns_exit_code_2_on_failure(tmp_path: Path) -> None:
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(json.dumps({"missing_inputs": ["matrix_json"], "observed_pressure_signals": [{"signal": "diagnostic_failures_nonproof"}]}, sort_keys=True), encoding="utf-8")
+    output = tmp_path / "contract.json"
+    subprocess.run([sys.executable, SCRIPT, "--output", str(output), "--health-snapshot-json", str(snapshot)], check=True)
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert "missing_matrix_evidence" in payload["observed_signal_summary"]["observed_signal_ids"]
+    assert "matrix_diagnostic_failure_observed" in payload["observed_signal_summary"]["observed_signal_ids"]
+    bad_output = tmp_path / "bad.json"
+    result = subprocess.run([sys.executable, SCRIPT, "--output", str(bad_output), "--health-snapshot-json", str(tmp_path / "missing.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "missing_health_snapshot_json" in result.stderr
+    assert not bad_output.exists()

--- a/tests/test_codex_workcell_pulse_contract.py
+++ b/tests/test_codex_workcell_pulse_contract.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_pulse_contract import (
+    CATEGORIES,
+    SEVERITY_HINTS,
+    CodexWorkcellPulseContractError,
+    CodexWorkcellPulseContractRequest,
+    build_codex_workcell_pulse_contract,
+    render_codex_workcell_pulse_contract_markdown,
+)
+
+REQUIRED_SIGNAL_IDS = {
+    "missing_architecture_map",
+    "missing_matrix_evidence",
+    "missing_finalizer_evidence",
+    "missing_pr_metadata_guard_evidence",
+    "missing_evidence_index",
+    "missing_lifecycle_doctor",
+    "missing_appendix_sidecar",
+    "missing_doctrine_map",
+    "matrix_required_failure_observed",
+    "matrix_diagnostic_failure_observed",
+    "finalizer_rerun_required_observed",
+    "stale_evidence_refresh_observed",
+    "generated_artifact_cleanup_incomplete_observed",
+    "authority_status_absent",
+    "provenance_absent",
+    "doctrine_context_absent",
+    "future_integration_unwired",
+    "federation_consensus_absent",
+    "daemon_repair_not_active",
+    "pulse_watch_not_active",
+}
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_required_signal_ids_categories_and_severities_are_present() -> None:
+    contract = build_codex_workcell_pulse_contract()
+    catalog = contract["signal_catalog"]
+    ids = {item["signal_id"] for item in catalog}
+    assert REQUIRED_SIGNAL_IDS <= ids
+    assert {item["category"] for item in catalog} <= set(CATEGORIES)
+    assert {item["severity_hint"] for item in catalog} <= set(SEVERITY_HINTS)
+
+
+def test_indexes_are_internally_consistent() -> None:
+    contract = build_codex_workcell_pulse_contract()
+    by_id = {item["signal_id"]: item for item in contract["signal_catalog"]}
+    for category, ids in contract["category_index"].items():
+        assert category in CATEGORIES
+        assert ids == sorted(ids)
+        assert all(by_id[signal_id]["category"] == category for signal_id in ids)
+    for severity, ids in contract["severity_index"].items():
+        assert severity in SEVERITY_HINTS
+        assert ids == sorted(ids)
+        assert all(by_id[signal_id]["severity_hint"] == severity for signal_id in ids)
+
+
+def test_non_authority_posture_and_future_requirements_are_bounded() -> None:
+    contract = build_codex_workcell_pulse_contract()
+    assert contract["not_runtime_authority"] is True
+    assert contract["not_watcher"] is True
+    assert contract["not_scheduler"] is True
+    assert contract["not_daemon_action"] is True
+    assert all(value is True for value in contract["non_authority_posture"].values())
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in contract["future_activation_requirements"])
+
+
+def test_no_signal_grants_readiness_daemon_or_schedule_authority() -> None:
+    contract = build_codex_workcell_pulse_contract()
+    forbidden = ("ready_to_commit", "ready_for_pr_metadata", "pr_metadata_guard_ready")
+    for signal in contract["signal_catalog"]:
+        text = json.dumps(signal, sort_keys=True).lower()
+        assert all(term not in text for term in forbidden)
+        assert "trigger daemon" in text
+        assert "schedule tasks" in text
+        assert "does not decide readiness" in text
+
+
+def test_health_snapshot_omitted_summary_is_not_provided() -> None:
+    summary = build_codex_workcell_pulse_contract()["health_snapshot_input_summary"]
+    assert summary == {"provided": False, "path": None, "digest": None, "byte_size": None}
+
+
+def test_health_snapshot_digest_size_and_observed_mapping(tmp_path: Path) -> None:
+    snapshot = {
+        "workcell_health_snapshot_id": "codex_workcell_health_snapshot.v1",
+        "missing_inputs": ["architecture_json", "matrix_json", "beneficial_trait_doctrine_json"],
+        "proof_summary": {"required_failure_count": 1, "diagnostic_failure_count": 1},
+        "authority_summary": {"pre_commit_rerun_required": True, "pre_commit_terminal_refresh_status": "stale"},
+        "doctrine_summary": {"provided": False},
+        "provenance_summary": {"appendix_provenance_digest_version": None},
+        "future_integration_snapshot": [{"integration": "pulse stale-evidence watch", "active_authority": False}, {"integration": "daemon repair recommendation", "active_authority": False}, {"integration": "federation drift consensus", "active_authority": False}],
+        "observed_pressure_signals": [{"signal": "matrix_required_failures"}, {"signal": "unknown_pressure", "value": 7}],
+    }
+    path = _write_json(tmp_path / "snapshot.json", snapshot)
+    raw = path.read_bytes()
+    contract = build_codex_workcell_pulse_contract(CodexWorkcellPulseContractRequest(health_snapshot_json=str(path)))
+    summary = contract["health_snapshot_input_summary"]
+    assert summary["provided"] is True
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+    assert summary["observed_pressure_signal_count"] == 2
+    assert summary["missing_inputs_count"] == 3
+    observed = contract["observed_signal_summary"]
+    assert "missing_architecture_map" in observed["observed_signal_ids"]
+    assert "matrix_required_failure_observed" in observed["observed_signal_ids"]
+    assert "finalizer_rerun_required_observed" in observed["observed_signal_ids"]
+    assert observed["unmatched_health_snapshot_pressure_signals"] == [{"signal": "unknown_pressure", "value": 7}]
+    assert observed["missing_contract_signal_ids"] == []
+    assert observed["observation_only"] is True
+
+
+def test_invalid_and_missing_health_snapshot_fail_cleanly(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    with pytest.raises(CodexWorkcellPulseContractError, match="invalid_health_snapshot_json"):
+        build_codex_workcell_pulse_contract(CodexWorkcellPulseContractRequest(health_snapshot_json=str(bad)))
+    with pytest.raises(CodexWorkcellPulseContractError, match="missing_health_snapshot_json"):
+        build_codex_workcell_pulse_contract(CodexWorkcellPulseContractRequest(health_snapshot_json=str(tmp_path / "missing.json")))
+
+
+def test_json_and_markdown_are_deterministic_and_markdown_escapes_cells(tmp_path: Path) -> None:
+    path = _write_json(tmp_path / "snapshot.json", {"observed_pressure_signals": [{"signal": "weird|pipe\nnewline"}], "missing_inputs": []})
+    req = CodexWorkcellPulseContractRequest(health_snapshot_json=str(path))
+    first = build_codex_workcell_pulse_contract(req)
+    second = build_codex_workcell_pulse_contract(req)
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    md1 = render_codex_workcell_pulse_contract_markdown(first)
+    md2 = render_codex_workcell_pulse_contract_markdown(first)
+    assert md1 == md2
+    assert md1.startswith("# Codex Workcell Pulse Contract")
+    assert "weird\\|pipe<br>newline" in md1


### PR DESCRIPTION
### Motivation
- Define a deterministic, metadata-only Pulse Observation Contract that names, classifies, and bounds pressure signals observed by the Codex Workcell Health Snapshot without introducing runtime authority or daemon behavior. 
- Provide a stable signal catalog and mapping rules so supplied health snapshots can be deterministically summarized for reviewer-only /pulse surfaces. 
- Keep the contract read-only and explicitly non-authority so future active watchers require a separate explicit implementation and operator consent. 

### Description
- Add `sentientos/codex_workcell_pulse_contract.py` which implements the pulse contract ID, stable category and severity enums, the required pulse signal catalog, health-snapshot input digesting, deterministic observed-signal mapping, unmatched-signal reporting, mount alignment, future-activation requirements, non-authority posture, and JSON/Markdown renderers. 
- Add CLI `scripts/build_codex_workcell_pulse_contract.py` supporting `--output`, optional `--markdown-output`, optional `--summary`, and optional `--health-snapshot-json` and exiting with code `2` on missing/invalid supplied snapshot. 
- Add focused tests `tests/test_codex_workcell_pulse_contract.py` and `tests/test_build_codex_workcell_pulse_contract_script.py` covering catalog completeness, category/severity enums, index consistency, non-authority posture, deterministic outputs, health snapshot mapping, unmatched-signal preservation, and CLI behavior. 
- Add documentation `docs/development/codex_workcell_pulse_contract.md` and link/notes to adjacent docs to explain boundaries and the distinction between the health snapshot and this read-only pulse catalog. 

### Testing
- Ran focused unit tests with `python -m scripts.run_tests -q tests/test_codex_workcell_pulse_contract.py tests/test_build_codex_workcell_pulse_contract_script.py` and they passed. 
- Built docs (after bootstrapping missing docs deps) using `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`, and the build succeeded. 
- Type checks with `python -m mypy sentientos/codex_workcell_pulse_contract.py scripts/build_codex_workcell_pulse_contract.py` passed and focused mypy/validation lanes passed. 
- Ran the full review matrix via `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` which completed (≈6m 3.9s) with `required_failure_count: 0` and produced `/tmp/work_item_review_packet_matrix.json`; finalize checks returned `ready_to_commit`, post-commit/pr-metadata finalize returned `ready_for_pr_metadata`, and the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a1f0215e8832fbfda48c1ebec17d8)