### PR TITLE
[sentientos:memory] add Codex workcell memory activation preflight

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -211,3 +211,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) may report candidate bundle structure, but its `verification_status` is never finalizer authority. It cannot replace pre-commit or pr-metadata finalizer decisions, authorize commit, authorize PR metadata, bypass guards, write `/ledger`, or archive `/glow`.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -203,3 +203,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is review-only evidence about candidate bundle structure. It is not recovery authority, does not recover or mutate files, does not write `/ledger`, does not archive `/glow`, and does not authorize commit, PR metadata, daemon action, task creation, scheduling, or alerts.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -150,3 +150,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can emit `memory_candidate_bundle_verified` for structural candidate consistency, but that status is not validation, matrix, finalizer, supervisor, PR metadata guard, clean-tree, commit, or PR authority. It does not write `/ledger`, archive `/glow`, mutate memory, trigger daemons, schedule work, create tasks, alert, train models, or establish federation consensus.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -114,3 +114,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is a metadata-only review layer for candidate memory bundles. It preserves architecture boundaries by avoiding runtime authority, ledger writes, glow archiving, daemon action, task creation, scheduling, alerts, model training, and federation consensus.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -42,3 +42,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) verifies candidate memory bundle structure only. It is not a daemon recommendation consumer or executor and does not trigger daemon action, schedule work, create tasks, decide readiness, write `/ledger`, or archive `/glow`.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -56,3 +56,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can inspect candidate records that reference supplied evidence artifacts. It does not observe live health, mutate memory, decide readiness, write `/ledger`, archive `/glow`, trigger daemons, schedule work, or create tasks.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -1,0 +1,36 @@
+# Codex Workcell Memory Activation Preflight
+
+The Codex Workcell Memory Activation Preflight is a deterministic, metadata-only report for future `/ledger` and `/glow` activation design. It reads a supplied memory contract JSON, memory candidate bundle JSON, and memory candidate verifier JSON; records raw-byte input summaries; and reports which prerequisite conditions are visible before any future writer could be designed or run.
+
+It is not an activation mechanism. It does not write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands, schedule work, trigger daemon action, create tasks, send alerts, train or modify models, establish federation consensus, decide commit readiness, authorize PR metadata, or create PRs.
+
+## Ladder position
+
+- The memory contract defines future `/ledger` receipt schemas and `/glow` archive schemas.
+- The memory candidate bundle stages candidate ledger receipt entries and glow archive records from supplied artifacts without writing memory.
+- The memory candidate verifier checks candidate bundle structure without writing ledger entries, archiving glow evidence, mutating memory, or creating authority.
+- The activation preflight reviews the three supplied reports and makes future activation gaps explicit while remaining metadata-only and inactive.
+
+## Preflight status is not permission
+
+`activation_preflight_status` is a future-design status only. Even `activation_prerequisites_satisfied_for_future_design` does not authorize an active writer, commit, PR metadata, matrix bypass, finalizer bypass, ledger write, glow archive, daemon action, task creation, model update, or federation action.
+
+## Future-only activation gaps
+
+The report intentionally keeps active memory writing blocked. Operator consent, writer implementation, storage policy, federation consensus, and vow digest boundary checks remain expected blocking gaps for actual activation, not failures of the metadata-only preflight.
+
+## Mount alignment
+
+- `/ledger`: preflight only; no ledger write.
+- `/glow`: preflight only; no archive write.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+- `/vow`: canonical constraints bounding activation interpretation and forbidden inference.
+
+## Future activation requirements
+
+All requirements are represented as future-only, unmet, and inactive: explicit ledger writer implementation, explicit glow archiver implementation, storage and retention policy, digest and parent-chain validation policy, operator consent, finalizer/guard non-bypass invariant, pulse watcher contract, daemon action contract, federation drift consensus rule, vow digest constraint check, tests proving no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The preflight declares that it is read-only, metadata-only, preflight-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch or poll files, rerun commands, decide readiness, bypass finalizer or PR metadata guard, authorize commit or PR creation, trigger daemon action, create or schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -51,3 +51,7 @@ The memory candidate bundle is read-only, metadata-only, and candidate-only. It 
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) can inspect a supplied candidate bundle for structural consistency and optional memory-contract type alignment. Its verification status is bundle-structure metadata only; it does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize commit/PR metadata, trigger daemons, create tasks, schedule work, alert, or establish federation consensus.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -98,3 +98,7 @@ ledger, archive glow, modify memory, watch files, poll state, rerun commands,
 decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize
 commit, authorize PR creation, trigger a daemon, create tasks, schedule tasks,
 send alerts, train or modify models, or establish federation consensus.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -115,3 +115,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) may use this contract to check whether candidate `/ledger` record types and candidate `/glow` archive item types are known. That check is structural metadata only and does not activate ledger writing, glow archiving, readiness authority, daemon action, task creation, scheduling, alerts, or federation consensus.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -55,3 +55,7 @@ The [Codex Workcell Memory Candidate Bundle](codex_workcell_memory_candidate_bun
 ## Memory candidate verifier boundary
 
 The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_verifier.md) is inactive relative to `/pulse`: it may report candidate bundle consistency, but it does not watch stored history, poll state, emit pressure signals, schedule work, trigger daemon action, write `/ledger`, or archive `/glow`.
+
+## Memory activation preflight boundary
+
+See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.

--- a/scripts/build_codex_workcell_memory_activation_preflight.py
+++ b/scripts/build_codex_workcell_memory_activation_preflight.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_memory_activation_preflight import (
+    CodexWorkcellMemoryActivationPreflightError,
+    build_codex_workcell_memory_activation_preflight,
+    read_json_input,
+    render_codex_workcell_memory_activation_preflight_markdown,
+    write_codex_workcell_memory_activation_preflight_json,
+    write_codex_workcell_memory_activation_preflight_markdown,
+)
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell memory activation preflight report.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--memory-contract-json")
+    parser.add_argument("--candidate-bundle-json")
+    parser.add_argument("--candidate-verifier-json")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        contract_summary, contract = read_json_input(args.memory_contract_json, "memory_contract_json")
+        bundle_summary, bundle = read_json_input(args.candidate_bundle_json, "candidate_bundle_json")
+        verifier_summary, verifier = read_json_input(args.candidate_verifier_json, "candidate_verifier_json")
+        report = build_codex_workcell_memory_activation_preflight(contract, contract_summary, bundle, bundle_summary, verifier, verifier_summary)
+    except CodexWorkcellMemoryActivationPreflightError as exc:
+        print(f"codex_workcell_memory_activation_preflight_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_memory_activation_preflight_json(report, args.output)
+    if args.markdown_output:
+        write_codex_workcell_memory_activation_preflight_markdown(render_codex_workcell_memory_activation_preflight_markdown(report), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"memory_activation_preflight_id": report["memory_activation_preflight_id"], "metadata_only": True, "preflight_only": True, "activation_preflight_status": report["activation_preflight_status"], "blocking_gap_count": report["activation_gap_summary"]["blocking_gap_count"], "output": args.output, "markdown_output": args.markdown_output}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_memory_activation_preflight.py
+++ b/sentientos/codex_workcell_memory_activation_preflight.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_MEMORY_ACTIVATION_PREFLIGHT_ID = "codex_workcell_memory_activation_preflight.v1"
+DIGEST_ALGO = "sha256"
+AUTHORITY_BOUNDARY = "Activation preflight metadata only; does not activate memory, write ledger, archive glow, mutate memory, decide readiness, run commands, trigger daemon action, schedule work, create tasks, alert, train models, or establish consensus."
+FORBIDDEN_INFERENCE = "Do not infer active writer permission, commit readiness, PR readiness, matrix authority, finalizer authority, PR metadata authority, ledger authority, glow authority, daemon authority, or federation consensus from this preflight."
+
+PREREQUISITE_IDS: tuple[tuple[str, str, str, str], ...] = (
+    ("memory_contract_supplied", "Memory contract supplied", "supplied_artifact", "memory contract JSON object is supplied"),
+    ("candidate_bundle_supplied", "Candidate bundle supplied", "supplied_artifact", "candidate bundle JSON object is supplied"),
+    ("candidate_verifier_supplied", "Candidate verifier supplied", "supplied_artifact", "candidate verifier JSON object is supplied"),
+    ("memory_contract_declares_no_writer_authority", "Contract declares no writer authority", "contract_boundary", "contract non-authority posture declares no ledger/glow/memory writes"),
+    ("candidate_bundle_declares_candidate_only", "Bundle declares candidate only", "candidate_boundary", "candidate bundle is candidate-only"),
+    ("candidate_bundle_declares_no_ledger_write", "Bundle declares no ledger write", "candidate_boundary", "candidate bundle did not write ledger"),
+    ("candidate_bundle_declares_no_glow_archive", "Bundle declares no glow archive", "candidate_boundary", "candidate bundle did not archive glow"),
+    ("candidate_verifier_declares_verifier_only", "Verifier declares verifier only", "verifier_boundary", "candidate verifier is verifier-only"),
+    ("candidate_verifier_declares_no_ledger_write", "Verifier declares no ledger write", "verifier_boundary", "candidate verifier did not write ledger"),
+    ("candidate_verifier_declares_no_glow_archive", "Verifier declares no glow archive", "verifier_boundary", "candidate verifier did not archive glow"),
+    ("candidate_verifier_status_verified", "Verifier status verified", "verifier_boundary", "verification_status is memory_candidate_bundle_verified"),
+    ("candidate_verifier_no_violations", "Verifier has no violations", "verifier_boundary", "violation_count is zero"),
+    ("ledger_schema_catalog_present", "Ledger schema catalog present", "schema_presence", "ledger record catalog is present"),
+    ("glow_schema_catalog_present", "Glow schema catalog present", "schema_presence", "glow archive catalog is present"),
+    ("source_artifact_alignment_present", "Source artifact alignment present", "traceability", "source artifact alignment is present"),
+    ("candidate_ledger_entries_trace_to_inputs", "Candidate ledger entries trace to inputs", "traceability", "candidate ledger entries retain source input digests"),
+    ("candidate_glow_items_trace_to_inputs", "Candidate glow items trace to inputs", "traceability", "candidate glow items retain source input digests"),
+    ("future_activation_requirements_inactive", "Future activation requirements inactive", "future_activation_gap", "future requirements are future-only, unmet, and inactive"),
+    ("finalizer_guard_non_bypass_declared", "Finalizer/guard non-bypass declared", "authority_boundary", "non-bypass invariant remains declared"),
+    ("operator_consent_not_present", "Operator consent not present", "future_activation_gap", "explicit operator consent is absent for actual activation"),
+    ("writer_implementation_not_present", "Writer implementation not present", "future_activation_gap", "active writer implementation is absent"),
+    ("storage_policy_not_present", "Storage policy not present", "future_activation_gap", "storage path and retention policy are absent"),
+    ("federation_consensus_not_present", "Federation consensus not present", "future_activation_gap", "federation drift consensus is absent"),
+    ("vow_digest_boundary_not_present", "Vow digest boundary not present", "future_activation_gap", "vow digest constraint check is absent"),
+)
+
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit ledger writer implementation", "explicit glow archiver implementation", "explicit storage path policy", "explicit retention policy",
+    "explicit digest verification policy", "explicit parent-chain validation policy", "explicit operator consent", "explicit finalizer/guard non-bypass invariant",
+    "explicit pulse watcher contract", "explicit daemon action contract", "explicit federation drift consensus rule", "explicit vow digest constraint check",
+    "tests proving no readiness authority", "docs marking active behavior",
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "memory_activation_preflight_is_read_only": True, "memory_activation_preflight_is_metadata_only": True, "memory_activation_preflight_is_preflight_only": True,
+    "memory_activation_preflight_does_not_activate_memory": True, "memory_activation_preflight_does_not_write_ledger": True, "memory_activation_preflight_does_not_archive_glow": True,
+    "memory_activation_preflight_does_not_modify_memory": True, "memory_activation_preflight_does_not_watch_files": True, "memory_activation_preflight_does_not_poll_state": True,
+    "memory_activation_preflight_does_not_rerun_commands": True, "memory_activation_preflight_does_not_decide_readiness": True, "memory_activation_preflight_does_not_bypass_finalizer": True,
+    "memory_activation_preflight_does_not_bypass_pr_metadata_guard": True, "memory_activation_preflight_does_not_authorize_commit": True, "memory_activation_preflight_does_not_authorize_pr_creation": True,
+    "memory_activation_preflight_does_not_trigger_daemon": True, "memory_activation_preflight_does_not_create_tasks": True, "memory_activation_preflight_does_not_schedule_tasks": True,
+    "memory_activation_preflight_does_not_send_alerts": True, "memory_activation_preflight_does_not_train_or_modify_models": True, "memory_activation_preflight_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellMemoryActivationPreflightError(ValueError):
+    pass
+
+def read_json_input(path_text: str | None, input_id: str) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellMemoryActivationPreflightError(f"missing_{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellMemoryActivationPreflightError(f"invalid_{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellMemoryActivationPreflightError(f"{input_id}_not_object:{path_text}")
+    return {"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+def _posture_true(data: Mapping[str, Any] | None, prefix: str, *names: str) -> bool:
+    posture = data.get("non_authority_posture", {}) if data else {}
+    return isinstance(posture, Mapping) and all(posture.get(f"{prefix}_{name}") is True for name in names)
+
+def _future_inactive(data: Mapping[str, Any] | None) -> bool:
+    future = data.get("future_activation_requirements", []) if data else []
+    return isinstance(future, list) and all(isinstance(i, Mapping) and i.get("active") is False and i.get("met") is False for i in future)
+
+def _catalog() -> list[dict[str, Any]]:
+    return [{"prerequisite_id": pid, "prerequisite_name": name, "category": cat, "required_for_future_activation": True, "expected_state": exp, "forbidden_inference": FORBIDDEN_INFERENCE, "reviewer_summary": exp} for pid, name, cat, exp in PREREQUISITE_IDS]
+
+def build_codex_workcell_memory_activation_preflight(memory_contract: Mapping[str, Any] | None, memory_contract_input_summary: Mapping[str, Any], candidate_bundle: Mapping[str, Any] | None, candidate_bundle_input_summary: Mapping[str, Any], candidate_verifier: Mapping[str, Any] | None, candidate_verifier_input_summary: Mapping[str, Any]) -> dict[str, Any]:
+    ledger = memory_contract.get("ledger_receipt_chain_contract", {}) if memory_contract else {}
+    glow = memory_contract.get("glow_evidence_archive_contract", {}) if memory_contract else {}
+    alignment = memory_contract.get("source_artifact_alignment", []) if memory_contract else []
+    entries = _as_list(candidate_bundle.get("candidate_ledger_entries") if candidate_bundle else None)
+    glow_items = _as_list(candidate_bundle.get("candidate_glow_items") if candidate_bundle else None)
+    vsummary = candidate_verifier.get("violation_summary", {}) if candidate_verifier else {}
+    checks: dict[str, tuple[bool, str, str, str]] = {
+        "memory_contract_supplied": (memory_contract is not None, str(memory_contract_input_summary.get("provided")), "memory_contract_json", "warning"),
+        "candidate_bundle_supplied": (candidate_bundle is not None, str(candidate_bundle_input_summary.get("provided")), "candidate_bundle_json", "warning"),
+        "candidate_verifier_supplied": (candidate_verifier is not None, str(candidate_verifier_input_summary.get("provided")), "candidate_verifier_json", "warning"),
+        "memory_contract_declares_no_writer_authority": (_posture_true(memory_contract, "memory_contract", "does_not_write_ledger", "does_not_archive_glow", "does_not_modify_memory"), "contract non-authority posture inspected", "memory_contract_json", "warning"),
+        "candidate_bundle_declares_candidate_only": (bool(candidate_bundle and (candidate_bundle.get("candidate_bundle_only") is True or candidate_bundle.get("candidate_only") is True)), "candidate-only flags inspected", "candidate_bundle_json", "warning"),
+        "candidate_bundle_declares_no_ledger_write": (bool(candidate_bundle and candidate_bundle.get("not_ledger_writer") is True and (candidate_bundle.get("candidate_chain_summary", {}) or {}).get("no_ledger_write_performed") is True), "bundle no ledger write flags inspected", "candidate_bundle_json", "warning"),
+        "candidate_bundle_declares_no_glow_archive": (bool(candidate_bundle and candidate_bundle.get("not_glow_archiver") is True and (candidate_bundle.get("candidate_archive_summary", {}) or {}).get("no_glow_archive_performed") is True), "bundle no glow archive flags inspected", "candidate_bundle_json", "warning"),
+        "candidate_verifier_declares_verifier_only": (bool(candidate_verifier and candidate_verifier.get("verifier_only") is True), "verifier-only flag inspected", "candidate_verifier_json", "warning"),
+        "candidate_verifier_declares_no_ledger_write": (bool(candidate_verifier and candidate_verifier.get("not_ledger_writer") is True), "verifier no ledger write flag inspected", "candidate_verifier_json", "warning"),
+        "candidate_verifier_declares_no_glow_archive": (bool(candidate_verifier and candidate_verifier.get("not_glow_archiver") is True), "verifier no glow archive flag inspected", "candidate_verifier_json", "warning"),
+        "candidate_verifier_status_verified": (bool(candidate_verifier and candidate_verifier.get("verification_status") == "memory_candidate_bundle_verified"), str(candidate_verifier.get("verification_status") if candidate_verifier else None), "candidate_verifier_json", "blocking_gap"),
+        "candidate_verifier_no_violations": (bool(candidate_verifier and vsummary.get("violation_count") == 0), str(vsummary.get("violation_count") if candidate_verifier else None), "candidate_verifier_json", "blocking_gap"),
+        "ledger_schema_catalog_present": (isinstance(ledger, Mapping) and isinstance(ledger.get("record_catalog"), list) and bool(ledger.get("record_catalog")), "ledger catalog inspected", "memory_contract_json", "warning"),
+        "glow_schema_catalog_present": (isinstance(glow, Mapping) and isinstance(glow.get("archive_catalog"), list) and bool(glow.get("archive_catalog")), "glow catalog inspected", "memory_contract_json", "warning"),
+        "source_artifact_alignment_present": (isinstance(alignment, list) and bool(alignment), "source alignment inspected", "memory_contract_json", "warning"),
+        "candidate_ledger_entries_trace_to_inputs": (all(isinstance(e, Mapping) and e.get("source_input_id") and e.get("source_artifact_digest") for e in entries), "candidate ledger trace inspected", "candidate_bundle_json", "warning"),
+        "candidate_glow_items_trace_to_inputs": (all(isinstance(g, Mapping) and g.get("source_input_id") and g.get("source_digest") for g in glow_items), "candidate glow trace inspected", "candidate_bundle_json", "warning"),
+        "future_activation_requirements_inactive": (_future_inactive(candidate_bundle) and _future_inactive(candidate_verifier), "future requirements inspected as inactive", "candidate_bundle_json,candidate_verifier_json", "warning"),
+        "finalizer_guard_non_bypass_declared": (NON_AUTHORITY_POSTURE["memory_activation_preflight_does_not_bypass_finalizer"] and NON_AUTHORITY_POSTURE["memory_activation_preflight_does_not_bypass_pr_metadata_guard"], "preflight non-bypass posture declared", "activation_preflight", "info"),
+        "operator_consent_not_present": (False, "expected future-only gap: no operator consent", "activation_preflight", "blocking_gap"),
+        "writer_implementation_not_present": (False, "expected future-only gap: no writer implementation", "activation_preflight", "blocking_gap"),
+        "storage_policy_not_present": (False, "expected future-only gap: no storage policy", "activation_preflight", "blocking_gap"),
+        "federation_consensus_not_present": (False, "expected future-only gap: no federation consensus", "activation_preflight", "blocking_gap"),
+        "vow_digest_boundary_not_present": (False, "expected future-only gap: no vow digest boundary", "activation_preflight", "blocking_gap"),
+    }
+    future_gap_ids = {"operator_consent_not_present", "writer_implementation_not_present", "storage_policy_not_present", "federation_consensus_not_present", "vow_digest_boundary_not_present"}
+    results = []
+    for pid, _, _, _ in PREREQUISITE_IDS:
+        passed, observed, source, severity_if_failed = checks[pid]
+        severity = "info" if passed else severity_if_failed
+        results.append({"prerequisite_id": pid, "passed": passed, "observed_state": observed, "evidence_source": source, "severity": severity, "details": "Expected blocking gap for actual activation; not a preflight failure." if pid in future_gap_ids else observed, "authority_boundary": AUTHORITY_BOUNDARY})
+    omitted = memory_contract is None or candidate_bundle is None or candidate_verifier is None
+    violations = candidate_verifier is not None and (vsummary.get("violation_count") not in (0, None) or candidate_verifier.get("verification_status") == "memory_candidate_bundle_failed")
+    status = "activation_prerequisites_failed" if violations else ("activation_prerequisites_incomplete" if omitted else "activation_prerequisites_satisfied_for_future_design")
+    blocking = [r["prerequisite_id"] for r in results if r["severity"] == "blocking_gap"]
+    return {
+        "memory_activation_preflight_id": WORKCELL_MEMORY_ACTIVATION_PREFLIGHT_ID, "metadata_only": True, "preflight_only": True, "activation_not_performed": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {"memory_contract_json": dict(memory_contract_input_summary), "candidate_bundle_json": dict(candidate_bundle_input_summary), "candidate_verifier_json": dict(candidate_verifier_input_summary)},
+        "memory_contract_summary": {"provided": memory_contract is not None, "workcell_memory_contract_id": memory_contract.get("workcell_memory_contract_id") if memory_contract else None, "ledger_record_catalog_count": len(ledger.get("record_catalog", [])) if isinstance(ledger, Mapping) else None, "glow_archive_catalog_count": len(glow.get("archive_catalog", [])) if isinstance(glow, Mapping) else None, "non_authority_posture_present": isinstance(memory_contract.get("non_authority_posture") if memory_contract else None, Mapping), "non_authority_posture_true": _posture_true(memory_contract, "memory_contract", "does_not_write_ledger", "does_not_archive_glow", "does_not_modify_memory")},
+        "candidate_bundle_summary": {"provided": candidate_bundle is not None, "memory_candidate_bundle_id": candidate_bundle.get("memory_candidate_bundle_id") if candidate_bundle else None, "candidate_ledger_entry_count": len(entries), "candidate_glow_item_count": len(glow_items), "candidate_only_seen": bool(candidate_bundle and (candidate_bundle.get("candidate_bundle_only") is True or candidate_bundle.get("candidate_only") is True)), "no_ledger_write_seen": checks["candidate_bundle_declares_no_ledger_write"][0], "no_glow_archive_seen": checks["candidate_bundle_declares_no_glow_archive"][0]},
+        "candidate_verifier_summary": {"provided": candidate_verifier is not None, "memory_candidate_verifier_id": candidate_verifier.get("memory_candidate_verifier_id") if candidate_verifier else None, "verification_status": candidate_verifier.get("verification_status") if candidate_verifier else None, "violation_count": vsummary.get("violation_count") if candidate_verifier else None, "warning_count": vsummary.get("warning_count") if candidate_verifier else None, "verifier_only_seen": bool(candidate_verifier and candidate_verifier.get("verifier_only") is True), "no_ledger_write_seen": bool(candidate_verifier and candidate_verifier.get("not_ledger_writer") is True), "no_glow_archive_seen": bool(candidate_verifier and candidate_verifier.get("not_glow_archiver") is True)},
+        "activation_prerequisite_catalog": _catalog(), "activation_prerequisite_results": results,
+        "activation_gap_summary": {"blocking_gap_count": len(blocking), "warning_count": sum(1 for r in results if r["severity"] == "warning"), "info_count": sum(1 for r in results if r["severity"] == "info"), "blocking_gap_ids": blocking, "activation_not_performed": True, "future_writer_requirements_unmet": True},
+        "activation_preflight_status": status,
+        "sentientos_mount_alignment": {"/ledger": "preflight only; no ledger write", "/glow": "preflight only; no archive write", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here", "/vow": "canonical constraints bounding activation interpretation and forbidden inference"},
+        "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
+
+def render_codex_workcell_memory_activation_preflight_markdown(report: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Memory Activation Preflight", "", "Deterministic metadata-only activation preflight. It does not activate memory, write /ledger, archive /glow, decide readiness, or authorize daemon/PR/commit action.", "", "## Input summaries", "| input | provided | digest | byte_size |", "| --- | --- | --- | --- |"]
+    for key, value in sorted(report["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value.get('provided'))} | {_cell(value.get('digest'))} | {_cell(value.get('byte_size'))} |")
+    for title, key in (("Memory contract summary", "memory_contract_summary"), ("Candidate bundle summary", "candidate_bundle_summary"), ("Candidate verifier summary", "candidate_verifier_summary")):
+        lines += ["", f"## {title}", f"`{_cell(report[key])}`"]
+    lines += ["", "## Activation prerequisite results", "| prerequisite_id | passed | severity | observed_state |", "| --- | --- | --- | --- |"]
+    for item in report["activation_prerequisite_results"]:
+        lines.append(f"| {_cell(item['prerequisite_id'])} | {_cell(item['passed'])} | {_cell(item['severity'])} | {_cell(item['observed_state'])} |")
+    lines += ["", "## Activation gap summary", f"`{_cell(report['activation_gap_summary'])}`", "", "## Activation preflight status", f"`{_cell(report['activation_preflight_status'])}`", "", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(report["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in report["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(report["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+def write_codex_workcell_memory_activation_preflight_json(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def write_codex_workcell_memory_activation_preflight_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_memory_activation_preflight_script.py
+++ b/tests/test_build_codex_workcell_memory_activation_preflight_script.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_memory_contract import build_codex_workcell_memory_contract
+from sentientos.codex_workcell_memory_candidate_verifier import verify_codex_workcell_memory_candidate_bundle
+from tests.test_codex_workcell_memory_candidate_verifier import _add_glow, _add_ledger, _bundle, _summary
+
+SCRIPT = "scripts/build_codex_workcell_memory_activation_preflight.py"
+
+
+def _write(path, data: dict) -> None:
+    path.write_text(json.dumps(data, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _fixtures(tmp_path):
+    contract = build_codex_workcell_memory_contract()
+    bundle = _add_glow(_add_ledger(_bundle()))
+    verifier = verify_codex_workcell_memory_candidate_bundle(bundle, _summary(bundle), contract, {"provided": True, "path": "contract.json", "digest": "d", "byte_size": 1, "readable_json": True, "error": None})
+    paths = []
+    for name, data in (("contract", contract), ("bundle", bundle), ("verifier", verifier)):
+        path = tmp_path / f"{name}.json"
+        _write(path, data)
+        paths.append(path)
+    return paths
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path) -> None:
+    contract, bundle, verifier = _fixtures(tmp_path)
+    output = tmp_path / "preflight.json"
+    markdown = tmp_path / "preflight.md"
+    result = subprocess.run([sys.executable, SCRIPT, "--memory-contract-json", str(contract), "--candidate-bundle-json", str(bundle), "--candidate-verifier-json", str(verifier), "--output", str(output), "--markdown-output", str(markdown), "--summary"], check=False, text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["activation_preflight_status"] == "activation_prerequisites_satisfied_for_future_design"
+    assert "activation_preflight_status" in result.stdout
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Memory Activation Preflight")
+
+
+@pytest.mark.parametrize("content", ["{", "[]"])
+def test_cli_invalid_or_non_object_json_exits_2(tmp_path, content: str) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(content, encoding="utf-8")
+    result = subprocess.run([sys.executable, SCRIPT, "--memory-contract-json", str(bad), "--output", str(tmp_path / "out.json")], check=False, text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "codex_workcell_memory_activation_preflight_error" in result.stderr
+
+
+def test_cli_missing_input_path_exits_2(tmp_path) -> None:
+    result = subprocess.run([sys.executable, SCRIPT, "--candidate-verifier-json", str(tmp_path / "missing.json"), "--output", str(tmp_path / "out.json")], check=False, text=True, capture_output=True)
+    assert result.returncode == 2

--- a/tests/test_codex_workcell_memory_activation_preflight.py
+++ b/tests/test_codex_workcell_memory_activation_preflight.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_memory_activation_preflight import (
+    NON_AUTHORITY_POSTURE,
+    build_codex_workcell_memory_activation_preflight,
+    render_codex_workcell_memory_activation_preflight_markdown,
+)
+from sentientos.codex_workcell_memory_candidate_verifier import verify_codex_workcell_memory_candidate_bundle
+from sentientos.codex_workcell_memory_contract import build_codex_workcell_memory_contract
+from tests.test_codex_workcell_memory_candidate_verifier import _add_glow, _add_ledger, _bundle, _summary
+
+
+def _input_summary(name: str, data: dict) -> dict:
+    raw = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+    return {"provided": True, "path": f"{name}.json", "digest_algo": "sha256", "digest": hashlib.sha256(raw).hexdigest(), "byte_size": len(raw), "readable_json": True, "error": None}
+
+
+def _omitted() -> dict:
+    return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+
+def _valid_inputs() -> tuple[dict, dict, dict]:
+    contract = build_codex_workcell_memory_contract()
+    bundle = _add_glow(_add_ledger(_bundle()))
+    verifier = verify_codex_workcell_memory_candidate_bundle(bundle, _summary(bundle), contract, _input_summary("contract", contract))
+    assert verifier["verification_status"] == "memory_candidate_bundle_verified"
+    return contract, bundle, verifier
+
+
+def _report(contract: dict | None = None, bundle: dict | None = None, verifier: dict | None = None) -> dict:
+    return build_codex_workcell_memory_activation_preflight(
+        contract, _input_summary("contract", contract) if contract else _omitted(),
+        bundle, _input_summary("bundle", bundle) if bundle else _omitted(),
+        verifier, _input_summary("verifier", verifier) if verifier else _omitted(),
+    )
+
+
+def test_omitted_inputs_produce_incomplete() -> None:
+    report = _report()
+    assert report["activation_preflight_status"] == "activation_prerequisites_incomplete"
+    assert report["activation_not_performed"] is True
+
+
+def test_valid_inputs_can_satisfy_future_design_while_writer_gaps_remain_visible() -> None:
+    report = _report(*_valid_inputs())
+    assert report["activation_preflight_status"] == "activation_prerequisites_satisfied_for_future_design"
+    assert report["activation_gap_summary"]["future_writer_requirements_unmet"] is True
+    for gap in ["operator_consent_not_present", "writer_implementation_not_present", "storage_policy_not_present", "federation_consensus_not_present", "vow_digest_boundary_not_present"]:
+        result = next(item for item in report["activation_prerequisite_results"] if item["prerequisite_id"] == gap)
+        assert result["severity"] == "blocking_gap"
+        assert result["passed"] is False
+
+
+def test_verifier_violations_produce_failed() -> None:
+    contract, bundle, verifier = _valid_inputs()
+    verifier["violation_summary"]["violation_count"] = 1
+    report = _report(contract, bundle, verifier)
+    assert report["activation_preflight_status"] == "activation_prerequisites_failed"
+
+
+@pytest.mark.parametrize("missing", ["contract", "bundle", "verifier"])
+def test_missing_required_artifact_is_incomplete(missing: str) -> None:
+    contract, bundle, verifier = _valid_inputs()
+    report = _report(None if missing == "contract" else contract, None if missing == "bundle" else bundle, None if missing == "verifier" else verifier)
+    assert report["activation_preflight_status"] == "activation_prerequisites_incomplete"
+
+
+def test_active_memory_is_never_performed_and_no_authority_flags_true() -> None:
+    report = _report(*_valid_inputs())
+    assert report["activation_not_performed"] is True
+    assert report["not_ledger_writer"] is True
+    assert report["not_glow_archiver"] is True
+    assert report["not_daemon_action"] is True
+    assert report["not_task_creator"] is True
+    assert report["not_scheduler"] is True
+    assert all(report["non_authority_posture"].get(key) is True for key in NON_AUTHORITY_POSTURE)
+    assert report["non_authority_posture"]["memory_activation_preflight_does_not_decide_readiness"] is True
+
+
+def test_future_requirements_are_future_only_inactive_unmet() -> None:
+    report = _report(*_valid_inputs())
+    assert all(item["status"] == "future_only" and item["active"] is False and item["met"] is False for item in report["future_activation_requirements"])
+
+
+def test_input_summaries_record_digest_and_size() -> None:
+    contract, bundle, verifier = _valid_inputs()
+    report = _report(contract, bundle, verifier)
+    summary = report["input_summaries"]["memory_contract_json"]
+    raw = json.dumps(contract, sort_keys=True, separators=(",", ":")).encode()
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+
+
+def test_json_and_markdown_are_deterministic_and_escape_cells() -> None:
+    report = _report(*_valid_inputs())
+    report["activation_prerequisite_results"][0]["observed_state"] = "a|b\nc"
+    first_json = json.dumps(report, sort_keys=True)
+    second_json = json.dumps(report, sort_keys=True)
+    assert first_json == second_json
+    first_md = render_codex_workcell_memory_activation_preflight_markdown(report)
+    second_md = render_codex_workcell_memory_activation_preflight_markdown(report)
+    assert first_md == second_md
+    assert "a\\|b<br>c" in first_md
+
+
+def test_preflight_does_not_grant_readiness_authority() -> None:
+    report = _report(*_valid_inputs())
+    assert "commit_readiness" not in report
+    assert "pr_metadata_readiness" not in report
+    assert report["non_authority_posture"]["memory_activation_preflight_does_not_authorize_commit"] is True
+    assert report["non_authority_posture"]["memory_activation_preflight_does_not_authorize_pr_creation"] is True


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only activation preflight that inspects a supplied memory contract, candidate bundle, and verifier report and makes future writer prerequisites explicit without performing any activation or granting authority.

### Description

- Add `sentientos/codex_workcell_memory_activation_preflight.py` implementing `WORKCELL_MEMORY_ACTIVATION_PREFLIGHT_ID`, `sha256` input summaries, a stable prerequisite catalog, evaluation logic producing `activation_preflight_status`, deterministic JSON output, and Markdown rendering with table-cell escaping. 
- Add CLI `scripts/build_codex_workcell_memory_activation_preflight.py` supporting `--output`, optional `--memory-contract-json`, `--candidate-bundle-json`, `--candidate-verifier-json`, `--markdown-output`, and `--summary`, and failing with exit code `2` on missing/invalid/non-object inputs.
- Add tests `tests/test_codex_workcell_memory_activation_preflight.py` and `tests/test_build_codex_workcell_memory_activation_preflight_script.py` covering omitted inputs, verified/no-violation flows, verifier violations, input-summary digest/size, deterministic JSON/Markdown, Markdown escaping, CLI error behavior, and non-authority posture assertions.
- Add documentation `docs/development/codex_workcell_memory_activation_preflight.md` and short boundary references to the requested adjacent docs to mark the activation-preflight as metadata-only and non-authoritative.

### Testing

- Ran the new focused unit tests and CLI tests with `python -m scripts.run_tests -q tests/test_codex_workcell_memory_activation_preflight.py tests/test_build_codex_workcell_memory_activation_preflight_script.py`, and they passed.
- Ran related workcell tests (`candidate_verifier`, `candidate_bundle`, `memory_contract`) and the targeted `mypy` checks, and they passed; JSON/Markdown outputs are deterministic and escaping is validated by tests.
- Built docs with `python scripts/build_docs.py` (bootstrapped docs deps when needed) and ran the repository finalizer checks; `codex_finalize_landing` pre-commit and pr-metadata stages returned `ready_to_commit` / `ready_for_pr_metadata`, and `codex_pr_metadata_guard.py` returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b89a4b2308320919958161ccdc5ac)