### PR TITLE
[sentientos:memory] add Codex workcell storage operator consent request packet

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -260,3 +260,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -252,3 +252,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -199,3 +199,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -163,3 +163,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -91,3 +91,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -105,3 +105,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -79,3 +79,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -100,3 +100,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -147,3 +147,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -164,3 +164,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -104,3 +104,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -59,3 +59,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -81,3 +81,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_operator_consent_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_contract.md
@@ -107,3 +107,7 @@ models, or establish federation consensus.
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet.md
@@ -1,0 +1,98 @@
+# Codex Workcell Storage Operator Consent Request Packet
+
+The Codex Workcell Storage Operator Consent Request Packet is a deterministic,
+metadata-only packet builder for a future operator-facing consent request shape.
+It assembles supplied consent, runtime authority, storage, vow, and dossier
+evidence into a compact packet with source SHA-256 digests, byte sizes, request
+scope, future response fields, and explicit non-authority posture.
+
+This packet is still not consent. It does not present a request to an operator,
+render UI, send a message, deliver an external notification, collect a response,
+imply approval, bind runtime authority, activate memory, write `/ledger`, archive
+`/glow`, mutate memory, watch files, poll state, schedule work, create tasks,
+trigger daemon action, decide readiness, authorize commits, authorize PR metadata,
+create PRs, establish federation consensus, or train or modify models.
+
+## Contract, verifier, and packet distinction
+
+- The [storage operator consent request contract](codex_workcell_storage_operator_consent_contract.md)
+  defines the future consent schema and required evidence policy.
+- The [storage operator consent request verifier](codex_workcell_storage_operator_consent_verifier.md)
+  verifies that the contract remains future-only and non-authoritative.
+- This request packet assembles the future request packet shape from supplied
+  evidence summaries and verified consent-policy artifacts, while keeping every
+  operator-response field empty, false, unavailable, and not collected.
+
+## Evidence digest packet
+
+For each supported optional input, the packet records whether it was supplied, the
+source path, SHA-256 digest, byte size, JSON readability, detected report ID when
+present, evidence role, and relevant status or digest when derivable. Omitted
+inputs remain explicit `provided: false` records with no digest and no byte size.
+The builder never runs other builders or verifiers; it only reads explicitly
+supplied JSON files.
+
+## Future operator request template
+
+The operator request template is metadata only. It is marked
+`template_not_presented`, `response_not_collected`, `no_message_sent`,
+`no_ui_rendered`, and `no_external_delivery`. The future requested scope is only
+`/ledger` and `/glow`, with explicit permissions for ledger writing and glow
+archiving. `/vow`, `/pulse`, `/daemon`, host absolute paths, network paths,
+temporary paths as canonical targets, and hidden backdoor paths remain forbidden.
+The default without a future explicit response is `deny_active_storage`.
+
+## Required future operator response fields
+
+Future fields such as operator identity, timestamp, scope statement, consent
+expiration, revocation acknowledgement, digest acknowledgements, finalizer/guard
+receipt acknowledgements, daemon/federation no-implied-consent acknowledgements,
+response completeness, and consent artifact creation all remain `null` or `false`
+in this packet. Active storage therefore remains blocked.
+
+## No implied consent from evidence or readiness
+
+Supplied reports, finalizer ready-to-commit status, PR metadata guard readiness,
+daemon recommendations, and federation state do not imply consent. Future consent
+must be explicit, scoped, time-bound, revocable, digest-bound, and operator-owned.
+This packet records missing operator response, missing identity, missing timestamp,
+missing scope statement, missing explicit ledger/glow allowances, missing
+expiration, missing revocation terms, missing digest acknowledgements, and missing
+runtime authority binding as blocking gaps.
+
+## Mount alignment
+
+- `/ledger`: future requested consent scope; no ledger write happens here.
+- `/glow`: future requested consent scope; no archive write happens here.
+- `/vow`: canonical digest evidence for future consent binding.
+- `/pulse`: future watcher boundary; this packet does not activate it.
+- `/daemon`: future action boundary; this packet does not activate it.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene remains separate from runtime behavior. The packet records
+that `https://github.com/` + `OpenAI/` + `SentientOS.git` is expected to be absent and that
+`https://github.com/Zombinator85/SentientOS.git` is the correct repository URL,
+but repository grep validation is performed by the landing task, not by this
+metadata packet.
+
+## Future activation requirements
+
+Future activation remains unmet and inactive until there is explicit operator
+identity capture, consent response capture, consent request presentation,
+timestamp capture, expiration and revocation policy, canonical vow/storage
+policy/transaction plan/execution dossier/runtime authority digest
+acknowledgement, active ledger writer and glow archiver implementations,
+finalizer and PR metadata guard runtime binding implementations, storage path and
+retention enforcement, digest verification, parent-chain validation, tests proving
+no readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The packet is read-only, metadata-only, and packet-only. It does not present a
+request, collect or imply consent, bind runtime authority, activate memory, write
+ledger entries, archive glow evidence, modify memory, watch files, poll state,
+rerun commands, decide readiness, bypass the finalizer, bypass the PR metadata
+guard, authorize commit, authorize PR creation, trigger daemons, create or
+schedule tasks, send alerts, train or modify models, or establish federation
+consensus.

--- a/docs/development/codex_workcell_storage_operator_consent_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_verifier.md
@@ -76,3 +76,7 @@ archive glow evidence, modify memory, watch files, poll state, rerun commands,
 decide readiness, bypass finalizer or PR metadata guard, authorize commits or PR
 creation, trigger daemons, create or schedule tasks, send alerts, train or modify
 models, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -98,3 +98,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -67,3 +67,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -74,3 +74,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_runtime_authority_verifier.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_verifier.md
@@ -37,3 +37,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -80,3 +80,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -58,3 +58,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -78,3 +78,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -87,3 +87,7 @@ See [Codex Workcell Storage Operator Consent Request Contract](codex_workcell_st
 ## Storage operator consent request verifier boundary
 
 See [Codex Workcell Storage Operator Consent Request Verifier](codex_workcell_storage_operator_consent_verifier.md) for the deterministic metadata-only verifier for the future operator consent request shape. The verifier does not collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, or establish federation consensus.
+
+## Storage operator consent request packet boundary
+
+See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_storage_operator_consent_request_packet.md) for the deterministic metadata-only future request packet shape. The packet does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger daemons, decide readiness, authorize commits, authorize PR metadata, create PRs, or establish federation consensus.

--- a/scripts/build_codex_workcell_storage_operator_consent_request_packet.py
+++ b/scripts/build_codex_workcell_storage_operator_consent_request_packet.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_operator_consent_request_packet import (
+    CodexWorkcellStorageOperatorConsentRequestPacketError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_operator_consent_request_packet,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_request_packet_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage operator consent request packet.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries = {}; reports = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summaries[input_id], reports[input_id] = read_json_input(path, input_id)
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        packet = build_codex_workcell_storage_operator_consent_request_packet(input_summaries=summaries, input_reports=reports, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageOperatorConsentRequestPacketError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(packet, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_operator_consent_request_packet_markdown(packet), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_operator_consent_request_packet_id": packet["storage_operator_consent_request_packet_id"], "supplied_report_count": packet["request_packet_context"]["supplied_report_count"], "consent_not_collected": packet["consent_not_collected"], "active_storage_allowed_now": packet["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_operator_consent_request_packet.py
+++ b/sentientos/codex_workcell_storage_operator_consent_request_packet.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PACKET_ID = "codex_workcell_storage_operator_consent_request_packet.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: dict[str, str] = {
+    "storage_operator_consent_contract_json": "consent_contract",
+    "storage_operator_consent_verifier_json": "consent_contract_verifier",
+    "storage_runtime_authority_contract_json": "runtime_authority_contract",
+    "storage_runtime_authority_verifier_json": "runtime_authority_verifier",
+    "storage_execution_dossier_json": "execution_dossier",
+    "storage_execution_dossier_verifier_json": "execution_dossier_verifier",
+    "storage_transaction_plan_json": "transaction_plan",
+    "storage_transaction_plan_verifier_json": "transaction_plan_verifier",
+    "storage_policy_contract_json": "storage_policy",
+    "storage_policy_verifier_json": "storage_policy_verifier",
+    "vow_boundary_contract_json": "vow_boundary",
+    "vow_alignment_attestation_json": "vow_attestation",
+}
+
+FORBIDDEN_SCOPE = ["/vow", "/pulse", "/daemon", "host_absolute_paths", "network_paths", "temp_paths_as_canonical", "hidden_backdoor_paths"]
+REQUIRED_DIGEST_BINDINGS = [
+    "canonical_vow_digest", "storage_policy_contract_digest", "storage_policy_verifier_digest",
+    "storage_transaction_plan_digest", "storage_transaction_plan_verifier_digest",
+    "storage_execution_dossier_digest", "storage_execution_dossier_verifier_digest",
+    "runtime_authority_contract_digest", "runtime_authority_verifier_digest",
+]
+BLOCKING_GAP_IDS = [
+    "consent_request_not_presented", "operator_response_missing", "operator_identity_missing",
+    "operator_timestamp_missing", "operator_scope_statement_missing", "explicit_ledger_write_allow_missing",
+    "explicit_glow_archive_allow_missing", "consent_expiration_missing", "consent_revocation_terms_missing",
+    "consent_digest_acknowledgements_missing", "runtime_authority_binding_missing",
+]
+FUTURE_REQUIREMENT_NAMES = [
+    "explicit operator identity capture", "explicit operator consent response capture", "explicit consent request presentation mechanism",
+    "explicit consent timestamp capture", "explicit consent expiration policy", "explicit consent revocation policy",
+    "explicit canonical vow digest acknowledgement", "explicit storage policy digest acknowledgement",
+    "explicit transaction plan digest acknowledgement", "explicit execution dossier digest acknowledgement",
+    "explicit runtime authority digest acknowledgement", "explicit active ledger writer implementation",
+    "explicit active glow archiver implementation", "explicit finalizer runtime binding implementation",
+    "explicit PR metadata guard runtime binding implementation", "explicit storage path enforcement", "explicit retention enforcement",
+    "explicit digest verification enforcement", "explicit parent-chain validation enforcement", "tests proving no readiness authority",
+    "docs marking active behavior",
+]
+NON_AUTHORITY_POSTURE = {name: True for name in [
+    "storage_operator_consent_request_packet_is_read_only",
+    "storage_operator_consent_request_packet_is_metadata_only",
+    "storage_operator_consent_request_packet_is_packet_only",
+    "storage_operator_consent_request_packet_does_not_present_request",
+    "storage_operator_consent_request_packet_does_not_collect_consent",
+    "storage_operator_consent_request_packet_does_not_imply_consent",
+    "storage_operator_consent_request_packet_does_not_bind_runtime_authority",
+    "storage_operator_consent_request_packet_does_not_activate_memory",
+    "storage_operator_consent_request_packet_does_not_write_ledger",
+    "storage_operator_consent_request_packet_does_not_archive_glow",
+    "storage_operator_consent_request_packet_does_not_modify_memory",
+    "storage_operator_consent_request_packet_does_not_watch_files",
+    "storage_operator_consent_request_packet_does_not_poll_state",
+    "storage_operator_consent_request_packet_does_not_rerun_commands",
+    "storage_operator_consent_request_packet_does_not_decide_readiness",
+    "storage_operator_consent_request_packet_does_not_bypass_finalizer",
+    "storage_operator_consent_request_packet_does_not_bypass_pr_metadata_guard",
+    "storage_operator_consent_request_packet_does_not_authorize_commit",
+    "storage_operator_consent_request_packet_does_not_authorize_pr_creation",
+    "storage_operator_consent_request_packet_does_not_trigger_daemon",
+    "storage_operator_consent_request_packet_does_not_create_tasks",
+    "storage_operator_consent_request_packet_does_not_schedule_tasks",
+    "storage_operator_consent_request_packet_does_not_send_alerts",
+    "storage_operator_consent_request_packet_does_not_train_or_modify_models",
+    "storage_operator_consent_request_packet_does_not_establish_federation_consensus",
+]}
+
+class CodexWorkcellStorageOperatorConsentRequestPacketError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageOperatorConsentRequestPacketError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes(); digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageOperatorConsentRequestPacketError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellStorageOperatorConsentRequestPacketError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _report_id(data: Mapping[str, Any]) -> Any:
+    for key in ("storage_operator_consent_contract_id", "storage_operator_consent_verifier_id", "storage_runtime_authority_contract_id", "storage_runtime_authority_verifier_id", "storage_execution_dossier_id", "storage_execution_dossier_verifier_id", "storage_transaction_plan_id", "storage_transaction_plan_verifier_id", "storage_policy_contract_id", "storage_policy_verifier_id", "vow_boundary_contract_id", "vow_alignment_attestation_id"):
+        if data.get(key) is not None:
+            return data[key]
+    return None
+
+def _status_or_digest(data: Mapping[str, Any]) -> Any:
+    for key in ("verification_status", "storage_execution_status", "storage_transaction_plan_verification_status", "storage_policy_verification_status", "digest", "source_digest"):
+        if data.get(key) is not None:
+            return data[key]
+    return None
+
+def build_codex_workcell_storage_operator_consent_request_packet(*, input_summaries: Mapping[str, Mapping[str, Any]], input_reports: Mapping[str, Mapping[str, Any]] | None = None, commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    reports = input_reports or {}
+    evidence = []
+    supplied_bindings: dict[str, str] = {}
+    binding_by_input = {
+        "vow_boundary_contract_json": "canonical_vow_digest", "storage_policy_contract_json": "storage_policy_contract_digest",
+        "storage_policy_verifier_json": "storage_policy_verifier_digest", "storage_transaction_plan_json": "storage_transaction_plan_digest",
+        "storage_transaction_plan_verifier_json": "storage_transaction_plan_verifier_digest", "storage_execution_dossier_json": "storage_execution_dossier_digest",
+        "storage_execution_dossier_verifier_json": "storage_execution_dossier_verifier_digest", "storage_runtime_authority_contract_json": "runtime_authority_contract_digest",
+        "storage_runtime_authority_verifier_json": "runtime_authority_verifier_digest",
+    }
+    for input_id, role in INPUT_SPECS.items():
+        summary = input_summaries.get(input_id, omitted_input(input_id))
+        data = reports.get(input_id, {})
+        provided = summary.get("provided") is True
+        digest = summary.get("digest") if provided else None
+        if provided and input_id in binding_by_input and isinstance(digest, str):
+            supplied_bindings[binding_by_input[input_id]] = digest
+        evidence.append({
+            "input_id": input_id, "provided": provided, "detected_report_id": _report_id(data), "evidence_role": role,
+            "source_digest": digest, "source_digest_algo": DIGEST_ALGO if provided else None, "source_byte_size": summary.get("byte_size") if provided else None,
+            "relevant_status_or_digest": _status_or_digest(data), "required_for_future_consent": True, "included_in_request_packet": provided,
+            "missing_reason": None if provided else "optional_input_not_supplied",
+        })
+    missing_bindings = [b for b in REQUIRED_DIGEST_BINDINGS if b not in supplied_bindings]
+    supplied_count = sum(1 for s in input_summaries.values() if s.get("provided") is True)
+    return {
+        "storage_operator_consent_request_packet_id": WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PACKET_ID,
+        "metadata_only": True, "request_packet_only": True, "consent_request_not_presented": True, "consent_not_collected": True,
+        "consent_not_implied": True, "operator_consent_present": False, "runtime_binding_not_performed": True,
+        "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False, "archives_performed": False,
+        "memory_mutation_performed": False, "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True,
+        "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True,
+        "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {k: input_summaries.get(k, omitted_input(k)) for k in INPUT_SPECS},
+        "request_packet_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied_count, "request_packet_only": True, "consent_request_not_presented": True, "consent_not_collected": True, "no_action_taken": True},
+        "evidence_digest_packet": evidence,
+        "operator_request_template": {"template_id": "storage_operator_consent_request_template.v1", "template_not_presented": True, "response_not_collected": True, "intended_operator_action": "future_explicit_review_only", "requested_scope": ["/ledger", "/glow"], "forbidden_scope": FORBIDDEN_SCOPE, "requested_permissions": ["explicit_allow_ledger_write", "explicit_allow_glow_archive"], "default_without_response": "deny_active_storage", "template_body_sections": ["evidence_summary", "requested_mount_scope", "digest_bindings", "lifetime_and_expiration", "revocation_terms", "denial_default", "non_authority_disclaimers"], "no_message_sent": True, "no_ui_rendered": True, "no_external_delivery": True},
+        "required_operator_response_fields": {"operator_identity": None, "operator_timestamp": None, "operator_scope_statement": None, "explicit_allow_ledger_write": False, "explicit_allow_glow_archive": False, "consent_expiration": None, "consent_revocation_terms_acknowledged": False, "canonical_vow_digest_acknowledged": False, "storage_policy_digest_acknowledged": False, "transaction_plan_digest_acknowledged": False, "execution_dossier_digest_acknowledged": False, "runtime_authority_digest_acknowledged": False, "finalizer_guard_receipts_acknowledged": False, "no_daemon_self_authorization_acknowledged": False, "no_federation_implied_consent_acknowledged": False, "response_complete": False, "consent_artifact_created": False},
+        "consent_scope_statement": {"allowed_mounts": ["/ledger", "/glow"], "ledger_write_requires_explicit_allow": True, "glow_archive_requires_explicit_allow": True, "forbidden_mounts": FORBIDDEN_SCOPE, "daemon_action_not_authorized": True, "model_training_not_authorized": True, "federation_consensus_not_authorized": True},
+        "consent_digest_binding_statement": {"digest_algorithm": DIGEST_ALGO, "required_digest_bindings": REQUIRED_DIGEST_BINDINGS, "supplied_digest_bindings": supplied_bindings, "missing_digest_bindings": missing_bindings, "digest_binding_not_acknowledged": True},
+        "consent_lifetime_statement": {"expiration_required": True, "expiration_supplied": False, "renewal_required_for_new_vow_digest": True, "renewal_required_for_new_storage_policy": True, "renewal_required_for_new_transaction_plan": True, "renewal_required_for_changed_mount_scope": True, "lifetime_not_started": True},
+        "consent_revocation_statement": {"revocation_terms_required": True, "revocation_terms_acknowledged": False, "revocation_must_block_new_writes": True, "revocation_must_block_new_archives": True, "revocation_must_not_delete_existing_receipts": True, "future_revocation_receipt_required": True, "revocation_not_performed": True},
+        "consent_denial_statement": {"default_without_response": "deny_active_storage", "missing_response_blocks_ledger_write": True, "missing_response_blocks_glow_archive": True, "incomplete_response_blocks_storage": True, "ambiguous_response_blocks_storage": True, "remote_or_daemon_response_not_accepted": True, "denial_not_runtime_decision_here": True},
+        "consent_authority_boundary_statement": {"request_packet_is_not_consent": True, "request_template_is_not_consent": True, "supplied_evidence_does_not_imply_consent": True, "finalizer_ready_to_commit_does_not_imply_consent": True, "pr_metadata_guard_ready_does_not_imply_consent": True, "daemon_recommendation_does_not_imply_consent": True, "federation_state_does_not_imply_consent": True, "future_operator_response_must_be_explicit": True, "authority_boundary_only": True},
+        "consent_request_gap_summary": {"consent_request_not_presented": True, "consent_not_collected": True, "consent_not_implied": True, "operator_consent_present": False, "active_storage_allowed_now": False, "runtime_binding_not_performed": True, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "blocking_gap_ids": BLOCKING_GAP_IDS},
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata packet.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future requested consent scope; no ledger write here", "/glow": "future requested consent scope; no archive write here", "/vow": "canonical digest evidence for future consent binding", "/pulse": "future watcher boundary; consent packet does not activate it", "/daemon": "future action boundary; consent packet does not activate it"},
+        "future_activation_requirements": [{"requirement": name, "status": "future_only", "met": False, "active": False} for name in FUTURE_REQUIREMENT_NAMES],
+        "non_authority_posture": NON_AUTHORITY_POSTURE,
+    }
+
+def _cell(value: Any) -> str:
+    return json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+
+def _escape(value: Any) -> str:
+    return _cell(value).replace("|", "\\|").replace("\n", "<br>")
+
+def _table(mapping: Mapping[str, Any]) -> str:
+    lines = ["| Field | Value |", "| --- | --- |"]
+    for key in sorted(mapping):
+        lines.append(f"| {_escape(key)} | {_escape(mapping[key])} |")
+    return "\n".join(lines)
+
+def render_codex_workcell_storage_operator_consent_request_packet_markdown(packet: Mapping[str, Any]) -> str:
+    sections = ["# Codex Workcell Storage Operator Consent Request Packet", "", "Deterministic metadata-only request packet shape. It is not presented, does not collect or imply consent, and grants no runtime authority."]
+    for title, key in [
+        ("Input summaries", "input_summaries"), ("Request packet context", "request_packet_context"), ("Evidence digest packet", "evidence_digest_packet"),
+        ("Operator request template", "operator_request_template"), ("Required operator response fields", "required_operator_response_fields"),
+        ("Consent scope statement", "consent_scope_statement"), ("Consent digest binding statement", "consent_digest_binding_statement"),
+        ("Consent lifetime statement", "consent_lifetime_statement"), ("Consent revocation statement", "consent_revocation_statement"),
+        ("Consent denial statement", "consent_denial_statement"), ("Consent authority boundary statement", "consent_authority_boundary_statement"),
+        ("Consent request gap summary", "consent_request_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"),
+        ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Future activation requirements", "future_activation_requirements"),
+        ("Non-authority posture", "non_authority_posture"),
+    ]:
+        value = packet.get(key)
+        sections += ["", f"## {title}", _table({str(i): v for i, v in enumerate(value)}) if isinstance(value, list) else _table(value if isinstance(value, Mapping) else {key: value})]
+    return "\n".join(sections) + "\n"

--- a/tests/test_build_codex_workcell_storage_operator_consent_request_packet_script.py
+++ b/tests/test_build_codex_workcell_storage_operator_consent_request_packet_script.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _run(args):
+    return subprocess.run([sys.executable, "scripts/build_codex_workcell_storage_operator_consent_request_packet.py", *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_summary_and_markdown(tmp_path):
+    input_path = tmp_path / "policy.json"
+    input_path.write_text('{"storage_policy_contract_id":"policy.v1"}\n', encoding="utf-8")
+    output = tmp_path / "packet.json"
+    markdown = tmp_path / "packet.md"
+    result = _run(["--output", str(output), "--storage-policy-contract-json", str(input_path), "--commit-sha", "abc", "--pr-number", "7", "--pr-title", "Title", "--markdown-output", str(markdown), "--summary"])
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert summary["storage_operator_consent_request_packet_id"] == "codex_workcell_storage_operator_consent_request_packet.v1"
+    assert summary["consent_not_collected"] is True
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["request_packet_context"]["supplied_report_count"] == 1
+    assert report["operator_consent_present"] is False
+    assert markdown.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Operator Consent Request Packet")
+
+
+def test_cli_invalid_missing_and_non_object_json_exit_2(tmp_path):
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{bad", encoding="utf-8")
+    missing = tmp_path / "missing.json"
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    for path, expected in ((invalid, "invalid_json"), (missing, "missing_json"), (array, "json_not_object")):
+        result = _run(["--output", str(output), "--storage-policy-contract-json", str(path)])
+        assert result.returncode == 2
+        assert expected in result.stderr
+
+
+def test_cli_output_and_markdown_are_deterministic_and_escaped(tmp_path):
+    output1 = tmp_path / "one.json"
+    output2 = tmp_path / "two.json"
+    markdown1 = tmp_path / "one.md"
+    markdown2 = tmp_path / "two.md"
+    args = ["--commit-sha", "abc", "--pr-title", "Pipe | New\nLine"]
+    first = _run(["--output", str(output1), "--markdown-output", str(markdown1), *args])
+    second = _run(["--output", str(output2), "--markdown-output", str(markdown2), *args])
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert output1.read_text(encoding="utf-8") == output2.read_text(encoding="utf-8")
+    assert markdown1.read_text(encoding="utf-8") == markdown2.read_text(encoding="utf-8")
+    assert "Pipe \\| New<br>Line" in markdown1.read_text(encoding="utf-8")
+
+
+def test_cli_preserves_no_authority(tmp_path):
+    output = tmp_path / "packet.json"
+    result = _run(["--output", str(output)])
+    assert result.returncode == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["consent_request_not_presented"] is True
+    assert report["consent_not_collected"] is True
+    assert report["consent_not_implied"] is True
+    posture = report["non_authority_posture"]
+    assert posture["storage_operator_consent_request_packet_does_not_authorize_commit"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_authorize_pr_creation"] is True

--- a/tests/test_codex_workcell_storage_operator_consent_request_packet.py
+++ b/tests/test_codex_workcell_storage_operator_consent_request_packet.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from sentientos.codex_workcell_storage_operator_consent_request_packet import (
+    BLOCKING_GAP_IDS,
+    FORBIDDEN_SCOPE,
+    INPUT_SPECS,
+    NON_AUTHORITY_POSTURE,
+    REQUIRED_DIGEST_BINDINGS,
+    build_codex_workcell_storage_operator_consent_request_packet,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_request_packet_markdown,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _packet(tmp_path):
+    raw = b'{"storage_policy_contract_id":"policy.v1","verification_status":"passed"}\n'
+    p = tmp_path / "policy.json"
+    p.write_bytes(raw)
+    summary, report = read_json_input(str(p), "storage_policy_contract_json")
+    summaries = {k: omitted_input(k) for k in INPUT_SPECS}
+    summaries["storage_policy_contract_json"] = summary
+    reports = {"storage_policy_contract_json": report}
+    return build_codex_workcell_storage_operator_consent_request_packet(
+        input_summaries=summaries,
+        input_reports=reports,
+        commit_sha="abc",
+        pr_number="7",
+        pr_title="Pipe | New\nLine",
+    ), raw
+
+
+def test_packet_required_non_authority_flags_and_context(tmp_path):
+    packet, _ = _packet(tmp_path)
+    assert packet["storage_operator_consent_request_packet_id"] == "codex_workcell_storage_operator_consent_request_packet.v1"
+    for key in ("metadata_only", "request_packet_only", "consent_request_not_presented", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"):
+        assert packet[key] is True
+    for key in ("operator_consent_present", "active_storage_allowed_now", "writes_performed", "archives_performed", "memory_mutation_performed", "execution_performed"):
+        assert packet[key] is False
+    assert packet["request_packet_context"] == {
+        "commit_sha": "abc", "pr_number": "7", "pr_title": "Pipe | New\nLine", "supplied_report_count": 1,
+        "request_packet_only": True, "consent_request_not_presented": True, "consent_not_collected": True, "no_action_taken": True,
+    }
+
+
+def test_evidence_records_supplied_digest_byte_size_and_omissions(tmp_path):
+    packet, raw = _packet(tmp_path)
+    evidence = {r["input_id"]: r for r in packet["evidence_digest_packet"]}
+    supplied = evidence["storage_policy_contract_json"]
+    assert supplied["provided"] is True
+    assert supplied["source_digest"] == hashlib.sha256(raw).hexdigest()
+    assert supplied["source_byte_size"] == len(raw)
+    assert supplied["detected_report_id"] == "policy.v1"
+    omitted = evidence["vow_boundary_contract_json"]
+    assert omitted["provided"] is False
+    assert omitted["missing_reason"] == "optional_input_not_supplied"
+    assert packet["input_summaries"]["vow_boundary_contract_json"]["provided"] is False
+
+
+def test_template_scope_response_fields_and_policy_statements(tmp_path):
+    packet, _ = _packet(tmp_path)
+    template = packet["operator_request_template"]
+    assert template["template_not_presented"] is True
+    assert template["response_not_collected"] is True
+    assert template["requested_scope"] == ["/ledger", "/glow"]
+    assert all(scope in template["forbidden_scope"] for scope in FORBIDDEN_SCOPE)
+    assert template["no_message_sent"] and template["no_ui_rendered"] and template["no_external_delivery"]
+    assert all(v in (None, False) for v in packet["required_operator_response_fields"].values())
+    assert packet["consent_scope_statement"]["allowed_mounts"] == ["/ledger", "/glow"]
+    assert packet["consent_scope_statement"]["daemon_action_not_authorized"] is True
+
+
+def test_digest_lifetime_revocation_denial_authority_gaps(tmp_path):
+    packet, _ = _packet(tmp_path)
+    digest = packet["consent_digest_binding_statement"]
+    assert digest["required_digest_bindings"] == REQUIRED_DIGEST_BINDINGS
+    assert digest["supplied_digest_bindings"]["storage_policy_contract_digest"]
+    assert "canonical_vow_digest" in digest["missing_digest_bindings"]
+    assert digest["digest_binding_not_acknowledged"] is True
+    assert packet["consent_lifetime_statement"]["expiration_required"] is True
+    assert packet["consent_lifetime_statement"]["lifetime_not_started"] is True
+    assert packet["consent_revocation_statement"]["revocation_terms_required"] is True
+    assert packet["consent_revocation_statement"]["revocation_not_performed"] is True
+    assert packet["consent_denial_statement"]["default_without_response"] == "deny_active_storage"
+    boundary = packet["consent_authority_boundary_statement"]
+    for key in ("request_packet_is_not_consent", "request_template_is_not_consent", "supplied_evidence_does_not_imply_consent", "finalizer_ready_to_commit_does_not_imply_consent", "pr_metadata_guard_ready_does_not_imply_consent", "daemon_recommendation_does_not_imply_consent", "federation_state_does_not_imply_consent"):
+        assert boundary[key] is True
+    assert all(gap in packet["consent_request_gap_summary"]["blocking_gap_ids"] for gap in BLOCKING_GAP_IDS)
+
+
+def test_hygiene_mount_future_and_non_authority_posture(tmp_path):
+    packet, _ = _packet(tmp_path)
+    hygiene = packet["reviewer_hygiene_summary"]
+    assert hygiene["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert hygiene["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert packet["sentientos_mount_alignment"]["/ledger"] == "future requested consent scope; no ledger write here"
+    assert all(item["status"] == "future_only" and item["met"] is False and item["active"] is False for item in packet["future_activation_requirements"])
+    assert packet["non_authority_posture"] == NON_AUTHORITY_POSTURE
+    assert all(packet["non_authority_posture"].values())
+
+
+def test_markdown_deterministic_and_escaped(tmp_path):
+    packet, _ = _packet(tmp_path)
+    one = render_codex_workcell_storage_operator_consent_request_packet_markdown(packet)
+    two = render_codex_workcell_storage_operator_consent_request_packet_markdown(packet)
+    assert one == two
+    assert one.startswith("# Codex Workcell Storage Operator Consent Request Packet")
+    assert "Pipe \\| New<br>Line" in one
+
+
+def test_packet_does_not_grant_readiness_or_runtime_authority(tmp_path):
+    packet, _ = _packet(tmp_path)
+    posture = packet["non_authority_posture"]
+    assert posture["storage_operator_consent_request_packet_does_not_decide_readiness"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_bind_runtime_authority"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_write_ledger"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_archive_glow"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_modify_memory"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_trigger_daemon"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_create_tasks"] is True
+    assert posture["storage_operator_consent_request_packet_does_not_schedule_tasks"] is True


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only builder that assembles a future operator-facing storage consent request packet from supplied evidence without presenting, collecting, implying, or enacting any consent or runtime authority.
- Make explicit the non-authority posture for future active `/ledger` and `/glow` actions and record digest/byte-size provenance for reviewer and finalizer flows.

### Description
- Added the packet module `sentientos/codex_workcell_storage_operator_consent_request_packet.py` implementing `WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PACKET_ID`, `DIGEST_ALGO`, `read_json_input`, `omitted_input`, `build_codex_workcell_storage_operator_consent_request_packet`, deterministic `render_*_markdown`, evidence-digest packet assembly, request-packet context, operator-request template, required future response fields, consent scope/digest/lifetime/revocation/denial/authority statements, future activation requirements, and full non-authority posture.
- Added CLI `scripts/build_codex_workcell_storage_operator_consent_request_packet.py` with required `--output`, optional evidence JSON args, `--commit-sha`, `--pr-number`, `--pr-title`, `--markdown-output`, and `--summary`, and with clean exit-on-invalid/missing/non-object JSON (exit code 2).
- Added focused tests `tests/test_codex_workcell_storage_operator_consent_request_packet.py` and `tests/test_build_codex_workcell_storage_operator_consent_request_packet_script.py` that validate flags/fields, digest/byte-size recording, omitted-input behavior, deterministic JSON/Markdown output and escaping, CLI error behavior, and preservation of non-authority posture.
- Added documentation `docs/development/codex_workcell_storage_operator_consent_request_packet.md` and inserted short boundary/link notes into adjacent docs to reference the new packet boundary only.

### Testing
- Ran focused unit tests `tests/test_codex_workcell_storage_operator_consent_request_packet.py` and CLI tests `tests/test_build_codex_workcell_storage_operator_consent_request_packet_script.py`, which passed.
- Verified deterministic JSON/Markdown rendering, CLI error paths (`invalid_json`, `missing_json`, `json_not_object` -> exit 2), omitted-input summaries, digest and byte-size recording, and retained non-authority flags via the added tests.
- Ran targeted `mypy` for the new module and script and `python scripts/build_docs.py` after bootstrapping docs deps; both succeeded (docs bootstrap performed when required).
- Ran the full work-item review packet matrix and landing flows; matrix and landing supervisor checks passed and the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4017e0e220832fb9d4a84282b874b9)