### PR TITLE
[codex:vow] add Codex workcell vow alignment attestation bundle

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -219,3 +219,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) is not finalizer authority. Its digest and alignment summaries cannot decide `ready_to_commit` or bypass this finalizer.
+
+## Vow alignment attestation boundary
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) is not a finalizer substitute. Its `attested`, `warning`, or `failed` statuses do not authorize commit or bypass finalizer decisions.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -211,3 +211,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) can describe forbidden inferences around recovery evidence, but it is not recovery authority and does not create commits, PR metadata, or runtime actions.
+
+## Vow alignment attestation boundary
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) can be reviewed as metadata evidence when present, but it does not recover task-owned files, create PR metadata, authorize commits, or replace recovery rail requirements.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -158,3 +158,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Workcell vow boundary contract
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) records canonical forbidden-inference constraints for `/vow`. It does not add validation gates, satisfy matrix proof, decide readiness, authorize commit, authorize PR metadata, or bypass finalizer/guard authority.
+
+## Vow alignment attestation boundary
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) is a metadata-only review artifact. It does not replace validation, matrix proof, supervisor decisions, finalizer readiness, PR metadata guard readiness, clean-tree checks, commits, or `make_pr`.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -122,3 +122,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) adds the `/vow` constraint digest surface for forbidden inferences. It does not activate runtime authority or change the architecture map into an execution plan.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind architecture reports to a supplied vow digest. Architecture alignment remains non-runtime metadata and does not create host, daemon, memory, commit, or PR authority.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -50,3 +50,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks recommendation-as-command and daemon-self-authorization inference. Daemon recommendations remain advisory metadata only.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind daemon recommendation reports to a supplied vow digest. Recommendations remain advisory metadata and the attestation does not command or trigger daemon action.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -64,3 +64,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks health-as-readiness inference. Health snapshots remain cockpit metadata and do not replace matrix, finalizer, guard, or operator authority.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind health snapshot reports to a supplied vow digest. Health alignment is reviewer metadata and does not decide readiness.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -38,3 +38,7 @@ The preflight declares that it is read-only, metadata-only, preflight-only, and 
 ## Vow boundary contract link
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) is the future `/vow` constraint digest surface referenced by this preflight. It blocks preflight-as-activation inference while remaining metadata-only and inactive.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may attest that activation preflight metadata is bound to a supplied vow digest. That attestation is not activation and does not authorize memory writers, watchers, daemons, or readiness.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -59,3 +59,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks candidate-as-write inference. Candidate bundle records remain staged metadata only, not `/ledger` entries or `/glow` archives.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind candidate bundle reports to a supplied vow digest. Candidate records remain metadata only and the attestation does not write `/ledger` or archive `/glow`.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -106,3 +106,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks verifier-as-readiness inference. Candidate verification remains structural metadata only and does not write `/ledger` or archive `/glow`.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind verifier reports to a supplied vow digest. Verification remains structural metadata and the attestation does not decide readiness.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -123,3 +123,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks schema-as-write inference. `/ledger` and `/glow` schemas remain future inactive shapes until separately adopted by explicit writer/archive contracts.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind memory contract reports to a supplied vow digest. Schema alignment remains inactive metadata and does not implement ledger writers or glow archivers.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -63,3 +63,7 @@ See [Codex Workcell Memory Activation Preflight](codex_workcell_memory_activatio
 ## Vow boundary note
 
 The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_contract.md) blocks pulse-as-action inference. Pulse signals remain inactive metadata unless a future explicit watcher/action contract is adopted.
+
+## Vow alignment attestation note
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind pulse contract reports to a supplied vow digest. Pulse metadata remains observational and the attestation does not watch, schedule, alert, or act.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -1,0 +1,43 @@
+# Codex Workcell Vow Alignment Attestation Bundle
+
+The Codex Workcell Vow Alignment Attestation Bundle is a deterministic, metadata-only `/vow` review artifact. It reads a supplied Codex Workcell Vow Digest Boundary Contract JSON and optional workcell report JSON files, records raw-byte SHA-256 digests and byte sizes, and emits per-report alignment attestations bound to the supplied canonical vow digest.
+
+It is not runtime authority. It does not activate memory, write `/ledger`, archive `/glow`, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, create PRs, establish federation consensus, or train/modify models.
+
+## Boundary contract vs. alignment attestation
+
+The vow boundary contract defines canonical constraints, the canonical vow digest, forbidden inference catalog, report-alignment categories, future-only activation requirements, and non-authority posture. The vow alignment attestation consumes that contract as input and binds supplied report artifacts to its digest for reviewer inspection.
+
+The attestation bundle does not recalculate authority, adopt the vow into runtime policy, or convert warnings/attestations into readiness. It only states whether supplied report metadata appears compatible with the supplied vow digest and forbidden inference boundary.
+
+## Digest binding
+
+For the required vow boundary contract JSON and every supplied optional report JSON, the CLI reads raw bytes, computes SHA-256, records byte size, and parses JSON object content. The supplied `canonical_vow_digest` and `canonical_vow_digest_algo` from the vow boundary contract are copied into every attestation record. If the supplied vow boundary contract lacks `canonical_vow_digest`, supplied report attestations fail rather than becoming authority.
+
+## Constraint and forbidden inference assignment
+
+Each supported report input has a stable mapping to applicable vow constraint IDs and forbidden inference IDs. Architecture reports bind to runtime-authority and hidden-authority constraints; health reports bind to health-is-not-readiness constraints; pulse reports bind to pulse-is-not-action constraints; daemon recommendation reports bind to recommendation-is-not-command constraints; memory surfaces bind to schema/candidate/verifier/preflight constraints that keep `/ledger`, `/glow`, readiness, and activation claims inactive.
+
+These mappings are reviewer metadata only. Missing expected IDs are reported as coverage gaps against the supplied vow boundary contract catalog; gaps do not authorize activation or readiness.
+
+## Attestation status is not readiness
+
+Per-report statuses are limited to `attested`, `warning`, and `failed`. A supplied report fails when `metadata_only` is false, non-authority posture contains false values, active authority is detected, or the vow digest is absent. Missing `metadata_only` or missing non-authority posture warns unless active authority is detected.
+
+No status grants readiness, finalizer bypass, PR metadata guard bypass, commit authority, PR creation authority, daemon execution, task creation, scheduling, ledger writing, glow archiving, memory mutation, federation consensus, or model training.
+
+## Mount relationship
+
+- `/vow`: canonical digest binding and forbidden inference attestation.
+- `/ledger`: future consumer of vow-bounded write policy; inactive here.
+- `/glow`: future consumer of vow-bounded archive policy; inactive here.
+- `/pulse`: future consumer of vow-bounded observation history; inactive here.
+- `/daemon`: future consumer of vow-bounded recommendation context; inactive here.
+
+## Future activation requirements
+
+Future activation remains unmet and inactive until separate contracts define explicit vow digest adoption policy, ledger writer implementation, glow archiver implementation, storage path policy, retention policy, digest verification policy, parent-chain validation policy, operator consent, finalizer/guard non-bypass invariant, pulse watcher contract, daemon action contract, federation drift consensus rule, tests proving no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The bundle declares that it is read-only, metadata-only, attestation-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commits, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -46,3 +46,7 @@ Future active memory work remains unmet and inactive until separate contracts de
 ## Non-authority posture
 
 The vow boundary contract declares that it is read-only, metadata-only, contract-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commits, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.
+
+## Vow alignment attestation boundary
+
+The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) can bind supplied workcell report artifacts to this contract digest for review. It remains metadata-only and does not create readiness, memory, daemon, commit, or PR metadata authority.

--- a/scripts/build_codex_workcell_vow_alignment_attestation.py
+++ b/scripts/build_codex_workcell_vow_alignment_attestation.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_vow_alignment_attestation import (
+    CodexWorkcellVowAlignmentAttestationError,
+    INPUT_IDS,
+    build_codex_workcell_vow_alignment_attestation,
+    read_json_input,
+    render_codex_workcell_vow_alignment_attestation_markdown,
+    write_codex_workcell_vow_alignment_attestation_json,
+    write_codex_workcell_vow_alignment_attestation_markdown,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell vow alignment attestation bundle.")
+    parser.add_argument("--vow-boundary-contract-json", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--architecture-json")
+    parser.add_argument("--health-snapshot-json")
+    parser.add_argument("--pulse-contract-json")
+    parser.add_argument("--daemon-recommendation-contract-json")
+    parser.add_argument("--memory-contract-json")
+    parser.add_argument("--memory-candidate-bundle-json")
+    parser.add_argument("--memory-candidate-verifier-json")
+    parser.add_argument("--memory-activation-preflight-json")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        vow_summary, vow_data = read_json_input(args.vow_boundary_contract_json, "vow_boundary_contract_json", required=True)
+        if vow_data is None:
+            raise CodexWorkcellVowAlignmentAttestationError("missing_required_vow_boundary_contract_json")
+        inputs = {input_id: read_json_input(getattr(args, input_id), input_id) for input_id in INPUT_IDS}
+        report = build_codex_workcell_vow_alignment_attestation((vow_summary, vow_data), inputs)
+    except CodexWorkcellVowAlignmentAttestationError as exc:
+        print(f"codex_workcell_vow_alignment_attestation_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_vow_alignment_attestation_json(report, args.output)
+    if args.markdown_output:
+        write_codex_workcell_vow_alignment_attestation_markdown(render_codex_workcell_vow_alignment_attestation_markdown(report), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"vow_alignment_attestation_id": report["vow_alignment_attestation_id"], "metadata_only": True, "attestation_bundle_only": True, "canonical_vow_digest": report["canonical_vow_digest"], "supplied_report_count": report["constraint_coverage_summary"]["supplied_report_count"], "failed_attestation_count": report["attestation_gap_summary"]["failed_attestation_count"], "output": args.output, "markdown_output": args.markdown_output}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_vow_alignment_attestation.py
+++ b/sentientos/codex_workcell_vow_alignment_attestation.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_VOW_ALIGNMENT_ATTESTATION_ID = "codex_workcell_vow_alignment_attestation.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_IDS: tuple[str, ...] = (
+    "architecture_json", "health_snapshot_json", "pulse_contract_json", "daemon_recommendation_contract_json",
+    "memory_contract_json", "memory_candidate_bundle_json", "memory_candidate_verifier_json", "memory_activation_preflight_json",
+)
+
+CONSTRAINT_MAP: dict[str, tuple[str, ...]] = {
+    "architecture_json": ("reports_do_not_create_runtime_authority", "no_runtime_or_host_action_without_explicit_boundary", "no_backdoor_or_hidden_authority"),
+    "health_snapshot_json": ("health_snapshots_are_not_decisions", "reports_do_not_create_runtime_authority"),
+    "pulse_contract_json": ("pulse_signals_are_not_actions", "reports_do_not_create_runtime_authority"),
+    "daemon_recommendation_contract_json": ("recommendations_are_not_commands", "daemon_must_not_self_authorize", "reports_do_not_create_runtime_authority"),
+    "memory_contract_json": ("ledger_schema_is_not_ledger_write", "glow_schema_is_not_glow_archive", "storage_policy_required_for_memory_writes", "reports_do_not_create_runtime_authority"),
+    "memory_candidate_bundle_json": ("memory_candidates_are_not_writes", "ledger_schema_is_not_ledger_write", "glow_schema_is_not_glow_archive", "reports_do_not_create_runtime_authority"),
+    "memory_candidate_verifier_json": ("memory_verification_is_not_readiness", "reports_do_not_create_runtime_authority"),
+    "memory_activation_preflight_json": ("activation_preflight_is_not_activation", "vow_digest_required_for_future_active_writers", "operator_consent_required_for_active_watchers_or_daemons", "reports_do_not_create_runtime_authority"),
+}
+
+FORBIDDEN_MAP: dict[str, tuple[str, ...]] = {
+    "architecture_json": ("architecture_map_implies_runtime_authority",),
+    "health_snapshot_json": ("health_snapshot_implies_readiness",),
+    "pulse_contract_json": ("pulse_contract_implies_action",),
+    "daemon_recommendation_contract_json": ("daemon_recommendation_implies_command",),
+    "memory_contract_json": ("memory_contract_implies_storage_write",),
+    "memory_candidate_bundle_json": ("memory_candidate_bundle_implies_ledger_write", "memory_candidate_bundle_implies_glow_archive"),
+    "memory_candidate_verifier_json": ("memory_candidate_verifier_implies_readiness",),
+    "memory_activation_preflight_json": ("memory_activation_preflight_implies_activation",),
+}
+
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit vow digest adoption policy", "explicit ledger writer implementation", "explicit glow archiver implementation",
+    "explicit storage path policy", "explicit retention policy", "explicit digest verification policy", "explicit parent-chain validation policy",
+    "explicit operator consent", "explicit finalizer/guard non-bypass invariant", "explicit pulse watcher contract", "explicit daemon action contract",
+    "explicit federation drift consensus rule", "tests proving no readiness authority", "docs marking active behavior",
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "vow_alignment_attestation_is_read_only": True,
+    "vow_alignment_attestation_is_metadata_only": True,
+    "vow_alignment_attestation_is_attestation_only": True,
+    "vow_alignment_attestation_does_not_activate_memory": True,
+    "vow_alignment_attestation_does_not_write_ledger": True,
+    "vow_alignment_attestation_does_not_archive_glow": True,
+    "vow_alignment_attestation_does_not_modify_memory": True,
+    "vow_alignment_attestation_does_not_watch_files": True,
+    "vow_alignment_attestation_does_not_poll_state": True,
+    "vow_alignment_attestation_does_not_rerun_commands": True,
+    "vow_alignment_attestation_does_not_decide_readiness": True,
+    "vow_alignment_attestation_does_not_bypass_finalizer": True,
+    "vow_alignment_attestation_does_not_bypass_pr_metadata_guard": True,
+    "vow_alignment_attestation_does_not_authorize_commit": True,
+    "vow_alignment_attestation_does_not_authorize_pr_creation": True,
+    "vow_alignment_attestation_does_not_trigger_daemon": True,
+    "vow_alignment_attestation_does_not_create_tasks": True,
+    "vow_alignment_attestation_does_not_schedule_tasks": True,
+    "vow_alignment_attestation_does_not_send_alerts": True,
+    "vow_alignment_attestation_does_not_train_or_modify_models": True,
+    "vow_alignment_attestation_does_not_establish_federation_consensus": True,
+}
+
+ACTIVE_AUTHORITY_KEYS = {
+    "active_writer", "active_daemon", "active_scheduler", "active_task_creator", "active_alerting",
+    "active_federation_consensus", "commit_authority", "pr_authority", "PR_authority", "finalizer_bypass", "pr_metadata_guard_bypass",
+    "memory_writer", "ledger_writer", "glow_archiver", "watcher", "scheduler", "executor", "daemon_action", "task_creator", "alerting_system",
+    "model_training", "reinforcement_learning", "runtime_authority", "federation_consensus",
+}
+
+class CodexWorkcellVowAlignmentAttestationError(ValueError):
+    pass
+
+
+def _omitted(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+
+def read_json_input(path_text: str | None, input_id: str, *, required: bool = False) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    if not path_text:
+        if required:
+            raise CodexWorkcellVowAlignmentAttestationError(f"missing_required_{input_id}")
+        return _omitted(input_id), None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellVowAlignmentAttestationError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellVowAlignmentAttestationError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellVowAlignmentAttestationError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+
+def _detected_report_id(data: Mapping[str, Any]) -> Any:
+    for key in sorted(data):
+        if key.endswith("_id") or key in {"doctor_report_id", "workcell_memory_contract_id"}:
+            return data.get(key)
+    return None
+
+
+def _posture(data: Mapping[str, Any]) -> tuple[bool, bool | None]:
+    posture = data.get("non_authority_posture")
+    if not isinstance(posture, Mapping):
+        return False, None
+    return True, all(value is True for value in posture.values())
+
+
+def _active_authority(data: Mapping[str, Any]) -> bool:
+    for key, value in data.items():
+        key_lower = key.lower()
+        if value is True and (key in ACTIVE_AUTHORITY_KEYS or key_lower in ACTIVE_AUTHORITY_KEYS or key_lower.startswith("active_") or key_lower.endswith("_authority")):
+            return True
+        if key_lower.startswith("not_") and value is False:
+            return True
+    present, all_true = _posture(data)
+    return bool(present and all_true is False)
+
+
+def _contract_summary(summary: Mapping[str, Any], contract: Mapping[str, Any]) -> dict[str, Any]:
+    posture_present, posture_all_true = _posture(contract)
+    constraints = contract.get("canonical_vow_constraints")
+    inferences = contract.get("forbidden_inference_catalog")
+    return {
+        "provided": True,
+        "vow_boundary_contract_id": contract.get("vow_boundary_contract_id"),
+        "canonical_vow_digest": contract.get("canonical_vow_digest"),
+        "canonical_vow_digest_algo": contract.get("canonical_vow_digest_algo"),
+        "canonical_constraint_count": len(constraints) if isinstance(constraints, list) else None,
+        "forbidden_inference_count": len(inferences) if isinstance(inferences, list) else None,
+        "non_authority_posture_present": posture_present,
+        "non_authority_posture_all_true": posture_all_true,
+        "source_digest": summary.get("digest"),
+        "source_digest_algo": summary.get("digest_algo"),
+        "source_byte_size": summary.get("byte_size"),
+    }
+
+
+def _record(input_id: str, summary: Mapping[str, Any], data: Mapping[str, Any], digest: Any, algo: Any) -> dict[str, Any]:
+    warnings: list[str] = []
+    violations: list[str] = []
+    metadata_seen = data.get("metadata_only")
+    posture_present, posture_all_true = _posture(data)
+    if metadata_seen is False:
+        violations.append("metadata_only_false")
+    elif metadata_seen is not True:
+        warnings.append("metadata_only_missing")
+    if not posture_present:
+        warnings.append("non_authority_posture_missing")
+    elif posture_all_true is False:
+        violations.append("non_authority_posture_false")
+    active = _active_authority(data)
+    if active:
+        violations.append("active_authority_detected")
+    if not digest:
+        violations.append("canonical_vow_digest_missing")
+    status = "failed" if violations else ("warning" if warnings else "attested")
+    return {
+        "attestation_id": f"{WORKCELL_VOW_ALIGNMENT_ATTESTATION_ID}:{input_id}",
+        "input_id": input_id,
+        "supplied": True,
+        "source_digest": summary.get("digest"),
+        "source_digest_algo": summary.get("digest_algo"),
+        "source_byte_size": summary.get("byte_size"),
+        "detected_report_id": _detected_report_id(data),
+        "canonical_vow_digest": digest,
+        "canonical_vow_digest_algo": algo,
+        "applicable_constraint_ids": list(CONSTRAINT_MAP[input_id]),
+        "applicable_forbidden_inference_ids": list(FORBIDDEN_MAP[input_id]),
+        "metadata_only_seen": metadata_seen,
+        "non_authority_posture_present": posture_present,
+        "non_authority_posture_all_true": posture_all_true,
+        "active_authority_detected": active,
+        "alignment_status": status,
+        "warnings": warnings,
+        "violations": violations,
+        "forbidden_inference_boundary": "Forbidden inference IDs remain false review boundaries; they are not readiness or activation authority.",
+        "authority_boundary": "Attestation does not activate memory, write ledger/glow, trigger daemons, schedule tasks, authorize commit, or authorize PR metadata.",
+        "no_action_taken": True,
+    }
+
+
+def build_codex_workcell_vow_alignment_attestation(vow_boundary_contract: tuple[Mapping[str, Any], Mapping[str, Any]], inputs: Mapping[str, tuple[Mapping[str, Any], Mapping[str, Any] | None]] | None = None) -> dict[str, Any]:
+    vow_summary, vow_data = vow_boundary_contract
+    contract_summary = _contract_summary(vow_summary, vow_data)
+    canonical_digest = vow_data.get("canonical_vow_digest")
+    canonical_algo = vow_data.get("canonical_vow_digest_algo", DIGEST_ALGO)
+    normalized = {input_id: (dict(inputs[input_id][0]), inputs[input_id][1]) if inputs and input_id in inputs else (_omitted(input_id), None) for input_id in INPUT_IDS}
+    records = [_record(input_id, summary, data, canonical_digest, canonical_algo) for input_id, (summary, data) in sorted(normalized.items()) if summary.get("provided") and data is not None]
+    applicable_constraints = sorted({cid for rec in records for cid in rec["applicable_constraint_ids"]})
+    applicable_inferences = sorted({iid for rec in records for iid in rec["applicable_forbidden_inference_ids"]})
+    canonical_constraints_raw = vow_data.get("canonical_vow_constraints")
+    canonical_constraints: list[Any] = canonical_constraints_raw if isinstance(canonical_constraints_raw, list) else []
+    canonical_constraint_ids = {str(item.get("constraint_id")) for item in canonical_constraints if isinstance(item, Mapping) and item.get("constraint_id")}
+    catalog_raw = vow_data.get("forbidden_inference_catalog")
+    catalog: list[Any] = catalog_raw if isinstance(catalog_raw, list) else []
+    catalog_ids = {str(item.get("inference_id")) for item in catalog if isinstance(item, Mapping) and item.get("inference_id")}
+    return {
+        "vow_alignment_attestation_id": WORKCELL_VOW_ALIGNMENT_ATTESTATION_ID,
+        "metadata_only": True, "attestation_bundle_only": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {key: dict(value[0]) for key, value in sorted(normalized.items())},
+        "vow_boundary_contract_summary": contract_summary,
+        "canonical_vow_digest": canonical_digest,
+        "canonical_vow_digest_algo": canonical_algo,
+        "attestation_records": records,
+        "constraint_coverage_summary": {"supplied_report_count": len(records), "attested_report_count": sum(r["alignment_status"] == "attested" for r in records), "warning_report_count": sum(r["alignment_status"] == "warning" for r in records), "failed_report_count": sum(r["alignment_status"] == "failed" for r in records), "canonical_constraint_count": len(canonical_constraints) if canonical_constraints else None, "applicable_constraint_count": len(applicable_constraints), "applicable_constraint_ids": applicable_constraints, "missing_expected_constraint_ids": sorted(set(applicable_constraints) - canonical_constraint_ids) if canonical_constraint_ids else [], "canonical_vow_digest": canonical_digest, "no_action_taken": True},
+        "forbidden_inference_coverage_summary": {"forbidden_inference_count": len(catalog) if catalog else None, "applicable_forbidden_inference_count": len(applicable_inferences), "applicable_forbidden_inference_ids": applicable_inferences, "missing_expected_forbidden_inference_ids": sorted(set(applicable_inferences) - catalog_ids) if catalog_ids else [], "no_action_taken": True},
+        "attestation_gap_summary": {"failed_attestation_count": sum(r["alignment_status"] == "failed" for r in records), "warning_attestation_count": sum(r["alignment_status"] == "warning" for r in records), "failed_input_ids": [r["input_id"] for r in records if r["alignment_status"] == "failed"], "warning_input_ids": [r["input_id"] for r in records if r["alignment_status"] == "warning"], "active_authority_detected": any(r["active_authority_detected"] for r in records), "vow_alignment_attestation_only": True, "no_action_taken": True, "not_readiness_authority": True},
+        "sentientos_mount_alignment": {"/vow": "canonical digest binding and forbidden inference attestation", "/ledger": "future consumer of vow-bounded write policy; inactive here", "/glow": "future consumer of vow-bounded archive policy; inactive here", "/pulse": "future consumer of vow-bounded observation history; inactive here", "/daemon": "future consumer of vow-bounded recommendation context; inactive here"},
+        "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+
+def render_codex_workcell_vow_alignment_attestation_markdown(report: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Vow Alignment Attestation Bundle", "", "Deterministic metadata-only attestation. It binds supplied report bytes to a supplied canonical vow digest but does not decide readiness, activate memory, write /ledger, archive /glow, run commands, trigger daemons, create tasks, schedule work, or authorize commits/PR metadata.", "", f"Canonical vow digest: `{_cell(report.get('canonical_vow_digest'))}`", "", "## Vow boundary contract summary", f"`{_cell(report['vow_boundary_contract_summary'])}`", "", "## Input summaries", "| input | provided | path | digest | byte_size |", "| --- | --- | --- | --- | --- |"]
+    for key, value in sorted(report["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value.get('provided'))} | {_cell(value.get('path'))} | {_cell(value.get('digest'))} | {_cell(value.get('byte_size'))} |")
+    lines += ["", "## Attestation records", "| input | status | report_id | constraints | forbidden inferences | warnings | violations |", "| --- | --- | --- | --- | --- | --- | --- |"]
+    for item in report["attestation_records"]:
+        lines.append(f"| {_cell(item['input_id'])} | {_cell(item['alignment_status'])} | {_cell(item['detected_report_id'])} | {_cell(item['applicable_constraint_ids'])} | {_cell(item['applicable_forbidden_inference_ids'])} | {_cell(item['warnings'])} | {_cell(item['violations'])} |")
+    for title, key in (("Constraint coverage summary", "constraint_coverage_summary"), ("Forbidden inference coverage summary", "forbidden_inference_coverage_summary"), ("Attestation gap summary", "attestation_gap_summary")):
+        lines += ["", f"## {title}", f"`{_cell(report[key])}`"]
+    lines += ["", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(report["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in report["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(report["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_codex_workcell_vow_alignment_attestation_json(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_codex_workcell_vow_alignment_attestation_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_vow_alignment_attestation_script.py
+++ b/tests/test_build_codex_workcell_vow_alignment_attestation_script.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import subprocess
+import sys
+
+from sentientos.codex_workcell_vow_boundary_contract import build_codex_workcell_vow_boundary_contract
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/build_codex_workcell_vow_alignment_attestation.py"
+
+
+def _write(path, data):
+    path.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+
+
+def _vow(tmp_path):
+    path = tmp_path / "vow.json"
+    _write(path, build_codex_workcell_vow_boundary_contract())
+    return path
+
+
+def test_required_vow_boundary_contract_input_is_enforced(tmp_path):
+    out = tmp_path / "out.json"
+    result = subprocess.run([sys.executable, SCRIPT, "--output", str(out)], text=True, capture_output=True)
+    assert result.returncode != 0
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path):
+    vow = _vow(tmp_path)
+    report = tmp_path / "arch.json"
+    _write(report, {"metadata_only": True, "non_authority_posture": {"x": True}, "architecture_id": "a"})
+    out = tmp_path / "out.json"
+    md = tmp_path / "out.md"
+    result = subprocess.run([sys.executable, SCRIPT, "--vow-boundary-contract-json", str(vow), "--architecture-json", str(report), "--output", str(out), "--markdown-output", str(md), "--summary"], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(out.read_text())
+    assert data["attestation_records"][0]["input_id"] == "architecture_json"
+    assert md.read_text().startswith("# Codex Workcell Vow Alignment Attestation Bundle")
+    assert json.loads(result.stdout)["supplied_report_count"] == 1
+
+
+def test_invalid_missing_and_non_object_json_exit_2(tmp_path):
+    vow = _vow(tmp_path)
+    for name, content, args in [
+        ("bad.json", "{", ["--architecture-json"]),
+        ("list.json", "[]", ["--architecture-json"]),
+    ]:
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        result = subprocess.run([sys.executable, SCRIPT, "--vow-boundary-contract-json", str(vow), *args, str(path), "--output", str(tmp_path / f"{name}.out")], text=True, capture_output=True)
+        assert result.returncode == 2
+    result = subprocess.run([sys.executable, SCRIPT, "--vow-boundary-contract-json", str(vow), "--architecture-json", str(tmp_path / "missing.json"), "--output", str(tmp_path / "missing.out")], text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_json_output_is_deterministic(tmp_path):
+    vow = _vow(tmp_path)
+    out1 = tmp_path / "one.json"
+    out2 = tmp_path / "two.json"
+    cmd = [sys.executable, SCRIPT, "--vow-boundary-contract-json", str(vow)]
+    assert subprocess.run([*cmd, "--output", str(out1)], capture_output=True).returncode == 0
+    assert subprocess.run([*cmd, "--output", str(out2)], capture_output=True).returncode == 0
+    assert out1.read_text() == out2.read_text()

--- a/tests/test_codex_workcell_vow_alignment_attestation.py
+++ b/tests/test_codex_workcell_vow_alignment_attestation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_vow_alignment_attestation import (
+    CONSTRAINT_MAP,
+    FORBIDDEN_MAP,
+    INPUT_IDS,
+    NON_AUTHORITY_POSTURE,
+    build_codex_workcell_vow_alignment_attestation,
+    read_json_input,
+    render_codex_workcell_vow_alignment_attestation_markdown,
+)
+from sentientos.codex_workcell_vow_boundary_contract import build_codex_workcell_vow_boundary_contract
+
+
+def _vow():
+    data = build_codex_workcell_vow_boundary_contract()
+    raw = json.dumps(data, sort_keys=True).encode()
+    return ({"provided": True, "digest": hashlib.sha256(raw).hexdigest(), "digest_algo": "sha256", "byte_size": len(raw)}, data)
+
+
+def _summary(data: dict):
+    raw = json.dumps(data, sort_keys=True).encode()
+    return {"provided": True, "digest": hashlib.sha256(raw).hexdigest(), "digest_algo": "sha256", "byte_size": len(raw), "readable_json": True, "error": None}
+
+
+def _report(**extra):
+    data = {"metadata_only": True, "non_authority_posture": {"x": True}, "sample_report_id": "r1"}
+    data.update(extra)
+    return data
+
+
+def _build(input_id: str, data: dict):
+    return build_codex_workcell_vow_alignment_attestation(_vow(), {input_id: (_summary(data), data)})
+
+
+def test_omitted_optional_reports_produce_no_records_and_no_readiness_authority():
+    report = build_codex_workcell_vow_alignment_attestation(_vow(), {})
+    assert report["attestation_records"] == []
+    assert report["attestation_gap_summary"]["not_readiness_authority"] is True
+    assert all(value is True for value in report["non_authority_posture"].values())
+    assert all(item["status"] == "future_only" and item["active"] is False and item["met"] is False for item in report["future_activation_requirements"])
+
+
+def test_supplied_vow_contract_digest_is_copied_into_attestations():
+    report = _build("architecture_json", _report())
+    assert report["attestation_records"][0]["canonical_vow_digest"] == _vow()[1]["canonical_vow_digest"]
+
+
+def test_missing_vow_contract_digest_fails_record():
+    summary, vow = _vow()
+    vow = dict(vow)
+    vow.pop("canonical_vow_digest")
+    report = build_codex_workcell_vow_alignment_attestation((summary, vow), {"architecture_json": (_summary(_report()), _report())})
+    assert report["attestation_records"][0]["alignment_status"] == "failed"
+    assert "canonical_vow_digest_missing" in report["attestation_records"][0]["violations"]
+
+
+def test_all_supported_inputs_receive_stable_constraints_and_forbidden_inferences():
+    for input_id in INPUT_IDS:
+        report = _build(input_id, _report())
+        record = report["attestation_records"][0]
+        assert record["applicable_constraint_ids"] == list(CONSTRAINT_MAP[input_id])
+        assert record["applicable_forbidden_inference_ids"] == list(FORBIDDEN_MAP[input_id])
+        assert record["alignment_status"] == "attested"
+
+
+def test_metadata_only_false_and_false_posture_fail():
+    assert _build("health_snapshot_json", _report(metadata_only=False))["attestation_records"][0]["alignment_status"] == "failed"
+    assert _build("pulse_contract_json", _report(non_authority_posture={"x": False}))["attestation_records"][0]["alignment_status"] == "failed"
+
+
+def test_active_authority_flags_fail():
+    for key in ("active_writer", "active_daemon", "active_scheduler", "active_task_creator", "active_alerting", "active_federation_consensus", "commit_authority", "pr_authority", "finalizer_bypass", "pr_metadata_guard_bypass"):
+        record = _build("daemon_recommendation_contract_json", _report(**{key: True}))["attestation_records"][0]
+        assert record["alignment_status"] == "failed"
+        assert record["active_authority_detected"] is True
+
+
+def test_missing_metadata_only_and_posture_warn():
+    record = _build("memory_contract_json", {"memory_contract_id": "m"})["attestation_records"][0]
+    assert record["alignment_status"] == "warning"
+    assert "metadata_only_missing" in record["warnings"]
+    assert "non_authority_posture_missing" in record["warnings"]
+
+
+def test_raw_byte_digest_and_size_recorded_for_supplied_input(tmp_path):
+    path = tmp_path / "report.json"
+    path.write_text('{"metadata_only":true,"non_authority_posture":{"x":true}}', encoding="utf-8")
+    summary, data = read_json_input(str(path), "architecture_json")
+    report = build_codex_workcell_vow_alignment_attestation(_vow(), {"architecture_json": (summary, data)})
+    record = report["attestation_records"][0]
+    assert record["source_digest"] == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert record["source_byte_size"] == len(path.read_bytes())
+
+
+def test_markdown_is_deterministic_and_escapes_cells():
+    data = _report(sample_report_id="pipe|newline\nvalue")
+    report = _build("memory_candidate_bundle_json", data)
+    one = render_codex_workcell_vow_alignment_attestation_markdown(report)
+    two = render_codex_workcell_vow_alignment_attestation_markdown(report)
+    assert one == two
+    assert "pipe\\|newline<br>value" in one
+
+
+def test_non_authority_flags_block_actions():
+    report = build_codex_workcell_vow_alignment_attestation(_vow(), {})
+    for key in ("vow_alignment_attestation_does_not_write_ledger", "vow_alignment_attestation_does_not_archive_glow", "vow_alignment_attestation_does_not_modify_memory", "vow_alignment_attestation_does_not_trigger_daemon", "vow_alignment_attestation_does_not_create_tasks", "vow_alignment_attestation_does_not_schedule_tasks"):
+        assert report["non_authority_posture"][key] is True
+    assert set(NON_AUTHORITY_POSTURE) == set(report["non_authority_posture"])


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only attestation bundle that binds supplied Codex workcell report artifacts to a supplied vow boundary contract digest for reviewer preflight without creating any runtime or authority effects.

### Description

- Add `sentientos/codex_workcell_vow_alignment_attestation.py` implementing `WORKCELL_VOW_ALIGNMENT_ATTESTATION_ID`, `DIGEST_ALGO`, stable report->constraint and report->forbidden-inference mappings, raw-byte SHA-256 input digesting, byte-size recording, JSON parsing/validation, per-report attestation records, coverage/gap summaries, mount alignment, future-only activation requirements, and full non-authority posture flags.
- Add CLI `scripts/build_codex_workcell_vow_alignment_attestation.py` with required `--vow-boundary-contract-json` and `--output` and optional inputs (`--architecture-json`, `--health-snapshot-json`, `--pulse-contract-json`, `--daemon-recommendation-contract-json`, `--memory-contract-json`, `--memory-candidate-bundle-json`, `--memory-candidate-verifier-json`, `--memory-activation-preflight-json`), plus `--markdown-output` and `--summary`; invalid/missing/non-object JSON produces exit code `2`.
- Add focused tests: `tests/test_codex_workcell_vow_alignment_attestation.py` (attestation logic, mapping coverage, warnings/violations, digest/byte-size recording, markdown determinism) and `tests/test_build_codex_workcell_vow_alignment_attestation_script.py` (CLI enforcement, JSON/Markdown/summary output, deterministic JSON, error exit codes).
- Add docs `docs/development/codex_workcell_vow_alignment_attestation.md` describing purpose, digest binding, mapping rules, non-authority posture and relationships to `/vow`, `/ledger`, `/glow`, `/pulse`, and `/daemon`; update adjacent docs with short boundary notes.

### Testing

- Focused unit tests `tests/test_codex_workcell_vow_alignment_attestation.py` and CLI tests `tests/test_build_codex_workcell_vow_alignment_attestation_script.py` were executed and passed.
- `mypy` type checks for the new module and CLI passed after minor fixes to signatures.
- Documentation build was run (bootstrapped docs deps as needed) and succeeded for the affected docs.
- Validation matrix was executed; matrix status passed (required failures 0, diagnostic/non-proof issues reported as diagnostics), and the landing finalizer reported `ready_to_commit` (pre-commit) and `ready_for_pr_metadata` (post-commit); the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c64eff1208320b51bfd415aed0c32)