### PR TITLE
[codex:memory] add Codex workcell storage execution readiness dossier

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -237,3 +237,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -229,3 +229,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -176,3 +176,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -140,3 +140,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -68,3 +68,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -82,3 +82,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -56,3 +56,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -77,3 +77,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -124,3 +124,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -141,3 +141,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -81,3 +81,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -1,0 +1,41 @@
+# Codex Workcell Storage Execution Readiness Dossier
+
+The Codex Workcell Storage Execution Readiness Dossier is a deterministic, metadata-only review artifact for the future design of active storage. It reads supplied memory, vow, storage policy, transaction plan, and verifier reports; records raw-byte SHA-256 digests and byte sizes; inventories detected report identifiers and status fields; and summarizes whether the documentation prerequisites for designing an active `/ledger` writer and `/glow` archiver are present.
+
+It is dossier-only. It does not activate memory, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide commit readiness, authorize PR metadata, create PRs, establish federation consensus, train models, or modify models.
+
+## Transaction plan verifier vs execution dossier
+
+The storage transaction plan verifier checks a supplied dry-run transaction plan structurally: planned mounts, planned paths, source digests, canonical vow context, parent-chain gaps, and dry-run non-authority posture. The execution dossier comes after those reports and inventories the broader evidence stack for reviewers who may later design an active writer. A `future_storage_design_dossier_complete` status is only a future-design dossier status; it is not finalizer readiness, PR metadata guard readiness, ledger authority, glow authority, daemon authority, storage activation, or permission to run an active writer.
+
+## Evidence inventory
+
+Each optional JSON input is read as raw bytes, hashed with SHA-256, measured by byte size, and parsed as a JSON object. Missing, invalid, or non-object JSON inputs fail cleanly in the CLI with exit code 2. Omitted optional inputs are recorded as not provided with null path, digest, and byte-size metadata. Supplied reports are inventoried by stable evidence roles: memory schema, memory candidate, memory verifier, memory preflight, vow boundary, vow attestation, storage policy, storage policy verifier, transaction plan, and transaction plan verifier.
+
+## Future design completeness
+
+The dossier is complete for future design review only when all required reports are supplied and verifier statuses that can be derived are successful. Missing reports make the dossier incomplete. Failed storage policy or transaction plan verifier statuses make the dossier failed. Active execution gaps remain blocking gaps in every case and never authorize storage.
+
+## Active execution gaps
+
+The dossier always records active writer implementation, operator consent, finalizer/guard runtime binding, storage path enforcement, retention enforcement, digest verification runtime, parent-chain runtime, pulse watcher contract, daemon action contract, and federation consensus as missing future-only gaps. `active_storage_allowed_now`, `execution_performed`, `writes_performed`, `archives_performed`, and `memory_mutation_performed` remain false.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene is documented as a landing-task grep responsibility, not dossier runtime behavior. The dossier records the correct repository URL `https://github.com/Zombinator85/SentientOS.git` and the bad attribution URL expected to be absent, but it does not run grep or modify files.
+
+## Mount alignment
+
+- `/ledger`: future active storage target; no ledger write here.
+- `/glow`: future active storage target; no archive write here.
+- `/vow`: canonical digest context for execution boundaries.
+- `/pulse`: future consumer of stored history; inactive here.
+- `/daemon`: future consumer of pulse/recommendation context; inactive here.
+
+## Future activation requirements
+
+Future activation remains unmet and inactive until explicit active ledger writer implementation, active glow archiver implementation, storage path enforcement, retention enforcement, digest verification enforcement, parent-chain validation enforcement, operator consent, finalizer/guard runtime binding, pulse watcher contract, daemon action contract, federation drift consensus rule, tests proving no readiness authority, and docs marking active behavior are added by a separate authorized task.
+
+## Non-authority posture
+
+The dossier is read-only, metadata-only, and dossier-only. It does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer, bypass PR metadata guard, authorize commit, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -75,3 +75,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -44,3 +44,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -57,3 +57,6 @@ The storage transaction plan is read-only, metadata-only, and dry-run-only. It d
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -35,3 +35,6 @@ Future activation remains unmet and inactive without explicit active ledger writ
 ## Non-authority posture
 
 The verifier is read-only, metadata-only, and verifier-only. It does not activate memory, write `/ledger`, archive `/glow`, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer, bypass PR metadata guard, authorize commit, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -55,3 +55,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -64,3 +64,6 @@ The [Codex Workcell Storage Transaction Dry-Run Plan](codex_workcell_storage_tra
 ## Storage transaction plan verifier boundary
 
 The [Codex Workcell Storage Transaction Plan Verifier](codex_workcell_storage_transaction_plan_verifier.md) is a deterministic metadata-only structural verifier for dry-run storage transaction plans. It checks planned `/ledger` and `/glow` transaction shape, paths, digests, parent-chain gaps, vow alignment context, transaction gaps, reviewer hygiene metadata, future activation requirements, and non-authority posture; it does not write, archive, activate memory, decide readiness, bypass finalizer/PR metadata guard, trigger daemons, schedule tasks, create PRs, or establish federation consensus.
+## Storage execution readiness dossier boundary
+
+The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_execution_dossier.md) may inventory this report as metadata-only evidence for future active-storage design. It does not write `/ledger`, archive `/glow`, activate memory, trigger daemons, decide readiness, authorize PR metadata, or grant runtime storage authority.

--- a/scripts/build_codex_workcell_storage_execution_dossier.py
+++ b/scripts/build_codex_workcell_storage_execution_dossier.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_execution_dossier import (
+    CodexWorkcellStorageExecutionDossierError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_execution_dossier,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_execution_dossier_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage execution readiness dossier.")
+    parser.add_argument("--output", required=True)
+    for input_id, _, _ in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries = {}; reports = {}
+    try:
+        for input_id, _, _ in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summary, loaded = read_json_input(path, input_id)
+                summaries[input_id] = summary; reports[input_id] = loaded
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        dossier = build_codex_workcell_storage_execution_dossier(input_summaries=summaries, input_reports=reports, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageExecutionDossierError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(dossier, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_execution_dossier_markdown(dossier), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_execution_dossier_id": dossier["storage_execution_dossier_id"], "storage_execution_status": dossier["storage_execution_status"], "supplied_report_count": dossier["dossier_context"]["supplied_report_count"], "active_storage_allowed_now": dossier["active_execution_gap_summary"]["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_execution_dossier.py
+++ b/sentientos/codex_workcell_storage_execution_dossier.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_EXECUTION_DOSSIER_ID = "codex_workcell_storage_execution_dossier.v1"
+DIGEST_ALGO = "sha256"
+AUTHORITY_BOUNDARY = "Storage execution readiness dossier is deterministic metadata only; it is not runtime authority, not a writer, not an archiver, not a watcher, not a scheduler, not an executor, and not finalizer or PR metadata authority."
+
+INPUT_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("memory_contract_json", "memory_schema", "memory_contract_supplied"),
+    ("memory_candidate_bundle_json", "memory_candidate", "memory_candidate_bundle_supplied"),
+    ("memory_candidate_verifier_json", "memory_verifier", "memory_candidate_verifier_supplied"),
+    ("memory_activation_preflight_json", "memory_preflight", "memory_activation_preflight_supplied"),
+    ("vow_boundary_contract_json", "vow_boundary", "vow_boundary_contract_supplied"),
+    ("vow_alignment_attestation_json", "vow_attestation", "vow_alignment_attestation_supplied"),
+    ("storage_policy_contract_json", "storage_policy", "storage_policy_contract_supplied"),
+    ("storage_policy_verifier_json", "storage_policy_verifier", "storage_policy_verifier_supplied"),
+    ("storage_transaction_plan_json", "transaction_plan", "storage_transaction_plan_supplied"),
+    ("storage_transaction_plan_verifier_json", "transaction_plan_verifier", "storage_transaction_plan_verifier_supplied"),
+)
+
+BLOCKING_GAP_IDS = [
+    "active_writer_implementation_missing", "operator_consent_missing", "finalizer_guard_runtime_binding_missing",
+    "storage_path_enforcement_missing", "retention_enforcement_missing", "digest_verification_runtime_missing",
+    "parent_chain_runtime_missing", "pulse_watcher_contract_missing", "daemon_action_contract_missing", "federation_consensus_missing",
+]
+FUTURE_REQUIREMENT_NAMES = [
+    "explicit active ledger writer implementation", "explicit active glow archiver implementation", "explicit storage path enforcement",
+    "explicit retention enforcement", "explicit digest verification enforcement", "explicit parent-chain validation enforcement",
+    "explicit operator consent", "explicit finalizer/guard runtime binding", "explicit pulse watcher contract",
+    "explicit daemon action contract", "explicit federation drift consensus rule", "tests proving no readiness authority", "docs marking active behavior",
+]
+NON_AUTHORITY_POSTURE = {
+    "storage_execution_dossier_is_read_only": True,
+    "storage_execution_dossier_is_metadata_only": True,
+    "storage_execution_dossier_is_dossier_only": True,
+    "storage_execution_dossier_does_not_activate_memory": True,
+    "storage_execution_dossier_does_not_write_ledger": True,
+    "storage_execution_dossier_does_not_archive_glow": True,
+    "storage_execution_dossier_does_not_modify_memory": True,
+    "storage_execution_dossier_does_not_watch_files": True,
+    "storage_execution_dossier_does_not_poll_state": True,
+    "storage_execution_dossier_does_not_rerun_commands": True,
+    "storage_execution_dossier_does_not_decide_readiness": True,
+    "storage_execution_dossier_does_not_bypass_finalizer": True,
+    "storage_execution_dossier_does_not_bypass_pr_metadata_guard": True,
+    "storage_execution_dossier_does_not_authorize_commit": True,
+    "storage_execution_dossier_does_not_authorize_pr_creation": True,
+    "storage_execution_dossier_does_not_trigger_daemon": True,
+    "storage_execution_dossier_does_not_create_tasks": True,
+    "storage_execution_dossier_does_not_schedule_tasks": True,
+    "storage_execution_dossier_does_not_send_alerts": True,
+    "storage_execution_dossier_does_not_train_or_modify_models": True,
+    "storage_execution_dossier_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellStorageExecutionDossierError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageExecutionDossierError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageExecutionDossierError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellStorageExecutionDossierError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _status(data: Mapping[str, Any]) -> Any:
+    for key in ("verification_status", "storage_policy_verification_status", "storage_transaction_plan_verification_status", "memory_candidate_verification_status", "activation_preflight_status", "storage_execution_status"):
+        if data.get(key) is not None:
+            return data.get(key)
+    return None
+
+def _report_id(data: Mapping[str, Any]) -> Any:
+    for key in ("storage_execution_dossier_id", "storage_transaction_plan_verifier_id", "storage_transaction_plan_id", "storage_policy_verifier_id", "storage_policy_contract_id", "vow_alignment_attestation_id", "vow_boundary_contract_id", "memory_activation_preflight_id", "memory_candidate_verifier_id", "memory_candidate_bundle_id", "memory_contract_id"):
+        if data.get(key):
+            return data.get(key)
+    return None
+
+def _digest(data: Mapping[str, Any]) -> Any:
+    for key in ("digest", "source_digest", "policy_digest", "plan_digest", "memory_contract_digest", "candidate_bundle_digest", "canonical_vow_digest"):
+        if data.get(key):
+            return data.get(key)
+    return None
+
+def _all_true(value: Any) -> bool | None:
+    if not isinstance(value, Mapping):
+        return None
+    return all(v is True for v in value.values())
+
+def _is_verified(data: Mapping[str, Any], good: str) -> bool | None:
+    s = _status(data)
+    if s is None:
+        return None
+    return s == good or s is True
+
+def build_codex_workcell_storage_execution_dossier(*, input_summaries: Mapping[str, Mapping[str, Any]], input_reports: Mapping[str, Mapping[str, Any]], commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    supplied_count = sum(1 for key, _, _ in INPUT_SPECS if input_summaries[key].get("provided") is True)
+    inventory = []
+    for input_id, role, _ in INPUT_SPECS:
+        summary = input_summaries[input_id]
+        data = input_reports.get(input_id, {})
+        nonauth = data.get("non_authority_posture")
+        inventory.append({"input_id": input_id, "provided": bool(summary.get("provided")), "detected_report_id": _report_id(data), "source_digest": summary.get("digest"), "source_digest_algo": summary.get("digest_algo") or DIGEST_ALGO, "source_byte_size": summary.get("byte_size"), "evidence_role": role, "relevant_status": _status(data), "relevant_digest": _digest(data), "non_authority_posture_present": isinstance(nonauth, Mapping), "non_authority_posture_all_true": _all_true(nonauth), "inventory_status": "supplied" if summary.get("provided") else "missing", "notes": [] if summary.get("provided") else ["optional input omitted; required for complete future-design dossier"]})
+    by = input_reports
+    policy_verified = _is_verified(by.get("storage_policy_verifier_json", {}), "storage_policy_verified")
+    plan_verified = _is_verified(by.get("storage_transaction_plan_verifier_json", {}), "storage_transaction_plan_verified")
+    candidate_verified = _is_verified(by.get("memory_candidate_verifier_json", {}), "memory_candidate_verified")
+    vow = by.get("vow_alignment_attestation_json", {})
+    failed = vow.get("failed_attestation_count")
+    warnings = vow.get("warning_attestation_count")
+    active = any(report.get("active_storage_allowed_now") is True or report.get("execution_performed") is True or report.get("writes_performed") is True or report.get("archives_performed") is True or report.get("memory_mutation_performed") is True for report in by.values())
+    all_supplied = supplied_count == len(INPUT_SPECS)
+    all_nonauth = all(i["non_authority_posture_all_true"] is not False for i in inventory if i["provided"])
+    failed_verified = policy_verified is False or plan_verified is False
+    status = "future_storage_design_dossier_failed" if failed_verified else ("future_storage_design_dossier_complete" if all_supplied else "future_storage_design_dossier_incomplete")
+    readiness: dict[str, Any] = {spec[2]: input_summaries[spec[0]].get("provided") is True for spec in INPUT_SPECS}
+    readiness.update({"storage_policy_verified": policy_verified, "storage_transaction_plan_verified": plan_verified, "memory_candidate_verified": candidate_verified, "vow_alignment_failed_count": failed, "vow_alignment_warning_count": warnings, "active_authority_detected": active, "all_required_reports_supplied": all_supplied, "all_supplied_reports_non_authoritative": all_nonauth, "dossier_ready_for_future_design_review": status == "future_storage_design_dossier_complete", "no_action_taken": True})
+    gaps = {"active_writer_implementation_present": False, "operator_consent_present": False, "finalizer_guard_runtime_binding_present": False, "storage_path_enforcement_present": False, "retention_enforcement_present": False, "digest_verification_runtime_present": False, "parent_chain_runtime_present": False, "pulse_watcher_contract_present": False, "daemon_action_contract_present": False, "federation_consensus_present": False, "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "blocking_gap_ids": BLOCKING_GAP_IDS, "warning_gap_ids": []}
+    prereq=[]
+    for _, _, pid in INPUT_SPECS:
+        passed = readiness[pid]
+        prereq.append({"prerequisite_id": pid, "category": "supplied_report", "passed": passed, "severity": "info" if passed else "warning", "observed_state": "supplied" if passed else "missing", "evidence_source": pid.replace("_supplied", "_json"), "authority_boundary": AUTHORITY_BOUNDARY})
+    for pid, val in (("storage_policy_verified", policy_verified), ("storage_transaction_plan_verified", plan_verified)):
+        prereq.append({"prerequisite_id": pid, "category": "verified_report", "passed": val is True, "severity": "info" if val is True else ("violation" if val is False else "warning"), "observed_state": "verified" if val is True else ("failed" if val is False else "unknown"), "evidence_source": pid, "authority_boundary": AUTHORITY_BOUNDARY})
+    for gap in BLOCKING_GAP_IDS:
+        prereq.append({"prerequisite_id": gap, "category": "active_execution_gap", "passed": True, "severity": "blocking_gap", "observed_state": "future-only unmet active execution gap documented", "evidence_source": "active_execution_gap_summary", "authority_boundary": AUTHORITY_BOUNDARY})
+    return {"storage_execution_dossier_id": WORKCELL_STORAGE_EXECUTION_DOSSIER_ID, "metadata_only": True, "dossier_only": True, "execution_not_performed": True, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True, "input_summaries": dict(input_summaries), "dossier_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied_count, "required_report_count": len(INPUT_SPECS), "dossier_only": True, "no_action_taken": True}, "evidence_inventory": inventory, "readiness_evidence_summary": readiness, "active_execution_gap_summary": gaps, "storage_execution_status": status, "execution_prerequisite_results": prereq, "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata dossier.", "docs_hygiene_only": True, "no_runtime_effect": True}, "sentientos_mount_alignment": {"/ledger": "future active storage target; no ledger write here", "/glow": "future active storage target; no archive write here", "/vow": "canonical digest context for execution boundaries", "/pulse": "future consumer of stored history; inactive here", "/daemon": "future consumer of pulse/recommendation context; inactive here"}, "future_activation_requirements": [{"requirement": r, "status": "future_only", "met": False, "active": False} for r in FUTURE_REQUIREMENT_NAMES], "non_authority_posture": dict(NON_AUTHORITY_POSTURE)}
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+def _table(headers: list[str], rows: list[list[Any]]) -> str:
+    out = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    out.extend("| " + " | ".join(_cell(c) for c in row) + " |" for row in rows)
+    return "\n".join(out) + "\n"
+
+def render_codex_workcell_storage_execution_dossier_markdown(report: Mapping[str, Any]) -> str:
+    parts = ["# Codex Workcell Storage Execution Readiness Dossier\n", "This deterministic dossier inventories supplied reports for future active-storage design only; it performs no execution and grants no storage, commit, PR, daemon, ledger, glow, or readiness authority.\n"]
+    parts.append("## Input summaries\n" + _table(["input", "provided", "path", "digest", "bytes"], [[k, v.get("provided"), v.get("path"), v.get("digest"), v.get("byte_size")] for k, v in sorted(report["input_summaries"].items())]))
+    parts.append("## Dossier context\n" + _table(["key", "value"], [[k, v] for k, v in report["dossier_context"].items()]))
+    parts.append("## Evidence inventory\n" + _table(["input", "role", "provided", "status", "digest"], [[i["input_id"], i["evidence_role"], i["provided"], i["relevant_status"], i["source_digest"]] for i in report["evidence_inventory"]]))
+    for title, key in (("Readiness evidence summary", "readiness_evidence_summary"), ("Active execution gap summary", "active_execution_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Non-authority posture", "non_authority_posture")):
+        parts.append(f"## {title}\n" + _table(["key", "value"], [[k, v] for k, v in report[key].items()]))
+    parts.append("## Storage execution status\n" + str(report["storage_execution_status"]) + "\n")
+    parts.append("## Execution prerequisite results\n" + _table(["id", "category", "passed", "severity", "observed"], [[r["prerequisite_id"], r["category"], r["passed"], r["severity"], r["observed_state"]] for r in report["execution_prerequisite_results"]]))
+    parts.append("## Future activation requirements\n" + _table(["requirement", "status", "met", "active"], [[r["requirement"], r["status"], r["met"], r["active"]] for r in report["future_activation_requirements"]]))
+    return "\n".join(parts)

--- a/tests/test_build_codex_workcell_storage_execution_dossier_script.py
+++ b/tests/test_build_codex_workcell_storage_execution_dossier_script.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import pytest
+import subprocess
+import sys
+from pathlib import Path
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_execution_dossier import INPUT_SPECS
+
+SCRIPT="scripts/build_codex_workcell_storage_execution_dossier.py"
+
+def _write_reports(tmp_path: Path):
+    args=[]
+    for input_id,_,_ in INPUT_SPECS:
+        data={"non_authority_posture":{"a":True}}
+        if input_id=="storage_policy_verifier_json": data["verification_status"]="storage_policy_verified"
+        if input_id=="storage_transaction_plan_verifier_json": data["verification_status"]="storage_transaction_plan_verified"
+        p=tmp_path/f"{input_id}.json"; p.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        args += ["--"+input_id.replace("_","-"), str(p)]
+    return args
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path: Path):
+    out=tmp_path/"out.json"; md=tmp_path/"out.md"
+    cmd=[sys.executable,SCRIPT,"--output",str(out),"--markdown-output",str(md),"--summary"]+_write_reports(tmp_path)
+    res=subprocess.run(cmd, check=True, text=True, capture_output=True)
+    assert "future_storage_design_dossier_complete" in res.stdout
+    first=out.read_text(); second=subprocess.run(cmd, check=True, text=True, capture_output=True)
+    assert second.returncode==0 and out.read_text()==first
+    assert md.read_text()==md.read_text()
+    data=json.loads(first)
+    assert data["active_execution_gap_summary"]["active_storage_allowed_now"] is False
+
+
+def test_cli_invalid_missing_and_non_object_exit_2(tmp_path: Path):
+    out=tmp_path/"out.json"
+    bad=tmp_path/"bad.json"; bad.write_text("{", encoding="utf-8")
+    res=subprocess.run([sys.executable,SCRIPT,"--output",str(out),"--memory-contract-json",str(bad)], text=True, capture_output=True)
+    assert res.returncode==2 and "invalid_json" in res.stderr
+    res=subprocess.run([sys.executable,SCRIPT,"--output",str(out),"--memory-contract-json",str(tmp_path/"missing.json")], text=True, capture_output=True)
+    assert res.returncode==2 and "missing_json" in res.stderr
+    arr=tmp_path/"arr.json"; arr.write_text("[]", encoding="utf-8")
+    res=subprocess.run([sys.executable,SCRIPT,"--output",str(out),"--memory-contract-json",str(arr)], text=True, capture_output=True)
+    assert res.returncode==2 and "json_not_object" in res.stderr
+
+
+def test_cli_omitted_inputs_incomplete(tmp_path: Path):
+    out=tmp_path/"out.json"
+    subprocess.run([sys.executable,SCRIPT,"--output",str(out),"--summary"], check=True, text=True, capture_output=True)
+    data=json.loads(out.read_text())
+    assert data["storage_execution_status"]=="future_storage_design_dossier_incomplete"
+    assert data["writes_performed"] is False and data["archives_performed"] is False
+    assert data["not_daemon_action"] is True and data["not_task_creator"] is True

--- a/tests/test_codex_workcell_storage_execution_dossier.py
+++ b/tests/test_codex_workcell_storage_execution_dossier.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_execution_dossier import INPUT_SPECS, build_codex_workcell_storage_execution_dossier, omitted_input, render_codex_workcell_storage_execution_dossier_markdown
+
+
+def _summaries_and_reports(all_inputs=True, policy_status="storage_policy_verified", plan_status="storage_transaction_plan_verified"):
+    summaries={}; reports={}
+    for input_id, _, _ in INPUT_SPECS:
+        if all_inputs:
+            raw=json.dumps({"x": input_id}, sort_keys=True).encode()
+            summaries[input_id]={"input_id":input_id,"provided":True,"path":f"/{input_id}.json","digest_algo":"sha256","digest":hashlib.sha256(raw).hexdigest(),"byte_size":len(raw),"readable_json":True,"error":None}
+            reports[input_id]={"non_authority_posture":{"a":True}}
+        else:
+            summaries[input_id]=omitted_input(input_id)
+    if all_inputs:
+        reports["storage_policy_verifier_json"].update({"storage_policy_verifier_id":"codex_workcell_storage_policy_verifier.v1","verification_status":policy_status})
+        reports["storage_transaction_plan_verifier_json"].update({"storage_transaction_plan_verifier_id":"codex_workcell_storage_transaction_plan_verifier.v1","verification_status":plan_status})
+        reports["memory_candidate_verifier_json"].update({"memory_candidate_verification_status":"memory_candidate_verified"})
+        reports["vow_alignment_attestation_json"].update({"failed_attestation_count":0,"warning_attestation_count":1})
+    return summaries,reports
+
+
+def test_omitted_inputs_incomplete_and_no_authority():
+    s,r=_summaries_and_reports(False)
+    d=build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r)
+    assert d["storage_execution_status"]=="future_storage_design_dossier_incomplete"
+    gap=d["active_execution_gap_summary"]
+    assert gap["active_storage_allowed_now"] is False
+    assert gap["execution_performed"] is False
+    assert gap["writes_performed"] is False
+    assert gap["archives_performed"] is False
+    assert gap["memory_mutation_performed"] is False
+    assert "active_writer_implementation_missing" in gap["blocking_gap_ids"]
+
+
+def test_all_required_reports_complete_while_active_gaps_remain():
+    s,r=_summaries_and_reports(True)
+    d=build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r,commit_sha="abc",pr_number="1",pr_title="t")
+    assert d["storage_execution_status"]=="future_storage_design_dossier_complete"
+    assert d["dossier_context"]["supplied_report_count"]==len(INPUT_SPECS)
+    assert d["readiness_evidence_summary"]["dossier_ready_for_future_design_review"] is True
+    assert d["active_execution_gap_summary"]["blocking_gap_ids"]
+    assert d["active_execution_gap_summary"]["active_storage_allowed_now"] is False
+    assert all(v is True for v in d["non_authority_posture"].values())
+    assert all(x["active"] is False and x["met"] is False for x in d["future_activation_requirements"])
+
+
+def test_failed_verifier_statuses_fail_dossier():
+    s,r=_summaries_and_reports(True, policy_status="storage_policy_failed")
+    assert build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r)["storage_execution_status"]=="future_storage_design_dossier_failed"
+    s,r=_summaries_and_reports(True, plan_status="storage_transaction_plan_failed")
+    assert build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r)["storage_execution_status"]=="future_storage_design_dossier_failed"
+
+
+def test_inventory_digest_hygiene_and_prerequisites():
+    s,r=_summaries_and_reports(True)
+    d=build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r)
+    inv=d["evidence_inventory"][0]
+    assert inv["source_digest"]==s[inv["input_id"]]["digest"]
+    assert inv["source_byte_size"]==s[inv["input_id"]]["byte_size"]
+    assert d["reviewer_hygiene_summary"]["bad_repo_url"]=="https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert d["reviewer_hygiene_summary"]["correct_repo_url"]=="https://github.com/Zombinator85/SentientOS.git"
+    assert any(x["severity"]=="blocking_gap" for x in d["execution_prerequisite_results"])
+
+
+def test_markdown_deterministic_and_escaping():
+    s,r=_summaries_and_reports(True)
+    s["memory_contract_json"]["path"]="a|b\nc"
+    d=build_codex_workcell_storage_execution_dossier(input_summaries=s,input_reports=r)
+    assert render_codex_workcell_storage_execution_dossier_markdown(d)==render_codex_workcell_storage_execution_dossier_markdown(d)
+    md=render_codex_workcell_storage_execution_dossier_markdown(d)
+    assert "a\\|b<br>c" in md
+    assert "Codex Workcell Storage Execution Readiness Dossier" in md


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only dossier that aggregates supplied memory, vow, storage policy, transaction plan, and verifier reports for reviewer-facing future active-storage design work. 
- Surface which verification preconditions are present and which active execution gaps remain while preserving a strict non-authority posture (no writes, no execution, no daemon/PR/finalizer authority).

### Description
- Add a new dossier module `sentientos/codex_workcell_storage_execution_dossier.py` that reads raw bytes for optional JSON inputs, computes SHA-256 digests and byte sizes, parses and validates JSON objects, inventories evidence by stable roles, summarizes readiness signals, and lists active-execution gaps and future activation requirements while enforcing non-authority flags and deterministic output. 
- Add a CLI `scripts/build_codex_workcell_storage_execution_dossier.py` implementing the required `--output` plus optional input flags, `--markdown-output`, commit/PR context flags, clean exit code `2` on invalid/missing/non-object JSON, deterministic JSON/Markdown emission, and a compact `--summary` mode. 
- Add focused unit tests `tests/test_codex_workcell_storage_execution_dossier.py` and CLI tests `tests/test_build_codex_workcell_storage_execution_dossier_script.py` validating incomplete/complete/failed status paths, non-authority posture, evidence digest/byte-size inventory, deterministic output, Markdown escaping, and CLI failure modes. 
- Add documentation `docs/development/codex_workcell_storage_execution_dossier.md` and short boundary notes to adjacent workcell docs so neighboring verifiers/planners can reference the dossier as metadata-only evidence without granting runtime storage authority.

### Testing
- Focused dossier unit tests (`tests/test_codex_workcell_storage_execution_dossier.py`) and CLI tests (`tests/test_build_codex_workcell_storage_execution_dossier_script.py`) executed and passed. 
- Related workcell test suites for transaction plan, policy, vow, and memory components were executed as part of the validation matrix and passed. 
- Docs build was bootstrapped and completed after the prescribed docs bootstrap, and `mypy` targeted checks on the new module and CLI passed. 
- Full landing validation (work item review packet matrix, landing supervisor, pre-commit and post-commit finalizer stages, and PR metadata guard) ran and returned readiness decisions for PR metadata (all automated checks reported passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3deb624830832f9ae3d35aac30d67e)