### PR TITLE
[codex:sentientos] seal bootstrap invocation argument contract

### DIFF
--- a/docs/development/codex_bootstrap_invocation_contract.md
+++ b/docs/development/codex_bootstrap_invocation_contract.md
@@ -1,0 +1,73 @@
+# Codex Bootstrap Invocation Contract
+
+This page seals the supported command-line contract for `scripts/bootstrap_codex_task.py` so repair prompts do not invent bootstrap flags and do not continue after invocation failures.
+
+## Supported CLI flags
+
+The bootstrap CLI currently supports exactly these flags:
+
+- `--task-name` (required)
+- `--task-goal` (required)
+- `--preset-id`
+- `--subsystem-kind`
+- `--commit-scope`
+- `--output-dir`
+- `--summary-output`
+- `--plan-output`
+- `--scaffold-output`
+- `--prompt-output`
+- `--verifier-output`
+- `--summary`
+- `--emit-prompt`
+- `--new-module`
+- `--new-cli`
+- `--test-path`
+- `--doc-path`
+- `--capability-id`
+- `--proof-bundle-artifact-kind`
+- `--commit-title`
+
+Do not use undocumented aliases or inferred flags. In particular, repair prompts must not use `--existing-module` or `--existing-cli`; those names are unsupported.
+
+## Invocation errors are not bootstrap decisions
+
+Unsupported bootstrap flags are command invocation errors raised by argument parsing. They are not `ready`, `ready_with_warnings`, `blocked`, `insufficient`, or `failed` bootstrap decisions, and they do not produce an implementation contract.
+
+If bootstrap exits nonzero because of unsupported arguments, stop immediately, fix the command line, and rerun bootstrap before implementation. Do not reinterpret an argument-parser failure as a blocked bootstrap artifact, and do not proceed from any prompt, scaffold, or summary that was not produced by a successful invocation.
+
+## Repair-task path pattern
+
+For repair tasks, use `--new-module` and `--new-cli` only when intentionally naming the module or CLI path that the scaffold should reason about, even if that path already exists. These flags identify the path surface for planner/scaffold metadata; they are not promises that the filesystem path is absent.
+
+If no module or CLI path needs scaffold reasoning, omit `--new-module` and `--new-cli` and list the explicit delta-specific files elsewhere in the task prompt. Do not invent `--existing-module`, `--existing-cli`, or similar unsupported bootstrap flags.
+
+## Minimal supported example
+
+```bash
+PYTHONPATH=. python scripts/bootstrap_codex_task.py \
+  --task-name "Example narrow repair" \
+  --task-goal "Document the repair goal." \
+  --subsystem-kind developer_workflow_metadata \
+  --commit-scope developer \
+  --commit-title "[codex:developer] document repair goal" \
+  --test-path tests/test_bootstrap_codex_task_script.py \
+  --doc-path docs/development/codex_bootstrap_invocation_contract.md \
+  --summary-output /tmp/codex_bootstrap.summary.json \
+  --summary
+```
+
+## Supported path-surface example
+
+```bash
+PYTHONPATH=. python scripts/bootstrap_codex_task.py \
+  --task-name "Example path repair" \
+  --task-goal "Repair bootstrap path metadata." \
+  --subsystem-kind developer_workflow_metadata \
+  --commit-scope developer \
+  --new-module sentientos/codex_task_bootstrapper.py \
+  --new-cli scripts/bootstrap_codex_task.py \
+  --test-path tests/test_bootstrap_codex_task_script.py \
+  --doc-path docs/development/codex_bootstrap_invocation_contract.md \
+  --commit-title "[codex:developer] repair bootstrap path metadata" \
+  --summary
+```

--- a/docs/development/codex_memory_chain_task_profile.md
+++ b/docs/development/codex_memory_chain_task_profile.md
@@ -26,6 +26,8 @@ For explicit surgical repairs, use [`codex_narrow_repair_task_template.md`](code
 
 Run the Codex task bootstrapper before implementation. Implement only from `ready` or `ready_with_warnings` bootstrap output. If bootstrap returns `blocked`, stop and report the blocker; blocked prompt/scaffold artifacts are diagnostic only and must not be used as implementation contracts.
 
+Use only the supported bootstrap CLI flags documented in [`codex_bootstrap_invocation_contract.md`](codex_bootstrap_invocation_contract.md). Unsupported bootstrap flags are invocation errors rather than ready/blocked bootstrap decisions; if argument parsing exits nonzero, stop, fix the invocation, and rerun bootstrap before implementation. For repair prompts, do not invent `--existing-module` or `--existing-cli`; use `--new-module` / `--new-cli` only when intentionally naming the path surface the scaffold should reason about, even if it already exists, or omit those flags and list delta-specific files in the prompt.
+
 If bootstrap tooling cannot express a root-law documentation touch such as `AGENTS.md`, keep the bootstrap artifact limited to allowed task docs and still obey the prompt's explicit authority to edit `AGENTS.md`; do not reinterpret that limitation as permission to ignore blocked bootstrap output or dirty-tree rules.
 
 ## Standard non-authority boundaries

--- a/docs/development/codex_narrow_repair_task_template.md
+++ b/docs/development/codex_narrow_repair_task_template.md
@@ -14,6 +14,12 @@ Document the exact command(s), error text, and preconditions.
 ## Exact files changed
 List only files touched by the repair.
 
+
+## Bootstrap invocation contract
+Run bootstrap with only the supported flags documented in [`codex_bootstrap_invocation_contract.md`](codex_bootstrap_invocation_contract.md). Unsupported flags are command invocation errors, not bootstrap `ready` or `blocked` decisions; if bootstrap exits nonzero because of unsupported arguments, stop, fix the invocation, and rerun bootstrap before implementation.
+
+For repair prompts, do not use unsupported `--existing-module` or `--existing-cli` flags. Use `--new-module` / `--new-cli` only when intentionally naming the module or CLI path that scaffold metadata should reason about, even when the path already exists, or omit those flags and provide explicit delta-specific files elsewhere in the prompt.
+
 ## Focused tests
 Run targeted tests that prove the localized fix.
 

--- a/docs/development/codex_open_work_roadmap_index.md
+++ b/docs/development/codex_open_work_roadmap_index.md
@@ -34,6 +34,11 @@ These tracks are consumed as of the local history through PR #1872 and should no
 | Context-hygiene denial-phase documentation consolidation | PR #1871 | Treat Phase 97-103 denial-phase documentation consolidation as sealed validation-only doctrine. | Must not add new denial-phase behavior, prompt assembly, prompt export, provider invocation, external disclosure, or runtime authority. |
 | Host-boundary deferred/blocked host-actuation label audit | PR #1872 | Treat deferred/blocked host labels as sealed non-authority review labels. | Must not add direct host actuation, fan/PWM/thermal writes, executor authority, admission grants, rollback actions, or panic-path behavior. |
 
+
+## Process-hardening notes
+
+- Bootstrap invocation drift is sealed by [`codex_bootstrap_invocation_contract.md`](codex_bootstrap_invocation_contract.md): future prompts must use only documented bootstrap flags, must not use unsupported `--existing-module` / `--existing-cli`, and must stop/retry bootstrap when argument parsing exits nonzero.
+
 ## Candidate next work tracks
 
 No fresh implementation roadmap is opened by this index. Future candidate additions require a separate bounded planning pass or one of the next-selection signals below; this document does not authorize any blocked surface.

--- a/tests/test_bootstrap_codex_task_script.py
+++ b/tests/test_bootstrap_codex_task_script.py
@@ -62,3 +62,90 @@ def test_script_plan_output_includes_metadata_fixture_root(tmp_path: Path) -> No
     assert code == 0
     payload = json.loads(plan.read_text(encoding="utf-8"))
     assert payload["fixture_root"] == "tests/fixtures/memory_commit_execution_gate/"
+
+SUPPORTED_BOOTSTRAP_FLAGS = {
+    "--task-name",
+    "--task-goal",
+    "--preset-id",
+    "--subsystem-kind",
+    "--commit-scope",
+    "--output-dir",
+    "--summary-output",
+    "--plan-output",
+    "--scaffold-output",
+    "--prompt-output",
+    "--verifier-output",
+    "--summary",
+    "--emit-prompt",
+    "--new-module",
+    "--new-cli",
+    "--test-path",
+    "--doc-path",
+    "--capability-id",
+    "--proof-bundle-artifact-kind",
+    "--commit-title",
+}
+
+
+def _documented_bootstrap_flags(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    flags = set()
+    for token in text.replace("`", " ").split():
+        if token.startswith("--"):
+            flags.add(token.rstrip(",.;:)"))
+    return flags
+
+
+def _documented_example_flags(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    flags: set[str] = set()
+    in_bash = False
+    for line in text.splitlines():
+        if line.strip() == "```bash":
+            in_bash = True
+            continue
+        if in_bash and line.strip() == "```":
+            in_bash = False
+            continue
+        if not in_bash:
+            continue
+        for token in line.split():
+            if token.startswith("--"):
+                flags.add(token.rstrip(",.;:)"))
+    return flags
+
+
+@pytest.mark.no_legacy_skip
+def test_invocation_contract_documents_supported_flags_exactly() -> None:
+    flags = _documented_bootstrap_flags(Path("docs/development/codex_bootstrap_invocation_contract.md"))
+    documented_supported = flags - {"--existing-module", "--existing-cli"}
+    assert SUPPORTED_BOOTSTRAP_FLAGS == documented_supported
+
+
+@pytest.mark.no_legacy_skip
+def test_invocation_contract_doc_examples_only_use_supported_flags() -> None:
+    flags = _documented_example_flags(Path("docs/development/codex_bootstrap_invocation_contract.md"))
+    assert "--existing-module" not in flags
+    assert "--existing-cli" not in flags
+    assert flags <= SUPPORTED_BOOTSTRAP_FLAGS
+
+
+@pytest.mark.no_legacy_skip
+@pytest.mark.parametrize("flag", ["--existing-module", "--existing-cli"])
+def test_unsupported_existing_path_flags_exit_nonzero(flag: str) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main([
+            "--task-name", "Unsupported flag repair",
+            "--task-goal", "prove unsupported flags stop bootstrap invocation",
+            flag, "sentientos/codex_task_bootstrapper.py",
+        ])
+    assert excinfo.value.code != 0
+
+
+@pytest.mark.no_legacy_skip
+def test_repair_task_pattern_documented_without_existing_flags() -> None:
+    text = Path("docs/development/codex_bootstrap_invocation_contract.md").read_text(encoding="utf-8")
+    assert "use `--new-module` and `--new-cli` only when intentionally naming" in text
+    assert "even if that path already exists" in text
+    assert "omit `--new-module` and `--new-cli`" in text
+    assert "Do not invent `--existing-module`, `--existing-cli`" in text


### PR DESCRIPTION
### Motivation
- A past repair used unsupported bootstrap flags (`--existing-module` / `--existing-cli`) and continued after bootstrap exited nonzero, revealing an invocation-contract gap. 
- The bootstrap invocation contract must be explicit so future repair prompts do not invent unsupported flags or treat argument-parser failures as bootstrap decisions. 
- This change is a process-hardening, developer-workflow metadata fix that clarifies allowed CLI flags and enforces stop-on-invocation-error behavior.

### Description
- Added a new docs page `docs/development/codex_bootstrap_invocation_contract.md` that lists the supported `scripts/bootstrap_codex_task.py` flags exactly and states unsupported flags are invocation errors, not bootstrap `ready/blocked` decisions. 
- Updated `docs/development/codex_memory_chain_task_profile.md`, `docs/development/codex_narrow_repair_task_template.md`, and `docs/development/codex_open_work_roadmap_index.md` to reference the sealed invocation contract and to remove/avoid recommending unsupported `--existing-module` / `--existing-cli` usage. 
- Extended and modified `tests/test_bootstrap_codex_task_script.py` to assert the docs/examples only use supported flags, to assert the documented supported-flag set matches actual documentation, to assert examples in the docs use only supported flags, and to assert unsupported flags (`--existing-module`, `--existing-cli`) cause the bootstrap CLI to exit nonzero. 
- Preserved bootstrap tooling behavior and validation posture (the CLI interface itself was not loosened); the docs/tests make the supported pattern explicit and codify the repair-task guidance to use `--new-module`/`--new-cli` only when intentionally naming scaffold surface paths.

### Testing
- Ran the focused bootstrap tests with `python -m scripts.run_tests -q tests/test_bootstrap_codex_task_script.py` and the modified test suite passed. 
- Ran docs verification and build with `python scripts/build_docs.py --bootstrap-docs`, `python scripts/build_docs.py --check-deps`, and `python scripts/build_docs.py` and the docs built successfully. 
- Ran static checks and hygiene: `python -m mypy scripts/bootstrap_codex_task.py sentientos/codex_task_bootstrapper.py sentientos/codex_task_scaffold_path_planner.py` and `python scripts/verify_context_hygiene_prompt_boundaries.py`, both of which passed. 
- Ran the work-item review matrix and landing sequence (`scripts/run_work_item_review_packet_matrix.py`, `scripts/codex_landing_supervisor.py evaluate`, `scripts/codex_finalize_landing.py finalize` pre-commit and pr-metadata phases) and the finalizer/landing-supervisor/pr-metadata guard checks returned the expected ready states for PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b3a2ec4dc832fb5ff87b4a88d4b12)