### PR TITLE
[codex:sentientos] complete the governed improvement signal plane and restore landing truth

### DIFF
--- a/codex/amendments.py
+++ b/codex/amendments.py
@@ -1179,6 +1179,18 @@ _RUNTIME_AMENDER: SpecAmender | None = None
 _RUNTIME_REVIEW_BOARD: AmendmentReviewBoard | None = None
 
 
+def _load_runtime_current_spec(root: Path, spec_id: str) -> Mapping[str, Any] | None:
+    safe = spec_id.replace("/", "_").replace("..", "_")
+    for candidate in (root / "specs" / f"{safe}.json", root / "specs" / safe / "spec.json"):
+        if candidate.exists():
+            try:
+                payload = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return None
+            return payload if isinstance(payload, Mapping) else None
+    return None
+
+
 def _runtime_amender(root: Path | str = Path("integration")) -> SpecAmender:
     global _RUNTIME_AMENDER
     if _RUNTIME_AMENDER is None:
@@ -1196,11 +1208,16 @@ def runtime_cycle(root: Path | str = Path("integration"), signals: Sequence[Mapp
         spec_id = str(item.get("spec_id") or "").strip()
         if not spec_id:
             continue
-        current_spec = {"id": spec_id, "version": "v1", "status": "active"}
+        current_spec = _load_runtime_current_spec(Path(root), spec_id)
+        if current_spec is None:
+            generated.append(f"missing_canonical_spec:{spec_id}")
+            continue
+        metadata = dict(item.get("metadata") or item)
+        metadata.setdefault("runtime_lineage", {"signal_id": item.get("signal_id"), "batch_id": item.get("batch_id"), "source_digest": item.get("source_digest"), "routing_receipt": item.get("routing_receipt")})
         proposal = engine.record_signal(
             spec_id,
             str(item.get("signal_type") or "recurring_failure"),
-            dict(item.get("metadata") or item),
+            metadata,
             current_spec=current_spec,
         )
         if proposal is not None:

--- a/sentientos/genesis_forge.py
+++ b/sentientos/genesis_forge.py
@@ -639,7 +639,7 @@ class GenesisForge:
                 proposals = self._forge_engine.draft_variants(need, k=1, seed=f"proposal-only:{need.capability}")
                 proposal = proposals[0]
                 stage_a = self._integrity_daemon.evaluate_report_stage_a(proposal)
-                stage_b = self._integrity_daemon.evaluate(proposal)
+                stage_b = self._integrity_daemon.evaluate_report_stage_b(proposal, probe_cache=getattr(stage_a, "probe", None))
                 report = self._trial_run.execute(proposal.blueprint)
                 details = {
                     "proposal_id": proposal.proposal_id,
@@ -650,18 +650,21 @@ class GenesisForge:
                     "stage_b_valid": getattr(stage_b, "valid", False),
                     "stage_b_reason_codes": list(getattr(stage_b, "reason_codes", ())),
                     "sandbox_trial_passed": report.passed,
-                    "proposal_ready_for_review": True,
+                    "proposal_ready_for_review": bool(getattr(stage_a, "valid_a", False) and getattr(stage_b, "valid", False) and report.passed),
+                    "proposal_only_boundary": "before_spec_binder_integration_and_adoption_rite_promotion",
                     "lineage_integrated": False,
                     "adoption_promoted": False,
                     "repository_mutation_performed": False,
                     "provider_network_git_operation_performed": False,
                 }
+                ready = bool(details["proposal_ready_for_review"])
                 self._ledger.log(
-                    "genesis_proposal_ready_for_review",
+                    "genesis_proposal_ready_for_review" if ready else "genesis_proposal_not_ready_for_review",
                     anomaly=Anomaly(kind="genesis_need", subject=need.capability),
                     details=details,
                 )
-                outcomes.append(GenesisOutcome(need=need, status="proposal_ready_for_review", details=details))
+                status = "proposal_ready_for_review" if ready else ("failed_trial" if not report.passed else "invalid_stage_b" if not getattr(stage_b, "valid", False) else "invalid_stage_a")
+                outcomes.append(GenesisOutcome(need=need, status=status, details=details))
             except GenesisForgeError as exc:
                 self._ledger.log(
                     "genesis_proposal_failed",
@@ -981,7 +984,8 @@ class GenesisForge:
                         "Sandbox validation failed",
                     )
                 router = get_constitutional_mutation_router()
-                adoption_correlation = f"genesis:{proposal.proposal_id}:{proposal.spec_id}"
+                admission_nonce = uuid.uuid4().hex
+                adoption_correlation = f"genesis:{proposal.proposal_id}:{proposal.spec_id}:{admission_nonce}"
                 lineage_correlation = adoption_correlation
                 router.register_handler(
                     "sentientos.genesis.lineage_integrate",

--- a/sentientos/governed_improvement_signal_plane.py
+++ b/sentientos/governed_improvement_signal_plane.py
@@ -6,15 +6,16 @@ network, Git, Codex workspace, adoption, or repository source mutation effects.
 """
 from __future__ import annotations
 
-import hashlib, json, os, re, tempfile
+import hashlib, json, os, re, tempfile, xml.etree.ElementTree as ET
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
+from codex.gap_seeker import CoverageReader, GapReporter, RepoScanner, GapSignal
+
 ALLOWED_SOURCES = {"run_tests","junit","coverage","mypy","covenant","telemetry","capability_gap","gap_seeker","model_observation"}
-AUTHORITY_FIELDS = ("adoption_performed","repository_mutation_performed","provider_or_network_or_git_operation_performed","trial_performed")
 GENESIS_KINDS = {"missing_capability","new_flow","uncovered_flow","capability_gap","telemetry_gap"}
-SPEC_KINDS = {"test_failure","mypy_error","recurring_failure","covenant_failure","typing_failure"}
+SPEC_KINDS = {"test_failure","mypy_error","type_error","recurring_failure","covenant_failure","typing_failure"}
 DIAGNOSTIC_KINDS = {"todo","fixme","unimplemented","coverage_gap","missing_tests","diagnostic"}
 MAX_RECORDS = 512
 MAX_BYTES = 2_000_000
@@ -22,19 +23,21 @@ MAX_BYTES = 2_000_000
 
 def _sha(data: bytes) -> str: return "sha256:" + hashlib.sha256(data).hexdigest()
 def _stable_json(obj: Any) -> str: return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-def _slug(text: str) -> str:
-    s = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
-    return s or "root"
+def _sid(payload: Mapping[str, Any]) -> str: return "gis-" + hashlib.sha256(_stable_json(payload).encode()).hexdigest()[:24]
 
 
-def canonical_repo_path(value: str | None, repo_root: Path | str = Path.cwd()) -> str | None:
+def canonical_repo_path(value: str | None, repo_root: Path | str = Path.cwd(), *, allow_external: bool = False) -> str | None:
     if value in (None, ""):
         return None
     p = Path(str(value))
+    root = Path(repo_root).resolve()
     if p.is_absolute():
+        resolved = p.resolve()
         try:
-            p = p.resolve().relative_to(Path(repo_root).resolve())
-        except Exception as exc:
+            return resolved.relative_to(root).as_posix()
+        except ValueError as exc:
+            if allow_external:
+                return "external:" + resolved.as_posix()
             raise ValueError(f"absolute_path_outside_repo:{value}") from exc
     if ".." in p.parts:
         raise ValueError(f"path_traversal:{value}")
@@ -62,9 +65,11 @@ class ImprovementSignal:
     repository_mutation_performed: bool = False
     provider_or_network_or_git_operation_performed: bool = False
     trial_performed: bool = False
-
     def semantic_payload(self) -> dict[str, Any]:
-        d = asdict(self); d.pop("signal_id", None); return d
+        d = asdict(self)
+        for k in ("signal_id", "observed_at"):
+            d.pop(k, None)
+        return d
     def to_dict(self) -> dict[str, Any]: return asdict(self)
 
 
@@ -76,8 +81,13 @@ class RoutingReceipt:
     target: str | None
     reason_codes: tuple[str, ...]
     required_downstream_review: str
+    candidate_identified: bool = False
+    proposal_generation_attempted: bool = False
     proposal_generation_occurred: bool = False
+    proposal_id: str | None = None
     trial_occurred: bool = False
+    trial_passed: bool | None = None
+    pending_review: bool = False
     adoption_occurred: bool = False
     repository_mutation_occurred: bool = False
     provider_network_git_operation_occurred: bool = False
@@ -93,8 +103,9 @@ class SignalBatch:
     contradiction_ids: tuple[str, ...] = ()
     invalid_reasons: tuple[str, ...] = ()
     input_counts_by_source: Mapping[str, int] | None = None
+    no_op: bool = False
     def to_dict(self) -> dict[str, Any]:
-        return {"schema":"governed_improvement_signal_batch:v1","batch_id":self.batch_id,"batch_digest":self.batch_digest,"signals":[s.to_dict() for s in self.signals],"duplicate_signal_ids":list(self.duplicate_signal_ids),"contradiction_ids":list(self.contradiction_ids),"invalid_reasons":list(self.invalid_reasons),"input_counts_by_source":dict(self.input_counts_by_source or {})}
+        return {"schema":"governed_improvement_signal_batch:v1","batch_id":self.batch_id,"batch_digest":self.batch_digest,"signals":[s.to_dict() for s in self.signals],"duplicate_signal_ids":list(self.duplicate_signal_ids),"contradiction_ids":list(self.contradiction_ids),"invalid_reasons":list(self.invalid_reasons),"input_counts_by_source":dict(self.input_counts_by_source or {}),"no_op":self.no_op}
 
 
 @dataclass(frozen=True)
@@ -113,46 +124,80 @@ def normalize_record(record: Mapping[str, Any], *, repo_root: Path | str = Path.
     kind = str(record.get("finding_kind") or record.get("kind") or "").strip()
     reasons = []
     if src not in ALLOWED_SOURCES: reasons.append("unknown_source_kind")
-    for f in ("adoption_performed","repository_mutation_performed","provider_or_network_or_git_operation_performed"):
+    for f in ("adoption_performed","repository_mutation_performed","provider_or_network_or_git_operation_performed","trial_performed"):
         if bool(record.get(f)): reasons.append(f"false_authority_claim:{f}")
     path = canonical_repo_path(record.get("subject_path") or record.get("path"), repo_root)
-    artifact = canonical_repo_path(record.get("source_artifact") or record.get("artifact"), repo_root)
-    digest = record.get("source_digest")
-    evidence_refs = tuple(sorted(str(x) for x in record.get("evidence_refs", ()) or ()))
-    payload: dict[str, Any] = {"source_kind":src,"finding_kind":kind,"severity":str(record.get("severity","medium")),"description":str(record.get("description") or record.get("message") or kind or src),"subject_path":path,"spec_id":record.get("spec_id"),"capability_id":record.get("capability_id"),"telemetry_stream":record.get("telemetry_stream"),"source_artifact":artifact,"source_digest":digest,"evidence_refs":evidence_refs,"observed_at":record.get("observed_at"),"routing_eligible":not reasons,"reason_codes":tuple(sorted(reasons)),"adoption_performed":False,"repository_mutation_performed":False,"provider_or_network_or_git_operation_performed":False,"trial_performed":False}
-    sid = "gis-" + hashlib.sha256(_stable_json(payload).encode()).hexdigest()[:24]
-    return ImprovementSignal(
-        signal_id=sid,
-        source_kind=str(payload["source_kind"]),
-        finding_kind=str(payload["finding_kind"]),
-        severity=str(payload["severity"]),
-        description=str(payload["description"]),
-        subject_path=payload.get("subject_path"),
-        spec_id=payload.get("spec_id"),
-        capability_id=payload.get("capability_id"),
-        telemetry_stream=payload.get("telemetry_stream"),
-        source_artifact=payload.get("source_artifact"),
-        source_digest=payload.get("source_digest"),
-        evidence_refs=tuple(payload["evidence_refs"]),
-        observed_at=payload.get("observed_at"),
-        routing_eligible=bool(payload["routing_eligible"]),
-        reason_codes=tuple(payload["reason_codes"]),
-    )
+    artifact = canonical_repo_path(record.get("source_artifact") or record.get("artifact"), repo_root, allow_external=True)
+    payload: dict[str, Any] = {"source_kind":src,"finding_kind":kind,"severity":str(record.get("severity","medium")),"description":str(record.get("description") or record.get("message") or kind or src),"subject_path":path,"spec_id":record.get("spec_id"),"capability_id":record.get("capability_id"),"telemetry_stream":record.get("telemetry_stream"),"source_artifact":artifact,"source_digest":record.get("source_digest"),"evidence_refs":tuple(sorted(str(x) for x in record.get("evidence_refs", ()) or ())),"routing_eligible":not reasons,"reason_codes":tuple(sorted(reasons)),"adoption_performed":False,"repository_mutation_performed":False,"provider_or_network_or_git_operation_performed":False,"trial_performed":False}
+    return ImprovementSignal(signal_id=_sid(payload), observed_at=record.get("observed_at"), **payload)
+
+
+def _record_from_gap(g: GapSignal) -> dict[str, Any]:
+    kind = "mypy_error" if g.source == "mypy" else g.kind
+    src = "mypy" if g.source == "mypy" else ("coverage" if g.source == "coverage" else "gap_seeker")
+    return {"source_kind": src, "finding_kind": kind, "severity": g.severity, "description": g.description, "subject_path": g.path.as_posix(), "evidence_refs": [f"line:{g.line}"], "spec_id": g.metadata.get("spec_id")}
+
+
+def _read_once(path: Path, *, expected_digest: str | None = None) -> tuple[bytes, str]:
+    data = path.read_bytes()
+    if len(data) > MAX_BYTES: raise ValueError("oversized_input")
+    digest = _sha(data)
+    if expected_digest and expected_digest != digest: raise ValueError("source_digest_mismatch")
+    return data, digest
+
+
+def records_from_artifact(source_kind: str, path: Path | str, *, repo_root: Path | str = Path.cwd(), expected_digest: str | None = None) -> list[dict[str, Any]]:
+    p = Path(path); data, digest = _read_once(p, expected_digest=expected_digest)
+    text = data.decode("utf-8", errors="replace")
+    artifact = str(p)
+    if source_kind == "coverage":
+        gaps = CoverageReader().collect(coverage_report=json.loads(text))
+        return [{**_record_from_gap(g), "source_artifact": artifact, "source_digest": digest} for g in gaps]
+    if source_kind == "mypy":
+        gaps = CoverageReader().collect(mypy_output=text)
+        return [{**_record_from_gap(g), "source_artifact": artifact, "source_digest": digest} for g in gaps]
+    if source_kind == "junit":
+        root = ET.fromstring(text); out=[]
+        for case in root.findall(".//testcase"):
+            failure = case.find("failure") or case.find("error")
+            if failure is not None:
+                out.append({"source_kind":"junit","finding_kind":"test_failure","severity":"high","description":failure.get("message") or (failure.text or "junit failure"),"subject_path":case.get("file") or case.get("classname","tests"),"spec_id":case.get("classname") or case.get("name"),"source_artifact":artifact,"source_digest":digest})
+        return out
+    payload = json.loads(text)
+    if source_kind == "run_tests":
+        failures = payload.get("failures") or payload.get("failed") or []
+        if isinstance(failures, int): failures = [{} for _ in range(failures)]
+        return [{"source_kind":"run_tests","finding_kind":"test_failure","severity":"high","description":str(f.get("message") or f.get("nodeid") or "run_tests failure"),"subject_path":f.get("path") or f.get("nodeid","tests"),"spec_id":f.get("spec_id") or f.get("nodeid"),"source_artifact":artifact,"source_digest":digest} for f in failures if isinstance(f, Mapping)]
+    if source_kind in {"covenant","telemetry","capability_gap","model_observation"}:
+        records = payload.get("signals") or payload.get("findings") or payload.get("observations") or payload
+        if isinstance(records, Mapping): records=[records]
+        return [{**dict(r), "source_kind": source_kind, "source_artifact": artifact, "source_digest": digest} for r in records if isinstance(r, Mapping)]
+    raise ValueError(f"unknown_artifact_source:{source_kind}")
+
+
+def collect_repository_evidence(*, repo_root: Path | str = Path.cwd(), artifacts: Sequence[Mapping[str, Any]] = (), direct_records: Sequence[Mapping[str, Any]] = (), scan_repo: bool = False) -> list[ImprovementSignal]:
+    records: list[Mapping[str, Any]] = []
+    total_direct = len(_stable_json(list(direct_records)).encode())
+    if total_direct > MAX_BYTES: raise ValueError("oversized_direct_input")
+    records.extend(direct_records)
+    for artifact in artifacts:
+        records.extend(records_from_artifact(str(artifact.get("source_kind")), Path(str(artifact.get("path"))), repo_root=repo_root, expected_digest=artifact.get("source_digest")))
+    if scan_repo:
+        gaps = GapReporter().aggregate(RepoScanner(repo_root).iter_gaps())
+        records.extend(_record_from_gap(g) for g in gaps[:MAX_RECORDS])
+    if len(records) > MAX_RECORDS: raise ValueError("too_many_records")
+    return [normalize_record(r, repo_root=repo_root) for r in records]
 
 
 def load_json_records(paths: Sequence[Path | str], *, repo_root: Path | str = Path.cwd()) -> list[ImprovementSignal]:
     out: list[ImprovementSignal] = []
-    total = 0
     for path in paths:
-        p = Path(path); data = p.read_bytes(); total += len(data)
-        if total > MAX_BYTES: raise ValueError("oversized_input")
-        digest = _sha(data); payload = json.loads(data.decode())
+        p = Path(path); data,digest = _read_once(p); payload = json.loads(data.decode())
         records = payload.get("signals") if isinstance(payload, dict) else payload
         if isinstance(records, dict): records = [records]
         for rec in records or []:
             if not isinstance(rec, Mapping): raise ValueError("malformed_record")
-            enriched = dict(rec); enriched.setdefault("source_artifact", str(p)); enriched.setdefault("source_digest", digest)
-            out.append(normalize_record(enriched, repo_root=repo_root))
+            out.append(normalize_record({**dict(rec), "source_artifact": str(p), "source_digest": digest}, repo_root=repo_root))
             if len(out) > MAX_RECORDS: raise ValueError("too_many_records")
     return out
 
@@ -160,69 +205,69 @@ def load_json_records(paths: Sequence[Path | str], *, repo_root: Path | str = Pa
 def build_batch(records: Iterable[Mapping[str, Any]] | Iterable[ImprovementSignal], *, repo_root: Path | str = Path.cwd()) -> SignalBatch:
     signals = [r if isinstance(r, ImprovementSignal) else normalize_record(r, repo_root=repo_root) for r in records]
     signals.sort(key=lambda s: (s.signal_id, s.source_kind, s.finding_kind))
-    seen: dict[str, ImprovementSignal] = {}; dup=[]; contradictions=[]; counts: dict[str,int]={}; unique=[]
-    by_subject: dict[tuple[Any,...], ImprovementSignal] = {}
-    invalid: list[str] = []
+    seen={}; dup=[]; contradictions=[]; counts={}; unique=[]; by_subject={}; invalid=[]
     for s in signals:
-        counts[s.source_kind]=counts.get(s.source_kind,0)+1
-        invalid.extend(s.reason_codes)
+        expected = _sid(s.semantic_payload())
+        if expected != s.signal_id: invalid.append("signal_id_mismatch")
+        counts[s.source_kind]=counts.get(s.source_kind,0)+1; invalid.extend(s.reason_codes)
         if s.signal_id in seen: dup.append(s.signal_id); continue
         key=(s.source_kind,s.finding_kind,s.subject_path,s.spec_id,s.capability_id,s.telemetry_stream)
         prev=by_subject.get(key)
-        if prev and (prev.description != s.description or prev.severity != s.severity):
-            contradictions.extend(sorted([prev.signal_id,s.signal_id]))
+        if prev and (prev.description != s.description or prev.severity != s.severity): contradictions.extend([prev.signal_id,s.signal_id])
         by_subject[key]=s; seen[s.signal_id]=s; unique.append(s)
-    body=[s.to_dict() for s in unique]
-    digest=_sha(_stable_json(body).encode())
-    return SignalBatch("gisb-"+hashlib.sha256(digest.encode()).hexdigest()[:24], digest, tuple(unique), tuple(sorted(set(dup))), tuple(sorted(set(contradictions))), tuple(sorted(set(invalid))), counts)
+    body=[s.to_dict() for s in unique]; digest=_sha(_stable_json(body).encode())
+    return SignalBatch("gisb-"+hashlib.sha256(digest.encode()).hexdigest()[:24], digest, tuple(unique), tuple(sorted(set(dup))), tuple(sorted(set(contradictions))), tuple(sorted(set(invalid))), counts, no_op=not unique)
 
 
 def route_batch(batch: SignalBatch) -> tuple[RoutingReceipt, ...]:
+    if batch.no_op:
+        return (RoutingReceipt("batch-noop", batch.batch_digest, "no_op", None, ("empty_input",), "none"),)
     receipts=[]
     for s in batch.signals:
-        reasons=list(s.reason_codes)
-        disposition="diagnostic_only"; target=s.subject_path or s.spec_id or s.capability_id
-        review="operator_review_required"
-        prop=False
+        reasons=list(s.reason_codes); disposition="diagnostic_only"; target=s.subject_path or s.spec_id or s.capability_id; review="operator_review_required"; candidate=False
         if not s.routing_eligible or reasons or s.signal_id in batch.contradiction_ids:
             disposition="blocked_invalid"; reasons.append("invalid_or_contradicted"); review="manual_triage_required"
         elif s.finding_kind in GENESIS_KINDS and (s.capability_id or s.telemetry_stream):
-            disposition="genesis_proposal_candidate"; target=s.capability_id or s.telemetry_stream; prop=True; reasons.append("missing_capability_or_new_flow")
+            disposition="genesis_proposal_candidate"; target=s.capability_id or s.telemetry_stream; candidate=True; reasons.append("missing_capability_or_new_flow")
         elif s.finding_kind in SPEC_KINDS and s.spec_id:
-            disposition="spec_amendment_candidate"; target=s.spec_id; prop=True; reasons.append("existing_spec_recurring_failure")
+            disposition="spec_amendment_candidate"; target=s.spec_id; candidate=True; reasons.append("existing_spec_recurring_failure")
         elif s.finding_kind in DIAGNOSTIC_KINDS:
             disposition="gap_seeker_diagnostic"; reasons.append("gap_seeker_supported_diagnostic")
         else:
             disposition="blocked_invalid"; reasons.append("no_safe_route")
-        receipts.append(RoutingReceipt(s.signal_id, s.source_digest or batch.batch_digest, disposition, target, tuple(sorted(set(reasons))), review, prop, False, False, False, False))
+        receipts.append(RoutingReceipt(s.signal_id, s.source_digest or batch.batch_digest, disposition, target, tuple(sorted(set(reasons))), review, candidate_identified=candidate))
     return tuple(sorted(receipts, key=lambda r: r.signal_id))
 
 
 def evaluate_signal_plane(records: Iterable[Mapping[str, Any]] | Iterable[ImprovementSignal] = (), *, repo_root: Path | str = Path.cwd()) -> SignalPlaneEvaluation:
-    batch=build_batch(records, repo_root=repo_root); receipts=route_batch(batch)
-    counts: dict[str,int]={}
+    batch=build_batch(records, repo_root=repo_root); receipts=route_batch(batch); counts={}
     for r in receipts: counts[r.disposition]=counts.get(r.disposition,0)+1
-    genesis=[]; amendments=[]
-    lookup={s.signal_id:s for s in batch.signals}
+    lookup={s.signal_id:s for s in batch.signals}; genesis=[]; amendments=[]
     for r in receipts:
-        s=lookup[r.signal_id]
+        s=lookup.get(r.signal_id)
+        if not s: continue
         if r.disposition=="genesis_proposal_candidate": genesis.append(s)
-        if r.disposition=="spec_amendment_candidate": amendments.append({"spec_id":s.spec_id,"signal_type":s.finding_kind,"metadata":s.to_dict()})
-    summary={"batch_id":batch.batch_id,"batch_digest":batch.batch_digest,"input_counts_by_source":dict(batch.input_counts_by_source or {}),"routed_counts_by_disposition":counts,"proposal_count":sum(1 for r in receipts if r.proposal_generation_occurred),"blocked_invalid_count":counts.get("blocked_invalid",0),"degraded": bool(batch.invalid_reasons or batch.contradiction_ids),"adoption_performed":False,"repository_mutation_performed":False,"provider_network_git_operation_performed":False}
-    genesis_inputs={"telemetry_streams":[{"name":s.telemetry_stream or s.capability_id or s.signal_id,"capability":s.capability_id or s.telemetry_stream or s.signal_id,"description":s.description,"sample_payload":{"signal_id":s.signal_id,"batch_id":batch.batch_id}} for s in genesis],"vows":[{"capability":s.capability_id or s.telemetry_stream or s.signal_id,"description":"proposal-only review required"} for s in genesis]}
+        if r.disposition=="spec_amendment_candidate": amendments.append({"spec_id":s.spec_id,"signal_type":s.finding_kind,"signal_id":s.signal_id,"batch_id":batch.batch_id,"source_digest":s.source_digest,"routing_receipt":r.to_dict(),"metadata":s.to_dict()})
+    summary={"batch_id":batch.batch_id,"batch_digest":batch.batch_digest,"input_counts_by_source":dict(batch.input_counts_by_source or {}),"routed_counts_by_disposition":counts,"proposal_count":0,"blocked_invalid_count":counts.get("blocked_invalid",0),"degraded": bool(batch.invalid_reasons or batch.contradiction_ids),"no_op":batch.no_op,"adoption_performed":False,"repository_mutation_performed":False,"provider_network_git_operation_performed":False}
+    genesis_inputs={"batch_id":batch.batch_id,"telemetry_streams":[{"name":s.telemetry_stream or s.capability_id or s.signal_id,"capability":s.capability_id or s.telemetry_stream or s.signal_id,"description":s.description,"sample_payload":{"signal_id":s.signal_id,"batch_id":batch.batch_id,"source_digest":s.source_digest}} for s in genesis],"vows":[{"capability":s.capability_id or s.telemetry_stream or s.signal_id,"description":"proposal-only review required"} for s in genesis]}
     return SignalPlaneEvaluation(batch, receipts, summary, genesis_inputs, tuple(amendments))
 
 
 def atomic_write_json(path: Path | str, payload: Mapping[str, Any]) -> None:
-    p=Path(path); p.parent.mkdir(parents=True, exist_ok=True)
-    data=json.dumps(payload, sort_keys=True, indent=2).encode()+b"\n"
-    fd,tmp=tempfile.mkstemp(prefix=p.name+".", dir=str(p.parent))
+    p=Path(path); p.parent.mkdir(parents=True, exist_ok=True); data=json.dumps(payload, sort_keys=True, indent=2).encode()+b"\n"; fd,tmp=tempfile.mkstemp(prefix=p.name+".", dir=str(p.parent))
     with os.fdopen(fd,"wb") as f: f.write(data)
     os.replace(tmp,p)
 
 
+def persist_runtime_artifacts(root: Path | str, evaluation: SignalPlaneEvaluation, *, tick_id: str) -> dict[str, str]:
+    base=Path(root)/"governed_improvement_signal_plane"/re.sub(r"[^A-Za-z0-9_.-]+","_",tick_id); base.mkdir(parents=True, exist_ok=True)
+    paths={"batch":base/"batch.json", "routing":base/"routing.json", "evaluation":base/"evaluation.json"}
+    atomic_write_json(paths["batch"], evaluation.batch.to_dict()); atomic_write_json(paths["routing"], {"receipts":[r.to_dict() for r in evaluation.receipts]}); atomic_write_json(paths["evaluation"], evaluation.to_dict())
+    return {k: str(v) for k,v in paths.items()}
+
+
 def render_markdown(e: SignalPlaneEvaluation) -> str:
-    lines=["# Governed Improvement Signal Plane", "", f"- Batch: `{e.batch.batch_id}`", f"- Digest: `{e.batch.batch_digest}`", "- Adoption performed: `false`", "- Repository mutation performed: `false`", "", "## Routing"]
+    lines=["# Governed Improvement Signal Plane", "", f"- Batch: `{e.batch.batch_id}`", f"- Digest: `{e.batch.batch_digest}`", f"- No-op: `{str(e.batch.no_op).lower()}`", "- Adoption performed: `false`", "- Repository mutation performed: `false`", "", "## Routing"]
     for r in e.receipts: lines.append(f"- `{r.signal_id}` → `{r.disposition}` ({', '.join(r.reason_codes)})")
     return "\n".join(lines)+"\n"
 
@@ -230,7 +275,10 @@ def render_markdown(e: SignalPlaneEvaluation) -> str:
 def validate_evaluation(payload: Mapping[str, Any]) -> tuple[bool, tuple[str,...]]:
     reasons=[]
     if payload.get("schema") != "governed_improvement_signal_plane_evaluation:v1": reasons.append("wrong_schema")
-    text=_stable_json(payload)
-    for token in ("adoption_occurred\":true","repository_mutation_occurred\":true","provider_network_git_operation_occurred\":true"):
-        if token in text: reasons.append("authority_claim_present")
+    summary = payload.get("summary") if isinstance(payload.get("summary"), Mapping) else {}
+    for key in ("adoption_performed","repository_mutation_performed","provider_network_git_operation_performed"):
+        if summary.get(key) is not False: reasons.append(f"authority_claim_present:{key}")
+    for receipt in payload.get("receipts", []) if isinstance(payload.get("receipts"), list) else []:
+        if isinstance(receipt, Mapping) and (receipt.get("adoption_occurred") or receipt.get("repository_mutation_occurred") or receipt.get("provider_network_git_operation_occurred")):
+            reasons.append("receipt_authority_claim_present")
     return (not reasons, tuple(sorted(set(reasons))))

--- a/sentientosd.py
+++ b/sentientosd.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import signal
+import inspect
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,7 +37,7 @@ from codex.amendments import (
 from codex.integrity_daemon import runtime_guard as runtime_integrity_guard
 from sentientos.codex_healer import runtime_monitor as runtime_healer_monitor
 from sentientos.genesis_forge import CovenantVow, TelemetryStream, runtime_expand as runtime_genesis_expand
-from sentientos.governed_improvement_signal_plane import SignalPlaneEvaluation, evaluate_signal_plane
+from sentientos.governed_improvement_signal_plane import SignalPlaneEvaluation, collect_repository_evidence, evaluate_signal_plane, persist_runtime_artifacts
 from sentientos.repository_mutation_handoff import (
     build_repository_mutation_handoff,
     resolve_observed_source_revision,
@@ -50,9 +51,12 @@ LOGGER = logging.getLogger(__name__)
 class RuntimeMaintenanceSurfaces:
     """Runtime facade that closes sentientosd loop calls onto real subsystem methods."""
 
-    def __init__(self, repo_root: Path, *, repository_mutation_handoff_root: Path | None = None) -> None:
+    def __init__(self, repo_root: Path, *, repository_mutation_handoff_root: Path | None = None, improvement_evidence_sources: list[dict[str, Any]] | None = None, runtime_state_root: Path | None = None) -> None:
         self._repo_root = Path(repo_root)
         self._repository_mutation_handoff_root = repository_mutation_handoff_root
+        self._improvement_evidence_sources = list(improvement_evidence_sources or [])
+        self._runtime_state_root = runtime_state_root or Path(os.environ.get("SENTIENTOS_RUNTIME_STATE_ROOT", "/tmp/sentientos-runtime-state"))
+        self._identify_admitted = False
         self._feedback: dict[str, Any] = {
             "schema": "runtime_maintenance_feedback:v1",
             "degraded": False,
@@ -60,7 +64,10 @@ class RuntimeMaintenanceSurfaces:
         }
 
     def identify_improvement_signals(self) -> SignalPlaneEvaluation:
-        evaluation = evaluate_signal_plane((), repo_root=self._repo_root)
+        records = collect_repository_evidence(repo_root=self._repo_root, artifacts=self._improvement_evidence_sources)
+        evaluation = evaluate_signal_plane(records, repo_root=self._repo_root)
+        artifacts = persist_runtime_artifacts(self._runtime_state_root, evaluation, tick_id=datetime.now(timezone.utc).isoformat())
+        self._identify_admitted = True
         self._feedback["surfaces"]["governed_improvement_signal_plane"] = {
             "status": "degraded" if evaluation.summary.get("degraded") else "ok",
             "batch_id": evaluation.batch.batch_id,
@@ -72,6 +79,7 @@ class RuntimeMaintenanceSurfaces:
             "adoption_performed": False,
             "repository_mutation_performed": False,
             "provider_network_git_operation_performed": False,
+            "runtime_artifacts": artifacts,
         }
         self._current_signal_evaluation = evaluation
         self._refresh_feedback()
@@ -95,12 +103,14 @@ class RuntimeMaintenanceSurfaces:
             for item in genesis_inputs.get("vows", [])
             if isinstance(item, dict)
         ]
-        try:
-            outcomes = runtime_genesis_expand(self._repo_root, telemetry_streams=telemetry_streams, vows=vows, proposal_only=True)
-        except TypeError as exc:
-            if "unexpected keyword" not in str(exc):
-                raise
-            outcomes = runtime_genesis_expand(self._repo_root)
+        if not self._identify_admitted:
+            outcomes = []
+        else:
+            sig = inspect.signature(runtime_genesis_expand)
+            if "telemetry_streams" in sig.parameters:
+                outcomes = runtime_genesis_expand(self._repo_root, telemetry_streams=telemetry_streams, vows=vows, proposal_only=True)
+            else:
+                outcomes = runtime_genesis_expand(self._repo_root)
         failed = sum(1 for item in outcomes if str(getattr(item, "status", "")).lower() in {"failed", "deferred_degraded_audit_trust"})
         self._feedback["surfaces"]["genesis_forge"] = {
             "status": "degraded" if failed else "ok",
@@ -112,12 +122,14 @@ class RuntimeMaintenanceSurfaces:
 
     def cycle(self) -> dict[str, Any]:
         evaluation = getattr(self, "_current_signal_evaluation", evaluate_signal_plane((), repo_root=self._repo_root))
-        try:
-            state = runtime_spec_cycle(self._repo_root / "integration", signals=evaluation.amendment_inputs)
-        except TypeError as exc:
-            if "unexpected keyword" not in str(exc):
-                raise
-            state = runtime_spec_cycle(self._repo_root / "integration")
+        if not self._identify_admitted:
+            state = {"panel": "Spec Amendments", "pending": [], "approved": [], "runtime_signal_count": 0, "blocked_by_identify_stage": True}
+        else:
+            sig = inspect.signature(runtime_spec_cycle)
+            if "signals" in sig.parameters:
+                state = runtime_spec_cycle(self._repo_root / "integration", signals=evaluation.amendment_inputs)
+            else:
+                state = runtime_spec_cycle(self._repo_root / "integration")
         pending = len(state.get("pending", [])) if isinstance(state.get("pending"), list) else 0
         self._feedback["surfaces"]["spec_amender"] = {
             "status": "ok",
@@ -253,63 +265,69 @@ def _run_maintenance_tick(
         current_surface = "identify_improvement_signals"
         current_correlation_id = f"{tick_id}:identify_improvement_signals"
         identify = getattr(runtime_surfaces, "identify_improvement_signals", None)
+        identify_allowed = True
         if callable(identify):
-            kernel.admit_and_execute(
+            decision, _identify_result = kernel.admit_and_execute(
                 ControlActionRequest(
                     action_kind="identify_improvement_signals",
                     authority_class=AuthorityClass.PROPOSAL_EVALUATION,
                     actor="sentientosd",
                     target_subsystem="governed_improvement_signal_plane",
                     requested_phase=LifecyclePhase.MAINTENANCE,
-                    metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+                    metadata={"correlation_id": current_correlation_id},
                 ),
                 execute=identify,
             )
-        feedback = runtime_surfaces.governance_feedback()
-        current_surface = "expand"
-        current_correlation_id = f"{tick_id}:expand"
-        kernel.admit_and_execute(
-            ControlActionRequest(
-                action_kind="expand",
-                authority_class=AuthorityClass.PROPOSAL_EVALUATION,
-                actor="sentientosd",
-                target_subsystem="genesis_forge",
-                requested_phase=LifecyclePhase.MAINTENANCE,
-                startup_symbol="GenesisForge",
-                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
-            ),
-            execute=runtime_surfaces.expand,
-        )
-        feedback = runtime_surfaces.governance_feedback()
-        current_surface = "cycle"
-        current_correlation_id = f"{tick_id}:cycle"
-        kernel.admit_and_execute(
-            ControlActionRequest(
-                action_kind="cycle",
-                authority_class=AuthorityClass.SPEC_AMENDMENT,
-                actor="sentientosd",
-                target_subsystem="spec_amender",
-                requested_phase=LifecyclePhase.MAINTENANCE,
-                startup_symbol="SpecAmender",
-                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
-            ),
-            execute=runtime_surfaces.cycle,
-        )
-        feedback = runtime_surfaces.governance_feedback()
-        current_surface = "guard"
-        current_correlation_id = f"{tick_id}:guard"
-        kernel.admit_and_execute(
-            ControlActionRequest(
-                action_kind="guard",
-                authority_class=AuthorityClass.PROPOSAL_EVALUATION,
-                actor="sentientosd",
-                target_subsystem="integrity_daemon",
-                requested_phase=LifecyclePhase.MAINTENANCE,
-                startup_symbol="IntegrityDaemon",
-                metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
-            ),
-            execute=runtime_surfaces.guard,
-        )
+            identify_allowed = bool(getattr(decision, "allowed", False))
+        if not identify_allowed:
+            runtime_surfaces._identify_admitted = False
+            runtime_surfaces._feedback["surfaces"]["governed_improvement_signal_plane"] = {"status": "degraded", "blocked_by_admission": True}
+        if identify_allowed:
+            feedback = runtime_surfaces.governance_feedback()
+            current_surface = "expand"
+            current_correlation_id = f"{tick_id}:expand"
+            kernel.admit_and_execute(
+                ControlActionRequest(
+                    action_kind="expand",
+                    authority_class=AuthorityClass.PROPOSAL_EVALUATION,
+                    actor="sentientosd",
+                    target_subsystem="genesis_forge",
+                    requested_phase=LifecyclePhase.MAINTENANCE,
+                    startup_symbol="GenesisForge",
+                    metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+                ),
+                execute=runtime_surfaces.expand,
+            )
+            feedback = runtime_surfaces.governance_feedback()
+            current_surface = "cycle"
+            current_correlation_id = f"{tick_id}:cycle"
+            kernel.admit_and_execute(
+                ControlActionRequest(
+                    action_kind="cycle",
+                    authority_class=AuthorityClass.SPEC_AMENDMENT,
+                    actor="sentientosd",
+                    target_subsystem="spec_amender",
+                    requested_phase=LifecyclePhase.MAINTENANCE,
+                    startup_symbol="SpecAmender",
+                    metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+                ),
+                execute=runtime_surfaces.cycle,
+            )
+            feedback = runtime_surfaces.governance_feedback()
+            current_surface = "guard"
+            current_correlation_id = f"{tick_id}:guard"
+            kernel.admit_and_execute(
+                ControlActionRequest(
+                    action_kind="guard",
+                    authority_class=AuthorityClass.PROPOSAL_EVALUATION,
+                    actor="sentientosd",
+                    target_subsystem="integrity_daemon",
+                    requested_phase=LifecyclePhase.MAINTENANCE,
+                    startup_symbol="IntegrityDaemon",
+                    metadata={"runtime_feedback": feedback, "correlation_id": current_correlation_id},
+                ),
+                execute=runtime_surfaces.guard,
+            )
         feedback = runtime_surfaces.governance_feedback()
         current_surface = "monitor"
         current_correlation_id = f"{tick_id}:monitor"
@@ -362,7 +380,7 @@ def _run_maintenance_tick(
 
         current_surface = "repository_mutation_handoff"
         current_correlation_id = f"{tick_id}:repository_mutation_handoff"
-        plan = runtime_surfaces.next_repository_mutation_handoff()
+        plan = runtime_surfaces.next_repository_mutation_handoff() if identify_allowed else None
         if plan:
             LOGGER.info("Codex amendment ready for repository mutation handoff review: %s", plan.message)
             runtime_surfaces.emit_repository_mutation_handoff(plan)


### PR DESCRIPTION
### Motivation
- Finish the landed governed-improvement signal plane so repository-native evidence is collected, routed deterministically, and enters the existing Genesis/Autogenesis/SpecAmender pipeline without claiming downstream effects early.
- Restore deterministic, falsifiable identities and receipts for signals and batches so routing, proposal, and amendment artifacts can be independently verified.
- Ensure the runtime maintenance loop admits identification before feeding Genesis/SpecAmender and persist runtime artifacts outside the repository for auditability.

### Description
- Implemented bounded repository-native evidence intake in `sentientos/governed_improvement_signal_plane.py` with parsers and adapters for `run_tests` JSON, JUnit XML, `coverage` JSON, `mypy` output (via `codex.gap_seeker.CoverageReader`), covenant/telemetry/capability artifacts, and `RepoScanner`/`GapReporter` integration; added digest checks, canonical path handling, and explicit external artifact modeling. (`records_from_artifact`, `collect_repository_evidence`, `_read_once`, `_record_from_gap`, new stability checks).
- Separated semantic identity from observation metadata by excluding `observed_at` from semantic payloads and recomputing signal IDs from canonical payloads; added `no_op` batch behavior and explicit deterministic `batch-noop` receipt for empty input; detect `signal_id_mismatch`, duplicates, contradictions, and invalid reason codes during batch construction. (changes in `normalize_record`, `build_batch`, `route_batch`, `evaluate_signal_plane`).
- Reworked routing receipts so they mark candidate identification but never claim proposal/adoption at routing time; added clearer receipt fields (candidate identification, proposal attempt flags, trial result fields) and included routing receipt information in amendment inputs. (`RoutingReceipt` shape and `route_batch` behavior).
- Wired runtime intake into `sentientosd.RuntimeMaintenanceSurfaces` so `identify_improvement_signals` consumes injectable `improvement_evidence_sources`, persists one immutable batch/routing/evaluation per tick to an injectable external runtime-state root, and gates downstream `expand`/`cycle`/`spec_amender` on identify admission; compatibility with older `runtime_*` signatures is preserved via introspection. (`sentientosd` ctor changes, `identify_improvement_signals`, `expand`, `cycle`, and tick gating logic).
- Tightened Genesis proposal-only semantics in `sentientos/genesis_forge.py` so `propose_for_review` requires structured stage-A validity, a stage-B evaluation (`evaluate_report_stage_b`), and a passed sandbox trial before reporting `proposal_ready_for_review`; non-ready outcomes are explicit (e.g., `invalid_stage_a`, `invalid_stage_b`, `failed_trial`).
- Fixed runtime amendment flow in `codex/amendments.py` so `runtime_cycle` loads the canonical existing spec from `integration/specs/...` instead of fabricating a minimal spec, attaches runtime lineage metadata, and omits proposals when the canonical spec is missing.
- Added small runtime safety and admission hardening: identify-stage denial prevents downstream consumption for the tick, and `sentientosd` records and uses admission decisions to avoid feeding Genesis/SpecAmender when not admitted.
- Added `persist_runtime_artifacts` to store per-tick `batch.json`, `routing.json`, and `evaluation.json` under an injectable runtime-state root and included `runtime_artifacts` metadata in feedback.

### Testing
- Compiled modified modules with `python -m py_compile sentientos/governed_improvement_signal_plane.py sentientosd.py sentientos/genesis_forge.py codex/amendments.py` and the compilation step passed.
- Ran focused tests and matrix commands used during verification: `python -m scripts.run_tests -q tests/test_sentientosd_runtime_closure.py` passed (runtime closure tests exercising the identify gating and feedback behavior succeeded).
- Ran the broader focused command (`python -m scripts.run_tests -q` for the listed focused files including `tests/test_genesis_forge.py` and related suites) and observed remaining failures in `tests/test_genesis_forge.py` (constitutional mutation router / adoption admission and related GenesisForge integration assertions); these are real, reproducible failures and block completing the full landing matrix.
- Summary of automated results: compilation ✅; `tests/test_sentientosd_runtime_closure.py` ✅; focused full set (governed signal plane + genesis + amendments + gap seeker + mypy baseline) ❌ due to remaining GenesisForge/admission interaction failures.

Note: commit `f44c207066d84904595e89cd7d9de38f742d7012` contains the changes described and preserves recovery artifacts; the full required matrix and landing finalizers were not completed because the GenesisForge broad-suite failures must be resolved before finalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a532eb90754832fa818e0f98eb81f21)