### PR TITLE
[codex:sentientos] add current-roadmap freshness verifier

### DIFF
--- a/docs/development/codex_open_work_roadmap_freshness_verifier.md
+++ b/docs/development/codex_open_work_roadmap_freshness_verifier.md
@@ -1,0 +1,48 @@
+# Codex Open-Work Roadmap Freshness Verifier
+
+`sentientos/codex_open_work_roadmap_freshness_verifier.py` is a deterministic developer-workflow metadata verifier for [`codex_open_work_roadmap_index.md`](codex_open_work_roadmap_index.md). It checks that the current roadmap still preserves consumed-work history, blocked-surface doctrine, bootstrap invocation contract wording, candidate non-authority wording, and the absence of positive authority-grant drift.
+
+Verifier success is only roadmap freshness evidence. It is not implementation selection, runtime authority, consent, policy truth, prompt assembly, prompt export, provider invocation, network authority, live-memory mutation, host action, ledger authority, glow authority, daemon authority, scheduler authority, model-training authority, federation authority, commit authority, PR authority, or readiness authority.
+
+## What it checks
+
+The verifier reads a Markdown roadmap and emits a stable JSON report with these result groups:
+
+- `consumed_work_results`: verifies required consumed PR markers from PR #1898 through PR #1917 and emits an informational PR #1918 observation when present or absent.
+- `blocked_surface_results`: verifies the sandboxed live-memory commit adapter envelope remains terminal, post-envelope implementation remains blocked, sandboxed readiness gate/packet/envelope and repeated ladders remain blocked, future continuation requires a complete topology decision, and metadata/review evidence is not live authority.
+- `bootstrap_contract_results`: verifies the roadmap links or names `codex_bootstrap_invocation_contract.md`, supported/documented bootstrap flags, unsupported `--existing-module` and `--existing-cli`, and the requirement to stop/retry bootstrap when argument parsing exits nonzero.
+- `candidate_track_results`: verifies the current candidate set remains exactly `Current-roadmap freshness verifier`, `Consent-ladder index/readability consolidation`, and `Next-selection packet template` unless a future roadmap refresh intentionally changes the set under a new consumed-work or selection posture. Candidate wording must remain documentation/review/test-only, require separate operator selection, not authorize implementation, and not grant runtime/live-memory/provider/network/prompt-export/host/ledger/glow/daemon/scheduler/model/federation authority.
+- `forbidden_authority_results`: fails on positive authorization language near forbidden surfaces while allowing denial phrases such as `must not`, `does not`, `do not`, `not authorized`, `blocked`, `forbidden`, `without authority`, or `requires separate authorization`.
+
+## CLI usage
+
+```bash
+python scripts/verify_codex_open_work_roadmap_freshness.py --summary
+```
+
+Options:
+
+- `--roadmap-path PATH`: roadmap Markdown to verify. Defaults to `docs/development/codex_open_work_roadmap_index.md`.
+- `--output PATH`: write deterministic JSON.
+- `--markdown-output PATH`: write deterministic Markdown.
+- `--summary`: print a compact JSON summary to stdout.
+
+## Exit statuses
+
+- `0`: verification ran successfully and found no violations.
+- `1`: verification ran successfully and found one or more violations.
+- `2`: the roadmap path is missing or unreadable, the roadmap is empty, or JSON/Markdown output cannot be written.
+
+## Output formats
+
+The JSON report includes `verifier_id`, `metadata_only`, `verifier_only`, source path, SHA-256 source digest, byte size, `verification_status`, the full `verification_checks` list, grouped result lists, a `violation_summary`, and the non-authority posture.
+
+The Markdown report contains deterministic sections for source summary, verification status, verification checks, consumed work results, blocked surface results, bootstrap contract results, candidate track results, forbidden authority results, violation summary, and non-authority posture. Table cells escape pipes and newlines for stable review rendering.
+
+## Relationship to the roadmap candidate list
+
+This verifier implements the `Current-roadmap freshness verifier` candidate as metadata-only review/test tooling. It does not select or implement the remaining candidate tracks, and a passing verifier does not authorize future implementation. Future work still requires separate operator selection, fresh bounded prompt text, successful bootstrap, matrix/finalizer/supervisor/PR metadata guard controls, and clean-tree landing rules.
+
+## Updating consumed-work markers
+
+When a new roadmap-refresh PR intentionally changes the current history, update the verifier's expected consumed-work marker list in `sentientos/codex_open_work_roadmap_freshness_verifier.py` and the focused tests in `tests/test_codex_open_work_roadmap_freshness_verifier.py` during that same bounded documentation/review/test task. The update should record why the new PR marker is part of consumed history and must preserve the non-authority posture: freshness evidence does not become consent, policy truth, runtime readiness, commit authority, PR authority, or implementation authority.

--- a/docs/development/codex_open_work_roadmap_index.md
+++ b/docs/development/codex_open_work_roadmap_index.md
@@ -58,6 +58,8 @@ Verifier/status/presentation/request/response/storage-policy/runtime-authority e
 
 ## Process-hardening notes
 
+- The current-roadmap freshness verifier is documented in [`codex_open_work_roadmap_freshness_verifier.md`](codex_open_work_roadmap_freshness_verifier.md) as metadata-only review/test evidence; verifier success does not select or implement any future track and grants no runtime, readiness, commit, PR, or implementation authority.
+
 - Bootstrap invocation drift is sealed by [`codex_bootstrap_invocation_contract.md`](codex_bootstrap_invocation_contract.md): future prompts must use only supported bootstrap flags / documented bootstrap flags, must not use unsupported `--existing-module` / `--existing-cli`, and must stop/retry bootstrap when argument parsing exits nonzero.
 
 ## Candidate next work tracks

--- a/scripts/verify_codex_open_work_roadmap_freshness.py
+++ b/scripts/verify_codex_open_work_roadmap_freshness.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sentientos.codex_open_work_roadmap_freshness_verifier import (
+    DEFAULT_ROADMAP_PATH,
+    VERIFIED,
+    dumps_report,
+    render_markdown,
+    verify_roadmap_file,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify current Codex open-work roadmap freshness metadata.")
+    parser.add_argument("--roadmap-path", type=Path, default=DEFAULT_ROADMAP_PATH)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        report = verify_roadmap_file(args.roadmap_path)
+        if args.output:
+            _write(args.output, dumps_report(report))
+        if args.markdown_output:
+            _write(args.markdown_output, render_markdown(report))
+    except (OSError, UnicodeDecodeError, ValueError, TypeError) as exc:
+        print(json.dumps({"status": "input_output_error", "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 2
+
+    if args.summary:
+        print(json.dumps({
+            "verification_status": report["verification_status"],
+            "violation_count": report["violation_summary"]["violation_count"],
+            "roadmap_path": report["roadmap_path"],
+        }, sort_keys=True))
+    return 0 if report["verification_status"] == VERIFIED else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentientos/codex_open_work_roadmap_freshness_verifier.py
+++ b/sentientos/codex_open_work_roadmap_freshness_verifier.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+VERIFIER_ID = "codex_open_work_roadmap_freshness_verifier.v1"
+VERIFIED = "codex_open_work_roadmap_freshness_verified"
+FAILED = "codex_open_work_roadmap_freshness_failed"
+DEFAULT_ROADMAP_PATH = Path("docs/development/codex_open_work_roadmap_index.md")
+AUTHORITY_BOUNDARY = "metadata-only roadmap freshness evidence; no implementation, runtime, readiness, commit, or PR authority"
+NON_AUTHORITY_POSTURE = (
+    "Verifier success is only roadmap freshness evidence. It is not implementation selection, "
+    "runtime authority, consent, policy truth, prompt assembly, prompt export, provider invocation, "
+    "network authority, live-memory mutation, host action, ledger authority, glow authority, daemon "
+    "authority, scheduler authority, model-training authority, federation authority, commit authority, "
+    "PR authority, or readiness authority."
+)
+
+REQUIRED_PRS = tuple(range(1898, 1918))
+CANDIDATES = (
+    "Current-roadmap freshness verifier",
+    "Consent-ladder index/readability consolidation",
+    "Next-selection packet template",
+)
+FORBIDDEN_SURFACES = (
+    "runtime authority",
+    "live-memory mutation",
+    "provider invocation",
+    "network calls",
+    "prompt export",
+    "host action",
+    "ledger writes",
+    "glow archives",
+    "daemon action",
+    "scheduler behavior",
+    "model training",
+    "federation authority",
+    "sandboxed readiness gate",
+    "sandboxed readiness packet",
+    "sandboxed readiness envelope",
+    "post-envelope sandboxed adapter continuation",
+)
+POSITIVE_AUTHORIZATION = (
+    "authorizes", "authorize", "grants", "grant", "allows", "allow", "enables", "enable",
+    "implements", "implement", "opens", "open", "selects", "select", "activates", "activate",
+)
+DENIAL_MARKERS = (
+    "must not", "does not", "do not", "not authorized", "blocked", "forbidden", "without authority",
+    "requires separate authorization", "never authorize", "not grant", "cannot", "no ", "non-authority",
+    "it is not", "not consent", "must not be reopened",
+)
+
+
+def _norm(text: str) -> str:
+    return re.sub(r"\s+", " ", text.lower()).strip()
+
+
+def _check(check_id: str, passed: bool, details: str, *, severity: str | None = None) -> dict[str, Any]:
+    return {
+        "check_id": check_id,
+        "passed": passed,
+        "severity": severity or ("info" if passed else "violation"),
+        "details": details,
+        "authority_boundary": AUTHORITY_BOUNDARY,
+    }
+
+
+def _contains_all(text: str, terms: Sequence[str]) -> bool:
+    norm = _norm(text)
+    return all(term.lower() in norm for term in terms)
+
+
+def _consumed_work_results(text: str) -> list[dict[str, Any]]:
+    results = []
+    for pr in REQUIRED_PRS:
+        marker = f"PR #{pr}"
+        results.append(_check(f"consumed_work.pr_{pr}", marker in text, f"Roadmap mentions {marker}."))
+    present_1918 = "PR #1918" in text
+    results.append(_check(
+        "consumed_work.pr_1918_optional",
+        True,
+        "Roadmap mentions optional PR #1918." if present_1918 else "Roadmap does not mention optional PR #1918; this is informational when current history intentionally records through PR #1917.",
+        severity="info",
+    ))
+    return results
+
+
+def _blocked_surface_results(text: str) -> list[dict[str, Any]]:
+    specs = (
+        ("blocked_surface.terminal_envelope", ("sandboxed_live_memory_commit_adapter_envelope", "terminal")),
+        ("blocked_surface.no_post_envelope", ("no post-envelope implementation",)),
+        ("blocked_surface.no_readiness_gate", ("sandboxed readiness gate",)),
+        ("blocked_surface.no_readiness_packet", ("readiness packet",)),
+        ("blocked_surface.no_readiness_envelope", ("readiness envelope",)),
+        ("blocked_surface.no_repeated_ladder", ("repeated sandboxed", "ladder")),
+        ("blocked_surface.topology_decision_required", ("complete topology decision",)),
+        ("blocked_surface.metadata_not_live_authority", ("metadata", "review evidence", "not", "live", "authority")),
+    )
+    return [_check(cid, _contains_all(text, terms), f"Required blocked-surface wording preserved: {', '.join(terms)}.") for cid, terms in specs]
+
+
+def _bootstrap_contract_results(text: str) -> list[dict[str, Any]]:
+    specs = (
+        ("bootstrap_contract.link", ("codex_bootstrap_invocation_contract.md",)),
+        ("bootstrap_contract.supported_flags", ("supported bootstrap flags",)),
+        ("bootstrap_contract.unsupported_existing_module", ("--existing-module",)),
+        ("bootstrap_contract.unsupported_existing_cli", ("--existing-cli",)),
+        ("bootstrap_contract.stop_retry_nonzero", ("argument parsing exits nonzero",)),
+    )
+    return [_check(cid, _contains_all(text, terms), f"Required bootstrap-contract wording preserved: {', '.join(terms)}.") for cid, terms in specs]
+
+
+def _candidate_section(text: str) -> str:
+    match = re.search(r"## Candidate next work tracks(?P<body>.*?)(?:\n## |\Z)", text, flags=re.S)
+    return match.group("body") if match else ""
+
+
+def _candidate_track_results(text: str) -> list[dict[str, Any]]:
+    section = _candidate_section(text)
+    results: list[dict[str, Any]] = []
+    for candidate in CANDIDATES:
+        count = section.count(f"| {candidate} |")
+        results.append(_check(f"candidate_track.{candidate.lower().replace(' ', '_').replace('/', '_').replace('-', '_')}", count == 1, f"Candidate appears exactly once in candidate table; count={count}."))
+    extra_rows = [line for line in section.splitlines() if line.startswith("| ") and not line.startswith("| ---") and "Candidate option" not in line]
+    names = [row.split("|")[1].strip() for row in extra_rows if len(row.split("|")) > 2]
+    results.append(_check("candidate_track.exact_candidate_set", tuple(names) == CANDIDATES, f"Candidate set is {names}."))
+    posture_specs = (
+        ("candidate_track.documentation_review_test_only", ("documentation/review/test-only",)),
+        ("candidate_track.separate_operator_selection", ("requires separate operator selection",)),
+        ("candidate_track.no_implementation_authority", ("does not authorize implementation",)),
+        ("candidate_track.no_runtime_authority_grant", ("does not grant runtime", "live-memory mutation", "provider invocation", "network call", "prompt export", "host action", "ledger write", "glow archive", "daemon action", "scheduler behavior", "model training", "federation authority")),
+    )
+    for cid, terms in posture_specs:
+        results.append(_check(cid, _contains_all(section, terms), f"Candidate non-authority posture preserved: {', '.join(terms)}."))
+    return results
+
+
+def _sentences(text: str) -> list[str]:
+    return [s.strip() for s in re.split(r"(?<=[.!?])\s+|\n+", text) if s.strip()]
+
+
+def _is_denial(sentence: str) -> bool:
+    lower = _norm(sentence)
+    return any(marker in lower for marker in DENIAL_MARKERS)
+
+
+def _forbidden_authority_results(text: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    sentences = _sentences(text)
+    for surface in FORBIDDEN_SURFACES:
+        bad: list[str] = []
+        surface_norm = surface.lower()
+        for sentence in sentences:
+            lower = _norm(sentence)
+            has_positive_verb = any(re.search(r"\b" + re.escape(verb) + r"\b", lower) for verb in POSITIVE_AUTHORIZATION)
+            if surface_norm in lower and has_positive_verb and not _is_denial(sentence):
+                bad.append(sentence)
+        findings.append(_check(
+            "forbidden_authority." + surface.replace("-", "_").replace(" ", "_"),
+            not bad,
+            "No positive authorization language detected." if not bad else "Positive authorization drift detected: " + " | ".join(bad),
+        ))
+    return findings
+
+
+def verify_roadmap_text(text: str, roadmap_path: str, *, source_bytes: bytes | None = None) -> dict[str, Any]:
+    raw = source_bytes if source_bytes is not None else text.encode("utf-8")
+    groups = {
+        "consumed_work_results": _consumed_work_results(text),
+        "blocked_surface_results": _blocked_surface_results(text),
+        "bootstrap_contract_results": _bootstrap_contract_results(text),
+        "candidate_track_results": _candidate_track_results(text),
+        "forbidden_authority_results": _forbidden_authority_results(text),
+    }
+    checks = [check for values in groups.values() for check in values]
+    violations = [check for check in checks if not check["passed"] and check["severity"] == "violation"]
+    return {
+        "verifier_id": VERIFIER_ID,
+        "metadata_only": True,
+        "verifier_only": True,
+        "roadmap_path": roadmap_path,
+        "source_digest_algo": "sha256",
+        "source_digest": hashlib.sha256(raw).hexdigest(),
+        "source_byte_size": len(raw),
+        "verification_status": VERIFIED if not violations else FAILED,
+        "verification_checks": checks,
+        **groups,
+        "violation_summary": {
+            "violation_count": len(violations),
+            "violation_check_ids": [str(check["check_id"]) for check in violations],
+        },
+        "non_authority_posture": NON_AUTHORITY_POSTURE,
+    }
+
+
+def verify_roadmap_file(path: Path) -> dict[str, Any]:
+    raw = path.read_bytes()
+    if not raw:
+        raise ValueError("roadmap file is empty")
+    text = raw.decode("utf-8")
+    if not text.strip():
+        raise ValueError("roadmap file is empty")
+    return verify_roadmap_text(text, str(path), source_bytes=raw)
+
+
+def dumps_report(report: Mapping[str, Any]) -> str:
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+
+def _cell(value: object) -> str:
+    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)
+    return text.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>")
+
+
+def _checks_table(checks: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = ["| Check ID | Passed | Severity | Details | Authority boundary |", "| --- | --- | --- | --- | --- |"]
+    for check in checks:
+        lines.append("| " + " | ".join(_cell(check[key]) for key in ("check_id", "passed", "severity", "details", "authority_boundary")) + " |")
+    return lines
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    sections: list[str] = [
+        "# Codex Open-Work Roadmap Freshness Verification",
+        "",
+        "## Source summary",
+        "| Field | Value |",
+        "| --- | --- |",
+    ]
+    for key in ("verifier_id", "metadata_only", "verifier_only", "roadmap_path", "source_digest_algo", "source_digest", "source_byte_size"):
+        sections.append(f"| {_cell(key)} | {_cell(report.get(key, ''))} |")
+    sections.extend(["", "## Verification status", f"`{_cell(report.get('verification_status', ''))}`", ""])
+    section_map = (
+        ("Verification checks", "verification_checks"),
+        ("Consumed work results", "consumed_work_results"),
+        ("Blocked surface results", "blocked_surface_results"),
+        ("Bootstrap contract results", "bootstrap_contract_results"),
+        ("Candidate track results", "candidate_track_results"),
+        ("Forbidden authority results", "forbidden_authority_results"),
+    )
+    for title, key in section_map:
+        sections.extend([f"## {title}", *_checks_table(report.get(key, [])), ""])
+    sections.extend([
+        "## Violation summary",
+        "| Field | Value |",
+        "| --- | --- |",
+    ])
+    summary = report.get("violation_summary", {})
+    if isinstance(summary, Mapping):
+        for key in sorted(summary):
+            sections.append(f"| {_cell(key)} | {_cell(summary[key])} |")
+    sections.extend(["", "## Non-authority posture", _cell(report.get("non_authority_posture", NON_AUTHORITY_POSTURE)), ""])
+    return "\n".join(sections)

--- a/tests/test_codex_open_work_roadmap_freshness_verifier.py
+++ b/tests/test_codex_open_work_roadmap_freshness_verifier.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from sentientos.codex_open_work_roadmap_freshness_verifier import (
+    FAILED,
+    NON_AUTHORITY_POSTURE,
+    VERIFIED,
+    dumps_report,
+    render_markdown,
+    verify_roadmap_text,
+)
+
+
+def valid_roadmap(include_1918: bool = False) -> str:
+    prs = "\n".join(f"- PR #{number} consumed metadata only." for number in range(1898, 1918))
+    optional = "\n- PR #1918 refreshed roadmap history." if include_1918 else ""
+    return f"""# Roadmap
+
+## Current sealed or paused areas
+
+- `sandboxed_live_memory_commit_adapter_envelope` is terminal for the sandboxed adapter branch.
+- No post-envelope implementation is authorized from that terminal envelope.
+- Do not create a sandboxed readiness gate, readiness packet, readiness envelope, or repeated sandboxed gate/packet/envelope/readiness ladder.
+- Future continuation requires a separate complete topology decision.
+- Metadata and review evidence is not live authority.
+
+## Recent consumed storage/operator consent and bootstrap-contract work
+
+{prs}{optional}
+
+## Process-hardening notes
+
+- Bootstrap invocation drift is sealed by [`codex_bootstrap_invocation_contract.md`](codex_bootstrap_invocation_contract.md): future prompts must use only supported bootstrap flags / documented bootstrap flags, must not use unsupported `--existing-module` / `--existing-cli`, and must stop/retry bootstrap when argument parsing exits nonzero.
+
+## Candidate next work tracks
+
+This section lists documentation/review/test-only options for a future operator to select. It does not select or implement any candidate, does not authorize implementation, and does not grant runtime, live-memory mutation, provider invocation, network call, prompt export, host action, ledger write, glow archive, daemon action, scheduler behavior, model training, or federation authority. Each candidate requires separate operator selection.
+
+| Candidate option | Scope if separately selected | Non-authority boundary |
+| --- | --- | --- |
+| Current-roadmap freshness verifier | Add or update docs/tests that check consumed-work entries and blocked-surface language stay current. | Review/test-only. Must not create runtime gates. |
+| Consent-ladder index/readability consolidation | Consolidate links among existing consent/storage contracts, verifiers, and dossiers without adding a new rung. | Documentation/readability-only. |
+| Next-selection packet template | Draft a template for choosing among safe docs/test-only work items without implying implementation authority. | Planning-only. Must require separate operator selection. |
+
+## Blocked task classes
+
+Do not select post-envelope sandboxed adapter continuation. Runtime authority is forbidden.
+"""
+
+
+def test_valid_current_roadmap_verifies() -> None:
+    report = verify_roadmap_text(valid_roadmap(), "roadmap.md")
+    assert report["verification_status"] == VERIFIED
+    assert report["metadata_only"] is True
+    assert report["verifier_only"] is True
+
+
+def test_source_digest_and_byte_size_are_deterministic() -> None:
+    text = valid_roadmap()
+    report = verify_roadmap_text(text, "roadmap.md")
+    assert report["source_digest"] == hashlib.sha256(text.encode()).hexdigest()
+    assert report["source_byte_size"] == len(text.encode())
+    assert verify_roadmap_text(text, "roadmap.md")["source_digest"] == report["source_digest"]
+
+
+def test_output_json_is_deterministic() -> None:
+    report = verify_roadmap_text(valid_roadmap(), "roadmap.md")
+    assert dumps_report(report) == dumps_report(report)
+
+
+def test_markdown_output_is_deterministic_and_escapes_pipes_newlines() -> None:
+    report = verify_roadmap_text(valid_roadmap(), "roadmap.md")
+    report["verification_checks"][0]["details"] = "alpha | beta\nnext"
+    rendered = render_markdown(report)
+    assert rendered == render_markdown(report)
+    assert "alpha \\| beta<br>next" in rendered
+
+
+def test_consumed_pr_markers_are_checked() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("PR #1904", "PR missing"), "roadmap.md")
+    assert report["verification_status"] == FAILED
+    assert "consumed_work.pr_1904" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_pr_1918_is_optional_info_if_not_recorded_as_consumed() -> None:
+    report = verify_roadmap_text(valid_roadmap(include_1918=False), "roadmap.md")
+    check = next(c for c in report["consumed_work_results"] if c["check_id"] == "consumed_work.pr_1918_optional")
+    assert check["passed"] is True
+    assert check["severity"] == "info"
+    assert "does not mention" in check["details"]
+
+
+def test_sandboxed_adapter_stop_language_is_required() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("terminal", "ongoing"), "roadmap.md")
+    assert report["verification_status"] == FAILED
+    assert "blocked_surface.terminal_envelope" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_bootstrap_invocation_contract_language_is_required() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("codex_bootstrap_invocation_contract.md", "other.md"), "roadmap.md")
+    assert report["verification_status"] == FAILED
+    assert "bootstrap_contract.link" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_unsupported_existing_module_and_cli_wording_is_required() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("--existing-module", "--old-module").replace("--existing-cli", "--old-cli"), "roadmap.md")
+    assert "bootstrap_contract.unsupported_existing_module" in report["violation_summary"]["violation_check_ids"]
+    assert "bootstrap_contract.unsupported_existing_cli" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_candidate_tracks_are_checked() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("| Next-selection packet template |", "| Other candidate |"), "roadmap.md")
+    assert report["verification_status"] == FAILED
+    assert "candidate_track.exact_candidate_set" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_candidates_must_require_separate_operator_selection() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("Each candidate requires separate operator selection.", "Each candidate can proceed."), "roadmap.md")
+    assert "candidate_track.separate_operator_selection" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_candidates_must_be_non_authority() -> None:
+    report = verify_roadmap_text(valid_roadmap().replace("does not authorize implementation", "can implement"), "roadmap.md")
+    assert "candidate_track.no_implementation_authority" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_forbidden_authority_positive_wording_fails() -> None:
+    report = verify_roadmap_text(valid_roadmap() + "\nThis roadmap authorizes runtime authority as current work.\n", "roadmap.md")
+    assert report["verification_status"] == FAILED
+    assert "forbidden_authority.runtime_authority" in report["violation_summary"]["violation_check_ids"]
+
+
+def test_denial_forbidden_wording_does_not_falsely_fail() -> None:
+    report = verify_roadmap_text(valid_roadmap() + "\nThis roadmap must not authorize runtime authority and provider invocation; both are forbidden.\n", "roadmap.md")
+    assert report["verification_status"] == VERIFIED
+
+
+def test_verifier_success_does_not_imply_implementation_selection() -> None:
+    report = verify_roadmap_text(valid_roadmap(), "roadmap.md")
+    posture = report["non_authority_posture"]
+    assert report["verification_status"] == VERIFIED
+    assert "not implementation selection" in posture
+
+
+def test_verifier_success_does_not_imply_runtime_readiness_pr_commit_authority() -> None:
+    posture = verify_roadmap_text(valid_roadmap(), "roadmap.md")["non_authority_posture"]
+    for phrase in ("runtime authority", "readiness authority", "PR authority", "commit authority"):
+        assert phrase in posture
+    assert posture == NON_AUTHORITY_POSTURE

--- a/tests/test_verify_codex_open_work_roadmap_freshness_script.py
+++ b/tests/test_verify_codex_open_work_roadmap_freshness_script.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.no_legacy_skip
+
+from scripts.verify_codex_open_work_roadmap_freshness import main
+from tests.test_codex_open_work_roadmap_freshness_verifier import valid_roadmap
+
+
+def test_missing_roadmap_exits_2(tmp_path: Path) -> None:
+    assert main(["--roadmap-path", str(tmp_path / "missing.md")]) == 2
+
+
+def test_empty_roadmap_exits_2(tmp_path: Path) -> None:
+    roadmap = tmp_path / "empty.md"
+    roadmap.write_text("", encoding="utf-8")
+    assert main(["--roadmap-path", str(roadmap)]) == 2
+
+
+def test_cli_writes_deterministic_json_and_markdown_outputs(tmp_path: Path) -> None:
+    roadmap = tmp_path / "roadmap.md"
+    roadmap.write_text(valid_roadmap(), encoding="utf-8")
+    output = tmp_path / "report.json"
+    markdown = tmp_path / "report.md"
+
+    assert main(["--roadmap-path", str(roadmap), "--output", str(output), "--markdown-output", str(markdown), "--summary"]) == 0
+    first_json = output.read_text(encoding="utf-8")
+    first_md = markdown.read_text(encoding="utf-8")
+    assert main(["--roadmap-path", str(roadmap), "--output", str(output), "--markdown-output", str(markdown)]) == 0
+    assert output.read_text(encoding="utf-8") == first_json
+    assert markdown.read_text(encoding="utf-8") == first_md
+    payload = json.loads(first_json)
+    assert payload["verification_status"] == "codex_open_work_roadmap_freshness_verified"
+
+
+def test_cli_returns_1_for_successful_verification_with_violations(tmp_path: Path) -> None:
+    roadmap = tmp_path / "roadmap.md"
+    roadmap.write_text(valid_roadmap().replace("PR #1898", "PR missing"), encoding="utf-8")
+    assert main(["--roadmap-path", str(roadmap)]) == 1
+
+
+def test_unwritable_output_exits_2(tmp_path: Path) -> None:
+    roadmap = tmp_path / "roadmap.md"
+    roadmap.write_text(valid_roadmap(), encoding="utf-8")
+    output_dir = tmp_path / "dir.json"
+    output_dir.mkdir()
+    assert main(["--roadmap-path", str(roadmap), "--output", str(output_dir)]) == 2


### PR DESCRIPTION
### Motivation
- Keep the open-work roadmap truthful and reviewable by adding deterministic, metadata-only freshness verification for consumed-work markers, blocked-surface doctrine, bootstrap-contract linkage, candidate non-authority wording, and forbidden authority-grant drift.
- Prevent accidental escalation of roadmap language into implementation or runtime authority by producing a verifiable, auditable JSON/Markdown report and an explicit non-authority posture.

### Description
- Add a deterministic verifier module `sentientos/codex_open_work_roadmap_freshness_verifier.py` that computes `sha256` source digests, byte sizes, grouped checks, and a compact violation summary under `verifier_id: codex_open_work_roadmap_freshness_verifier.v1`.
- Provide a CLI `scripts/verify_codex_open_work_roadmap_freshness.py` with `--roadmap-path`, `--output`, `--markdown-output`, and `--summary` that returns `2` for I/O/empty-roadmap errors, `1` for found violations, and `0` for a clean verification.
- Add deterministic Markdown rendering that escapes pipes/newlines and includes source summary, verification checks, grouped results, violation summary, and an explicit non-authority posture documented at `docs/development/codex_open_work_roadmap_freshness_verifier.md`.
- Add focused tests in `tests/test_codex_open_work_roadmap_freshness_verifier.py` and `tests/test_verify_codex_open_work_roadmap_freshness_script.py`, and add a short link from `docs/development/codex_open_work_roadmap_index.md` to the new verifier doc without expanding roadmap authority.

### Testing
- Ran focused verifier/script tests with `python -m scripts.run_tests -q tests/test_codex_open_work_roadmap_freshness_verifier.py tests/test_verify_codex_open_work_roadmap_freshness_script.py` and they passed.
- Verified roadmap index coverage with `python -m scripts.run_tests -q tests/test_codex_open_work_roadmap_index.py` and the index checks passed.
- Built docs after bootstrapping docs deps with `python scripts/build_docs.py --bootstrap-docs && python scripts/build_docs.py` and the docs build completed successfully.
- Ran targeted type checks with `python -m mypy sentientos/codex_open_work_roadmap_freshness_verifier.py scripts/verify_codex_open_work_roadmap_freshness.py` and the mypy run passed.
- Executed the full review packet matrix with `timeout 1200 python scripts/run_work_item_review_packet_matrix.py --summary --output /tmp/work_item_review_packet_matrix.json` and the matrix runner returned `status=passed` (required_failure_count=0).
- Evaluated landing supervisor and finalizer flows with `scripts/codex_landing_supervisor.py` and `scripts/codex_finalize_landing.py` in the prescribed sequence and obtained `ready_for_pr_metadata` / `ready_to_commit` decisions; the PR metadata guard returned `pr_metadata_guard_ready`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4bd8a878f4832fbf31bec285cebe1d)