### PR TITLE
[sentientos:daemon] define Codex workcell repair recommendation contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -196,3 +196,7 @@ The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) may rend
 ## Pulse contract non-bypass note
 
 The Codex Workcell Pulse Contract may label finalizer pressure from supplied health snapshot metadata, including rerun or stale-evidence observations. It is not landing authority and cannot replace, bypass, or weaken pre-commit finalizer readiness, post-commit/pr-metadata finalizer readiness, or PR metadata guard readiness.
+
+## Daemon recommendation contract note
+
+Daemon recommendation contract output is reviewer context only. It does not replace, bypass, rerun, or satisfy finalizer readiness authority, and it cannot authorize commit or PR metadata. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -188,3 +188,7 @@ The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) can summ
 ## Pulse contract evidence note
 
 The Codex Workcell Pulse Contract may classify evidence recovery pressure observed in a supplied health snapshot, such as missing evidence index, lifecycle doctor, appendix sidecar, or stale refresh signals. These labels are observation-only and do not trigger recovery, daemon repair, alerts, scheduling, or federation action.
+
+## Daemon recommendation contract note
+
+The daemon recommendation contract may identify metadata-only recommendation classes for supplied pulse signals, but recovery authority remains with existing recovery rail procedure. It does not create recovery tasks, schedule work, write ledger entries, or trigger daemon repair. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -135,3 +135,7 @@ The [Codex Workcell Health Snapshot](codex_workcell_health_snapshot.md) is a coc
 ## Pulse contract validation boundary
 
 The Codex Workcell Pulse Contract is a deterministic metadata catalog for pressure signal names and categories. It does not add a landing gate, does not decide matrix success, does not authorize commits or PR metadata, and does not make skipped, nonexecuted, timed-out, stale, or missing proof count as validation.
+
+## Daemon recommendation contract note
+
+Daemon recommendation contract artifacts are non-authoritative review surfaces. They do not create validation lanes, decide readiness, bypass the finalizer, bypass the PR metadata guard, or authorize commit/PR metadata. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -99,3 +99,7 @@ The Codex Workcell Architecture answers “How do the workcell organs and flows 
 ## Pulse contract relationship
 
 The Codex Workcell Pulse Contract is a metadata-only catalog layered after the architecture map and health snapshot. It can classify architecture-related pressure such as a missing architecture map, but it does not change workcell architecture, mount behavior, scheduler behavior, daemon behavior, or authority.
+
+## Daemon recommendation contract boundary
+
+The daemon recommendation contract fills the future repair-recommendation grammar described by the architecture map without making the daemon substrate active. It maps pulse signals to metadata-only recommendations and cannot schedule, execute, create tasks, or authorize landing. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -1,0 +1,33 @@
+# Codex Workcell Daemon Recommendation Contract
+
+The Codex workcell daemon recommendation contract is a deterministic, metadata-only grammar for mapping existing Codex workcell pulse signal IDs into bounded repair recommendation classes. It is built by `scripts/build_codex_workcell_daemon_recommendation_contract.py` and implemented in `sentientos/codex_workcell_daemon_recommendation_contract.py`.
+
+This contract differs from the pulse contract: the pulse contract names pressure signals, categories, and severity hints; this recommendation contract consumes those existing signal IDs and names review-only recommendation classes such as providing missing evidence, inspecting proof pressure, preserving a boundary, or requiring a future contract.
+
+This contract also differs from actual daemon repair or daemon action. It does not watch files, poll state, run commands, create tasks, schedule work, send alerts, decide readiness, authorize commits, authorize PR metadata, write ledger entries, modify memory, train or modify models, or establish federation consensus. Applicable recommendations are observations for reviewers only.
+
+## Recommendation mapping
+
+The contract maps supplied pulse `observed_signal_summary.observed_signal_ids` to static recommendation IDs. Unknown observed signal IDs are preserved as unmatched. If no pulse contract JSON is supplied, observed and applicable recommendation lists remain empty and marked as not provided.
+
+The recommendation catalog includes evidence-provision recommendations, proof/authority/freshness/provenance/doctrine inspection recommendations, future-integration documentation, boundary preservation, and future-contract requirements. Every source signal ID must already exist in the Codex workcell pulse contract.
+
+## Input handling
+
+The builder may read `--pulse-contract-json` and `--health-snapshot-json`. Each supplied input is read as raw bytes, hashed with SHA-256, byte-counted, and parsed as JSON object metadata. Missing, invalid, or non-object JSON fails cleanly before output is trusted. Omitted inputs are recorded with `provided: false` and no digest.
+
+## SentientOS mount alignment
+
+- `/daemon`: future repair recommendation consumer; inactive here.
+- `/pulse`: source pressure signal categories and severity hints.
+- `/glow`: future archive for observation surfaces and evidence context.
+- `/ledger`: future receipt history context.
+- `/vow`: canonical constraints bounding forbidden action and non-authority interpretation.
+
+## Future activation requirements
+
+All activation requirements are represented as future-only, unmet, and inactive. Active behavior would require a separate daemon implementation, explicit operator consent, command execution boundary, scheduler boundary, alerting boundary, task creation boundary, finalizer/guard non-bypass invariant, ledger/glow storage policy, pulse watcher contract, federation drift consensus rule, vow digest constraint check, tests proving no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The contract is read-only and metadata-only. It cannot bypass the finalizer or PR metadata guard, cannot authorize commit or PR creation, cannot trigger daemon action, cannot create or schedule tasks, cannot send alerts, cannot watch or poll, cannot train or modify models, and cannot establish federation consensus.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -41,3 +41,7 @@ Its recommendations are phrased as observation recommendations only, such as sup
 ## Pulse contract relationship
 
 The Codex Workcell Health Snapshot answers what is currently observable from supplied metadata artifacts. The Codex Workcell Pulse Contract consumes an optional snapshot JSON only as input evidence and answers how observed pressure signals are named, classified, bounded, and prepared for future `/pulse` observation. It does not run this snapshot builder or decide readiness.
+
+## Daemon recommendation contract boundary
+
+Health snapshot metadata may be referenced by the daemon recommendation contract for digest and input-summary context, but recommendations are derived from supplied pulse contract observed signal IDs and remain observation-only. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -40,3 +40,7 @@ Before this contract could become an active watcher, a separate future implement
 ## Non-authority posture
 
 The contract is read-only, metadata-only, does not watch files, does not poll state, does not rerun commands, does not decide readiness, does not bypass the finalizer or PR metadata guard, does not authorize commit or PR creation, does not trigger daemons, does not schedule tasks, does not send alerts, does not train or modify models, and does not establish federation consensus.
+
+## Daemon recommendation contract link
+
+The daemon recommendation contract maps this contract's stable pulse signal IDs into review-only repair recommendation classes. It remains metadata-only and does not activate watching, scheduling, daemon action, readiness decisions, commits, PR metadata, ledger writes, memory mutation, model training, or federation consensus. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.

--- a/scripts/build_codex_workcell_daemon_recommendation_contract.py
+++ b/scripts/build_codex_workcell_daemon_recommendation_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_daemon_recommendation_contract import (
+    CodexWorkcellDaemonRecommendationContractError,
+    CodexWorkcellDaemonRecommendationContractRequest,
+    build_codex_workcell_daemon_recommendation_contract,
+    render_codex_workcell_daemon_recommendation_contract_markdown,
+    write_codex_workcell_daemon_recommendation_contract_json,
+    write_codex_workcell_daemon_recommendation_contract_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell daemon recommendation contract.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--pulse-contract-json")
+    parser.add_argument("--health-snapshot-json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        contract = build_codex_workcell_daemon_recommendation_contract(CodexWorkcellDaemonRecommendationContractRequest(pulse_contract_json=args.pulse_contract_json, health_snapshot_json=args.health_snapshot_json))
+    except CodexWorkcellDaemonRecommendationContractError as exc:
+        print(f"codex_workcell_daemon_recommendation_contract_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_daemon_recommendation_contract_json(contract, args.output)
+    if args.markdown_output:
+        write_codex_workcell_daemon_recommendation_contract_markdown(render_codex_workcell_daemon_recommendation_contract_markdown(contract), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"daemon_recommendation_contract_id": contract["daemon_recommendation_contract_id"], "metadata_only": True, "daemon_recommendation_contract_only": True, "output": args.output, "markdown_output": args.markdown_output, "pulse_contract_provided": contract["pulse_contract_input_summary"].get("provided"), "health_snapshot_provided": contract["health_snapshot_input_summary"].get("provided"), "recommendation_count": len(contract["recommendation_catalog"]), "applicable_recommendation_count": len(contract["observed_recommendation_summary"].get("applicable_recommendation_ids", []))}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_daemon_recommendation_contract.py
+++ b/sentientos/codex_workcell_daemon_recommendation_contract.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from sentientos.codex_workcell_pulse_contract import CATEGORIES as PULSE_CATEGORIES
+from sentientos.codex_workcell_pulse_contract import SEVERITY_HINTS as PULSE_SEVERITY_HINTS
+from sentientos.codex_workcell_pulse_contract import _signal_catalog
+
+DAEMON_RECOMMENDATION_CONTRACT_ID = "codex_workcell_daemon_recommendation_contract.v1"
+DIGEST_ALGO = "sha256"
+RECOMMENDATION_TYPES: tuple[str, ...] = (
+    "provide_missing_evidence",
+    "inspect_proof_pressure",
+    "inspect_authority_pressure",
+    "inspect_freshness_pressure",
+    "inspect_provenance_pressure",
+    "inspect_doctrine_pressure",
+    "document_future_integration",
+    "preserve_boundary",
+    "require_future_contract",
+)
+SEVERITY_FLOORS: tuple[str, ...] = ("info", "watch", "caution", "blocked_observation")
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "daemon_recommendation_contract_is_read_only": True,
+    "daemon_recommendation_contract_is_metadata_only": True,
+    "daemon_recommendation_contract_does_not_watch_files": True,
+    "daemon_recommendation_contract_does_not_poll_state": True,
+    "daemon_recommendation_contract_does_not_rerun_commands": True,
+    "daemon_recommendation_contract_does_not_decide_readiness": True,
+    "daemon_recommendation_contract_does_not_bypass_finalizer": True,
+    "daemon_recommendation_contract_does_not_bypass_pr_metadata_guard": True,
+    "daemon_recommendation_contract_does_not_authorize_commit": True,
+    "daemon_recommendation_contract_does_not_authorize_pr_creation": True,
+    "daemon_recommendation_contract_does_not_trigger_daemon": True,
+    "daemon_recommendation_contract_does_not_create_tasks": True,
+    "daemon_recommendation_contract_does_not_schedule_tasks": True,
+    "daemon_recommendation_contract_does_not_send_alerts": True,
+    "daemon_recommendation_contract_does_not_train_or_modify_models": True,
+    "daemon_recommendation_contract_does_not_establish_federation_consensus": True,
+}
+
+FUTURE_ACTIVATION_REQUIREMENTS: tuple[str, ...] = (
+    "explicit separate daemon implementation",
+    "explicit operator consent",
+    "explicit command execution boundary",
+    "explicit scheduler boundary",
+    "explicit alerting boundary",
+    "explicit task creation boundary",
+    "explicit finalizer/guard non-bypass invariant",
+    "explicit ledger/glow storage policy",
+    "explicit pulse watcher contract",
+    "explicit federation drift consensus rule",
+    "explicit vow digest constraint check",
+    "tests proving no readiness authority",
+    "docs marking active behavior",
+)
+
+# recommendation_id, name, type, source_signal_ids, source_categories, severity_floor, text, boundary note
+_RECOMMENDATION_SPECS: tuple[tuple[str, str, str, tuple[str, ...], tuple[str, ...], str, str, str], ...] = (
+    ("provide_architecture_evidence", "Provide architecture evidence", "provide_missing_evidence", ("missing_architecture_map",), ("missing_input",), "watch", "Supply the architecture map evidence to the reviewing surface.", "Architecture evidence does not authorize landing."),
+    ("provide_matrix_evidence", "Provide matrix evidence", "provide_missing_evidence", ("missing_matrix_evidence",), ("missing_input",), "caution", "Supply matrix evidence metadata for review.", "Matrix evidence remains proof context only."),
+    ("provide_finalizer_evidence", "Provide finalizer evidence", "provide_missing_evidence", ("missing_finalizer_evidence",), ("missing_input",), "caution", "Supply finalizer evidence metadata for the appropriate phase.", "Only the finalizer may decide its phase readiness."),
+    ("provide_pr_metadata_guard_evidence", "Provide PR metadata guard evidence", "provide_missing_evidence", ("missing_pr_metadata_guard_evidence",), ("missing_input",), "caution", "Supply PR metadata guard evidence metadata.", "Only the guard may authorize PR metadata."),
+    ("provide_evidence_index", "Provide evidence index", "provide_missing_evidence", ("missing_evidence_index",), ("missing_input",), "watch", "Supply the landing evidence index metadata.", "The index catalogs artifacts only."),
+    ("provide_lifecycle_doctor", "Provide lifecycle doctor", "provide_missing_evidence", ("missing_lifecycle_doctor",), ("missing_input",), "watch", "Supply lifecycle doctor diagnostic metadata.", "Doctor output is advisory context only."),
+    ("provide_appendix_sidecar", "Provide appendix sidecar", "provide_missing_evidence", ("missing_appendix_sidecar",), ("provenance_pressure",), "watch", "Supply appendix provenance sidecar metadata.", "Provenance does not verify readiness."),
+    ("provide_doctrine_map", "Provide doctrine map", "provide_missing_evidence", ("missing_doctrine_map",), ("doctrine_pressure",), "watch", "Supply doctrine map metadata for reviewer context.", "Doctrine context does not train or modify models."),
+    ("inspect_required_matrix_failures", "Inspect required matrix failures", "inspect_proof_pressure", ("matrix_required_failure_observed",), ("proof_pressure",), "blocked_observation", "Inspect required matrix failures in the source matrix evidence.", "Inspection does not rerun commands."),
+    ("inspect_diagnostic_nonproof_lanes", "Inspect diagnostic nonproof lanes", "inspect_proof_pressure", ("matrix_diagnostic_failure_observed",), ("proof_pressure",), "watch", "Inspect diagnostic nonproof lane failures as reviewer context.", "Diagnostics cannot become proof authority."),
+    ("inspect_finalizer_rerun_signal", "Inspect finalizer rerun signal", "inspect_authority_pressure", ("finalizer_rerun_required_observed", "authority_status_absent"), ("authority_pressure",), "caution", "Inspect finalizer rerun or absent authority status metadata.", "Recommendation cannot decide readiness or rerun finalizer."),
+    ("inspect_stale_evidence_refresh", "Inspect stale evidence refresh", "inspect_freshness_pressure", ("stale_evidence_refresh_observed",), ("freshness_pressure",), "caution", "Inspect stale evidence refresh pressure before relying on evidence context.", "Recommendation cannot make evidence fresh."),
+    ("inspect_generated_artifact_cleanup", "Inspect generated artifact cleanup", "inspect_freshness_pressure", ("generated_artifact_cleanup_incomplete_observed",), ("freshness_pressure",), "caution", "Inspect generated artifact cleanup pressure.", "Recommendation cannot clean artifacts."),
+    ("preserve_unmatched_pressure_signal", "Preserve unmatched pressure signal", "preserve_boundary", ("provenance_absent",), ("provenance_pressure",), "watch", "Preserve unmatched or provenance pressure for human review.", "Unknown pressure must not be converted into action."),
+    ("document_future_integration_gap", "Document future integration gap", "document_future_integration", ("future_integration_unwired",), ("future_integration_pressure",), "info", "Document unwired future integration as inactive metadata.", "Future integration remains inactive."),
+    ("preserve_daemon_inactive_boundary", "Preserve daemon inactive boundary", "preserve_boundary", ("daemon_repair_not_active",), ("daemon_boundary",), "info", "Preserve the daemon repair inactive boundary.", "No daemon action is triggered."),
+    ("require_explicit_watcher_activation_contract", "Require explicit watcher activation contract", "require_future_contract", ("pulse_watch_not_active",), ("future_integration_pressure",), "info", "Require a separate watcher activation contract before any watching.", "This contract does not watch files."),
+    ("require_explicit_scheduler_activation_contract", "Require explicit scheduler activation contract", "require_future_contract", ("pulse_watch_not_active",), ("future_integration_pressure",), "info", "Require a separate scheduler activation contract before scheduling.", "This contract does not schedule tasks."),
+    ("require_explicit_daemon_action_contract", "Require explicit daemon action contract", "require_future_contract", ("daemon_repair_not_active",), ("daemon_boundary",), "info", "Require a separate daemon action contract before daemon repair behavior.", "This contract does not trigger daemon action."),
+    ("require_federation_consensus_contract", "Require federation consensus contract", "require_future_contract", ("federation_consensus_absent",), ("federation_boundary",), "info", "Require a separate consensus contract before federation drift adoption.", "This contract establishes no federation consensus."),
+    ("require_ledger_glow_storage_policy", "Require ledger glow storage policy", "require_future_contract", ("provenance_absent",), ("provenance_pressure",), "info", "Require explicit ledger/glow storage policy before archival writes.", "This contract writes no ledger or glow memory."),
+    ("require_vow_digest_boundary_check", "Require vow digest boundary check", "require_future_contract", ("doctrine_context_absent",), ("doctrine_pressure",), "watch", "Require explicit vow digest constraint checks before future active interpretation.", "This contract does not override canonical constraints."),
+)
+
+class CodexWorkcellDaemonRecommendationContractError(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class CodexWorkcellDaemonRecommendationContractRequest:
+    pulse_contract_json: str | None = None
+    health_snapshot_json: str | None = None
+
+
+def _known_signal_ids() -> set[str]:
+    return {str(item["signal_id"]) for item in _signal_catalog()}
+
+
+def _catalog() -> list[dict[str, Any]]:
+    known = _known_signal_ids()
+    catalog = []
+    for rec_id, name, rec_type, signal_ids, categories, floor, text, boundary in _RECOMMENDATION_SPECS:
+        if rec_type not in RECOMMENDATION_TYPES or floor not in SEVERITY_FLOORS or not set(signal_ids) <= known:
+            raise CodexWorkcellDaemonRecommendationContractError(f"invalid_recommendation_spec:{rec_id}")
+        catalog.append({
+            "recommendation_id": rec_id,
+            "recommendation_name": name,
+            "recommendation_type": rec_type,
+            "source_signal_ids": list(signal_ids),
+            "source_categories": list(categories),
+            "severity_floor": floor,
+            "recommendation_text": text,
+            "forbidden_action": "Must not trigger daemon action, create tasks, schedule work, send alerts, watch files, poll state, run commands, decide readiness, authorize commit, authorize PR metadata, write ledger entries, modify memory, establish federation consensus, or train/modify models.",
+            "required_operator_boundary": "Any active repair, scheduling, command execution, alerting, task creation, storage, federation, or landing authority requires a separate explicit operator-authorized contract.",
+            "daemon_non_action_boundary": boundary,
+            "reviewer_summary": f"{name} maps {', '.join(signal_ids)} to {rec_type} with {floor} severity floor.",
+        })
+    return catalog
+
+
+def _index(catalog: list[dict[str, Any]], key: str, values: tuple[str, ...]) -> dict[str, list[str]]:
+    return {value: sorted(str(item["recommendation_id"]) for item in catalog if item[key] == value) for value in values}
+
+
+def _source_signal_index(catalog: list[dict[str, Any]]) -> dict[str, list[str]]:
+    index: dict[str, list[str]] = {signal_id: [] for signal_id in sorted(_known_signal_ids())}
+    for item in catalog:
+        for signal_id in item["source_signal_ids"]:
+            index[str(signal_id)].append(str(item["recommendation_id"]))
+    return {key: sorted(value) for key, value in index.items() if value}
+
+
+def _read_json(path_text: str | None, label: str) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellDaemonRecommendationContractError(f"missing_{label}_json:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellDaemonRecommendationContractError(f"invalid_{label}_json:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellDaemonRecommendationContractError(f"{label}_json_not_object:{path_text}")
+    return {"provided": True, "path": path_text, "readable_json": True, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "error": None}, loaded
+
+
+def _pulse_summary(summary: dict[str, Any], pulse: Mapping[str, Any] | None) -> dict[str, Any]:
+    if pulse is None:
+        return summary
+    out = dict(summary)
+    for src, dst in (("pulse_contract_id", "pulse_contract_id"),):
+        if src in pulse:
+            out[dst] = pulse[src]
+    obs = pulse.get("observed_signal_summary")
+    if isinstance(obs, Mapping):
+        if isinstance(obs.get("observed_signal_ids"), list):
+            out["observed_signal_count"] = len(obs["observed_signal_ids"])
+        if isinstance(obs.get("unmatched_health_snapshot_pressure_signals"), list):
+            out["unmatched_health_snapshot_pressure_signal_count"] = len(obs["unmatched_health_snapshot_pressure_signals"])
+    if isinstance(pulse.get("category_index"), Mapping):
+        out["category_count"] = len(pulse["category_index"])
+    if isinstance(pulse.get("severity_index"), Mapping):
+        out["severity_count"] = len(pulse["severity_index"])
+    return out
+
+
+def _health_summary(summary: dict[str, Any], health: Mapping[str, Any] | None) -> dict[str, Any]:
+    if health is None:
+        return summary
+    out = dict(summary)
+    if "workcell_health_snapshot_id" in health:
+        out["workcell_health_snapshot_id"] = health["workcell_health_snapshot_id"]
+    if isinstance(health.get("observed_pressure_signals"), list):
+        out["observed_pressure_signal_count"] = len(health["observed_pressure_signals"])
+    if isinstance(health.get("missing_inputs"), list):
+        out["missing_input_count"] = len(health["missing_inputs"])
+    return out
+
+
+def _observed_recommendations(pulse: Mapping[str, Any] | None, catalog: list[dict[str, Any]]) -> dict[str, Any]:
+    base = {"recommendation_only": True, "no_action_taken": True}
+    if pulse is None:
+        return {"provided": False, "observed_signal_ids": [], "applicable_recommendation_ids": [], "unmatched_observed_signal_ids": [], "recommendation_types_observed": [], "severity_hints_observed": [], **base}
+    raw = pulse.get("observed_signal_summary")
+    observed_raw = raw.get("observed_signal_ids") if isinstance(raw, Mapping) else []
+    observed = sorted(str(item) for item in observed_raw) if isinstance(observed_raw, list) else []
+    index = _source_signal_index(catalog)
+    applicable = sorted({rec for signal_id in observed for rec in index.get(signal_id, [])})
+    by_id = {str(item["recommendation_id"]): item for item in catalog}
+    return {"provided": True, "observed_signal_ids": observed, "applicable_recommendation_ids": applicable, "unmatched_observed_signal_ids": sorted(signal_id for signal_id in observed if signal_id not in index), "recommendation_types_observed": sorted({str(by_id[r]["recommendation_type"]) for r in applicable}), "severity_hints_observed": sorted({str(by_id[r]["severity_floor"]) for r in applicable}), **base}
+
+
+def build_codex_workcell_daemon_recommendation_contract(request: CodexWorkcellDaemonRecommendationContractRequest | None = None) -> dict[str, Any]:
+    request = request or CodexWorkcellDaemonRecommendationContractRequest()
+    catalog = _catalog()
+    pulse_summary_raw, pulse = _read_json(request.pulse_contract_json, "pulse_contract")
+    health_summary_raw, health = _read_json(request.health_snapshot_json, "health_snapshot")
+    return {
+        "daemon_recommendation_contract_id": DAEMON_RECOMMENDATION_CONTRACT_ID,
+        "metadata_only": True,
+        "daemon_recommendation_contract_only": True,
+        "not_runtime_authority": True,
+        "not_watcher": True,
+        "not_scheduler": True,
+        "not_executor": True,
+        "not_daemon_action": True,
+        "not_task_creator": True,
+        "not_alerting_system": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "recommendation_catalog": catalog,
+        "recommendation_type_index": _index(catalog, "recommendation_type", RECOMMENDATION_TYPES),
+        "source_signal_index": _source_signal_index(catalog),
+        "pulse_contract_input_summary": _pulse_summary(pulse_summary_raw, pulse),
+        "health_snapshot_input_summary": _health_summary(health_summary_raw, health),
+        "observed_recommendation_summary": _observed_recommendations(pulse, catalog),
+        "sentientos_mount_alignment": {"/daemon": "future repair recommendation consumer; inactive here", "/pulse": "source pressure signal categories and severity hints", "/glow": "future archive for observation surfaces and evidence context", "/ledger": "future receipt history context", "/vow": "canonical constraints bounding forbidden action and non-authority interpretation"},
+        "future_activation_requirements": [{"requirement": item, "status": "future_only", "met": False, "active": False} for item in FUTURE_ACTIVATION_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\\r\\n", "<br>").replace("\\n", "<br>").replace("\\r", "<br>").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
+def render_codex_workcell_daemon_recommendation_contract_markdown(contract: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Daemon Recommendation Contract", "", "This is a deterministic metadata-only recommendation grammar. It maps supplied pulse signal IDs to bounded review recommendations only; it does not watch, poll, schedule, alert, create tasks, execute commands, trigger daemon action, decide readiness, authorize commit, authorize PR metadata, write ledger/glow memory, train models, or establish federation consensus."]
+    for title, key in (("Pulse contract input summary", "pulse_contract_input_summary"), ("Health snapshot input summary", "health_snapshot_input_summary")):
+        lines += ["", f"## {title}", "| key | value |", "| --- | --- |"]
+        for item_key, value in sorted(contract[key].items()):
+            lines.append(f"| {_cell(item_key)} | {_cell(value)} |")
+    lines += ["", "## Recommendation catalog", "| recommendation_id | recommendation_name | recommendation_type | source_signal_ids | source_categories | severity_floor | reviewer_summary |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for item in contract["recommendation_catalog"]:
+        lines.append(f"| {_cell(item['recommendation_id'])} | {_cell(item['recommendation_name'])} | {_cell(item['recommendation_type'])} | {_cell(item['source_signal_ids'])} | {_cell(item['source_categories'])} | {_cell(item['severity_floor'])} | {_cell(item['reviewer_summary'])} |")
+    if contract["pulse_contract_input_summary"].get("provided"):
+        lines += ["", "## Applicable recommendation summary", "| key | value |", "| --- | --- |"]
+        for item_key, value in sorted(contract["observed_recommendation_summary"].items()):
+            lines.append(f"| {_cell(item_key)} | {_cell(value)} |")
+    for title, key in (("Recommendation type index", "recommendation_type_index"), ("Source signal index", "source_signal_index"), ("SentientOS mount alignment", "sentientos_mount_alignment")):
+        lines += ["", f"## {title}", "| key | value |", "| --- | --- |"]
+        for item_key, value in sorted(contract[key].items()):
+            lines.append(f"| {_cell(item_key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in contract["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(contract["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_daemon_recommendation_contract_json(contract: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_daemon_recommendation_contract_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_daemon_recommendation_contract_script.py
+++ b/tests/test_build_codex_workcell_daemon_recommendation_contract_script.py
@@ -1,0 +1,54 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/build_codex_workcell_daemon_recommendation_contract.py"
+
+
+def run_cmd(*args):
+    return subprocess.run([sys.executable, SCRIPT, *args], text=True, capture_output=True)
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path):
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = run_cmd("--output", str(output), "--markdown-output", str(markdown), "--summary")
+    assert result.returncode == 0, result.stderr
+    data = json.loads(output.read_text())
+    summary = json.loads(result.stdout)
+    assert data["daemon_recommendation_contract_id"] == "codex_workcell_daemon_recommendation_contract.v1"
+    assert summary["recommendation_count"] == len(data["recommendation_catalog"])
+    assert markdown.read_text().startswith("# Codex Workcell Daemon Recommendation Contract")
+
+
+def test_cli_writes_supplied_inputs(tmp_path):
+    pulse = tmp_path / "pulse.json"
+    health = tmp_path / "health.json"
+    pulse.write_text('{"observed_signal_summary":{"observed_signal_ids":["missing_finalizer_evidence"]}}')
+    health.write_text('{"workcell_health_snapshot_id":"h"}')
+    output = tmp_path / "contract.json"
+    result = run_cmd("--output", str(output), "--pulse-contract-json", str(pulse), "--health-snapshot-json", str(health), "--summary")
+    assert result.returncode == 0, result.stderr
+    data = json.loads(output.read_text())
+    assert data["pulse_contract_input_summary"]["provided"] is True
+    assert data["health_snapshot_input_summary"]["provided"] is True
+    assert "provide_finalizer_evidence" in data["observed_recommendation_summary"]["applicable_recommendation_ids"]
+
+
+def test_cli_clean_input_failures_exit_2(tmp_path):
+    output = tmp_path / "out.json"
+    bad = tmp_path / "bad.json"
+    bad.write_text("{")
+    for args in [
+        ("--output", str(output), "--pulse-contract-json", str(tmp_path / "missing-pulse.json")),
+        ("--output", str(output), "--pulse-contract-json", str(bad)),
+        ("--output", str(output), "--health-snapshot-json", str(tmp_path / "missing-health.json")),
+        ("--output", str(output), "--health-snapshot-json", str(bad)),
+    ]:
+        result = run_cmd(*args)
+        assert result.returncode == 2
+        assert "codex_workcell_daemon_recommendation_contract_error" in result.stderr

--- a/tests/test_codex_workcell_daemon_recommendation_contract.py
+++ b/tests/test_codex_workcell_daemon_recommendation_contract.py
@@ -1,0 +1,108 @@
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_daemon_recommendation_contract import (
+    NON_AUTHORITY_POSTURE,
+    RECOMMENDATION_TYPES,
+    SEVERITY_FLOORS,
+    CodexWorkcellDaemonRecommendationContractRequest,
+    _cell,
+    build_codex_workcell_daemon_recommendation_contract,
+    render_codex_workcell_daemon_recommendation_contract_markdown,
+)
+from sentientos.codex_workcell_pulse_contract import _signal_catalog
+
+REQUIRED_IDS = {
+    "provide_architecture_evidence", "provide_matrix_evidence", "provide_finalizer_evidence",
+    "provide_pr_metadata_guard_evidence", "provide_evidence_index", "provide_lifecycle_doctor",
+    "provide_appendix_sidecar", "provide_doctrine_map", "inspect_required_matrix_failures",
+    "inspect_diagnostic_nonproof_lanes", "inspect_finalizer_rerun_signal", "inspect_stale_evidence_refresh",
+    "inspect_generated_artifact_cleanup", "preserve_unmatched_pressure_signal", "document_future_integration_gap",
+    "preserve_daemon_inactive_boundary", "require_explicit_watcher_activation_contract",
+    "require_explicit_scheduler_activation_contract", "require_explicit_daemon_action_contract",
+    "require_federation_consensus_contract", "require_ledger_glow_storage_policy", "require_vow_digest_boundary_check",
+}
+
+
+def test_required_recommendations_indexes_and_known_types():
+    contract = build_codex_workcell_daemon_recommendation_contract()
+    catalog = contract["recommendation_catalog"]
+    ids = {item["recommendation_id"] for item in catalog}
+    assert REQUIRED_IDS <= ids
+    known_signals = {item["signal_id"] for item in _signal_catalog()}
+    for item in catalog:
+        assert item["recommendation_type"] in RECOMMENDATION_TYPES
+        assert item["severity_floor"] in SEVERITY_FLOORS
+        assert set(item["source_signal_ids"]) <= known_signals
+        assert "does not" in item["forbidden_action"].lower() or "must not" in item["forbidden_action"].lower()
+        text = json.dumps(item).lower()
+        assert "authorize commit" in text
+        assert "trigger daemon action" in text
+        assert "create tasks" in text
+        assert "schedule" in text
+        assert "send alerts" in text
+    by_type = {kind: sorted(i["recommendation_id"] for i in catalog if i["recommendation_type"] == kind) for kind in RECOMMENDATION_TYPES}
+    assert contract["recommendation_type_index"] == by_type
+    source_index = {}
+    for item in catalog:
+        for signal in item["source_signal_ids"]:
+            source_index.setdefault(signal, []).append(item["recommendation_id"])
+    assert contract["source_signal_index"] == {k: sorted(v) for k, v in sorted(source_index.items())}
+
+
+def test_non_authority_and_future_requirements_are_inactive():
+    contract = build_codex_workcell_daemon_recommendation_contract()
+    assert set(NON_AUTHORITY_POSTURE) <= set(contract["non_authority_posture"])
+    assert all(contract["non_authority_posture"].values())
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in contract["future_activation_requirements"])
+    assert contract["not_runtime_authority"] is True
+    assert contract["not_daemon_action"] is True
+    assert contract["not_task_creator"] is True
+    assert contract["not_scheduler"] is True
+    assert contract["not_alerting_system"] is True
+
+
+def test_omitted_inputs_have_false_summaries():
+    contract = build_codex_workcell_daemon_recommendation_contract()
+    for key in ("pulse_contract_input_summary", "health_snapshot_input_summary"):
+        summary = contract[key]
+        assert summary["provided"] is False
+        assert summary["path"] is None
+        assert summary["digest"] is None
+        assert summary["byte_size"] is None
+        assert summary["readable_json"] is False
+        assert summary["error"] is None
+    assert contract["observed_recommendation_summary"]["provided"] is False
+    assert contract["observed_recommendation_summary"]["applicable_recommendation_ids"] == []
+
+
+def test_supplied_inputs_digest_size_and_observed_mapping(tmp_path):
+    pulse_raw = b'{"pulse_contract_id":"pulse","category_index":{"a":[]},"severity_index":{"b":[]},"observed_signal_summary":{"observed_signal_ids":["missing_matrix_evidence","unknown_signal"],"unmatched_health_snapshot_pressure_signals":["x"]}}'
+    health_raw = b'{"workcell_health_snapshot_id":"health","observed_pressure_signals":["p"],"missing_inputs":["m"]}'
+    pulse = tmp_path / "pulse.json"
+    health = tmp_path / "health.json"
+    pulse.write_bytes(pulse_raw)
+    health.write_bytes(health_raw)
+    contract = build_codex_workcell_daemon_recommendation_contract(CodexWorkcellDaemonRecommendationContractRequest(str(pulse), str(health)))
+    assert contract["pulse_contract_input_summary"]["digest"] == hashlib.sha256(pulse_raw).hexdigest()
+    assert contract["pulse_contract_input_summary"]["byte_size"] == len(pulse_raw)
+    assert contract["pulse_contract_input_summary"]["observed_signal_count"] == 2
+    assert contract["health_snapshot_input_summary"]["digest"] == hashlib.sha256(health_raw).hexdigest()
+    assert contract["health_snapshot_input_summary"]["byte_size"] == len(health_raw)
+    observed = contract["observed_recommendation_summary"]
+    assert "provide_matrix_evidence" in observed["applicable_recommendation_ids"]
+    assert observed["unmatched_observed_signal_ids"] == ["unknown_signal"]
+    assert observed["recommendation_only"] is True
+    assert observed["no_action_taken"] is True
+
+
+def test_json_and_markdown_are_deterministic_and_escape_cells():
+    first = build_codex_workcell_daemon_recommendation_contract()
+    second = build_codex_workcell_daemon_recommendation_contract()
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert render_codex_workcell_daemon_recommendation_contract_markdown(first) == render_codex_workcell_daemon_recommendation_contract_markdown(second)
+    assert _cell("a|b\nc") == "a\\|b<br>c"


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only grammar that maps existing Codex workcell pulse signal IDs into bounded daemon repair recommendation classes while preserving strict non-authority posture. 
- Reuse the existing pulse/health snapshot architecture and implementation patterns (stable IDs, SHA-256 raw-byte digests, deterministic JSON/Markdown, tuple-backed catalogs, dataclass requests, CLI with exit code 2 on clean input failures).

### Description

- Add `sentientos/codex_workcell_daemon_recommendation_contract.py` implementing `DAEMON_RECOMMENDATION_CONTRACT_ID`, `DIGEST_ALGO`, `RECOMMENDATION_TYPES`, `SEVERITY_FLOORS`, a static recommendation catalog, deterministic `recommendation_type_index` and `source_signal_index`, read/raw-byte JSON input summaries, observed-signal -> recommendation mapping, mount alignment, future-only activation requirements, and a full non-authority posture dictionary. 
- Add CLI `scripts/build_codex_workcell_daemon_recommendation_contract.py` with required `--output`, optional `--markdown-output`, `--summary`, `--pulse-contract-json` and `--health-snapshot-json`, and clean `exit 2` on input failures. 
- Add focused tests `tests/test_codex_workcell_daemon_recommendation_contract.py` and `tests/test_build_codex_workcell_daemon_recommendation_contract_script.py` covering catalog completeness, index consistency, source-signal validation against the pulse contract, input digest/byte-size handling, observed mapping/unmatched signals, deterministic JSON/Markdown, Markdown escaping, and CLI failure semantics. 
- Add `docs/development/codex_workcell_daemon_recommendation_contract.md` and insert short boundary/link notes into adjacent docs (`codex_workcell_pulse_contract.md`, `codex_workcell_health_snapshot.md`, `codex_workcell_architecture.md`, `codex_finalize_landing.md`, `codex_landing_evidence_recovery_rail.md`, `codex_validation_and_landing_contract.md`) to emphasize reviewer-only/non-authority boundaries.

### Testing

- Ran the new focused tests with `python -m scripts.run_tests -q tests/test_codex_workcell_daemon_recommendation_contract.py tests/test_build_codex_workcell_daemon_recommendation_contract_script.py` and they passed. 
- Ran the related contract/test matrix and validation lanes: `python -m scripts.run_tests -q` for pulse/health/architecture and several adjacent proof/index/doctor tests; `python -m mypy sentientos/codex_workcell_daemon_recommendation_contract.py scripts/build_codex_workcell_daemon_recommendation_contract.py` passed after a minor typing fix. 
- Docs build initially reported missing deps and was bootstrapped with `python scripts/build_docs.py --bootstrap-docs` and then `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` completed successfully. 
- Full work-item review matrix run `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` returned `status: passed` with `required_failures: 0` and `diagnostic_failures: 43` (diagnostic-only items). 
- Pre-commit finalizer returned `ready_to_commit`, post-commit/pr-metadata finalizer returned `ready_for_pr_metadata`, and PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b0fe6f090832fb6cf81930fca44fb)