### PR TITLE
[codex:memory] add storage operator consent evidence dossier

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -276,3 +276,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -268,3 +268,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -215,3 +215,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -179,3 +179,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -107,3 +107,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -121,3 +121,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -95,3 +95,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -116,3 +116,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -163,3 +163,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -180,3 +180,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -120,3 +120,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -75,3 +75,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -97,3 +97,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_contract.md
@@ -123,3 +123,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_evidence_dossier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_evidence_dossier.md
@@ -1,0 +1,105 @@
+# Codex Workcell Storage Operator Consent Evidence Dossier
+
+The Codex workcell storage operator consent evidence dossier is a deterministic,
+metadata-only report that inventories supplied consent-ladder evidence. It reads
+JSON reports for the request contract, request verifier, request packet, packet
+verifier, response artifact contract, response verifier, runtime authority
+boundary, execution dossier, transaction plan, storage policy, vow boundary, and
+vow attestation, then emits a compact dossier that records digests, byte sizes,
+reported statuses, and boundary posture.
+
+It is not consent and is not an approval gate. It does not create a response
+artifact, collect an operator response, collect consent, imply consent, present a
+request, render UI, send messages, bind runtime authority, activate memory,
+write `/ledger`, archive `/glow`, mutate memory, watch files, poll state, run
+commands, schedule work, trigger daemon action, decide readiness, authorize a
+commit, authorize PR metadata, create PRs, establish federation consensus, or
+train or modify models.
+
+## Difference from the response artifact verifier
+
+The response artifact verifier checks that the response artifact contract remains
+future-only: no response artifact exists, no operator response exists, no consent
+is collected or implied, no approval exists, no runtime authority is bound, and
+active storage remains blocked. The evidence dossier is one layer later: it
+summarizes which future consent-design reports have been supplied and whether
+supplied verifier reports have their expected verified statuses. It still keeps
+all real-world consent gaps open.
+
+## Inventoried evidence
+
+The dossier inventories these supported evidence roles:
+
+- consent response contract and verifier
+- consent request packet and verifier
+- consent request contract and verifier
+- runtime authority contract and verifier
+- execution dossier and verifier
+- transaction plan and verifier
+- storage policy and verifier
+- vow boundary and vow attestation
+
+For every supplied input, the dossier records the raw-byte SHA-256 digest, byte
+size, parsed object status, detected report identifier, relevant verification
+status or digest, and non-authority posture when present. Omitted optional inputs
+are represented deterministically as `provided: false` with null digest and byte
+size fields.
+
+## Complete consent-design evidence is still not consent
+
+`storage_operator_consent_evidence_dossier_complete` means only that required
+future consent-design reports were supplied, expected verifier statuses matched,
+and no active authority signal was detected in supplied metadata. It does not
+mean an operator saw a request, responded, signed a response, allowed ledger
+writes, allowed glow archives, acknowledged digests, accepted revocation terms,
+or permitted active storage.
+
+Finalizer readiness, PR metadata guard readiness, daemon recommendations,
+federation state, request packets, response schemas, supplied evidence, and a
+complete evidence dossier never imply operator consent. They also do not grant
+ledger authority, glow authority, runtime authority, daemon authority, commit
+readiness, PR readiness, or permission to run an active writer.
+
+## Missing real-world consent gaps
+
+The dossier always preserves the real-world consent gaps as blocking gaps:
+request presentation is missing, response artifact creation is missing, operator
+response is missing, operator identity and timestamp are missing, scope and
+status statements are missing, explicit ledger and glow allows are missing,
+digest acknowledgements are missing, expiration and revocation acknowledgements
+are missing, response signature is missing, runtime authority binding is missing,
+and active writer implementation is missing. Active storage remains blocked.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene is a repository validation concern, not runtime behavior.
+The dossier records the expected correct repository URL
+`https://github.com/Zombinator85/SentientOS.git` and notes that grep validation is
+performed by the landing task. It does not run grep, alter documentation, contact
+GitHub, or change runtime behavior.
+
+## SentientOS mount alignment
+
+- `/ledger`: future consent-scoped storage target; no ledger write here.
+- `/glow`: future consent-scoped archive target; no archive write here.
+- `/vow`: canonical digest context for future consent evidence.
+- `/pulse`: future watcher boundary; the dossier does not activate it.
+- `/daemon`: future action boundary; the dossier does not activate it.
+
+## Future activation requirements
+
+Future activation remains unmet and inactive until explicit request presentation,
+response artifact creation, operator response collection, operator identity and
+signature binding, timestamp capture, scope and response status capture, explicit
+ledger and glow allow capture, digest acknowledgement capture, expiration and
+revocation acknowledgement, active ledger writer and glow archiver
+implementation, finalizer and PR metadata guard runtime binding implementation,
+tests proving no readiness authority, and docs marking active behavior exist.
+
+## Non-authority posture
+
+The dossier is read-only, metadata-only, and dossier-only. It is not a writer,
+archiver, daemon action, scheduler, consent collector, response collector, UI
+renderer, message sender, external delivery system, runtime binder, readiness
+authority, commit authority, PR metadata authority, task creator, alerting
+system, model-training system, or federation consensus mechanism.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet.md
@@ -108,3 +108,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
@@ -43,3 +43,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_response_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_response_contract.md
@@ -55,3 +55,7 @@ Future activation remains unmet and inactive until explicit operator identity ca
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_response_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_response_verifier.md
@@ -37,3 +37,7 @@ Future active behavior remains unmet and inactive until explicit operator identi
 ## Non-authority posture
 
 All verifier posture flags remain true: read-only, metadata-only, verifier-only, no response artifact creation, no response collection, no consent collection or implication, no runtime authority binding, no memory activation, no ledger write, no glow archive, no memory mutation, no file watching, no polling, no command reruns, no readiness decision, no finalizer or PR guard bypass, no commit or PR creation authorization, no daemon trigger, no task creation, no scheduling, no alerts, no UI rendering, no messages, no external delivery, no model training/modification, and no federation consensus.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_operator_consent_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_verifier.md
@@ -92,3 +92,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -114,3 +114,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -83,3 +83,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -90,3 +90,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_runtime_authority_verifier.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_verifier.md
@@ -53,3 +53,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -96,3 +96,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -74,3 +74,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -94,3 +94,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -103,3 +103,7 @@ The [Codex Workcell Storage Operator Consent Response Artifact Contract](codex_w
 ## Storage operator consent response verifier boundary
 
 The [Codex Workcell Storage Operator Consent Response Artifact Verifier](codex_workcell_storage_operator_consent_response_verifier.md) is a deterministic metadata-only structural verifier for the future response artifact contract. It creates no response artifact, collects or implies no consent, grants no readiness, storage, ledger, glow, daemon, federation, UI, message, scheduler, commit, PR metadata, or runtime authority, and leaves active storage blocked.
+
+## Storage operator consent evidence dossier boundary
+
+See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_storage_operator_consent_evidence_dossier.md). The dossier inventories future consent-design evidence only; it does not present a request, collect a response or consent, imply approval, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide readiness, or authorize commit/PR metadata.

--- a/scripts/build_codex_workcell_storage_operator_consent_evidence_dossier.py
+++ b/scripts/build_codex_workcell_storage_operator_consent_evidence_dossier.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_operator_consent_evidence_dossier import (
+    CodexWorkcellStorageOperatorConsentEvidenceDossierError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_operator_consent_evidence_dossier,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_evidence_dossier_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage operator consent evidence dossier.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--pr-number")
+    parser.add_argument("--pr-title")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries: dict[str, dict[str, object]] = {}
+    reports: dict[str, dict[str, object]] = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summaries[input_id], reports[input_id] = read_json_input(path, input_id)
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries=summaries, input_reports=reports, commit_sha=args.commit_sha, pr_number=args.pr_number, pr_title=args.pr_title)
+    except CodexWorkcellStorageOperatorConsentEvidenceDossierError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(dossier, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_operator_consent_evidence_dossier_markdown(dossier), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_operator_consent_evidence_dossier_id": dossier["storage_operator_consent_evidence_dossier_id"], "consent_evidence_status": dossier["consent_evidence_status"], "supplied_report_count": dossier["evidence_dossier_context"]["supplied_report_count"], "active_storage_allowed_now": dossier["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_operator_consent_evidence_dossier.py
+++ b/sentientos/codex_workcell_storage_operator_consent_evidence_dossier.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_OPERATOR_CONSENT_EVIDENCE_DOSSIER_ID = "codex_workcell_storage_operator_consent_evidence_dossier.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: dict[str, tuple[str, str | None, bool]] = {
+    "storage_operator_consent_response_contract_json": ("consent_response_contract", None, True),
+    "storage_operator_consent_response_verifier_json": ("consent_response_verifier", "storage_operator_consent_response_contract_verified", True),
+    "storage_operator_consent_request_packet_json": ("consent_request_packet", None, True),
+    "storage_operator_consent_request_packet_verifier_json": ("consent_request_packet_verifier", "storage_operator_consent_request_packet_verified", True),
+    "storage_operator_consent_contract_json": ("consent_request_contract", None, True),
+    "storage_operator_consent_verifier_json": ("consent_request_verifier", "storage_operator_consent_contract_verified", True),
+    "storage_runtime_authority_contract_json": ("runtime_authority_contract", None, True),
+    "storage_runtime_authority_verifier_json": ("runtime_authority_verifier", "storage_runtime_authority_contract_verified", True),
+    "storage_execution_dossier_json": ("execution_dossier", None, True),
+    "storage_execution_dossier_verifier_json": ("execution_dossier_verifier", "storage_execution_dossier_verified", True),
+    "storage_transaction_plan_json": ("transaction_plan", None, True),
+    "storage_transaction_plan_verifier_json": ("transaction_plan_verifier", "storage_transaction_plan_verified", True),
+    "storage_policy_contract_json": ("storage_policy", None, True),
+    "storage_policy_verifier_json": ("storage_policy_verifier", "storage_policy_contract_verified", True),
+    "vow_boundary_contract_json": ("vow_boundary", None, True),
+    "vow_alignment_attestation_json": ("vow_attestation", None, True),
+}
+
+SUMMARY_KEYS = {
+    "storage_operator_consent_contract_json": "consent_request_contract_supplied",
+    "storage_operator_consent_verifier_json": "consent_request_verifier_supplied",
+    "storage_operator_consent_request_packet_json": "consent_request_packet_supplied",
+    "storage_operator_consent_request_packet_verifier_json": "consent_request_packet_verifier_supplied",
+    "storage_operator_consent_response_contract_json": "consent_response_contract_supplied",
+    "storage_operator_consent_response_verifier_json": "consent_response_verifier_supplied",
+    "storage_runtime_authority_contract_json": "runtime_authority_contract_supplied",
+    "storage_runtime_authority_verifier_json": "runtime_authority_verifier_supplied",
+    "storage_execution_dossier_json": "execution_dossier_supplied",
+    "storage_execution_dossier_verifier_json": "execution_dossier_verifier_supplied",
+    "storage_transaction_plan_json": "transaction_plan_supplied",
+    "storage_transaction_plan_verifier_json": "transaction_plan_verifier_supplied",
+    "storage_policy_contract_json": "storage_policy_contract_supplied",
+    "storage_policy_verifier_json": "storage_policy_verifier_supplied",
+    "vow_boundary_contract_json": "vow_boundary_contract_supplied",
+    "vow_alignment_attestation_json": "vow_alignment_attestation_supplied",
+}
+
+BLOCKING_GAP_IDS = [
+    "consent_request_presentation_missing", "response_artifact_missing", "operator_response_missing",
+    "operator_identity_missing", "operator_timestamp_missing", "operator_scope_statement_missing",
+    "response_status_missing", "explicit_ledger_write_allow_missing", "explicit_glow_archive_allow_missing",
+    "digest_acknowledgements_missing", "expiration_timestamp_missing", "revocation_terms_acknowledgement_missing",
+    "response_signature_missing", "runtime_authority_binding_missing", "active_writer_implementation_missing",
+]
+
+FUTURE_REQUIREMENT_NAMES = [
+    "explicit consent request presentation mechanism", "explicit operator response artifact creation",
+    "explicit operator response collection", "explicit operator identity capture",
+    "explicit operator response signature binding", "explicit operator timestamp capture",
+    "explicit operator scope statement capture", "explicit response status capture",
+    "explicit ledger write allow capture", "explicit glow archive allow capture",
+    "explicit digest acknowledgement capture", "explicit expiration timestamp capture",
+    "explicit revocation terms acknowledgement", "explicit active ledger writer implementation",
+    "explicit active glow archiver implementation", "explicit finalizer runtime binding implementation",
+    "explicit PR metadata guard runtime binding implementation", "tests proving no readiness authority",
+    "docs marking active behavior",
+]
+
+NON_AUTHORITY_KEYS = [
+    "is_read_only", "is_metadata_only", "is_dossier_only", "does_not_present_request", "does_not_render_ui",
+    "does_not_send_messages", "does_not_deliver_externally", "does_not_create_response_artifact",
+    "does_not_collect_response", "does_not_collect_consent", "does_not_imply_consent",
+    "does_not_bind_runtime_authority", "does_not_activate_memory", "does_not_write_ledger",
+    "does_not_archive_glow", "does_not_modify_memory", "does_not_watch_files", "does_not_poll_state",
+    "does_not_rerun_commands", "does_not_decide_readiness", "does_not_bypass_finalizer",
+    "does_not_bypass_pr_metadata_guard", "does_not_authorize_commit", "does_not_authorize_pr_creation",
+    "does_not_trigger_daemon", "does_not_create_tasks", "does_not_schedule_tasks", "does_not_send_alerts",
+    "does_not_train_or_modify_models", "does_not_establish_federation_consensus",
+]
+NON_AUTHORITY_POSTURE = {f"storage_operator_consent_evidence_dossier_{k}": True for k in NON_AUTHORITY_KEYS}
+
+class CodexWorkcellStorageOperatorConsentEvidenceDossierError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageOperatorConsentEvidenceDossierError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageOperatorConsentEvidenceDossierError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(data, dict):
+        raise CodexWorkcellStorageOperatorConsentEvidenceDossierError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, data
+
+def _detected_report_id(report: Mapping[str, Any]) -> Any:
+    for key in sorted(report):
+        if key.endswith("_id"):
+            return report.get(key)
+    return None
+
+def _relevant(report: Mapping[str, Any]) -> Any:
+    for key in ("verification_status", "consent_evidence_status", "digest", "source_digest"):
+        if key in report:
+            return report.get(key)
+    return _detected_report_id(report)
+
+def _posture_all_true(report: Mapping[str, Any]) -> tuple[bool | None, bool | None]:
+    posture = report.get("non_authority_posture")
+    if not isinstance(posture, Mapping):
+        return None, None
+    return True, all(v is True for v in posture.values())
+
+def _active_signal(report: Mapping[str, Any]) -> bool:
+    bad_true = {"operator_response_present", "operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed", "consent_collected", "consent_implied", "runtime_binding_performed", "response_artifact_created"}
+    bad_false = {"response_artifact_not_created", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"}
+    for k, v in report.items():
+        if k in bad_true and v is True:
+            return True
+        if k in bad_false and v is False:
+            return True
+        if isinstance(v, Mapping) and _active_signal(v):
+            return True
+    return False
+
+def _inventory(input_summaries: Mapping[str, Mapping[str, Any]], reports: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for input_id, (role, expected, required) in INPUT_SPECS.items():
+        summary = input_summaries.get(input_id, omitted_input(input_id))
+        report = reports.get(input_id, {})
+        provided = summary.get("provided") is True
+        present, all_true = _posture_all_true(report)
+        status_matches = None if expected is None or not provided else report.get("verification_status") == expected
+        inv_status = "supplied" if provided else "missing"
+        notes = []
+        if not provided:
+            notes.append("required design evidence report omitted")
+        if provided and expected is not None and not status_matches:
+            inv_status = "failed"; notes.append("verifier status does not match expected verified status")
+        if provided and _active_signal(report):
+            inv_status = "failed"; notes.append("active authority signal detected")
+        rows.append({
+            "input_id": input_id, "provided": provided, "detected_report_id": _detected_report_id(report) if provided else None,
+            "evidence_role": role, "source_digest": summary.get("digest"), "source_digest_algo": summary.get("digest_algo") if provided else None,
+            "source_byte_size": summary.get("byte_size"), "relevant_status_or_digest": _relevant(report) if provided else None,
+            "expected_verified_status": expected, "status_matches_expected": status_matches,
+            "non_authority_posture_present": present, "non_authority_posture_all_true": all_true,
+            "required_for_design_dossier": required, "inventory_status": inv_status, "notes": notes,
+        })
+    return rows
+
+def build_codex_workcell_storage_operator_consent_evidence_dossier(*, input_summaries: Mapping[str, Mapping[str, Any]], input_reports: Mapping[str, Mapping[str, Any]] | None = None, commit_sha: str | None = None, pr_number: str | None = None, pr_title: str | None = None) -> dict[str, Any]:
+    reports = input_reports or {}
+    supplied_count = sum(1 for s in input_summaries.values() if s.get("provided") is True)
+    inventory = _inventory(input_summaries, reports)
+    all_required = all(r["provided"] for r in inventory if r["required_for_design_dossier"])
+    verifier_rows = [r for r in inventory if r["expected_verified_status"]]
+    verifiers_passed = all(r["status_matches_expected"] is True for r in verifier_rows if r["provided"])
+    active_detected = any(r["inventory_status"] == "failed" and "active authority signal detected" in r["notes"] for r in inventory)
+    failed = any(r["inventory_status"] == "failed" for r in inventory)
+    status = "storage_operator_consent_evidence_dossier_failed" if failed or active_detected else ("storage_operator_consent_evidence_dossier_complete" if all_required and verifiers_passed else "storage_operator_consent_evidence_dossier_incomplete")
+    summary = {out: input_summaries.get(inp, omitted_input(inp)).get("provided") is True for inp, out in SUMMARY_KEYS.items()}
+    summary.update({
+        "all_required_design_reports_supplied": all_required,
+        "all_supplied_verifiers_passed": verifiers_passed,
+        "all_supplied_reports_non_authoritative": not active_detected,
+        "future_consent_design_evidence_complete": status == "storage_operator_consent_evidence_dossier_complete",
+        "response_artifact_created_detected": False, "operator_response_detected": False, "consent_collected_detected": False,
+        "consent_implied_detected": False, "runtime_binding_detected": False, "active_storage_authority_detected": False,
+        "no_action_taken": True,
+    })
+    missing: dict[str, Any] = {k: False for k in ["consent_request_presentation_mechanism_present", "consent_request_presented", "ui_rendered", "message_sent", "external_delivery_performed", "response_artifact_created", "operator_response_present", "operator_identity_present", "operator_timestamp_present", "operator_scope_statement_present", "response_status_present", "explicit_ledger_write_allow_present", "explicit_glow_archive_allow_present", "digest_acknowledgements_present", "expiration_timestamp_present", "revocation_terms_acknowledged", "response_signature_present", "runtime_authority_binding_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"]}
+    missing["blocking_gap_ids"] = BLOCKING_GAP_IDS
+    prereq_ids = ["consent_request_contract_supplied", "consent_request_verifier_supplied", "consent_request_packet_supplied", "consent_request_packet_verifier_supplied", "consent_response_contract_supplied", "consent_response_verifier_supplied", "runtime_authority_contract_supplied", "runtime_authority_verifier_supplied"]
+    prereqs = [{"prerequisite_id": p, "category": "supplied_report", "passed": bool(summary[p]), "severity": "info" if summary[p] else "warning", "observed_state": summary[p], "evidence_source": "input_summaries", "authority_boundary": "metadata evidence only; not consent or readiness"} for p in prereq_ids]
+    for p in ["request_packet_not_presented", "response_artifact_not_created", "operator_response_absent", "operator_identity_missing", "operator_timestamp_missing", "operator_scope_statement_missing", "response_status_missing", "explicit_ledger_write_allow_missing", "explicit_glow_archive_allow_missing", "digest_acknowledgements_missing", "expiration_timestamp_missing", "revocation_terms_acknowledgement_missing", "response_signature_missing", "runtime_authority_binding_missing", "active_storage_disallowed"]:
+        prereqs.append({"prerequisite_id": p, "category": "authority_boundary" if p in {"request_packet_not_presented", "response_artifact_not_created", "active_storage_disallowed"} else "missing_real_world_consent_gap", "passed": True, "severity": "blocking_gap" if p not in {"request_packet_not_presented", "response_artifact_not_created", "active_storage_disallowed"} else "info", "observed_state": "future_only_unmet_or_absent", "evidence_source": "missing_real_world_consent_summary", "authority_boundary": "gap remains; no consent, storage, ledger, glow, daemon, commit, PR, or readiness authority"})
+    return {
+        "storage_operator_consent_evidence_dossier_id": WORKCELL_STORAGE_OPERATOR_CONSENT_EVIDENCE_DOSSIER_ID,
+        "metadata_only": True, "evidence_dossier_only": True, "consent_design_evidence_only": True,
+        "response_artifact_not_created": True, "operator_response_present": False, "consent_request_not_presented": True,
+        "consent_not_collected": True, "consent_not_implied": True, "operator_consent_present": False,
+        "runtime_binding_not_performed": True, "active_storage_allowed_now": False, "execution_performed": False,
+        "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False,
+        "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True,
+        "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True,
+        "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {k: input_summaries.get(k, omitted_input(k)) for k in INPUT_SPECS},
+        "evidence_dossier_context": {"commit_sha": commit_sha, "pr_number": pr_number, "pr_title": pr_title, "supplied_report_count": supplied_count, "required_design_report_count": len(INPUT_SPECS), "evidence_dossier_only": True, "consent_design_evidence_only": True, "response_artifact_not_created": True, "consent_not_collected": True, "no_action_taken": True},
+        "consent_ladder_inventory": inventory, "consent_design_evidence_summary": summary,
+        "missing_real_world_consent_summary": missing, "consent_evidence_status": status,
+        "consent_prerequisite_results": prereqs,
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata dossier.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future consent-scoped storage target; no ledger write here", "/glow": "future consent-scoped archive target; no archive write here", "/vow": "canonical digest context for future consent evidence", "/pulse": "future watcher boundary; consent evidence dossier does not activate it", "/daemon": "future action boundary; consent evidence dossier does not activate it"},
+        "future_activation_requirements": [{"requirement": n, "status": "future_only", "met": False, "active": False} for n in FUTURE_REQUIREMENT_NAMES],
+        "non_authority_posture": NON_AUTHORITY_POSTURE,
+    }
+
+def _cell(value: Any) -> str:
+    return json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+
+def _escape(value: Any) -> str:
+    return _cell(value).replace("|", "\\|").replace("\n", "<br>")
+
+def _table(mapping: Mapping[str, Any]) -> str:
+    lines = ["| Field | Value |", "| --- | --- |"]
+    for key in sorted(mapping):
+        lines.append(f"| {_escape(key)} | {_escape(mapping[key])} |")
+    return "\n".join(lines)
+
+def render_codex_workcell_storage_operator_consent_evidence_dossier_markdown(dossier: Mapping[str, Any]) -> str:
+    sections = ["# Codex Workcell Storage Operator Consent Evidence Dossier", "", "Deterministic metadata-only consent-design evidence dossier. It inventories supplied reports, preserves real-world consent gaps, and grants no consent, storage, runtime, ledger, glow, daemon, readiness, commit, PR, UI, message, or federation authority."]
+    keys = [("Input summaries", "input_summaries"), ("Evidence dossier context", "evidence_dossier_context"), ("Consent ladder inventory", "consent_ladder_inventory"), ("Consent design evidence summary", "consent_design_evidence_summary"), ("Missing real-world consent summary", "missing_real_world_consent_summary"), ("Consent evidence status", "consent_evidence_status"), ("Consent prerequisite results", "consent_prerequisite_results"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Future activation requirements", "future_activation_requirements"), ("Non-authority posture", "non_authority_posture")]
+    for title, key in keys:
+        value = dossier.get(key)
+        sections += ["", f"## {title}", _table({str(i): v for i, v in enumerate(value)}) if isinstance(value, list) else _table(value if isinstance(value, Mapping) else {key: value})]
+    return "\n".join(sections) + "\n"

--- a/tests/test_build_codex_workcell_storage_operator_consent_evidence_dossier_script.py
+++ b/tests/test_build_codex_workcell_storage_operator_consent_evidence_dossier_script.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+SCRIPT = "scripts/build_codex_workcell_storage_operator_consent_evidence_dossier.py"
+
+
+def run_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, SCRIPT, *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_markdown_and_summary_deterministically(tmp_path) -> None:
+    sample = tmp_path / "sample.json"
+    sample.write_text('{"field":"value|with\\nnewline"}', encoding="utf-8")
+    out = tmp_path / "out.json"
+    md = tmp_path / "out.md"
+    result = run_cmd("--output", str(out), "--storage-policy-contract-json", str(sample), "--commit-sha", "abc", "--pr-number", "9", "--pr-title", "Title", "--markdown-output", str(md), "--summary")
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(out.read_text(encoding="utf-8"))
+    assert parsed["evidence_dossier_context"]["commit_sha"] == "abc"
+    assert parsed["consent_evidence_status"] == "storage_operator_consent_evidence_dossier_incomplete"
+    assert parsed["response_artifact_not_created"] is True
+    assert parsed["operator_response_present"] is False
+    assert parsed["consent_request_not_presented"] is True
+    assert parsed["consent_not_collected"] is True
+    assert parsed["consent_not_implied"] is True
+    assert parsed["runtime_binding_not_performed"] is True
+    assert parsed["writes_performed"] is False
+    assert parsed["archives_performed"] is False
+    assert parsed["memory_mutation_performed"] is False
+    assert "storage_operator_consent_evidence_dossier_id" in result.stdout
+    assert md.read_text(encoding="utf-8").startswith("# Codex Workcell Storage Operator Consent Evidence Dossier")
+    out2 = tmp_path / "out2.json"
+    result2 = run_cmd("--output", str(out2), "--storage-policy-contract-json", str(sample), "--commit-sha", "abc", "--pr-number", "9", "--pr-title", "Title")
+    assert result2.returncode == 0
+    assert out.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")
+
+
+def test_cli_clean_input_errors_exit_2(tmp_path) -> None:
+    out = tmp_path / "out.json"
+    missing = run_cmd("--output", str(out), "--storage-policy-contract-json", str(tmp_path / "missing.json"))
+    assert missing.returncode == 2
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text("{", encoding="utf-8")
+    invalid = run_cmd("--output", str(out), "--storage-policy-contract-json", str(invalid_path))
+    assert invalid.returncode == 2
+    list_path = tmp_path / "list.json"
+    list_path.write_text("[]", encoding="utf-8")
+    non_object = run_cmd("--output", str(out), "--storage-policy-contract-json", str(list_path))
+    assert non_object.returncode == 2

--- a/tests/test_codex_workcell_storage_operator_consent_evidence_dossier.py
+++ b/tests/test_codex_workcell_storage_operator_consent_evidence_dossier.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from sentientos.codex_workcell_storage_operator_consent_evidence_dossier import (
+    BLOCKING_GAP_IDS,
+    INPUT_SPECS,
+    NON_AUTHORITY_POSTURE,
+    WORKCELL_STORAGE_OPERATOR_CONSENT_EVIDENCE_DOSSIER_ID,
+    build_codex_workcell_storage_operator_consent_evidence_dossier,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_evidence_dossier_markdown,
+)
+
+pytestmark = pytest.mark.no_legacy_skip
+
+EXPECTED = {
+    "storage_operator_consent_response_verifier_json": "storage_operator_consent_response_contract_verified",
+    "storage_operator_consent_request_packet_verifier_json": "storage_operator_consent_request_packet_verified",
+    "storage_operator_consent_verifier_json": "storage_operator_consent_contract_verified",
+    "storage_runtime_authority_verifier_json": "storage_runtime_authority_contract_verified",
+    "storage_execution_dossier_verifier_json": "storage_execution_dossier_verified",
+    "storage_transaction_plan_verifier_json": "storage_transaction_plan_verified",
+    "storage_policy_verifier_json": "storage_policy_contract_verified",
+}
+
+
+def _summaries_reports(tmp_path, overrides=None):
+    summaries = {}
+    reports = {}
+    overrides = overrides or {}
+    for input_id in INPUT_SPECS:
+        report = {"report_id": input_id, "metadata_only": True, "non_authority_posture": {"x": True}}
+        if input_id in EXPECTED:
+            report["verification_status"] = EXPECTED[input_id]
+        report.update(overrides.get(input_id, {}))
+        path = tmp_path / f"{input_id}.json"
+        import json
+        path.write_text(json.dumps(report, sort_keys=True), encoding="utf-8")
+        summaries[input_id], reports[input_id] = read_json_input(str(path), input_id)
+    return summaries, reports
+
+
+def test_required_flags_and_omitted_inputs_incomplete() -> None:
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries={k: omitted_input(k) for k in INPUT_SPECS})
+    assert dossier["storage_operator_consent_evidence_dossier_id"] == WORKCELL_STORAGE_OPERATOR_CONSENT_EVIDENCE_DOSSIER_ID
+    for key in ["metadata_only", "evidence_dossier_only", "consent_design_evidence_only", "response_artifact_not_created", "consent_request_not_presented", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"]:
+        assert dossier[key] is True
+    for key in ["operator_response_present", "operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"]:
+        assert dossier[key] is False
+    assert dossier["consent_evidence_status"] == "storage_operator_consent_evidence_dossier_incomplete"
+    assert all(v is True for v in dossier["non_authority_posture"].values())
+    assert dossier["non_authority_posture"] == NON_AUTHORITY_POSTURE
+    assert all(r["inventory_status"] == "missing" and r["provided"] is False for r in dossier["consent_ladder_inventory"])
+
+
+def test_all_required_reports_can_complete_while_real_world_gaps_remain(tmp_path) -> None:
+    summaries, reports = _summaries_reports(tmp_path)
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries=summaries, input_reports=reports, commit_sha="abc", pr_number="7", pr_title="title")
+    assert dossier["consent_evidence_status"] == "storage_operator_consent_evidence_dossier_complete"
+    assert dossier["evidence_dossier_context"]["commit_sha"] == "abc"
+    summary = dossier["consent_design_evidence_summary"]
+    assert summary["all_required_design_reports_supplied"] is True
+    assert summary["all_supplied_verifiers_passed"] is True
+    assert summary["future_consent_design_evidence_complete"] is True
+    assert summary["response_artifact_created_detected"] is False
+    assert summary["operator_response_detected"] is False
+    missing = dossier["missing_real_world_consent_summary"]
+    assert missing["operator_response_present"] is False
+    assert all(gap in missing["blocking_gap_ids"] for gap in BLOCKING_GAP_IDS)
+    assert all(r["status"] == "future_only" and r["met"] is False and r["active"] is False for r in dossier["future_activation_requirements"])
+    assert any(r["prerequisite_id"] == "active_storage_disallowed" and r["passed"] is True for r in dossier["consent_prerequisite_results"])
+
+
+@pytest.mark.parametrize("input_id", [
+    "storage_operator_consent_response_verifier_json",
+    "storage_operator_consent_request_packet_verifier_json",
+    "storage_operator_consent_verifier_json",
+    "storage_runtime_authority_verifier_json",
+])
+def test_failed_verifier_status_fails_dossier(tmp_path, input_id) -> None:
+    summaries, reports = _summaries_reports(tmp_path, {input_id: {"verification_status": "failed"}})
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries=summaries, input_reports=reports)
+    assert dossier["consent_evidence_status"] == "storage_operator_consent_evidence_dossier_failed"
+    row = next(r for r in dossier["consent_ladder_inventory"] if r["input_id"] == input_id)
+    assert row["inventory_status"] == "failed"
+
+
+def test_active_authority_signal_fails_but_output_never_grants_authority(tmp_path) -> None:
+    summaries, reports = _summaries_reports(tmp_path, {"storage_policy_contract_json": {"active_storage_allowed_now": True}})
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries=summaries, input_reports=reports)
+    assert dossier["consent_evidence_status"] == "storage_operator_consent_evidence_dossier_failed"
+    assert dossier["active_storage_allowed_now"] is False
+    assert dossier["operator_consent_present"] is False
+    assert dossier["operator_response_present"] is False
+    assert dossier["response_artifact_not_created"] is True
+
+
+def test_digest_byte_size_summary_hygiene_and_markdown_escape(tmp_path) -> None:
+    payload = b'{"note":"a|b\\nc"}'
+    path = tmp_path / "one.json"
+    path.write_bytes(payload)
+    summary, report = read_json_input(str(path), "storage_policy_contract_json")
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries={"storage_policy_contract_json": summary}, input_reports={"storage_policy_contract_json": report}, pr_title="a|b\nc")
+    inv = next(r for r in dossier["consent_ladder_inventory"] if r["input_id"] == "storage_policy_contract_json")
+    assert inv["source_digest"] == hashlib.sha256(payload).hexdigest()
+    assert inv["source_byte_size"] == len(payload)
+    assert dossier["input_summaries"]["storage_operator_consent_response_contract_json"]["provided"] is False
+    assert dossier["reviewer_hygiene_summary"]["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert dossier["reviewer_hygiene_summary"]["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    md1 = render_codex_workcell_storage_operator_consent_evidence_dossier_markdown(dossier)
+    md2 = render_codex_workcell_storage_operator_consent_evidence_dossier_markdown(dossier)
+    assert md1 == md2
+    assert "a\\|b" in md1 and "<br>" in md1
+
+
+def test_no_readiness_or_runtime_actions_are_granted() -> None:
+    dossier = build_codex_workcell_storage_operator_consent_evidence_dossier(input_summaries={})
+    posture = dossier["non_authority_posture"]
+    for suffix in ["does_not_decide_readiness", "does_not_present_request", "does_not_render_ui", "does_not_send_messages", "does_not_create_response_artifact", "does_not_collect_response", "does_not_collect_consent", "does_not_imply_consent", "does_not_bind_runtime_authority", "does_not_write_ledger", "does_not_archive_glow", "does_not_modify_memory", "does_not_trigger_daemon", "does_not_create_tasks", "does_not_schedule_tasks"]:
+        assert posture[f"storage_operator_consent_evidence_dossier_{suffix}"] is True


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only evidence dossier that inventories the Codex workcell storage consent ladder without creating or implying any real-world operator consent or runtime authority.
- Make consent-design evidence machine-readable (digests, byte sizes, verification status) so reviewers can assess which future-only design artifacts are present while preserving all missing consent gaps.
- Keep strict non-authority posture: the dossier must never present requests, collect responses/consent, activate storage, write ledgers/archives, bind runtime authority, or trigger runtime actions.

### Description
- Adds a new dossier module `sentientos/codex_workcell_storage_operator_consent_evidence_dossier.py` that implements input summaries, SHA-256 digests, byte sizes, parsed-object validation, consent ladder inventory, status derivation (complete/incomplete/failed), missing real-world consent summary, future activation requirements, and full non-authority posture.
- Adds a CLI builder `scripts/build_codex_workcell_storage_operator_consent_evidence_dossier.py` with `--output` plus the specified optional JSON inputs, `--commit-sha`, `--pr-number`, `--pr-title`, `--markdown-output`, and `--summary`; the CLI returns exit code `2` on missing/invalid/non-object JSON inputs and writes deterministic JSON and optional Markdown.
- Adds focused tests `tests/test_codex_workcell_storage_operator_consent_evidence_dossier.py` and `tests/test_build_codex_workcell_storage_operator_consent_evidence_dossier_script.py` covering omitted inputs, complete-but-still-no-consent cases, verifier failures, active-authority detection, digest/byte-size recording, deterministic Markdown escaping, and CLI input-error behavior.
- Adds documentation `docs/development/codex_workcell_storage_operator_consent_evidence_dossier.md` describing purpose, inventoried evidence, differences from the response verifier, preserved consent gaps, mount alignment, future activation requirements, and non-authority posture; and short boundary links were appended to adjacent docs to reference the dossier.

### Testing
- Ran the focused dossier tests and CLI tests: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_operator_consent_evidence_dossier.py tests/test_build_codex_workcell_storage_operator_consent_evidence_dossier_script.py` — passed.
- Verified related response-verifier tests and scripts: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_operator_consent_response_verifier.py tests/test_verify_codex_workcell_storage_operator_consent_response_contract_script.py` — passed.
- Docs build initially required bootstrapping dependencies (`mkdocs`, `watchdog`), which was performed and `python scripts/build_docs.py --check-deps` / `python scripts/build_docs.py` completed successfully after bootstrap.
- Type checking: targeted `mypy` for the new module and CLI passed after a small type fix.
- Full work-item review packet matrix: `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` — matrix passed (required_failure_count=0).
- Landing and metadata gates: landing supervisor, pre-commit finalizer (`ready_to_commit`), post-commit/pr-metadata finalizer (`ready_for_pr_metadata`), and PR metadata guard (`pr_metadata_guard_ready`) all indicated ready; commit created with the change set.

If you want, I can extract a short example of the dossier JSON shape or run any additional focused checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4102ca863c832faf6441d6167af76e)