### PR TITLE
[codex:memory] add storage consent presentation boundary contract

### DIFF
--- a/docs/development/codex_finalize_landing.md
+++ b/docs/development/codex_finalize_landing.md
@@ -284,3 +284,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_landing_evidence_recovery_rail.md
+++ b/docs/development/codex_landing_evidence_recovery_rail.md
@@ -276,3 +276,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_validation_and_landing_contract.md
+++ b/docs/development/codex_validation_and_landing_contract.md
@@ -223,3 +223,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_architecture.md
+++ b/docs/development/codex_workcell_architecture.md
@@ -187,3 +187,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_daemon_recommendation_contract.md
+++ b/docs/development/codex_workcell_daemon_recommendation_contract.md
@@ -115,3 +115,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_health_snapshot.md
+++ b/docs/development/codex_workcell_health_snapshot.md
@@ -129,3 +129,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_memory_activation_preflight.md
+++ b/docs/development/codex_workcell_memory_activation_preflight.md
@@ -103,3 +103,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_memory_candidate_bundle.md
+++ b/docs/development/codex_workcell_memory_candidate_bundle.md
@@ -124,3 +124,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_memory_candidate_verifier.md
+++ b/docs/development/codex_workcell_memory_candidate_verifier.md
@@ -171,3 +171,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_memory_contract.md
+++ b/docs/development/codex_workcell_memory_contract.md
@@ -188,3 +188,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_pulse_contract.md
+++ b/docs/development/codex_workcell_pulse_contract.md
@@ -128,3 +128,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_execution_dossier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier.md
@@ -83,3 +83,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_execution_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_execution_dossier_verifier.md
@@ -105,3 +105,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_contract.md
@@ -131,3 +131,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_evidence_dossier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_evidence_dossier.md
@@ -107,3 +107,7 @@ system, model-training system, or federation consensus mechanism.
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_evidence_dossier_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_evidence_dossier_verifier.md
@@ -13,3 +13,7 @@ Reviewer URL hygiene is reported as documentation hygiene only. Repository grep 
 Mount alignment is explicit: `/ledger` is verification-only with no ledger write, `/glow` is verification-only with no archive write, `/vow` is canonical digest context for future consent evidence, `/pulse` is a future watcher boundary that is not activated, and `/daemon` is a future action boundary that is not activated.
 
 This verifier is not a writer, archiver, daemon action, scheduler, consent collector, response collector, UI renderer, message sender, external delivery system, runtime binder, watcher, poller, command runner, readiness authority, commit authority, PR authority, model trainer, reinforcement learner, or federation consensus system.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet.md
@@ -116,3 +116,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_packet_verifier.md
@@ -51,3 +51,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_request_presentation_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_presentation_contract.md
@@ -1,0 +1,55 @@
+# Codex Workcell Storage Operator Consent Request Presentation Boundary Contract
+
+The Codex workcell storage operator consent request presentation boundary contract is a deterministic, metadata-only, future-only contract for the missing authority layer between a consent request packet and any real operator-facing presentation. It defines the requirements, surfaces, denied inferences, missing gaps, mount alignment, and non-authority posture that must exist before any future system may present a storage operator consent request packet.
+
+This contract does not present a request, render UI, send messages, deliver externally, create a response artifact, collect a response, collect or imply consent, bind runtime authority, activate memory or storage, write `/ledger`, archive `/glow`, mutate memory, watch files, poll state, run commands, call networks, invoke providers, schedule tasks, create tasks, send alerts, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, create PRs, establish federation consensus, or train or modify models.
+
+## Ladder position
+
+- The storage operator consent request contract defines the future request requirements.
+- The request verifier verifies that request contract shape without collecting consent.
+- The request packet packages future operator-facing request metadata but does not present it.
+- The packet verifier verifies packet structure but does not prove presentation.
+- The response artifact contract defines a future response schema but does not create a response artifact.
+- The response verifier verifies that schema boundary without proving a response exists.
+- The evidence dossier inventories consent-design evidence but does not prove an operator saw anything.
+- The evidence dossier verifier verifies that dossier boundary without closing the presentation gap.
+- This presentation boundary contract names the future-only presentation authority requirements and still performs no presentation.
+
+## Why packet and evidence existence are not presentation
+
+A request packet existing is not presentation because no explicit presentation mechanism, channel authorization, operator identity target, digest-bound display, cancellation path, audit receipt path, UI authority, message authority, external delivery authority, response artifact creation authority, response collection authority, consent collection authority, runtime binding, ledger writer, or glow archiver is active. A verified packet is still only verified metadata.
+
+Complete or verified consent-design evidence is not presentation either. Evidence completeness can show that the design ladder is internally consistent, but it cannot show that an operator saw the request, reviewed the digest inventory, acknowledged ledger or glow implications, selected expiration terms, accepted revocation terms, signed a response, or granted consent.
+
+## Presentation authority remains separate
+
+Presentation authority is separate from UI rendering, message delivery, external delivery, response artifact creation, response collection, consent collection, runtime binding, and active storage. Each of those actions requires explicit future authority and must remain inactive here.
+
+Finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, storage policy evidence, and runtime authority contracts do not imply presentation authority. They are review, evidence, policy, or boundary signals, not operator-facing presentation permission.
+
+Operator silence, notification delivery, local file creation, message delivery, or a displayed copy cannot imply consent. Consent requires a future explicit response path, identity boundary, scope statement, digest acknowledgement, expiration boundary, revocation boundary, and response status boundary.
+
+## Active storage remains blocked
+
+Active storage remains blocked because request presentation is missing, consent collection is missing, response artifact creation is missing, runtime binding is missing, and active `/ledger` and `/glow` writer implementations are not authorized by this metadata contract.
+
+## Reviewer URL hygiene
+
+Reviewer URL hygiene remains separate from runtime behavior. The contract records that `https://github.com/Zombinator85/SentientOS.git` is the correct repository URL and that the legacy bad OpenAI repository URL is expected absent, but grep validation is performed by the landing task rather than by this contract.
+
+## SentientOS mount alignment
+
+- `/ledger`: future operator consent presentation receipt chain only; no ledger write.
+- `/glow`: future presentation evidence archive only; no archive write.
+- `/vow`: canonical digest context for future presentation and consent constraints.
+- `/pulse`: future presentation freshness or drift signal boundary; not activated.
+- `/daemon`: future bounded presentation repair recommendation boundary; not activated and no daemon action.
+
+## Future activation requirements
+
+Future activation requires an explicit presentation mechanism, presentation channel authorization, operator identity targeting, request packet digest binding, evidence dossier digest binding, vow digest binding, operator-facing scope display, ledger and glow allow questions, digest acknowledgement display, expiration policy display, revocation terms display, no-implied-consent and no-readiness-authority notices, response artifact path, response collection boundary, operator cancellation path, presentation audit receipt path, UI/message/external delivery authority when used, response artifact creation authority, response collection authority, consent collection authority, runtime authority binding implementation, active ledger writer implementation, active glow archiver implementation, tests proving no presentation readiness authority, and docs marking active behavior.
+
+## Non-authority posture
+
+The presentation boundary contract is metadata-only, contract-only, and future-only. It is not a presentation runner, UI renderer, message sender, external delivery system, response artifact creator, response collector, consent collector, runtime authority, memory writer, ledger writer, glow archiver, watcher, scheduler, executor, daemon action, task creator, alerting system, model trainer, reinforcement learning system, readiness authority, commit authority, PR authority, or federation consensus mechanism.

--- a/docs/development/codex_workcell_storage_operator_consent_response_contract.md
+++ b/docs/development/codex_workcell_storage_operator_consent_response_contract.md
@@ -63,3 +63,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_response_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_response_verifier.md
@@ -45,3 +45,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_operator_consent_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_verifier.md
@@ -100,3 +100,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_policy_contract.md
+++ b/docs/development/codex_workcell_storage_policy_contract.md
@@ -122,3 +122,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_policy_verifier.md
+++ b/docs/development/codex_workcell_storage_policy_verifier.md
@@ -91,3 +91,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_runtime_authority_contract.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_contract.md
@@ -98,3 +98,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_runtime_authority_verifier.md
+++ b/docs/development/codex_workcell_storage_runtime_authority_verifier.md
@@ -61,3 +61,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_transaction_plan.md
+++ b/docs/development/codex_workcell_storage_transaction_plan.md
@@ -104,3 +104,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_storage_transaction_plan_verifier.md
+++ b/docs/development/codex_workcell_storage_transaction_plan_verifier.md
@@ -82,3 +82,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_vow_alignment_attestation.md
+++ b/docs/development/codex_workcell_vow_alignment_attestation.md
@@ -102,3 +102,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/docs/development/codex_workcell_vow_boundary_contract.md
+++ b/docs/development/codex_workcell_vow_boundary_contract.md
@@ -111,3 +111,7 @@ See [Codex Workcell Storage Operator Consent Evidence Dossier](codex_workcell_st
 ## Storage Operator Consent Evidence Dossier Verifier Boundary
 
 See [Codex Workcell Storage Operator Consent Evidence Dossier Verifier](codex_workcell_storage_operator_consent_evidence_dossier_verifier.md). The verifier is deterministic metadata-only structural evidence review; it does not present requests, collect or imply consent, create response artifacts, bind runtime authority, activate storage, write `/ledger`, archive `/glow`, trigger `/daemon`, decide finalizer/PR readiness, or replace missing real-world operator consent.
+
+## Storage Operator Consent Request Presentation Boundary
+
+See [Codex Workcell Storage Operator Consent Request Presentation Boundary Contract](codex_workcell_storage_operator_consent_request_presentation_contract.md). The boundary is deterministic metadata only: request packets, verifier success, evidence dossiers, finalizer readiness, PR metadata guard readiness, matrix passage, daemon recommendations, federation state, runtime authority contracts, storage policy evidence, local files, notifications, displayed copies, and operator silence do not prove presentation, create a response artifact, collect consent, bind runtime authority, or allow active storage.

--- a/scripts/build_codex_workcell_storage_operator_consent_request_presentation_contract.py
+++ b/scripts/build_codex_workcell_storage_operator_consent_request_presentation_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_workcell_storage_operator_consent_request_presentation_contract import (
+    CodexWorkcellStorageOperatorConsentRequestPresentationContractError,
+    INPUT_SPECS,
+    build_codex_workcell_storage_operator_consent_request_presentation_contract,
+    omitted_input,
+    read_json_input,
+    render_codex_workcell_storage_operator_consent_request_presentation_contract_markdown,
+)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a metadata-only Codex workcell storage operator consent request presentation boundary contract.")
+    parser.add_argument("--output", required=True)
+    for input_id in INPUT_SPECS:
+        parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
+    parser.add_argument("--commit")
+    parser.add_argument("--pr")
+    parser.add_argument("--markdown-output")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    summaries: dict[str, dict[str, object]] = {}
+    reports: dict[str, dict[str, object]] = {}
+    try:
+        for input_id in INPUT_SPECS:
+            path = getattr(args, input_id)
+            if path:
+                summaries[input_id], reports[input_id] = read_json_input(path, input_id)
+            else:
+                summaries[input_id] = omitted_input(input_id)
+        contract = build_codex_workcell_storage_operator_consent_request_presentation_contract(input_summaries=summaries, input_reports=reports, commit=args.commit, pr=args.pr)
+    except CodexWorkcellStorageOperatorConsentRequestPresentationContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    Path(args.output).write_text(json.dumps(contract, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(render_codex_workcell_storage_operator_consent_request_presentation_contract_markdown(contract), encoding="utf-8")
+    if args.summary:
+        print(json.dumps({"storage_operator_consent_request_presentation_contract_id": contract["storage_operator_consent_request_presentation_contract_id"], "supplied_input_count": contract["presentation_boundary_context"]["supplied_input_count"], "presentation_not_performed": contract["presentation_not_performed"], "active_storage_allowed_now": contract["active_storage_allowed_now"]}, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_workcell_storage_operator_consent_request_presentation_contract.py
+++ b/sentientos/codex_workcell_storage_operator_consent_request_presentation_contract.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID = "codex_workcell_storage_operator_consent_request_presentation_contract.v1"
+DIGEST_ALGO = "sha256"
+
+INPUT_SPECS: dict[str, str] = {
+    "storage_operator_consent_request_packet_json": "storage_operator_consent_request_packet",
+    "storage_operator_consent_request_packet_verifier_json": "storage_operator_consent_request_packet_verifier",
+    "storage_operator_consent_evidence_dossier_json": "storage_operator_consent_evidence_dossier",
+    "storage_operator_consent_evidence_dossier_verifier_json": "storage_operator_consent_evidence_dossier_verifier",
+    "storage_operator_consent_response_contract_json": "storage_operator_consent_response_contract",
+    "storage_operator_consent_response_verifier_json": "storage_operator_consent_response_verifier",
+    "storage_operator_consent_contract_json": "storage_operator_consent_contract",
+    "storage_operator_consent_verifier_json": "storage_operator_consent_verifier",
+    "storage_runtime_authority_contract_json": "storage_runtime_authority_contract",
+    "storage_runtime_authority_verifier_json": "storage_runtime_authority_verifier",
+    "vow_boundary_contract_json": "vow_boundary_contract",
+    "vow_alignment_attestation_json": "vow_alignment_attestation",
+}
+
+PRESENTATION_SURFACES = [
+    "operator_request_display", "operator_request_review_surface", "operator_request_acknowledgement_surface",
+    "operator_scope_confirmation_surface", "operator_digest_review_surface", "operator_ledger_write_allow_prompt",
+    "operator_glow_archive_allow_prompt", "operator_expiration_selection_surface", "operator_revocation_terms_surface",
+    "operator_response_signature_surface", "local_ui_rendering", "local_cli_prompt", "local_file_drop",
+    "local_notification", "external_message_delivery", "email_delivery", "chat_delivery", "webhook_delivery",
+    "browser_or_app_surface", "response_artifact_creation", "response_collection", "consent_collection",
+    "runtime_authority_binding", "active_storage_activation",
+]
+PRESENTATION_AUTHORITY_REQUIREMENTS = [
+    "explicit_operator_presentation_allow", "explicit_presentation_channel", "explicit_operator_identity_target",
+    "explicit_request_packet_digest_binding", "explicit_evidence_dossier_digest_binding", "explicit_vow_digest_context",
+    "explicit_scope_statement_display", "explicit_ledger_write_allow_question", "explicit_glow_archive_allow_question",
+    "explicit_digest_acknowledgement_display", "explicit_expiration_policy_display", "explicit_revocation_terms_display",
+    "explicit_response_artifact_path", "explicit_response_collection_boundary", "explicit_no_implied_consent_notice",
+    "explicit_no_readiness_authority_notice", "explicit_no_daemon_authority_notice", "explicit_no_federation_authority_notice",
+    "explicit_audit_receipt_path", "explicit_presentation_revocation_or_cancellation_path",
+]
+OPERATOR_ATTENTION_REQUIREMENTS = [
+    "operator_must_see_requested_scope", "operator_must_see_ledger_write_implication", "operator_must_see_glow_archive_implication",
+    "operator_must_see_digest_inventory", "operator_must_see_missing_runtime_binding_gap", "operator_must_see_denied_implied_consent_notice",
+    "operator_must_see_revocation_terms", "operator_must_see_expiration_terms", "operator_must_see_response_artifact_path",
+    "operator_must_have_cancel_option",
+]
+DELIVERY_SCOPE_REQUIREMENTS = [
+    "presentation_channel_must_be_explicit", "external_delivery_must_be_explicitly_allowed", "message_delivery_must_be_explicitly_allowed",
+    "ui_rendering_must_be_explicitly_allowed", "local_file_drop_must_be_explicitly_allowed", "no_hidden_delivery_channel",
+    "no_background_delivery", "no_third_party_delivery_without_scope", "no_cross_device_delivery_without_scope",
+]
+REQUEST_PACKET_INTEGRITY_REQUIREMENTS = [
+    "request_packet_digest_must_match_presented_packet", "request_packet_verifier_status_must_be_bound",
+    "evidence_dossier_digest_must_be_bound", "evidence_dossier_verifier_status_must_be_bound",
+    "vow_boundary_digest_must_be_bound_if_supplied", "presentation_copy_must_not_modify_requested_scope",
+    "presentation_copy_must_not_add_permissions", "presentation_copy_must_preserve_denial_default",
+    "presentation_copy_must_preserve_empty_response_fields", "presentation_copy_must_preserve_missing_consent_gaps",
+]
+RESPONSE_PATH_REQUIREMENTS = [
+    "response_artifact_schema_must_be_bound", "response_artifact_path_must_be_explicit", "response_collection_boundary_must_be_explicit",
+    "response_signature_boundary_must_be_explicit", "response_timestamp_boundary_must_be_explicit", "response_identity_boundary_must_be_explicit",
+    "response_scope_statement_boundary_must_be_explicit", "response_status_boundary_must_be_explicit",
+    "response_revocation_boundary_must_be_explicit", "response_expiration_boundary_must_be_explicit",
+]
+DENIED_INFERENCES = [
+    "request_packet_exists_implies_presented", "request_packet_verified_implies_presented", "evidence_dossier_complete_implies_presented",
+    "evidence_dossier_verified_implies_presented", "presentation_contract_exists_implies_presentation_authority",
+    "response_contract_exists_implies_response_artifact_created", "response_verifier_passed_implies_response_exists",
+    "operator_consent_contract_exists_implies_consent", "finalizer_ready_implies_presentation_authority",
+    "pr_metadata_guard_ready_implies_presentation_authority", "matrix_passed_implies_presentation_authority",
+    "daemon_recommendation_implies_presentation_authority", "federation_state_implies_presentation_authority",
+    "runtime_authority_contract_exists_implies_runtime_binding", "storage_policy_verified_implies_presentation_authority",
+    "request_display_copy_implies_operator_saw_request", "local_file_written_implies_operator_reviewed_request",
+    "notification_sent_implies_consent", "message_delivered_implies_consent", "operator_silence_implies_consent",
+]
+MISSING_GAPS = [
+    "presentation_mechanism_missing", "presentation_channel_missing", "operator_identity_target_missing",
+    "request_packet_digest_binding_missing", "evidence_dossier_digest_binding_missing", "vow_digest_context_missing",
+    "scope_statement_display_missing", "ledger_write_allow_question_missing", "glow_archive_allow_question_missing",
+    "digest_acknowledgement_display_missing", "expiration_policy_display_missing", "revocation_terms_display_missing",
+    "no_implied_consent_notice_missing", "no_readiness_authority_notice_missing", "response_artifact_path_missing",
+    "response_collection_boundary_missing", "operator_cancel_path_missing", "audit_receipt_path_missing",
+    "ui_rendering_authority_missing", "message_delivery_authority_missing", "external_delivery_authority_missing",
+    "response_artifact_creation_authority_missing", "response_collection_authority_missing", "consent_collection_authority_missing",
+    "runtime_authority_binding_missing", "active_storage_authority_missing",
+]
+FUTURE_ACTIVATION_REQUIREMENTS = [
+    "explicit request presentation mechanism implementation", "explicit presentation channel authorization", "explicit operator identity targeting",
+    "explicit request packet digest binding", "explicit evidence dossier digest binding", "explicit vow digest binding",
+    "explicit operator-facing scope display", "explicit ledger write allow question display", "explicit glow archive allow question display",
+    "explicit digest acknowledgement display", "explicit expiration policy display", "explicit revocation terms display",
+    "explicit no-implied-consent notice display", "explicit no-readiness-authority notice display", "explicit response artifact path",
+    "explicit response collection boundary", "explicit operator cancellation path", "explicit presentation audit receipt path",
+    "explicit UI rendering authority if UI is used", "explicit message delivery authority if messages are used",
+    "explicit external delivery authority if external delivery is used", "explicit response artifact creation authority",
+    "explicit response collection authority", "explicit consent collection authority", "explicit runtime authority binding implementation",
+    "explicit active ledger writer implementation", "explicit active glow archiver implementation", "tests proving no presentation readiness authority",
+    "docs marking active behavior",
+]
+NON_AUTHORITY_SUFFIXES = [
+    "is_metadata_only", "is_contract_only", "is_future_only", "does_not_present_request", "does_not_render_ui",
+    "does_not_send_messages", "does_not_deliver_externally", "does_not_create_response_artifact", "does_not_collect_response",
+    "does_not_collect_consent", "does_not_imply_consent", "does_not_bind_runtime_authority", "does_not_activate_memory",
+    "does_not_activate_storage", "does_not_write_ledger", "does_not_archive_glow", "does_not_modify_memory",
+    "does_not_watch_files", "does_not_poll_state", "does_not_run_commands", "does_not_call_network",
+    "does_not_invoke_providers", "does_not_decide_readiness", "does_not_bypass_finalizer", "does_not_bypass_pr_metadata_guard",
+    "does_not_authorize_commit", "does_not_authorize_pr_creation", "does_not_trigger_daemon", "does_not_create_tasks",
+    "does_not_schedule_tasks", "does_not_send_alerts", "does_not_train_or_modify_models", "does_not_establish_federation_consensus",
+]
+NON_AUTHORITY_POSTURE = {f"storage_operator_consent_request_presentation_contract_{suffix}": True for suffix in NON_AUTHORITY_SUFFIXES}
+
+class CodexWorkcellStorageOperatorConsentRequestPresentationContractError(ValueError):
+    pass
+
+def omitted_input(input_id: str) -> dict[str, Any]:
+    return {"input_id": input_id, "provided": False, "path": None, "digest": None, "byte_size": None, "readable_json": False, "error": None}
+
+def read_json_input(path_text: str, input_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = Path(path_text)
+    if not path.exists():
+        raise CodexWorkcellStorageOperatorConsentRequestPresentationContractError(f"missing_json:{input_id}:{path_text}")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexWorkcellStorageOperatorConsentRequestPresentationContractError(f"invalid_json:{input_id}:{path_text}:{exc}") from exc
+    if not isinstance(data, dict):
+        raise CodexWorkcellStorageOperatorConsentRequestPresentationContractError(f"json_not_object:{input_id}:{path_text}")
+    return {"input_id": input_id, "provided": True, "path": path_text, "digest_algo": DIGEST_ALGO, "digest": digest, "byte_size": len(raw), "readable_json": True, "error": None}, data
+
+def _records(ids: list[str], key: str) -> list[dict[str, Any]]:
+    return [{key: item, "future_only": True, "currently_satisfied": False, "authority_boundary": "future explicit operator presentation authority required; no active authority here"} for item in ids]
+
+def build_codex_workcell_storage_operator_consent_request_presentation_contract(*, input_summaries: Mapping[str, Mapping[str, Any]], input_reports: Mapping[str, Mapping[str, Any]] | None = None, commit: str | None = None, pr: str | None = None) -> dict[str, Any]:
+    supplied_count = sum(1 for summary in input_summaries.values() if summary.get("provided") is True)
+    return {
+        "storage_operator_consent_request_presentation_contract_id": WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID,
+        "metadata_only": True, "contract_only": True, "future_only": True, "presentation_not_performed": True,
+        "request_not_presented": True, "ui_not_rendered": True, "message_not_sent": True, "external_delivery_not_performed": True,
+        "response_artifact_not_created": True, "response_not_collected": True, "consent_not_collected": True, "consent_not_implied": True,
+        "operator_consent_present": False, "runtime_binding_not_performed": True, "active_storage_allowed_now": False,
+        "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False,
+        "not_presentation_runner": True, "not_ui_renderer": True, "not_message_sender": True, "not_external_delivery_system": True,
+        "not_response_artifact_creator": True, "not_response_collector": True, "not_consent_collector": True, "not_runtime_authority": True,
+        "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True,
+        "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True,
+        "not_reinforcement_learning": True,
+        "input_summaries": {k: input_summaries.get(k, omitted_input(k)) for k in INPUT_SPECS},
+        "presentation_boundary_context": {
+            "commit": commit, "pr": pr, "supplied_input_count": supplied_count, "supported_input_count": len(INPUT_SPECS),
+            "presentation_authority_separate_from": ["request_packet_existence", "packet_verification", "evidence_dossier_completeness", "dossier_verification", "response_schema_existence", "response_verifier_success", "finalizer_readiness", "pr_metadata_guard_readiness", "matrix_passage", "daemon_recommendations", "federation_state", "runtime_authority_contract_presence", "storage_policy_evidence"],
+            "no_request_presentation_action_occurred": True,
+        },
+        "presentation_surface_inventory": [{"surface_id": s, "description": f"Future-only inactive boundary for {s}.", "future_only": True, "active_now": False, "required_before_activation": "explicit scoped operator presentation authority", "denied_inference": f"{s}_exists_or_is_named_does_not_imply_consent_or_presentation", "authority_boundary": "metadata only; not a presentation runner", "notes": "No UI, message, delivery, response, consent, runtime binding, ledger write, glow archive, daemon action, or storage activation occurs."} for s in PRESENTATION_SURFACES],
+        "required_presentation_authority_requirements": [{"requirement_id": r, "required_before_presentation": True, "currently_satisfied": False, "authority_boundary": "missing explicit future presentation authority", "missing_gap_id": r + "_missing", "severity": "blocking"} for r in PRESENTATION_AUTHORITY_REQUIREMENTS],
+        "required_operator_attention_requirements": _records(OPERATOR_ATTENTION_REQUIREMENTS, "requirement_id"),
+        "required_delivery_scope_requirements": _records(DELIVERY_SCOPE_REQUIREMENTS, "requirement_id"),
+        "required_request_packet_integrity_requirements": _records(REQUEST_PACKET_INTEGRITY_REQUIREMENTS, "requirement_id"),
+        "required_response_path_requirements": _records(RESPONSE_PATH_REQUIREMENTS, "requirement_id"),
+        "denied_inferences": [{"inference_id": i, "denied": True, "authority_boundary": "denied by presentation boundary contract; no consent, presentation, response, readiness, daemon, federation, runtime, or active storage authority follows"} for i in DENIED_INFERENCES],
+        "missing_real_world_presentation_summary": [{"gap_id": g, "present": True, "severity": "blocking", "active": False} for g in MISSING_GAPS],
+        "reviewer_hygiene_summary": {"bad_openai_repo_url_expected_absent": True, "correct_repo_url": "https://github.com/Zombinator85/SentientOS.git", "bad_repo_url": "https://github.com/" + "OpenAI/" + "SentientOS.git", "hygiene_check_note": "Repository grep validation is performed by the landing task, not by this metadata contract.", "docs_hygiene_only": True, "no_runtime_effect": True},
+        "sentientos_mount_alignment": {"/ledger": "future operator consent presentation receipt chain only; no ledger write", "/glow": "future presentation evidence archive only; no archive write", "/vow": "canonical digest context for future presentation and consent constraints", "/pulse": "future presentation freshness/drift signal boundary; not activated", "/daemon": "future bounded presentation repair recommendation boundary; not activated and no daemon action"},
+        "future_activation_requirements": [{"requirement": r, "future_only": True, "met": False, "active": False} for r in FUTURE_ACTIVATION_REQUIREMENTS],
+        "non_authority_posture": NON_AUTHORITY_POSTURE,
+    }
+
+def _cell(value: Any) -> str:
+    return json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+
+def _escape(value: Any) -> str:
+    return _cell(value).replace("|", "\\|").replace("\n", "<br>")
+
+def _table(mapping: Mapping[str, Any]) -> str:
+    lines = ["| Field | Value |", "| --- | --- |"]
+    for key in sorted(mapping):
+        lines.append(f"| {_escape(key)} | {_escape(mapping[key])} |")
+    return "\n".join(lines)
+
+def render_codex_workcell_storage_operator_consent_request_presentation_contract_markdown(contract: Mapping[str, Any]) -> str:
+    sections = ["# Codex Workcell Storage Operator Consent Request Presentation Boundary Contract", "", "Deterministic metadata-only future presentation boundary. It does not present a request, render UI, send messages, deliver externally, create or collect responses, collect or imply consent, bind runtime authority, activate storage, write ledger entries, archive glow evidence, trigger daemons, decide readiness, create PRs, call networks, invoke providers, or train models."]
+    for title, key in [("Input summaries", "input_summaries"), ("Presentation boundary context", "presentation_boundary_context"), ("Presentation surface inventory", "presentation_surface_inventory"), ("Required presentation authority requirements", "required_presentation_authority_requirements"), ("Operator attention requirements", "required_operator_attention_requirements"), ("Delivery scope requirements", "required_delivery_scope_requirements"), ("Request packet integrity requirements", "required_request_packet_integrity_requirements"), ("Response path requirements", "required_response_path_requirements"), ("Denied inferences", "denied_inferences"), ("Missing real-world presentation summary", "missing_real_world_presentation_summary"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Future activation requirements", "future_activation_requirements"), ("Non-authority posture", "non_authority_posture")]:
+        value = contract.get(key)
+        sections += ["", f"## {title}", _table({str(i): v for i, v in enumerate(value)}) if isinstance(value, list) else _table(value if isinstance(value, Mapping) else {key: value})]
+    return "\n".join(sections) + "\n"

--- a/tests/test_build_codex_workcell_storage_operator_consent_request_presentation_contract_script.py
+++ b/tests/test_build_codex_workcell_storage_operator_consent_request_presentation_contract_script.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+import subprocess
+import sys
+from pathlib import Path
+
+
+pytestmark = pytest.mark.no_legacy_skip
+SCRIPT = Path("scripts/build_codex_workcell_storage_operator_consent_request_presentation_contract.py")
+
+
+def run_builder(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True, check=False)
+
+
+def test_cli_writes_json_markdown_and_summary_with_input_digest(tmp_path: Path):
+    sample = tmp_path / "packet|name.json"
+    raw = b'{"field":"value|with\\nnewline"}'
+    sample.write_bytes(raw)
+    output = tmp_path / "contract.json"
+    markdown = tmp_path / "contract.md"
+    result = run_builder("--output", str(output), "--storage-operator-consent-request-packet-json", str(sample), "--commit", "abc", "--pr", "9", "--markdown-output", str(markdown), "--summary")
+    assert result.returncode == 0, result.stderr
+    assert "storage_operator_consent_request_presentation_contract_id" in result.stdout
+    contract = json.loads(output.read_text())
+    summary = contract["input_summaries"]["storage_operator_consent_request_packet_json"]
+    assert summary["provided"] is True
+    assert summary["digest"] == hashlib.sha256(raw).hexdigest()
+    assert summary["byte_size"] == len(raw)
+    assert contract["presentation_boundary_context"]["supplied_input_count"] == 1
+    assert markdown.read_text() == markdown.read_text()
+    assert "\\|" in markdown.read_text()
+
+
+def test_cli_rejects_invalid_missing_and_non_object_json(tmp_path: Path):
+    output = tmp_path / "out.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{")
+    assert run_builder("--output", str(output), "--storage-operator-consent-request-packet-json", str(invalid)).returncode == 2
+    assert run_builder("--output", str(output), "--storage-operator-consent-request-packet-json", str(tmp_path / "missing.json")).returncode == 2
+    array = tmp_path / "array.json"
+    array.write_text("[]")
+    assert run_builder("--output", str(output), "--storage-operator-consent-request-packet-json", str(array)).returncode == 2
+
+
+def test_cli_json_output_is_deterministic(tmp_path: Path):
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    assert run_builder("--output", str(first)).returncode == 0
+    assert run_builder("--output", str(second)).returncode == 0
+    assert first.read_text() == second.read_text()
+    contract = json.loads(first.read_text())
+    denied = {row["inference_id"] for row in contract["denied_inferences"]}
+    assert "operator_silence_implies_consent" in denied
+    assert "message_delivered_implies_consent" in denied
+    assert "finalizer_ready_implies_presentation_authority" in denied
+    assert "daemon_recommendation_implies_presentation_authority" in denied

--- a/tests/test_codex_workcell_storage_operator_consent_request_presentation_contract.py
+++ b/tests/test_codex_workcell_storage_operator_consent_request_presentation_contract.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+pytestmark = pytest.mark.no_legacy_skip
+from sentientos.codex_workcell_storage_operator_consent_request_presentation_contract import (
+    DELIVERY_SCOPE_REQUIREMENTS,
+    DENIED_INFERENCES,
+    FUTURE_ACTIVATION_REQUIREMENTS,
+    INPUT_SPECS,
+    MISSING_GAPS,
+    NON_AUTHORITY_POSTURE,
+    OPERATOR_ATTENTION_REQUIREMENTS,
+    PRESENTATION_AUTHORITY_REQUIREMENTS,
+    PRESENTATION_SURFACES,
+    REQUEST_PACKET_INTEGRITY_REQUIREMENTS,
+    RESPONSE_PATH_REQUIREMENTS,
+    WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID,
+    build_codex_workcell_storage_operator_consent_request_presentation_contract,
+    omitted_input,
+    render_codex_workcell_storage_operator_consent_request_presentation_contract_markdown,
+)
+
+
+def _contract():
+    summaries = {key: omitted_input(key) for key in INPUT_SPECS}
+    return build_codex_workcell_storage_operator_consent_request_presentation_contract(input_summaries=summaries, commit="abc", pr="123")
+
+
+def test_contract_flags_and_no_active_authority():
+    contract = _contract()
+    assert contract["storage_operator_consent_request_presentation_contract_id"] == WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID
+    for key in ("metadata_only", "contract_only", "future_only", "presentation_not_performed", "request_not_presented", "ui_not_rendered", "message_not_sent", "external_delivery_not_performed", "response_artifact_not_created", "response_not_collected", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"):
+        assert contract[key] is True
+    for key in ("operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"):
+        assert contract[key] is False
+    for key in ("not_presentation_runner", "not_ui_renderer", "not_message_sender", "not_external_delivery_system", "not_response_artifact_creator", "not_response_collector", "not_consent_collector", "not_runtime_authority", "not_memory_writer", "not_ledger_writer", "not_glow_archiver", "not_watcher", "not_scheduler", "not_executor", "not_daemon_action", "not_task_creator", "not_alerting_system", "not_model_training", "not_reinforcement_learning"):
+        assert contract[key] is True
+
+
+def test_boundary_context_denies_readiness_and_presentation_inferences():
+    context = _contract()["presentation_boundary_context"]
+    assert context["commit"] == "abc"
+    assert context["pr"] == "123"
+    assert context["no_request_presentation_action_occurred"] is True
+    separated = set(context["presentation_authority_separate_from"])
+    for item in ["request_packet_existence", "packet_verification", "evidence_dossier_completeness", "dossier_verification", "response_schema_existence", "response_verifier_success", "finalizer_readiness", "pr_metadata_guard_readiness", "matrix_passage", "daemon_recommendations", "federation_state", "runtime_authority_contract_presence", "storage_policy_evidence"]:
+        assert item in separated
+
+
+def test_required_inventories_are_future_only_unsatisfied_or_denied():
+    contract = _contract()
+    surfaces = {row["surface_id"]: row for row in contract["presentation_surface_inventory"]}
+    assert set(PRESENTATION_SURFACES) <= set(surfaces)
+    assert all(row["future_only"] is True and row["active_now"] is False for row in surfaces.values())
+    for key, expected in [("required_presentation_authority_requirements", PRESENTATION_AUTHORITY_REQUIREMENTS), ("required_operator_attention_requirements", OPERATOR_ATTENTION_REQUIREMENTS), ("required_delivery_scope_requirements", DELIVERY_SCOPE_REQUIREMENTS), ("required_request_packet_integrity_requirements", REQUEST_PACKET_INTEGRITY_REQUIREMENTS), ("required_response_path_requirements", RESPONSE_PATH_REQUIREMENTS)]:
+        rows = {row["requirement_id"]: row for row in contract[key]}
+        assert set(expected) <= set(rows)
+        assert all(row["currently_satisfied"] is False for row in rows.values())
+    denied = {row["inference_id"]: row for row in contract["denied_inferences"]}
+    assert set(DENIED_INFERENCES) <= set(denied)
+    assert all(row["denied"] is True for row in denied.values())
+    gaps = {row["gap_id"]: row for row in contract["missing_real_world_presentation_summary"]}
+    assert set(MISSING_GAPS) <= set(gaps)
+    assert all(row["present"] is True and row["severity"] == "blocking" and row["active"] is False for row in gaps.values())
+
+
+def test_hygiene_mount_future_requirements_and_non_authority_posture():
+    contract = _contract()
+    hygiene = contract["reviewer_hygiene_summary"]
+    assert hygiene["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
+    assert hygiene["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
+    assert set(contract["sentientos_mount_alignment"]) == {"/ledger", "/glow", "/vow", "/pulse", "/daemon"}
+    assert "no ledger write" in contract["sentientos_mount_alignment"]["/ledger"]
+    futures = {row["requirement"]: row for row in contract["future_activation_requirements"]}
+    assert set(FUTURE_ACTIVATION_REQUIREMENTS) <= set(futures)
+    assert all(row["future_only"] is True and row["met"] is False and row["active"] is False for row in futures.values())
+    assert contract["non_authority_posture"] == NON_AUTHORITY_POSTURE
+    assert all(contract["non_authority_posture"].values())
+
+
+def test_omitted_inputs_and_deterministic_json_and_markdown_escaping():
+    contract = _contract()
+    assert set(contract["input_summaries"]) == set(INPUT_SPECS)
+    assert all(summary["provided"] is False and summary["digest"] is None for summary in contract["input_summaries"].values())
+    assert json.dumps(contract, sort_keys=True) == json.dumps(_contract(), sort_keys=True)
+    contract["input_summaries"]["storage_operator_consent_request_packet_json"]["path"] = "pipe|newline\nvalue"
+    markdown = render_codex_workcell_storage_operator_consent_request_presentation_contract_markdown(contract)
+    assert "Codex Workcell Storage Operator Consent Request Presentation Boundary Contract" in markdown
+    assert "\\|" in markdown or "<br>" in markdown


### PR DESCRIPTION
### Motivation
- Provide a deterministic, metadata-only boundary that names the future operator-facing presentation authority required before any consent request packet may be presented to an operator. 
- Preserve and make explicit all denied inferences and real-world presentation gaps so evidence/packet/verifier artifacts cannot be mistaken for presentation, consent, runtime binding, or active storage authority. 
- Keep the module strictly non-authoritative and future-only so it never performs UI rendering, messaging, delivery, ledger/glow writes, runtime binding, or other side effects.

### Description
- Added the presentation contract module `sentientos/codex_workcell_storage_operator_consent_request_presentation_contract.py` implementing `WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID`, `DIGEST_ALGO`, input handling, inventory, future-only requirement records, denied-inference list, missing-gap summary, mount alignment, future activation requirements, and the non-authority posture flags. 
- Added a CLI builder `scripts/build_codex_workcell_storage_operator_consent_request_presentation_contract.py` that accepts the required optional JSON inputs, computes SHA-256 digests and byte sizes, validates JSON-object inputs (exits 2 on missing/invalid/non-object), writes deterministic JSON output, and emits optional Markdown and a compact summary. 
- Added focused tests `tests/test_codex_workcell_storage_operator_consent_request_presentation_contract.py` and `tests/test_build_codex_workcell_storage_operator_consent_request_presentation_contract_script.py` that verify non-authority flags, future-only presentation surfaces, unsatisfied requirements, denied inferences, deterministic JSON/Markdown, input-digest summaries, and CLI error handling. 
- Added contract documentation `docs/development/codex_workcell_storage_operator_consent_request_presentation_contract.md` and inserted short boundary references/notes into the adjacent consent-ladder docs to link the new presentation boundary (these updates are intentionally short cross-references and do not change behavior).

### Testing
- Ran focused unit tests: `tests/test_codex_workcell_storage_operator_consent_request_presentation_contract.py` and `tests/test_build_codex_workcell_storage_operator_consent_request_presentation_contract_script.py` and they passed after adding deterministic escaping adjustments. 
- Verified related consent-layer tests and evidence dossier tests; they passed in the validation runs. 
- Built docs successfully after bootstrapping docs deps (`python scripts/build_docs.py --bootstrap-docs`), and `python scripts/build_docs.py --check-deps` / full build completed. 
- Type checks (`mypy` on the new module and script) passed and the full review matrix ran to `passed`; codex finalizer and PR metadata guard reported readiness for PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a482106b75c832fa7c17d24ed00878c)