### PR TITLE
[codex:memory] add Codex workcell storage policy contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -223,3 +223,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation boundary
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) is not a finalizer substitute. Its `attested`, `warning`, or `failed` statuses do not authorize commit or bypass finalizer decisions.
+## Workcell storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) is not finalizer authority. It must not be used to authorize commit, bypass finalizer checks, or replace current landing evidence.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -215,3 +215,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation boundary
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) can be reviewed as metadata evidence when present, but it does not recover task-owned files, create PR metadata, authorize commits, or replace recovery rail requirements.
+## Workcell storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) may describe future recovery evidence storage paths, but recovery remains governed by existing evidence artifacts and does not gain active `/ledger` or `/glow` writes from the policy.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -162,3 +162,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation boundary
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) is a metadata-only review artifact. It does not replace validation, matrix proof, supervisor decisions, finalizer readiness, PR metadata guard readiness, clean-tree checks, commits, or `make_pr`.
+## Workcell storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) is not validation, matrix, finalizer, or PR metadata guard authority. Its policy status must not be treated as readiness.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -126,3 +126,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind architecture reports to a supplied vow digest. Architecture alignment remains non-runtime metadata and does not create host, daemon, memory, commit, or PR authority.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) adds future `/ledger` and `/glow` storage policy to the workcell ladder without adding runtime authority to the architecture map.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -54,3 +54,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind daemon recommendation reports to a supplied vow digest. Recommendations remain advisory metadata and the attestation does not command or trigger daemon action.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) is future storage metadata only; daemon recommendations remain advisory and cannot invoke storage, ledger, glow, or task actions.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -68,3 +68,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind health snapshot reports to a supplied vow digest. Health alignment is reviewer metadata and does not decide readiness.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) can define future archival policy for health snapshots; health snapshots still do not decide readiness or write storage.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -42,3 +42,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may attest that activation preflight metadata is bound to a supplied vow digest. That attestation is not activation and does not authorize memory writers, watchers, daemons, or readiness.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) fills the storage path, retention, digest, and parent-chain policy descriptions as metadata only; activation preflight remains inactive and active storage remains blocked.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -63,3 +63,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind candidate bundle reports to a supplied vow digest. Candidate records remain metadata only and the attestation does not write `/ledger` or archive `/glow`.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) names future `/ledger` and `/glow` path policy for candidate records, but candidate bundles remain unwritten metadata.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -110,3 +110,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind verifier reports to a supplied vow digest. Verification remains structural metadata and the attestation does not decide readiness.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) defines future storage constraints for verified candidates without turning candidate verification into readiness, `/ledger` writes, or `/glow` archives.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -127,3 +127,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind memory contract reports to a supplied vow digest. Schema alignment remains inactive metadata and does not implement ledger writers or glow archivers.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) extends the memory schemas with future storage path, retention, digest, parent-chain, and vow-bound adoption policy while preserving the rule that schemas are not writes.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -67,3 +67,6 @@ The [Codex Workcell Vow Digest Boundary Contract](codex_workcell_vow_boundary_co
 ## Vow alignment attestation note
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) may bind pulse contract reports to a supplied vow digest. Pulse metadata remains observational and the attestation does not watch, schedule, alert, or act.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) may describe future stored pulse history policy, but pulse contracts remain non-watching, non-scheduling, and non-executing metadata.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -1,0 +1,66 @@
+# Codex Workcell Storage Policy Contract
+
+The Codex Workcell Storage Policy Contract is a deterministic, metadata-only contract for future `/ledger` and `/glow` storage implementations. It defines storage path policy, retention policy, digest verification policy, parent-chain validation policy, and vow-bound adoption requirements without performing storage work.
+
+This contract is not a writer. It does not activate memory, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide readiness, authorize commit, authorize PR metadata, create PRs, establish federation consensus, or train or modify models.
+
+## Relation to earlier workcell layers
+
+- The memory contract defines future ledger and glow schemas; this storage policy defines where and under which review constraints future writers may store those schemas.
+- The memory candidate bundle proposes candidate records; this contract does not accept, persist, or apply those candidates.
+- The memory candidate verifier checks candidate shape; this contract does not turn verification into readiness or storage authority.
+- The memory activation preflight exposes missing storage path, retention, digest, and parent-chain policies as future gaps; this contract supplies deterministic policy metadata but still leaves active storage blocked.
+- The vow boundary contract defines the canonical vow digest and forbidden inference catalog; this contract requires that digest for future storage adoption.
+- The vow alignment attestation binds supplied reports to the vow digest; this contract records whether that attestation was supplied but does not adopt it as active authority.
+
+## `/ledger` path policy
+
+Future ledger writers are limited to policy-only path patterns under `/ledger/codex/workcell/` keyed by commit SHA, PR number, or canonical vow digest. Ledger entries require source digest, parent-chain validation, vow digest, finalizer/guard non-bypass context, and operator consent.
+
+Forbidden ledger paths include absolute host paths outside `/ledger`, hidden backdoor paths, temp paths as canonical ledger storage, network paths, provider-specific opaque paths, and paths missing digest or commit/PR lineage. Forbidden write modes include appending without parent digest, overwriting without a prior receipt, writing without vow or source digest, writing without finalizer/guard context, and writing as readiness authority.
+
+## `/glow` path policy
+
+Future glow archivers are limited to policy-only path patterns under `/glow/codex/workcell/` keyed by commit SHA, PR number, or canonical vow digest, with review markdown under a commit-scoped review path. Glow archives require source digest, related ledger context, vow digest, retention hint, and operator consent.
+
+Forbidden glow paths include absolute host paths outside `/glow`, hidden backdoor paths, temp paths as canonical glow archive, network paths, provider-specific opaque paths, archive paths missing source digest, and archive paths missing vow digest. Forbidden archive modes include archiving without source digest, ledger context, vow digest, retention hint, or treating the archive as readiness authority or model-training data.
+
+## Digest verification policy
+
+The contract declares future-only digest requirements for raw byte SHA-256 input digests, source artifact digests, canonical vow digest, candidate bundle digest, candidate verifier digest, preflight digest, ledger entry parent-link digests, and glow item archive-context digests. These records are policy-only and do not verify or write anything by themselves.
+
+## Parent-chain validation policy
+
+The contract requires future active writers to carry parent entry IDs and parent entry digests after initial entries, require prior receipts before overwrite, block active writes on missing parent chains or parent digest mismatches, and never treat parent-chain validation as readiness authority.
+
+## Retention policy
+
+The contract defines policy-only retention classes for landing receipts, matrix receipts, finalizer receipts, PR guard receipts, evidence archives, doctrine archives, vow boundaries, and storage policy records. It does not delete, expire, archive, or move files.
+
+## Path scope policy
+
+The contract scopes future active storage to `/ledger` and `/glow`, forbids absolute host paths, network paths, hidden backdoor paths, and temp paths as canonical storage, and requires digest lineage and vow digest lineage. Path scope records are metadata only.
+
+## Vow adoption relationship
+
+When supplied, vow boundary and vow alignment inputs are summarized by raw-byte digest, byte size, and selected canonical digest metadata. If they are omitted, vow adoption remains future-only and unmet. Supplying these inputs does not perform adoption, activate storage, or authorize any write.
+
+## Why active storage remains blocked
+
+Active storage remains blocked because the contract intentionally reports no active writer implementation, no operator consent, no active storage harness, no active write tests, no finalizer/guard runtime binding, and no federation consensus. `active_storage_allowed_now` remains false.
+
+## Mount alignment
+
+- `/ledger`: future consumer of ledger storage policy; inactive here.
+- `/glow`: future consumer of glow storage policy; inactive here.
+- `/vow`: canonical digest required for future storage adoption.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse and recommendation context; inactive here.
+
+## Future activation requirements
+
+Future activation requires explicit active ledger writer implementation, active glow archiver implementation, storage path enforcement, retention enforcement, digest verification enforcement, parent-chain validation enforcement, operator consent, finalizer/guard runtime binding, pulse watcher contract, daemon action contract, federation drift consensus rule, tests proving no readiness authority, and docs marking active behavior. All are future-only, unmet, and inactive in this contract.
+
+## Non-authority posture
+
+The storage policy contract is read-only, metadata-only, and policy-only. It does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commit, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -41,3 +41,6 @@ Future activation remains unmet and inactive until separate contracts define exp
 ## Non-authority posture
 
 The bundle declares that it is read-only, metadata-only, attestation-only, and does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata guard, authorize commits, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) consumes vow boundary and attestation metadata as future-only storage adoption context; it does not make attestation an active writer, readiness decision, ledger write, or glow archive.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -50,3 +50,6 @@ The vow boundary contract declares that it is read-only, metadata-only, contract
 ## Vow alignment attestation boundary
 
 The [Codex Workcell Vow Alignment Attestation Bundle](codex_workcell_vow_alignment_attestation.md) can bind supplied workcell report artifacts to this contract digest for review. It remains metadata-only and does not create readiness, memory, daemon, commit, or PR metadata authority.
+## Storage policy boundary
+
+The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contract.md) requires the canonical vow digest for future `/ledger` and `/glow` adoption, but the digest remains non-authority metadata until an explicit active writer contract exists.

--- a/scripts/build_codex_workcell_storage_policy_contract.py
+++ b/scripts/build_codex_workcell_storage_policy_contract.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sentientos.codex_workcell_storage_policy_contract import (
+    CodexWorkcellStoragePolicyContractError,
+    INPUT_IDS,
+    build_codex_workcell_storage_policy_contract,
+    read_json_input,
+    render_codex_workcell_storage_policy_contract_markdown,
+    write_codex_workcell_storage_policy_contract_json,
+    write_codex_workcell_storage_policy_contract_markdown,
+)
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage policy contract.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--vow-boundary-contract-json")
+    parser.add_argument("--vow-alignment-attestation-json")
+    parser.add_argument("--memory-contract-json")
+    parser.add_argument("--memory-activation-preflight-json")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    return parser
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        inputs = {input_id: read_json_input(getattr(args, input_id), input_id) for input_id in INPUT_IDS}
+        report = build_codex_workcell_storage_policy_contract(inputs)
+    except CodexWorkcellStoragePolicyContractError as exc:
+        print(f"codex_workcell_storage_policy_contract_error: {exc}", file=sys.stderr)
+        return 2
+    write_codex_workcell_storage_policy_contract_json(report, args.output)
+    if args.markdown_output:
+        write_codex_workcell_storage_policy_contract_markdown(render_codex_workcell_storage_policy_contract_markdown(report), args.markdown_output)
+    if args.summary:
+        print(json.dumps({"storage_policy_contract_id": report["storage_policy_contract_id"], "metadata_only": True, "storage_policy_contract_only": True, "active_storage_allowed_now": report["storage_activation_gap_summary"]["active_storage_allowed_now"], "output": args.output, "markdown_output": args.markdown_output}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_policy_contract.py
+++ b/sentientos/codex_workcell_storage_policy_contract.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_POLICY_CONTRACT_ID = "codex_workcell_storage_policy_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_IDS: tuple[str, ...] = (
+    "vow_boundary_contract_json",
+    "vow_alignment_attestation_json",
+    "memory_contract_json",
+    "memory_activation_preflight_json",
+)
+
+LEDGER_RECORD_TYPES: tuple[str, ...] = (
+    "codex_landing_receipt", "matrix_receipt", "finalizer_receipt", "pr_metadata_guard_receipt",
+    "evidence_index_receipt", "appendix_provenance_receipt", "health_snapshot_receipt",
+    "pulse_contract_receipt", "daemon_recommendation_contract_receipt", "memory_contract_receipt",
+    "memory_candidate_bundle_receipt", "memory_candidate_verifier_receipt", "memory_activation_preflight_receipt",
+    "vow_boundary_contract_receipt", "vow_alignment_attestation_receipt", "storage_policy_contract_receipt",
+)
+
+GLOW_ARCHIVE_ITEM_TYPES: tuple[str, ...] = (
+    "workcell_architecture_snapshot", "workcell_health_snapshot", "pulse_contract_snapshot",
+    "daemon_recommendation_contract_snapshot", "memory_contract_snapshot", "memory_candidate_bundle_snapshot",
+    "memory_candidate_verifier_snapshot", "memory_activation_preflight_snapshot", "vow_boundary_contract_snapshot",
+    "vow_alignment_attestation_snapshot", "storage_policy_contract_snapshot", "evidence_index_snapshot",
+    "evidence_appendix_markdown", "evidence_appendix_sidecar", "doctrine_map_snapshot", "matrix_report_snapshot",
+    "finalizer_report_snapshot", "pr_metadata_guard_snapshot",
+)
+
+DIGEST_CHECKS: tuple[str, ...] = (
+    "source_artifact_digest_required", "raw_byte_sha256_required", "canonical_vow_digest_required",
+    "candidate_bundle_digest_required", "candidate_verifier_digest_required", "preflight_digest_required",
+    "ledger_entry_digest_required_for_parent_links", "glow_item_digest_required_for_archive_context",
+)
+PARENT_CHAIN_CHECKS: tuple[str, ...] = (
+    "parent_entry_id_required_after_initial_entry", "parent_entry_digest_required_after_initial_entry",
+    "overwrite_requires_prior_receipt", "missing_parent_chain_blocks_active_write",
+    "parent_digest_mismatch_blocks_active_write", "parent_chain_validation_is_not_readiness_authority",
+)
+RETENTION_CLASSES: tuple[str, ...] = (
+    "landing_receipt_retention", "matrix_receipt_retention", "finalizer_receipt_retention",
+    "pr_guard_receipt_retention", "evidence_archive_retention", "doctrine_archive_retention",
+    "vow_boundary_retention", "storage_policy_retention",
+)
+PATH_SCOPE_IDS: tuple[str, ...] = (
+    "ledger_mount_scope", "glow_mount_scope", "no_absolute_host_paths", "no_network_paths",
+    "no_hidden_backdoor_paths", "no_temp_paths_as_canonical", "digest_lineage_required", "vow_digest_lineage_required",
+)
+BLOCKING_GAP_IDS: tuple[str, ...] = (
+    "active_writer_implementation_missing", "operator_consent_missing", "active_storage_harness_missing",
+    "active_write_tests_missing", "finalizer_guard_runtime_binding_missing", "federation_consensus_missing",
+)
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit active ledger writer implementation", "explicit active glow archiver implementation",
+    "explicit storage path enforcement", "explicit retention enforcement", "explicit digest verification enforcement",
+    "explicit parent-chain validation enforcement", "explicit operator consent", "explicit finalizer/guard runtime binding",
+    "explicit pulse watcher contract", "explicit daemon action contract", "explicit federation drift consensus rule",
+    "tests proving no readiness authority", "docs marking active behavior",
+)
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "storage_policy_contract_is_read_only": True,
+    "storage_policy_contract_is_metadata_only": True,
+    "storage_policy_contract_is_policy_only": True,
+    "storage_policy_contract_does_not_activate_memory": True,
+    "storage_policy_contract_does_not_write_ledger": True,
+    "storage_policy_contract_does_not_archive_glow": True,
+    "storage_policy_contract_does_not_modify_memory": True,
+    "storage_policy_contract_does_not_watch_files": True,
+    "storage_policy_contract_does_not_poll_state": True,
+    "storage_policy_contract_does_not_rerun_commands": True,
+    "storage_policy_contract_does_not_decide_readiness": True,
+    "storage_policy_contract_does_not_bypass_finalizer": True,
+    "storage_policy_contract_does_not_bypass_pr_metadata_guard": True,
+    "storage_policy_contract_does_not_authorize_commit": True,
+    "storage_policy_contract_does_not_authorize_pr_creation": True,
+    "storage_policy_contract_does_not_trigger_daemon": True,
+    "storage_policy_contract_does_not_create_tasks": True,
+    "storage_policy_contract_does_not_schedule_tasks": True,
+    "storage_policy_contract_does_not_send_alerts": True,
+    "storage_policy_contract_does_not_train_or_modify_models": True,
+    "storage_policy_contract_does_not_establish_federation_consensus": True,
+}
+FORBIDDEN_INFERENCE = "Do not infer active storage, readiness, memory mutation, daemon action, task creation, model training, finalizer bypass, PR metadata authority, or federation consensus from this policy metadata."
+
+class CodexWorkcellStoragePolicyContractError(ValueError):
+    pass
+
+def _omitted() -> dict[str, Any]:
+    return {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str | None, input_id: str) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    if path_text is None:
+        return _omitted(), None
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStoragePolicyContractError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStoragePolicyContractError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellStoragePolicyContractError(f"json_not_object:{input_id}:{path_text}")
+    return {"provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _count_list(data: Mapping[str, Any] | None, key: str) -> int | None:
+    value = data.get(key) if data else None
+    return len(value) if isinstance(value, list) else None
+
+def _vow_adoption_summary(inputs: Mapping[str, tuple[Mapping[str, Any], Mapping[str, Any] | None]]) -> dict[str, Any]:
+    vb_sum, vb = inputs["vow_boundary_contract_json"]
+    va_sum, va = inputs["vow_alignment_attestation_json"]
+    records = va.get("attestation_records") if va else None
+    return {
+        "vow_boundary_contract": ({"provided": False, "vow_adoption_policy": "future_only_unmet"} if not vb_sum.get("provided") else {
+            "provided": True, "vow_boundary_contract_id": vb.get("vow_boundary_contract_id") if vb else None,
+            "canonical_vow_digest": vb.get("canonical_vow_digest") if vb else None,
+            "canonical_vow_digest_algo": vb.get("canonical_vow_digest_algo") if vb else None,
+            "canonical_constraint_count": _count_list(vb, "canonical_vow_constraints"),
+            "forbidden_inference_count": _count_list(vb, "forbidden_inference_catalog"),
+            "source_digest": vb_sum.get("digest"), "source_digest_algo": vb_sum.get("digest_algo"), "source_byte_size": vb_sum.get("byte_size"),
+        }),
+        "vow_alignment_attestation": ({"provided": False, "vow_adoption_policy": "future_only_unmet"} if not va_sum.get("provided") else {
+            "provided": True, "vow_alignment_attestation_id": va.get("vow_alignment_attestation_id") if va else None,
+            "canonical_vow_digest": va.get("canonical_vow_digest") if va else None,
+            "attestation_record_count": len(records) if isinstance(records, list) else None,
+            "failed_attestation_count": (va.get("attestation_gap_summary", {}) or {}).get("failed_attestation_count") if va else None,
+            "warning_attestation_count": (va.get("attestation_gap_summary", {}) or {}).get("warning_attestation_count") if va else None,
+            "source_digest": va_sum.get("digest"), "source_digest_algo": va_sum.get("digest_algo"), "source_byte_size": va_sum.get("byte_size"),
+        }),
+        "policy_status": "future_only_unmet" if not (vb_sum.get("provided") and va_sum.get("provided")) else "vow_bound_inputs_supplied_for_review_only",
+        "adoption_not_performed": True,
+    }
+
+def _records(ids: tuple[str, ...], id_key: str, **extra: Any) -> list[dict[str, Any]]:
+    return [{id_key: item, **extra, "forbidden_inference": FORBIDDEN_INFERENCE, "reviewer_summary": f"{item} is a policy-only requirement for a future active writer; inactive here."} for item in ids]
+
+def build_codex_workcell_storage_policy_contract(inputs: Mapping[str, tuple[Mapping[str, Any], Mapping[str, Any] | None]] | None = None) -> dict[str, Any]:
+    normalized = {input_id: (dict(inputs[input_id][0]), inputs[input_id][1]) if inputs and input_id in inputs else (_omitted(), None) for input_id in INPUT_IDS}
+    return {
+        "storage_policy_contract_id": WORKCELL_STORAGE_POLICY_CONTRACT_ID,
+        "metadata_only": True, "storage_policy_contract_only": True,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True,
+        "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True,
+        "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {key: value[0] for key, value in sorted(normalized.items())},
+        "vow_adoption_summary": _vow_adoption_summary(normalized),
+        "ledger_storage_policy": {"policy_id": "codex_workcell_ledger_storage_policy.v1", "mount": "/ledger", "policy_only": True, "write_not_performed": True, "allowed_record_types": list(LEDGER_RECORD_TYPES), "required_source_digest": True, "required_parent_chain_validation": True, "required_vow_digest": True, "required_finalizer_guard_non_bypass": True, "required_operator_consent": True, "allowed_path_patterns": ["/ledger/codex/workcell/{commit_sha}/{record_type}.json", "/ledger/codex/workcell/{pr_number}/{record_type}.json", "/ledger/codex/workcell/{canonical_vow_digest}/{record_type}.json"], "forbidden_path_patterns": ["absolute host paths outside declared mount", "hidden backdoor paths", "temp paths as canonical ledger storage", "network paths", "provider-specific opaque paths", "paths missing digest or commit/pr lineage"], "forbidden_write_modes": ["append_without_parent_digest", "overwrite_without_prior_receipt", "write_without_vow_digest", "write_without_source_digest", "write_without_finalizer_guard_context", "write_as_readiness_authority"], "reviewer_summary": "Static future /ledger policy only; no ledger write is performed."},
+        "glow_storage_policy": {"policy_id": "codex_workcell_glow_storage_policy.v1", "mount": "/glow", "policy_only": True, "archive_not_performed": True, "allowed_archive_item_types": list(GLOW_ARCHIVE_ITEM_TYPES), "required_source_digest": True, "required_related_ledger_entry": True, "required_vow_digest": True, "required_retention_hint": True, "required_operator_consent": True, "allowed_path_patterns": ["/glow/codex/workcell/{commit_sha}/{archive_item_type}.json", "/glow/codex/workcell/{pr_number}/{archive_item_type}.json", "/glow/codex/workcell/{canonical_vow_digest}/{archive_item_type}.json", "/glow/codex/workcell/{commit_sha}/review/{archive_item_type}.md"], "forbidden_path_patterns": ["absolute host paths outside declared mount", "hidden backdoor paths", "temp paths as canonical glow archive", "network paths", "provider-specific opaque paths", "archive paths missing source digest", "archive paths missing vow digest"], "forbidden_archive_modes": ["archive_without_source_digest", "archive_without_related_ledger_context", "archive_without_vow_digest", "archive_without_retention_hint", "archive_as_readiness_authority", "archive_as_model_training_data"], "reviewer_summary": "Static future /glow policy only; no glow archive is performed."},
+        "digest_verification_policy": _records(DIGEST_CHECKS, "verification_id", digest_algo=DIGEST_ALGO, required=True, policy_only=True),
+        "parent_chain_validation_policy": _records(PARENT_CHAIN_CHECKS, "validation_id", required_for_active_writer=True, policy_only=True),
+        "retention_policy": _records(RETENTION_CLASSES, "retention_id", retention_scope="future_codex_workcell_storage", retention_hint="retain until explicit future retention authority defines disposal", policy_only=True, deletion_not_performed=True),
+        "path_scope_policy": _records(PATH_SCOPE_IDS, "path_scope_id", applies_to_mounts=["/ledger", "/glow"], allowed=False, policy_only=True),
+        "storage_activation_gap_summary": {"vow_boundary_contract_supplied": bool(normalized["vow_boundary_contract_json"][0].get("provided")), "vow_alignment_attestation_supplied": bool(normalized["vow_alignment_attestation_json"][0].get("provided")), "memory_contract_supplied": bool(normalized["memory_contract_json"][0].get("provided")), "activation_preflight_supplied": bool(normalized["memory_activation_preflight_json"][0].get("provided")), "storage_policy_contract_only": True, "active_writer_implementation_present": False, "operator_consent_present": False, "ledger_write_performed": False, "glow_archive_performed": False, "memory_mutation_performed": False, "active_storage_allowed_now": False, "blocking_gap_ids": list(BLOCKING_GAP_IDS)},
+        "sentientos_mount_alignment": {"/ledger": "future consumer of ledger storage policy; inactive here", "/glow": "future consumer of glow storage policy; inactive here", "/vow": "canonical digest required for future storage adoption", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here"},
+        "future_activation_requirements": [{"requirement": req, "status": "future_only", "met": False, "active": False} for req in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(sorted(NON_AUTHORITY_POSTURE.items())),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else ("" if value is None else str(value))
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")
+
+def render_codex_workcell_storage_policy_contract_markdown(report: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Storage Policy Contract", "", "Deterministic metadata-only storage policy for future /ledger and /glow writers. It is not a writer, archiver, watcher, scheduler, readiness decision, daemon action, task creator, model trainer, or federation consensus mechanism.", "", "## Input summaries", "| input | provided | path | digest | byte_size |", "| --- | --- | --- | --- | --- |"]
+    for key, value in sorted(report["input_summaries"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value.get('provided'))} | {_cell(value.get('path'))} | {_cell(value.get('digest'))} | {_cell(value.get('byte_size'))} |")
+    sections = (("Vow adoption summary", "vow_adoption_summary"), ("Ledger storage policy", "ledger_storage_policy"), ("Glow storage policy", "glow_storage_policy"), ("Storage activation gap summary", "storage_activation_gap_summary"))
+    for title, key in sections:
+        lines += ["", f"## {title}", f"`{_cell(report[key])}`"]
+    for title, key, id_key in (("Digest verification policy", "digest_verification_policy", "verification_id"), ("Parent-chain validation policy", "parent_chain_validation_policy", "validation_id"), ("Retention policy", "retention_policy", "retention_id"), ("Path scope policy", "path_scope_policy", "path_scope_id")):
+        lines += ["", f"## {title}", f"| {id_key} | summary |", "| --- | --- |"]
+        for item in report[key]:
+            lines.append(f"| {_cell(item[id_key])} | {_cell(item['reviewer_summary'])} |")
+    lines += ["", "## SentientOS mount alignment", "| mount | alignment |", "| --- | --- |"]
+    for key, value in sorted(report["sentientos_mount_alignment"].items()):
+        lines.append(f"| {_cell(key)} | {_cell(value)} |")
+    lines += ["", "## Future activation requirements", "| requirement | status | met | active |", "| --- | --- | --- | --- |"]
+    for item in report["future_activation_requirements"]:
+        lines.append(f"| {_cell(item['requirement'])} | {_cell(item['status'])} | {_cell(item['met'])} | {_cell(item['active'])} |")
+    lines += ["", "## Non-authority posture"] + [f"- **{key}:** {str(value).lower()}" for key, value in sorted(report["non_authority_posture"].items())]
+    lines.append("")
+    return "\n".join(lines)
+
+def write_codex_workcell_storage_policy_contract_json(report: Mapping[str, Any], output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def write_codex_workcell_storage_policy_contract_markdown(markdown: str, output: str) -> None:
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(output).write_text(markdown, encoding="utf-8")

--- a/tests/test_build_codex_workcell_storage_policy_contract_script.py
+++ b/tests/test_build_codex_workcell_storage_policy_contract_script.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+import subprocess
+import sys
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "scripts/build_codex_workcell_storage_policy_contract.py", *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path) -> None:
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = run_cli("--output", str(output), "--markdown-output", str(markdown), "--summary")
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["storage_policy_contract_id"] == "codex_workcell_storage_policy_contract.v1"
+    assert report["storage_activation_gap_summary"]["active_storage_allowed_now"] is False
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Policy Contract")
+    summary = json.loads(result.stdout)
+    assert summary["storage_policy_contract_only"] is True
+
+
+def test_cli_json_output_is_deterministic(tmp_path) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    assert run_cli("--output", str(first)).returncode == 0
+    assert run_cli("--output", str(second)).returncode == 0
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_cli_markdown_output_is_deterministic(tmp_path) -> None:
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    assert run_cli("--output", str(tmp_path / "a.json"), "--markdown-output", str(first)).returncode == 0
+    assert run_cli("--output", str(tmp_path / "b.json"), "--markdown-output", str(second)).returncode == 0
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_cli_invalid_json_missing_path_and_non_object_exit_2(tmp_path) -> None:
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{not-json", encoding="utf-8")
+    missing = tmp_path / "missing.json"
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    assert run_cli("--output", str(output), "--vow-boundary-contract-json", str(invalid)).returncode == 2
+    assert run_cli("--output", str(output), "--vow-boundary-contract-json", str(missing)).returncode == 2
+    assert run_cli("--output", str(output), "--vow-boundary-contract-json", str(array)).returncode == 2
+
+
+def test_cli_records_supplied_input_digest(tmp_path) -> None:
+    vow = tmp_path / "vow.json"
+    vow.write_text(json.dumps({"vow_boundary_contract_id": "v", "canonical_vow_digest": "d"}, sort_keys=True), encoding="utf-8")
+    output = tmp_path / "out.json"
+    result = run_cli("--output", str(output), "--vow-boundary-contract-json", str(vow))
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["input_summaries"]["vow_boundary_contract_json"]["provided"] is True
+    assert report["input_summaries"]["vow_boundary_contract_json"]["byte_size"] == len(vow.read_bytes())

--- a/tests/test_codex_workcell_storage_policy_contract.py
+++ b/tests/test_codex_workcell_storage_policy_contract.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_policy_contract import (
+    DIGEST_CHECKS,
+    GLOW_ARCHIVE_ITEM_TYPES,
+    LEDGER_RECORD_TYPES,
+    PARENT_CHAIN_CHECKS,
+    PATH_SCOPE_IDS,
+    RETENTION_CLASSES,
+    WORKCELL_STORAGE_POLICY_CONTRACT_ID,
+    build_codex_workcell_storage_policy_contract,
+    read_json_input,
+    render_codex_workcell_storage_policy_contract_markdown,
+)
+
+
+def test_contract_shape_and_required_policy_catalogs() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    assert report["storage_policy_contract_id"] == WORKCELL_STORAGE_POLICY_CONTRACT_ID
+    for key in ("metadata_only", "storage_policy_contract_only", "not_runtime_authority", "not_memory_writer", "not_ledger_writer", "not_glow_archiver", "not_daemon_action"):
+        assert report[key] is True
+    assert set(LEDGER_RECORD_TYPES) <= set(report["ledger_storage_policy"]["allowed_record_types"])
+    assert set(GLOW_ARCHIVE_ITEM_TYPES) <= set(report["glow_storage_policy"]["allowed_archive_item_types"])
+    assert {r["verification_id"] for r in report["digest_verification_policy"]} == set(DIGEST_CHECKS)
+    assert {r["validation_id"] for r in report["parent_chain_validation_policy"]} == set(PARENT_CHAIN_CHECKS)
+    assert {r["retention_id"] for r in report["retention_policy"]} == set(RETENTION_CLASSES)
+    assert {r["path_scope_id"] for r in report["path_scope_policy"]} == set(PATH_SCOPE_IDS)
+
+
+def test_storage_remains_inactive_and_non_authoritative() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    gap = report["storage_activation_gap_summary"]
+    assert gap["active_storage_allowed_now"] is False
+    assert gap["active_writer_implementation_present"] is False
+    assert gap["operator_consent_present"] is False
+    assert gap["ledger_write_performed"] is False
+    assert gap["glow_archive_performed"] is False
+    assert gap["memory_mutation_performed"] is False
+    assert all(value is True for value in report["non_authority_posture"].values())
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in report["future_activation_requirements"])
+
+
+def test_path_scope_blocks_host_network_backdoor_and_temp_paths() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    ledger_forbidden = report["ledger_storage_policy"]["forbidden_path_patterns"]
+    glow_forbidden = report["glow_storage_policy"]["forbidden_path_patterns"]
+    for phrase in ("absolute host paths outside declared mount", "hidden backdoor paths", "network paths"):
+        assert phrase in ledger_forbidden
+        assert phrase in glow_forbidden
+    assert "temp paths as canonical ledger storage" in ledger_forbidden
+    assert "temp paths as canonical glow archive" in glow_forbidden
+
+
+def test_supplied_vow_inputs_record_raw_byte_digest_and_size(tmp_path) -> None:
+    boundary = {"vow_boundary_contract_id": "vow", "canonical_vow_digest": "abc", "canonical_vow_digest_algo": "sha256", "canonical_vow_constraints": [{"constraint_id": "c"}], "forbidden_inference_catalog": [{"inference_id": "f"}]}
+    attestation = {"vow_alignment_attestation_id": "att", "canonical_vow_digest": "abc", "attestation_records": [{"alignment_status": "attested"}], "attestation_gap_summary": {"failed_attestation_count": 0, "warning_attestation_count": 0}}
+    boundary_path = tmp_path / "boundary.json"
+    attestation_path = tmp_path / "attestation.json"
+    boundary_path.write_text(json.dumps(boundary, sort_keys=True), encoding="utf-8")
+    attestation_path.write_text(json.dumps(attestation, sort_keys=True), encoding="utf-8")
+    inputs = {
+        "vow_boundary_contract_json": read_json_input(str(boundary_path), "vow_boundary_contract_json"),
+        "vow_alignment_attestation_json": read_json_input(str(attestation_path), "vow_alignment_attestation_json"),
+    }
+    report = build_codex_workcell_storage_policy_contract(inputs)
+    assert report["input_summaries"]["vow_boundary_contract_json"]["digest"] == hashlib.sha256(boundary_path.read_bytes()).hexdigest()
+    assert report["input_summaries"]["vow_boundary_contract_json"]["byte_size"] == len(boundary_path.read_bytes())
+    assert report["input_summaries"]["vow_alignment_attestation_json"]["digest"] == hashlib.sha256(attestation_path.read_bytes()).hexdigest()
+    assert report["input_summaries"]["vow_alignment_attestation_json"]["byte_size"] == len(attestation_path.read_bytes())
+    assert report["vow_adoption_summary"]["vow_boundary_contract"]["canonical_constraint_count"] == 1
+    assert report["vow_adoption_summary"]["vow_alignment_attestation"]["attestation_record_count"] == 1
+
+
+def test_omitted_inputs_are_represented_false() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    for summary in report["input_summaries"].values():
+        assert summary == {"provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+    assert report["vow_adoption_summary"]["policy_status"] == "future_only_unmet"
+
+
+def test_contract_does_not_grant_runtime_or_storage_authority() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    posture = report["non_authority_posture"]
+    for suffix in ("does_not_decide_readiness", "does_not_write_ledger", "does_not_archive_glow", "does_not_modify_memory", "does_not_trigger_daemon", "does_not_create_tasks", "does_not_schedule_tasks"):
+        assert posture[f"storage_policy_contract_{suffix}"] is True
+
+
+def test_markdown_escaping_handles_pipes_and_newlines() -> None:
+    report = build_codex_workcell_storage_policy_contract()
+    report["sentientos_mount_alignment"]["/ledger"] = "pipe | and\nnewline"
+    markdown = render_codex_workcell_storage_policy_contract_markdown(report)
+    assert "pipe \\| and<br>newline" in markdown


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only storage policy contract that defines future `/ledger` and `/glow` path policy, retention, digest verification, parent-chain validation, and vow-bound adoption rules without performing any storage or runtime actions.
- Surface activation gaps (operator consent, active writer implementations, finalizer bindings, federation consensus, etc.) so future writers/archivers can adopt policy safely while preserving non-authority posture.

### Description

- Add a new contract module `sentientos/codex_workcell_storage_policy_contract.py` implementing `WORKCELL_STORAGE_POLICY_CONTRACT_ID = "codex_workcell_storage_policy_contract.v1"`, `DIGEST_ALGO = "sha256"`, input summaries, vow adoption summary, `ledger_storage_policy`, `glow_storage_policy`, `digest_verification_policy`, `parent_chain_validation_policy`, `retention_policy`, `path_scope_policy`, `storage_activation_gap_summary`, mount alignment, future activation requirements, and full non-authority flags.
- Add CLI builder `scripts/build_codex_workcell_storage_policy_contract.py` that accepts `--output` (required), optional `--vow-boundary-contract-json`, `--vow-alignment-attestation-json`, `--memory-contract-json`, `--memory-activation-preflight-json`, optional `--markdown-output`, and `--summary`; it reads raw bytes, computes SHA-256, records byte size, parses JSON objects, fails with exit code `2` on missing/invalid/non-object inputs, and writes deterministic JSON and optional Markdown (with table-cell escaping).
- Add focused tests `tests/test_codex_workcell_storage_policy_contract.py` and `tests/test_build_codex_workcell_storage_policy_contract_script.py` covering contract shape, allowed record/archive types, digest/parent/retention/path policies, omitted vs supplied input summaries, deterministic JSON/Markdown outputs, CLI failure modes, and Markdown escaping.
- Add `docs/development/codex_workcell_storage_policy_contract.md` documenting purpose, boundary rules, `/ledger` and `/glow` path policies, digest verification, parent-chain validation, retention, path-scope, vow adoption relationship, why active storage remains blocked, mount alignment, future activation requirements, and non-authority posture; and add short boundary references into adjacent workcell docs.

### Testing

- Ran the focused test lanes: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_policy_contract.py tests/test_build_codex_workcell_storage_policy_contract_script.py`; tests passed (deterministic output, input digest recording, omission handling, CLI exit codes, Markdown escaping).
- Ran adjacent workcell focused test suites, docs build and bootstrap: `python scripts/build_docs.py --bootstrap-docs`, `python scripts/build_docs.py --check-deps`, `python scripts/build_docs.py`; docs built successfully after bootstrapping.
- Type checking and validation: `python -m mypy sentientos/codex_workcell_storage_policy_contract.py scripts/build_codex_workcell_storage_policy_contract.py` passed; `python scripts/verify_context_hygiene_prompt_boundaries.py` returned clean.
- Full landing validation performed: the work-item review matrix was generated, the finalizer pre-commit reported `ready_to_commit`, the post-commit/pr-metadata finalizer reported `ready_for_pr_metadata`, and the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ca4cb00c08320be4c114ebfa939fb)