### PR TITLE
[codex:memory] add Codex workcell storage transaction dry-run planner

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -230,3 +230,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -222,3 +222,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -169,3 +169,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -133,3 +133,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -61,3 +61,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -75,3 +75,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -49,3 +49,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -70,3 +70,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -117,3 +117,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -134,3 +134,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -74,3 +74,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -68,3 +68,6 @@ The storage policy contract is read-only, metadata-only, and policy-only. It doe
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -37,3 +37,6 @@ Active storage still requires explicit ledger writer implementation, glow archiv
 ## Non-authority posture
 
 The verifier is read-only, metadata-only, and verifier-only. It does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer, bypass PR metadata guard, authorize commit, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -1,0 +1,55 @@
+# Codex Workcell Storage Transaction Dry-Run Plan
+
+The Codex Workcell Storage Transaction Dry-Run Planner is a deterministic, metadata-only planner for future `/ledger` and `/glow` storage transactions. It reads supplied storage policy, storage policy verifier, memory candidate bundle, memory candidate verifier, vow boundary, and vow alignment reports, then emits would-write and would-archive plans without writing anything.
+
+The planner is not a writer or archiver. It does not activate memory, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide readiness, authorize commit, authorize PR metadata, create PRs, establish federation consensus, or train or modify models.
+
+## Policy, verifier, and transaction plan boundaries
+
+- The [storage policy contract](codex_workcell_storage_policy_contract.md) defines future-only path, digest, retention, parent-chain, consent, and mount rules.
+- The [storage policy verifier](codex_workcell_storage_policy_verifier.md) checks the supplied policy structure and confirms that active storage remains blocked.
+- This transaction plan consumes those supplied reports plus candidate and vow reports to describe exact future `/ledger` and `/glow` operations an explicitly separate active writer would need to perform later.
+
+A dry-run transaction plan is not readiness authority and cannot replace the finalizer, PR metadata guard, validation matrix, operator consent, or active writer implementation.
+
+## Candidate records to planned transactions
+
+Each `candidate_ledger_entries` item from the memory candidate bundle becomes one `ledger_write_candidate` plan with a deterministic transaction ID, source input ID, source artifact digest metadata, parent-chain context, canonical vow digest context, and `write_performed: false`.
+
+Each `candidate_glow_items` item becomes one `glow_archive_candidate` plan with a deterministic transaction ID, source input ID, source digest metadata, related candidate ledger entry context, retention requirement, canonical vow digest context, and `archive_performed: false`.
+
+## Planned path selection
+
+The planner uses allowed path templates declared by the supplied storage policy. It prefers templates in this order:
+
+1. `commit_sha`, when supplied;
+2. `pr_number`, when supplied;
+3. `canonical_vow_digest`, when available from CLI, vow boundary, or vow attestation.
+
+If none of those values are available, `planned_path` is `null` and the transaction records a blocking path gap. The planner never constructs absolute host paths, network paths, provider-opaque paths, temp canonical paths, or hidden backdoor paths.
+
+## Gaps and validations
+
+The plan reports path validation, digest validation, parent-chain planning, vow alignment, and an aggregate transaction gap summary. Missing source digests, missing parent context, unverified storage policy, unverified candidate bundle, failed vow alignment, forbidden paths, missing operator consent, missing finalizer/guard runtime binding, and missing active writer implementation remain blocking gaps for any future active write.
+
+Parent-chain context is planned but never written. Digest status is summarized but not enforced as an active storage operation. Vow alignment is checked for planning only and performs no vow adoption.
+
+## Reviewer URL hygiene
+
+The reviewer hygiene summary records that bad OpenAI-owned SentientOS repository attribution is expected to be absent and that the correct clone URL is `https://github.com/Zombinator85/SentientOS.git`. Repository grep validation remains part of the landing task, not runtime planner behavior, and legitimate OpenAI API/model/ChatGPT/Codex references remain outside this planner's authority.
+
+## Mount alignment
+
+- `/ledger`: dry-run transaction planning only; no ledger write.
+- `/glow`: dry-run transaction planning only; no archive write.
+- `/vow`: canonical digest context for transaction constraints.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+
+## Future activation requirements
+
+Future activation requires explicit active ledger writer implementation, active glow archiver implementation, storage path enforcement, retention enforcement, digest verification enforcement, parent-chain validation enforcement, operator consent, finalizer/guard runtime binding, pulse watcher contract, daemon action contract, federation drift consensus rule, tests proving no readiness authority, and docs marking active behavior. All are future-only, unmet, and inactive in this planner.
+
+## Non-authority posture
+
+The storage transaction plan is read-only, metadata-only, and dry-run-only. It does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer, bypass PR metadata guard, authorize commit, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -48,3 +48,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -57,3 +57,6 @@ The [Codex Workcell Storage Policy Contract](codex_workcell_storage_policy_contr
 ## Storage policy verifier boundary
 
 See [Codex Workcell Storage Policy Verifier](codex_workcell_storage_policy_verifier.md) for the metadata-only structural verifier for storage policy contracts. Its verification status is not readiness authority and it does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, schedule tasks, or bypass finalizer/PR metadata guard requirements.
+## Storage transaction dry-run planner boundary
+
+The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_transaction_plan.md) is the next metadata-only layer for supplied storage policy, candidate, verifier, and vow reports. It emits future `/ledger` and `/glow` would-write plans only; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, or create PRs.

--- a/scripts/build_codex_workcell_storage_transaction_plan.py
+++ b/scripts/build_codex_workcell_storage_transaction_plan.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_transaction_plan import (
+    CodexWorkcellStorageTransactionPlanError,
+    build_codex_workcell_storage_transaction_plan,
+    read_json_input,
+    render_codex_workcell_storage_transaction_plan_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage transaction dry-run plan.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--storage-policy-contract-json", required=True)
+    parser.add_argument("--storage-policy-verifier-json", required=True)
+    parser.add_argument("--memory-candidate-bundle-json", required=True)
+    parser.add_argument("--memory-candidate-verifier-json", required=True)
+    parser.add_argument("--vow-boundary-contract-json", required=True)
+    parser.add_argument("--vow-alignment-attestation-json", required=True)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--canonical-vow-digest")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        inputs = {}
+        data = {}
+        for attr, input_id in (
+            ("storage_policy_contract_json", "storage_policy_contract_json"), ("storage_policy_verifier_json", "storage_policy_verifier_json"),
+            ("memory_candidate_bundle_json", "memory_candidate_bundle_json"), ("memory_candidate_verifier_json", "memory_candidate_verifier_json"),
+            ("vow_boundary_contract_json", "vow_boundary_contract_json"), ("vow_alignment_attestation_json", "vow_alignment_attestation_json"),
+        ):
+            summary, loaded = read_json_input(getattr(args, attr), input_id)
+            inputs[input_id] = summary
+            data[input_id] = loaded
+        plan = build_codex_workcell_storage_transaction_plan(
+            storage_policy_contract=data["storage_policy_contract_json"], storage_policy_verifier=data["storage_policy_verifier_json"],
+            memory_candidate_bundle=data["memory_candidate_bundle_json"], memory_candidate_verifier=data["memory_candidate_verifier_json"],
+            vow_boundary_contract=data["vow_boundary_contract_json"], vow_alignment_attestation=data["vow_alignment_attestation_json"], input_summaries=inputs,
+            commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title, canonical_vow_digest=args.canonical_vow_digest,
+        )
+    except CodexWorkcellStorageTransactionPlanError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(plan, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_transaction_plan_markdown(plan), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_transaction_plan_id": plan["storage_transaction_plan_id"], "planned_ledger_transaction_count": len(plan["ledger_transaction_plan"]), "planned_glow_transaction_count": len(plan["glow_transaction_plan"]), "blocking_gap_count": plan["transaction_gap_summary"]["blocking_gap_count"], "active_storage_allowed_now": plan["transaction_gap_summary"]["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_transaction_plan.py
+++ b/sentientos/codex_workcell_storage_transaction_plan.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_TRANSACTION_PLAN_ID = "codex_workcell_storage_transaction_plan.v1"
+DIGEST_ALGO = "sha256"
+AUTHORITY_BOUNDARY = "Storage transaction plan is deterministic metadata only; it does not activate memory, write ledger entries, archive glow evidence, mutate memory, watch, poll, run commands, schedule, alert, create tasks, trigger daemons, decide readiness, authorize commit or PR metadata, train models, or establish federation consensus."
+FORBIDDEN_INFERENCE = "Do not infer active storage, readiness, commit authority, PR metadata authority, daemon action, task creation, model training, or federation consensus from this dry-run transaction plan."
+FUTURE_REQUIREMENT_NAMES: tuple[str, ...] = (
+    "explicit active ledger writer implementation", "explicit active glow archiver implementation", "explicit storage path enforcement", "explicit retention enforcement",
+    "explicit digest verification enforcement", "explicit parent-chain validation enforcement", "explicit operator consent", "explicit finalizer/guard runtime binding",
+    "explicit pulse watcher contract", "explicit daemon action contract", "explicit federation drift consensus rule", "tests proving no readiness authority", "docs marking active behavior",
+)
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "storage_transaction_plan_is_read_only": True, "storage_transaction_plan_is_metadata_only": True, "storage_transaction_plan_is_dry_run_only": True,
+    "storage_transaction_plan_does_not_activate_memory": True, "storage_transaction_plan_does_not_write_ledger": True, "storage_transaction_plan_does_not_archive_glow": True,
+    "storage_transaction_plan_does_not_modify_memory": True, "storage_transaction_plan_does_not_watch_files": True, "storage_transaction_plan_does_not_poll_state": True,
+    "storage_transaction_plan_does_not_rerun_commands": True, "storage_transaction_plan_does_not_decide_readiness": True, "storage_transaction_plan_does_not_bypass_finalizer": True,
+    "storage_transaction_plan_does_not_bypass_pr_metadata_guard": True, "storage_transaction_plan_does_not_authorize_commit": True, "storage_transaction_plan_does_not_authorize_pr_creation": True,
+    "storage_transaction_plan_does_not_trigger_daemon": True, "storage_transaction_plan_does_not_create_tasks": True, "storage_transaction_plan_does_not_schedule_tasks": True,
+    "storage_transaction_plan_does_not_send_alerts": True, "storage_transaction_plan_does_not_train_or_modify_models": True, "storage_transaction_plan_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellStorageTransactionPlanError(ValueError):
+    pass
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], Mapping[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageTransactionPlanError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageTransactionPlanError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise CodexWorkcellStorageTransactionPlanError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+def _stable_id(*parts: Any) -> str:
+    raw = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+def _get(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = mapping.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+def _derive_canonical_vow_digest(vow_boundary: Mapping[str, Any], vow_attestation: Mapping[str, Any], explicit: str | None) -> tuple[str | None, str | None]:
+    if explicit:
+        return explicit, "cli"
+    for source, data in (("vow_boundary_contract", vow_boundary), ("vow_alignment_attestation", vow_attestation)):
+        value = _get(data, "canonical_vow_digest", "vow_digest")
+        if isinstance(value, str) and value:
+            return value, source
+        for key in ("vow_boundary_summary", "vow_alignment_summary", "planning_context"):
+            nested = data.get(key)
+            if isinstance(nested, Mapping):
+                value = _get(nested, "canonical_vow_digest", "vow_digest")
+                if isinstance(value, str) and value:
+                    return value, f"{source}.{key}"
+    return None, None
+
+def _status(data: Mapping[str, Any], *keys: str) -> Any:
+    direct = _get(data, *keys)
+    if direct is not None:
+        return direct
+    for value in data.values():
+        if isinstance(value, Mapping):
+            found = _get(value, *keys)
+            if found is not None:
+                return found
+    return None
+
+def _count(data: Mapping[str, Any], *keys: str) -> int | None:
+    value = _status(data, *keys)
+    return int(value) if isinstance(value, int) else None
+
+def _verified_storage(status: Any) -> bool:
+    return status in ("storage_policy_verified", "verified", "passed", True)
+
+def _verified_candidate(status: Any) -> bool:
+    return status in ("memory_candidate_bundle_verified", "verified", "passed", True)
+
+def _templates(policy: Mapping[str, Any], section: str) -> list[str]:
+    value = policy.get(section)
+    if not isinstance(value, Mapping):
+        return []
+    return [str(item) for item in _as_list(value.get("allowed_path_patterns")) if isinstance(item, str)]
+
+def _safe_path(path: str, mount: str) -> bool:
+    if not path.startswith(f"{mount}/"):
+        return False
+    lowered = path.lower()
+    return not (path.startswith("//") or re.match(r"^[A-Za-z]:", path) or "://" in path or "/tmp/" in lowered or "/temp/" in lowered or "/." in path or ".." in path or "backdoor" in lowered or "provider" in lowered)
+
+def _plan_path(templates: list[str], mount: str, context: Mapping[str, Any], type_key: str, type_value: Any) -> tuple[str | None, str | None, bool]:
+    preferences = (("commit_sha", context.get("commit_sha")), ("pr_number", context.get("pr_number")), ("canonical_vow_digest", context.get("canonical_vow_digest")))
+    for key, value in preferences:
+        if value in (None, ""):
+            continue
+        for template in templates:
+            if "{" + key + "}" not in template:
+                continue
+            try:
+                path = template.format(commit_sha=context.get("commit_sha"), pr_number=context.get("pr_number"), canonical_vow_digest=context.get("canonical_vow_digest"), record_type=type_value, archive_item_type=type_value)
+            except KeyError:
+                continue
+            if _safe_path(path, mount):
+                return path, template, False
+            return None, template, True
+    return None, None, False
+
+def build_codex_workcell_storage_transaction_plan(*, storage_policy_contract: Mapping[str, Any], storage_policy_verifier: Mapping[str, Any], memory_candidate_bundle: Mapping[str, Any], memory_candidate_verifier: Mapping[str, Any], vow_boundary_contract: Mapping[str, Any], vow_alignment_attestation: Mapping[str, Any], input_summaries: Mapping[str, Mapping[str, Any]] | None = None, commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None, canonical_vow_digest: str | None = None) -> dict[str, Any]:
+    vow_digest, vow_source = _derive_canonical_vow_digest(vow_boundary_contract, vow_alignment_attestation, canonical_vow_digest)
+    storage_status = _status(storage_policy_verifier, "verification_status", "storage_policy_verification_status", "status")
+    candidate_status = _status(memory_candidate_verifier, "verification_status", "memory_candidate_verification_status", "status")
+    failed = _count(vow_alignment_attestation, "failed_attestation_count", "failure_count", "failed_count") or 0
+    warnings = _count(vow_alignment_attestation, "warning_attestation_count", "warning_count") or 0
+    active_authority = bool(_status(vow_alignment_attestation, "active_authority_detected"))
+    context = {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "canonical_vow_digest": vow_digest, "storage_policy_verification_status": storage_status, "memory_candidate_verification_status": candidate_status, "vow_attestation_failed_count": failed, "vow_attestation_warning_count": warnings, "dry_run_only": True, "no_action_taken": True}
+    ledger_by_candidate: dict[str, str] = {}
+    forbidden_ids: list[str] = []
+    path_gap_ids: list[str] = []
+    missing_digest_ids: list[str] = []
+    parent_missing_ids: list[str] = []
+    ledger_plan: list[dict[str, Any]] = []
+    for entry in _as_list(memory_candidate_bundle.get("candidate_ledger_entries")):
+        if not isinstance(entry, Mapping):
+            continue
+        txid = "ledger-tx-" + _stable_id(entry.get("candidate_entry_id"), entry.get("source_input_id"), entry.get("would_be_record_type"))
+        planned, template, forbidden = _plan_path(_templates(storage_policy_contract, "ledger_storage_policy"), "/ledger", context, "record_type", entry.get("would_be_record_type"))
+        if planned is None:
+            path_gap_ids.append(txid)
+        if forbidden:
+            forbidden_ids.append(txid)
+        if not entry.get("source_artifact_digest"):
+            missing_digest_ids.append(txid)
+        if not (entry.get("parent_entry_id") and entry.get("parent_entry_digest")):
+            parent_missing_ids.append(txid)
+        ledger_by_candidate[str(entry.get("candidate_entry_id"))] = txid
+        ledger_plan.append({"transaction_id": txid, "transaction_kind": "ledger_write_candidate", "dry_run_only": True, "write_performed": False, "source_candidate_entry_id": entry.get("candidate_entry_id"), "source_input_id": entry.get("source_input_id"), "would_write_record_type": entry.get("would_be_record_type"), "planned_mount": "/ledger", "planned_path": planned, "path_template_used": template, "source_artifact_digest": entry.get("source_artifact_digest"), "source_artifact_digest_algo": entry.get("source_artifact_digest_algo") or DIGEST_ALGO, "source_artifact_byte_size": entry.get("source_artifact_byte_size"), "canonical_vow_digest": vow_digest, "parent_entry_id": entry.get("parent_entry_id"), "parent_entry_digest": entry.get("parent_entry_digest"), "parent_chain_required": True, "finalizer_guard_context_required": True, "operator_consent_required": True, "storage_policy_required": True, "forbidden_inference": entry.get("forbidden_inference") or FORBIDDEN_INFERENCE, "authority_boundary": entry.get("authority_boundary") or AUTHORITY_BOUNDARY})
+    glow_plan: list[dict[str, Any]] = []
+    for item in _as_list(memory_candidate_bundle.get("candidate_glow_items")):
+        if not isinstance(item, Mapping):
+            continue
+        txid = "glow-tx-" + _stable_id(item.get("candidate_glow_item_id"), item.get("source_input_id"), item.get("would_be_archive_item_type"))
+        planned, template, forbidden = _plan_path(_templates(storage_policy_contract, "glow_storage_policy"), "/glow", context, "archive_item_type", item.get("would_be_archive_item_type"))
+        if planned is None:
+            path_gap_ids.append(txid)
+        if forbidden:
+            forbidden_ids.append(txid)
+        if not item.get("source_digest"):
+            missing_digest_ids.append(txid)
+        related = item.get("related_candidate_ledger_entry_id")
+        glow_plan.append({"transaction_id": txid, "transaction_kind": "glow_archive_candidate", "dry_run_only": True, "archive_performed": False, "source_candidate_glow_item_id": item.get("candidate_glow_item_id"), "source_input_id": item.get("source_input_id"), "would_archive_item_type": item.get("would_be_archive_item_type"), "planned_mount": "/glow", "planned_path": planned, "path_template_used": template, "source_digest": item.get("source_digest"), "source_digest_algo": item.get("source_digest_algo") or DIGEST_ALGO, "source_byte_size": item.get("source_byte_size", item.get("byte_size")), "related_candidate_ledger_entry_id": related, "related_planned_ledger_transaction_id": ledger_by_candidate.get(str(related)) if related is not None else None, "canonical_vow_digest": vow_digest, "retention_hint_required": True, "operator_consent_required": True, "storage_policy_required": True, "forbidden_inference": item.get("forbidden_inference") or FORBIDDEN_INFERENCE, "authority_boundary": item.get("authority_boundary") or AUTHORITY_BOUNDARY})
+    planned_paths = [tx["planned_path"] for tx in ledger_plan + glow_plan if tx.get("planned_path")]
+    bad_paths = [tx["transaction_id"] for tx in ledger_plan + glow_plan if tx.get("planned_path") and not _safe_path(str(tx["planned_path"]), str(tx["planned_mount"]))]
+    forbidden_ids = sorted(set(forbidden_ids + bad_paths))
+    blocking = {"active_writer_implementation_missing", "operator_consent_missing", "finalizer_guard_runtime_binding_missing"}
+    if path_gap_ids: blocking.add("missing_commit_pr_or_vow_digest_for_path")
+    if missing_digest_ids: blocking.add("missing_source_digest")
+    if parent_missing_ids: blocking.add("missing_parent_context")
+    if not _verified_storage(storage_status): blocking.add("storage_policy_not_verified")
+    if not _verified_candidate(candidate_status): blocking.add("memory_candidate_bundle_not_verified")
+    if failed or active_authority: blocking.add("vow_alignment_failed")
+    if forbidden_ids: blocking.add("forbidden_path_detected")
+    parent_required_ids = [tx["transaction_id"] for tx in ledger_plan]
+    return {
+        "storage_transaction_plan_id": WORKCELL_STORAGE_TRANSACTION_PLAN_ID, "metadata_only": True, "dry_run_only": True, "transaction_plan_only": True,
+        "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "not_runtime_authority": True, "not_memory_writer": True,
+        "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True,
+        "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": dict(sorted((input_summaries or {}).items())), "planning_context": context, "ledger_transaction_plan": ledger_plan, "glow_transaction_plan": glow_plan,
+        "transaction_path_validation": {"planned_ledger_transaction_count": len(ledger_plan), "planned_glow_transaction_count": len(glow_plan), "ledger_paths_planned_count": sum(1 for tx in ledger_plan if tx.get("planned_path")), "glow_paths_planned_count": sum(1 for tx in glow_plan if tx.get("planned_path")), "path_gap_count": len(path_gap_ids), "path_gap_transaction_ids": sorted(path_gap_ids), "forbidden_path_detected": bool(forbidden_ids), "forbidden_path_transaction_ids": forbidden_ids, "all_planned_paths_under_declared_mounts": all(str(p).startswith(("/ledger/", "/glow/")) for p in planned_paths), "no_host_paths": not forbidden_ids, "no_network_paths": not forbidden_ids, "no_temp_canonical_paths": not forbidden_ids, "no_backdoor_paths": not forbidden_ids, "validation_only": True},
+        "transaction_digest_validation": {"ledger_transactions_with_source_digest_count": sum(1 for tx in ledger_plan if tx.get("source_artifact_digest")), "glow_transactions_with_source_digest_count": sum(1 for tx in glow_plan if tx.get("source_digest")), "missing_digest_transaction_ids": sorted(missing_digest_ids), "canonical_vow_digest_present": vow_digest is not None, "canonical_vow_digest_source": vow_source, "digest_validation_only": True},
+        "transaction_parent_chain_plan": {"parent_chain_planning_only": True, "parent_chain_required": True, "transactions_requiring_parent_context": parent_required_ids, "transactions_with_parent_context": [tx["transaction_id"] for tx in ledger_plan if tx.get("parent_entry_id") and tx.get("parent_entry_digest")], "transactions_missing_parent_context": sorted(parent_missing_ids), "missing_parent_context_transaction_ids": sorted(parent_missing_ids), "missing_parent_context_blocks_active_write": True, "no_parent_chain_written": True},
+        "transaction_vow_alignment": {"canonical_vow_digest": vow_digest, "vow_boundary_contract_supplied": True, "vow_alignment_attestation_supplied": True, "failed_attestation_count": failed, "warning_attestation_count": warnings, "active_authority_detected": active_authority, "vow_alignment_blocks_active_write": bool(failed or active_authority), "vow_alignment_checked_for_plan": True, "no_vow_adoption_performed": True},
+        "transaction_gap_summary": {"planned_ledger_transaction_count": len(ledger_plan), "planned_glow_transaction_count": len(glow_plan), "blocking_gap_count": len(blocking), "warning_gap_count": 1 if warnings else 0, "blocking_gap_ids": sorted(blocking), "warning_gap_ids": ["vow_alignment_warnings_present"] if warnings else [], "active_storage_allowed_now": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "dry_run_only": True, "no_action_taken": True},
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI" + "/SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata planner.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "dry-run transaction planning only; no ledger write", "/glow": "dry-run transaction planning only; no archive write", "/vow": "canonical digest context for transaction constraints", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here"},
+        "future_activation_requirements": [{"requirement": name, "status": "future_only", "met": False, "active": False} for name in FUTURE_REQUIREMENT_NAMES],
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+
+def _cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", "<br>") if value is not None else ""
+
+def _table(headers: list[str], rows: list[list[Any]]) -> list[str]:
+    return ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"] + ["| " + " | ".join(_cell(v) for v in row) + " |" for row in rows]
+
+def render_codex_workcell_storage_transaction_plan_markdown(plan: Mapping[str, Any]) -> str:
+    lines = ["# Codex Workcell Storage Transaction Dry-Run Plan", "", "Deterministic metadata-only future `/ledger` and `/glow` would-write plan. It is not a writer, archiver, readiness decision, daemon action, scheduler, task creator, model trainer, or federation consensus mechanism."]
+    lines += ["", "## Input summaries"] + _table(["input", "path", "digest", "byte_size"], [[k, v.get("path"), v.get("digest"), v.get("byte_size")] for k, v in sorted(dict(plan.get("input_summaries", {})).items()) if isinstance(v, Mapping)])
+    context = plan.get("planning_context", {}) if isinstance(plan.get("planning_context"), Mapping) else {}
+    lines += ["", "## Planning context"] + _table(["field", "value"], [[k, v] for k, v in sorted(context.items())])
+    lines += ["", "## Ledger transaction plan"] + _table(["id", "candidate", "type", "path", "write"], [[x.get("transaction_id"), x.get("source_candidate_entry_id"), x.get("would_write_record_type"), x.get("planned_path"), x.get("write_performed")] for x in _as_list(plan.get("ledger_transaction_plan")) if isinstance(x, Mapping)])
+    lines += ["", "## Glow transaction plan"] + _table(["id", "candidate", "type", "path", "archive"], [[x.get("transaction_id"), x.get("source_candidate_glow_item_id"), x.get("would_archive_item_type"), x.get("planned_path"), x.get("archive_performed")] for x in _as_list(plan.get("glow_transaction_plan")) if isinstance(x, Mapping)])
+    for title, key in (("Transaction path validation", "transaction_path_validation"), ("Transaction digest validation", "transaction_digest_validation"), ("Transaction parent-chain plan", "transaction_parent_chain_plan"), ("Transaction vow alignment", "transaction_vow_alignment"), ("Transaction gap summary", "transaction_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Non-authority posture", "non_authority_posture")):
+        data = plan.get(key, {}) if isinstance(plan.get(key), Mapping) else {}
+        lines += ["", f"## {title}"] + _table(["field", "value"], [[k, v] for k, v in sorted(data.items())])
+    lines += ["", "## Future activation requirements"] + _table(["requirement", "status", "met", "active"], [[x.get("requirement"), x.get("status"), x.get("met"), x.get("active")] for x in _as_list(plan.get("future_activation_requirements")) if isinstance(x, Mapping)])
+    return "\n".join(lines) + "\n"

--- a/tests/test_build_codex_workcell_storage_transaction_plan_script.py
+++ b/tests/test_build_codex_workcell_storage_transaction_plan_script.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_policy_contract import build_codex_workcell_storage_policy_contract
+
+SCRIPT = Path("scripts/build_codex_workcell_storage_transaction_plan.py")
+
+
+def _write(path: Path, data: object) -> Path:
+    path.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _args(tmp_path: Path) -> tuple[list[str], Path, Path]:
+    output = tmp_path / "plan.json"
+    markdown = tmp_path / "plan.md"
+    files = {
+        "storage-policy-contract-json": _write(tmp_path / "policy.json", build_codex_workcell_storage_policy_contract()),
+        "storage-policy-verifier-json": _write(tmp_path / "policy_verifier.json", {"verification_status": "storage_policy_verified"}),
+        "memory-candidate-bundle-json": _write(tmp_path / "bundle.json", {"candidate_ledger_entries": [{"candidate_entry_id": "e1", "source_input_id": "matrix_json", "would_be_record_type": "matrix_receipt", "source_artifact_digest": "abc", "parent_entry_id": "p", "parent_entry_digest": "pd"}], "candidate_glow_items": [{"candidate_glow_item_id": "g1", "source_input_id": "matrix_json", "would_be_archive_item_type": "matrix_report_snapshot", "source_digest": "def", "related_candidate_ledger_entry_id": "e1"}]}),
+        "memory-candidate-verifier-json": _write(tmp_path / "candidate_verifier.json", {"verification_status": "memory_candidate_bundle_verified"}),
+        "vow-boundary-contract-json": _write(tmp_path / "vow.json", {"canonical_vow_digest": "vow"}),
+        "vow-alignment-attestation-json": _write(tmp_path / "attest.json", {"failed_attestation_count": 0, "warning_attestation_count": 0}),
+    }
+    args = [sys.executable, str(SCRIPT), "--output", str(output), "--markdown-output", str(markdown), "--commit-sha", "abc123", "--pr-title", "title | newline\ncell", "--summary"]
+    for flag, path in files.items():
+        args += [f"--{flag}", str(path)]
+    return args, output, markdown
+
+
+def test_cli_writes_json_markdown_and_summary_deterministically(tmp_path: Path) -> None:
+    args, output, markdown = _args(tmp_path)
+    first = subprocess.run(args, check=True, text=True, capture_output=True)
+    first_json = output.read_text(encoding="utf-8")
+    first_md = markdown.read_text(encoding="utf-8")
+    second = subprocess.run(args, check=True, text=True, capture_output=True)
+    assert first.stdout == second.stdout
+    assert first_json == output.read_text(encoding="utf-8")
+    assert first_md == markdown.read_text(encoding="utf-8")
+    summary = json.loads(first.stdout)
+    assert summary["planned_ledger_transaction_count"] == 1
+    data = json.loads(first_json)
+    assert data["ledger_transaction_plan"][0]["planned_path"] == "/ledger/codex/workcell/abc123/matrix_receipt.json"
+    assert "title \\| newline<br>cell" in first_md
+
+
+@pytest.mark.parametrize(("filename", "contents"), [("bad.json", "{"), ("list.json", "[]")])
+def test_invalid_or_non_object_required_json_exits_2(tmp_path: Path, filename: str, contents: str) -> None:
+    args, _output, _markdown = _args(tmp_path)
+    bad = tmp_path / filename
+    bad.write_text(contents, encoding="utf-8")
+    index = args.index("--storage-policy-verifier-json") + 1
+    args[index] = str(bad)
+    result = subprocess.run(args, text=True, capture_output=True)
+    assert result.returncode == 2
+
+
+def test_missing_required_json_path_exits_2(tmp_path: Path) -> None:
+    args, _output, _markdown = _args(tmp_path)
+    index = args.index("--storage-policy-verifier-json") + 1
+    args[index] = str(tmp_path / "missing.json")
+    result = subprocess.run(args, text=True, capture_output=True)
+    assert result.returncode == 2

--- a/tests/test_codex_workcell_storage_transaction_plan.py
+++ b/tests/test_codex_workcell_storage_transaction_plan.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_policy_contract import build_codex_workcell_storage_policy_contract
+from sentientos.codex_workcell_storage_transaction_plan import NON_AUTHORITY_POSTURE, build_codex_workcell_storage_transaction_plan, render_codex_workcell_storage_transaction_plan_markdown
+
+
+def _policy() -> dict:
+    return build_codex_workcell_storage_policy_contract()
+
+
+def _verifier(status: str = "storage_policy_verified") -> dict:
+    return {"verification_status": status}
+
+
+def _candidate_verifier(status: str = "memory_candidate_bundle_verified") -> dict:
+    return {"verification_status": status}
+
+
+def _bundle() -> dict:
+    return {
+        "candidate_ledger_entries": [{"candidate_entry_id": "e1", "source_input_id": "matrix_json", "would_be_record_type": "matrix_receipt", "source_artifact_digest": "abc", "source_artifact_digest_algo": "sha256", "source_artifact_byte_size": 9, "parent_entry_id": "p1", "parent_entry_digest": "pd"}],
+        "candidate_glow_items": [{"candidate_glow_item_id": "g1", "source_input_id": "matrix_json", "would_be_archive_item_type": "matrix_report_snapshot", "source_digest": "def", "source_digest_algo": "sha256", "byte_size": 8, "related_candidate_ledger_entry_id": "e1"}],
+    }
+
+
+def _plan(**overrides) -> dict:
+    kwargs = {"storage_policy_contract": _policy(), "storage_policy_verifier": _verifier(), "memory_candidate_bundle": _bundle(), "memory_candidate_verifier": _candidate_verifier(), "vow_boundary_contract": {"canonical_vow_digest": "vow123"}, "vow_alignment_attestation": {"failed_attestation_count": 0, "warning_attestation_count": 0, "active_authority_detected": False}, "commit_sha": "abc123"}
+    kwargs.update(overrides)
+    return build_codex_workcell_storage_transaction_plan(**kwargs)
+
+
+def test_minimal_valid_supplied_reports_produce_deterministic_dry_run_output() -> None:
+    first = _plan()
+    second = _plan()
+    assert first == second
+    assert first["storage_transaction_plan_id"] == "codex_workcell_storage_transaction_plan.v1"
+    assert first["dry_run_only"] is True
+    assert first["writes_performed"] is False
+    assert first["archives_performed"] is False
+    assert first["memory_mutation_performed"] is False
+
+
+def test_ledger_candidate_entries_and_glow_items_become_transaction_plans() -> None:
+    plan = _plan()
+    assert plan["ledger_transaction_plan"][0]["source_candidate_entry_id"] == "e1"
+    assert plan["ledger_transaction_plan"][0]["transaction_kind"] == "ledger_write_candidate"
+    assert plan["glow_transaction_plan"][0]["source_candidate_glow_item_id"] == "g1"
+    assert plan["glow_transaction_plan"][0]["related_planned_ledger_transaction_id"] == plan["ledger_transaction_plan"][0]["transaction_id"]
+
+
+@pytest.mark.parametrize(("kwargs", "expected"), [({"commit_sha": "c1", "pr_number": "99", "canonical_vow_digest": "v1"}, "/ledger/codex/workcell/c1/matrix_receipt.json"), ({"commit_sha": None, "pr_number": "99", "canonical_vow_digest": "v1"}, "/ledger/codex/workcell/99/matrix_receipt.json"), ({"commit_sha": None, "pr_number": None, "canonical_vow_digest": "v1", "vow_boundary_contract": {}}, "/ledger/codex/workcell/v1/matrix_receipt.json")])
+def test_planned_ledger_paths_prefer_commit_then_pr_then_vow(kwargs: dict, expected: str) -> None:
+    assert _plan(**kwargs)["ledger_transaction_plan"][0]["planned_path"] == expected
+
+
+@pytest.mark.parametrize(("kwargs", "expected"), [({"commit_sha": "c1", "pr_number": "99", "canonical_vow_digest": "v1"}, "/glow/codex/workcell/c1/matrix_report_snapshot.json"), ({"commit_sha": None, "pr_number": "99", "canonical_vow_digest": "v1"}, "/glow/codex/workcell/99/matrix_report_snapshot.json"), ({"commit_sha": None, "pr_number": None, "canonical_vow_digest": "v1", "vow_boundary_contract": {}}, "/glow/codex/workcell/v1/matrix_report_snapshot.json")])
+def test_planned_glow_paths_prefer_commit_then_pr_then_vow(kwargs: dict, expected: str) -> None:
+    assert _plan(**kwargs)["glow_transaction_plan"][0]["planned_path"] == expected
+
+
+def test_missing_commit_pr_or_vow_digest_produces_blocking_path_gap() -> None:
+    plan = _plan(commit_sha=None, pr_number=None, canonical_vow_digest=None, vow_boundary_contract={})
+    assert plan["ledger_transaction_plan"][0]["planned_path"] is None
+    assert "missing_commit_pr_or_vow_digest_for_path" in plan["transaction_gap_summary"]["blocking_gap_ids"]
+
+
+def test_forbidden_host_network_temp_backdoor_paths_are_never_produced() -> None:
+    policy = _policy()
+    policy["ledger_storage_policy"]["allowed_path_patterns"] = ["/tmp/{commit_sha}/{record_type}.json", "https://evil/{record_type}", "/ledger/.backdoor/{record_type}.json"]
+    plan = _plan(storage_policy_contract=policy)
+    assert plan["ledger_transaction_plan"][0]["planned_path"] is None
+    assert plan["transaction_path_validation"]["forbidden_path_detected"] is True
+
+
+def test_source_digests_are_propagated_and_missing_source_digest_blocks() -> None:
+    plan = _plan()
+    assert plan["ledger_transaction_plan"][0]["source_artifact_digest"] == "abc"
+    assert plan["glow_transaction_plan"][0]["source_digest"] == "def"
+    bundle = _bundle()
+    del bundle["candidate_ledger_entries"][0]["source_artifact_digest"]
+    del bundle["candidate_glow_items"][0]["source_digest"]
+    missing = _plan(memory_candidate_bundle=bundle)
+    assert "missing_source_digest" in missing["transaction_gap_summary"]["blocking_gap_ids"]
+    assert len(missing["transaction_digest_validation"]["missing_digest_transaction_ids"]) == 2
+
+
+def test_parent_context_is_planned_but_not_written_and_missing_parent_blocks_active_write_only() -> None:
+    bundle = _bundle()
+    del bundle["candidate_ledger_entries"][0]["parent_entry_id"]
+    plan = _plan(memory_candidate_bundle=bundle)
+    assert plan["transaction_parent_chain_plan"]["no_parent_chain_written"] is True
+    assert plan["transaction_parent_chain_plan"]["missing_parent_context_blocks_active_write"] is True
+    assert "missing_parent_context" in plan["transaction_gap_summary"]["blocking_gap_ids"]
+    assert plan["dry_run_only"] is True
+
+
+def test_unverified_inputs_and_failed_vow_attestation_produce_blocking_gaps() -> None:
+    plan = _plan(storage_policy_verifier=_verifier("storage_policy_failed"), memory_candidate_verifier=_candidate_verifier("failed"), vow_alignment_attestation={"failed_attestation_count": 1, "active_authority_detected": True})
+    assert {"storage_policy_not_verified", "memory_candidate_bundle_not_verified", "vow_alignment_failed"} <= set(plan["transaction_gap_summary"]["blocking_gap_ids"])
+    assert plan["transaction_vow_alignment"]["vow_alignment_blocks_active_write"] is True
+
+
+def test_non_authority_posture_future_requirements_and_hygiene_are_present() -> None:
+    plan = _plan()
+    assert plan["transaction_gap_summary"]["active_storage_allowed_now"] is False
+    assert plan["reviewer_hygiene_summary"]["bad_repo_url"] == "https://github.com/" + "OpenAI" + "/SentientOS.git"
+    assert plan["reviewer_hygiene_summary"]["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert plan["non_authority_posture"] == NON_AUTHORITY_POSTURE
+    assert all(plan["non_authority_posture"].values())
+    assert all(item["active"] is False and item["met"] is False and item["status"] == "future_only" for item in plan["future_activation_requirements"])
+
+
+def test_planner_does_not_grant_readiness_or_write_archive_modify_trigger_or_schedule() -> None:
+    plan = _plan()
+    assert "ready" not in plan
+    assert plan["not_daemon_action"] is True
+    assert plan["not_task_creator"] is True
+    assert plan["not_scheduler"] is True
+    assert plan["writes_performed"] is False
+    assert plan["archives_performed"] is False
+    assert plan["memory_mutation_performed"] is False
+
+
+def test_markdown_output_is_deterministic_and_escapes_pipes_newlines() -> None:
+    plan = _plan(pr_title="has | pipe\nand newline")
+    first = render_codex_workcell_storage_transaction_plan_markdown(plan)
+    second = render_codex_workcell_storage_transaction_plan_markdown(copy.deepcopy(plan))
+    assert first == second
+    assert "has \\| pipe<br>and newline" in first
+    assert first.startswith("# Codex Workcell Storage Transaction Dry-Run Plan")


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only planner that converts verified candidate/contract/attestation reports into exact future `/ledger` and `/glow` would-write plans without performing any writes, activation, or runtime actions.
- Surface deterministic path, digest, parent-chain, and vow alignment gaps so downstream active writers and operators can implement and satisfy required runtime contracts without this planner granting any readiness or write authority.

### Description

- Add `sentientos/codex_workcell_storage_transaction_plan.py` implementing `build_codex_workcell_storage_transaction_plan`, deterministic transaction ID generation, safe path planning, forbidden-path detection, digest/parent/vow/policy gap summaries, reviewer hygiene metadata, mount alignment, future-activation requirements, and complete non-authority posture flags; constants `WORKCELL_STORAGE_TRANSACTION_PLAN_ID` and `DIGEST_ALGO` included.
- Add CLI wrapper `scripts/build_codex_workcell_storage_transaction_plan.py` that reads required JSON inputs (records raw-byte `sha256` digests and byte sizes), fails with exit code `2` for missing/invalid/non-object JSON, emits deterministic JSON output, optionally writes deterministic Markdown, and prints a compact summary when requested.
- Add unit tests: `tests/test_codex_workcell_storage_transaction_plan.py` (planner behaviors, path preference, forbidden paths, digestion/parent gaps, vow/policy blocking gaps, non-authority posture, markdown escaping) and `tests/test_build_codex_workcell_storage_transaction_plan_script.py` (CLI JSON/Markdown/summary determinism and error handling).
- Add `docs/development/codex_workcell_storage_transaction_plan.md` documenting purpose, boundaries, path selection rules, gap semantics, mount alignment, future activation requirements, and non-authority posture; add short boundary mentions to adjacent docs to link the new planner.

### Testing

- Focused unit tests: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_transaction_plan.py tests/test_build_codex_workcell_storage_transaction_plan_script.py` — passed.
- Adjacent regression & integration lanes: targeted workcell tests, storage policy verifier/contract tests, vow/boundary tests, candidate bundle/verifier tests and related build scripts were executed and passed in the validation sequence.
- Tooling and infra checks: `python scripts/build_docs.py --bootstrap-docs && python scripts/build_docs.py` (docs bootstrapped and built), `python -m mypy sentientos/codex_workcell_storage_transaction_plan.py scripts/build_codex_workcell_storage_transaction_plan.py` (passed), and `scripts/run_work_item_review_packet_matrix.py --summary` (full matrix ran and reported `passed` for required lanes).
- Landing validation: the project's finalizer and PR-metadata guard flows were run as part of validation (pre-commit finalizer returned `ready_to_commit`, post-commit/pr-metadata finalizer returned `ready_for_pr_metadata`, and PR metadata guard returned `pr_metadata_guard_ready`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3da898c2f883208948bae2df3d246d)