### PR TITLE
[codex:memory] add storage operator consent request contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -252,3 +252,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -244,3 +244,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -191,3 +191,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -155,3 +155,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -83,3 +83,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -97,3 +97,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -71,3 +71,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -92,3 +92,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -139,3 +139,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -156,3 +156,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -96,3 +96,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -51,3 +51,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -73,3 +73,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_contract.md
@@ -1,0 +1,105 @@
+# Codex Workcell Storage Operator Consent Request Contract
+
+The Codex Workcell Storage Operator Consent Request Contract is a deterministic,
+metadata-only contract for the future explicit operator consent artifact that
+would be required before active `/ledger` writes or `/glow` archival. It defines
+request shape, evidence, scope, digest bindings, lifetime, revocation, and denial
+rules only.
+
+This contract is not consent. It does not collect operator approval, imply
+operator approval, activate memory, bind runtime authority, write ledger entries,
+archive glow evidence, mutate memory, watch files, poll state, schedule work,
+trigger daemon action, decide readiness, authorize commits, authorize PR metadata,
+create PRs, establish federation consensus, or train or modify models.
+
+## Relationship to runtime authority verification
+
+The storage runtime authority boundary contract and verifier prove that runtime
+bindings remain absent and active storage is blocked. This operator consent
+request contract covers the separate missing boundary: what a future explicit
+operator consent artifact must contain. Runtime authority evidence can be a
+future input to consent, but runtime authority evidence is not itself consent.
+
+## Future explicit consent evidence
+
+A future consent artifact must explicitly reference operator identity, operator
+timestamp, operator scope statement, canonical vow digest, storage policy contract
+and verifier digests, transaction plan and verifier digests, execution dossier and
+verifier digests, runtime authority contract and verifier digests, pre-commit
+finalizer receipt, PR metadata finalizer receipt, and PR metadata guard receipt.
+Missing or ambiguous evidence keeps active storage denied.
+
+## Scope and mounts
+
+Future consent may only scope active storage to `/ledger` and `/glow`, and ledger
+writes and glow archival must each be explicitly allowed. `/vow`, `/pulse`, and
+`/daemon` are forbidden as active storage targets here. Host absolute paths,
+network paths, temporary paths as canonical targets, and hidden backdoor paths are
+also forbidden.
+
+Mount alignment remains narrow:
+
+- `/ledger`: future consent scope target; no ledger write here.
+- `/glow`: future consent scope target; no archive write here.
+- `/vow`: canonical digest required for future consent binding.
+- `/pulse`: future watcher boundary; consent here does not activate it.
+- `/daemon`: future action boundary; consent here does not activate it.
+
+## Digest binding requirements
+
+A future consent artifact must bind sha256 digests for the canonical vow, storage
+policy, transaction plan, execution dossier, and runtime authority evidence. This
+contract may summarize supplied report digests, but digest binding is not
+performed here and supplied reports do not imply consent.
+
+## Lifetime, renewal, revocation, and denial
+
+Future consent must include expiration and revocation terms. Renewal is required
+for a new vow digest, new storage policy, new transaction plan, or changed mount
+scope. Revocation must block future writes and archives, must not delete existing
+receipts, and must create a future revocation receipt. The default without
+explicit consent is `deny_active_storage`.
+
+## Forbidden implied consent
+
+Finalizer ready-to-commit status, PR metadata guard readiness, daemon
+recommendations, supplied reports, federation state, and this schema do not imply
+operator consent. Remote or daemon consent is not accepted for this boundary;
+future operator consent must be explicit and scoped.
+
+## Active storage remains blocked
+
+The contract records that operator consent is absent, runtime binding is not
+performed, active storage is not allowed now, execution is not performed, writes
+are not performed, archives are not performed, and memory mutation is not
+performed. Blocking gaps include missing operator consent, operator identity,
+consent timestamp, consent scope, digest bindings, expiration, revocation terms,
+explicit ledger write allowance, explicit glow archive allowance, and runtime
+authority binding.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene is separate from runtime behavior. The contract records that
+the OpenAI-hosted SentientOS repository URL is expected to be absent and that the
+correct repository URL is `https://github.com/Zombinator85/SentientOS.git`, but
+repository grep validation is performed by the landing task, not by this metadata
+contract.
+
+## Future activation requirements
+
+Future activation remains unmet and inactive until explicit operator identity,
+explicit operator consent, timestamp, expiration, revocation, digest bindings,
+active ledger writer implementation, active glow archiver implementation,
+finalizer and PR metadata guard runtime binding implementations, storage path
+enforcement, retention enforcement, digest verification enforcement,
+parent-chain validation enforcement, no-readiness-authority tests, and active
+behavior docs exist.
+
+## Non-authority posture
+
+The contract is read-only, metadata-only, and contract-only. It does not collect
+or imply consent, bind runtime authority, activate memory, write ledger entries,
+archive glow evidence, modify memory, watch files, poll state, rerun commands,
+decide readiness, bypass finalizer or PR metadata guard, authorize commit or PR
+creation, trigger daemons, create or schedule tasks, send alerts, train or modify
+models, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -90,3 +90,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -59,3 +59,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -66,3 +66,7 @@ The storage runtime authority boundary contract is read-only, metadata-only, and
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_runtime_authority_verifier.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_verifier.md
@@ -29,3 +29,7 @@ Reviewer URL hygiene remains a landing-task grep responsibility, not runtime beh
 Active storage remains blocked until explicit active ledger writer and glow archiver implementations, finalizer and PR metadata guard runtime bindings, operator consent capture, storage path enforcement, retention enforcement, digest verification enforcement, parent-chain validation enforcement, pulse watcher contract, daemon action contract, federation drift consensus rule, negative readiness-authority tests, and active-behavior docs exist in a future authorized layer.
 
 The verifier is read-only, metadata-only, verifier-only, and does not bind runtime authority, activate memory, write ledger, archive glow, modify memory, watch files, poll state, rerun commands, decide readiness, bypass finalizer or PR metadata guard, authorize commits or PR creation, trigger daemons, create or schedule tasks, send alerts, train or modify models, or establish federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -72,3 +72,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -50,3 +50,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -70,3 +70,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -79,3 +79,7 @@ The [Codex Workcell Storage Runtime Authority Boundary Contract](codex_workcell_
 ## Storage runtime authority verifier boundary
 
 See [Codex Workcell Storage Runtime Authority Boundary Verifier](codex_workcell_storage_runtime_authority_verifier.md) for the metadata-only structural verifier that checks the future-only runtime authority contract without granting readiness, binding runtime authority, writing `/ledger`, archiving `/glow`, mutating memory, scheduling work, triggering daemon action, or establishing federation consensus.
+
+## Storage operator consent request boundary
+
+See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_storage_operator_consent_contract.md) for the metadata-only future consent request shape. That contract does not collect consent, imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, or authorize PR metadata.

--- a/scripts/build_codex_workcell_storage_operator_consent_contract.py
+++ b/scripts/build_codex_workcell_storage_operator_consent_contract.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_operator_consent_contract import (
+    CodexWorkcellStorageOperatorConsentContractError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_operator_consent_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_contract_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage operator consent request contract.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            summaries[input_id] = read_json_input(path, input_id)[0] if path else omitted_input(input_id)
+        contract = build_codex_workcell_storage_operator_consent_contract(input_summaries=summaries, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageOperatorConsentContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(contract, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_operator_consent_contract_markdown(contract), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_operator_consent_contract_id": contract["storage_operator_consent_contract_id"], "supplied_report_count": contract["consent_context"]["supplied_report_count"], "consent_not_collected": contract["consent_not_collected"], "active_storage_allowed_now": contract["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_operator_consent_contract.py
+++ b/sentientos/codex_workcell_storage_operator_consent_contract.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_OPERATOR_CONSENT_CONTRACT_ID = "codex_workcell_storage_operator_consent_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: tuple[str, ...] = (
+    "storage_runtime_authority_contract_json", "storage_runtime_authority_verifier_json",
+    "storage_execution_dossier_json", "storage_execution_dossier_verifier_json",
+    "storage_transaction_plan_json", "storage_transaction_plan_verifier_json",
+    "storage_policy_contract_json", "storage_policy_verifier_json",
+    "vow_boundary_contract_json", "vow_alignment_attestation_json",
+)
+
+SCHEMA_IDS: tuple[str, ...] = (
+    "operator_identity_required", "consent_timestamp_required", "consent_scope_required",
+    "consent_mount_scope_required", "canonical_vow_digest_required", "storage_policy_digest_required",
+    "storage_policy_verifier_digest_required", "transaction_plan_digest_required",
+    "transaction_plan_verifier_digest_required", "execution_dossier_digest_required",
+    "execution_dossier_verifier_digest_required", "runtime_authority_contract_digest_required",
+    "runtime_authority_verifier_digest_required", "finalizer_guard_evidence_required",
+    "explicit_allow_ledger_write_required", "explicit_allow_glow_archive_required",
+    "explicit_denial_default_required", "revocation_terms_required", "expiration_terms_required",
+    "no_daemon_self_authorization_required", "no_federation_implied_consent_required",
+)
+
+REQUIRED_EVIDENCE_IDS: tuple[str, ...] = (
+    "canonical_vow_digest", "storage_policy_contract_digest", "storage_policy_verifier_digest",
+    "storage_transaction_plan_digest", "storage_transaction_plan_verifier_digest",
+    "storage_execution_dossier_digest", "storage_execution_dossier_verifier_digest",
+    "runtime_authority_contract_digest", "runtime_authority_verifier_digest",
+    "finalizer_pre_commit_receipt", "pr_metadata_finalizer_receipt", "pr_metadata_guard_receipt",
+    "operator_identity", "operator_timestamp", "operator_scope_statement",
+)
+
+INPUT_TO_EVIDENCE: dict[str, str] = {
+    "vow_boundary_contract_json": "canonical_vow_digest",
+    "vow_alignment_attestation_json": "canonical_vow_digest",
+    "storage_policy_contract_json": "storage_policy_contract_digest",
+    "storage_policy_verifier_json": "storage_policy_verifier_digest",
+    "storage_transaction_plan_json": "storage_transaction_plan_digest",
+    "storage_transaction_plan_verifier_json": "storage_transaction_plan_verifier_digest",
+    "storage_execution_dossier_json": "storage_execution_dossier_digest",
+    "storage_execution_dossier_verifier_json": "storage_execution_dossier_verifier_digest",
+    "storage_runtime_authority_contract_json": "runtime_authority_contract_digest",
+    "storage_runtime_authority_verifier_json": "runtime_authority_verifier_digest",
+}
+
+BLOCKING_GAP_IDS: tuple[str, ...] = (
+    "operator_consent_missing", "operator_identity_missing", "consent_timestamp_missing",
+    "consent_scope_missing", "consent_digest_bindings_missing", "consent_expiration_missing",
+    "consent_revocation_terms_missing", "explicit_ledger_write_allow_missing",
+    "explicit_glow_archive_allow_missing", "runtime_authority_binding_missing",
+)
+
+FUTURE_REQUIREMENTS: tuple[str, ...] = (
+    "explicit operator identity capture", "explicit operator consent capture", "explicit consent timestamp capture",
+    "explicit consent expiration policy", "explicit consent revocation policy", "explicit canonical vow digest binding",
+    "explicit storage policy digest binding", "explicit transaction plan digest binding", "explicit execution dossier digest binding",
+    "explicit runtime authority digest binding", "explicit active ledger writer implementation", "explicit active glow archiver implementation",
+    "explicit finalizer runtime binding implementation", "explicit PR metadata guard runtime binding implementation",
+    "explicit storage path enforcement", "explicit retention enforcement", "explicit digest verification enforcement",
+    "explicit parent-chain validation enforcement", "tests proving no readiness authority", "docs marking active behavior",
+)
+
+NON_AUTHORITY_POSTURE: dict[str, bool] = {
+    "storage_operator_consent_contract_is_read_only": True,
+    "storage_operator_consent_contract_is_metadata_only": True,
+    "storage_operator_consent_contract_is_contract_only": True,
+    "storage_operator_consent_contract_does_not_collect_consent": True,
+    "storage_operator_consent_contract_does_not_imply_consent": True,
+    "storage_operator_consent_contract_does_not_bind_runtime_authority": True,
+    "storage_operator_consent_contract_does_not_activate_memory": True,
+    "storage_operator_consent_contract_does_not_write_ledger": True,
+    "storage_operator_consent_contract_does_not_archive_glow": True,
+    "storage_operator_consent_contract_does_not_modify_memory": True,
+    "storage_operator_consent_contract_does_not_watch_files": True,
+    "storage_operator_consent_contract_does_not_poll_state": True,
+    "storage_operator_consent_contract_does_not_rerun_commands": True,
+    "storage_operator_consent_contract_does_not_decide_readiness": True,
+    "storage_operator_consent_contract_does_not_bypass_finalizer": True,
+    "storage_operator_consent_contract_does_not_bypass_pr_metadata_guard": True,
+    "storage_operator_consent_contract_does_not_authorize_commit": True,
+    "storage_operator_consent_contract_does_not_authorize_pr_creation": True,
+    "storage_operator_consent_contract_does_not_trigger_daemon": True,
+    "storage_operator_consent_contract_does_not_create_tasks": True,
+    "storage_operator_consent_contract_does_not_schedule_tasks": True,
+    "storage_operator_consent_contract_does_not_send_alerts": True,
+    "storage_operator_consent_contract_does_not_train_or_modify_models": True,
+    "storage_operator_consent_contract_does_not_establish_federation_consensus": True,
+}
+
+class CodexWorkcellStorageOperatorConsentContractError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageOperatorConsentContractError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageOperatorConsentContractError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellStorageOperatorConsentContractError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _schema() -> list[dict[str, Any]]:
+    return [{"schema_field_id": sid, "required_for_future_consent": True, "currently_satisfied": False, "future_only": True, "active": False, "forbidden_inference": "This future consent field is not satisfied by reports, readiness, daemon output, federation state, or this contract.", "reviewer_summary": f"Future explicit consent artifact must include {sid}; inactive here."} for sid in SCHEMA_IDS]
+
+def _supplied_evidence(input_summaries: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    return sorted({eid for iid, eid in INPUT_TO_EVIDENCE.items() if input_summaries[iid].get("provided") is True})
+
+def build_codex_workcell_storage_operator_consent_contract(*, input_summaries: Mapping[str, Mapping[str, Any]], commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    supplied_count = sum(1 for iid in INPUT_SPECS if input_summaries[iid].get("provided") is True)
+    supplied_evidence = _supplied_evidence(input_summaries)
+    missing = [eid for eid in REQUIRED_EVIDENCE_IDS if eid not in supplied_evidence]
+    top: dict[str, Any] = {
+        "storage_operator_consent_contract_id": WORKCELL_STORAGE_OPERATOR_CONSENT_CONTRACT_ID,
+        "metadata_only": True, "consent_contract_only": True, "consent_request_shape_only": True,
+        "consent_not_collected": True, "operator_consent_present": False, "runtime_binding_not_performed": True,
+        "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False,
+        "archives_performed": False, "memory_mutation_performed": False,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True,
+        "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True,
+        "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True,
+        "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": dict(input_summaries),
+        "consent_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied_count, "consent_contract_only": True, "consent_not_collected": True, "no_action_taken": True},
+        "consent_request_schema": _schema(),
+        "required_consent_evidence": {"required_evidence_ids": list(REQUIRED_EVIDENCE_IDS), "supplied_evidence_ids": supplied_evidence, "missing_evidence_ids": missing, "evidence_collection_not_performed": True, "consent_not_collected": True, "policy_only": True},
+        "consent_scope_policy": {"allowed_mounts": ["/ledger", "/glow"], "forbidden_mounts": ["/vow", "/pulse", "/daemon", "host_absolute_paths", "network_paths", "temp_paths_as_canonical", "hidden_backdoor_paths"], "ledger_write_must_be_explicit": True, "glow_archive_must_be_explicit": True, "consent_does_not_authorize_daemon_action": True, "consent_does_not_authorize_model_training": True, "consent_does_not_authorize_federation_consensus": True, "policy_only": True},
+        "consent_digest_binding_policy": {"canonical_vow_digest_required": True, "storage_policy_digest_required": True, "transaction_plan_digest_required": True, "execution_dossier_digest_required": True, "runtime_authority_digest_required": True, "digest_algorithm": DIGEST_ALGO, "digest_binding_not_performed": True, "missing_digest_bindings": missing, "policy_only": True},
+        "consent_lifetime_policy": {"expiration_required": True, "revocation_required": True, "renewal_required_for_new_vow_digest": True, "renewal_required_for_new_storage_policy": True, "renewal_required_for_new_transaction_plan": True, "renewal_required_for_changed_mount_scope": True, "consent_lifetime_not_started": True, "policy_only": True},
+        "consent_revocation_policy": {"revocation_must_block_new_writes": True, "revocation_must_block_new_archives": True, "revocation_must_not_delete_existing_receipts": True, "revocation_must_create_future_revocation_receipt": True, "revocation_not_performed": True, "policy_only": True},
+        "consent_denial_policy": {"default_without_consent": "deny_active_storage", "missing_consent_blocks_ledger_write": True, "missing_consent_blocks_glow_archive": True, "ambiguous_consent_blocks_storage": True, "remote_or_daemon_consent_not_accepted": True, "consent_denial_not_runtime_decision_here": True, "policy_only": True},
+        "consent_authority_boundary": {"consent_contract_is_not_consent": True, "consent_schema_is_not_operator_approval": True, "supplied_reports_do_not_imply_consent": True, "finalizer_ready_to_commit_does_not_imply_consent": True, "pr_metadata_guard_ready_does_not_imply_consent": True, "daemon_recommendation_does_not_imply_consent": True, "federation_state_does_not_imply_consent": True, "future_operator_consent_must_be_explicit": True, "authority_boundary_only": True},
+        "consent_activation_gap_summary": {"operator_consent_present": False, "consent_not_collected": True, "active_storage_allowed_now": False, "runtime_binding_not_performed": True, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "blocking_gap_ids": list(BLOCKING_GAP_IDS)},
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata contract.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future consent scope target; no ledger write here", "/glow": "future consent scope target; no archive write here", "/vow": "canonical digest required for future consent binding", "/pulse": "future watcher boundary; consent here does not activate it", "/daemon": "future action boundary; consent here does not activate it"},
+        "future_activation_requirements": [{"requirement": req, "status": "future_only", "met": False, "active": False} for req in FUTURE_REQUIREMENTS],
+        "non_authority_posture": dict(NON_AUTHORITY_POSTURE),
+    }
+    return top
+
+def _cell(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+def _table(headers: list[str], rows: list[list[Any]]) -> str:
+    out = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    out.extend("| " + " | ".join(_cell(c) for c in row) + " |" for row in rows)
+    return "\n".join(out) + "\n"
+
+def render_codex_workcell_storage_operator_consent_contract_markdown(report: Mapping[str, Any]) -> str:
+    parts = ["# Codex Workcell Storage Operator Consent Request Contract\n", "This deterministic metadata-only contract defines the future explicit operator consent request shape for `/ledger` and `/glow`; it collects no consent, implies no consent, binds no runtime authority, and performs no write, archive, memory mutation, readiness decision, daemon action, scheduling, alerting, task creation, command execution, PR creation, model training, or federation consensus.\n"]
+    parts.append("## Input summaries\n" + _table(["input", "provided", "path", "digest", "bytes"], [[k, v.get("provided"), v.get("path"), v.get("digest"), v.get("byte_size")] for k, v in sorted(report["input_summaries"].items())]))
+    parts.append("## Consent context\n" + _table(["key", "value"], [[k, v] for k, v in report["consent_context"].items()]))
+    parts.append("## Consent request schema\n" + _table(["id", "future_only", "currently_satisfied", "active", "summary"], [[r["schema_field_id"], r["future_only"], r["currently_satisfied"], r["active"], r["reviewer_summary"]] for r in report["consent_request_schema"]]))
+    sections = (("Required consent evidence", "required_consent_evidence"), ("Consent scope policy", "consent_scope_policy"), ("Consent digest binding policy", "consent_digest_binding_policy"), ("Consent lifetime policy", "consent_lifetime_policy"), ("Consent revocation policy", "consent_revocation_policy"), ("Consent denial policy", "consent_denial_policy"), ("Consent authority boundary", "consent_authority_boundary"), ("Consent activation gap summary", "consent_activation_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Non-authority posture", "non_authority_posture"))
+    for title, key in sections:
+        parts.append(f"## {title}\n" + _table(["key", "value"], [[k, v] for k, v in report[key].items()]))
+    parts.append("## Future activation requirements\n" + _table(["requirement", "status", "met", "active"], [[r["requirement"], r["status"], r["met"], r["active"]] for r in report["future_activation_requirements"]]))
+    return "\n".join(parts)

--- a/tests/test_build_codex_workcell_storage_operator_consent_contract_script.py
+++ b/tests/test_build_codex_workcell_storage_operator_consent_contract_script.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run(args):
+    return subprocess.run([sys.executable, "scripts/build_codex_workcell_storage_operator_consent_contract.py", *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_summary_and_markdown(tmp_path):
+    input_path = tmp_path / "policy.json"
+    input_path.write_text('{"policy":"ok"}\n', encoding="utf-8")
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = _run(["--output", str(output), "--storage-policy-contract-json", str(input_path), "--commit-sha", "abc", "--pr-number", "7", "--pr-title", "Title", "--markdown-output", str(markdown), "--summary"])
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert summary["storage_operator_consent_contract_id"] == "codex_workcell_storage_operator_consent_contract.v1"
+    assert summary["consent_not_collected"] is True
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["consent_context"]["supplied_report_count"] == 1
+    assert report["operator_consent_present"] is False
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Operator Consent Request Contract")
+
+
+def test_cli_invalid_missing_and_non_object_json_exit_2(tmp_path):
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{bad", encoding="utf-8")
+    missing = tmp_path / "missing.json"
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    for path, expected in ((invalid, "invalid_json"), (missing, "missing_json"), (array, "json_not_object")):
+        result = _run(["--output", str(output), "--storage-policy-contract-json", str(path)])
+        assert result.returncode == 2
+        assert expected in result.stderr
+
+
+def test_cli_output_and_markdown_are_deterministic_and_escaped(tmp_path):
+    output1 = tmp_path / "one.json"
+    output2 = tmp_path / "two.json"
+    markdown1 = tmp_path / "one.md"
+    markdown2 = tmp_path / "two.md"
+    args = ["--commit-sha", "abc", "--pr-title", "Pipe | New\nLine"]
+    first = _run(["--output", str(output1), "--markdown-output", str(markdown1), *args])
+    second = _run(["--output", str(output2), "--markdown-output", str(markdown2), *args])
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert output1.read_text(encoding="utf-8") == output2.read_text(encoding="utf-8")
+    assert markdown1.read_text(encoding="utf-8") == markdown2.read_text(encoding="utf-8")
+    assert "Pipe \\| New<br>Line" in markdown1.read_text(encoding="utf-8")
+
+
+def test_cli_preserves_non_authority_posture(tmp_path):
+    output = tmp_path / "contract.json"
+    result = _run(["--output", str(output)])
+    assert result.returncode == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    posture = report["non_authority_posture"]
+    assert posture["storage_operator_consent_contract_does_not_collect_consent"] is True
+    assert posture["storage_operator_consent_contract_does_not_bind_runtime_authority"] is True
+    assert posture["storage_operator_consent_contract_does_not_write_ledger"] is True
+    assert posture["storage_operator_consent_contract_does_not_archive_glow"] is True
+    assert posture["storage_operator_consent_contract_does_not_modify_memory"] is True
+    assert posture["storage_operator_consent_contract_does_not_trigger_daemon"] is True
+    assert posture["storage_operator_consent_contract_does_not_create_tasks"] is True
+    assert posture["storage_operator_consent_contract_does_not_schedule_tasks"] is True
+    assert posture["storage_operator_consent_contract_does_not_decide_readiness"] is True

--- a/tests/test_codex_workcell_storage_operator_consent_contract.py
+++ b/tests/test_codex_workcell_storage_operator_consent_contract.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_workcell_storage_operator_consent_contract import (
+    BLOCKING_GAP_IDS,
+    INPUT_SPECS,
+    NON_AUTHORITY_POSTURE,
+    REQUIRED_EVIDENCE_IDS,
+    SCHEMA_IDS,
+    build_codex_workcell_storage_operator_consent_contract,
+    omitted_input,
+    read_json_input,
+)
+
+
+def _summaries():
+    return {input_id: omitted_input(input_id) for input_id in INPUT_SPECS}
+
+
+def test_contract_emits_required_flags_and_no_authority():
+    report = build_codex_workcell_storage_operator_consent_contract(input_summaries=_summaries())
+    assert report["storage_operator_consent_contract_id"] == "codex_workcell_storage_operator_consent_contract.v1"
+    for key in ("metadata_only", "consent_contract_only", "consent_request_shape_only", "consent_not_collected", "runtime_binding_not_performed"):
+        assert report[key] is True
+    for key in ("operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"):
+        assert report[key] is False
+    assert all(report["non_authority_posture"][key] is True for key in NON_AUTHORITY_POSTURE)
+
+
+def test_schema_evidence_scope_digest_lifetime_revocation_denial_and_boundary():
+    report = build_codex_workcell_storage_operator_consent_contract(input_summaries=_summaries())
+    schema = {row["schema_field_id"]: row for row in report["consent_request_schema"]}
+    assert set(SCHEMA_IDS) <= set(schema)
+    assert all(row["future_only"] is True and row["currently_satisfied"] is False and row["active"] is False for row in schema.values())
+    evidence = report["required_consent_evidence"]
+    assert evidence["required_evidence_ids"] == list(REQUIRED_EVIDENCE_IDS)
+    assert evidence["evidence_collection_not_performed"] is True
+    scope = report["consent_scope_policy"]
+    assert scope["allowed_mounts"] == ["/ledger", "/glow"]
+    assert set(scope["forbidden_mounts"]) >= {"/vow", "/pulse", "/daemon", "host_absolute_paths", "network_paths", "temp_paths_as_canonical", "hidden_backdoor_paths"}
+    digest = report["consent_digest_binding_policy"]
+    assert digest["canonical_vow_digest_required"] and digest["storage_policy_digest_required"] and digest["transaction_plan_digest_required"] and digest["execution_dossier_digest_required"] and digest["runtime_authority_digest_required"]
+    assert digest["digest_algorithm"] == "sha256"
+    lifetime = report["consent_lifetime_policy"]
+    assert lifetime["expiration_required"] and lifetime["renewal_required_for_new_vow_digest"] and lifetime["renewal_required_for_changed_mount_scope"]
+    revocation = report["consent_revocation_policy"]
+    assert revocation["revocation_must_block_new_writes"] and revocation["revocation_must_block_new_archives"] and revocation["revocation_must_not_delete_existing_receipts"]
+    assert report["consent_denial_policy"]["default_without_consent"] == "deny_active_storage"
+    boundary = report["consent_authority_boundary"]
+    assert boundary["consent_contract_is_not_consent"] and boundary["consent_schema_is_not_operator_approval"]
+    assert boundary["supplied_reports_do_not_imply_consent"] and boundary["finalizer_ready_to_commit_does_not_imply_consent"]
+    assert boundary["pr_metadata_guard_ready_does_not_imply_consent"] and boundary["daemon_recommendation_does_not_imply_consent"] and boundary["federation_state_does_not_imply_consent"]
+
+
+def test_activation_gaps_hygiene_mounts_and_future_requirements():
+    report = build_codex_workcell_storage_operator_consent_contract(input_summaries=_summaries())
+    assert set(BLOCKING_GAP_IDS) <= set(report["consent_activation_gap_summary"]["blocking_gap_ids"])
+    hygiene = report["reviewer_hygiene_summary"]
+    assert hygiene["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert hygiene["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert report["sentientos_mount_alignment"]["/ledger"] == "future consent scope target; no ledger write here"
+    assert report["sentientos_mount_alignment"]["/glow"] == "future consent scope target; no archive write here"
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in report["future_activation_requirements"])
+
+
+def test_input_summaries_record_digest_and_omissions(tmp_path):
+    supplied = tmp_path / "policy.json"
+    raw = b'{"ok": true}\n'
+    supplied.write_bytes(raw)
+    summaries = _summaries()
+    summaries["storage_policy_contract_json"], _ = read_json_input(str(supplied), "storage_policy_contract_json")
+    report = build_codex_workcell_storage_operator_consent_contract(input_summaries=summaries, commit_sha="abc", pr_number="5", pr_title="title")
+    summary = report["input_summaries"]["storage_policy_contract_json"]
+    assert summary["provided"] is True
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+    assert report["input_summaries"]["storage_runtime_authority_contract_json"]["provided"] is False
+    assert report["consent_context"]["supplied_report_count"] == 1
+    assert report["consent_context"]["commit_sha"] == "abc"
+    assert "storage_policy_contract_digest" in report["required_consent_evidence"]["supplied_evidence_ids"]


### PR DESCRIPTION
### Motivation

- Define a deterministic, metadata-only operator consent request contract that specifies the exact shape, evidence, scope, digests, mounts, lifetime/revocation, and authority boundaries required for any future explicit operator consent for `/ledger` and `/glow` without collecting or implying consent.
- Provide a safe, non-authoritative artifact that documents what a future operator consent artifact must contain while ensuring no runtime authority, writes, archives, memory mutations, daemon actions, task scheduling, or federation effects are performed.

### Description

- Add `sentientos/codex_workcell_storage_operator_consent_contract.py` implementing the contract generator with constants `WORKCELL_STORAGE_OPERATOR_CONSENT_CONTRACT_ID` and `DIGEST_ALGO = "sha256"`, input handling, deterministic JSON output shape, future-only consent schema, required evidence lists, scope/digest/lifetime/revocation/denial policies, activation-gap catalog, mount alignment, future activation requirements, and non-authority posture flags.
- Add CLI `scripts/build_codex_workcell_storage_operator_consent_contract.py` that accepts the requested optional JSON inputs, computes sha256 digests/byte sizes, fails cleanly on missing/invalid/non-object JSON (exit code 2), emits deterministic JSON and optional Markdown, and supports `--summary` output.
- Add focused tests `tests/test_codex_workcell_storage_operator_consent_contract.py` and `tests/test_build_codex_workcell_storage_operator_consent_contract_script.py` covering contract shape, schema/evidence/scope/digest/lifetime/revocation/denial/authority flags, input digest and omission handling, CLI error paths, deterministic output, and markdown escaping.
- Add `docs/development/codex_workcell_storage_operator_consent_contract.md` and insert short boundary references into the adjacent development docs to point reviewers to the new metadata-only consent request boundary (these references are explicit that the contract does not grant runtime authority or perform any runtime actions).

### Testing

- Ran focused unit tests for the new contract and CLI (`tests/test_codex_workcell_storage_operator_consent_contract.py` and `tests/test_build_codex_workcell_storage_operator_consent_contract_script.py`) and they passed; CLI error cases and deterministic/escaped Markdown were validated.
- Ran related runtime-authority focused regression tests and targeted `mypy` on the new module/CLI, and both passed; docs build initially required bootstrapping but the matrix bootstrapped docs dependencies and the docs check/build completed successfully.
- Executed the full work-item review packet matrix and landing finalizers (pre-commit and pr-metadata) as part of the landing workflow and the PR metadata guard returned ready (matrix/finalizer/guard steps passed as required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3f2e020204832fa049aacae3b181fd)