### PR TITLE
[codex:memory] add Codex workcell memory candidate bundle

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -203,3 +203,7 @@ Daemon recommendation contract output is reviewer context only. It does not repl
 ## Workcell memory contract boundary
 
 The Codex Workcell Memory Contract can describe future receipt metadata for finalizer artifacts, but it cannot replace this finalizer, authorize readiness, bypass phase checks, write ledger entries, or create PR metadata authority.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may include supplied finalizer JSON as candidate review metadata only. Candidate records do not replace this finalizer, do not make stale evidence fresh, do not authorize commit, and do not authorize PR metadata.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -195,3 +195,7 @@ The daemon recommendation contract may identify metadata-only recommendation cla
 ## Workcell memory contract boundary
 
 The Codex Workcell Memory Contract can name future `/ledger` receipt-chain and `/glow` archive roles for recovery evidence, but recovery remains governed by this rail; the memory contract does not archive files or recover task-owned files.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) can summarize supplied recovery and evidence artifacts as candidate `/ledger` and `/glow` records for review. It does not recover files, write archives, mutate memory, create tasks, or bypass recovery and landing rails.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -142,3 +142,7 @@ Daemon recommendation contract artifacts are non-authoritative review surfaces. 
 ## Workcell memory contract boundary
 
 The Codex Workcell Memory Contract defines future metadata shapes for landed evidence history and archive review surfaces. It does not add validation gates, satisfy matrix lanes, authorize commit, authorize PR metadata, or bypass required finalizer and guard checks.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) is a deterministic review surface over supplied artifacts. It does not add validation lanes, satisfy matrix proof, bypass finalizer or PR metadata guard authority, authorize commit, authorize PR creation, write ledger entries, archive glow items, or create runtime authority.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -106,3 +106,7 @@ The daemon recommendation contract fills the future repair-recommendation gramma
 ## Memory contract boundary
 
 The Codex Workcell Memory Contract is the next metadata-only layer after architecture, health, pulse, and daemon recommendation contracts. It names future `/ledger` and `/glow` schemas while remaining non-authoritative and non-writing.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) adds a review-only rendering layer for supplied architecture and landing artifacts. It produces candidate `/ledger` and `/glow` metadata without storage, mutation, daemon action, scheduling, readiness authority, or federation consensus.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -34,3 +34,7 @@ The contract is read-only and metadata-only. It cannot bypass the finalizer or P
 ## Memory contract boundary
 
 The Codex Workcell Memory Contract defines future `/ledger` receipt-chain and `/glow` evidence-archive metadata for recommendation artifacts, but it does not write memory, archive evidence, trigger daemon action, or create authority.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied daemon recommendation contract JSON as candidate memory review metadata only. The bundle does not trigger daemon action, schedule repair, create tasks, or convert recommendations into authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -48,3 +48,7 @@ Health snapshot metadata may be referenced by the daemon recommendation contract
 ## Memory contract boundary
 
 The Codex Workcell Memory Contract defines how health snapshots could be represented in future `/ledger` and `/glow` metadata, without writing ledger entries, archiving glow evidence, or changing snapshot authority.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied health snapshot JSON as candidate memory metadata. This does not make the health snapshot a gate, readiness decision, ledger write, glow archive, or runtime authority.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -1,0 +1,49 @@
+# Codex Workcell Memory Candidate Bundle
+
+The Codex Workcell Memory Candidate Bundle is a deterministic, metadata-only review artifact. It reads only supplied JSON artifacts, records raw-byte SHA-256 digests and byte sizes, and renders candidate `/ledger` receipt entries plus candidate `/glow` archive items for reviewer inspection.
+
+It is staging only. It does not write ledger entries, archive glow records, mutate memory, watch files, poll state, schedule work, trigger daemon action, create tasks, send alerts, decide readiness, authorize commits, authorize PR metadata, establish federation consensus, or train/modify models.
+
+## Memory contract vs. candidate bundle
+
+The [Codex Workcell Memory Contract](codex_workcell_memory_contract.md) defines future metadata schemas, record families, archive item families, source artifact alignment, mount alignment, and activation requirements for `/ledger` and `/glow` surfaces. The candidate bundle consumes an optional already-built memory contract JSON plus optional evidence artifacts and renders concrete candidate records that show what future receipt/archive metadata could look like.
+
+If no memory contract JSON is supplied, the bundle uses the module's static fallback mappings. Those fallback mappings are schema-review metadata only and do not become storage policy or authority.
+
+## Candidate ledger entries vs. actual ledger writes
+
+Candidate ledger entries are deterministic JSON objects with `candidate_only: true` and `no_write_performed: true`. They include the source input id, source digest, byte size, candidate record type, optional discoverable commit/PR/status metadata, and explicit forbidden inference text.
+
+A candidate ledger entry is not an actual `/ledger` write. It does not create a receipt chain, verify a parent chain, seal a commit, approve a PR, satisfy validation, or make evidence fresh. Active ledger behavior would require a separate ledger writer implementation, storage path policy, retention policy, digest verification policy, parent-chain validation policy, operator consent, finalizer/guard non-bypass invariant, tests proving no readiness authority, and docs marking active behavior.
+
+## Candidate glow items vs. actual glow archiving
+
+Candidate glow items are deterministic JSON objects with `candidate_only: true` and `no_archive_performed: true`. They include the source path, source digest, byte size, archive item type, optional related candidate ledger id, review surface, memory scope, authority boundary, and forbidden inference.
+
+A candidate glow item is not an actual `/glow` archive record. It does not copy files, persist evidence, decide retention, disclose artifacts, activate a watcher, mutate memory, or train models. Active glow archiving would require a separate archiver implementation and explicit storage, retention, digest verification, operator consent, and documentation controls.
+
+## How supplied artifacts become candidate records
+
+The builder accepts optional JSON inputs for the memory contract, architecture map, health snapshot, pulse contract, daemon recommendation contract, matrix report, pre-commit finalizer, PR metadata finalizer, PR metadata guard, evidence index, appendix sidecar, and doctrine map. For every supplied input it reads raw bytes, computes SHA-256, records byte size, parses JSON as an object, and fails cleanly if the file is missing, invalid JSON, or non-object JSON.
+
+Only supplied artifacts produce candidate records. Omitted inputs remain `provided: false` with null path, digest, and byte size. The builder does not run artifact builders, tests, matrix lanes, finalizers, guard commands, docs commands, git, shell commands, providers, network calls, watchers, or daemons.
+
+## Review-only source artifact map
+
+The source artifact map links each supplied input id to its candidate ledger entry ids and candidate glow item ids. This map supports reviewer traceability from source artifact bytes to candidate records. It is not a provenance seal, proof result, readiness decision, storage manifest, archive inventory, or federation consensus record.
+
+## SentientOS mount relation
+
+- `/ledger`: candidate receipt entries only; no ledger write.
+- `/glow`: candidate archive records only; no archive write.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+- `/vow`: canonical constraints bounding candidate interpretation and forbidden inference.
+
+## Future activation requirements
+
+All activation requirements are represented as future-only, unmet, and inactive: explicit ledger writer implementation, explicit glow archiver implementation, explicit storage path policy, explicit retention policy, explicit digest verification policy, explicit parent-chain validation policy, explicit operator consent, explicit finalizer/guard non-bypass invariant, explicit pulse watcher contract, explicit daemon action contract, explicit federation drift consensus rule, explicit vow digest constraint check, tests proving no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The memory candidate bundle is read-only, metadata-only, and candidate-only. It does not write ledger, archive glow, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commit, authorize PR creation, trigger a daemon, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -107,3 +107,7 @@ archive glow, modify memory, watch files, poll state, rerun commands, decide
 readiness, bypass the finalizer, bypass the PR metadata guard, authorize commit,
 authorize PR creation, trigger a daemon, create tasks, schedule tasks, send
 alerts, train or modify models, or establish federation consensus.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) can render deterministic candidate `/ledger` entries and candidate `/glow` items from supplied artifacts using these schema families. It is review-only metadata and does not write ledger entries, archive glow evidence, mutate memory, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -47,3 +47,7 @@ The daemon recommendation contract maps this contract's stable pulse signal IDs 
 ## Memory contract boundary
 
 The Codex Workcell Memory Contract may describe future `/ledger` and `/glow` metadata that `/pulse` could consume only after a separate watcher contract is activated; it is inactive here and does not watch, poll, or decide pressure.
+
+## Memory candidate bundle boundary
+
+The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied pulse contract JSON as candidate `/ledger` and `/glow` review metadata. It does not activate pulse watching, poll state, decide pressure, or authorize landing.

--- a/scripts/build_codex_workcell_memory_candidate_bundle.py
+++ b/scripts/build_codex_workcell_memory_candidate_bundle.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_memory_candidate_bundle import (
+    CodexWorkcellMemoryCandidateBundleError,
+    CodexWorkcellMemoryCandidateBundleRequest,
+    build_codex_workcell_memory_candidate_bundle,
+    render_codex_workcell_memory_candidate_bundle_markdown,
+    write_codex_workcell_memory_candidate_bundle_json,
+    write_codex_workcell_memory_candidate_bundle_markdown,
+)
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell memory candidate bundle.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    for arg in ("memory-contract-json", "architecture-json", "health-snapshot-json", "pulse-contract-json", "daemon-recommendation-contract-json", "matrix-json", "pre-commit-finalizer-json", "pr-metadata-finalizer-json", "pr-metadata-guard-json", "evidence-index-json", "appendix-sidecar-json", "doctrine-map-json"):
+        parser.add_argument(f"--{arg}")
+    return parser
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        bundle = build_codex_workcell_memory_candidate_bundle(CodexWorkcellMemoryCandidateBundleRequest(**{k: getattr(args, k) for k in CodexWorkcellMemoryCandidateBundleRequest.__dataclass_fields__}))
+    except CodexWorkcellMemoryCandidateBundleError as exc:
+        print(f"codex_workcell_memory_candidate_bundle_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_memory_candidate_bundle_json(bundle, args.output)
+    if args.markdown_output:
+        write_codex_workcell_memory_candidate_bundle_markdown(render_codex_workcell_memory_candidate_bundle_markdown(bundle), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"memory_candidate_bundle_id": bundle["memory_candidate_bundle_id"], "metadata_only": True, "candidate_bundle_only": True, "output": args.output, "markdown_output": args.markdown_output, "candidate_ledger_entry_count": bundle["candidate_chain_summary"]["candidate_ledger_entry_count"], "candidate_glow_item_count": bundle["candidate_archive_summary"]["candidate_glow_item_count"], "provided_input_count": sum(1 for item in bundle["input_summaries"].values() if item.get("provided"))}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_memory_candidate_bundle.py
+++ b/sentientos/codex_workcell_memory_candidate_bundle.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_MEMORY_CANDIDATE_BUNDLE_ID = "codex_workcell_memory_candidate_bundle.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_IDS: tuple[str, ...] = (
+    "memory_contract_json", "architecture_json", "health_snapshot_json", "pulse_contract_json",
+    "daemon_recommendation_contract_json", "matrix_json", "pre_commit_finalizer_json",
+    "pr_metadata_finalizer_json", "pr_metadata_guard_json", "evidence_index_json",
+    "appendix_sidecar_json", "doctrine_map_json",
+)
+
+LEDGER_BY_INPUT: dict[str, str | None] = {
+    "memory_contract_json": "memory_contract_receipt",
+    "architecture_json": "codex_landing_receipt",
+    "health_snapshot_json": "health_snapshot_receipt",
+    "pulse_contract_json": "pulse_contract_receipt",
+    "daemon_recommendation_contract_json": "daemon_recommendation_contract_receipt",
+    "matrix_json": "matrix_receipt",
+    "pre_commit_finalizer_json": "finalizer_receipt",
+    "pr_metadata_finalizer_json": "finalizer_receipt",
+    "pr_metadata_guard_json": "pr_metadata_guard_receipt",
+    "evidence_index_json": "evidence_index_receipt",
+    "appendix_sidecar_json": "appendix_provenance_receipt",
+    "doctrine_map_json": None,
+}
+
+GLOW_BY_INPUT: dict[str, str] = {
+    "memory_contract_json": "memory_contract_snapshot",
+    "architecture_json": "workcell_architecture_snapshot",
+    "health_snapshot_json": "workcell_health_snapshot",
+    "pulse_contract_json": "pulse_contract_snapshot",
+    "daemon_recommendation_contract_json": "daemon_recommendation_contract_snapshot",
+    "matrix_json": "matrix_report_snapshot",
+    "pre_commit_finalizer_json": "finalizer_report_snapshot",
+    "pr_metadata_finalizer_json": "finalizer_report_snapshot",
+    "pr_metadata_guard_json": "pr_metadata_guard_snapshot",
+    "evidence_index_json": "evidence_index_snapshot",
+    "appendix_sidecar_json": "evidence_appendix_sidecar",
+    "doctrine_map_json": "doctrine_map_snapshot",
+}
+
+FAMILY_BY_INPUT: dict[str, str] = {key: key.removesuffix("_json").replace("_", " ") for key in INPUT_IDS}
+FUTURE_ACTIVATION_REQUIREMENTS: tuple[str, ...] = (
+    "explicit ledger writer implementation", "explicit glow archiver implementation", "explicit storage path policy",
+    "explicit retention policy", "explicit digest verification policy", "explicit parent-chain validation policy",
+    "explicit operator consent", "explicit finalizer/guard non-bypass invariant", "explicit pulse watcher contract",
+    "explicit daemon action contract", "explicit federation drift consensus rule", "explicit vow digest constraint check",
+    "tests proving no readiness authority", "docs marking active behavior",
+)
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "memory_candidate_bundle_is_read_only": True,
+    "memory_candidate_bundle_is_metadata_only": True,
+    "memory_candidate_bundle_is_candidate_only": True,
+    "memory_candidate_bundle_does_not_write_ledger": True,
+    "memory_candidate_bundle_does_not_archive_glow": True,
+    "memory_candidate_bundle_does_not_modify_memory": True,
+    "memory_candidate_bundle_does_not_watch_files": True,
+    "memory_candidate_bundle_does_not_poll_state": True,
+    "memory_candidate_bundle_does_not_rerun_commands": True,
+    "memory_candidate_bundle_does_not_decide_readiness": True,
+    "memory_candidate_bundle_does_not_bypass_finalizer": True,
+    "memory_candidate_bundle_does_not_bypass_pr_metadata_guard": True,
+    "memory_candidate_bundle_does_not_authorize_commit": True,
+    "memory_candidate_bundle_does_not_authorize_pr_creation": True,
+    "memory_candidate_bundle_does_not_trigger_daemon": True,
+    "memory_candidate_bundle_does_not_create_tasks": True,
+    "memory_candidate_bundle_does_not_schedule_tasks": True,
+    "memory_candidate_bundle_does_not_send_alerts": True,
+    "memory_candidate_bundle_does_not_train_or_modify_models": True,
+    "memory_candidate_bundle_does_not_establish_federation_consensus": True,
+}
+AUTHORITY_BOUNDARY = "Candidate metadata only; does not write memory, decide readiness, authorize landing, trigger daemon action, schedule work, alert, or establish consensus."
+FORBIDDEN_INFERENCE = "Do not infer ledger persistence, glow archiving, readiness, commit authority, PR metadata authority, daemon action, task creation, model training, or federation consensus from this candidate record."
+
+class CodexWorkcellMemoryCandidateBundleError(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class CodexWorkcellMemoryCandidateBundleRequest:
+    memory_contract_json: str | None = None
+    architecture_json: str | None = None
+    health_snapshot_json: str | None = None
+    pulse_contract_json: str | None = None
+    daemon_recommendation_contract_json: str | None = None
+    matrix_json: str | None = None
+    pre_commit_finalizer_json: str | None = None
+    pr_metadata_finalizer_json: str | None = None
+    pr_metadata_guard_json: str | None = None
+    evidence_index_json: str | None = None
+    appendix_sidecar_json: str | None = None
+    doctrine_map_json: str | None = None
+
+def _stable_id(prefix: str, *parts: Any) -> str:
+    payload = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:24]}"
+
+def _read_json(path_text: str | None, input_id: str) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return ({"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None)
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellMemoryCandidateBundleError(f"missing_{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellMemoryCandidateBundleError(f"invalid_{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellMemoryCandidateBundleError(f"{input_id}_not_object:{path_text}")
+    return {"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _discover(data: Mapping[str, Any] | None, *keys: str) -> Any:
+    if data is None:
+        return None
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return value
+    for value in data.values():
+        if isinstance(value, Mapping):
+            found = _discover(value, *keys)
+            if found is not None:
+                return found
+    return None
+
+def _artifact_id(data: Mapping[str, Any] | None) -> Any:
+    if data is None:
+        return None
+    for key, value in data.items():
+        if key.endswith("_id") and isinstance(value, (str, int, float)):
+            return value
+    return _discover(data, "artifact_id", "id")
+
+def _contract_summary(summary: Mapping[str, Any], data: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not summary.get("provided"):
+        return {"provided": False, "fallback_mapping": "Candidate records are built from static fallback mappings in this module."}
+    ledger = data.get("ledger_receipt_chain_contract", {}) if data else {}
+    glow = data.get("glow_evidence_archive_contract", {}) if data else {}
+    alignment = data.get("source_artifact_alignment", []) if data else []
+    return {
+        "provided": True,
+        "workcell_memory_contract_id": data.get("workcell_memory_contract_id") if data else None,
+        "ledger_record_type_count": len(ledger.get("record_catalog", [])) if isinstance(ledger, Mapping) else None,
+        "glow_archive_item_type_count": len(glow.get("archive_catalog", [])) if isinstance(glow, Mapping) else None,
+        "source_artifact_alignment_count": len(alignment) if isinstance(alignment, list) else None,
+    }
+
+def build_codex_workcell_memory_candidate_bundle(request: CodexWorkcellMemoryCandidateBundleRequest | None = None) -> dict[str, Any]:
+    request = request or CodexWorkcellMemoryCandidateBundleRequest()
+    input_summaries: dict[str, dict[str, Any]] = {}
+    data_by_input: dict[str, Mapping[str, Any] | None] = {}
+    for input_id in INPUT_IDS:
+        summary, data = _read_json(getattr(request, input_id), input_id)
+        input_summaries[input_id] = summary
+        data_by_input[input_id] = data
+    ledger_entries: list[dict[str, Any]] = []
+    glow_items: list[dict[str, Any]] = []
+    entry_id_by_input: dict[str, str] = {}
+    for input_id in INPUT_IDS:
+        summary = input_summaries[input_id]
+        if not summary["provided"] or LEDGER_BY_INPUT[input_id] is None:
+            continue
+        data = data_by_input[input_id]
+        entry_id = _stable_id("candidate-ledger", input_id, summary["digest"], LEDGER_BY_INPUT[input_id])
+        entry_id_by_input[input_id] = entry_id
+        ledger_entries.append({
+            "candidate_entry_id": entry_id, "candidate_only": True, "would_be_record_type": LEDGER_BY_INPUT[input_id],
+            "source_input_id": input_id, "source_artifact_digest": summary["digest"], "source_artifact_digest_algo": DIGEST_ALGO,
+            "source_artifact_byte_size": summary["byte_size"], "source_artifact_id": _artifact_id(data),
+            "parent_entry_id": _discover(data, "parent_entry_id"), "parent_entry_digest": _discover(data, "parent_entry_digest"),
+            "commit_sha": _discover(data, "commit_sha", "head_sha"), "pr_number": _discover(data, "pr_number", "pull_request_number"),
+            "pr_title": _discover(data, "pr_title", "title"), "merge_commit_sha": _discover(data, "merge_commit_sha"),
+            "observed_status": _discover(data, "status", "decision", "proof_status", "matrix_status", "finalizer_status", "pr_metadata_guard_status"),
+            "authority_boundary": AUTHORITY_BOUNDARY, "forbidden_inference": FORBIDDEN_INFERENCE, "no_write_performed": True,
+        })
+    for input_id in INPUT_IDS:
+        summary = input_summaries[input_id]
+        if not summary["provided"]:
+            continue
+        data = data_by_input[input_id]
+        glow_items.append({
+            "candidate_glow_item_id": _stable_id("candidate-glow", input_id, summary["digest"], GLOW_BY_INPUT[input_id]),
+            "candidate_only": True, "would_be_archive_item_type": GLOW_BY_INPUT[input_id], "source_input_id": input_id,
+            "source_path": summary["path"], "source_digest": summary["digest"], "source_digest_algo": DIGEST_ALGO,
+            "byte_size": summary["byte_size"], "source_artifact_id": _artifact_id(data),
+            "related_candidate_ledger_entry_id": entry_id_by_input.get(input_id), "related_commit_sha": _discover(data, "commit_sha", "head_sha"),
+            "related_pr_number": _discover(data, "pr_number", "pull_request_number"), "review_surface": "candidate memory review",
+            "memory_scope": "metadata-only candidate /glow archive record", "authority_boundary": AUTHORITY_BOUNDARY,
+            "forbidden_inference": FORBIDDEN_INFERENCE, "no_archive_performed": True,
+        })
+    source_map = []
+    for input_id in INPUT_IDS:
+        summary = input_summaries[input_id]
+        if summary["provided"]:
+            source_map.append({"input_id": input_id, "provided": True, "digest": summary["digest"], "byte_size": summary["byte_size"],
+                "candidate_ledger_entry_ids": [e["candidate_entry_id"] for e in ledger_entries if e["source_input_id"] == input_id],
+                "candidate_glow_item_ids": [g["candidate_glow_item_id"] for g in glow_items if g["source_input_id"] == input_id],
+                "source_family": FAMILY_BY_INPUT[input_id], "authority_boundary": AUTHORITY_BOUNDARY})
+    parent_observed = sum(1 for e in ledger_entries if e["parent_entry_id"] or e["parent_entry_digest"])
+    related_observed = sum(1 for g in glow_items if g["related_candidate_ledger_entry_id"])
+    return {
+        "memory_candidate_bundle_id": WORKCELL_MEMORY_CANDIDATE_BUNDLE_ID, "metadata_only": True, "candidate_bundle_only": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True,
+        "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True,
+        "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": input_summaries, "contract_summary": _contract_summary(input_summaries["memory_contract_json"], data_by_input["memory_contract_json"]),
+        "candidate_ledger_entries": ledger_entries, "candidate_glow_items": glow_items, "source_artifact_map": source_map,
+        "candidate_chain_summary": {"candidate_ledger_entry_count": len(ledger_entries), "candidate_record_types": sorted({str(e["would_be_record_type"]) for e in ledger_entries}), "parent_links_observed_count": parent_observed, "parent_links_missing_count": len(ledger_entries) - parent_observed, "candidate_only": True, "no_ledger_write_performed": True},
+        "candidate_archive_summary": {"candidate_glow_item_count": len(glow_items), "candidate_archive_item_types": sorted({str(g["would_be_archive_item_type"]) for g in glow_items}), "related_ledger_links_observed_count": related_observed, "related_ledger_links_missing_count": len(glow_items) - related_observed, "candidate_only": True, "no_glow_archive_performed": True},
+        "sentientos_mount_alignment": {"/ledger": "candidate receipt entries only; no ledger write", "/glow": "candidate archive records only; no archive write", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here", "/vow": "canonical constraints bounding candidate interpretation and forbidden inference"},
+        "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_ACTIVATION_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
+
+def render_codex_workcell_memory_candidate_bundle_markdown(bundle: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Memory Candidate Bundle", "", "Deterministic metadata-only candidate records for review. This bundle does not write /ledger, archive /glow, mutate memory, decide readiness, authorize landing, trigger daemon action, schedule work, create tasks, alert, or train models."]
+    lines += ["", "## Input summary", "| input | provided | path | digest | byte_size | readable_json | error |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for key, summary in sorted(bundle["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(summary.get('provided'))} | {_cell(summary.get('path'))} | {_cell(summary.get('digest'))} | {_cell(summary.get('byte_size'))} | {_cell(summary.get('readable_json'))} | {_cell(summary.get('error'))} |")
+    lines += ["", "## Contract summary", f"`{_cell(bundle['contract_summary'])}`", "", "## Candidate ledger entries", "| candidate_entry_id | type | input | artifact_id | digest | byte_size | status | no_write |", "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+    for e in bundle["candidate_ledger_entries"]:
+        lines.append(f"| {_cell(e['candidate_entry_id'])} | {_cell(e['would_be_record_type'])} | {_cell(e['source_input_id'])} | {_cell(e.get('source_artifact_id'))} | {_cell(e['source_artifact_digest'])} | {_cell(e['source_artifact_byte_size'])} | {_cell(e.get('observed_status'))} | {_cell(e['no_write_performed'])} |")
+    lines += ["", "## Candidate glow items", "| candidate_glow_item_id | type | input | path | artifact_id | digest | related_ledger | no_archive |", "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+    for g in bundle["candidate_glow_items"]:
+        lines.append(f"| {_cell(g['candidate_glow_item_id'])} | {_cell(g['would_be_archive_item_type'])} | {_cell(g['source_input_id'])} | {_cell(g['source_path'])} | {_cell(g.get('source_artifact_id'))} | {_cell(g['source_digest'])} | {_cell(g.get('related_candidate_ledger_entry_id'))} | {_cell(g['no_archive_performed'])} |")
+    lines += ["", "## Source artifact map", "| input | family | ledger_ids | glow_ids |", "| --- | --- | --- | --- |"]
+    for item in bundle["source_artifact_map"]:
+        lines.append(f"| {_cell(item['input_id'])} | {_cell(item['source_family'])} | {_cell(item['candidate_ledger_entry_ids'])} | {_cell(item['candidate_glow_item_ids'])} |")
+    for title, key in (("Candidate chain summary", "candidate_chain_summary"), ("Candidate archive summary", "candidate_archive_summary")):
+        lines += ["", f"## {title}", f"`{_cell(bundle[key])}`"]
+    lines += ["", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(bundle["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in bundle["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(bundle["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+def write_codex_workcell_memory_candidate_bundle_json(bundle: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def write_codex_workcell_memory_candidate_bundle_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_memory_candidate_bundle_script.py
+++ b/tests/test_build_codex_workcell_memory_candidate_bundle_script.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+import sys
+
+SCRIPT = "scripts/build_codex_workcell_memory_candidate_bundle.py"
+
+
+def _run(args):
+    return subprocess.run([sys.executable, SCRIPT, *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_summary_and_markdown(tmp_path) -> None:
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(json.dumps({"status": "passed", "title": "A|B"}) + "\n", encoding="utf-8")
+    output = tmp_path / "bundle.json"
+    markdown = tmp_path / "bundle.md"
+    result = _run(["--output", str(output), "--markdown-output", str(markdown), "--summary", "--matrix-json", str(matrix)])
+    assert result.returncode == 0, result.stderr
+    bundle = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert summary["candidate_ledger_entry_count"] == 1
+    assert bundle["candidate_ledger_entries"][0]["would_be_record_type"] == "matrix_receipt"
+    assert markdown.exists()
+    assert "# Codex Workcell Memory Candidate Bundle" in markdown.read_text(encoding="utf-8")
+
+
+def test_cli_input_errors_exit_2(tmp_path) -> None:
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{no", encoding="utf-8")
+    assert _run(["--output", str(output), "--matrix-json", str(invalid)]).returncode == 2
+    assert _run(["--output", str(output), "--matrix-json", str(tmp_path / "missing.json")]).returncode == 2
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    assert _run(["--output", str(output), "--matrix-json", str(array)]).returncode == 2
+
+
+def test_cli_json_output_is_deterministic(tmp_path) -> None:
+    finalizer = tmp_path / "finalizer.json"
+    finalizer.write_text(json.dumps({"status": "ready_to_commit"}, sort_keys=True) + "\n", encoding="utf-8")
+    one = tmp_path / "one.json"
+    two = tmp_path / "two.json"
+    assert _run(["--output", str(one), "--pre-commit-finalizer-json", str(finalizer)]).returncode == 0
+    assert _run(["--output", str(two), "--pre-commit-finalizer-json", str(finalizer)]).returncode == 0
+    assert one.read_text(encoding="utf-8") == two.read_text(encoding="utf-8")

--- a/tests/test_codex_workcell_memory_candidate_bundle.py
+++ b/tests/test_codex_workcell_memory_candidate_bundle.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_memory_candidate_bundle import (
+    INPUT_IDS,
+    NON_AUTHORITY_POSTURE,
+    CodexWorkcellMemoryCandidateBundleRequest,
+    build_codex_workcell_memory_candidate_bundle,
+    render_codex_workcell_memory_candidate_bundle_markdown,
+)
+
+
+def _write(tmp_path, name: str, data: dict) -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(data, sort_keys=True) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def test_omitted_inputs_produce_no_candidates() -> None:
+    bundle = build_codex_workcell_memory_candidate_bundle()
+    assert all(not bundle["input_summaries"][key]["provided"] for key in INPUT_IDS)
+    assert bundle["candidate_ledger_entries"] == []
+    assert bundle["candidate_glow_items"] == []
+    assert bundle["contract_summary"]["provided"] is False
+
+
+def test_supplied_inputs_create_expected_candidate_records(tmp_path) -> None:
+    paths = {
+        "matrix_json": _write(tmp_path, "matrix.json", {"matrix_status": "passed", "commit_sha": "abc"}),
+        "pre_commit_finalizer_json": _write(tmp_path, "pre.json", {"status": "ready_to_commit"}),
+        "pr_metadata_guard_json": _write(tmp_path, "guard.json", {"pr_metadata_guard_status": "pr_metadata_guard_ready"}),
+        "health_snapshot_json": _write(tmp_path, "health.json", {"workcell_health_snapshot_id": "health-1"}),
+        "pulse_contract_json": _write(tmp_path, "pulse.json", {"pulse_contract_id": "pulse-1"}),
+        "daemon_recommendation_contract_json": _write(tmp_path, "daemon.json", {"daemon_recommendation_contract_id": "daemon-1"}),
+        "memory_contract_json": _write(tmp_path, "memory.json", {"workcell_memory_contract_id": "mem-1", "ledger_receipt_chain_contract": {"record_catalog": [{"record_type": "x"}]}, "glow_evidence_archive_contract": {"archive_catalog": [{"archive_item_type": "y"}]}, "source_artifact_alignment": [{}]}),
+    }
+    bundle = build_codex_workcell_memory_candidate_bundle(CodexWorkcellMemoryCandidateBundleRequest(**paths))
+    assert bundle["candidate_chain_summary"]["candidate_ledger_entry_count"] == 7
+    assert bundle["candidate_archive_summary"]["candidate_glow_item_count"] == 7
+    types = {entry["would_be_record_type"] for entry in bundle["candidate_ledger_entries"]}
+    assert {"matrix_receipt", "finalizer_receipt", "pr_metadata_guard_receipt", "health_snapshot_receipt", "pulse_contract_receipt", "daemon_recommendation_contract_receipt", "memory_contract_receipt"} <= types
+    glow_types = {item["would_be_archive_item_type"] for item in bundle["candidate_glow_items"]}
+    assert {"matrix_report_snapshot", "finalizer_report_snapshot", "pr_metadata_guard_snapshot", "workcell_health_snapshot", "pulse_contract_snapshot", "daemon_recommendation_contract_snapshot", "memory_contract_snapshot"} <= glow_types
+    assert bundle["contract_summary"]["workcell_memory_contract_id"] == "mem-1"
+
+
+def test_raw_digest_size_source_map_and_determinism(tmp_path) -> None:
+    path = _write(tmp_path, "matrix.json", {"status": "ok|pipe", "artifact_id": "a\nb"})
+    raw = (tmp_path / "matrix.json").read_bytes()
+    req = CodexWorkcellMemoryCandidateBundleRequest(matrix_json=path)
+    first = build_codex_workcell_memory_candidate_bundle(req)
+    second = build_codex_workcell_memory_candidate_bundle(req)
+    assert first == second
+    summary = first["input_summaries"]["matrix_json"]
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+    mapped = first["source_artifact_map"][0]
+    assert mapped["input_id"] == "matrix_json"
+    assert mapped["candidate_ledger_entry_ids"] == [first["candidate_ledger_entries"][0]["candidate_entry_id"]]
+    assert mapped["candidate_glow_item_ids"] == [first["candidate_glow_items"][0]["candidate_glow_item_id"]]
+    assert first["candidate_chain_summary"]["parent_links_missing_count"] == 1
+    assert first["candidate_archive_summary"]["related_ledger_links_observed_count"] == 1
+    md1 = render_codex_workcell_memory_candidate_bundle_markdown(first)
+    md2 = render_codex_workcell_memory_candidate_bundle_markdown(second)
+    assert md1 == md2
+    assert "ok\\|pipe" in md1
+    assert "a<br>b" in md1
+
+
+def test_non_authority_future_mount_flags(tmp_path) -> None:
+    bundle = build_codex_workcell_memory_candidate_bundle(CodexWorkcellMemoryCandidateBundleRequest(doctrine_map_json=_write(tmp_path, "doctrine.json", {"status": "context"})))
+    assert bundle["candidate_ledger_entries"] == []
+    assert bundle["candidate_glow_items"][0]["no_archive_performed"] is True
+    assert bundle["not_ledger_writer"] is True
+    assert bundle["not_glow_archiver"] is True
+    assert bundle["not_daemon_action"] is True
+    assert bundle["not_scheduler"] is True
+    assert all(bundle["non_authority_posture"][key] is True for key in NON_AUTHORITY_POSTURE)
+    assert all(item["status"] == "future_only" and item["active"] is False and item["met"] is False for item in bundle["future_activation_requirements"])
+    assert bundle["sentientos_mount_alignment"]["/ledger"].endswith("no ledger write")


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only review surface that renders what future `/ledger` receipt entries and `/glow` archive records would look like from supplied Codex workcell artifacts without performing any writes, archiving, memory mutation, daemon action, scheduling, or authority decisions.

### Description
- Add `sentientos/codex_workcell_memory_candidate_bundle.py` which implements the stable candidate-bundle id, `sha256` raw-byte digests, input handling for the requested optional JSON artifacts, deterministic candidate `/ledger` entries and candidate `/glow` items, source-artifact map, chain/archive summaries, mount alignment, future-only activation requirements, and explicit non-authority posture flags.
- Add CLI `scripts/build_codex_workcell_memory_candidate_bundle.py` with required `--output`, optional `--markdown-output` and `--summary`, the requested optional JSON inputs, deterministic JSON output, deterministic compact Markdown rendering (with pipe/newline escaping), and clean `exit 2` behavior for missing/invalid/non-object JSON inputs.
- Add focused tests `tests/test_codex_workcell_memory_candidate_bundle.py` and `tests/test_build_codex_workcell_memory_candidate_bundle_script.py` that verify omitted vs supplied inputs, digest/byte_size provenance, deterministic IDs and outputs, Markdown escaping, source-artifact linking, summary counts, non-authority posture, and CLI error semantics.
- Add `docs/development/codex_workcell_memory_candidate_bundle.md` and small boundary notes in adjacent docs to document the bundle purpose, differences to the memory contract, and to emphasize the review-only, non-writing, non-authoritative posture.

### Testing
- Ran unit/CLI tests: `python -m scripts.run_tests -q tests/test_codex_workcell_memory_candidate_bundle.py tests/test_build_codex_workcell_memory_candidate_bundle_script.py` and related contract/script test pairs; the added tests passed in the final run.
- Ran `python -m mypy sentientos/codex_workcell_memory_candidate_bundle.py scripts/build_codex_workcell_memory_candidate_bundle.py`, `python scripts/build_docs.py` (bootstrapped docs deps when needed), and `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json`, all of which completed successfully in validation.
- Ran the Codex landing finalizer and PR metadata guard flows (`codex_finalize_landing.py finalize --phase pre-commit` and `--phase pr-metadata`, then `codex_pr_metadata_guard.py verify`) and reached `ready_to_commit`, `ready_for_pr_metadata`, and `pr_metadata_guard_ready` respectively.
- CLI behavior verified: JSON and Markdown outputs are produced deterministically and the CLI exits with code `2` for missing/invalid/non-object JSON inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b417d89ac8320aad82ed397d6e93b)