### PR TITLE
[codex:memory] add storage operator consent response contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -268,3 +268,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -260,3 +260,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -207,3 +207,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -171,3 +171,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -99,3 +99,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -113,3 +113,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -87,3 +87,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -108,3 +108,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -155,3 +155,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -172,3 +172,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -112,3 +112,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -67,3 +67,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -89,3 +89,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_operator_consent_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_contract.md
@@ -115,3 +115,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet.md
@@ -100,3 +100,7 @@ consensus.
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
@@ -35,3 +35,7 @@ Future active behavior requires explicit operator identity capture, explicit con
 ## Non-authority posture
 
 All verifier posture flags are true: read-only, metadata-only, verifier-only, no request presentation, no UI rendering, no messages, no external delivery, no consent collection or implication, no runtime authority binding, no memory activation, no ledger write, no glow archive, no memory mutation, no file watching, no polling, no command reruns, no readiness decision, no finalizer or PR guard bypass, no commit or PR authorization, no daemon trigger, no task creation, no scheduling, no alerts, no model training/modification, and no federation consensus.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_operator_consent_response_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_response_contract.md
@@ -1,0 +1,53 @@
+# Codex Workcell Storage Operator Consent Response Artifact Contract
+
+The Codex Workcell Storage Operator Consent Response Artifact Contract is a deterministic, metadata-only contract for the **future shape** of an explicit operator response artifact for active `/ledger` and `/glow` storage consent. It defines required fields, digest acknowledgements, explicit allow/deny semantics, expiration, revocation, scope, evidence bindings, denial-by-default behavior, activation gaps, mount alignment, and non-authority posture.
+
+This contract is not a response artifact. It does not collect a response, create consent, imply consent, approve storage, bind runtime authority, activate memory, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, schedule tasks, trigger daemon action, render UI, send messages, establish federation consensus, train models, decide readiness, authorize commits, authorize PR metadata, or create PRs.
+
+## Request packet verifier versus response artifact contract
+
+The [storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) proves that the request packet was not presented, no UI was rendered, no message was sent, no operator response was collected, no consent was implied, no runtime authority was bound, and active storage remains blocked. This response artifact contract is the next metadata layer: it describes what a future response artifact would need to contain, while still leaving `operator_response_present` false and `response_artifact_not_created` true.
+
+## Future response artifact schema
+
+A future response artifact would have to include stable identifiers and versioning, request packet and verifier digest acknowledgements, operator identity, operator timestamp, operator scope statement, response status, explicit ledger/glow allow flags, explicit deny support, canonical vow and storage-policy digest acknowledgements, transaction-plan and execution-dossier acknowledgements, runtime-authority acknowledgements, finalizer/guard receipt acknowledgements, expiration timestamp, revocation terms acknowledgement, daemon/federation no-implied-consent acknowledgements, denial-default acknowledgement, and a response signature placeholder. Every schema record emitted here is future-only, unmet, inactive, and not a source of consent.
+
+## Response status and denial by default
+
+Allowed future statuses are `absent`, `denied`, `approved_for_scoped_storage`, `expired`, `revoked`, `incomplete`, `ambiguous`, and `invalid`. The current status is always `absent`. Absent, denied, incomplete, ambiguous, expired, revoked, and invalid statuses block storage. `approved_for_scoped_storage` is listed only as a future status and is not present in this contract.
+
+## Explicit allow semantics
+
+Future active storage requires separate explicit allow flags for `/ledger` writes and `/glow` archives. Both flags are absent here. Ledger writes and glow archives remain blocked without explicit operator-provided allow values in a future response artifact.
+
+## Digest acknowledgement requirements
+
+A future response must acknowledge SHA-256 digests for the request packet, request packet verifier, canonical vow, storage policy contract and verifier, storage transaction plan and verifier, storage execution dossier and verifier, runtime authority contract and verifier, pre-commit finalizer receipt, PR metadata finalizer receipt, and PR metadata guard receipt. This contract collects none of those acknowledgements.
+
+## Scope, expiration, renewal, and revocation
+
+Future scope is limited to `/ledger` and `/glow`. `/vow`, `/pulse`, `/daemon`, host absolute paths, network paths, temporary paths as canonical targets, and hidden backdoor paths remain forbidden. A future response must include an expiration timestamp, renewal for changed vow digest, storage policy, transaction plan, or mount scope, and revocation terms. Revocation must block new writes and archives while preserving existing receipts.
+
+## No implied consent from readiness, evidence, daemon, or federation state
+
+Request packets, supplied evidence, finalizer ready-to-commit status, PR metadata guard readiness, daemon recommendations, and federation state do not imply consent. A future operator response must be explicit, signature-bound, scoped, time-bound, revocable, and digest-bound.
+
+## Active storage remains blocked
+
+The activation gap summary keeps the response artifact, operator response, operator identity, timestamp, scope statement, response status, explicit ledger/glow allow flags, digest acknowledgements, expiration, revocation acknowledgement, response signature, and runtime authority binding as missing. Therefore active storage remains blocked.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene is separate from runtime behavior. The contract records the expected correct repository URL as `https://github.com/Zombinator85/SentientOS.git` and notes that repository grep validation is performed by the landing task, not by this metadata contract.
+
+## SentientOS mount alignment
+
+- `/ledger`: future response-scoped consent target; no ledger write happens here.
+- `/glow`: future response-scoped consent target; no archive write happens here.
+- `/vow`: canonical digest acknowledgement required for future consent response binding.
+- `/pulse`: future watcher boundary; this contract does not activate it.
+- `/daemon`: future action boundary; this contract does not activate it.
+
+## Future activation requirements and non-authority posture
+
+Future activation remains unmet and inactive until explicit operator identity capture, response artifact creation, signature binding, timestamp capture, scope statement capture, response status capture, ledger/glow allow capture, digest acknowledgements, expiration capture, revocation acknowledgement, active ledger writer, active glow archiver, finalizer runtime binding, PR metadata guard runtime binding, tests proving no readiness authority, and docs marking active behavior exist. This contract remains read-only, metadata-only, contract-only, not a writer, not an archiver, not a daemon action, not a scheduler, not a consent collector, not a response collector, not a UI renderer, not a message sender, and not a runtime binder.

--- a/docs/development/codex_workcell_storage_operator_consent_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_verifier.md
@@ -84,3 +84,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -106,3 +106,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -75,3 +75,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -82,3 +82,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_runtime_authority_verifier.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_verifier.md
@@ -45,3 +45,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -88,3 +88,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -66,3 +66,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -86,3 +86,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -95,3 +95,7 @@ See [Codex Workcell Storage Operator Consent Request Packet](codex_workcell_stor
 ## Operator consent request packet verifier boundary
 
 The [Codex workcell storage operator consent request packet verifier](codex_workcell_storage_operator_consent_request_packet_verifier.md) is a deterministic metadata-only structural check for request packet JSON. It does not present a request, collect or imply consent, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or replace finalizer/PR metadata guard authority.
+
+## Storage operator consent response artifact boundary
+
+The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_workcell_storage_operator_consent_response_contract.md) defines only the future response artifact schema for explicit `/ledger` and `/glow` consent. It does not create a response artifact, collect or imply consent, bind runtime authority, activate memory, write ledger entries, archive glow evidence, render UI, send messages, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, or create PRs.

--- a/scripts/build_codex_workcell_storage_operator_consent_response_contract.py
+++ b/scripts/build_codex_workcell_storage_operator_consent_response_contract.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_operator_consent_response_contract import (
+    CodexWorkcellStorageOperatorConsentResponseContractError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_operator_consent_response_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_response_contract_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage operator consent response artifact contract.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries: dict[str, dict[str, object]] = {}
+    reports: dict[str, dict[str, object]] = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summaries[input_id], reports[input_id] = read_json_input(path, input_id)
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        contract = build_codex_workcell_storage_operator_consent_response_contract(input_summaries=summaries, input_reports=reports, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageOperatorConsentResponseContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(contract, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_operator_consent_response_contract_markdown(contract), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_operator_consent_response_contract_id": contract["storage_operator_consent_response_contract_id"], "supplied_report_count": contract["response_contract_context"]["supplied_report_count"], "response_artifact_not_created": contract["response_artifact_not_created"], "active_storage_allowed_now": contract["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_operator_consent_response_contract.py
+++ b/sentientos/codex_workcell_storage_operator_consent_response_contract.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_OPERATOR_CONSENT_RESPONSE_CONTRACT_ID = "codex_workcell_storage_operator_consent_response_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: dict[str, str] = {
+    "storage_operator_consent_request_packet_json": "request_packet",
+    "storage_operator_consent_request_packet_verifier_json": "request_packet_verifier",
+    "storage_operator_consent_contract_json": "consent_contract",
+    "storage_operator_consent_verifier_json": "consent_verifier",
+    "storage_runtime_authority_contract_json": "runtime_authority_contract",
+    "storage_runtime_authority_verifier_json": "runtime_authority_verifier",
+    "storage_execution_dossier_json": "execution_dossier",
+    "storage_execution_dossier_verifier_json": "execution_dossier_verifier",
+    "storage_transaction_plan_json": "transaction_plan",
+    "storage_transaction_plan_verifier_json": "transaction_plan_verifier",
+    "storage_policy_contract_json": "storage_policy_contract",
+    "storage_policy_verifier_json": "storage_policy_verifier",
+    "vow_boundary_contract_json": "vow_boundary_contract",
+    "vow_alignment_attestation_json": "vow_alignment_attestation",
+}
+
+SCHEMA_FIELD_IDS = [
+    "response_artifact_id_required", "response_artifact_version_required", "request_packet_digest_required",
+    "request_packet_verifier_digest_required", "operator_identity_required", "operator_timestamp_required",
+    "operator_scope_statement_required", "response_status_required", "explicit_allow_ledger_write_required",
+    "explicit_allow_glow_archive_required", "explicit_deny_storage_supported",
+    "canonical_vow_digest_acknowledgement_required", "storage_policy_digest_acknowledgement_required",
+    "storage_policy_verifier_digest_acknowledgement_required", "transaction_plan_digest_acknowledgement_required",
+    "transaction_plan_verifier_digest_acknowledgement_required", "execution_dossier_digest_acknowledgement_required",
+    "execution_dossier_verifier_digest_acknowledgement_required", "runtime_authority_contract_digest_acknowledgement_required",
+    "runtime_authority_verifier_digest_acknowledgement_required", "finalizer_guard_receipts_acknowledgement_required",
+    "expiration_timestamp_required", "revocation_terms_acknowledgement_required",
+    "no_daemon_self_authorization_acknowledgement_required", "no_federation_implied_consent_acknowledgement_required",
+    "denial_default_acknowledgement_required", "response_signature_placeholder_required",
+]
+REQUIRED_ACKNOWLEDGEMENT_IDS = [
+    "request_packet_digest", "request_packet_verifier_digest", "canonical_vow_digest",
+    "storage_policy_contract_digest", "storage_policy_verifier_digest", "storage_transaction_plan_digest",
+    "storage_transaction_plan_verifier_digest", "storage_execution_dossier_digest",
+    "storage_execution_dossier_verifier_digest", "runtime_authority_contract_digest",
+    "runtime_authority_verifier_digest", "finalizer_pre_commit_receipt_digest",
+    "pr_metadata_finalizer_receipt_digest", "pr_metadata_guard_receipt_digest",
+]
+FORBIDDEN_MOUNTS = ["/vow", "/pulse", "/daemon", "host_absolute_paths", "network_paths", "temp_paths_as_canonical", "hidden_backdoor_paths"]
+BLOCKING_GAP_IDS = [
+    "response_artifact_missing", "operator_response_missing", "operator_identity_missing", "operator_timestamp_missing",
+    "operator_scope_statement_missing", "response_status_missing", "explicit_ledger_write_allow_missing",
+    "explicit_glow_archive_allow_missing", "digest_acknowledgements_missing", "expiration_timestamp_missing",
+    "revocation_terms_acknowledgement_missing", "response_signature_missing", "runtime_authority_binding_missing",
+]
+FUTURE_REQUIREMENT_NAMES = [
+    "explicit operator identity capture", "explicit operator response artifact creation", "explicit operator response signature binding",
+    "explicit operator timestamp capture", "explicit operator scope statement capture", "explicit response status capture",
+    "explicit ledger write allow capture", "explicit glow archive allow capture", "explicit canonical vow digest acknowledgement",
+    "explicit storage policy digest acknowledgement", "explicit transaction plan digest acknowledgement",
+    "explicit execution dossier digest acknowledgement", "explicit runtime authority digest acknowledgement",
+    "explicit expiration timestamp capture", "explicit revocation terms acknowledgement", "explicit active ledger writer implementation",
+    "explicit active glow archiver implementation", "explicit finalizer runtime binding implementation",
+    "explicit PR metadata guard runtime binding implementation", "tests proving no readiness authority", "docs marking active behavior",
+]
+NON_AUTHORITY_POSTURE = {name: True for name in [
+    "storage_operator_consent_response_contract_is_read_only", "storage_operator_consent_response_contract_is_metadata_only",
+    "storage_operator_consent_response_contract_is_contract_only", "storage_operator_consent_response_contract_does_not_create_response_artifact",
+    "storage_operator_consent_response_contract_does_not_collect_response", "storage_operator_consent_response_contract_does_not_collect_consent",
+    "storage_operator_consent_response_contract_does_not_imply_consent", "storage_operator_consent_response_contract_does_not_bind_runtime_authority",
+    "storage_operator_consent_response_contract_does_not_activate_memory", "storage_operator_consent_response_contract_does_not_write_ledger",
+    "storage_operator_consent_response_contract_does_not_archive_glow", "storage_operator_consent_response_contract_does_not_modify_memory",
+    "storage_operator_consent_response_contract_does_not_watch_files", "storage_operator_consent_response_contract_does_not_poll_state",
+    "storage_operator_consent_response_contract_does_not_rerun_commands", "storage_operator_consent_response_contract_does_not_decide_readiness",
+    "storage_operator_consent_response_contract_does_not_bypass_finalizer", "storage_operator_consent_response_contract_does_not_bypass_pr_metadata_guard",
+    "storage_operator_consent_response_contract_does_not_authorize_commit", "storage_operator_consent_response_contract_does_not_authorize_pr_creation",
+    "storage_operator_consent_response_contract_does_not_trigger_daemon", "storage_operator_consent_response_contract_does_not_create_tasks",
+    "storage_operator_consent_response_contract_does_not_schedule_tasks", "storage_operator_consent_response_contract_does_not_send_alerts",
+    "storage_operator_consent_response_contract_does_not_render_ui", "storage_operator_consent_response_contract_does_not_send_messages",
+    "storage_operator_consent_response_contract_does_not_train_or_modify_models", "storage_operator_consent_response_contract_does_not_establish_federation_consensus",
+]}
+
+class CodexWorkcellStorageOperatorConsentResponseContractError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageOperatorConsentResponseContractError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        loaded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageOperatorConsentResponseContractError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CodexWorkcellStorageOperatorConsentResponseContractError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, loaded
+
+def _schema_record(field_id: str) -> dict[str, Any]:
+    return {"schema_field_id": field_id, "required_for_future_response_artifact": True, "currently_satisfied": False, "future_only": True, "active": False, "forbidden_inference": "This schema field does not imply consent, response collection, or runtime authority.", "reviewer_summary": f"Future response artifact must explicitly satisfy {field_id}; this contract does not."}
+
+def build_codex_workcell_storage_operator_consent_response_contract(*, input_summaries: Mapping[str, Mapping[str, Any]], input_reports: Mapping[str, Mapping[str, Any]] | None = None, commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    _ = input_reports
+    supplied_count = sum(1 for s in input_summaries.values() if s.get("provided") is True)
+    return {
+        "storage_operator_consent_response_contract_id": WORKCELL_STORAGE_OPERATOR_CONSENT_RESPONSE_CONTRACT_ID,
+        "metadata_only": True, "response_contract_only": True, "response_artifact_schema_only": True,
+        "response_artifact_not_created": True, "operator_response_present": False, "consent_not_collected": True,
+        "consent_not_implied": True, "operator_consent_present": False, "runtime_binding_not_performed": True,
+        "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False,
+        "archives_performed": False, "memory_mutation_performed": False, "not_runtime_authority": True,
+        "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True,
+        "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True,
+        "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {k: input_summaries.get(k, omitted_input(k)) for k in INPUT_SPECS},
+        "response_contract_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied_count, "response_contract_only": True, "response_artifact_not_created": True, "consent_not_collected": True, "no_action_taken": True},
+        "response_artifact_schema": [_schema_record(x) for x in SCHEMA_FIELD_IDS],
+        "response_status_policy": {"allowed_response_statuses": ["absent", "denied", "approved_for_scoped_storage", "expired", "revoked", "incomplete", "ambiguous", "invalid"], "current_response_status": "absent", "absent_status_blocks_storage": True, "denied_status_blocks_storage": True, "incomplete_status_blocks_storage": True, "ambiguous_status_blocks_storage": True, "expired_status_blocks_storage": True, "revoked_status_blocks_storage": True, "invalid_status_blocks_storage": True, "approved_status_not_present_here": True, "policy_only": True},
+        "explicit_allow_policy": {"explicit_allow_ledger_write_required": True, "explicit_allow_glow_archive_required": True, "explicit_allow_ledger_write_present": False, "explicit_allow_glow_archive_present": False, "ledger_write_blocked_without_explicit_allow": True, "glow_archive_blocked_without_explicit_allow": True, "allow_flags_not_collected": True, "policy_only": True},
+        "digest_acknowledgement_policy": {"digest_algorithm": DIGEST_ALGO, "required_acknowledgement_ids": REQUIRED_ACKNOWLEDGEMENT_IDS, "supplied_acknowledgement_ids": [], "missing_acknowledgement_ids": REQUIRED_ACKNOWLEDGEMENT_IDS, "acknowledgements_not_collected": True, "policy_only": True},
+        "scope_acknowledgement_policy": {"allowed_mounts": ["/ledger", "/glow"], "forbidden_mounts": FORBIDDEN_MOUNTS, "mount_scope_acknowledgement_required": True, "mount_scope_acknowledgement_present": False, "daemon_action_not_authorized": True, "model_training_not_authorized": True, "federation_consensus_not_authorized": True, "policy_only": True},
+        "expiration_policy": {"expiration_timestamp_required": True, "expiration_timestamp_present": False, "expired_or_missing_expiration_blocks_storage": True, "renewal_required_for_new_vow_digest": True, "renewal_required_for_new_storage_policy": True, "renewal_required_for_new_transaction_plan": True, "renewal_required_for_changed_mount_scope": True, "lifetime_not_started": True, "policy_only": True},
+        "revocation_policy": {"revocation_terms_acknowledgement_required": True, "revocation_terms_acknowledged": False, "future_revocation_must_block_new_writes": True, "future_revocation_must_block_new_archives": True, "future_revocation_must_not_delete_existing_receipts": True, "future_revocation_receipt_required": True, "revocation_not_performed": True, "policy_only": True},
+        "denial_and_ambiguity_policy": {"default_without_response": "deny_active_storage", "missing_response_blocks_ledger_write": True, "missing_response_blocks_glow_archive": True, "incomplete_response_blocks_storage": True, "ambiguous_response_blocks_storage": True, "denied_response_blocks_storage": True, "remote_or_daemon_response_not_accepted": True, "federation_state_not_accepted_as_response": True, "denial_not_runtime_decision_here": True, "policy_only": True},
+        "response_authority_boundary": {"response_contract_is_not_response_artifact": True, "response_schema_is_not_operator_approval": True, "request_packet_is_not_consent": True, "supplied_evidence_does_not_imply_consent": True, "finalizer_ready_to_commit_does_not_imply_consent": True, "pr_metadata_guard_ready_does_not_imply_consent": True, "daemon_recommendation_does_not_imply_consent": True, "federation_state_does_not_imply_consent": True, "future_operator_response_must_be_explicit": True, "future_operator_response_must_be_signature_bound": True, "authority_boundary_only": True},
+        "response_activation_gap_summary": {"response_artifact_not_created": True, "operator_response_present": False, "consent_not_collected": True, "consent_not_implied": True, "operator_consent_present": False, "active_storage_allowed_now": False, "runtime_binding_not_performed": True, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "blocking_gap_ids": BLOCKING_GAP_IDS},
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata contract.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future response-scoped consent target; no ledger write here", "/glow": "future response-scoped consent target; no archive write here", "/vow": "canonical digest acknowledgement required for future consent response binding", "/pulse": "future watcher boundary; response contract does not activate it", "/daemon": "future action boundary; response contract does not activate it"},
+        "future_activation_requirements": [{"requirement": name, "status": "future_only", "met": False, "active": False} for name in FUTURE_REQUIREMENT_NAMES],
+        "non_authority_posture": NON_AUTHORITY_POSTURE,
+    }
+
+def _cell(value: Any) -> str:
+    return json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+
+def _escape(value: Any) -> str:
+    return _cell(value).replace("|", "\\|").replace("\n", "<br>")
+
+def _table(mapping: Mapping[str, Any]) -> str:
+    lines = ["| Field | Value |", "| --- | --- |"]
+    for key in sorted(mapping):
+        lines.append(f"| {_escape(key)} | {_escape(mapping[key])} |")
+    return "\n".join(lines)
+
+def render_codex_workcell_storage_operator_consent_response_contract_markdown(contract: Mapping[str, Any]) -> str:
+    sections = ["# Codex Workcell Storage Operator Consent Response Artifact Contract", "", "Deterministic metadata-only response artifact schema contract. It is not a response artifact, does not collect or imply consent, and grants no runtime authority."]
+    section_keys = [("Input summaries", "input_summaries"), ("Response contract context", "response_contract_context"), ("Response artifact schema", "response_artifact_schema"), ("Response status policy", "response_status_policy"), ("Explicit allow policy", "explicit_allow_policy"), ("Digest acknowledgement policy", "digest_acknowledgement_policy"), ("Scope acknowledgement policy", "scope_acknowledgement_policy"), ("Expiration policy", "expiration_policy"), ("Revocation policy", "revocation_policy"), ("Denial and ambiguity policy", "denial_and_ambiguity_policy"), ("Response authority boundary", "response_authority_boundary"), ("Response activation gap summary", "response_activation_gap_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Future activation requirements", "future_activation_requirements"), ("Non-authority posture", "non_authority_posture")]
+    for title, key in section_keys:
+        value = contract.get(key)
+        sections += ["", f"## {title}", _table({str(i): v for i, v in enumerate(value)}) if isinstance(value, list) else _table(value if isinstance(value, Mapping) else {key: value})]
+    return "\n".join(sections) + "\n"

--- a/tests/test_build_codex_workcell_storage_operator_consent_response_contract_script.py
+++ b/tests/test_build_codex_workcell_storage_operator_consent_response_contract_script.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import subprocess
+import sys
+
+pytestmark = pytest.mark.no_legacy_skip
+
+SCRIPT = "scripts/build_codex_workcell_storage_operator_consent_response_contract.py"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, SCRIPT, *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_markdown_and_summary(tmp_path) -> None:
+    sample = tmp_path / "sample.json"
+    sample.write_text('{"field":"value|with\\nnewline"}', encoding="utf-8")
+    out = tmp_path / "out.json"
+    md = tmp_path / "out.md"
+    result = run_cmd("--output", str(out), "--storage-policy-contract-json", str(sample), "--commit-sha", "abc", "--pr-number", "9", "--pr-title", "Title", "--markdown-output", str(md), "--summary")
+    assert result.returncode == 0, result.stderr
+    data1 = out.read_text(encoding="utf-8")
+    parsed = json.loads(data1)
+    assert parsed["response_contract_context"]["commit_sha"] == "abc"
+    assert parsed["response_artifact_not_created"] is True
+    assert parsed["operator_response_present"] is False
+    assert parsed["consent_not_collected"] is True
+    assert parsed["consent_not_implied"] is True
+    assert parsed["runtime_binding_not_performed"] is True
+    assert parsed["writes_performed"] is False
+    assert parsed["archives_performed"] is False
+    assert parsed["memory_mutation_performed"] is False
+    assert "storage_operator_consent_response_contract_id" in result.stdout
+    assert md.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Operator Consent Response Artifact Contract")
+    out2 = tmp_path / "out2.json"
+    result2 = run_cmd("--output", str(out2), "--storage-policy-contract-json", str(sample), "--commit-sha", "abc", "--pr-number", "9", "--pr-title", "Title")
+    assert result2.returncode == 0
+    assert data1 == out2.read_text(encoding="utf-8")
+
+
+def test_cli_clean_input_errors_exit_2(tmp_path) -> None:
+    out = tmp_path / "out.json"
+    missing = run_cmd("--output", str(out), "--storage-policy-contract-json", str(tmp_path / "missing.json"))
+    assert missing.returncode == 2
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text("{", encoding="utf-8")
+    invalid = run_cmd("--output", str(out), "--storage-policy-contract-json", str(invalid_path))
+    assert invalid.returncode == 2
+    list_path = tmp_path / "list.json"
+    list_path.write_text("[]", encoding="utf-8")
+    non_object = run_cmd("--output", str(out), "--storage-policy-contract-json", str(list_path))
+    assert non_object.returncode == 2

--- a/tests/test_codex_workcell_storage_operator_consent_response_contract.py
+++ b/tests/test_codex_workcell_storage_operator_consent_response_contract.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from sentientos.codex_workcell_storage_operator_consent_response_contract import (
+    BLOCKING_GAP_IDS,
+    FORBIDDEN_MOUNTS,
+    INPUT_SPECS,
+    REQUIRED_ACKNOWLEDGEMENT_IDS,
+    SCHEMA_FIELD_IDS,
+    WORKCELL_STORAGE_OPERATOR_CONSENT_RESPONSE_CONTRACT_ID,
+    build_codex_workcell_storage_operator_consent_response_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_response_contract_markdown,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+
+def _contract():
+    return build_codex_workcell_storage_operator_consent_response_contract(
+        input_summaries={k: omitted_input(k) for k in INPUT_SPECS}, commit_sha="abc", pr_number="1", pr_title="title"
+    )
+
+
+def test_contract_required_flags_and_non_authority() -> None:
+    c = _contract()
+    assert c["storage_operator_consent_response_contract_id"] == WORKCELL_STORAGE_OPERATOR_CONSENT_RESPONSE_CONTRACT_ID
+    for key in ["metadata_only", "response_contract_only", "response_artifact_schema_only", "response_artifact_not_created", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"]:
+        assert c[key] is True
+    for key in ["operator_response_present", "operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"]:
+        assert c[key] is False
+    assert all(v is True for v in c["non_authority_posture"].values())
+    for required in ["storage_operator_consent_response_contract_does_not_render_ui", "storage_operator_consent_response_contract_does_not_send_messages", "storage_operator_consent_response_contract_does_not_write_ledger", "storage_operator_consent_response_contract_does_not_archive_glow", "storage_operator_consent_response_contract_does_not_trigger_daemon", "storage_operator_consent_response_contract_does_not_create_tasks", "storage_operator_consent_response_contract_does_not_schedule_tasks", "storage_operator_consent_response_contract_does_not_decide_readiness"]:
+        assert c["non_authority_posture"][required] is True
+
+
+def test_schema_policy_gap_and_future_requirements() -> None:
+    c = _contract()
+    records = c["response_artifact_schema"]
+    assert [r["schema_field_id"] for r in records] == SCHEMA_FIELD_IDS
+    assert all(r["future_only"] is True and r["currently_satisfied"] is False and r["active"] is False for r in records)
+    status = c["response_status_policy"]
+    assert status["current_response_status"] == "absent"
+    for key in ["absent_status_blocks_storage", "denied_status_blocks_storage", "incomplete_status_blocks_storage", "ambiguous_status_blocks_storage", "expired_status_blocks_storage", "revoked_status_blocks_storage", "invalid_status_blocks_storage", "approved_status_not_present_here"]:
+        assert status[key] is True
+    allow = c["explicit_allow_policy"]
+    assert allow["explicit_allow_ledger_write_required"] is True and allow["explicit_allow_glow_archive_required"] is True
+    assert allow["explicit_allow_ledger_write_present"] is False and allow["explicit_allow_glow_archive_present"] is False
+    digest = c["digest_acknowledgement_policy"]
+    assert digest["required_acknowledgement_ids"] == REQUIRED_ACKNOWLEDGEMENT_IDS
+    assert digest["supplied_acknowledgement_ids"] == []
+    assert digest["missing_acknowledgement_ids"] == REQUIRED_ACKNOWLEDGEMENT_IDS
+    assert digest["acknowledgements_not_collected"] is True
+    scope = c["scope_acknowledgement_policy"]
+    assert scope["allowed_mounts"] == ["/ledger", "/glow"]
+    assert all(x in scope["forbidden_mounts"] for x in FORBIDDEN_MOUNTS)
+    assert c["expiration_policy"]["expiration_timestamp_required"] is True
+    assert c["expiration_policy"]["expiration_timestamp_present"] is False
+    assert c["revocation_policy"]["revocation_terms_acknowledgement_required"] is True
+    assert c["revocation_policy"]["revocation_terms_acknowledged"] is False
+    assert c["denial_and_ambiguity_policy"]["default_without_response"] == "deny_active_storage"
+    boundary = c["response_authority_boundary"]
+    for key in ["response_contract_is_not_response_artifact", "response_schema_is_not_operator_approval", "request_packet_is_not_consent", "supplied_evidence_does_not_imply_consent", "finalizer_ready_to_commit_does_not_imply_consent", "pr_metadata_guard_ready_does_not_imply_consent", "daemon_recommendation_does_not_imply_consent", "federation_state_does_not_imply_consent"]:
+        assert boundary[key] is True
+    assert all(x in c["response_activation_gap_summary"]["blocking_gap_ids"] for x in BLOCKING_GAP_IDS)
+    assert all(r["status"] == "future_only" and r["met"] is False and r["active"] is False for r in c["future_activation_requirements"])
+
+
+def test_inputs_hygiene_mounts_and_markdown_escape(tmp_path) -> None:
+    payload = b'{"note":"a|b\\nc"}'
+    path = tmp_path / "input.json"
+    path.write_bytes(payload)
+    summary, report = read_json_input(str(path), "storage_policy_contract_json")
+    c = build_codex_workcell_storage_operator_consent_response_contract(input_summaries={"storage_policy_contract_json": summary}, input_reports={"storage_policy_contract_json": report}, pr_title="a|b\nc")
+    assert c["input_summaries"]["storage_policy_contract_json"]["digest"] == hashlib.sha256(payload).hexdigest()
+    assert c["input_summaries"]["storage_policy_contract_json"]["byte_size"] == len(payload)
+    assert c["input_summaries"]["storage_operator_consent_request_packet_json"]["provided"] is False
+    assert c["reviewer_hygiene_summary"]["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert c["reviewer_hygiene_summary"]["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert c["sentientos_mount_alignment"]["/ledger"].endswith("no ledger write here")
+    md1 = render_codex_workcell_storage_operator_consent_response_contract_markdown(c)
+    md2 = render_codex_workcell_storage_operator_consent_response_contract_markdown(c)
+    assert md1 == md2
+    assert "a\\|b" in md1 and "<br>" in md1


### PR DESCRIPTION
### Motivation

- Add a deterministic, metadata-only Codex Workcell Storage Operator Consent Response Artifact Contract that defines the shape and policies for a future operator response artifact without collecting a response or granting any runtime authority. 
- Ensure the contract records required schema fields, digest acknowledgements, explicit allow/deny semantics, expiration, revocation, scope, activation gaps, and reviewer hygiene while explicitly blocking active `/ledger` and `/glow` writes until a real operator artifact exists. 
- Keep the surface strictly non-authoritative so it cannot present UI, collect consent, write ledgers, archive glow, mutate memory, bind runtime authority, trigger daemons, or affect landing/finalizer readiness.

### Description

- Added `sentientos/codex_workcell_storage_operator_consent_response_contract.py` which implements `WORKCELL_STORAGE_OPERATOR_CONSENT_RESPONSE_CONTRACT_ID`, `DIGEST_ALGO`, input handling, deterministic `response_artifact_schema` records, and full policy structures for status, explicit allow, digest acknowledgements, scope, expiration, revocation, authority boundaries, activation gaps, and non-authority posture. 
- Added CLI builder `scripts/build_codex_workcell_storage_operator_consent_response_contract.py` with required `--output` and optional evidence inputs, commit/PR metadata args, deterministic JSON/Markdown outputs, and clean exit-code `2` behavior on missing/invalid/non-object JSON. 
- Added focused tests `tests/test_codex_workcell_storage_operator_consent_response_contract.py` and `tests/test_build_codex_workcell_storage_operator_consent_response_contract_script.py` that verify contract flags, schema records, policy defaults, omitted-input behavior, digest/byte_size recording, Markdown determinism and escaping, and CLI error handling. 
- Added documentation `docs/development/codex_workcell_storage_operator_consent_response_contract.md` and inserted short boundary references into adjacent workcell docs to note the response-contract boundary without expanding runtime authority.

### Testing

- Bootstrapped the task with `PYTHONPATH=. python scripts/bootstrap_codex_task.py ...` which returned `ready_with_warnings`. 
- Ran focused tests with `python -m scripts.run_tests -q tests/test_codex_workcell_storage_operator_consent_response_contract.py tests/test_build_codex_workcell_storage_operator_consent_response_contract_script.py` and the new tests passed (legacy skips handled via markers). 
- Performed broader verification including `python scripts/build_docs.py --bootstrap-docs` / `python scripts/build_docs.py`, targeted `mypy` on the new module/CLI, and `python scripts/codex_pr_metadata_guard.py verify`, all of which completed successfully. 
- Executed the full work-item matrix `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` and ran the landing finalizers (`codex_finalize_landing.py` phases) and landing supervisor; the matrix and finalizers passed and the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a40507604ec832f83bf9de8b3ebd064)