### PR TITLE
[codex:memory] add Codex workcell memory candidate verifier

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -207,3 +207,7 @@ The Codex Workcell Memory Contract can describe future receipt metadata for fina
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may include supplied finalizer JSON as candidate review metadata only. Candidate records do not replace this finalizer, do not make stale evidence fresh, do not authorize commit, and do not authorize PR metadata.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) may report candidate bundle structure, but its `verification_status` is never finalizer authority. It cannot replace pre-commit or pr-metadata finalizer decisions, authorize commit, authorize PR metadata, bypass guards, write `/ledger`, or archive `/glow`.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -199,3 +199,7 @@ The Codex Workcell Memory Contract can name future `/ledger` receipt-chain and `
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) can summarize supplied recovery and evidence artifacts as candidate `/ledger` and `/glow` records for review. It does not recover files, write archives, mutate memory, create tasks, or bypass recovery and landing rails.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is review-only evidence about candidate bundle structure. It is not recovery authority, does not recover or mutate files, does not write `/ledger`, does not archive `/glow`, and does not authorize commit, PR metadata, daemon action, task creation, scheduling, or alerts.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -146,3 +146,7 @@ The Codex Workcell Memory Contract defines future metadata shapes for landed evi
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) is a deterministic review surface over supplied artifacts. It does not add validation lanes, satisfy matrix proof, bypass finalizer or PR metadata guard authority, authorize commit, authorize PR creation, write ledger entries, archive glow items, or create runtime authority.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can emit `memory_candidate_bundle_verified` for structural candidate consistency, but that status is not validation, matrix, finalizer, supervisor, PR metadata guard, clean-tree, commit, or PR authority. It does not write `/ledger`, archive `/glow`, mutate memory, trigger daemons, schedule work, create tasks, alert, train models, or establish federation consensus.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -110,3 +110,7 @@ The Codex Workcell Memory Contract is the next metadata-only layer after archite
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) adds a review-only rendering layer for supplied architecture and landing artifacts. It produces candidate `/ledger` and `/glow` metadata without storage, mutation, daemon action, scheduling, readiness authority, or federation consensus.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is a metadata-only review layer for candidate memory bundles. It preserves architecture boundaries by avoiding runtime authority, ledger writes, glow archiving, daemon action, task creation, scheduling, alerts, model training, and federation consensus.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -38,3 +38,7 @@ The Codex Workcell Memory Contract defines future `/ledger` receipt-chain and `/
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied daemon recommendation contract JSON as candidate memory review metadata only. The bundle does not trigger daemon action, schedule repair, create tasks, or convert recommendations into authority.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) verifies candidate memory bundle structure only. It is not a daemon recommendation consumer or executor and does not trigger daemon action, schedule work, create tasks, decide readiness, write `/ledger`, or archive `/glow`.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -52,3 +52,7 @@ The Codex Workcell Memory Contract defines how health snapshots could be represe
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied health snapshot JSON as candidate memory metadata. This does not make the health snapshot a gate, readiness decision, ledger write, glow archive, or runtime authority.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can inspect candidate records that reference supplied evidence artifacts. It does not observe live health, mutate memory, decide readiness, write `/ledger`, archive `/glow`, trigger daemons, schedule work, or create tasks.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -47,3 +47,7 @@ All activation requirements are represented as future-only, unmet, and inactive:
 ## Non-authority posture
 
 The memory candidate bundle is read-only, metadata-only, and candidate-only. It does not write ledger, archive glow, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commit, authorize PR creation, trigger a daemon, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can inspect a supplied candidate bundle for structural consistency and optional memory-contract type alignment. Its verification status is bundle-structure metadata only; it does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize commit/PR metadata, trigger daemons, create tasks, schedule work, alert, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -1,0 +1,100 @@
+# Codex Workcell Memory Candidate Verifier
+
+The Codex Workcell Memory Candidate Verifier is a deterministic, metadata-only
+inspection surface for JSON emitted by the Codex Workcell Memory Candidate
+Bundle. It reads a supplied candidate bundle JSON, optionally reads a supplied
+memory contract JSON, and emits a structural verification report for reviewer
+inspection.
+
+It is verifier-only. It does not write `/ledger` entries, archive `/glow`
+evidence, mutate memory, watch files, poll state, rerun commands, schedule work,
+trigger daemon action, create tasks, send alerts, decide readiness, authorize
+commit, authorize PR metadata, create PRs, establish federation consensus, train
+models, or modify models.
+
+## Contract, candidate bundle, and verifier
+
+- The [Codex Workcell Memory Contract](codex_workcell_memory_contract.md)
+  defines future `/ledger` receipt-chain record types and future `/glow` archive
+  item types. It is schema metadata, not a writer.
+- The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md)
+  renders candidate `/ledger` receipt entries and candidate `/glow` archive
+  records from supplied artifacts. It is candidate metadata, not storage.
+- This verifier checks whether a supplied candidate bundle is internally
+  consistent and, when a memory contract is supplied, whether candidate record
+  and archive types are known by that contract.
+
+## Structural checks
+
+The verifier reports deterministic check objects with a stable `check_id`,
+`passed` boolean, `severity`, `details`, and `authority_boundary`. Checks cover:
+
+- bundle object shape and metadata-only/candidate-only declarations;
+- no-ledger-write and no-glow-archive declarations;
+- input summaries, candidate ledger entries, candidate glow items, and source
+  artifact map shape;
+- uniqueness of candidate ledger entry ids and candidate glow item ids;
+- ledger/glow references to provided inputs;
+- source artifact map links to existing candidate ledger/glow ids;
+- candidate chain/archive summary count agreement;
+- per-entry `candidate_only`, `no_write_performed`, and
+  `no_archive_performed` flags;
+- inactive future activation requirements;
+- non-authority posture presence and true values;
+- contract-known record and archive item types when a memory contract is
+  supplied.
+
+## Verification status is not readiness authority
+
+`verification_status` is only bundle-structure status. It may be
+`memory_candidate_bundle_verified`, `memory_candidate_bundle_failed`, or
+`memory_candidate_bundle_incomplete`, but none of those statuses is commit
+readiness, PR readiness, matrix authority, finalizer authority, PR metadata
+authority, ledger authority, glow authority, daemon authority, or federation
+consensus.
+
+The normal landing sequence remains bootstrap, validation, matrix, pre-commit
+finalizer, commit, post-commit/pr-metadata finalizer, PR metadata guard, and PR
+metadata creation under the authoritative tools.
+
+## Candidate verification is not ledger writing
+
+The verifier reads candidate bundle bytes and reports structural consistency. It
+does not create ledger entry ids, append ledger files, seal a chain, validate a
+parent chain as active history, choose storage paths, or assert that a candidate
+receipt exists in `/ledger`.
+
+## Candidate verification is not glow archiving
+
+The verifier reads candidate glow item metadata and reports structural
+consistency. It does not copy files, retain evidence, publish archive records,
+choose archive storage, disclose evidence externally, or assert that a candidate
+item exists in `/glow`.
+
+## SentientOS mount relation
+
+- `/ledger`: candidate verification only; no ledger write.
+- `/glow`: candidate verification only; no archive write.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+- `/vow`: canonical constraints bounding verification interpretation and
+  forbidden inference.
+
+## Future activation requirements
+
+All future activation requirements remain future-only, unmet, and inactive:
+explicit ledger writer implementation, explicit glow archiver implementation,
+explicit storage path policy, explicit retention policy, explicit digest
+verification policy, explicit parent-chain validation policy, explicit operator
+consent, explicit finalizer/guard non-bypass invariant, explicit pulse watcher
+contract, explicit daemon action contract, explicit federation drift consensus
+rule, explicit vow digest constraint check, tests proving no readiness authority,
+and docs marking active behavior.
+
+## Non-authority posture
+
+The verifier is read-only, metadata-only, and verifier-only. It does not write
+ledger, archive glow, modify memory, watch files, poll state, rerun commands,
+decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize
+commit, authorize PR creation, trigger a daemon, create tasks, schedule tasks,
+send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -111,3 +111,7 @@ alerts, train or modify models, or establish federation consensus.
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) can render deterministic candidate `/ledger` entries and candidate `/glow` items from supplied artifacts using these schema families. It is review-only metadata and does not write ledger entries, archive glow evidence, mutate memory, decide readiness, or authorize commit/PR metadata.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) may use this contract to check whether candidate `/ledger` record types and candidate `/glow` archive item types are known. That check is structural metadata only and does not activate ledger writing, glow archiving, readiness authority, daemon action, task creation, scheduling, alerts, or federation consensus.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -51,3 +51,7 @@ The Codex Workcell Memory Contract may describe future `/ledger` and `/glow` met
 ## Memory candidate bundle boundary
 
 The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bundle.md) may represent a supplied pulse contract JSON as candidate `/ledger` and `/glow` review metadata. It does not activate pulse watching, poll state, decide pressure, or authorize landing.
+
+## Memory candidate verifier boundary
+
+The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is inactive relative to `/pulse`: it may report candidate bundle consistency, but it does not watch stored history, poll state, emit pressure signals, schedule work, trigger daemon action, write `/ledger`, or archive `/glow`.

--- a/scripts/verify_codex_workcell_memory_candidate_bundle.py
+++ b/scripts/verify_codex_workcell_memory_candidate_bundle.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_memory_candidate_verifier import (
+    CodexWorkcellMemoryCandidateVerifierError,
+    read_json_input,
+    render_codex_workcell_memory_candidate_verifier_markdown,
+    verify_codex_workcell_memory_candidate_bundle,
+    write_codex_workcell_memory_candidate_verifier_json,
+    write_codex_workcell_memory_candidate_verifier_markdown,
+)
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify a metadata-only Codex workcell memory candidate bundle.")
+    parser.add_argument("--candidate-bundle-json", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--memory-contract-json")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        candidate_summary, candidate = read_json_input(args.candidate_bundle_json, "candidate_bundle_json", required=True)
+        if candidate is None:
+            raise CodexWorkcellMemoryCandidateVerifierError("missing_candidate_bundle_json")
+        contract_summary, contract = read_json_input(args.memory_contract_json, "memory_contract_json", required=False)
+        report = verify_codex_workcell_memory_candidate_bundle(candidate, candidate_summary, contract, contract_summary)
+    except CodexWorkcellMemoryCandidateVerifierError as exc:
+        print(f"codex_workcell_memory_candidate_verifier_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_memory_candidate_verifier_json(report, args.output)
+    if args.markdown_output:
+        write_codex_workcell_memory_candidate_verifier_markdown(render_codex_workcell_memory_candidate_verifier_markdown(report), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"memory_candidate_verifier_id": report["memory_candidate_verifier_id"], "metadata_only": True, "verifier_only": True, "verification_status": report["verification_status"], "violation_count": report["violation_summary"]["violation_count"], "warning_count": report["violation_summary"]["warning_count"], "output": args.output, "markdown_output": args.markdown_output}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_memory_candidate_verifier.py
+++ b/sentientos/codex_workcell_memory_candidate_verifier.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from sentientos.codex_workcell_memory_candidate_bundle import GLOW_BY_INPUT, LEDGER_BY_INPUT
+from sentientos.codex_workcell_memory_contract import GLOW_ARCHIVE_ITEM_TYPES, LEDGER_RECORD_TYPES, SOURCE_ARTIFACT_FAMILIES
+
+WORKCELL_MEMORY_CANDIDATE_VERIFIER_ID = "codex_workcell_memory_candidate_verifier.v1"
+DIGEST_ALGO = "sha256"
+AUTHORITY_BOUNDARY = "Verifier metadata only; does not write ledger, archive glow, mutate memory, decide readiness, run commands, trigger daemon action, schedule work, create tasks, alert, train models, or establish consensus."
+
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit ledger writer implementation", "explicit glow archiver implementation", "explicit storage path policy",
+    "explicit retention policy", "explicit digest verification policy", "explicit parent-chain validation policy",
+    "explicit operator consent", "explicit finalizer/guard non-bypass invariant", "explicit pulse watcher contract",
+    "explicit daemon action contract", "explicit federation drift consensus rule", "explicit vow digest constraint check",
+    "tests proving no readiness authority", "docs marking active behavior",
+)
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "memory_candidate_verifier_is_read_only": True,
+    "memory_candidate_verifier_is_metadata_only": True,
+    "memory_candidate_verifier_is_verifier_only": True,
+    "memory_candidate_verifier_does_not_write_ledger": True,
+    "memory_candidate_verifier_does_not_archive_glow": True,
+    "memory_candidate_verifier_does_not_modify_memory": True,
+    "memory_candidate_verifier_does_not_watch_files": True,
+    "memory_candidate_verifier_does_not_poll_state": True,
+    "memory_candidate_verifier_does_not_rerun_commands": True,
+    "memory_candidate_verifier_does_not_decide_readiness": True,
+    "memory_candidate_verifier_does_not_bypass_finalizer": True,
+    "memory_candidate_verifier_does_not_bypass_pr_metadata_guard": True,
+    "memory_candidate_verifier_does_not_authorize_commit": True,
+    "memory_candidate_verifier_does_not_authorize_pr_creation": True,
+    "memory_candidate_verifier_does_not_trigger_daemon": True,
+    "memory_candidate_verifier_does_not_create_tasks": True,
+    "memory_candidate_verifier_does_not_schedule_tasks": True,
+    "memory_candidate_verifier_does_not_send_alerts": True,
+    "memory_candidate_verifier_does_not_train_or_modify_models": True,
+    "memory_candidate_verifier_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellMemoryCandidateVerifierError(ValueError):
+    pass
+
+def read_json_input(path_text: str | None, input_id: str, *, required: bool) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        if required:
+            raise CodexWorkcellMemoryCandidateVerifierError(f"missing_{input_id}")
+        return ({"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None)
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellMemoryCandidateVerifierError(f"missing_{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellMemoryCandidateVerifierError(f"invalid_{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellMemoryCandidateVerifierError(f"{input_id}_not_object:{path_text}")
+    return ({"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded)
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+def _provided_inputs(bundle: Mapping[str, Any]) -> set[str]:
+    summaries = bundle.get("input_summaries", {})
+    if not isinstance(summaries, Mapping):
+        return set()
+    return {str(k) for k, v in summaries.items() if isinstance(v, Mapping) and v.get("provided") is True}
+
+def _known_from_contract(contract: Mapping[str, Any] | None) -> tuple[set[str], set[str], list[str]]:
+    if contract is None:
+        return set(LEDGER_RECORD_TYPES) | {v for v in LEDGER_BY_INPUT.values() if v}, set(GLOW_ARCHIVE_ITEM_TYPES) | set(GLOW_BY_INPUT.values()), list(SOURCE_ARTIFACT_FAMILIES)
+    ledger = contract.get("ledger_receipt_chain_contract", {})
+    glow = contract.get("glow_evidence_archive_contract", {})
+    alignment = contract.get("source_artifact_alignment", [])
+    record_types = {str(item.get("record_type")) for item in _as_list(ledger.get("record_catalog") if isinstance(ledger, Mapping) else None) if isinstance(item, Mapping) and item.get("record_type")}
+    item_types = {str(item.get("archive_item_type")) for item in _as_list(glow.get("archive_catalog") if isinstance(glow, Mapping) else None) if isinstance(item, Mapping) and item.get("archive_item_type")}
+    families = [str(item.get("artifact_family")) for item in _as_list(alignment) if isinstance(item, Mapping) and item.get("artifact_family")]
+    return record_types, item_types, families
+
+def _check(check_id: str, passed: bool, details: str, severity_if_failed: str = "violation") -> dict[str, Any]:
+    return {"check_id": check_id, "passed": passed, "severity": "info" if passed else severity_if_failed, "details": details, "authority_boundary": AUTHORITY_BOUNDARY}
+
+def verify_codex_workcell_memory_candidate_bundle(candidate_bundle: Mapping[str, Any], candidate_summary: Mapping[str, Any], memory_contract: Mapping[str, Any] | None = None, memory_contract_summary_input: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    contract_provided = memory_contract is not None
+    known_records, known_glow, families = _known_from_contract(memory_contract)
+    ledger_entries = _as_list(candidate_bundle.get("candidate_ledger_entries"))
+    glow_items = _as_list(candidate_bundle.get("candidate_glow_items"))
+    source_map = _as_list(candidate_bundle.get("source_artifact_map"))
+    provided_inputs = _provided_inputs(candidate_bundle)
+    ledger_ids = [str(e.get("candidate_entry_id")) for e in ledger_entries if isinstance(e, Mapping) and e.get("candidate_entry_id") is not None]
+    glow_ids = [str(g.get("candidate_glow_item_id")) for g in glow_items if isinstance(g, Mapping) and g.get("candidate_glow_item_id") is not None]
+    ledger_id_set, glow_id_set = set(ledger_ids), set(glow_ids)
+
+    ledger_results = []
+    for e in ledger_entries:
+        if not isinstance(e, Mapping):
+            continue
+        sid = e.get("source_input_id")
+        typ = e.get("would_be_record_type")
+        violations = []
+        if sid not in provided_inputs: violations.append("source_input_missing")
+        if typ not in known_records: violations.append("unknown_record_type")
+        if e.get("candidate_only") is not True: violations.append("candidate_only_not_true")
+        if e.get("no_write_performed") is not True: violations.append("no_write_performed_not_true")
+        if not e.get("source_artifact_digest"): violations.append("source_digest_missing")
+        ledger_results.append({"candidate_entry_id": e.get("candidate_entry_id"), "source_input_id": sid, "source_input_provided": sid in provided_inputs, "would_be_record_type": typ, "record_type_known": typ in known_records, "candidate_only_seen": e.get("candidate_only") is True, "no_write_performed_seen": e.get("no_write_performed") is True, "source_digest_seen": bool(e.get("source_artifact_digest")), "passed": not violations, "violations": violations, "authority_boundary": AUTHORITY_BOUNDARY})
+
+    glow_results = []
+    for g in glow_items:
+        if not isinstance(g, Mapping):
+            continue
+        sid = g.get("source_input_id")
+        typ = g.get("would_be_archive_item_type")
+        related = g.get("related_candidate_ledger_entry_id")
+        violations = []
+        if sid not in provided_inputs: violations.append("source_input_missing")
+        if typ not in known_glow: violations.append("unknown_archive_item_type")
+        if g.get("candidate_only") is not True: violations.append("candidate_only_not_true")
+        if g.get("no_archive_performed") is not True: violations.append("no_archive_performed_not_true")
+        if not g.get("source_digest"): violations.append("source_digest_missing")
+        if related is not None and related not in ledger_id_set: violations.append("related_candidate_ledger_entry_id_missing")
+        glow_results.append({"candidate_glow_item_id": g.get("candidate_glow_item_id"), "source_input_id": sid, "source_input_provided": sid in provided_inputs, "would_be_archive_item_type": typ, "archive_item_type_known": typ in known_glow, "candidate_only_seen": g.get("candidate_only") is True, "no_archive_performed_seen": g.get("no_archive_performed") is True, "source_digest_seen": bool(g.get("source_digest")), "related_candidate_ledger_entry_id_seen": related, "related_candidate_ledger_entry_id_exists": related in ledger_id_set if related is not None else None, "passed": not violations, "violations": violations, "authority_boundary": AUTHORITY_BOUNDARY})
+
+    source_results = []
+    for item in source_map:
+        if not isinstance(item, Mapping):
+            continue
+        linked_l = [str(x) for x in _as_list(item.get("candidate_ledger_entry_ids"))]
+        linked_g = [str(x) for x in _as_list(item.get("candidate_glow_item_ids"))]
+        l_ok = all(x in ledger_id_set for x in linked_l)
+        g_ok = all(x in glow_id_set for x in linked_g)
+        violations = ([] if item.get("input_id") in provided_inputs else ["source_input_missing"]) + ([] if l_ok else ["linked_ledger_id_missing"]) + ([] if g_ok else ["linked_glow_id_missing"])
+        source_results.append({"input_id": item.get("input_id"), "provided": item.get("input_id") in provided_inputs, "linked_candidate_ledger_entry_ids": linked_l, "linked_candidate_glow_item_ids": linked_g, "all_linked_ledger_ids_exist": l_ok, "all_linked_glow_ids_exist": g_ok, "passed": not violations, "violations": violations, "authority_boundary": AUTHORITY_BOUNDARY})
+
+    chain = candidate_bundle.get("candidate_chain_summary", {}) if isinstance(candidate_bundle.get("candidate_chain_summary"), Mapping) else {}
+    archive = candidate_bundle.get("candidate_archive_summary", {}) if isinstance(candidate_bundle.get("candidate_archive_summary"), Mapping) else {}
+    chain_results = {"reported_candidate_ledger_entry_count": chain.get("candidate_ledger_entry_count"), "actual_candidate_ledger_entry_count": len(ledger_entries), "reported_candidate_glow_item_count": None, "actual_candidate_glow_item_count": len(glow_items), "count_match": chain.get("candidate_ledger_entry_count") == len(ledger_entries), "no_ledger_write_performed_seen": chain.get("no_ledger_write_performed") is True, "no_glow_archive_performed_seen": None}
+    archive_results = {"reported_candidate_ledger_entry_count": None, "actual_candidate_ledger_entry_count": len(ledger_entries), "reported_candidate_glow_item_count": archive.get("candidate_glow_item_count"), "actual_candidate_glow_item_count": len(glow_items), "count_match": archive.get("candidate_glow_item_count") == len(glow_items), "no_ledger_write_performed_seen": None, "no_glow_archive_performed_seen": archive.get("no_glow_archive_performed") is True}
+    future = candidate_bundle.get("future_activation_requirements", [])
+    posture = candidate_bundle.get("non_authority_posture", {})
+    required_posture = {k.replace("memory_candidate_verifier", "memory_candidate_bundle"): True for k in NON_AUTHORITY_POSTURE}
+
+    checks = [
+        _check("candidate_bundle_is_object", isinstance(candidate_bundle, Mapping), "candidate bundle parsed as JSON object"),
+        _check("candidate_bundle_declares_metadata_only", candidate_bundle.get("metadata_only") is True, "metadata_only must be true"),
+        _check("candidate_bundle_declares_candidate_only", candidate_bundle.get("candidate_bundle_only") is True or candidate_bundle.get("candidate_only") is True, "candidate-only declaration must be true"),
+        _check("candidate_bundle_declares_no_ledger_write", candidate_bundle.get("not_ledger_writer") is True and chain.get("no_ledger_write_performed") is True, "no ledger write declarations must be true"),
+        _check("candidate_bundle_declares_no_glow_archive", candidate_bundle.get("not_glow_archiver") is True and archive.get("no_glow_archive_performed") is True, "no glow archive declarations must be true"),
+        _check("input_summaries_exist", isinstance(candidate_bundle.get("input_summaries"), Mapping), "input_summaries must exist"),
+        _check("candidate_ledger_entries_are_list", isinstance(candidate_bundle.get("candidate_ledger_entries"), list), "candidate_ledger_entries must be a list"),
+        _check("candidate_glow_items_are_list", isinstance(candidate_bundle.get("candidate_glow_items"), list), "candidate_glow_items must be a list"),
+        _check("source_artifact_map_exists", isinstance(candidate_bundle.get("source_artifact_map"), list), "source_artifact_map must be a list"),
+        _check("candidate_ledger_entry_ids_unique", len(ledger_ids) == len(ledger_id_set), "candidate ledger entry ids must be unique"),
+        _check("candidate_glow_item_ids_unique", len(glow_ids) == len(glow_id_set), "candidate glow item ids must be unique"),
+        _check("ledger_entries_reference_provided_inputs", all(r["source_input_provided"] for r in ledger_results), "ledger entries must reference provided inputs"),
+        _check("glow_items_reference_provided_inputs", all(r["source_input_provided"] for r in glow_results), "glow items must reference provided inputs"),
+        _check("source_artifact_map_links_existing_ledger_ids", all(r["all_linked_ledger_ids_exist"] for r in source_results), "source map ledger ids must exist"),
+        _check("source_artifact_map_links_existing_glow_ids", all(r["all_linked_glow_ids_exist"] for r in source_results), "source map glow ids must exist"),
+        _check("candidate_chain_summary_counts_match", bool(chain_results["count_match"]), "chain summary count must match actual ledger entries"),
+        _check("candidate_archive_summary_counts_match", bool(archive_results["count_match"]), "archive summary count must match actual glow items"),
+        _check("ledger_entries_have_candidate_only_true", all(r["candidate_only_seen"] for r in ledger_results), "ledger entries must have candidate_only true"),
+        _check("glow_items_have_candidate_only_true", all(r["candidate_only_seen"] for r in glow_results), "glow items must have candidate_only true"),
+        _check("ledger_entries_have_no_write_true", all(r["no_write_performed_seen"] for r in ledger_results), "ledger entries must have no_write_performed true"),
+        _check("glow_items_have_no_archive_true", all(r["no_archive_performed_seen"] for r in glow_results), "glow items must have no_archive_performed true"),
+        _check("future_activation_requirements_inactive", isinstance(future, list) and all(isinstance(i, Mapping) and i.get("active") is False and i.get("met") is False for i in future), "future activation requirements must be inactive and unmet"),
+        _check("non_authority_posture_present", isinstance(posture, Mapping), "non_authority_posture must be present"),
+        _check("non_authority_posture_true", isinstance(posture, Mapping) and all(posture.get(k) is True for k in required_posture), "bundle non-authority posture flags must be true"),
+        _check("contract_record_types_known_when_contract_supplied", (not contract_provided) or all(r["record_type_known"] for r in ledger_results), "record types must be known when contract supplied"),
+        _check("contract_glow_item_types_known_when_contract_supplied", (not contract_provided) or all(r["archive_item_type_known"] for r in glow_results), "archive item types must be known when contract supplied"),
+    ]
+    violation_ids = [c["check_id"] for c in checks if not c["passed"] and c["severity"] == "violation"]
+    warning_ids = [c["check_id"] for c in checks if not c["passed"] and c["severity"] == "warning"]
+    status = "memory_candidate_bundle_verified" if not violation_ids else ("memory_candidate_bundle_incomplete" if not isinstance(candidate_bundle.get("input_summaries"), Mapping) else "memory_candidate_bundle_failed")
+    msum = dict(memory_contract_summary_input or {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None})
+    memory_contract_summary = {"provided": contract_provided, "workcell_memory_contract_id": memory_contract.get("workcell_memory_contract_id") if memory_contract else None, "known_ledger_record_types": sorted(known_records), "known_glow_archive_item_types": sorted(known_glow), "known_source_artifact_families": sorted(families), "digest": msum.get("digest"), "byte_size": msum.get("byte_size")}
+    return {
+        "memory_candidate_verifier_id": WORKCELL_MEMORY_CANDIDATE_VERIFIER_ID, "metadata_only": True, "verifier_only": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {"candidate_bundle_json": dict(candidate_summary), "memory_contract_json": msum},
+        "candidate_bundle_summary": {"candidate_bundle_id": candidate_bundle.get("memory_candidate_bundle_id"), "candidate_ledger_entry_count": len(ledger_entries), "candidate_glow_item_count": len(glow_items), "source_artifact_count": len(source_map), "candidate_only": candidate_bundle.get("candidate_bundle_only", candidate_bundle.get("candidate_only")), "no_ledger_write_performed": chain.get("no_ledger_write_performed"), "no_glow_archive_performed": archive.get("no_glow_archive_performed"), "digest": candidate_summary.get("digest"), "byte_size": candidate_summary.get("byte_size")},
+        "memory_contract_summary": memory_contract_summary, "verification_status": status, "verification_checks": checks,
+        "violation_summary": {"violation_count": len(violation_ids), "warning_count": len(warning_ids), "info_count": sum(1 for c in checks if c["severity"] == "info"), "violation_check_ids": violation_ids, "warning_check_ids": warning_ids, "verifier_only": True, "no_action_taken": True},
+        "candidate_ledger_entry_results": ledger_results, "candidate_glow_item_results": glow_results, "source_artifact_map_results": source_results,
+        "chain_summary_results": chain_results, "archive_summary_results": archive_results,
+        "sentientos_mount_alignment": {"/ledger": "candidate verification only; no ledger write", "/glow": "candidate verification only; no archive write", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here", "/vow": "canonical constraints bounding verification interpretation and forbidden inference"},
+        "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\\r\\n", "<br>").replace("\\n", "<br>").replace("\\r", "<br>").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+def render_codex_workcell_memory_candidate_verifier_markdown(report: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Memory Candidate Verifier", "", "Deterministic metadata-only structural verification. This report is verifier-only and does not grant readiness, write /ledger, archive /glow, mutate memory, trigger daemons, schedule work, create tasks, alert, train models, or establish consensus."]
+    lines += ["", "## Input summary", "| input | provided | path | digest | byte_size | readable_json | error |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for key, summary in sorted(report["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(summary.get('provided'))} | {_cell(summary.get('path'))} | {_cell(summary.get('digest'))} | {_cell(summary.get('byte_size'))} | {_cell(summary.get('readable_json'))} | {_cell(summary.get('error'))} |")
+    for title, key in (("Candidate bundle summary", "candidate_bundle_summary"), ("Memory contract summary", "memory_contract_summary")):
+        lines += ["", f"## {title}", f"`{_cell(report[key])}`"]
+    lines += ["", "## Verification status", _cell(report["verification_status"]), "", "## Verification checks", "| check_id | passed | severity | details |", "| --- | --- | --- | --- |"]
+    for check in report["verification_checks"]:
+        lines.append(f"| {_cell(check['check_id'])} | {_cell(check['passed'])} | {_cell(check['severity'])} | {_cell(check['details'])} |")
+    lines += ["", "## Violation summary", f"`{_cell(report['violation_summary'])}`", "", "## Candidate ledger entry results", "| candidate_entry_id | input | type | passed | violations |", "| --- | --- | --- | --- | --- |"]
+    for item in report["candidate_ledger_entry_results"]:
+        lines.append(f"| {_cell(item.get('candidate_entry_id'))} | {_cell(item.get('source_input_id'))} | {_cell(item.get('would_be_record_type'))} | {_cell(item.get('passed'))} | {_cell(item.get('violations'))} |")
+    lines += ["", "## Candidate glow item results", "| candidate_glow_item_id | input | type | related_ledger | passed | violations |", "| --- | --- | --- | --- | --- | --- |"]
+    for item in report["candidate_glow_item_results"]:
+        lines.append(f"| {_cell(item.get('candidate_glow_item_id'))} | {_cell(item.get('source_input_id'))} | {_cell(item.get('would_be_archive_item_type'))} | {_cell(item.get('related_candidate_ledger_entry_id_seen'))} | {_cell(item.get('passed'))} | {_cell(item.get('violations'))} |")
+    lines += ["", "## Source artifact map results", "| input | provided | ledger_ids | glow_ids | passed | violations |", "| --- | --- | --- | --- | --- | --- |"]
+    for item in report["source_artifact_map_results"]:
+        lines.append(f"| {_cell(item.get('input_id'))} | {_cell(item.get('provided'))} | {_cell(item.get('linked_candidate_ledger_entry_ids'))} | {_cell(item.get('linked_candidate_glow_item_ids'))} | {_cell(item.get('passed'))} | {_cell(item.get('violations'))} |")
+    lines += ["", "## Chain/archive summary results", f"`{_cell({'chain': report['chain_summary_results'], 'archive': report['archive_summary_results']})}`"]
+    lines += ["", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(report["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in report["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(report["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+def write_codex_workcell_memory_candidate_verifier_json(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def write_codex_workcell_memory_candidate_verifier_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_codex_workcell_memory_candidate_verifier.py
+++ b/tests/test_codex_workcell_memory_candidate_verifier.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_memory_candidate_verifier import (
+    NON_AUTHORITY_POSTURE,
+    render_codex_workcell_memory_candidate_verifier_markdown,
+    verify_codex_workcell_memory_candidate_bundle,
+)
+from sentientos.codex_workcell_memory_contract import build_codex_workcell_memory_contract
+
+
+def _summary(bundle: dict) -> dict:
+    raw = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode()
+    return {"provided": True, "path": "bundle.json", "digest_algo": "sha256", "digest": hashlib.sha256(raw).hexdigest(), "byte_size": len(raw), "readable_json": True, "error": None}
+
+
+def _bundle() -> dict:
+    return {
+        "memory_candidate_bundle_id": "codex_workcell_memory_candidate_bundle.v1",
+        "metadata_only": True,
+        "candidate_bundle_only": True,
+        "not_ledger_writer": True,
+        "not_glow_archiver": True,
+        "input_summaries": {"matrix_json": {"provided": True, "path": "m.json", "digest": "d", "byte_size": 1, "readable_json": True, "error": None}},
+        "candidate_ledger_entries": [],
+        "candidate_glow_items": [],
+        "source_artifact_map": [],
+        "candidate_chain_summary": {"candidate_ledger_entry_count": 0, "no_ledger_write_performed": True},
+        "candidate_archive_summary": {"candidate_glow_item_count": 0, "no_glow_archive_performed": True},
+        "future_activation_requirements": [{"requirement": "explicit ledger writer implementation", "status": "future_only", "met": False, "active": False}],
+        "non_authority_posture": {k.replace("memory_candidate_verifier", "memory_candidate_bundle"): True for k in NON_AUTHORITY_POSTURE},
+    }
+
+
+def _verify(bundle: dict, contract: dict | None = None) -> dict:
+    return verify_codex_workcell_memory_candidate_bundle(bundle, _summary(bundle), contract, {"provided": bool(contract), "path": "contract.json" if contract else None, "digest": "c" if contract else None, "byte_size": 1 if contract else None, "readable_json": bool(contract), "error": None})
+
+
+def _add_ledger(bundle: dict, **overrides) -> dict:
+    entry = {"candidate_entry_id": "e1", "source_input_id": "matrix_json", "would_be_record_type": "matrix_receipt", "candidate_only": True, "no_write_performed": True, "source_artifact_digest": "d"}
+    entry.update(overrides)
+    bundle["candidate_ledger_entries"] = [entry]
+    bundle["candidate_chain_summary"]["candidate_ledger_entry_count"] = 1
+    bundle["source_artifact_map"] = [{"input_id": "matrix_json", "provided": True, "candidate_ledger_entry_ids": [entry["candidate_entry_id"]], "candidate_glow_item_ids": []}]
+    return bundle
+
+
+def _add_glow(bundle: dict, **overrides) -> dict:
+    item = {"candidate_glow_item_id": "g1", "source_input_id": "matrix_json", "would_be_archive_item_type": "matrix_report_snapshot", "candidate_only": True, "no_archive_performed": True, "source_digest": "d", "related_candidate_ledger_entry_id": None}
+    item.update(overrides)
+    bundle["candidate_glow_items"] = [item]
+    bundle["candidate_archive_summary"]["candidate_glow_item_count"] = 1
+    if not bundle["source_artifact_map"]:
+        bundle["source_artifact_map"] = [{"input_id": "matrix_json", "provided": True, "candidate_ledger_entry_ids": [], "candidate_glow_item_ids": [item["candidate_glow_item_id"]]}]
+    else:
+        bundle["source_artifact_map"][0]["candidate_glow_item_ids"] = [item["candidate_glow_item_id"]]
+    return bundle
+
+
+def test_valid_minimal_candidate_bundle_verifies_with_no_entries_items() -> None:
+    report = _verify(_bundle())
+    assert report["verification_status"] == "memory_candidate_bundle_verified"
+    assert report["violation_summary"]["violation_count"] == 0
+
+
+def test_supplied_candidate_ledger_entry_referencing_provided_input_passes() -> None:
+    report = _verify(_add_ledger(_bundle()))
+    assert report["candidate_ledger_entry_results"][0]["passed"] is True
+
+
+def test_supplied_candidate_glow_item_referencing_provided_input_passes() -> None:
+    report = _verify(_add_glow(_bundle()))
+    assert report["candidate_glow_item_results"][0]["passed"] is True
+
+
+def test_ledger_entry_referencing_missing_input_fails() -> None:
+    report = _verify(_add_ledger(_bundle(), source_input_id="missing"))
+    assert "ledger_entries_reference_provided_inputs" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_glow_item_referencing_missing_input_fails() -> None:
+    report = _verify(_add_glow(_bundle(), source_input_id="missing"))
+    assert "glow_items_reference_provided_inputs" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_duplicate_candidate_ledger_entry_ids_fail() -> None:
+    b = _add_ledger(_bundle())
+    b["candidate_ledger_entries"].append(copy.deepcopy(b["candidate_ledger_entries"][0]))
+    b["candidate_chain_summary"]["candidate_ledger_entry_count"] = 2
+    report = _verify(b)
+    assert "candidate_ledger_entry_ids_unique" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_duplicate_candidate_glow_item_ids_fail() -> None:
+    b = _add_glow(_bundle())
+    b["candidate_glow_items"].append(copy.deepcopy(b["candidate_glow_items"][0]))
+    b["candidate_archive_summary"]["candidate_glow_item_count"] = 2
+    report = _verify(b)
+    assert "candidate_glow_item_ids_unique" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_source_artifact_map_linked_ids_must_exist() -> None:
+    b = _bundle()
+    b["source_artifact_map"] = [{"input_id": "matrix_json", "provided": True, "candidate_ledger_entry_ids": ["missing"], "candidate_glow_item_ids": ["missing"]}]
+    report = _verify(b)
+    assert "source_artifact_map_links_existing_ledger_ids" in report["violation_summary"]["violation_check_ids"]
+    assert "source_artifact_map_links_existing_glow_ids" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_chain_summary_count_mismatch_fails() -> None:
+    b = _add_ledger(_bundle())
+    b["candidate_chain_summary"]["candidate_ledger_entry_count"] = 0
+    assert "candidate_chain_summary_counts_match" in _verify(b)["violation_summary"]["violation_check_ids"]
+
+
+def test_archive_summary_count_mismatch_fails() -> None:
+    b = _add_glow(_bundle())
+    b["candidate_archive_summary"]["candidate_glow_item_count"] = 0
+    assert "candidate_archive_summary_counts_match" in _verify(b)["violation_summary"]["violation_check_ids"]
+
+
+def test_missing_candidate_only_on_entries_items_fails() -> None:
+    b = _add_glow(_add_ledger(_bundle(), candidate_only=False), candidate_only=False)
+    ids = _verify(b)["violation_summary"]["violation_check_ids"]
+    assert "ledger_entries_have_candidate_only_true" in ids
+    assert "glow_items_have_candidate_only_true" in ids
+
+
+def test_missing_no_write_or_archive_flags_fail() -> None:
+    b = _add_glow(_add_ledger(_bundle(), no_write_performed=False), no_archive_performed=False)
+    ids = _verify(b)["violation_summary"]["violation_check_ids"]
+    assert "ledger_entries_have_no_write_true" in ids
+    assert "glow_items_have_no_archive_true" in ids
+
+
+def test_future_activation_requirements_must_be_inactive() -> None:
+    b = _bundle(); b["future_activation_requirements"][0]["active"] = True
+    assert "future_activation_requirements_inactive" in _verify(b)["violation_summary"]["violation_check_ids"]
+
+
+def test_non_authority_posture_flags_present_and_true() -> None:
+    report = _verify(_bundle())
+    assert all(report["non_authority_posture"].values())
+    b = _bundle(); b["non_authority_posture"] = {}
+    assert "non_authority_posture_true" in _verify(b)["violation_summary"]["violation_check_ids"]
+
+
+def test_supplied_memory_contract_validates_known_types_and_unknown_fails() -> None:
+    contract = build_codex_workcell_memory_contract()
+    assert _verify(_add_glow(_add_ledger(_bundle())), contract)["verification_status"] == "memory_candidate_bundle_verified"
+    b = _add_glow(_add_ledger(_bundle(), would_be_record_type="strange"), would_be_archive_item_type="odd")
+    ids = _verify(b, contract)["violation_summary"]["violation_check_ids"]
+    assert "contract_record_types_known_when_contract_supplied" in ids
+    assert "contract_glow_item_types_known_when_contract_supplied" in ids
+
+
+def test_json_and_markdown_are_deterministic_and_escape_tables() -> None:
+    b = _add_ledger(_bundle(), candidate_entry_id="pipe|newline\nentry")
+    first = _verify(b); second = _verify(b)
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    md1 = render_codex_workcell_memory_candidate_verifier_markdown(first)
+    md2 = render_codex_workcell_memory_candidate_verifier_markdown(second)
+    assert md1 == md2
+    assert "pipe\\|newline<br>entry" in md1
+
+
+def test_verifier_does_not_grant_authority_or_write_or_trigger() -> None:
+    report = _verify(_bundle())
+    assert report["not_ledger_writer"] is True
+    assert report["not_glow_archiver"] is True
+    assert report["not_memory_writer"] is True
+    assert report["not_daemon_action"] is True
+    assert report["not_task_creator"] is True
+    assert report["not_scheduler"] is True
+    assert report["non_authority_posture"]["memory_candidate_verifier_does_not_decide_readiness"] is True
+    assert report["violation_summary"]["no_action_taken"] is True

--- a/tests/test_verify_codex_workcell_memory_candidate_bundle_script.py
+++ b/tests/test_verify_codex_workcell_memory_candidate_bundle_script.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import subprocess
+import sys
+
+from tests.test_codex_workcell_memory_candidate_verifier import _bundle
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/verify_codex_workcell_memory_candidate_bundle.py"
+
+
+def test_invalid_candidate_bundle_json_exits_2(tmp_path) -> None:
+    bad = tmp_path / "bad.json"; bad.write_text("{", encoding="utf-8")
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(bad), "--output", str(tmp_path / "out.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_missing_candidate_bundle_path_exits_2(tmp_path) -> None:
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(tmp_path / "missing.json"), "--output", str(tmp_path / "out.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_non_object_candidate_bundle_json_exits_2(tmp_path) -> None:
+    bad = tmp_path / "bad.json"; bad.write_text("[]", encoding="utf-8")
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(bad), "--output", str(tmp_path / "out.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_invalid_memory_contract_json_exits_2(tmp_path) -> None:
+    bundle = tmp_path / "bundle.json"; bundle.write_text(json.dumps(_bundle()), encoding="utf-8")
+    bad = tmp_path / "bad_contract.json"; bad.write_text("{", encoding="utf-8")
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(bundle), "--memory-contract-json", str(bad), "--output", str(tmp_path / "out.json")], text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_cli_writes_json_summary_and_markdown(tmp_path) -> None:
+    bundle = tmp_path / "bundle.json"; bundle.write_text(json.dumps(_bundle(), sort_keys=True), encoding="utf-8")
+    out = tmp_path / "out.json"; md = tmp_path / "out.md"
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(bundle), "--output", str(out), "--markdown-output", str(md), "--summary"], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    report = json.loads(out.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert report["verification_status"] == "memory_candidate_bundle_verified"
+    assert summary["verifier_only"] is True
+    assert md.read_text(encoding="utf-8").startswith("# Codex Workcell Memory Candidate Verifier")
+
+
+def test_cli_output_is_deterministic(tmp_path) -> None:
+    bundle = tmp_path / "bundle.json"; bundle.write_text(json.dumps(_bundle(), sort_keys=True), encoding="utf-8")
+    out1 = tmp_path / "out1.json"; out2 = tmp_path / "out2.json"
+    for out in (out1, out2):
+        result = subprocess.run([sys.executable, SCRIPT, "--candidate-bundle-json", str(bundle), "--output", str(out)], text=True, capture_output=True)
+        assert result.returncode == 0
+    assert out1.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only verifier to validate the structural integrity of Codex Workcell Memory Candidate Bundles before any ledger or glow writer exists. 
- Ensure candidate bundles are checked without granting runtime authority, writing ledger entries, archiving glow evidence, mutating memory, triggering daemons, or scheduling work. 
- Make verification deterministic and reviewer-friendly (JSON + optional Markdown) with clear non-authority posture and future-activation requirements declared.

### Description
- Add `sentientos/codex_workcell_memory_candidate_verifier.py` implementing `WORKCELL_MEMORY_CANDIDATE_VERIFIER_ID`, `DIGEST_ALGO`, raw-byte input reading with SHA-256 digests/byte sizes, deterministic structural checks, per-entry/glow/source-map result objects, chain/archive comparison, mount alignment, future activation requirements, and explicit non-authority posture. 
- Add CLI `scripts/verify_codex_workcell_memory_candidate_bundle.py` with required `--candidate-bundle-json` and `--output`, optional `--memory-contract-json` and `--markdown-output`, deterministic JSON/Markdown writers, and clean exit code `2` on input errors. 
- Add focused unit tests `tests/test_codex_workcell_memory_candidate_verifier.py` and CLI tests `tests/test_verify_codex_workcell_memory_candidate_bundle_script.py` covering the required check list (uniqueness, references, summary counts, candidate/no-write/no-archive flags, contract alignment, deterministic output, and error exits). 
- Add reviewer documentation `docs/development/codex_workcell_memory_candidate_verifier.md` and short boundary notes in adjacent docs to clarify that verifier outputs are structural metadata only and do not confer any landing or runtime authority.

### Testing
- Ran the focused verifier unit tests: `python -m scripts.run_tests -q tests/test_codex_workcell_memory_candidate_verifier.py tests/test_verify_codex_workcell_memory_candidate_bundle_script.py`, and those tests passed. 
- Verified adjacent builder/contract tests and related lanes via `python -m scripts.run_tests` invocations used in the landing flow and observed successful runs for the targeted lanes invoked during validation. 
- Built docs with `python scripts/build_docs.py --bootstrap-docs` / `--check-deps` / full build and ran `mypy` on the new module and CLI (`python -m mypy sentientos/codex_workcell_memory_candidate_verifier.py scripts/verify_codex_workcell_memory_candidate_bundle.py`), all of which succeeded. 
- The repository finalizer and PR metadata guard automation ran as part of the landing flow and returned `ready_to_commit`, `ready_for_pr_metadata`, and `pr_metadata_guard_ready` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b694588d08320a2af1c69c95eeec1)