### PR TITLE
[codex:vow] add Codex workcell vow digest boundary contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -215,3 +215,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) is not finalizer authority. Its digest and alignment summaries cannot decide `ready_to_commit` or bypass this finalizer.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -207,3 +207,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) can describe forbidden inferences around recovery evidence, but it is not recovery authority and does not create commits, PR metadata, or runtime actions.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -154,3 +154,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Workcell vow boundary contract
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) records canonical forbidden-inference constraints for `/vow`. It does not add validation gates, satisfy matrix proof, decide readiness, authorize commit, authorize PR metadata, or bypass finalizer/guard authority.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -118,3 +118,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) adds the `/vow` constraint digest surface for forbidden inferences. It does not activate runtime authority or change the architecture map into an execution plan.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -46,3 +46,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks recommendation-as-command and daemon-self-authorization inference. Daemon recommendations remain advisory metadata only.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -60,3 +60,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks health-as-readiness inference. Health snapshots remain cockpit metadata and do not replace matrix, finalizer, guard, or operator authority.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -34,3 +34,7 @@ All requirements are represented as future-only, unmet, and inactive: explicit l
 ## Non-authority posture
 
 The preflight declares that it is read-only, metadata-only, preflight-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch or poll files, rerun commands, decide readiness, bypass finalizer or PR metadata guard, authorize commit or PR creation, trigger daemon action, create or schedule tasks, send alerts, train or modify models, or establish federation consensus.
+
+## Vow boundary contract link
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) is the future `/vow` constraint digest surface referenced by this preflight. It blocks preflight-as-activation inference while remaining metadata-only and inactive.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -55,3 +55,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks candidate-as-write inference. Candidate bundle records remain staged metadata only, not `/ledger` entries or `/glow` archives.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -102,3 +102,7 @@ send alerts, train or modify models, or establish federation consensus.
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks verifier-as-readiness inference. Candidate verification remains structural metadata only and does not write `/ledger` or archive `/glow`.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -119,3 +119,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks schema-as-write inference. `/ledger` and `/glow` schemas remain future inactive shapes until separately adopted by explicit writer/archive contracts.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -59,3 +59,7 @@ The [Codex Workcell Memory Candidate Verifier](codex_workcell_memory_candidate_v
 ## Memory activation preflight boundary
 
 See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activation_preflight.md) for the metadata-only future activation prerequisite report. That preflight does not write `/ledger`, archive `/glow`, mutate memory, decide readiness, authorize PR metadata, trigger daemon action, or create active memory authority.
+
+## Vow boundary note
+
+The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks pulse-as-action inference. Pulse signals remain inactive metadata unless a future explicit watcher/action contract is adopted.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -1,0 +1,48 @@
+# Codex Workcell Vow Digest Boundary Contract
+
+The Codex Workcell Vow Digest Boundary Contract is a deterministic, metadata-only `/vow` report. It publishes canonical constraint records, a stable SHA-256 digest over those constraints, forbidden inference mappings, and optional alignment summaries for supplied workcell reports.
+
+It is not active authority. It does not activate memory, write `/ledger`, archive `/glow`, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, create PRs, establish federation consensus, or train/modify models.
+
+## How it differs from adjacent workcell surfaces
+
+- Architecture maps describe the workcell shape and future surfaces; the vow boundary says which authority claims must not be inferred from that shape.
+- Health snapshots render supplied evidence as cockpit/vitals metadata; the vow boundary blocks health-as-readiness inference.
+- Pulse contracts define pressure signal names; the vow boundary blocks pulse-as-action inference.
+- Daemon recommendation contracts describe advisory repair recommendations; the vow boundary blocks recommendation-as-command and daemon self-authorization inference.
+- Memory contracts define future `/ledger` and `/glow` schemas; the vow boundary blocks schema-as-write inference.
+- Memory candidate bundles stage candidate records; the vow boundary blocks candidate-as-ledger-write or candidate-as-glow-archive inference.
+- Memory candidate verifiers inspect candidate structure; the vow boundary blocks verification-as-readiness inference.
+- Memory activation preflight exposes future activation prerequisites and gaps; the vow boundary blocks preflight-as-activation inference.
+
+## Canonical constraint digest
+
+The contract sorts canonical constraint records by `constraint_id`, serializes only those records with `json.dumps(sort_keys=True, separators=(",", ":"))`, and computes a SHA-256 digest over the UTF-8 bytes. Input paths, input report content, timestamps, runtime environment details, and alignment summaries are excluded from the canonical vow digest.
+
+That digest is stable review metadata only. A matching digest does not authorize writers, daemons, runtime action, finalizer bypass, PR metadata guard bypass, commit, PR creation, federation adoption, or memory activation.
+
+## Forbidden inference catalog
+
+The forbidden inference catalog maps workcell surfaces to claims that must remain false. It blocks claims such as architecture implying runtime authority, health implying readiness, pulse implying action, daemon recommendation implying command, memory contract implying storage write, candidate bundle implying `/ledger` or `/glow` writes, verifier implying readiness, activation preflight implying activation, evidence indexes or appendices implying authority, doctrine maps implying model training, provenance digests implying trust without source authority, and future integrations implying active behavior.
+
+## Report alignment summaries
+
+When optional report JSON files are supplied, the CLI reads raw bytes, records SHA-256 digest and byte size, parses JSON object content, and emits alignment metadata. Omitted inputs are `not_supplied`. Supplied reports missing `metadata_only` warn rather than fail. Supplied reports with false non-authority posture, active writer flags, active daemon flags, scheduler flags, or other active authority indicators fail alignment.
+
+Alignment is not readiness authority. It is a reviewer-facing boundary check only.
+
+## Mount relationship
+
+- `/vow`: canonical constraint digest and forbidden inference boundary.
+- `/ledger`: future consumer of vow-bounded write policy; inactive here.
+- `/glow`: future consumer of vow-bounded archive policy; inactive here.
+- `/pulse`: future consumer of vow-bounded observation history; inactive here.
+- `/daemon`: future consumer of vow-bounded recommendation context; inactive here.
+
+## Future activation requirements
+
+Future active memory work remains unmet and inactive until separate contracts define explicit vow digest adoption policy, ledger writer implementation, glow archiver implementation, storage path policy, retention policy, digest verification policy, parent-chain validation policy, operator consent, finalizer/guard non-bypass invariant, pulse watcher contract, daemon action contract, federation drift consensus rule, tests proving no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The vow boundary contract declares that it is read-only, metadata-only, contract-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commits, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/scripts/build_codex_workcell_vow_boundary_contract.py
+++ b/scripts/build_codex_workcell_vow_boundary_contract.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_vow_boundary_contract import (
+    CodexWorkcellVowBoundaryContractError,
+    INPUT_IDS,
+    build_codex_workcell_vow_boundary_contract,
+    read_json_input,
+    render_codex_workcell_vow_boundary_contract_markdown,
+    write_codex_workcell_vow_boundary_contract_json,
+    write_codex_workcell_vow_boundary_contract_markdown,
+)
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell vow digest boundary contract.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--architecture-json")
+    parser.add_argument("--health-snapshot-json")
+    parser.add_argument("--pulse-contract-json")
+    parser.add_argument("--daemon-recommendation-contract-json")
+    parser.add_argument("--memory-contract-json")
+    parser.add_argument("--memory-candidate-bundle-json")
+    parser.add_argument("--memory-candidate-verifier-json")
+    parser.add_argument("--memory-activation-preflight-json")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        inputs = {}
+        for input_id in INPUT_IDS:
+            path = getattr(args, input_id)
+            inputs[input_id] = read_json_input(path, input_id)
+        report = build_codex_workcell_vow_boundary_contract(inputs)
+    except CodexWorkcellVowBoundaryContractError as exc:
+        print(f"codex_workcell_vow_boundary_contract_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_vow_boundary_contract_json(report, args.output)
+    if args.markdown_output:
+        write_codex_workcell_vow_boundary_contract_markdown(render_codex_workcell_vow_boundary_contract_markdown(report), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"vow_boundary_contract_id": report["vow_boundary_contract_id"], "metadata_only": True, "vow_boundary_contract_only": True, "canonical_vow_digest": report["canonical_vow_digest"], "supplied_report_count": report["vow_gap_summary"]["supplied_report_count"], "failed_report_count": report["vow_gap_summary"]["failed_report_count"], "output": args.output, "markdown_output": args.markdown_output}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_vow_boundary_contract.py
+++ b/sentientos/codex_workcell_vow_boundary_contract.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+WORKCELL_VOW_BOUNDARY_CONTRACT_ID = "codex_workcell_vow_boundary_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_IDS: tuple[str, ...] = (
+    "architecture_json",
+    "health_snapshot_json",
+    "pulse_contract_json",
+    "daemon_recommendation_contract_json",
+    "memory_contract_json",
+    "memory_candidate_bundle_json",
+    "memory_candidate_verifier_json",
+    "memory_activation_preflight_json",
+)
+
+CONSTRAINT_ROWS: tuple[tuple[str, str, str, str, str, str, str], ...] = (
+    ("finalizer_authority_only_for_commit_readiness", "Finalizer authority only for commit readiness", "finalizer_boundary", "Only the landing finalizer may report commit-readiness under its own contract.", "Do not infer finalizer authority from workcell reports or vow digests.", "Use the explicit finalizer contract and current finalizer artifact.", "Commit readiness stays with the finalizer."),
+    ("pr_metadata_guard_authority_only_for_pr_metadata", "PR metadata guard authority only for PR metadata", "guard_boundary", "Only the PR metadata guard may authorize PR metadata creation under its own contract.", "Do not infer PR metadata readiness from workcell reports or vow digests.", "Use the explicit PR metadata guard contract and current guard artifact.", "PR metadata authority stays with the guard."),
+    ("reports_do_not_create_runtime_authority", "Reports do not create runtime authority", "report_boundary", "Metadata reports are review surfaces only.", "Do not infer runtime authority from a report existing or aligning.", "Create a separate runtime authority contract with operator consent.", "Reports remain non-executable."),
+    ("recommendations_are_not_commands", "Recommendations are not commands", "recommendation_boundary", "Recommendations may describe possible repairs but cannot command execution.", "Do not treat recommendations as commands, tickets, tasks, or daemon actions.", "Create an explicit command/action contract with admission and rollback.", "Recommendation surfaces are advisory."),
+    ("pulse_signals_are_not_actions", "Pulse signals are not actions", "pulse_boundary", "Pulse signals name observation pressure but do not perform actions.", "Do not infer watcher, scheduler, task, or alert behavior from pulse signals.", "Create an explicit pulse watcher contract and consent boundary.", "Pulse remains inactive metadata."),
+    ("health_snapshots_are_not_decisions", "Health snapshots are not decisions", "health_boundary", "Health snapshots render supplied evidence but do not decide readiness.", "Do not infer commit, PR, or operational readiness from health snapshots.", "Use finalizer, guard, matrix, and explicit operator decision contracts.", "Health is a cockpit view, not authority."),
+    ("memory_candidates_are_not_writes", "Memory candidates are not writes", "memory_boundary", "Memory candidate records are staged metadata only.", "Do not infer /ledger writes or /glow archives from candidates.", "Create explicit storage writer and archive contracts.", "Candidates are not persisted memory."),
+    ("memory_verification_is_not_readiness", "Memory verification is not readiness", "memory_boundary", "Candidate verification checks structure only.", "Do not infer landing readiness from candidate verification status.", "Use authoritative validation, finalizer, and guard flows.", "Verification is not readiness."),
+    ("activation_preflight_is_not_activation", "Activation preflight is not activation", "memory_boundary", "Activation preflight exposes future gaps without activating memory.", "Do not infer active memory writer behavior from preflight status.", "Create explicit active writer, storage, consent, and policy contracts.", "Preflight remains inactive."),
+    ("ledger_schema_is_not_ledger_write", "Ledger schema is not ledger write", "storage_boundary", "A /ledger schema only describes future record shape.", "Do not infer a ledger entry was written from schema presence.", "Create explicit ledger writer implementation and storage policy.", "Schema is not storage."),
+    ("glow_schema_is_not_glow_archive", "Glow schema is not glow archive", "storage_boundary", "A /glow schema only describes future archive shape.", "Do not infer glow evidence was archived from schema presence.", "Create explicit glow archiver implementation and retention policy.", "Schema is not archive."),
+    ("evidence_indexes_are_not_authority", "Evidence indexes are not authority", "proof_boundary", "Evidence indexes locate artifacts and hints but do not decide authority.", "Do not infer proof, freshness, or readiness from index presence alone.", "Read underlying artifacts through authoritative rails.", "Indexes improve reviewability only."),
+    ("appendices_are_review_context_only", "Appendices are review context only", "proof_boundary", "Appendices render reviewer context and do not add gates.", "Do not infer validation proof or authority from appendix prose.", "Use required matrix, finalizer, and guard artifacts.", "Appendices are not proof lanes."),
+    ("doctrine_maps_do_not_train_models", "Doctrine maps do not train models", "report_boundary", "Doctrine maps describe review rubrics and do not train or modify models.", "Do not infer model training, RL, or policy update from doctrine metadata.", "Create explicit model governance and training contracts.", "Doctrine is not training."),
+    ("provenance_digests_do_not_verify_authority", "Provenance digests do not verify authority", "proof_boundary", "Digests identify bytes but do not prove source authority by themselves.", "Do not infer trust without source, policy, and authority checks.", "Create explicit provenance source and verification policy.", "Digest equality is not authority."),
+    ("future_integrations_are_inactive_without_explicit_contract", "Future integrations inactive without explicit contract", "report_boundary", "Future integrations remain inactive until separately contracted.", "Do not infer active behavior from roadmap or future integration text.", "Create explicit integration contract and validation.", "Future text is not activation."),
+    ("daemon_must_not_self_authorize", "Daemon must not self-authorize", "daemon_boundary", "Daemon surfaces cannot grant themselves action authority.", "Do not infer daemon execution authority from recommendations or alignment.", "Require explicit daemon action contract with operator authority.", "Daemons need external admission."),
+    ("federation_consensus_not_implied", "Federation consensus not implied", "federation_boundary", "Local reports and digests do not establish federation consensus.", "Do not infer federation adoption, sync, merge, or consensus.", "Create explicit federation drift and consensus rule.", "Consensus is not implied."),
+    ("no_skipped_or_nonexecuted_tests_as_required_proof", "No skipped or nonexecuted tests as required proof", "proof_boundary", "Skipped, missing, stale, or nonexecuted checks cannot satisfy required proof.", "Do not count diagnostic or non-proof lanes as required proof.", "Run and pass authoritative required proof lanes.", "Proof must execute and pass."),
+    ("no_runtime_or_host_action_without_explicit_boundary", "No runtime or host action without explicit boundary", "operator_boundary", "Runtime or host actions require explicit boundary, consent, audit, and rollback.", "Do not infer host actuation permission from metadata.", "Create explicit runtime/host action boundary contract.", "Host action remains blocked."),
+    ("no_backdoor_or_hidden_authority", "No backdoor or hidden authority", "operator_boundary", "All authority must be declared, auditable, and explicit.", "Do not infer hidden authority from omissions or implementation detail.", "Declare authority in explicit contracts and docs.", "No hidden grants."),
+    ("operator_consent_required_for_active_watchers_or_daemons", "Operator consent required for active watchers or daemons", "operator_boundary", "Active watchers or daemons require explicit operator consent.", "Do not infer consent from report generation.", "Create explicit consent and revocation policy.", "Consent is required before activity."),
+    ("storage_policy_required_for_memory_writes", "Storage policy required for memory writes", "storage_boundary", "Memory writes require explicit storage path and retention policy.", "Do not infer write permission without storage policy.", "Create explicit storage path, retention, and verification policy.", "Storage policy gates future writers."),
+    ("vow_digest_required_for_future_active_writers", "Vow digest required for future active writers", "vow_boundary", "Future active writers must adopt an explicit vow digest boundary.", "Do not infer writer authority from digest presence alone.", "Create explicit vow adoption policy linked to writer contract.", "The vow digest is a future prerequisite, not authority."),
+)
+
+INFERENCE_ROWS: tuple[tuple[str, str, str, str, tuple[str, ...], str], ...] = (
+    ("architecture_map_implies_runtime_authority", "architecture_map", "architecture map grants runtime authority", "architecture maps review surfaces and future boundaries only", ("reports_do_not_create_runtime_authority",), "false"),
+    ("health_snapshot_implies_readiness", "health_snapshot", "health snapshot decides readiness", "health snapshots summarize supplied evidence only", ("health_snapshots_are_not_decisions",), "false"),
+    ("pulse_contract_implies_action", "pulse_contract", "pulse contract triggers actions", "pulse contracts name inactive signal categories", ("pulse_signals_are_not_actions",), "false"),
+    ("daemon_recommendation_implies_command", "daemon_recommendation_contract", "daemon recommendation is a command", "recommendations are advisory metadata", ("recommendations_are_not_commands", "daemon_must_not_self_authorize"), "false"),
+    ("memory_contract_implies_storage_write", "memory_contract", "memory contract writes storage", "memory contracts define future schema only", ("ledger_schema_is_not_ledger_write", "glow_schema_is_not_glow_archive"), "false"),
+    ("memory_candidate_bundle_implies_ledger_write", "memory_candidate_bundle", "candidate bundle writes /ledger", "candidate bundles stage candidate records only", ("memory_candidates_are_not_writes",), "false"),
+    ("memory_candidate_bundle_implies_glow_archive", "memory_candidate_bundle", "candidate bundle archives /glow", "candidate bundles stage candidate archive items only", ("memory_candidates_are_not_writes",), "false"),
+    ("memory_candidate_verifier_implies_readiness", "memory_candidate_verifier", "candidate verification grants readiness", "verification checks structure only", ("memory_verification_is_not_readiness",), "false"),
+    ("memory_activation_preflight_implies_activation", "memory_activation_preflight", "activation preflight activates memory", "preflight exposes inactive future gaps", ("activation_preflight_is_not_activation",), "false"),
+    ("matrix_diagnostic_nonproof_implies_required_proof", "matrix_diagnostic_lane", "diagnostic or nonexecuted lane satisfies proof", "only executed passing required proof lanes satisfy proof", ("no_skipped_or_nonexecuted_tests_as_required_proof",), "false"),
+    ("evidence_index_implies_authority", "evidence_index", "evidence index grants authority", "indexes locate artifacts only", ("evidence_indexes_are_not_authority",), "false"),
+    ("appendix_implies_authority", "evidence_appendix", "appendix grants authority", "appendices render review context only", ("appendices_are_review_context_only",), "false"),
+    ("doctrine_map_implies_model_training", "doctrine_map", "doctrine map trains or modifies models", "doctrine maps are static metadata", ("doctrine_maps_do_not_train_models",), "false"),
+    ("provenance_digest_implies_trust_without_source", "provenance_digest", "digest alone proves authority or trust", "digests identify bytes only", ("provenance_digests_do_not_verify_authority",), "false"),
+    ("future_integration_implies_active_behavior", "future_integration", "future integration is active behavior", "future integrations are inactive without explicit contracts", ("future_integrations_are_inactive_without_explicit_contract",), "false"),
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "vow_boundary_contract_is_read_only": True,
+    "vow_boundary_contract_is_metadata_only": True,
+    "vow_boundary_contract_is_contract_only": True,
+    "vow_boundary_contract_does_not_activate_memory": True,
+    "vow_boundary_contract_does_not_write_ledger": True,
+    "vow_boundary_contract_does_not_archive_glow": True,
+    "vow_boundary_contract_does_not_modify_memory": True,
+    "vow_boundary_contract_does_not_watch_files": True,
+    "vow_boundary_contract_does_not_poll_state": True,
+    "vow_boundary_contract_does_not_rerun_commands": True,
+    "vow_boundary_contract_does_not_decide_readiness": True,
+    "vow_boundary_contract_does_not_bypass_finalizer": True,
+    "vow_boundary_contract_does_not_bypass_pr_metadata_guard": True,
+    "vow_boundary_contract_does_not_authorize_commit": True,
+    "vow_boundary_contract_does_not_authorize_pr_creation": True,
+    "vow_boundary_contract_does_not_trigger_daemon": True,
+    "vow_boundary_contract_does_not_create_tasks": True,
+    "vow_boundary_contract_does_not_schedule_tasks": True,
+    "vow_boundary_contract_does_not_send_alerts": True,
+    "vow_boundary_contract_does_not_train_or_modify_models": True,
+    "vow_boundary_contract_does_not_establish_federation_consensus": True,
+}
+
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit vow digest adoption policy", "explicit ledger writer implementation", "explicit glow archiver implementation", "explicit storage path policy", "explicit retention policy", "explicit digest verification policy", "explicit parent-chain validation policy", "explicit operator consent", "explicit finalizer/guard non-bypass invariant", "explicit pulse watcher contract", "explicit daemon action contract", "explicit federation drift consensus rule", "tests proving no readiness authority", "docs marking active behavior",
+)
+
+class CodexWorkcellVowBoundaryContractError(ValueError):
+    pass
+
+def canonical_vow_constraints() -> list[dict[str, str]]:
+    return [{"constraint_id": cid, "constraint_name": name, "constraint_category": cat, "canonical_statement": stmt, "forbidden_inference": forb, "required_future_contract": req, "reviewer_summary": summ} for cid, name, cat, stmt, forb, req, summ in sorted(CONSTRAINT_ROWS)]
+
+def compute_canonical_vow_digest(constraints: Sequence[Mapping[str, Any]] | None = None) -> str:
+    records = sorted((constraints or canonical_vow_constraints()), key=lambda item: str(item["constraint_id"]))
+    canonical = json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+def forbidden_inference_catalog() -> list[dict[str, Any]]:
+    return [{"inference_id": iid, "source_surface": src, "forbidden_claim": claim, "allowed_claim": allowed, "blocking_constraint_ids": list(blockers), "authority_boundary": boundary} for iid, src, claim, allowed, blockers, boundary in sorted(INFERENCE_ROWS)]
+
+def read_json_input(path_text: str | None, input_id: str) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellVowBoundaryContractError(f"missing_{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellVowBoundaryContractError(f"invalid_{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellVowBoundaryContractError(f"{input_id}_not_object:{path_text}")
+    return {"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _detected_report_id(data: Mapping[str, Any] | None) -> Any:
+    if not data:
+        return None
+    for key in sorted(data):
+        if key.endswith("_id") or key in {"doctor_report_id", "workcell_memory_contract_id"}:
+            return data.get(key)
+    return None
+
+def _active_authority(data: Mapping[str, Any] | None) -> bool:
+    if not data:
+        return False
+    active_true_keys = {"memory_writer", "ledger_writer", "glow_archiver", "watcher", "scheduler", "executor", "daemon_action", "task_creator", "alerting_system", "model_training", "reinforcement_learning", "runtime_authority"}
+    for key, value in data.items():
+        if (key in active_true_keys or key.startswith("active_") or key.endswith("_authority")) and value is True:
+            return True
+        if key.startswith("not_") and value is False:
+            return True
+    posture = data.get("non_authority_posture")
+    if isinstance(posture, Mapping) and any(value is False for value in posture.values()):
+        return True
+    return False
+
+def _applicable_inferences(input_id: str) -> list[str]:
+    surface = input_id.removesuffix("_json")
+    aliases = {"architecture": "architecture_map", "daemon_recommendation_contract": "daemon_recommendation_contract"}
+    target = aliases.get(surface, surface)
+    return [item["inference_id"] for item in forbidden_inference_catalog() if item["source_surface"] == target]
+
+def _alignment(input_id: str, summary: Mapping[str, Any], data: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not summary.get("provided"):
+        return {"input_id": input_id, "provided": False, "source_digest": None, "source_digest_algo": None, "source_byte_size": None, "detected_report_id": None, "metadata_only_seen": None, "non_authority_posture_present": False, "non_authority_posture_all_true": None, "forbidden_inference_ids_applicable": _applicable_inferences(input_id), "alignment_status": "not_supplied", "alignment_notes": ["input not supplied; no action taken"]}
+    posture = data.get("non_authority_posture") if data else None
+    posture_present = isinstance(posture, Mapping)
+    posture_all_true = all(value is True for value in posture.values()) if isinstance(posture, Mapping) else None
+    active = _active_authority(data)
+    metadata_seen = data.get("metadata_only") if data else None
+    notes: list[str] = []
+    status = "aligned"
+    if metadata_seen is not True:
+        status = "warning"
+        notes.append("metadata_only flag missing or not true")
+    if posture_present and not posture_all_true:
+        status = "failed"
+        notes.append("non_authority_posture contains false values")
+    if active:
+        status = "failed"
+        notes.append("active writer, daemon, scheduler, or authority flag detected")
+    if not notes:
+        notes.append("metadata-only non-authority alignment observed")
+    return {"input_id": input_id, "provided": True, "source_digest": summary.get("digest"), "source_digest_algo": summary.get("digest_algo"), "source_byte_size": summary.get("byte_size"), "detected_report_id": _detected_report_id(data), "metadata_only_seen": metadata_seen, "non_authority_posture_present": posture_present, "non_authority_posture_all_true": posture_all_true, "forbidden_inference_ids_applicable": _applicable_inferences(input_id), "alignment_status": status, "alignment_notes": notes}
+
+def build_codex_workcell_vow_boundary_contract(inputs: Mapping[str, tuple[Mapping[str, Any], Mapping[str, Any] | None]] | None = None) -> dict[str, Any]:
+    normalized = {input_id: (dict(inputs[input_id][0]), inputs[input_id][1]) if inputs and input_id in inputs else ({"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}, None) for input_id in INPUT_IDS}
+    constraints = canonical_vow_constraints()
+    inferences = forbidden_inference_catalog()
+    alignments = [_alignment(input_id, summary, data) for input_id, (summary, data) in sorted(normalized.items())]
+    return {
+        "vow_boundary_contract_id": WORKCELL_VOW_BOUNDARY_CONTRACT_ID,
+        "metadata_only": True, "vow_boundary_contract_only": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {key: dict(value[0]) for key, value in sorted(normalized.items())},
+        "canonical_vow_constraints": constraints,
+        "canonical_vow_digest": compute_canonical_vow_digest(constraints),
+        "canonical_vow_digest_algo": DIGEST_ALGO,
+        "forbidden_inference_catalog": inferences,
+        "report_alignment_results": alignments,
+        "vow_gap_summary": {"supplied_report_count": sum(1 for a in alignments if a["provided"]), "aligned_report_count": sum(1 for a in alignments if a["alignment_status"] == "aligned"), "warning_report_count": sum(1 for a in alignments if a["alignment_status"] == "warning"), "failed_report_count": sum(1 for a in alignments if a["alignment_status"] == "failed"), "not_supplied_report_count": sum(1 for a in alignments if a["alignment_status"] == "not_supplied"), "canonical_constraint_count": len(constraints), "forbidden_inference_count": len(inferences), "canonical_vow_digest_present": True, "active_authority_detected": any(a["alignment_status"] == "failed" for a in alignments), "vow_boundary_contract_only": True, "no_action_taken": True},
+        "sentientos_mount_alignment": {"/vow": "canonical constraint digest and forbidden inference boundary", "/ledger": "future consumer of vow-bounded write policy; inactive here", "/glow": "future consumer of vow-bounded archive policy; inactive here", "/pulse": "future consumer of vow-bounded observation history; inactive here", "/daemon": "future consumer of vow-bounded recommendation context; inactive here"},
+        "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+def render_codex_workcell_vow_boundary_contract_markdown(report: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Vow Digest Boundary Contract", "", "Deterministic metadata-only /vow boundary. It records forbidden inferences and a canonical constraint digest, but does not activate memory, write /ledger, archive /glow, decide readiness, trigger daemons, create tasks, schedule work, or authorize commits/PR metadata.", "", f"Canonical vow digest: `{_cell(report['canonical_vow_digest'])}`", "", "## Input summaries", "| input | provided | path | digest | byte_size |", "| --- | --- | --- | --- | --- |"]
+    for key, value in sorted(report["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value.get('provided'))} | {_cell(value.get('path'))} | {_cell(value.get('digest'))} | {_cell(value.get('byte_size'))} |")
+    lines += ["", "## Canonical vow constraints", "| constraint_id | category | statement | forbidden inference |", "| --- | --- | --- | --- |"]
+    for item in report["canonical_vow_constraints"]:
+        lines.append(f"| {_cell(item['constraint_id'])} | {_cell(item['constraint_category'])} | {_cell(item['canonical_statement'])} | {_cell(item['forbidden_inference'])} |")
+    lines += ["", "## Forbidden inference catalog", "| inference_id | source_surface | forbidden_claim | allowed_claim |", "| --- | --- | --- | --- |"]
+    for item in report["forbidden_inference_catalog"]:
+        lines.append(f"| {_cell(item['inference_id'])} | {_cell(item['source_surface'])} | {_cell(item['forbidden_claim'])} | {_cell(item['allowed_claim'])} |")
+    lines += ["", "## Report alignment results", "| input | status | report_id | notes |", "| --- | --- | --- | --- |"]
+    for item in report["report_alignment_results"]:
+        lines.append(f"| {_cell(item['input_id'])} | {_cell(item['alignment_status'])} | {_cell(item['detected_report_id'])} | {_cell(item['alignment_notes'])} |")
+    lines += ["", "## Vow gap summary", f"`{_cell(report['vow_gap_summary'])}`", "", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(report["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in report["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(report["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+def write_codex_workcell_vow_boundary_contract_json(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def write_codex_workcell_vow_boundary_contract_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_vow_boundary_contract_script.py
+++ b/tests/test_build_codex_workcell_vow_boundary_contract_script.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/build_codex_workcell_vow_boundary_contract.py")
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True, check=False)
+
+def test_cli_writes_json_summary_and_markdown(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"metadata_only": True, "non_authority_posture": {"safe": True}}), encoding="utf-8")
+    output = tmp_path / "out.json"
+    markdown = tmp_path / "out.md"
+    result = _run("--output", str(output), "--health-snapshot-json", str(input_path), "--markdown-output", str(markdown), "--summary")
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    summary = json.loads(result.stdout)
+    assert summary["vow_boundary_contract_id"] == "codex_workcell_vow_boundary_contract.v1"
+    assert report["vow_gap_summary"]["supplied_report_count"] == 1
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Vow Digest Boundary Contract")
+
+def test_cli_invalid_json_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    result = _run("--output", str(tmp_path / "out.json"), "--architecture-json", str(bad))
+    assert result.returncode == 2
+    assert "invalid_architecture_json" in result.stderr
+
+def test_cli_missing_input_path_exits_2(tmp_path: Path) -> None:
+    result = _run("--output", str(tmp_path / "out.json"), "--architecture-json", str(tmp_path / "missing.json"))
+    assert result.returncode == 2
+    assert "missing_architecture_json" in result.stderr
+
+def test_cli_non_object_json_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "list.json"
+    bad.write_text("[]", encoding="utf-8")
+    result = _run("--output", str(tmp_path / "out.json"), "--architecture-json", str(bad))
+    assert result.returncode == 2
+    assert "architecture_json_not_object" in result.stderr
+
+def test_cli_json_and_markdown_are_deterministic(tmp_path: Path) -> None:
+    input_path = tmp_path / "a|b.json"
+    input_path.write_text(json.dumps({"metadata_only": True, "non_authority_posture": {"safe": True}, "text": "a|b\nc"}, sort_keys=True), encoding="utf-8")
+    out1, out2 = tmp_path / "one.json", tmp_path / "two.json"
+    md1, md2 = tmp_path / "one.md", tmp_path / "two.md"
+    assert _run("--output", str(out1), "--architecture-json", str(input_path), "--markdown-output", str(md1)).returncode == 0
+    assert _run("--output", str(out2), "--architecture-json", str(input_path), "--markdown-output", str(md2)).returncode == 0
+    assert out1.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")
+    assert md1.read_text(encoding="utf-8") == md2.read_text(encoding="utf-8")
+    assert "\\|" in md1.read_text(encoding="utf-8") or "a\\|b" in md1.read_text(encoding="utf-8")

--- a/tests/test_codex_workcell_vow_boundary_contract.py
+++ b/tests/test_codex_workcell_vow_boundary_contract.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_vow_boundary_contract import (
+    INPUT_IDS,
+    NON_AUTHORITY_POSTURE,
+    build_codex_workcell_vow_boundary_contract,
+    canonical_vow_constraints,
+    compute_canonical_vow_digest,
+    forbidden_inference_catalog,
+    render_codex_workcell_vow_boundary_contract_markdown,
+)
+
+REQUIRED_CONSTRAINT_IDS = {
+    "finalizer_authority_only_for_commit_readiness", "pr_metadata_guard_authority_only_for_pr_metadata", "reports_do_not_create_runtime_authority", "recommendations_are_not_commands", "pulse_signals_are_not_actions", "health_snapshots_are_not_decisions", "memory_candidates_are_not_writes", "memory_verification_is_not_readiness", "activation_preflight_is_not_activation", "ledger_schema_is_not_ledger_write", "glow_schema_is_not_glow_archive", "evidence_indexes_are_not_authority", "appendices_are_review_context_only", "doctrine_maps_do_not_train_models", "provenance_digests_do_not_verify_authority", "future_integrations_are_inactive_without_explicit_contract", "daemon_must_not_self_authorize", "federation_consensus_not_implied", "no_skipped_or_nonexecuted_tests_as_required_proof", "no_runtime_or_host_action_without_explicit_boundary", "no_backdoor_or_hidden_authority", "operator_consent_required_for_active_watchers_or_daemons", "storage_policy_required_for_memory_writes", "vow_digest_required_for_future_active_writers",
+}
+REQUIRED_INFERENCE_IDS = {
+    "architecture_map_implies_runtime_authority", "health_snapshot_implies_readiness", "pulse_contract_implies_action", "daemon_recommendation_implies_command", "memory_contract_implies_storage_write", "memory_candidate_bundle_implies_ledger_write", "memory_candidate_bundle_implies_glow_archive", "memory_candidate_verifier_implies_readiness", "memory_activation_preflight_implies_activation", "matrix_diagnostic_nonproof_implies_required_proof", "evidence_index_implies_authority", "appendix_implies_authority", "doctrine_map_implies_model_training", "provenance_digest_implies_trust_without_source", "future_integration_implies_active_behavior",
+}
+
+def _summary(raw: bytes, path: str = "x.json") -> dict[str, object]:
+    return {"provided": True, "path": path, "digest_algo": "sha256", "digest": hashlib.sha256(raw).hexdigest(), "byte_size": len(raw), "readable_json": True, "error": None}
+
+def test_canonical_constraint_ids_are_present() -> None:
+    assert REQUIRED_CONSTRAINT_IDS <= {item["constraint_id"] for item in canonical_vow_constraints()}
+
+def test_canonical_vow_digest_is_deterministic_and_changes_with_constraints() -> None:
+    first = compute_canonical_vow_digest()
+    assert first == compute_canonical_vow_digest(list(reversed(canonical_vow_constraints())))
+    changed = [dict(item) for item in canonical_vow_constraints()]
+    changed[0]["canonical_statement"] += " changed"
+    assert compute_canonical_vow_digest(changed) != first
+
+def test_canonical_vow_digest_independent_of_inputs() -> None:
+    raw1 = b'{"metadata_only":true,"non_authority_posture":{"x":true}}'
+    raw2 = b'{"metadata_only":true,"non_authority_posture":{"x":true},"extra":"changed"}'
+    report1 = build_codex_workcell_vow_boundary_contract({"health_snapshot_json": (_summary(raw1, "a.json"), json.loads(raw1))})
+    report2 = build_codex_workcell_vow_boundary_contract({"health_snapshot_json": (_summary(raw2, "b.json"), json.loads(raw2))})
+    assert report1["canonical_vow_digest"] == report2["canonical_vow_digest"] == compute_canonical_vow_digest()
+
+def test_forbidden_inference_catalog_contains_required_ids() -> None:
+    assert REQUIRED_INFERENCE_IDS <= {item["inference_id"] for item in forbidden_inference_catalog()}
+
+def test_omitted_inputs_are_not_supplied() -> None:
+    report = build_codex_workcell_vow_boundary_contract()
+    assert {item["alignment_status"] for item in report["report_alignment_results"]} == {"not_supplied"}
+    assert report["vow_gap_summary"]["not_supplied_report_count"] == len(INPUT_IDS)
+
+def test_supplied_metadata_only_non_authority_report_aligns_and_records_digest() -> None:
+    data = {"metadata_only": True, "non_authority_posture": {"safe": True}, "health_snapshot_id": "h"}
+    raw = json.dumps(data, sort_keys=True).encode()
+    report = build_codex_workcell_vow_boundary_contract({"health_snapshot_json": (_summary(raw, "pipe|newline\nvalue.json"), data)})
+    result = next(item for item in report["report_alignment_results"] if item["input_id"] == "health_snapshot_json")
+    assert result["alignment_status"] == "aligned"
+    assert result["source_digest"] == hashlib.sha256(raw).hexdigest()
+    assert result["source_byte_size"] == len(raw)
+
+def test_supplied_report_lacking_metadata_only_warns() -> None:
+    data = {"non_authority_posture": {"safe": True}}
+    raw = json.dumps(data).encode()
+    result = next(item for item in build_codex_workcell_vow_boundary_contract({"pulse_contract_json": (_summary(raw), data)})["report_alignment_results"] if item["input_id"] == "pulse_contract_json")
+    assert result["alignment_status"] == "warning"
+
+def test_false_non_authority_posture_fails_alignment() -> None:
+    data = {"metadata_only": True, "non_authority_posture": {"safe": False}}
+    raw = json.dumps(data).encode()
+    report = build_codex_workcell_vow_boundary_contract({"memory_contract_json": (_summary(raw), data)})
+    assert report["vow_gap_summary"]["failed_report_count"] == 1
+    assert report["vow_gap_summary"]["active_authority_detected"] is True
+
+def test_active_writer_daemon_or_scheduler_authority_fails_alignment() -> None:
+    for flag in ("active_writer", "daemon_action", "scheduler"):
+        data = {"metadata_only": True, "non_authority_posture": {"safe": True}, flag: True}
+        raw = json.dumps(data).encode()
+        report = build_codex_workcell_vow_boundary_contract({"daemon_recommendation_contract_json": (_summary(raw), data)})
+        assert next(item for item in report["report_alignment_results"] if item["provided"])["alignment_status"] == "failed"
+
+def test_json_and_markdown_are_deterministic_and_escape_cells() -> None:
+    data = {"metadata_only": True, "non_authority_posture": {"safe": True}, "note": "pipe | newline\nvalue"}
+    raw = json.dumps(data).encode()
+    report = build_codex_workcell_vow_boundary_contract({"architecture_json": (_summary(raw, "pipe|newline\nvalue.json"), data)})
+    assert json.dumps(report, sort_keys=True) == json.dumps(build_codex_workcell_vow_boundary_contract({"architecture_json": (_summary(raw, "pipe|newline\nvalue.json"), data)}), sort_keys=True)
+    md1 = render_codex_workcell_vow_boundary_contract_markdown(report)
+    md2 = render_codex_workcell_vow_boundary_contract_markdown(report)
+    assert md1 == md2
+    assert "\\|" in render_codex_workcell_vow_boundary_contract_markdown({**report, "vow_gap_summary": {"x": "a|b\nc"}})
+    assert "<br>" in render_codex_workcell_vow_boundary_contract_markdown({**report, "vow_gap_summary": {"x": "a|b\nc"}})
+
+def test_contract_does_not_grant_authority_or_write_memory() -> None:
+    report = build_codex_workcell_vow_boundary_contract()
+    for key in ("not_runtime_authority", "not_memory_writer", "not_ledger_writer", "not_glow_archiver", "not_daemon_action", "not_task_creator", "not_scheduler"):
+        assert report[key] is True
+    assert all(NON_AUTHORITY_POSTURE.values())
+    assert all(report["non_authority_posture"].values())
+    assert "ready" not in report
+
+def test_future_activation_requirements_are_future_only_inactive() -> None:
+    report = build_codex_workcell_vow_boundary_contract()
+    assert report["future_activation_requirements"]
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in report["future_activation_requirements"])


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only `/vow` boundary that records canonical constraint records and a stable SHA-256 vow digest to prevent reviewer surfaces from being misinterpreted as runtime/landing authority.
- Make forbidden-inference mappings explicit so adjacent workcell reports (architecture, health, pulse, daemon recommendations, memory artifacts, activation preflight, etc.) cannot be used to infer active writers, commits, PR metadata, daemon actions, or federation consensus.
- Maintain a strict non-authority posture: this contract must be read-only and must not activate memory, write ledger entries, archive glow, schedule or trigger actions, or alter readiness gates.

### Description

- Add `sentientos/codex_workcell_vow_boundary_contract.py` implementing canonical constraint records, deterministic constraint-only SHA-256 digest (`DIGEST_ALGO = "sha256"`), forbidden inference catalog, input raw-byte summaries, alignment rules, vow-gap summary, mount alignment, future-only activation requirements, and explicit non-authority posture flags.
- Add CLI `scripts/build_codex_workcell_vow_boundary_contract.py` with required `--output` and optional inputs for the workcell surfaces, deterministic JSON/Markdown outputs, `--markdown-output`, `--summary`, and clean exit-code-2 error handling for missing/invalid/non-object JSON inputs.
- Add focused tests: `tests/test_codex_workcell_vow_boundary_contract.py` and `tests/test_build_codex_workcell_vow_boundary_contract_script.py` that assert presence of canonical constraints and forbidden inferences, digest determinism and input independence, alignment outcomes (aligned/warning/failed/not_supplied), raw-byte digests/byte sizes, CLI error behavior, and deterministic Markdown escaping.
- Add docs `docs/development/codex_workcell_vow_boundary_contract.md` and short boundary notes to adjacent docs to record the `/vow` surface and to emphasize the non-authority, metadata-only nature of the contract.

### Testing

- Ran focused unit/CLI tests: `python -m scripts.run_tests -q tests/test_codex_workcell_vow_boundary_contract.py tests/test_build_codex_workcell_vow_boundary_contract_script.py`; the targeted tests passed (some legacy-marked tests were skipped under the test harness quarantine).
- Ran the broader validation lanes used for landing: multiple `python -m scripts.run_tests -q ...` lanes for related Codex workcell surfaces and they completed successfully in the validation matrix used here.
- Built docs and bootstrapped docs deps: `python scripts/build_docs.py --bootstrap-docs` then `python scripts/build_docs.py --check-deps` and `python scripts/build_docs.py`, which completed after the docs bootstrap.
- Type checks: `python -m mypy sentientos/codex_workcell_vow_boundary_contract.py scripts/build_codex_workcell_vow_boundary_contract.py` completed with no issues for the added files.
- Finalizer and PR-gate automation were exercised as part of the validation flow and returned readiness artifacts used for this landing (pre-commit and pr-metadata finalizer stages ran and returned the expected ready statuses).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c48b39ff08320a4af97178149da50)