### PR TITLE
[codex:sentientos] harden storage consent presentation verifier output contract

### DIFF
--- a/docs/development/codex_workcell_storage_operator_consent_request_presentation_verifier.md
+++ b/docs/development/codex_workcell_storage_operator_consent_request_presentation_verifier.md
@@ -2,24 +2,50 @@
 
 `codex_workcell_storage_operator_consent_request_presentation_verifier.v1` is the deterministic metadata-only verifier for `codex_workcell_storage_operator_consent_request_presentation_contract.v1`.
 
-The verifier reads a required presentation boundary contract JSON and optional supporting consent-ladder JSON reports, records raw-byte `sha256` digests and byte sizes, and emits deterministic JSON plus optional deterministic Markdown.
-
-It verifies only structure. `verification_status` is not presentation, UI rendering, message delivery, response artifact creation, response collection, consent, operator approval, runtime binding, storage activation, readiness, ledger authority, glow authority, daemon authority, scheduler authority, model authority, or federation authority.
+The verifier reads a required presentation boundary contract JSON and optional supporting consent-ladder JSON reports, records raw-byte `sha256` digests and byte sizes, and emits deterministic JSON plus optional deterministic Markdown. It verifies only structure. A verified presentation-boundary structure is still not presentation.
 
 ## CLI
 
+Use the canonical flag first:
+
 ```bash
 python scripts/verify_codex_workcell_storage_operator_consent_request_presentation_contract.py \
-  --presentation-contract-json /path/to/presentation_contract.json \
+  --storage-operator-consent-request-presentation-contract-json /path/to/presentation_contract.json \
   --output /tmp/presentation_verifier.json \
   --markdown-output /tmp/presentation_verifier.md \
   --summary
 ```
 
-Missing files, invalid JSON, or non-object JSON are rejected with exit code `2` before any report is written.
+`--presentation-contract-json` remains a legacy alias. If both flags are supplied, they must be the same path string or the CLI exits `2` with a clean input error. Missing files, invalid JSON, or non-object JSON are rejected with exit code `2` before any report is written.
 
-## Verified boundaries
+## Exact output sections
 
-The report verifies the contract ID and non-authority flags; inactive future-only presentation surfaces; unsatisfied presentation authority, operator attention, delivery scope, request packet integrity, and response path requirements; denied inferences; blocking inactive missing-presentation gaps; future-only unmet activation requirements; reviewer hygiene URL metadata; and `/ledger`, `/glow`, `/vow`, `/pulse`, and `/daemon` mount alignment without activation or writes.
+The JSON report includes top-level non-authority flags, `input_summaries`, `presentation_contract_summary`, `optional_context_summary`, `verification_status`, `verification_checks`, `presentation_surface_results`, `presentation_authority_requirement_results`, `operator_attention_requirement_results`, `delivery_scope_requirement_results`, `request_packet_integrity_requirement_results`, `response_path_requirement_results`, `denied_inference_results`, `missing_real_world_presentation_results`, `reviewer_hygiene_summary`, `violation_summary`, `sentientos_mount_alignment`, `future_activation_requirements`, and `non_authority_posture`.
 
-The verifier does not present a request, render UI, send messages, deliver externally, create response artifacts, collect responses, collect or imply consent, bind runtime authority, activate memory or storage, write ledger entries, archive glow evidence, mutate memory, watch, poll, schedule, alert, create tasks, call networks or providers, trigger daemon action, authorize commit or PR metadata, open PRs, or establish federation consensus.
+`presentation_contract_summary` records the presentation contract ID when present, the observed metadata/future/non-authority flags, derivable inventory counts, non-authority posture presence/all-true status, and source digest algorithm, digest, and byte size. `optional_context_summary` is deterministic for every optional input and marks omitted inputs as not provided; supplied context rows are `context_only` and include detected IDs/statuses when derivable.
+
+## Verification status meanings
+
+Allowed statuses are exactly:
+
+- `storage_operator_consent_request_presentation_contract_verified`: every violation-severity structural check passes.
+- `storage_operator_consent_request_presentation_contract_failed`: major sections are evaluable, but required flags, IDs, or values are wrong.
+- `storage_operator_consent_request_presentation_contract_incomplete`: major inventories/requirements/denied-inference/gap sections are missing or not lists, so the verifier cannot evaluate the boundary as proper sections.
+
+`verification_status` is structure-only. It does not imply consent, runtime authority, storage activation, readiness, daemon authority, federation authority, ledger authority, glow authority, finalizer authority, PR metadata authority, or presentation authority.
+
+## Non-authority posture
+
+The verifier does not present a request, render UI, send messages, deliver externally, create a response artifact, collect response, collect consent, imply consent, bind runtime authority, activate memory or storage, write ledger entries, archive glow evidence, mutate memory, watch files, poll state, run commands from inside the verifier, call providers, call networks, schedule tasks, create tasks, send alerts, trigger daemon action, decide readiness, authorize commits, authorize PR metadata, create PRs, establish federation consensus, or train/modify models.
+
+Operator silence, notification delivery, message delivery, local files, or displayed copies cannot imply consent. Request packet existence, evidence dossier completeness, response contract existence, response verifier success, finalizer readiness, PR metadata guard readiness, matrix readiness, daemon state, federation state, storage policy, runtime authority contracts, or consent-design evidence cannot imply presentation authority.
+
+Reviewer URL hygiene remains metadata-only and separate from runtime behavior. It helps reviewers ensure no bad ``OpenAI` organization repository attribution for SentientOS` repository attribution reappears while preserving legitimate OpenAI API/model/ChatGPT/Codex references.
+
+## Mount alignment
+
+The verifier reports relation to `/ledger`, `/glow`, `/vow`, `/pulse`, and `/daemon` only as metadata: no ledger write, no glow archive, no vow mutation, no pulse activation, and no daemon action occurs.
+
+## Markdown report
+
+The deterministic Markdown report includes sections for input summaries, presentation contract summary, optional context summary, verification status, verification checks, all result sections, reviewer hygiene summary, violation summary, SentientOS mount alignment, future activation requirements, and non-authority posture. Table cells escape pipes and newlines.

--- a/scripts/verify_codex_workcell_storage_operator_consent_request_presentation_contract.py
+++ b/scripts/verify_codex_workcell_storage_operator_consent_request_presentation_contract.py
@@ -17,7 +17,8 @@ from sentientos.codex_workcell_storage_operator_consent_request_presentation_ver
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Verify a metadata-only Codex workcell storage operator consent request presentation contract JSON.")
-    parser.add_argument("--presentation-contract-json", required=True)
+    parser.add_argument("--storage-operator-consent-request-presentation-contract-json", dest="canonical_presentation_contract_json")
+    parser.add_argument("--presentation-contract-json", dest="legacy_presentation_contract_json")
     parser.add_argument("--output", required=True)
     parser.add_argument("--markdown-output")
     parser.add_argument("--summary", action="store_true")
@@ -25,7 +26,12 @@ def main(argv: list[str] | None = None) -> int:
         parser.add_argument("--" + input_id.replace("_", "-"), dest=input_id)
     args = parser.parse_args(argv)
     try:
-        contract_summary, contract = read_json_input(args.presentation_contract_json, "presentation_contract_json")
+        contract_path = args.canonical_presentation_contract_json or args.legacy_presentation_contract_json
+        if not contract_path:
+            raise CodexWorkcellStorageOperatorConsentRequestPresentationVerifierError("missing_required_argument:--storage-operator-consent-request-presentation-contract-json")
+        if args.canonical_presentation_contract_json and args.legacy_presentation_contract_json and args.canonical_presentation_contract_json != args.legacy_presentation_contract_json:
+            raise CodexWorkcellStorageOperatorConsentRequestPresentationVerifierError("conflicting_presentation_contract_paths")
+        contract_summary, contract = read_json_input(contract_path, "presentation_contract_json")
         optional_reports: dict[str, dict[str, object]] = {}
         optional_summaries: dict[str, dict[str, object]] = {}
         for input_id in OPTIONAL_INPUT_IDS:

--- a/sentientos/codex_workcell_storage_operator_consent_request_presentation_verifier.py
+++ b/sentientos/codex_workcell_storage_operator_consent_request_presentation_verifier.py
@@ -80,36 +80,146 @@ def _status_or_id(data: Mapping[str, Any]) -> Any:
             return data.get(key)
     return None
 
+
+def _source_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "source_digest": summary.get("digest"),
+        "source_digest_algo": summary.get("digest_algo"),
+        "source_byte_size": summary.get("byte_size"),
+    }
+
+def _result(required: list[str], rows_any: Any, *, key: str, section: str) -> tuple[dict[str, Any], bool]:
+    rows = _ids(rows_any, key)
+    missing = [item for item in required if item not in rows]
+    common = {"requirement_count": len(rows), "required_requirement_ids_present": not missing, "missing_requirement_ids": missing}
+    if section == "presentation_surface_results":
+        res = {
+            "surface_count": len(rows), "required_surface_ids_present": not missing, "missing_surface_ids": missing,
+            "all_surfaces_future_only": all(rows[i].get("future_only") is True for i in required if i in rows),
+            "all_surfaces_inactive": all(rows[i].get("active_now") is False for i in required if i in rows),
+            "all_surfaces_have_denied_inference": all(bool(rows[i].get("denied_inference")) for i in required if i in rows),
+            "all_surfaces_have_authority_boundary": all(bool(rows[i].get("authority_boundary")) for i in required if i in rows),
+        }
+    elif section == "presentation_authority_requirement_results":
+        res = {**common,
+            "all_required_before_presentation": all(rows[i].get("required_before_presentation") is True for i in required if i in rows),
+            "all_currently_satisfied_false": all(rows[i].get("currently_satisfied") is False for i in required if i in rows),
+            "all_have_missing_gap_id": all(bool(rows[i].get("missing_gap_id")) for i in required if i in rows),
+            "all_have_authority_boundary": all(bool(rows[i].get("authority_boundary")) for i in required if i in rows),
+        }
+    else:
+        res = {**common,
+            "all_future_only": all(rows[i].get("future_only") is True for i in required if i in rows),
+            "all_currently_satisfied_false": all(rows[i].get("currently_satisfied") is False for i in required if i in rows),
+        }
+    violations = [k for k, v in res.items() if isinstance(v, bool) and not v]
+    res["passed"] = not violations
+    res["violations"] = violations
+    return res, isinstance(rows_any, list)
+
+def _presentation_contract_summary(contract: Mapping[str, Any], contract_summary: Mapping[str, Any]) -> dict[str, Any]:
+    posture = contract.get("non_authority_posture")
+    return {
+        "storage_operator_consent_request_presentation_contract_id": contract.get("storage_operator_consent_request_presentation_contract_id"),
+        **{key: contract.get(key) for key in ("metadata_only", "contract_only", "future_only", "presentation_not_performed", "request_not_presented", "ui_not_rendered", "message_not_sent", "external_delivery_not_performed", "response_artifact_not_created", "response_not_collected", "consent_not_collected", "consent_not_implied", "operator_consent_present", "runtime_binding_not_performed", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed")},
+        "presentation_surface_count": len(contract.get("presentation_surface_inventory", [])) if isinstance(contract.get("presentation_surface_inventory"), list) else None,
+        "denied_inference_count": len(contract.get("denied_inferences", [])) if isinstance(contract.get("denied_inferences"), list) else None,
+        "missing_presentation_gap_count": len(contract.get("missing_real_world_presentation_summary", [])) if isinstance(contract.get("missing_real_world_presentation_summary"), list) else None,
+        "non_authority_posture_present": isinstance(posture, Mapping),
+        "non_authority_posture_all_true": _all_true(posture) if isinstance(posture, Mapping) else None,
+        **_source_summary(contract_summary),
+    }
+
+def _optional_context_summary(optional_reports: Mapping[str, Mapping[str, Any]], optional_summaries: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for input_id in OPTIONAL_INPUT_IDS:
+        summary = optional_summaries[input_id]
+        report = optional_reports.get(input_id, {})
+        rows.append({
+            "input_id": input_id,
+            "provided": summary.get("provided"),
+            "detected_report_id": _status_or_id(report),
+            "source_digest": summary.get("digest"),
+            "source_digest_algo": summary.get("digest_algo"),
+            "source_byte_size": summary.get("byte_size"),
+            "relevant_status_or_digest": _status_or_id(report) or summary.get("digest"),
+            "context_only": True,
+        })
+    return rows
+
 def verify_codex_workcell_storage_operator_consent_request_presentation_contract(*, contract: Mapping[str, Any], contract_summary: Mapping[str, Any], optional_reports: Mapping[str, Mapping[str, Any]], optional_summaries: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
-    _check(checks, "contract_id_valid", contract.get("storage_operator_consent_request_presentation_contract_id") == WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID, "Contract ID must match v1 presentation boundary contract.")
-    for key in TOP_LEVEL_TRUE_FLAGS:
-        _check(checks, f"{key}_true", contract.get(key) is True, f"{key} must be true.")
-    for key in TOP_LEVEL_FALSE_FLAGS:
-        _check(checks, f"{key}_false", contract.get(key) is False, f"{key} must be false.")
+    def add(cid: str, passed: bool, details: str, severity: str = "violation") -> None:
+        checks.append({"check_id": cid, "passed": passed, "severity": "info" if passed else severity, "details": details, "authority_boundary": AUTHORITY_BOUNDARY})
+    add("presentation_contract_is_object", isinstance(contract, Mapping), "Presentation contract JSON must be an object.")
+    add("presentation_contract_id_matches", contract.get("storage_operator_consent_request_presentation_contract_id") == WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_CONTRACT_ID, "Contract ID must match canonical v1 ID.")
+    for key in ("metadata_only", "contract_only", "future_only"):
+        add(f"presentation_contract_declares_{key.replace('_only','')}_only", contract.get(key) is True, f"{key} must be true.")
+    for key in ("presentation_not_performed", "request_not_presented", "ui_not_rendered", "message_not_sent", "external_delivery_not_performed", "response_artifact_not_created", "response_not_collected", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"):
+        add(f"{key}_true", contract.get(key) is True, f"{key} must be true.")
+    for key in ("operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"):
+        add(f"{key}_false", contract.get(key) is False, f"{key} must be false.")
     context = cast(Mapping[str, Any], contract.get("presentation_boundary_context") if isinstance(contract.get("presentation_boundary_context"), Mapping) else {})
     separated = set(context.get("presentation_authority_separate_from") or [])
-    _check(checks, "presentation_boundary_context_complete", all(item in separated for item in SEPARATE_FROM) and context.get("no_request_presentation_action_occurred") is True, "Presentation authority must be separate from packet/evidence/response/readiness/daemon/federation/runtime/storage evidence.")
-    surfaces = _ids(contract.get("presentation_surface_inventory"), "surface_id")
-    _check(checks, "required_presentation_surfaces_future_only_inactive", all(s in surfaces and surfaces[s].get("future_only") is True and surfaces[s].get("active_now") is False for s in PRESENTATION_SURFACES), "All presentation surfaces must be present, future-only, and inactive.")
-    for field, expected in (("required_presentation_authority_requirements", PRESENTATION_AUTHORITY_REQUIREMENTS), ("required_operator_attention_requirements", OPERATOR_ATTENTION_REQUIREMENTS), ("required_delivery_scope_requirements", DELIVERY_SCOPE_REQUIREMENTS), ("required_request_packet_integrity_requirements", REQUEST_PACKET_INTEGRITY_REQUIREMENTS), ("required_response_path_requirements", RESPONSE_PATH_REQUIREMENTS)):
-        rows = _ids(contract.get(field), "requirement_id")
-        _check(checks, f"{field}_present_unsatisfied", all(r in rows and rows[r].get("currently_satisfied") is False for r in expected), f"{field} must contain required unsatisfied requirements.")
-    denied = _ids(contract.get("denied_inferences"), "inference_id")
-    _check(checks, "required_denied_inferences_denied", all(i in denied and denied[i].get("denied") is True for i in DENIED_INFERENCES), "Required inferences must be present and denied.")
-    gaps = _ids(contract.get("missing_real_world_presentation_summary"), "gap_id")
-    _check(checks, "missing_real_world_presentation_gaps_blocking_inactive", all(g in gaps and gaps[g].get("present") is True and gaps[g].get("severity") == "blocking" and gaps[g].get("active") is False for g in MISSING_GAPS), "Missing real-world presentation gaps must be present, blocking, and inactive.")
-    futures = _ids(contract.get("future_activation_requirements"), "requirement")
-    _check(checks, "future_activation_requirements_future_only_unmet_inactive", all(r in futures and futures[r].get("future_only") is True and futures[r].get("met") is False and futures[r].get("active") is False for r in FUTURE_ACTIVATION_REQUIREMENTS), "Future activation requirements must be future-only, unmet, and inactive.")
+    add("presentation_boundary_context_present", bool(context), "Presentation boundary context must be present.")
+    add("presentation_authority_separated_from_packet_and_evidence", all(item in separated for item in SEPARATE_FROM) and context.get("no_request_presentation_action_occurred") is True, "Presentation authority must stay separate from packet/evidence/readiness/daemon/federation/runtime/storage evidence.")
+    surface_results, surfaces_list = _result(PRESENTATION_SURFACES, contract.get("presentation_surface_inventory"), key="surface_id", section="presentation_surface_results")
+    add("presentation_surface_inventory_present", surfaces_list, "Presentation surface inventory must be a list.")
+    add("presentation_surface_inventory_complete", surface_results["required_surface_ids_present"], "All required presentation surface IDs must be present.")
+    add("presentation_surfaces_future_only_and_inactive", surface_results["all_surfaces_future_only"] and surface_results["all_surfaces_inactive"], "All presentation surfaces must be future-only and inactive.")
+    authority_results, authority_list = _result(PRESENTATION_AUTHORITY_REQUIREMENTS, contract.get("required_presentation_authority_requirements"), key="requirement_id", section="presentation_authority_requirement_results")
+    add("presentation_authority_requirements_present", authority_list, "Presentation authority requirements must be a list.")
+    add("presentation_authority_requirements_unsatisfied", authority_results["required_requirement_ids_present"] and authority_results["all_currently_satisfied_false"], "Presentation authority requirements must be present and unsatisfied.")
+    section_defs = [
+        ("operator_attention", OPERATOR_ATTENTION_REQUIREMENTS, "required_operator_attention_requirements"),
+        ("delivery_scope", DELIVERY_SCOPE_REQUIREMENTS, "required_delivery_scope_requirements"),
+        ("request_packet_integrity", REQUEST_PACKET_INTEGRITY_REQUIREMENTS, "required_request_packet_integrity_requirements"),
+        ("response_path", RESPONSE_PATH_REQUIREMENTS, "required_response_path_requirements"),
+    ]
+    extra_results: dict[str, dict[str, Any]] = {}
+    major_ok = surfaces_list and authority_list
+    for prefix, required, field in section_defs:
+        res, is_list = _result(required, contract.get(field), key="requirement_id", section=prefix)
+        extra_results[f"{prefix}_requirement_results"] = res
+        major_ok = major_ok and is_list
+        add(f"{prefix}_requirements_present", is_list, f"{field} must be a list.")
+        add(f"{prefix}_requirements_unsatisfied", res["required_requirement_ids_present"] and res["all_currently_satisfied_false"], f"{field} required IDs must be present and unsatisfied.")
+    denied_rows = _ids(contract.get("denied_inferences"), "inference_id")
+    denied_missing = [i for i in DENIED_INFERENCES if i not in denied_rows]
+    denied_results = {"denied_inference_count": len(denied_rows), "required_inference_ids_present": not denied_missing, "missing_inference_ids": denied_missing, "all_denied": all(denied_rows[i].get("denied") is True for i in DENIED_INFERENCES if i in denied_rows), "no_inference_grants_authority": all("authority" in str(denied_rows[i].get("authority_boundary", "")) for i in DENIED_INFERENCES if i in denied_rows)}
+    denied_results["violations"] = [k for k, v in denied_results.items() if isinstance(v, bool) and not v]
+    denied_results["passed"] = not denied_results["violations"]
+    denied_is_list = isinstance(contract.get("denied_inferences"), list); major_ok = major_ok and denied_is_list
+    add("denied_inferences_present", denied_is_list, "Denied inferences must be a list.")
+    add("denied_inferences_all_denied", bool(denied_results["required_inference_ids_present"] and denied_results["all_denied"]), "All required denied inferences must be present and denied.")
+    gap_rows = _ids(contract.get("missing_real_world_presentation_summary"), "gap_id")
+    gap_missing = [g for g in MISSING_GAPS if g not in gap_rows]
+    gap_results = {"required_gap_ids_present": not gap_missing, "missing_gap_ids": gap_missing, "all_required_gaps_blocking": all(gap_rows[g].get("severity") == "blocking" for g in MISSING_GAPS if g in gap_rows), "all_required_gaps_inactive": all(gap_rows[g].get("active") is False for g in MISSING_GAPS if g in gap_rows), "presentation_mechanism_present_is_false": contract.get("presentation_mechanism_present", False) is False, "request_presented_is_false": contract.get("request_presented", False) is False, "ui_rendered_is_false": contract.get("ui_rendered", False) is False, "message_sent_is_false": contract.get("message_sent", False) is False, "external_delivery_performed_is_false": contract.get("external_delivery_performed", False) is False, "response_artifact_created_is_false": contract.get("response_artifact_created", False) is False, "response_collected_is_false": contract.get("response_collected", False) is False, "consent_collected_is_false": contract.get("consent_collected", False) is False, "consent_implied_is_false": contract.get("consent_implied", False) is False, "active_storage_allowed_now_is_false": contract.get("active_storage_allowed_now") is False}
+    gap_results["violations"] = [k for k, v in gap_results.items() if isinstance(v, bool) and not v]
+    gap_results["passed"] = not gap_results["violations"]
+    gaps_is_list = isinstance(contract.get("missing_real_world_presentation_summary"), list); major_ok = major_ok and gaps_is_list
+    add("missing_real_world_presentation_summary_present", gaps_is_list, "Missing real-world presentation summary must be a list.")
+    add("required_presentation_gap_ids_present", bool(gap_results["required_gap_ids_present"]), "All required missing-presentation gap IDs must be present.")
+    future_rows = _ids(contract.get("future_activation_requirements"), "requirement")
+    add("future_activation_requirements_inactive", all(r in future_rows and future_rows[r].get("future_only") is True and future_rows[r].get("met") is False and future_rows[r].get("active") is False for r in FUTURE_ACTIVATION_REQUIREMENTS), "Future activation requirements must be inactive and unmet.")
     hygiene = cast(Mapping[str, Any], contract.get("reviewer_hygiene_summary") if isinstance(contract.get("reviewer_hygiene_summary"), Mapping) else {})
-    _check(checks, "reviewer_hygiene_metadata_only_urls", hygiene.get("correct_repo_url") == "https://github.com/Zombinator85/SentientOS.git" and hygiene.get("bad_repo_url") == "https://github.com/" + "OpenAI/" + "SentientOS.git" and hygiene.get("docs_hygiene_only") is True and hygiene.get("no_runtime_effect") is True, "Reviewer hygiene must preserve correct and bad URLs as metadata only.")
+    add("reviewer_hygiene_bad_openai_repo_url_absent", hygiene.get("bad_openai_repo_url_expected_absent") is True and hygiene.get("docs_hygiene_only") is True and hygiene.get("no_runtime_effect") is True, "Reviewer hygiene remains metadata-only and expects bad `OpenAI` organization repository attribution for SentientOS attribution absent in docs.")
+    posture = contract.get("non_authority_posture")
+    add("non_authority_posture_present", isinstance(posture, Mapping), "Non-authority posture must be present.")
+    add("non_authority_posture_true", _all_true(posture) if isinstance(posture, Mapping) else False, "Every non-authority posture field must be true.")
+    violation_ids = [c["check_id"] for c in checks if c["severity"] == "violation" and not c["passed"]]
+    warning_ids = [c["check_id"] for c in checks if c["severity"] == "warning" and not c["passed"]]
+    status = "storage_operator_consent_request_presentation_contract_incomplete" if not major_ok else ("storage_operator_consent_request_presentation_contract_verified" if not violation_ids else "storage_operator_consent_request_presentation_contract_failed")
     mounts = cast(Mapping[str, Any], contract.get("sentientos_mount_alignment") if isinstance(contract.get("sentientos_mount_alignment"), Mapping) else {})
-    _check(checks, "mount_alignment_present_without_activation_or_writes", all(m in mounts for m in MOUNTS) and all("no ledger write" in str(mounts.get(m, "")) or "no archive write" in str(mounts.get(m, "")) or "not activated" in str(mounts.get(m, "")) or "canonical digest" in str(mounts.get(m, "")) for m in MOUNTS), "Mount alignment must cover /ledger, /glow, /vow, /pulse, and /daemon without activation or writes.")
-    _check(checks, "non_authority_posture_exact_all_true", contract.get("non_authority_posture") == NON_AUTHORITY_POSTURE and _all_true(contract.get("non_authority_posture")), "Non-authority posture must match contract constants and all values must be true.")
-    violation_ids = [c["check_id"] for c in checks if not c["passed"]]
-    status = "storage_operator_consent_request_presentation_contract_verified" if not violation_ids else "storage_operator_consent_request_presentation_contract_failed"
-    optional_summary = [{"input_id": k, "provided": optional_summaries[k].get("provided"), "path": optional_summaries[k].get("path"), "source_digest_algo": optional_summaries[k].get("digest_algo"), "source_digest": optional_summaries[k].get("digest"), "source_byte_size": optional_summaries[k].get("byte_size"), "detected_status_or_id": _status_or_id(optional_reports.get(k, {})), "context_only": True} for k in OPTIONAL_INPUT_IDS]
-    return {"storage_operator_consent_request_presentation_verifier_id": WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_VERIFIER_ID, "metadata_only": True, "verifier_only": True, "presentation_not_performed": True, "request_not_presented": True, "ui_not_rendered": True, "message_not_sent": True, "external_delivery_not_performed": True, "response_artifact_not_created": True, "response_not_collected": True, "consent_not_collected": True, "consent_not_implied": True, "operator_consent_present": False, "runtime_binding_not_performed": True, "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False, "verification_status": status, "verification_checks": checks, "input_summaries": {"presentation_contract_json": dict(contract_summary), **{k: dict(v) for k, v in optional_summaries.items()}}, "optional_context_summary": optional_summary, "denied_inference_results": {"required_count": len(DENIED_INFERENCES), "passed": all(i in denied and denied[i].get("denied") is True for i in DENIED_INFERENCES), "denied_inference_ids": list(DENIED_INFERENCES)}, "missing_presentation_gap_results": {"required_count": len(MISSING_GAPS), "passed": all(g in gaps and gaps[g].get("present") is True and gaps[g].get("severity") == "blocking" and gaps[g].get("active") is False for g in MISSING_GAPS), "gap_ids": list(MISSING_GAPS)}, "reviewer_hygiene_summary": dict(hygiene), "sentientos_mount_alignment": dict(mounts), "future_activation_requirements": contract.get("future_activation_requirements"), "non_authority_posture": dict(NON_AUTHORITY_POSTURE), "violation_summary": {"violation_count": len(violation_ids), "violation_check_ids": violation_ids, "verifier_only": True, "no_action_taken": True}}
+    report: dict[str, Any] = {"storage_operator_consent_request_presentation_verifier_id": WORKCELL_STORAGE_OPERATOR_CONSENT_REQUEST_PRESENTATION_VERIFIER_ID,
+        "metadata_only": True, "verifier_only": True, "presentation_not_performed": True, "request_not_presented": True, "ui_not_rendered": True, "message_not_sent": True, "external_delivery_not_performed": True, "response_artifact_not_created": True, "response_not_collected": True, "consent_not_collected": True, "consent_not_implied": True, "operator_consent_present": False, "runtime_binding_not_performed": True, "active_storage_allowed_now": False, "execution_performed": False, "writes_performed": False, "archives_performed": False, "memory_mutation_performed": False,
+        "not_presentation_runner": True, "not_ui_renderer": True, "not_message_sender": True, "not_external_delivery_system": True, "not_response_artifact_creator": True, "not_response_collector": True, "not_consent_collector": True, "not_runtime_authority": True, "not_memory_writer": True, "not_ledger_writer": True, "not_glow_archiver": True, "not_watcher": True, "not_scheduler": True, "not_executor": True, "not_daemon_action": True, "not_task_creator": True, "not_alerting_system": True, "not_model_training": True, "not_reinforcement_learning": True,
+        "input_summaries": {"presentation_contract_json": dict(contract_summary), **{k: dict(v) for k, v in optional_summaries.items()}},
+        "presentation_contract_summary": _presentation_contract_summary(contract, contract_summary), "optional_context_summary": _optional_context_summary(optional_reports, optional_summaries), "verification_status": status, "verification_checks": checks,
+        "presentation_surface_results": surface_results, "presentation_authority_requirement_results": authority_results, **extra_results, "denied_inference_results": denied_results, "missing_real_world_presentation_results": gap_results, "missing_presentation_gap_results": gap_results,
+        "reviewer_hygiene_summary": dict(hygiene), "violation_summary": {"violation_count": len(violation_ids), "warning_count": len(warning_ids), "info_count": sum(1 for c in checks if c["severity"] == "info"), "violation_check_ids": violation_ids, "warning_check_ids": warning_ids, "verifier_only": True, "no_action_taken": True},
+        "sentientos_mount_alignment": dict(mounts), "future_activation_requirements": contract.get("future_activation_requirements"), "non_authority_posture": dict(NON_AUTHORITY_POSTURE)}
+    return report
 
 def _cell(value: Any) -> str:
     return (json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)).replace("|", "\\|").replace("\n", "<br>")
@@ -118,5 +228,17 @@ def _table(rows: list[list[Any]]) -> str:
     return "| Field | Value |\n| --- | --- |\n" + "".join(f"| {_cell(a)} | {_cell(b)} |\n" for a, b in rows)
 
 def render_codex_workcell_storage_operator_consent_request_presentation_verifier_markdown(report: Mapping[str, Any]) -> str:
-    parts = ["# Codex Workcell Storage Operator Consent Request Presentation Verifier", "", AUTHORITY_BOUNDARY, "", "## Verification status", str(report.get("verification_status")), "", "## Input summaries", _table([[k, v] for k, v in sorted(cast(Mapping[str, Any], report.get("input_summaries", {})).items())]), "", "## Verification checks", _table([[c.get("check_id"), c.get("passed")] for c in cast(list[Mapping[str, Any]], report.get("verification_checks", []))]), "", "## Violation summary", _table([[k, v] for k, v in cast(Mapping[str, Any], report.get("violation_summary", {})).items()])]
-    return "\n".join(parts) + "\n"
+    parts = ["# Codex Workcell Storage Operator Consent Request Presentation Verifier", "", "This deterministic verifier is metadata-only: it checks presentation-boundary structure but does not present a request, render UI, send messages, deliver externally, create or collect responses, collect or imply consent, bind runtime authority, activate storage, write ledger entries, archive glow evidence, trigger daemons, decide readiness, create PR metadata, or establish federation authority.", ""]
+    sections = [("Input summaries", "input_summaries"), ("Presentation contract summary", "presentation_contract_summary"), ("Optional context summary", "optional_context_summary"), ("Verification status", "verification_status"), ("Verification checks", "verification_checks"), ("Presentation surface results", "presentation_surface_results"), ("Presentation authority requirement results", "presentation_authority_requirement_results"), ("Operator attention requirement results", "operator_attention_requirement_results"), ("Delivery scope requirement results", "delivery_scope_requirement_results"), ("Request packet integrity requirement results", "request_packet_integrity_requirement_results"), ("Response path requirement results", "response_path_requirement_results"), ("Denied inference results", "denied_inference_results"), ("Missing real-world presentation results", "missing_real_world_presentation_results"), ("Reviewer hygiene summary", "reviewer_hygiene_summary"), ("Violation summary", "violation_summary"), ("SentientOS mount alignment", "sentientos_mount_alignment"), ("Future activation requirements", "future_activation_requirements"), ("Non-authority posture", "non_authority_posture")]
+    for title, key in sections:
+        value = report.get(key)
+        parts += [f"## {title}"]
+        if key == "verification_status":
+            parts += [str(value), ""]
+        elif isinstance(value, Mapping):
+            parts += [_table([[k, v] for k, v in sorted(value.items())]), ""]
+        elif isinstance(value, list):
+            parts += [_table([[str(i), v] for i, v in enumerate(value)]), ""]
+        else:
+            parts += [_table([[key, value]]), ""]
+    return "\n".join(parts).rstrip() + "\n"

--- a/tests/test_codex_workcell_storage_operator_consent_request_presentation_verifier.py
+++ b/tests/test_codex_workcell_storage_operator_consent_request_presentation_verifier.py
@@ -11,59 +11,69 @@ pytestmark = pytest.mark.no_legacy_skip
 from sentientos.codex_workcell_storage_operator_consent_request_presentation_contract import INPUT_SPECS, build_codex_workcell_storage_operator_consent_request_presentation_contract, omitted_input as omitted_contract_input
 from sentientos.codex_workcell_storage_operator_consent_request_presentation_verifier import OPTIONAL_INPUT_IDS, omitted_input, read_json_input, render_codex_workcell_storage_operator_consent_request_presentation_verifier_markdown, verify_codex_workcell_storage_operator_consent_request_presentation_contract
 
+REQUIRED_TOP_LEVEL = """storage_operator_consent_request_presentation_verifier_id metadata_only verifier_only presentation_not_performed request_not_presented ui_not_rendered message_not_sent external_delivery_not_performed response_artifact_not_created response_not_collected consent_not_collected consent_not_implied operator_consent_present runtime_binding_not_performed active_storage_allowed_now execution_performed writes_performed archives_performed memory_mutation_performed not_presentation_runner not_ui_renderer not_message_sender not_external_delivery_system not_response_artifact_creator not_response_collector not_consent_collector not_runtime_authority not_memory_writer not_ledger_writer not_glow_archiver not_watcher not_scheduler not_executor not_daemon_action not_task_creator not_alerting_system not_model_training not_reinforcement_learning input_summaries presentation_contract_summary optional_context_summary verification_status verification_checks presentation_surface_results presentation_authority_requirement_results operator_attention_requirement_results delivery_scope_requirement_results request_packet_integrity_requirement_results response_path_requirement_results denied_inference_results missing_real_world_presentation_results reviewer_hygiene_summary violation_summary sentientos_mount_alignment future_activation_requirements non_authority_posture""".split()
+REQUIRED_CHECKS = """presentation_contract_is_object presentation_contract_id_matches presentation_contract_declares_metadata_only presentation_contract_declares_contract_only presentation_contract_declares_future_only presentation_not_performed_true request_not_presented_true ui_not_rendered_true message_not_sent_true external_delivery_not_performed_true response_artifact_not_created_true response_not_collected_true consent_not_collected_true consent_not_implied_true operator_consent_present_false runtime_binding_not_performed_true active_storage_allowed_now_false execution_performed_false writes_performed_false archives_performed_false memory_mutation_performed_false presentation_boundary_context_present presentation_authority_separated_from_packet_and_evidence presentation_surface_inventory_present presentation_surface_inventory_complete presentation_surfaces_future_only_and_inactive presentation_authority_requirements_present presentation_authority_requirements_unsatisfied operator_attention_requirements_present operator_attention_requirements_unsatisfied delivery_scope_requirements_present delivery_scope_requirements_unsatisfied request_packet_integrity_requirements_present request_packet_integrity_requirements_unsatisfied response_path_requirements_present response_path_requirements_unsatisfied denied_inferences_present denied_inferences_all_denied missing_real_world_presentation_summary_present required_presentation_gap_ids_present future_activation_requirements_inactive reviewer_hygiene_bad_openai_repo_url_absent non_authority_posture_present non_authority_posture_true""".split()
+RESULT_SECTIONS = """presentation_surface_results presentation_authority_requirement_results operator_attention_requirement_results delivery_scope_requirement_results request_packet_integrity_requirement_results response_path_requirement_results denied_inference_results missing_real_world_presentation_results""".split()
 
 def _contract() -> dict[str, object]:
     return build_codex_workcell_storage_operator_consent_request_presentation_contract(input_summaries={k: omitted_contract_input(k) for k in INPUT_SPECS}, commit="abc", pr="9")
 
+def _summary() -> dict[str, object]:
+    return {"input_id": "presentation_contract_json", "provided": True, "path": "contract.json", "digest_algo": "sha256", "digest": "abc", "byte_size": 10, "readable_json": True, "error": None}
 
-def _report(contract: dict[str, object] | None = None) -> dict[str, object]:
-    return verify_codex_workcell_storage_operator_consent_request_presentation_contract(contract=contract or _contract(), contract_summary={"input_id": "presentation_contract_json", "provided": True, "path": "contract.json", "digest_algo": "sha256", "digest": "abc", "byte_size": 10, "readable_json": True, "error": None}, optional_reports={}, optional_summaries={k: omitted_input(k) for k in OPTIONAL_INPUT_IDS})
+def _report(contract: dict[str, object] | None = None, optional_reports: dict[str, dict[str, object]] | None = None) -> dict[str, object]:
+    return verify_codex_workcell_storage_operator_consent_request_presentation_contract(contract=contract or _contract(), contract_summary=_summary(), optional_reports=optional_reports or {}, optional_summaries={k: omitted_input(k) for k in OPTIONAL_INPUT_IDS})
 
-
-def test_verifier_accepts_landed_contract_shape_and_preserves_non_authority():
+def test_verifier_output_contract_is_hardened_and_non_authoritative():
     report = _report()
     assert report["verification_status"] == "storage_operator_consent_request_presentation_contract_verified"
-    assert report["violation_summary"]["violation_count"] == 0
-    for key in ("metadata_only", "verifier_only", "presentation_not_performed", "request_not_presented", "ui_not_rendered", "message_not_sent", "external_delivery_not_performed", "response_artifact_not_created", "response_not_collected", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed"):
+    assert set(REQUIRED_TOP_LEVEL) <= set(report)
+    assert report["missing_real_world_presentation_results"] is report["missing_presentation_gap_results"]
+    assert {c["check_id"] for c in report["verification_checks"]} >= set(REQUIRED_CHECKS)
+    assert all({"check_id", "passed", "severity", "details", "authority_boundary"} <= set(c) for c in report["verification_checks"])
+    assert set(RESULT_SECTIONS) <= set(report)
+    for key in ("metadata_only", "verifier_only", "presentation_not_performed", "request_not_presented", "ui_not_rendered", "message_not_sent", "external_delivery_not_performed", "response_artifact_not_created", "response_not_collected", "consent_not_collected", "consent_not_implied", "runtime_binding_not_performed", "not_runtime_authority", "not_ledger_writer", "not_glow_archiver", "not_daemon_action", "not_scheduler"):
         assert report[key] is True
     for key in ("operator_consent_present", "active_storage_allowed_now", "execution_performed", "writes_performed", "archives_performed", "memory_mutation_performed"):
         assert report[key] is False
 
+def test_summary_optional_context_violation_and_result_shapes():
+    report = _report(optional_reports={"storage_operator_consent_request_packet_json": {"storage_operator_consent_request_packet_id": "packet.v1"}})
+    pcs = report["presentation_contract_summary"]
+    assert pcs["storage_operator_consent_request_presentation_contract_id"]
+    assert pcs["source_digest"] == "abc" and pcs["source_digest_algo"] == "sha256" and pcs["source_byte_size"] == 10
+    optional = report["optional_context_summary"]
+    assert all({"input_id", "provided", "detected_report_id", "source_digest", "source_digest_algo", "source_byte_size", "relevant_status_or_digest", "context_only"} <= set(row) for row in optional)
+    assert any(row["detected_report_id"] == "packet.v1" for row in optional)
+    vs = report["violation_summary"]
+    assert {"violation_count", "warning_count", "info_count", "violation_check_ids", "warning_check_ids", "verifier_only", "no_action_taken"} <= set(vs)
+    assert vs["violation_count"] == 0 and vs["warning_count"] == 0 and vs["verifier_only"] is True and vs["no_action_taken"] is True
+    assert report["denied_inference_results"]["all_denied"] is True
+    assert report["missing_real_world_presentation_results"]["request_presented_is_false"] is True
 
-def test_denied_inferences_gaps_hygiene_mounts_and_future_requirements():
-    report = _report()
-    assert report["denied_inference_results"]["passed"] is True
-    assert "operator_silence_implies_consent" in report["denied_inference_results"]["denied_inference_ids"]
-    assert report["missing_presentation_gap_results"]["passed"] is True
-    assert "presentation_mechanism_missing" in report["missing_presentation_gap_results"]["gap_ids"]
-    assert report["reviewer_hygiene_summary"]["correct_repo_url"] == "https://github.com/Zombinator85/SentientOS.git"
-    assert report["reviewer_hygiene_summary"]["bad_repo_url"] == "https://github.com/" + "OpenAI/" + "SentientOS.git"
-    assert set(report["sentientos_mount_alignment"]) == {"/ledger", "/glow", "/vow", "/pulse", "/daemon"}
-    assert all(row["future_only"] is True and row["met"] is False and row["active"] is False for row in report["future_activation_requirements"])
-
-
-def test_verifier_reports_structure_failures_without_taking_action():
-    contract = _contract()
-    contract["message_not_sent"] = False
-    contract["denied_inferences"] = []
-    report = _report(contract)
+def test_failed_and_incomplete_statuses_are_deterministic():
+    failed = _contract(); failed["message_not_sent"] = False
+    report = _report(failed)
     assert report["verification_status"] == "storage_operator_consent_request_presentation_contract_failed"
     assert "message_not_sent_true" in report["violation_summary"]["violation_check_ids"]
-    assert "required_denied_inferences_denied" in report["violation_summary"]["violation_check_ids"]
-    assert report["violation_summary"]["no_action_taken"] is True
+    incomplete = _contract(); incomplete["denied_inferences"] = {}
+    incomplete_report = _report(incomplete)
+    assert incomplete_report["verification_status"] == "storage_operator_consent_request_presentation_contract_incomplete"
 
-
-def test_read_json_input_records_raw_digest_and_rejects_bad_json(tmp_path: Path):
+def test_read_json_and_markdown_are_deterministic_and_escaped(tmp_path: Path):
     path = tmp_path / "contract.json"
     raw = json.dumps(_contract(), sort_keys=True).encode()
     path.write_bytes(raw)
     summary, loaded = read_json_input(str(path), "presentation_contract_json")
     assert loaded["metadata_only"] is True
     assert summary["digest"] == hashlib.sha256(raw).hexdigest()
-    assert summary["byte_size"] == len(raw)
-    markdown = render_codex_workcell_storage_operator_consent_request_presentation_verifier_markdown(_report())
-    assert "Verification status" in markdown
-    bad = tmp_path / "bad.json"
-    bad.write_text("[]")
+    report = _report(); report["reviewer_hygiene_summary"]["pipe\nkey"] = "a|b\nc"
+    md1 = render_codex_workcell_storage_operator_consent_request_presentation_verifier_markdown(report)
+    md2 = render_codex_workcell_storage_operator_consent_request_presentation_verifier_markdown(report)
+    assert md1 == md2
+    for section in ("Presentation contract summary", "Optional context summary", "Presentation surface results", "Denied inference results", "Missing real-world presentation results", "SentientOS mount alignment", "Future activation requirements", "Non-authority posture"):
+        assert section in md1
+    assert "a\\|b<br>c" in md1 or "pipe<br>key" in md1
+    bad = tmp_path / "bad.json"; bad.write_text("[]")
     with pytest.raises(ValueError):
         read_json_input(str(bad), "presentation_contract_json")

--- a/tests/test_verify_codex_workcell_storage_operator_consent_request_presentation_contract_script.py
+++ b/tests/test_verify_codex_workcell_storage_operator_consent_request_presentation_contract_script.py
@@ -13,38 +13,36 @@ from sentientos.codex_workcell_storage_operator_consent_request_presentation_con
 
 SCRIPT = Path("scripts/verify_codex_workcell_storage_operator_consent_request_presentation_contract.py")
 
-
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True, check=False)
-
 
 def write_contract(path: Path) -> None:
     path.write_text(json.dumps(build_codex_workcell_storage_operator_consent_request_presentation_contract(input_summaries={k: omitted_input(k) for k in INPUT_SPECS}), sort_keys=True))
 
-
-def test_cli_writes_deterministic_json_markdown_and_summary(tmp_path: Path):
-    contract = tmp_path / "contract.json"
-    write_contract(contract)
-    out = tmp_path / "report.json"
-    md = tmp_path / "report.md"
-    result = run_cli("--presentation-contract-json", str(contract), "--output", str(out), "--markdown-output", str(md), "--summary")
+def test_canonical_and_legacy_cli_flags_write_deterministic_json_markdown_and_summary(tmp_path: Path):
+    contract = tmp_path / "contract.json"; write_contract(contract)
+    out = tmp_path / "report.json"; md = tmp_path / "report.md"
+    result = run_cli("--storage-operator-consent-request-presentation-contract-json", str(contract), "--output", str(out), "--markdown-output", str(md), "--summary")
     assert result.returncode == 0, result.stderr
-    assert "storage_operator_consent_request_presentation_verifier_id" in result.stdout
     report = json.loads(out.read_text())
     assert report["verification_status"] == "storage_operator_consent_request_presentation_contract_verified"
     assert report["input_summaries"]["presentation_contract_json"]["byte_size"] == contract.stat().st_size
-    assert "Verification checks" in md.read_text()
+    assert "Presentation contract summary" in md.read_text()
     out2 = tmp_path / "report2.json"
     assert run_cli("--presentation-contract-json", str(contract), "--output", str(out2)).returncode == 0
-    assert out.read_text() == out.read_text()
+    assert json.loads(out2.read_text())["verification_status"] == report["verification_status"]
+    out3 = tmp_path / "report3.json"
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(contract), "--presentation-contract-json", str(contract), "--output", str(out3)).returncode == 0
 
-
-def test_cli_rejects_missing_invalid_and_non_object_json(tmp_path: Path):
+def test_cli_rejects_conflicting_missing_invalid_non_object_and_optional_json(tmp_path: Path):
     out = tmp_path / "report.json"
-    assert run_cli("--presentation-contract-json", str(tmp_path / "missing.json"), "--output", str(out)).returncode == 2
-    invalid = tmp_path / "invalid.json"
-    invalid.write_text("{")
-    assert run_cli("--presentation-contract-json", str(invalid), "--output", str(out)).returncode == 2
-    array = tmp_path / "array.json"
-    array.write_text("[]")
-    assert run_cli("--presentation-contract-json", str(array), "--output", str(out)).returncode == 2
+    c1 = tmp_path / "c1.json"; c2 = tmp_path / "c2.json"; write_contract(c1); write_contract(c2)
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(c1), "--presentation-contract-json", str(c2), "--output", str(out)).returncode == 2
+    assert run_cli("--output", str(out)).returncode == 2
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(tmp_path / "missing.json"), "--output", str(out)).returncode == 2
+    invalid = tmp_path / "invalid.json"; invalid.write_text("{")
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(invalid), "--output", str(out)).returncode == 2
+    array = tmp_path / "array.json"; array.write_text("[]")
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(array), "--output", str(out)).returncode == 2
+    bad_optional = tmp_path / "bad_optional.json"; bad_optional.write_text("{")
+    assert run_cli("--storage-operator-consent-request-presentation-contract-json", str(c1), "--storage-operator-consent-request-packet-json", str(bad_optional), "--output", str(out)).returncode == 2


### PR DESCRIPTION
### Motivation

- The previously landed verifier exposed a thinner, underbuilt output shape and CLI than the intended deterministic metadata-only contract and required hardening to match the contract exactly.
- The goal is to expand the verifier's deterministic report, check IDs, result sections, CLI behavior, docs, and tests while preserving the strict non-authority posture (no presentation, consent, runtime, storage, ledger, glow, daemon, scheduling, or federation authority).

### Description

- Add canonical CLI flag `--storage-operator-consent-request-presentation-contract-json` while keeping `--presentation-contract-json` as a legacy alias and reject conflicting paths with a clean exit (`2`).
- Expand the JSON report to include all required top-level fields, `presentation_contract_summary`, deterministic `optional_context_summary`, canonical `verification_status` values, full `verification_checks` with deterministic check IDs and `authority_boundary`, and the exact result sections including `missing_real_world_presentation_results` (kept `missing_presentation_gap_results` as compatibility alias).
- Add helpers to derive `presentation_contract_summary` and optional-context summaries with `source_digest`/`source_digest_algo`/`source_byte_size`, implement deterministic Markdown rendering with table escaping, and derive `violation_summary` counts from checks; preserve all non-authority flags and mount alignment metadata.
- Update CLI script, verifier module, tests, and docs to assert the canonical flag, deterministic output shape, exact check IDs and result-section shapes, error behaviors for invalid/missing JSON, and Markdown escaping; use constants from the existing presentation contract module where applicable.

### Testing

- Ran focused verifier tests: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_operator_consent_request_presentation_verifier.py tests/test_verify_codex_workcell_storage_operator_consent_request_presentation_contract_script.py` and they passed.
- Ran related presentation contract tests: `python -m scripts.run_tests -q tests/test_codex_workcell_storage_operator_consent_request_presentation_contract.py tests/test_build_codex_workcell_storage_operator_consent_request_presentation_contract_script.py` and they passed.
- Verified context hygiene with `python scripts/verify_context_hygiene_prompt_boundaries.py`, built docs (bootstrapped when necessary) with `python scripts/build_docs.py --bootstrap-docs && python scripts/build_docs.py`, and ran targeted mypy on the verifier and CLI; all passed.
- Ran the full work-item review packet matrix (`timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json`), landing supervisor evaluation, pre-commit and post-commit finalizers, and `python scripts/codex_pr_metadata_guard.py verify`; matrix and landing guards reported success (`passed` / `ready_for_pr_metadata`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4adccee33c832fa0067ea4bde960a3)