### PR TITLE
[codex:memory] define Codex workcell ledger and glow memory contracts

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -200,3 +200,6 @@ The Codex Workcell Pulse Contract may label finalizer pressure from supplied hea
 ## Daemon recommendation contract note
 
 Daemon recommendation contract output is reviewer context only. It does not replace, bypass, rerun, or satisfy finalizer readiness authority, and it cannot authorize commit or PR metadata. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Workcell memory contract boundary
+
+The Codex Workcell Memory Contract can describe future receipt metadata for finalizer artifacts, but it cannot replace this finalizer, authorize readiness, bypass phase checks, write ledger entries, or create PR metadata authority.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -192,3 +192,6 @@ The Codex Workcell Pulse Contract may classify evidence recovery pressure observ
 ## Daemon recommendation contract note
 
 The daemon recommendation contract may identify metadata-only recommendation classes for supplied pulse signals, but recovery authority remains with existing recovery rail procedure. It does not create recovery tasks, schedule work, write ledger entries, or trigger daemon repair. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Workcell memory contract boundary
+
+The Codex Workcell Memory Contract can name future `/ledger` receipt-chain and `/glow` archive roles for recovery evidence, but recovery remains governed by this rail; the memory contract does not archive files or recover task-owned files.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -139,3 +139,6 @@ The Codex Workcell Pulse Contract is a deterministic metadata catalog for pressu
 ## Daemon recommendation contract note
 
 Daemon recommendation contract artifacts are non-authoritative review surfaces. They do not create validation lanes, decide readiness, bypass the finalizer, bypass the PR metadata guard, or authorize commit/PR metadata. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Workcell memory contract boundary
+
+The Codex Workcell Memory Contract defines future metadata shapes for landed evidence history and archive review surfaces. It does not add validation gates, satisfy matrix lanes, authorize commit, authorize PR metadata, or bypass required finalizer and guard checks.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -103,3 +103,6 @@ The Codex Workcell Pulse Contract is a metadata-only catalog layered after the a
 ## Daemon recommendation contract boundary
 
 The daemon recommendation contract fills the future repair-recommendation grammar described by the architecture map without making the daemon substrate active. It maps pulse signals to metadata-only recommendations and cannot schedule, execute, create tasks, or authorize landing. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Memory contract boundary
+
+The Codex Workcell Memory Contract is the next metadata-only layer after architecture, health, pulse, and daemon recommendation contracts. It names future `/ledger` and `/glow` schemas while remaining non-authoritative and non-writing.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -31,3 +31,6 @@ All activation requirements are represented as future-only, unmet, and inactive.
 ## Non-authority posture
 
 The contract is read-only and metadata-only. It cannot bypass the finalizer or PR metadata guard, cannot authorize commit or PR creation, cannot trigger daemon action, cannot create or schedule tasks, cannot send alerts, cannot watch or poll, cannot train or modify models, and cannot establish federation consensus.
+## Memory contract boundary
+
+The Codex Workcell Memory Contract defines future `/ledger` receipt-chain and `/glow` evidence-archive metadata for recommendation artifacts, but it does not write memory, archive evidence, trigger daemon action, or create authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -45,3 +45,6 @@ The Codex Workcell Health Snapshot answers what is currently observable from sup
 ## Daemon recommendation contract boundary
 
 Health snapshot metadata may be referenced by the daemon recommendation contract for digest and input-summary context, but recommendations are derived from supplied pulse contract observed signal IDs and remain observation-only. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Memory contract boundary
+
+The Codex Workcell Memory Contract defines how health snapshots could be represented in future `/ledger` and `/glow` metadata, without writing ledger entries, archiving glow evidence, or changing snapshot authority.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -1,0 +1,109 @@
+# Codex Workcell Memory Contract
+
+The Codex Workcell Memory Contract defines deterministic, metadata-only schemas
+for future `/ledger` receipt-chain records and future `/glow` evidence-archive
+records. It is a review grammar for landed Codex workcell evidence; it is not a
+storage writer, ledger writer, glow archiver, watcher, scheduler, daemon action,
+readiness authority, PR metadata authority, federation consensus mechanism, or
+model-training surface.
+
+## Purpose
+
+The workcell ladder is intentionally layered:
+
+1. The workcell architecture names the shape of bounded Codex evidence.
+2. The health snapshot observes supplied metadata.
+3. The pulse contract names pressure from health metadata.
+4. The daemon recommendation contract maps pressure into bounded, non-actionable
+   recommendations.
+5. This memory contract names how future landed evidence could be represented as
+   receipt-chain metadata and archive metadata without performing either action.
+
+## `/ledger` receipt-chain schema, not ledger writing
+
+The `/ledger` section defines canonical field names and record-type catalogs for
+future tamper-evident landing history. Record types include landing receipts,
+matrix receipts, finalizer receipts, PR metadata guard receipts, evidence index
+receipts, appendix provenance receipts, health snapshots, pulse contracts,
+daemon recommendation contracts, and this memory contract.
+
+This contract does not write actual ledger entries. It does not validate parent
+chains, choose storage paths, verify readiness, authorize commit, authorize PR
+metadata, or establish federation consensus. Future active ledger behavior needs
+an explicit ledger writer implementation, storage policy, digest verification
+policy, parent-chain validation policy, operator consent, and tests proving no
+readiness bypass.
+
+## `/glow` evidence-archive schema, not glow archiving
+
+The `/glow` section defines canonical field names and archive item catalogs for
+future review-surface memory. Archive item types include workcell architecture,
+health snapshot, pulse contract, daemon recommendation contract, evidence index,
+evidence appendix markdown, evidence appendix sidecar, doctrine map, matrix
+report, finalizer report, and PR metadata guard snapshots.
+
+This contract does not archive files or write glow memory. It does not decide
+retention, disclose evidence externally, mutate memory, watch files, poll state,
+trigger daemon action, or train models. Future active glow behavior needs an
+explicit archiver implementation, retention policy, storage path policy, digest
+verification policy, operator consent, and docs marking the behavior active.
+
+## Distinctions from adjacent evidence surfaces
+
+- Health snapshot: observes supplied landing metadata; the memory contract only
+  defines future receipt/archive representation for such artifacts.
+- Pulse contract: classifies pressure; the memory contract does not consume
+  history to produce pressure and does not activate a watcher.
+- Daemon recommendation contract: maps pulse signals to non-actionable repair
+  recommendations; the memory contract does not recommend repair or trigger a
+  daemon.
+- Matrix: test/proof evidence; the memory contract defines possible future
+  receipt/archive metadata for a matrix report, not matrix truth.
+- Finalizer: landing authority for its phase; the memory contract cannot replace
+  or bypass finalizer decisions.
+- PR metadata guard: authority before PR metadata; the memory contract cannot
+  replace or bypass the guard.
+- Evidence index and appendix: reviewer evidence surfaces; the memory contract
+  only names future ledger/glow roles for them.
+- Doctrine map: constraints context; the memory contract preserves `/vow`
+  boundaries and forbidden inference rather than training or modifying models.
+
+## Source artifact alignment
+
+The contract maps matrix reports, finalizer reports, PR metadata guard reports,
+evidence index artifacts, evidence appendix markdown, evidence appendix sidecars,
+doctrine maps, workcell architecture, health snapshots, pulse contracts, daemon
+recommendation contracts, and memory contracts to future `/ledger` roles and
+future `/glow` roles. Every aligned source expects a digest, but alignment itself
+does not create, verify, store, archive, or approve the artifact.
+
+## SentientOS mount alignment
+
+- `/ledger`: future tamper-evident landing history and receipt chain; inactive
+  here.
+- `/glow`: future archived evidence memory and review-surface archive; inactive
+  here.
+- `/pulse`: future consumer of ledger/glow history for pressure observation;
+  inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+- `/vow`: canonical constraints bounding memory interpretation and forbidden
+  inference.
+
+## Future activation requirements
+
+All activation requirements are future-only, unmet, and inactive in this task:
+explicit ledger writer implementation, explicit glow archiver implementation,
+explicit storage path policy, explicit retention policy, explicit digest
+verification policy, explicit parent-chain validation policy, explicit operator
+consent, explicit finalizer/guard non-bypass invariant, explicit pulse watcher
+contract, explicit daemon action contract, explicit federation drift consensus
+rule, explicit vow digest constraint check, tests proving no readiness authority,
+and docs marking active behavior.
+
+## Non-authority posture
+
+The memory contract is read-only and metadata-only. It does not write ledger,
+archive glow, modify memory, watch files, poll state, rerun commands, decide
+readiness, bypass the finalizer, bypass the PR metadata guard, authorize commit,
+authorize PR creation, trigger a daemon, create tasks, schedule tasks, send
+alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -44,3 +44,6 @@ The contract is read-only, metadata-only, does not watch files, does not poll st
 ## Daemon recommendation contract link
 
 The daemon recommendation contract maps this contract's stable pulse signal IDs into review-only repair recommendation classes. It remains metadata-only and does not activate watching, scheduling, daemon action, readiness decisions, commits, PR metadata, ledger writes, memory mutation, model training, or federation consensus. See `docs/development/codex_workcell_daemon_recommendation_contract.md`.
+## Memory contract boundary
+
+The Codex Workcell Memory Contract may describe future `/ledger` and `/glow` metadata that `/pulse` could consume only after a separate watcher contract is activated; it is inactive here and does not watch, poll, or decide pressure.

--- a/scripts/build_codex_workcell_memory_contract.py
+++ b/scripts/build_codex_workcell_memory_contract.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_memory_contract import (
+    CodexWorkcellMemoryContractError,
+    CodexWorkcellMemoryContractRequest,
+    build_codex_workcell_memory_contract,
+    render_codex_workcell_memory_contract_markdown,
+    write_codex_workcell_memory_contract_json,
+    write_codex_workcell_memory_contract_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell memory contract.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--health-snapshot-json")
+    parser.add_argument("--pulse-contract-json")
+    parser.add_argument("--daemon-recommendation-contract-json")
+    parser.add_argument("--evidence-index-json")
+    parser.add_argument("--appendix-sidecar-json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        contract = build_codex_workcell_memory_contract(
+            CodexWorkcellMemoryContractRequest(
+                health_snapshot_json=args.health_snapshot_json,
+                pulse_contract_json=args.pulse_contract_json,
+                daemon_recommendation_contract_json=args.daemon_recommendation_contract_json,
+                evidence_index_json=args.evidence_index_json,
+                appendix_sidecar_json=args.appendix_sidecar_json,
+            )
+        )
+    except CodexWorkcellMemoryContractError as exc:
+        print(f"codex_workcell_memory_contract_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_memory_contract_json(contract, args.output)
+    if args.markdown_output:
+        write_codex_workcell_memory_contract_markdown(render_codex_workcell_memory_contract_markdown(contract), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"workcell_memory_contract_id": contract["workcell_memory_contract_id"], "metadata_only": True, "memory_contract_only": True, "output": args.output, "markdown_output": args.markdown_output, "ledger_record_type_count": len(contract["ledger_record_type_index"]), "glow_archive_item_type_count": len(contract["glow_archive_item_type_index"]), "provided_input_count": sum(1 for item in contract["input_summaries"].values() if item.get("provided"))}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_memory_contract.py
+++ b/sentientos/codex_workcell_memory_contract.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_MEMORY_CONTRACT_ID = "codex_workcell_memory_contract.v1"
+DIGEST_ALGO = "sha256"
+
+LEDGER_RECORD_TYPES: tuple[str, ...] = (
+    "codex_landing_receipt",
+    "matrix_receipt",
+    "finalizer_receipt",
+    "pr_metadata_guard_receipt",
+    "evidence_index_receipt",
+    "appendix_provenance_receipt",
+    "health_snapshot_receipt",
+    "pulse_contract_receipt",
+    "daemon_recommendation_contract_receipt",
+    "memory_contract_receipt",
+)
+
+LEDGER_CHAIN_FIELDS: tuple[str, ...] = (
+    "ledger_entry_id",
+    "record_type",
+    "created_at",
+    "source_artifact_id",
+    "source_artifact_digest",
+    "source_artifact_digest_algo",
+    "parent_entry_id",
+    "parent_entry_digest",
+    "commit_sha",
+    "pr_number",
+    "pr_title",
+    "merge_commit_sha",
+    "finalizer_status",
+    "pr_metadata_guard_status",
+    "matrix_status",
+    "non_authority_posture",
+)
+
+GLOW_ARCHIVE_ITEM_TYPES: tuple[str, ...] = (
+    "workcell_architecture_snapshot",
+    "workcell_health_snapshot",
+    "pulse_contract_snapshot",
+    "daemon_recommendation_contract_snapshot",
+    "evidence_index_snapshot",
+    "evidence_appendix_markdown",
+    "evidence_appendix_sidecar",
+    "doctrine_map_snapshot",
+    "matrix_report_snapshot",
+    "finalizer_report_snapshot",
+    "pr_metadata_guard_snapshot",
+)
+
+GLOW_ARCHIVE_FIELDS: tuple[str, ...] = (
+    "glow_item_id",
+    "archive_item_type",
+    "created_at",
+    "source_path",
+    "source_artifact_id",
+    "source_digest",
+    "source_digest_algo",
+    "byte_size",
+    "related_ledger_entry_id",
+    "related_commit_sha",
+    "related_pr_number",
+    "review_surface",
+    "memory_scope",
+    "non_authority_posture",
+)
+
+SOURCE_ARTIFACT_FAMILIES: tuple[str, ...] = (
+    "matrix report",
+    "finalizer report",
+    "PR metadata guard report",
+    "evidence index",
+    "evidence appendix markdown",
+    "evidence appendix sidecar",
+    "doctrine map",
+    "workcell architecture",
+    "health snapshot",
+    "pulse contract",
+    "daemon recommendation contract",
+    "memory contract",
+)
+
+FUTURE_ACTIVATION_REQUIREMENTS: tuple[str, ...] = (
+    "explicit ledger writer implementation",
+    "explicit glow archiver implementation",
+    "explicit storage path policy",
+    "explicit retention policy",
+    "explicit digest verification policy",
+    "explicit parent-chain validation policy",
+    "explicit operator consent",
+    "explicit finalizer/guard non-bypass invariant",
+    "explicit pulse watcher contract",
+    "explicit daemon action contract",
+    "explicit federation drift consensus rule",
+    "explicit vow digest constraint check",
+    "tests proving no readiness authority",
+    "docs marking active behavior",
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "memory_contract_is_read_only": True,
+    "memory_contract_is_metadata_only": True,
+    "memory_contract_does_not_write_ledger": True,
+    "memory_contract_does_not_archive_glow": True,
+    "memory_contract_does_not_modify_memory": True,
+    "memory_contract_does_not_watch_files": True,
+    "memory_contract_does_not_poll_state": True,
+    "memory_contract_does_not_rerun_commands": True,
+    "memory_contract_does_not_decide_readiness": True,
+    "memory_contract_does_not_bypass_finalizer": True,
+    "memory_contract_does_not_bypass_pr_metadata_guard": True,
+    "memory_contract_does_not_authorize_commit": True,
+    "memory_contract_does_not_authorize_pr_creation": True,
+    "memory_contract_does_not_trigger_daemon": True,
+    "memory_contract_does_not_create_tasks": True,
+    "memory_contract_does_not_schedule_tasks": True,
+    "memory_contract_does_not_send_alerts": True,
+    "memory_contract_does_not_train_or_modify_models": True,
+    "memory_contract_does_not_establish_federation_consensus": True,
+}
+
+LEDGER_FORBIDDEN_INFERENCE = "Receipt schema metadata does not write ledger entries, verify readiness, authorize commit or PR metadata, establish consensus, or mutate memory."
+GLOW_FORBIDDEN_INFERENCE = "Archive schema metadata does not archive files, write glow memory, decide retention, authorize disclosure, trigger watchers, or mutate memory."
+
+_LEDGER_RECORD_SPECS: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...], str], ...] = tuple(
+    (
+        record_type,
+        record_type.replace("_", " ").title(),
+        ("ledger_entry_id", "record_type", "created_at", "source_artifact_digest", "source_artifact_digest_algo", "non_authority_posture"),
+        ("source_artifact_digest", "parent_entry_digest"),
+        ("parent_entry_id", "parent_entry_digest"),
+        ("created_at",),
+        f"Defines future /ledger metadata for {record_type}; inactive and non-writing here.",
+    )
+    for record_type in LEDGER_RECORD_TYPES
+)
+
+_GLOW_ITEM_SPECS: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...], str, str], ...] = tuple(
+    (
+        item_type,
+        item_type.replace("_", " ").title(),
+        ("glow_item_id", "archive_item_type", "created_at", "source_digest", "source_digest_algo", "byte_size", "non_authority_posture"),
+        ("source_digest",),
+        ("source_path", "source_artifact_id", "related_ledger_entry_id", "related_commit_sha", "related_pr_number"),
+        "future policy required before retention is active",
+        f"Defines future /glow metadata for {item_type}; inactive and non-archiving here.",
+    )
+    for item_type in GLOW_ARCHIVE_ITEM_TYPES
+)
+
+class CodexWorkcellMemoryContractError(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class CodexWorkcellMemoryContractRequest:
+    health_snapshot_json: str | None = None
+    pulse_contract_json: str | None = None
+    daemon_recommendation_contract_json: str | None = None
+    evidence_index_json: str | None = None
+    appendix_sidecar_json: str | None = None
+
+
+def _read_json(path_text: str | None, label: str) -> dict[str, Any]:
+    if path_text is None:
+        return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellMemoryContractError(f"missing_{label}_json:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellMemoryContractError(f"invalid_{label}_json:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellMemoryContractError(f"{label}_json_not_object:{path_text}")
+    summary: dict[str, Any] = {"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}
+    for key in ("workcell_health_snapshot_id", "pulse_contract_id", "daemon_recommendation_contract_id", "codex_landing_evidence_index_id", "appendix_sidecar_id"):
+        if key in loaded:
+            summary[key] = loaded[key]
+    return summary
+
+
+def _ledger_catalog() -> list[dict[str, Any]]:
+    return [
+        {
+            "record_type": record_type,
+            "record_name": name,
+            "required_fields": list(required),
+            "digest_fields": list(digests),
+            "parent_reference_fields": list(parents),
+            "timestamp_fields": list(timestamps),
+            "authority_boundary": boundary,
+            "forbidden_inference": LEDGER_FORBIDDEN_INFERENCE,
+            "reviewer_summary": f"{name} defines future receipt-chain metadata only.",
+        }
+        for record_type, name, required, digests, parents, timestamps, boundary in _LEDGER_RECORD_SPECS
+    ]
+
+
+def _glow_catalog() -> list[dict[str, Any]]:
+    return [
+        {
+            "archive_item_type": item_type,
+            "archive_item_name": name,
+            "required_metadata_fields": list(required),
+            "digest_fields": list(digests),
+            "source_reference_fields": list(source_refs),
+            "retention_hint": retention_hint,
+            "authority_boundary": boundary,
+            "forbidden_inference": GLOW_FORBIDDEN_INFERENCE,
+            "reviewer_summary": f"{name} defines future evidence-archive metadata only.",
+        }
+        for item_type, name, required, digests, source_refs, retention_hint, boundary in _GLOW_ITEM_SPECS
+    ]
+
+
+def _source_artifact_alignment() -> list[dict[str, Any]]:
+    return [
+        {
+            "artifact_family": family,
+            "ledger_role": f"future receipt metadata for {family}",
+            "glow_role": f"future archive metadata for {family}",
+            "source_digest_expected": True,
+            "authority_boundary": "Alignment only; does not create, verify, store, archive, or approve the artifact.",
+            "forbidden_inference": "Artifact alignment does not imply readiness, storage, retention, memory mutation, daemon action, federation consensus, or model training.",
+        }
+        for family in SOURCE_ARTIFACT_FAMILIES
+    ]
+
+
+def _index(catalog: list[dict[str, Any]], key: str) -> dict[str, dict[str, Any]]:
+    return {str(item[key]): {"position": index, "name": str(item.get(key.replace("type", "name"), item[key]))} for index, item in enumerate(catalog)}
+
+
+def build_codex_workcell_memory_contract(request: CodexWorkcellMemoryContractRequest | None = None) -> dict[str, Any]:
+    request = request or CodexWorkcellMemoryContractRequest()
+    ledger_catalog = _ledger_catalog()
+    glow_catalog = _glow_catalog()
+    return {
+        "workcell_memory_contract_id": WORKCELL_MEMORY_CONTRACT_ID,
+        "metadata_only": True,
+        "memory_contract_only": True,
+        "not_runtime_authority": True,
+        "not_memory_writer": True,
+        "not_ledger_writer": True,
+        "not_glow_archiver": True,
+        "not_watcher": True,
+        "not_scheduler": True,
+        "not_executor": True,
+        "not_daemon_action": True,
+        "not_task_creator": True,
+        "not_alerting_system": True,
+        "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "input_summaries": {
+            "health_snapshot_json": _read_json(request.health_snapshot_json, "health_snapshot"),
+            "pulse_contract_json": _read_json(request.pulse_contract_json, "pulse_contract"),
+            "daemon_recommendation_contract_json": _read_json(request.daemon_recommendation_contract_json, "daemon_recommendation_contract"),
+            "evidence_index_json": _read_json(request.evidence_index_json, "evidence_index"),
+            "appendix_sidecar_json": _read_json(request.appendix_sidecar_json, "appendix_sidecar"),
+        },
+        "ledger_receipt_chain_contract": {"mount": "/ledger", "active": False, "writes_ledger_entries": False, "canonical_fields": list(LEDGER_CHAIN_FIELDS), "record_catalog": ledger_catalog},
+        "glow_evidence_archive_contract": {"mount": "/glow", "active": False, "archives_evidence": False, "canonical_fields": list(GLOW_ARCHIVE_FIELDS), "archive_catalog": glow_catalog},
+        "ledger_record_type_index": _index(ledger_catalog, "record_type"),
+        "glow_archive_item_type_index": _index(glow_catalog, "archive_item_type"),
+        "source_artifact_alignment": _source_artifact_alignment(),
+        "sentientos_mount_alignment": {
+            "/ledger": "future tamper-evident landing history and receipt chain; inactive here",
+            "/glow": "future archived evidence memory and review-surface archive; inactive here",
+            "/pulse": "future consumer of ledger/glow history for pressure observation; inactive here",
+            "/daemon": "future consumer of pulse/recommendation context; inactive here",
+            "/vow": "canonical constraints bounding memory interpretation and forbidden inference",
+        },
+        "future_activation_requirements": [{"requirement": item, "status": "future_only", "met": False, "active": False} for item in FUTURE_ACTIVATION_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\\r\\n", "<br>").replace("\\n", "<br>").replace("\\r", "<br>").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
+def render_codex_workcell_memory_contract_markdown(contract: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Memory Contract", "", "This deterministic metadata-only contract defines future /ledger receipt-chain and /glow evidence-archive schemas. It does not write ledger entries, archive files, mutate memory, watch, poll, schedule, alert, create tasks, trigger daemon action, decide readiness, authorize commit or PR metadata, train models, or establish federation consensus."]
+    lines += ["", "## Input summary", "| input | provided | path | digest | byte_size | readable_json | error |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for key, summary in sorted(contract["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(summary.get('provided'))} | {_cell(summary.get('path'))} | {_cell(summary.get('digest'))} | {_cell(summary.get('byte_size'))} | {_cell(summary.get('readable_json'))} | {_cell(summary.get('error'))} |")
+    lines += ["", "## /ledger receipt-chain contract", "| record_type | record_name | required_fields | digest_fields | parent_reference_fields | timestamp_fields | reviewer_summary |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for item in contract["ledger_receipt_chain_contract"]["record_catalog"]:
+        lines.append(f"| {_cell(item['record_type'])} | {_cell(item['record_name'])} | {_cell(item['required_fields'])} | {_cell(item['digest_fields'])} | {_cell(item['parent_reference_fields'])} | {_cell(item['timestamp_fields'])} | {_cell(item['reviewer_summary'])} |")
+    lines += ["", "## /glow evidence-archive contract", "| archive_item_type | archive_item_name | required_metadata_fields | digest_fields | source_reference_fields | retention_hint | reviewer_summary |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for item in contract["glow_evidence_archive_contract"]["archive_catalog"]:
+        lines.append(f"| {_cell(item['archive_item_type'])} | {_cell(item['archive_item_name'])} | {_cell(item['required_metadata_fields'])} | {_cell(item['digest_fields'])} | {_cell(item['source_reference_fields'])} | {_cell(item['retention_hint'])} | {_cell(item['reviewer_summary'])} |")
+    lines += ["", "## Source artifact alignment", "| artifact_family | ledger_role | glow_role | source_digest_expected |", "| --- | --- | --- | --- |"]
+    for item in contract["source_artifact_alignment"]:
+        lines.append(f"| {_cell(item['artifact_family'])} | {_cell(item['ledger_role'])} | {_cell(item['glow_role'])} | {_cell(item['source_digest_expected'])} |")
+    lines += ["", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(contract["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in contract["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(contract["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_memory_contract_json(contract: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_memory_contract_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_memory_contract_script.py
+++ b/tests/test_build_codex_workcell_memory_contract_script.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+import json
+import subprocess
+import sys
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "scripts/build_codex_workcell_memory_contract.py", *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_and_summary(tmp_path) -> None:
+    input_path = tmp_path / "health.json"
+    raw = b'{"workcell_health_snapshot_id":"h1"}\n'
+    input_path.write_bytes(raw)
+    output = tmp_path / "contract.json"
+    result = run_script("--output", str(output), "--summary", "--health-snapshot-json", str(input_path))
+    assert result.returncode == 0, result.stderr
+    data = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert summary["workcell_memory_contract_id"] == "codex_workcell_memory_contract.v1"
+    assert summary["provided_input_count"] == 1
+    assert data["input_summaries"]["health_snapshot_json"]["digest"] == hashlib.sha256(raw).hexdigest()
+
+
+def test_cli_writes_markdown_when_requested(tmp_path) -> None:
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = run_script("--output", str(output), "--markdown-output", str(markdown))
+    assert result.returncode == 0, result.stderr
+    assert output.exists()
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Memory Contract")
+    assert "## /ledger receipt-chain contract" in markdown.read_text(encoding="utf-8")
+
+
+def test_invalid_json_input_fails_with_exit_code_2(tmp_path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    result = run_script("--output", str(tmp_path / "out.json"), "--health-snapshot-json", str(bad))
+    assert result.returncode == 2
+    assert "invalid_health_snapshot_json" in result.stderr
+
+
+def test_missing_json_input_path_fails_with_exit_code_2(tmp_path) -> None:
+    result = run_script("--output", str(tmp_path / "out.json"), "--health-snapshot-json", str(tmp_path / "missing.json"))
+    assert result.returncode == 2
+    assert "missing_health_snapshot_json" in result.stderr
+
+
+def test_non_object_json_input_fails_with_exit_code_2(tmp_path) -> None:
+    bad = tmp_path / "array.json"
+    bad.write_text("[]", encoding="utf-8")
+    result = run_script("--output", str(tmp_path / "out.json"), "--pulse-contract-json", str(bad))
+    assert result.returncode == 2
+    assert "pulse_contract_json_not_object" in result.stderr
+
+
+def test_cli_json_and_markdown_are_deterministic(tmp_path) -> None:
+    input_path = tmp_path / "input.json"
+    input_path.write_text('{"stable": true}\n', encoding="utf-8")
+    out1 = tmp_path / "one.json"
+    out2 = tmp_path / "two.json"
+    md1 = tmp_path / "one.md"
+    md2 = tmp_path / "two.md"
+    result1 = run_script("--output", str(out1), "--markdown-output", str(md1), "--evidence-index-json", str(input_path))
+    result2 = run_script("--output", str(out2), "--markdown-output", str(md2), "--evidence-index-json", str(input_path))
+    assert result1.returncode == 0, result1.stderr
+    assert result2.returncode == 0, result2.stderr
+    assert out1.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")
+    assert md1.read_text(encoding="utf-8") == md2.read_text(encoding="utf-8")

--- a/tests/test_codex_workcell_memory_contract.py
+++ b/tests/test_codex_workcell_memory_contract.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_memory_contract import (
+    FUTURE_ACTIVATION_REQUIREMENTS,
+    GLOW_ARCHIVE_ITEM_TYPES,
+    LEDGER_RECORD_TYPES,
+    NON_AUTHORITY_POSTURE,
+    SOURCE_ARTIFACT_FAMILIES,
+    CodexWorkcellMemoryContractRequest,
+    build_codex_workcell_memory_contract,
+    render_codex_workcell_memory_contract_markdown,
+)
+
+
+def test_required_ledger_record_types_and_index_are_consistent() -> None:
+    contract = build_codex_workcell_memory_contract()
+    catalog = contract["ledger_receipt_chain_contract"]["record_catalog"]
+    assert {item["record_type"] for item in catalog} >= set(LEDGER_RECORD_TYPES)
+    assert set(contract["ledger_record_type_index"]) == {item["record_type"] for item in catalog}
+    for record_type, entry in contract["ledger_record_type_index"].items():
+        assert catalog[entry["position"]]["record_type"] == record_type
+
+
+def test_required_glow_archive_item_types_and_index_are_consistent() -> None:
+    contract = build_codex_workcell_memory_contract()
+    catalog = contract["glow_evidence_archive_contract"]["archive_catalog"]
+    assert {item["archive_item_type"] for item in catalog} >= set(GLOW_ARCHIVE_ITEM_TYPES)
+    assert set(contract["glow_archive_item_type_index"]) == {item["archive_item_type"] for item in catalog}
+    for item_type, entry in contract["glow_archive_item_type_index"].items():
+        assert catalog[entry["position"]]["archive_item_type"] == item_type
+
+
+def test_source_artifact_alignment_includes_required_families() -> None:
+    contract = build_codex_workcell_memory_contract()
+    assert {item["artifact_family"] for item in contract["source_artifact_alignment"]} >= set(SOURCE_ARTIFACT_FAMILIES)
+    assert all(item["source_digest_expected"] is True for item in contract["source_artifact_alignment"])
+
+
+def test_non_authority_posture_flags_are_present_and_true() -> None:
+    contract = build_codex_workcell_memory_contract()
+    assert set(NON_AUTHORITY_POSTURE) <= set(contract["non_authority_posture"])
+    assert all(contract["non_authority_posture"][key] is True for key in NON_AUTHORITY_POSTURE)
+    assert contract["not_ledger_writer"] is True
+    assert contract["not_glow_archiver"] is True
+    assert contract["not_memory_writer"] is True
+
+
+def test_future_activation_requirements_are_future_only_inactive_unmet() -> None:
+    contract = build_codex_workcell_memory_contract()
+    assert {item["requirement"] for item in contract["future_activation_requirements"]} == set(FUTURE_ACTIVATION_REQUIREMENTS)
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in contract["future_activation_requirements"])
+
+
+def test_contract_does_not_grant_runtime_or_readiness_authority() -> None:
+    contract = build_codex_workcell_memory_contract()
+    posture = contract["non_authority_posture"]
+    assert posture["memory_contract_does_not_decide_readiness"] is True
+    assert posture["memory_contract_does_not_authorize_commit"] is True
+    assert posture["memory_contract_does_not_authorize_pr_creation"] is True
+    assert posture["memory_contract_does_not_bypass_finalizer"] is True
+    assert posture["memory_contract_does_not_bypass_pr_metadata_guard"] is True
+
+
+def test_contract_does_not_write_ledger_archive_glow_modify_memory_or_trigger_actions() -> None:
+    contract = build_codex_workcell_memory_contract()
+    posture = contract["non_authority_posture"]
+    for key in (
+        "memory_contract_does_not_write_ledger",
+        "memory_contract_does_not_archive_glow",
+        "memory_contract_does_not_modify_memory",
+        "memory_contract_does_not_trigger_daemon",
+        "memory_contract_does_not_create_tasks",
+        "memory_contract_does_not_schedule_tasks",
+        "memory_contract_does_not_send_alerts",
+    ):
+        assert posture[key] is True
+    assert contract["ledger_receipt_chain_contract"]["writes_ledger_entries"] is False
+    assert contract["glow_evidence_archive_contract"]["archives_evidence"] is False
+
+
+def test_omitted_inputs_produce_provided_false_summaries() -> None:
+    contract = build_codex_workcell_memory_contract()
+    for summary in contract["input_summaries"].values():
+        assert summary == {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+
+def test_supplied_json_inputs_record_raw_byte_digest_and_size(tmp_path) -> None:
+    payload = b'{"alpha": true, "text": "pipe|newline\\n"}'
+    path = tmp_path / "input.json"
+    path.write_bytes(payload)
+    contract = build_codex_workcell_memory_contract(CodexWorkcellMemoryContractRequest(health_snapshot_json=str(path)))
+    summary = contract["input_summaries"]["health_snapshot_json"]
+    assert summary["provided"] is True
+    assert summary["digest"] == hashlib.sha256(payload).hexdigest()
+    assert summary["byte_size"] == len(payload)
+    assert summary["readable_json"] is True
+
+
+def test_json_output_is_deterministic_for_same_inputs(tmp_path) -> None:
+    path = tmp_path / "input.json"
+    path.write_text('{"stable": true}\n', encoding="utf-8")
+    request = CodexWorkcellMemoryContractRequest(pulse_contract_json=str(path))
+    assert build_codex_workcell_memory_contract(request) == build_codex_workcell_memory_contract(request)
+
+
+def test_markdown_output_is_deterministic_and_escapes_tables() -> None:
+    contract = build_codex_workcell_memory_contract()
+    contract["input_summaries"]["health_snapshot_json"] = {"provided": True, "path": "a|b\nc", "digest": "d|e", "byte_size": 1, "readable_json": True, "error": None}
+    first = render_codex_workcell_memory_contract_markdown(contract)
+    second = render_codex_workcell_memory_contract_markdown(contract)
+    assert first == second
+    assert "a\\|b<br>c" in first
+    assert "d\\|e" in first


### PR DESCRIPTION
### Motivation
- Create a deterministic, metadata-only memory contract that names how landed Codex workcell evidence would be represented for future `/ledger` receipt-chains and `/glow` evidence archives while remaining explicitly non-authoritative and non-writing. 
- Provide a stable review grammar and input-summary behavior (raw-byte digests, byte sizes, readable-json checks) so downstream surfaces can be implemented later without embedding runtime authority or performing storage/archive actions.

### Description
- Add `sentientos/codex_workcell_memory_contract.py` implementing `WORKCELL_MEMORY_CONTRACT_ID`, `DIGEST_ALGO`, static `/ledger` record-type catalog, static `/glow` archive-item catalog, canonical ledger/glow fields, source-artifact alignment, SentientOS mount alignment, future-only activation requirements, and a comprehensive non-authority posture. 
- Add CLI builder `scripts/build_codex_workcell_memory_contract.py` with required `--output`, optional `--markdown-output`/`--summary`, optional input flags, raw-byte JSON reading, SHA-256 digest and byte-size recording, clean failure exit code `2` on missing/invalid/non-object inputs, deterministic JSON writer, and deterministic Markdown renderer with table-escaping. 
- Add tests `tests/test_codex_workcell_memory_contract.py` and `tests/test_build_codex_workcell_memory_contract_script.py` covering catalog completeness, index consistency, source-artifact alignment, non-authority posture, future-only activation requirements, omitted-input summaries, raw-byte digest/size recording, deterministic JSON/Markdown outputs, Markdown table escaping, and CLI error behavior. 
- Add documentation `docs/development/codex_workcell_memory_contract.md` describing purpose, `/ledger` vs ledger-writing boundary, `/glow` vs archiving boundary, source alignment, mount alignment, future activation requirements, and non-authority posture, and add short boundary notes to adjacent workcell docs to clarify inactive/non-writing behavior. 

### Testing
- Unit and CLI tests: ran `python -m scripts.run_tests -q tests/test_codex_workcell_memory_contract.py tests/test_build_codex_workcell_memory_contract_script.py` and related workcell contract test suites, and the added tests passed. 
- Integration/validation: ran the full local validation steps including `python scripts/build_docs.py` (bootstrapped docs deps), `python -m mypy sentientos/codex_workcell_memory_contract.py scripts/build_codex_workcell_memory_contract.py`, `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json`, and `python scripts/codex_finalize_landing.py finalize` (pre-commit and pr-metadata phases); these completed and the finalizer produced `ready_to_commit` and `ready_for_pr_metadata` decisions. 
- PR metadata guard: ran `python scripts/codex_pr_metadata_guard.py verify` which returned `pr_metadata_guard_ready`. 
- Summary: focused tests, docs build, type checks, matrix run, finalizers, and PR guard all completed successfully in the validation run; no automated failures remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b29d5ef5c832f83ea9f5191ce606b)