### PR TITLE
[codex:memory] add Codex workcell storage runtime authority boundary contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -244,3 +244,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -236,3 +236,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -183,3 +183,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -147,3 +147,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -75,3 +75,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -89,3 +89,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -63,3 +63,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -84,3 +84,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -131,3 +131,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -148,3 +148,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -88,3 +88,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -43,3 +43,7 @@ The dossier is read-only, metadata-only, and dossier-only. It does not activate 
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -65,3 +65,7 @@ no ledger write, no glow archive, no memory modification, no watchers, no
 polling, no rerun commands, no readiness decision, no finalizer/guard bypass,
 no commit or PR authority, no daemon trigger, no task creation or scheduling,
 no alerts, no model training, and no federation consensus.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -82,3 +82,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -51,3 +51,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -1,0 +1,64 @@
+# Codex Workcell Storage Runtime Authority Boundary Contract
+
+The Codex Workcell Storage Runtime Authority Boundary Contract is a deterministic, metadata-only contract for future active `/ledger` and `/glow` storage work. It defines the runtime authority bindings that a later authorized implementation would need before any active storage behavior could exist.
+
+It is contract-only. It does not activate memory, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands, schedule tasks, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, create PRs, establish federation consensus, train models, or modify models.
+
+## Dossier/verifier vs runtime authority boundary
+
+The storage execution dossier inventories the evidence stack for future active-storage design. The storage execution dossier verifier checks that dossier structurally and confirms that active execution gaps remain visible. This runtime authority boundary contract comes after them as a policy map of future runtime bindings; it does not verify the dossier, rerun any builder, rerun any verifier, or transform report status into authority.
+
+A complete dossier, a passing dossier verifier, `ready_to_commit`, and `pr_metadata_guard_ready` are review and landing statuses only. They are not runtime write authority for `/ledger` or archive authority for `/glow`.
+
+## Required future runtime bindings
+
+Future active storage remains blocked until an authorized later task supplies explicit implementations and tests for:
+
+- active ledger writer implementation;
+- active glow archiver implementation;
+- finalizer runtime binding implementation;
+- PR metadata guard runtime binding implementation;
+- explicit operator consent capture;
+- storage path enforcement;
+- retention enforcement;
+- digest verification enforcement;
+- parent-chain validation enforcement;
+- pulse watcher contract;
+- daemon action contract;
+- federation drift consensus rule;
+- tests proving no readiness authority;
+- docs marking active behavior.
+
+Every requirement is represented as future-only, unmet, and inactive in this contract.
+
+## Finalizer and guard readiness are not write authority
+
+The contract records that finalizer and PR metadata guard bindings are required for any future active storage design. It also records that finalizer `ready_to_commit` and PR metadata guard readiness are not runtime write authority. They control landing flow; they do not permit ledger writes, glow archives, daemon action, storage execution, or memory mutation.
+
+## Operator consent is required and absent
+
+Operator consent is explicitly required, absent, and not collected by this contract. Future consent must be explicit, scoped to `/ledger` and `/glow`, and must reference the canonical vow digest, storage policy, and transaction plan. This contract never infers consent from reports, tests, validation, matrix output, finalizer output, guard output, or PR metadata.
+
+## Why active storage remains blocked
+
+Active storage remains blocked because the active writer implementation, operator consent, finalizer/guard runtime binding, storage path enforcement, retention enforcement, digest verification runtime, parent-chain runtime, pulse watcher contract, daemon action contract, and federation consensus are all absent. The contract preserves those gap IDs as blocking future-only gaps.
+
+## Not a writer or archiver
+
+The contract is read-only and metadata-only. It can render JSON and Markdown artifacts for review, but those artifacts do not write `/ledger`, archive `/glow`, alter memory, watch paths, poll state, schedule work, create tasks, trigger daemons, establish consensus, or train models.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene remains a landing-task grep responsibility. The contract records the correct repository URL `https://github.com/Zombinator85/SentientOS.git` and the bad attribution URL expected to be absent, but it does not run grep, modify files, or make hygiene a runtime behavior.
+
+## SentientOS mount alignment
+
+- `/ledger`: future runtime storage target; no ledger write here.
+- `/glow`: future runtime archive target; no archive write here.
+- `/vow`: canonical digest context required for runtime authority boundaries.
+- `/pulse`: future watcher boundary; inactive here.
+- `/daemon`: future action boundary; inactive here.
+
+## Non-authority posture
+
+The storage runtime authority boundary contract is read-only, metadata-only, and contract-only. It does not bind runtime authority, activate memory, write ledger entries, archive glow evidence, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer, bypass PR metadata guard, authorize commits, authorize PR creation, trigger daemons, create tasks, schedule tasks, send alerts, train or modify models, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -64,3 +64,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -42,3 +42,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -62,3 +62,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -71,3 +71,7 @@ The [Codex Workcell Storage Execution Readiness Dossier](codex_workcell_storage_
 ## Storage execution dossier verifier boundary
 
 See [Codex Workcell Storage Execution Dossier Verifier](codex_workcell_storage_execution_dossier_verifier.md) for the metadata-only structural verifier that checks dossier evidence inventory, inactive future activation requirements, active execution gaps, reviewer URL hygiene context, and non-authority posture without granting readiness, storage, ledger, glow, daemon, finalizer, PR metadata, commit, task, scheduler, alerting, model-training, or federation authority.
+
+## Storage runtime authority boundary contract note
+
+The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_storage_runtime_authority_contract.md) records future-only runtime binding requirements for active `/ledger` and `/glow` storage. It is metadata-only and does not grant readiness, finalizer authority, PR metadata authority, runtime write authority, ledger writes, glow archives, daemon action, scheduling, memory mutation, or federation consensus.

--- a/scripts/build_codex_workcell_storage_runtime_authority_contract.py
+++ b/scripts/build_codex_workcell_storage_runtime_authority_contract.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_runtime_authority_contract import (
+    CodexWorkcellStorageRuntimeAuthorityContractError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_runtime_authority_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_runtime_authority_contract_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage runtime authority boundary contract.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summary, _loaded = read_json_input(path, input_id)
+                summaries[input_id] = summary
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        contract = build_codex_workcell_storage_runtime_authority_contract(input_summaries=summaries, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageRuntimeAuthorityContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(contract, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_runtime_authority_contract_markdown(contract), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_runtime_authority_contract_id": contract["storage_runtime_authority_contract_id"], "supplied_report_count": contract["runtime_context"]["supplied_report_count"], "active_storage_allowed_now": contract["active_storage_allowed_now"], "runtime_binding_not_performed": contract["runtime_binding_not_performed"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_runtime_authority_contract.py
+++ b/sentientos/codex_workcell_storage_runtime_authority_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_RUNTIME_AUTHORITY_CONTRACT_ID = "codex_workcell_storage_runtime_authority_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: tuple[str, ...] = (
+    "storage_execution_dossier_json",
+    "storage_execution_dossier_verifier_json",
+    "storage_transaction_plan_json",
+    "storage_transaction_plan_verifier_json",
+    "storage_policy_contract_json",
+    "storage_policy_verifier_json",
+    "vow_boundary_contract_json",
+    "vow_alignment_attestation_json",
+    "memory_activation_preflight_json",
+)
+
+BOUNDARY_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("finalizer_runtime_binding_required", "finalizer_guard_boundary", "Finalizer ready-to-commit status is not runtime write authority."),
+    ("pr_metadata_guard_runtime_binding_required", "finalizer_guard_boundary", "PR metadata guard readiness is not runtime write authority."),
+    ("operator_consent_required", "operator_boundary", "Explicit scoped operator consent is required and absent."),
+    ("vow_digest_runtime_binding_required", "vow_boundary", "Canonical vow digest must be bound at runtime before active storage."),
+    ("storage_policy_runtime_binding_required", "storage_boundary", "Storage policy must be bound by an active implementation before writes."),
+    ("transaction_plan_runtime_binding_required", "transaction_boundary", "Transaction plan must be bound by an active implementation before writes."),
+    ("transaction_plan_verifier_runtime_binding_required", "transaction_boundary", "Transaction plan verification must be bound before writes."),
+    ("storage_execution_dossier_runtime_binding_required", "dossier_boundary", "Execution dossier is review evidence, not runtime authority."),
+    ("storage_execution_dossier_verifier_runtime_binding_required", "dossier_boundary", "Dossier verifier is review evidence, not runtime authority."),
+    ("ledger_writer_implementation_required", "ledger_glow_boundary", "No active /ledger writer exists here."),
+    ("glow_archiver_implementation_required", "ledger_glow_boundary", "No active /glow archiver exists here."),
+    ("storage_path_enforcement_required", "storage_boundary", "Runtime path enforcement is future-only and absent."),
+    ("retention_enforcement_required", "storage_boundary", "Runtime retention enforcement is future-only and absent."),
+    ("digest_verification_runtime_required", "storage_boundary", "Runtime digest verification is future-only and absent."),
+    ("parent_chain_runtime_required", "storage_boundary", "Runtime parent-chain validation is future-only and absent."),
+    ("pulse_watcher_contract_required", "pulse_daemon_boundary", "Pulse watcher contract is future-only and absent."),
+    ("daemon_action_contract_required", "pulse_daemon_boundary", "Daemon action contract is future-only and absent."),
+    ("federation_consensus_required", "federation_boundary", "Federation consensus is future-only and absent."),
+    ("no_self_authorizing_daemon", "anti_bypass_boundary", "Daemon outputs cannot self-authorize storage."),
+    ("no_report_status_as_runtime_authority", "anti_bypass_boundary", "Report statuses cannot become runtime authority."),
+    ("no_finalizer_guard_bypass", "anti_bypass_boundary", "Finalizer and PR metadata guard cannot be bypassed."),
+    ("no_active_storage_without_all_runtime_bindings", "anti_bypass_boundary", "Active storage remains blocked until every future binding exists."),
+)
+
+BLOCKING_GAP_IDS: tuple[str, ...] = (
+    "active_writer_implementation_missing", "operator_consent_missing", "finalizer_guard_runtime_binding_missing",
+    "storage_path_enforcement_missing", "retention_enforcement_missing", "digest_verification_runtime_missing",
+    "parent_chain_runtime_missing", "pulse_watcher_contract_missing", "daemon_action_contract_missing", "federation_consensus_missing",
+)
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit active ledger writer implementation", "explicit active glow archiver implementation", "explicit finalizer runtime binding implementation",
+    "explicit PR metadata guard runtime binding implementation", "explicit operator consent capture", "explicit storage path enforcement",
+    "explicit retention enforcement", "explicit digest verification enforcement", "explicit parent-chain validation enforcement",
+    "explicit pulse watcher contract", "explicit daemon action contract", "explicit federation drift consensus rule",
+    "tests proving no readiness authority", "docs marking active behavior",
+)
+NON_AUTHORITY_POSTURE = {
+    "storage_runtime_authority_contract_is_read_only": True,
+    "storage_runtime_authority_contract_is_metadata_only": True,
+    "storage_runtime_authority_contract_is_contract_only": True,
+    "storage_runtime_authority_contract_does_not_bind_runtime_authority": True,
+    "storage_runtime_authority_contract_does_not_activate_memory": True,
+    "storage_runtime_authority_contract_does_not_write_ledger": True,
+    "storage_runtime_authority_contract_does_not_archive_glow": True,
+    "storage_runtime_authority_contract_does_not_modify_memory": True,
+    "storage_runtime_authority_contract_does_not_watch_files": True,
+    "storage_runtime_authority_contract_does_not_poll_state": True,
+    "storage_runtime_authority_contract_does_not_rerun_commands": True,
+    "storage_runtime_authority_contract_does_not_decide_readiness": True,
+    "storage_runtime_authority_contract_does_not_bypass_finalizer": True,
+    "storage_runtime_authority_contract_does_not_bypass_pr_metadata_guard": True,
+    "storage_runtime_authority_contract_does_not_authorize_commit": True,
+    "storage_runtime_authority_contract_does_not_authorize_pr_creation": True,
+    "storage_runtime_authority_contract_does_not_trigger_daemon": True,
+    "storage_runtime_authority_contract_does_not_create_tasks": True,
+    "storage_runtime_authority_contract_does_not_schedule_tasks": True,
+    "storage_runtime_authority_contract_does_not_send_alerts": True,
+    "storage_runtime_authority_contract_does_not_train_or_modify_models": True,
+    "storage_runtime_authority_contract_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellStorageRuntimeAuthorityContractError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageRuntimeAuthorityContractError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageRuntimeAuthorityContractError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellStorageRuntimeAuthorityContractError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _boundary_catalog() -> list[dict[str, Any]]:
+    return [{"boundary_id": bid, "category": cat, "required_for_active_storage": True, "currently_bound": False, "future_only": True, "active": False, "forbidden_inference": summary, "reviewer_summary": summary} for bid, cat, summary in BOUNDARY_SPECS]
+
+def build_codex_workcell_storage_runtime_authority_contract(*, input_summaries: Mapping[str, Mapping[str, Any]], commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    supplied = sum(1 for input_id in INPUT_SPECS if input_summaries[input_id].get("provided") is True)
+    return {
+        "storage_runtime_authority_contract_id": WORKCELL_STORAGE_RUNTIME_AUTHORITY_CONTRACT_ID,
+        "metadata_only": True, "runtime_authority_contract_only": True, "runtime_binding_not_performed": True,
+        "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": dict(input_summaries),
+        "runtime_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied, "runtime_authority_contract_only": True, "no_action_taken": True},
+        "runtime_authority_boundary_catalog": _boundary_catalog(),
+        "finalizer_guard_binding_policy": {"finalizer_runtime_binding_required": True, "pr_metadata_guard_runtime_binding_required": True, "finalizer_ready_to_commit_is_not_runtime_write_authority": True, "pr_metadata_guard_ready_is_not_runtime_write_authority": True, "no_finalizer_guard_bypass": True, "currently_bound": False, "binding_not_performed": True, "policy_only": True, "required_future_evidence": ["finalizer_runtime_binding_implementation", "pr_metadata_guard_runtime_binding_implementation", "negative_tests_for_no_write_authority"]},
+        "operator_consent_policy": {"operator_consent_required": True, "operator_consent_present": False, "consent_not_collected": True, "consent_must_be_explicit": True, "consent_must_be_scoped_to_mounts": ["/ledger", "/glow"], "consent_must_reference_vow_digest": True, "consent_must_reference_storage_policy": True, "consent_must_reference_transaction_plan": True, "policy_only": True},
+        "storage_enforcement_policy": {"storage_path_enforcement_required": True, "retention_enforcement_required": True, "active_ledger_writer_required": True, "active_glow_archiver_required": True, "active_ledger_writer_present": False, "active_glow_archiver_present": False, "enforcement_not_performed": True, "policy_only": True, "forbidden_runtime_write_modes": ["write_without_operator_consent", "write_without_finalizer_guard_runtime_binding", "write_without_vow_digest", "write_without_storage_policy", "write_without_transaction_plan", "write_without_transaction_plan_verification", "write_without_digest_verification", "write_without_parent_chain_validation", "archive_without_related_ledger_context", "archive_as_model_training_data", "report_status_as_runtime_authority"]},
+        "digest_and_parent_runtime_policy": {"digest_verification_runtime_required": True, "parent_chain_runtime_required": True, "digest_verification_runtime_present": False, "parent_chain_runtime_present": False, "runtime_verification_not_performed": True, "policy_only": True, "required_digest_bindings": ["source_artifact_digest", "canonical_vow_digest", "storage_policy_digest", "transaction_plan_digest", "transaction_plan_verifier_digest", "dossier_digest", "dossier_verifier_digest"], "required_parent_chain_bindings": ["prior_ledger_entry_id", "prior_ledger_entry_digest", "overwrite_receipt_context", "missing_parent_blocks_write", "parent_digest_mismatch_blocks_write"]},
+        "pulse_daemon_runtime_boundary": {"pulse_watcher_contract_required": True, "daemon_action_contract_required": True, "pulse_watcher_contract_present": False, "daemon_action_contract_present": False, "daemon_self_authorization_forbidden": True, "pulse_signals_are_not_actions": True, "daemon_recommendations_are_not_commands": True, "boundary_only": True},
+        "federation_runtime_boundary": {"federation_consensus_required": True, "federation_consensus_present": False, "federation_consensus_not_established": True, "local_storage_authority_not_implied_by_remote_state": True, "remote_consensus_not_implied": True, "boundary_only": True},
+        "runtime_activation_gap_summary": {"active_storage_allowed_now": False, "runtime_binding_not_performed": True, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "active_writer_implementation_present": False, "operator_consent_present": False, "finalizer_guard_runtime_binding_present": False, "storage_path_enforcement_present": False, "retention_enforcement_present": False, "digest_verification_runtime_present": False, "parent_chain_runtime_present": False, "pulse_watcher_contract_present": False, "daemon_action_contract_present": False, "federation_consensus_present": False, "blocking_gap_ids": list(BLOCKING_GAP_IDS)},
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata contract.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future runtime storage target; no ledger write here", "/glow": "future runtime archive target; no archive write here", "/vow": "canonical digest context required for runtime authority boundaries", "/pulse": "future watcher boundary; inactive here", "/daemon": "future action boundary; inactive here"},
+        "future_activation_requirements": [{"requirement": req, "status": "future_only", "met": False, "active": False} for req in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+def _table(headers: list[str], rows: list[list[Any]]) -> str:
+    out = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    out.extend("| " + " | ".join(_cell(c) for c in row) + " |" for row in rows)
+    return "\n".join(out) + "\n"
+
+def render_codex_workcell_storage_runtime_authority_contract_markdown(report: Mapping[str, Any]) -> str:
+    parts = ["# Codex Workcell Storage Runtime Authority Boundary Contract\n", "This deterministic metadata-only contract defines future runtime authority bindings for active `/ledger` and `/glow` storage; it performs no binding, readiness decision, write, archive, memory mutation, daemon action, task creation, scheduling, command execution, or federation consensus.\n"]
+    parts.append("## Input summaries\n" + _table(["input", "provided", "path", "digest", "bytes"], [[k, v.get("provided"), v.get("path"), v.get("digest"), v.get("byte_size")] for k, v in sorted(report["input_summaries"].items())]))
+    parts.append("## Runtime context\n" + _table(["key", "value"], [[k, v] for k, v in report["runtime_context"].items()]))
+    parts.append("## Runtime authority boundary catalog\n" + _table(["id", "category", "future_only", "currently_bound", "active", "summary"], [[b["boundary_id"], b["category"], b["future_only"], b["currently_bound"], b["active"], b["reviewer_summary"]] for b in report["runtime_authority_boundary_catalog"]]))
+    for title, key in (("Finalizer/guard binding policy", "finalizer_guard_binding_policy"), ("Operator consent policy", "operator_consent_policy"), ("Storage enforcement policy", "storage_enforcement_policy"), ("Digest and parent runtime policy", "digest_and_parent_runtime_policy"), ("Pulse/daemon runtime boundary", "pulse_daemon_runtime_boundary"), ("Federation runtime boundary", "federation_runtime_boundary"), ("Runtime activation gap summary", "runtime_activation_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Non-authority posture", "non_authority_posture")):
+        parts.append(f"## {title}\n" + _table(["key", "value"], [[k, v] for k, v in report[key].items()]))
+    parts.append("## Future activation requirements\n" + _table(["requirement", "status", "met", "active"], [[r["requirement"], r["status"], r["met"], r["active"]] for r in report["future_activation_requirements"]]))
+    return "\n".join(parts)

--- a/tests/test_build_codex_workcell_storage_runtime_authority_contract_script.py
+++ b/tests/test_build_codex_workcell_storage_runtime_authority_contract_script.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+import subprocess
+import sys
+
+
+def _run(args):
+    return subprocess.run([sys.executable, "scripts/build_codex_workcell_storage_runtime_authority_contract.py", *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_summary_and_markdown(tmp_path):
+    input_path = tmp_path / "policy.json"
+    input_path.write_text('{"policy":"ok"}\n', encoding="utf-8")
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = _run(["--output", str(output), "--storage-policy-contract-json", str(input_path), "--commit-sha", "abc", "--pr-number", "7", "--pr-title", "Title", "--markdown-output", str(markdown), "--summary"])
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert summary["storage_runtime_authority_contract_id"] == "codex_workcell_storage_runtime_authority_contract.v1"
+    assert summary["runtime_binding_not_performed"] is True
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["runtime_context"]["supplied_report_count"] == 1
+    assert report["runtime_context"]["commit_sha"] == "abc"
+    assert report["input_summaries"]["storage_policy_contract_json"]["provided"] is True
+    assert report["input_summaries"]["storage_execution_dossier_json"]["provided"] is False
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Runtime Authority Boundary Contract")
+
+
+def test_cli_invalid_missing_and_non_object_json_exit_2(tmp_path):
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{bad", encoding="utf-8")
+    missing = tmp_path / "missing.json"
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    for path, expected in ((invalid, "invalid_json"), (missing, "missing_json"), (array, "json_not_object")):
+        result = _run(["--output", str(output), "--storage-policy-contract-json", str(path)])
+        assert result.returncode == 2
+        assert expected in result.stderr
+
+
+def test_cli_output_is_deterministic(tmp_path):
+    output1 = tmp_path / "one.json"
+    output2 = tmp_path / "two.json"
+    markdown1 = tmp_path / "one.md"
+    markdown2 = tmp_path / "two.md"
+    args = ["--commit-sha", "abc", "--pr-title", "Pipe | New\nLine"]
+    first = _run(["--output", str(output1), "--markdown-output", str(markdown1), *args])
+    second = _run(["--output", str(output2), "--markdown-output", str(markdown2), *args])
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert output1.read_text(encoding="utf-8") == output2.read_text(encoding="utf-8")
+    assert markdown1.read_text(encoding="utf-8") == markdown2.read_text(encoding="utf-8")
+    assert "Pipe \\| New<br>Line" in markdown1.read_text(encoding="utf-8")

--- a/tests/test_codex_workcell_storage_runtime_authority_contract.py
+++ b/tests/test_codex_workcell_storage_runtime_authority_contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_runtime_authority_contract import (
+    BOUNDARY_SPECS,
+    BLOCKING_GAP_IDS,
+    FUTURE_REQUIREMENTS,
+    INPUT_SPECS,
+    WORKCELL_STORAGE_RUNTIME_AUTHORITY_CONTRACT_ID,
+    build_codex_workcell_storage_runtime_authority_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_runtime_authority_contract_markdown,
+)
+
+
+def _contract():
+    return build_codex_workcell_storage_runtime_authority_contract(
+        input_summaries={input_id: omitted_input(input_id) for input_id in INPUT_SPECS},
+        commit_sha="abc123",
+        pr_number="42",
+        pr_title="title",
+    )
+
+
+def test_contract_flags_and_runtime_context_are_non_authoritative():
+    report = _contract()
+    assert report["storage_runtime_authority_contract_id"] == WORKCELL_STORAGE_RUNTIME_AUTHORITY_CONTRACT_ID
+    for key in ("metadata_only", "runtime_authority_contract_only", "runtime_binding_not_performed"):
+        assert report[key] is True
+    for key in ("active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"):
+        assert report[key] is False
+    assert report["runtime_context"] == {"commit_sha": "abc123", "pr_number": "42", "pr_title": "title", "supplied_report_count": 0, "runtime_authority_contract_only": True, "no_action_taken": True}
+
+
+def test_boundary_catalog_contains_all_required_future_inactive_boundaries():
+    report = _contract()
+    expected = {boundary_id for boundary_id, _category, _summary in BOUNDARY_SPECS}
+    catalog = report["runtime_authority_boundary_catalog"]
+    assert {entry["boundary_id"] for entry in catalog} == expected
+    for entry in catalog:
+        assert entry["required_for_active_storage"] is True
+        assert entry["currently_bound"] is False
+        assert entry["future_only"] is True
+        assert entry["active"] is False
+        assert entry["forbidden_inference"]
+        assert entry["reviewer_summary"]
+
+
+def test_policy_sections_keep_authority_absent():
+    report = _contract()
+    finalizer = report["finalizer_guard_binding_policy"]
+    assert finalizer["finalizer_ready_to_commit_is_not_runtime_write_authority"] is True
+    assert finalizer["pr_metadata_guard_ready_is_not_runtime_write_authority"] is True
+    assert finalizer["currently_bound"] is False
+    assert finalizer["binding_not_performed"] is True
+    consent = report["operator_consent_policy"]
+    assert consent["operator_consent_required"] is True
+    assert consent["operator_consent_present"] is False
+    assert consent["consent_must_be_scoped_to_mounts"] == ["/ledger", "/glow"]
+    storage = report["storage_enforcement_policy"]
+    assert storage["active_ledger_writer_present"] is False
+    assert storage["active_glow_archiver_present"] is False
+    assert "report_status_as_runtime_authority" in storage["forbidden_runtime_write_modes"]
+    digest = report["digest_and_parent_runtime_policy"]
+    assert digest["digest_verification_runtime_present"] is False
+    assert digest["parent_chain_runtime_present"] is False
+    assert digest["runtime_verification_not_performed"] is True
+    pulse = report["pulse_daemon_runtime_boundary"]
+    assert pulse["pulse_watcher_contract_present"] is False
+    assert pulse["daemon_action_contract_present"] is False
+    assert pulse["daemon_recommendations_are_not_commands"] is True
+    federation = report["federation_runtime_boundary"]
+    assert federation["federation_consensus_present"] is False
+    assert federation["federation_consensus_not_established"] is True
+
+
+def test_gap_hygiene_future_requirements_and_non_authority_posture():
+    report = _contract()
+    gaps = report["runtime_activation_gap_summary"]
+    for gap in BLOCKING_GAP_IDS:
+        assert gap in gaps["blocking_gap_ids"]
+    assert gaps["active_storage_allowed_now"] is False
+    assert gaps["runtime_binding_not_performed"] is True
+    hygiene = report["reviewer_hygiene_summary"]
+    assert hygiene["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert hygiene["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert hygiene["no_runtime_effect"] is True
+    assert {item["requirement"] for item in report["future_activation_requirements"]} == set(FUTURE_REQUIREMENTS)
+    for item in report["future_activation_requirements"]:
+        assert item["status"] == "future_only"
+        assert item["met"] is False
+        assert item["active"] is False
+    assert all(value is True for value in report["non_authority_posture"].values())
+    for key in ("storage_runtime_authority_contract_does_not_decide_readiness", "storage_runtime_authority_contract_does_not_bind_runtime_authority", "storage_runtime_authority_contract_does_not_write_ledger", "storage_runtime_authority_contract_does_not_archive_glow", "storage_runtime_authority_contract_does_not_modify_memory", "storage_runtime_authority_contract_does_not_trigger_daemon", "storage_runtime_authority_contract_does_not_create_tasks", "storage_runtime_authority_contract_does_not_schedule_tasks"):
+        assert report["non_authority_posture"][key] is True
+
+
+def test_input_summaries_record_raw_digest_and_omissions(tmp_path):
+    path = tmp_path / "input.json"
+    raw = b'{"name":"report"}\n'
+    path.write_bytes(raw)
+    summary, loaded = read_json_input(str(path), "storage_policy_contract_json")
+    assert loaded == {"name": "report"}
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+    omitted = omitted_input("storage_execution_dossier_json")
+    assert omitted == {"input_id": "storage_execution_dossier_json", "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+
+def test_json_and_markdown_are_deterministic_and_escape_cells():
+    report = _contract()
+    first = json.dumps(report, sort_keys=True, indent=2)
+    second = json.dumps(_contract(), sort_keys=True, indent=2)
+    assert first == second
+    report["runtime_context"]["pr_title"] = "pipe | newline\nvalue"
+    md1 = render_codex_workcell_storage_runtime_authority_contract_markdown(report)
+    md2 = render_codex_workcell_storage_runtime_authority_contract_markdown(report)
+    assert md1 == md2
+    assert "pipe \\| newline<br>value" in md1
+    assert md1.startswith("# Codex Workcell Storage Runtime Authority Boundary Contract")


### PR DESCRIPTION
### Motivation

- Provide a deterministic, metadata-only runtime authority boundary contract that enumerates the runtime bindings required before any active `/ledger` or `/glow` storage may be enabled. 
- Ensure the workcell storage ladder preserves and documents active execution gaps (writer implementation, operator consent, finalizer/guard runtime binding, path/retention enforcement, digest/parent-chain verification, pulse/daemon boundaries, federation) while remaining strictly non-authoritative. 

### Description

- Add the contract module `sentientos/codex_workcell_storage_runtime_authority_contract.py` which emits a deterministic JSON contract with `storage_runtime_authority_contract_id`, `runtime_authority_boundary_catalog`, policy sections, gap summary, non-authority posture flags, and raw-byte SHA-256 input summaries. 
- Add the CLI `scripts/build_codex_workcell_storage_runtime_authority_contract.py` which accepts optional evidence JSON inputs, computes digests/byte-sizes, fails cleanly for missing/invalid/non-object JSON (exit code `2`), writes deterministic JSON, and optionally renders Markdown. 
- Add focused tests `tests/test_codex_workcell_storage_runtime_authority_contract.py` and `tests/test_build_codex_workcell_storage_runtime_authority_contract_script.py` covering contract flags, inactive/future-only boundaries, absent authority artifacts, deterministic JSON/Markdown, Markdown escaping, and CLI error behavior. 
- Add `docs/development/codex_workcell_storage_runtime_authority_contract.md` and add short boundary notes linking this contract from adjacent storage and validation docs so reviewers can find the boundary mapping. 

### Testing

- Ran focused unit and CLI tests with `python -m scripts.run_tests -q tests/test_codex_workcell_storage_runtime_authority_contract.py tests/test_build_codex_workcell_storage_runtime_authority_contract_script.py`, and the tests passed. 
- Built and checked docs with `python scripts/build_docs.py --bootstrap-docs` and `python scripts/build_docs.py`, and the docs build completed after bootstrapping. 
- Ran targeted static typing with `python -m mypy sentientos/codex_workcell_storage_runtime_authority_contract.py scripts/build_codex_workcell_storage_runtime_authority_contract.py`, and the checks passed. 
- Executed the repository landing validation matrix and landing tools (`python scripts/run_work_item_review_packet_matrix.py`, `python scripts/codex_landing_supervisor.py evaluate`, `python scripts/codex_finalize_landing.py finalize`, and `python scripts/codex_pr_metadata_guard.py verify`) as part of the landing workflow and received the expected ready statuses for PR metadata guard and finalizer stages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ebe4c71a0832f83023c51cb1d8131)